### PR TITLE
Fix training bomb ghost/admin notification

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -277,7 +277,7 @@
 	activate()
 	add_fingerprint(user)
 	// We don't really concern ourselves with duds or fakes after this
-	if(isnull(payload) || istype(payload, /obj/machinery/syndicatebomb/training))
+	if(isnull(payload) || istype(payload, /obj/item/bombcore/training))
 		return
 
 	notify_ghosts(


### PR DESCRIPTION
## About The Pull Request

Mistake: Training bomb gives an admin/ghost notification 

## Why It's Good For The Game

`istype()` typo

## Changelog

:cl: ArchBTW
fix: Fix training bomb ghost/admin notification
/:cl:
