### PR TITLE
Obsolete pepperspray code

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -225,12 +225,6 @@
 	user.visible_message(span_suicide("[user] begins huffing \the [src]! It looks like [user.p_theyre()] getting a dirty high!"))
 	return OXYLOSS
 
-// Fix pepperspraying yourself
-/obj/item/reagent_containers/spray/pepper/try_spray(atom/target, mob/user)
-	if (target.loc == user)
-		return FALSE
-	return ..()
-
 //water flower
 /obj/item/reagent_containers/spray/waterflower
 	name = "water flower"
@@ -313,11 +307,6 @@
 	stream_range = 7
 	amount_per_transfer_from_this = 10
 	volume = 600
-
-/obj/item/reagent_containers/spray/chemsprayer/try_spray(atom/target, mob/user)
-	if (target.loc == user)
-		return FALSE
-	return ..()
 
 /obj/item/reagent_containers/spray/chemsprayer/spray(atom/A, mob/user)
 	var/direction = get_dir(src, A)


### PR DESCRIPTION
## About The Pull Request

Just removes a piece of obsolete pepperspray code that never worked
It's supposed to prevent clicking on your sprite with pepperspray

The code doesn't work, and I don't think it makes sense to keep/fix it, see WIGFTG

If a maintainer thinks it should be fixed, I'll reopen the other PR (https://github.com/tgstation/tgstation/pull/94393)

## Why It's Good For The Game

We can already baton ourselves, or spray ourselves with all other spray bottles (besides pepperspray, if this code worked)
It's an inconsistency with how other spray bottles work
Spraying/batoning yourself is sometimes stupid and funny

## Changelog

Not player facing, code never worked