### PR TITLE
Moves bar sign on Catwalk's kitchen

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -26252,7 +26252,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "hgu" = (
-/obj/structure/sign/poster/contraband/eat/directional/north,
+/obj/machinery/barsign{
+	pixel_y = 32;
+	dir = 1
+	},
 /turf/open/floor/iron/stairs/medium{
 	dir = 8
 	},
@@ -56018,10 +56021,6 @@
 	pixel_x = -7;
 	pixel_y = -3
 	},
-/obj/machinery/barsign{
-	pixel_y = 32;
-	dir = 1
-	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/service/kitchen)
 "pen" = (
@@ -72397,6 +72396,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/sign/poster/contraband/eat/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/lounge)
 "tEU" = (


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

because elevator breaks it everytime it moves up/down

## Changelog

:cl:
map: Moved bar sign on Catwalk's kitchen.
/:cl:
