### PR TITLE
Blacklists TCG card decks from spawners

### DIFF
--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -188,6 +188,7 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 	icon_state = "deck_up"
 	base_icon_state = "deck"
 	obj_flags = UNIQUE_RENAME
+	spawn_blacklisted = TRUE
 	var/flipped = FALSE
 	var/static/radial_draw = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_draw")
 	var/static/radial_shuffle = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_shuffle")


### PR DESCRIPTION
## About The Pull Request

Empty TCG card decks cannot appear in spawners anymore

## Why It's Good For The Game

getting the concept of trading cards but no cards for christmas is a pretty unthoughtful gift

## Changelog
:cl:

fix: Empty TCG game decks will no longer appear in presents

/:cl:
