### PR TITLE
[Exploit] Prevents the use of the Pay Stand to remove funds from the departamental budget card.

### DIFF
--- a/code/modules/economy/holopay.dm
+++ b/code/modules/economy/holopay.dm
@@ -80,6 +80,10 @@
 		return ..()
 	/// Users can pay with an ID to skip the UI
 	if(isidcard(held_item))
+		if(istype(held_item, /obj/item/card/id/departmental_budget))
+			balloon_alert(user, "invalid payment card")
+			to_chat(user, span_warning("You cannot use a departamental card for this."))
+			return FALSE
 		if(force_fee && tgui_alert(item_holder, "This holopay has a [force_fee] [MONEY_SYMBOL] fee. Confirm?", "Holopay Fee", list("Pay", "Cancel")) != "Pay")
 			return TRUE
 		process_payment(user)
@@ -263,6 +267,10 @@
 	if(payee == linked_card?.registered_account)
 		balloon_alert(user, "invalid transaction")
 		to_chat(user, span_warning("You can't pay yourself."))
+		return FALSE
+	if(istype(id_card, /obj/item/card/id/departmental_budget))
+		balloon_alert(user, "invalid payment card")
+		to_chat(user, span_warning("You cannot use a departamental card for this."))
 		return FALSE
 	/// If the user has enough money, ask them the amount or charge the force fee
 	var/amount = force_fee || tgui_input_number(user, "How much? (Max: [payee.account_balance])", "Patronage", max_value = payee.account_balance)


### PR DESCRIPTION
## About The Pull Request
Makes the paystand check for departamental budget cards and reject them, either when its paid directly or using the interface.

## Why It's Good For The Game
We already placed checks to avoid removing money directly from the departamental budget card, so the intent of not using it to bypass the bank console is clear, yet, the pay stand allows to remove credits from it with ease, thus the patching of those instances.

fixes #91530

## Proof of Testing

<img width="303" height="187" alt="image" src="https://github.com/user-attachments/assets/e8ba2f22-2d35-4e80-a70e-80c7ea61ee36" />


## Changelog
:cl:
fix: fixes exploit with paystands that allows anyone with the cargo budget card (or any other departamental card) to leech budgets with ease.
/:cl:
