### PR TITLE
regenerate_organs now removes emp-derived failure from organs

### DIFF
--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -341,6 +341,8 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	// Delegate to species if possible.
 	if(dna?.species)
 		for(var/obj/item/organ/organ as anything in organs)
+			if(organ.organ_flags & ORGAN_EMP)
+				organ.organ_flags &= ~ORGAN_EMP
 			if(remove_hazardous && (organ.organ_flags & ORGAN_HAZARDOUS))
 				qdel(organ)
 				continue


### PR DESCRIPTION
## About The Pull Request

regenerate_organs is a carbon proc that heals all of your organs and replaces missing ones. It's called when you use a regenerative extract or an implanted legion core or get ahealed or whatever. This PR makes it remove emp-derived failure from your cybernetic organs, because it's supposed to fullheal them and that feels like it should be a part of fullhealing.

## Why It's Good For The Game

bugfix

## Changelog

:cl:
fix:full healing effects now remove emp-derived failure from cybernetic organs
/:cl:
