### PR TITLE
Make `TextInputModal`'s current character length consistent with `length_char`

### DIFF
--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -66,6 +66,11 @@ export const TextInputModal = (props) => {
       act('cancel');
     }
   }
+
+  // This is the length of the input in terms of unicode code points.
+  // Should be equivalent to what length_char would output for the same string in BYOND.
+  const char_length = [...input].length;
+
   return (
     <Window title={title} width={325} height={windowHeight}>
       {timeout && <Loader value={timeout} />}
@@ -91,7 +96,7 @@ export const TextInputModal = (props) => {
             <Stack.Item>
               <InputButtons
                 input={input}
-                message={`${input.length}/${max_length || '∞'}`}
+                message={`${char_length}/${max_length || '∞'}`}
               />
             </Stack.Item>
           </Stack>


### PR DESCRIPTION
## About The Pull Request

This makes it so `TextInputModal`'s character length display in the UI will count by unicode code points instead of just `str.length`, consistent with how `length_char` should behave:
<img width="602" height="128" alt="image" src="https://github.com/user-attachments/assets/0413ac95-4c4e-4501-a39c-58ce8fbd88d3" />


### Before
<img width="325" height="135" alt="2025-12-18 (1766103838)" src="https://github.com/user-attachments/assets/60f6d397-fbc5-4530-ba88-546fd5a407f5" />

### After / Fixed
<img width="325" height="153" alt="2025-12-18 (1766104561)" src="https://github.com/user-attachments/assets/d67782f2-08bb-4496-a241-4cc46e4b31ff" />
<img width="325" height="153" alt="2025-12-18 (1766104566)" src="https://github.com/user-attachments/assets/95d1e3b1-b2ab-4ba1-aa1e-838b60da7bf2" />
<img width="325" height="153" alt="2025-12-18 (1766104573)" src="https://github.com/user-attachments/assets/27e9737c-75b8-47cf-b472-22db21c379fe" />

## Why It's Good For The Game

consistency is good

## Changelog
:cl:
fix: Tgui text input modals now properly display the length of text inputs that contain unicode characters such as emojis.
/:cl:
