### PR TITLE
Adds min/max stat tracking macros, minor cleanup, autoprofile hook

### DIFF
--- a/code/__DEFINES/stat_tracking.dm
+++ b/code/__DEFINES/stat_tracking.dm
@@ -15,7 +15,8 @@
 #define INIT_COST(costs, counting) \
 	var/list/_costs = costs; \
 	var/list/_counting = counting; \
-	var/_usage = TICK_USAGE;
+	var/_usage = TICK_USAGE; \
+	var/_cost = 0;
 
 // STATIC cost tracking macro. Uses static lists instead of the normal global ones
 // Good for debug stuff, and for running before globals init
@@ -33,10 +34,22 @@
 	} \
 	_usage = TICK_USAGE;
 
+#define SET_COST_BOUNDS(category) \
+	do { \
+		_cost = TICK_USAGE; \
+		var/_tmp_delta = TICK_DELTA_TO_MS(_cost - _usage);\
+		_costs[category] += _tmp_delta;\
+		_counting[category] += 1;\
+		_costs["[category]_min"] = min(_tmp_delta, _costs["[category]_min"] || INFINITY);\
+		_counting["[category]_min"] += 1;\
+		_costs["[category]_max"] = max(_tmp_delta, _costs["[category]_max"] || 0);\
+		_counting["[category]_max"] += 1;\
+	} while(FALSE); \
+	_usage = TICK_USAGE;
 
 #define SET_COST(category) \
 	do { \
-		var/_cost = TICK_USAGE; \
+		_cost = TICK_USAGE; \
 		_costs[category] += TICK_DELTA_TO_MS(_cost - _usage);\
 		_counting[category] += 1; \
 	} while(FALSE); \

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -108,6 +108,9 @@
 /// Prefer the autowiki build target instead.
 // #define AUTOWIKI
 
+/// If defined, we boot up, run world.run_performance_tests() and then shut down the server
+// #define PERFORMANCE_TESTS
+
 /// If this is uncommented, will profile mapload atom initializations
 // #define PROFILE_MAPLOAD_INIT_ATOM
 

--- a/code/controllers/subsystem/cameras.dm
+++ b/code/controllers/subsystem/cameras.dm
@@ -30,6 +30,23 @@ SUBSYSTEM_DEF(cameras)
 	RegisterSignal(SSmapping, COMSIG_PLANE_OFFSET_INCREASE, PROC_REF(on_offset_growth))
 	return SS_INIT_SUCCESS
 
+/datum/controller/subsystem/cameras/proc/update_all_chunks()
+	//Hell code, we're bound to end the round somehow so let's stop if from ending while we work
+	SSticker.delay_end = TRUE
+	var/x1 = 1
+	var/y1 = 1
+	var/x2 = world.maxx
+	var/y2 = world.maxy
+	var/list/visibleChunks = list()
+
+	for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
+		for(var/x = x1; x <= x2; x += CHUNK_SIZE)
+			for(var/y = y1; y <= y2; y += CHUNK_SIZE)
+				visibleChunks |= generate_chunk(x, y, z)
+	stat_tracking_export_to_csv_later("camera_chunks.csv", GLOB.camera_cost, GLOB.camera_count)
+	SSticker.delay_end = FALSE
+	shutdown()
+
 /datum/controller/subsystem/cameras/fire(resumed = FALSE)
 	if(!resumed)
 		src.current_run = chunks_to_update.Copy()

--- a/code/controllers/subsystem/cameras.dm
+++ b/code/controllers/subsystem/cameras.dm
@@ -30,23 +30,6 @@ SUBSYSTEM_DEF(cameras)
 	RegisterSignal(SSmapping, COMSIG_PLANE_OFFSET_INCREASE, PROC_REF(on_offset_growth))
 	return SS_INIT_SUCCESS
 
-/datum/controller/subsystem/cameras/proc/update_all_chunks()
-	//Hell code, we're bound to end the round somehow so let's stop if from ending while we work
-	SSticker.delay_end = TRUE
-	var/x1 = 1
-	var/y1 = 1
-	var/x2 = world.maxx
-	var/y2 = world.maxy
-	var/list/visibleChunks = list()
-
-	for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
-		for(var/x = x1; x <= x2; x += CHUNK_SIZE)
-			for(var/y = y1; y <= y2; y += CHUNK_SIZE)
-				visibleChunks |= generate_chunk(x, y, z)
-	stat_tracking_export_to_csv_later("camera_chunks.csv", GLOB.camera_cost, GLOB.camera_count)
-	SSticker.delay_end = FALSE
-	shutdown()
-
 /datum/controller/subsystem/cameras/fire(resumed = FALSE)
 	if(!resumed)
 		src.current_run = chunks_to_update.Copy()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -186,7 +186,7 @@ GLOBAL_VAR(restart_counter)
 	setup_autowiki()
 	#endif
 
-	#ifdef AUTOWIKI
+	#ifdef PERFORMANCE_TESTS
 	queue_performance_tests()
 	#endif
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -186,14 +186,9 @@ GLOBAL_VAR(restart_counter)
 	setup_autowiki()
 	#endif
 
-	//run_performance_tests()
-
-/world/proc/run_performance_tests()
-	//trigger things to run the whole process
-	Master.sleep_offline_after_initializations = FALSE
-	SSticker.start_immediately = TRUE
-	var/datum/callback/cb = CALLBACK(SScameras, TYPE_PROC_REF(/datum/controller/subsystem/cameras, update_all_chunks))
-	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_addtimer), cb, 10 SECONDS))
+	#ifdef AUTOWIKI
+	queue_performance_tests()
+	#endif
 
 /world/proc/HandleTestRun()
 	//trigger things to run the whole process
@@ -207,6 +202,25 @@ GLOBAL_VAR(restart_counter)
 	cb = VARSET_CALLBACK(SSticker, force_ending, ADMIN_FORCE_END_ROUND)
 #endif
 	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_addtimer), cb, 10 SECONDS))
+
+/world/proc/queue_performance_tests()
+	//trigger things to run the whole process
+	Master.sleep_offline_after_initializations = FALSE
+	SSticker.start_immediately = TRUE
+	var/datum/callback/cb = CALLBACK(src, PROC_REF(run_performance_tests))
+	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_addtimer), cb, 10 SECONDS))
+
+/// Stub proc intended to be filled with code that does some test, profiles it, and logs that test.
+/// Intended to be used with line by line macros, but you should live your truth
+/world/proc/run_performance_tests()
+	// In case we do somethin that could otherwise end the round
+	SSticker.delay_end = TRUE
+	// Your code goes here
+
+	// Logging goes here
+	// (sample line by line) stat_tracking_export_to_csv_later("file_name.csv", GLOB.cost_list, GLOB.count_list)
+	SSticker.delay_end = FALSE
+	shutdown()
 
 /// Returns a list of data about the world state, don't clutter
 /world/proc/get_world_state_for_logging()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -186,6 +186,15 @@ GLOBAL_VAR(restart_counter)
 	setup_autowiki()
 	#endif
 
+	//run_performance_tests()
+
+/world/proc/run_performance_tests()
+	//trigger things to run the whole process
+	Master.sleep_offline_after_initializations = FALSE
+	SSticker.start_immediately = TRUE
+	var/datum/callback/cb = CALLBACK(SScameras, TYPE_PROC_REF(/datum/controller/subsystem/cameras, update_all_chunks))
+	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_addtimer), cb, 10 SECONDS))
+
 /world/proc/HandleTestRun()
 	//trigger things to run the whole process
 	Master.sleep_offline_after_initializations = FALSE


### PR DESCRIPTION
## About The Pull Request

I found myself wondering about the best/worse cases of a block of code, this lets me answer that pretty trivially.

Also, makes _cost a permanent var, since as is it ends up getting redefined a bunch for no reason.

Fun Bonus!

[Implements generic semi automated performance testing support](https://github.com/tgstation/tgstation/pull/94529/commits/967ca317db036113174a7f9be8bbe249f91415e6)
[967ca31](https://github.com/tgstation/tgstation/pull/94529/commits/967ca317db036113174a7f9be8bbe249f91415e6)

I found myself sitting at my desk waiting for the game to init so I could run a proc on a subsystem, then close the game.
Figured that was extremely automatable, so here we go
