### PR TITLE
Updates the bun version to 1.3.5

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -14,7 +14,7 @@ export RUST_G_VERSION=4.2.0
 export NODE_VERSION_LTS=22.11.0
 
 # Bun version
-export BUN_VERSION=1.2.23
+export BUN_VERSION=1.3.5
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.11

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -14,7 +14,7 @@ export RUST_G_VERSION=4.2.0
 export NODE_VERSION_LTS=22.11.0
 
 # Bun version
-export BUN_VERSION=1.2.16
+export BUN_VERSION=1.2.23
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.11

--- a/tools/tgs_scripts/PreCompile.sh
+++ b/tools/tgs_scripts/PreCompile.sh
@@ -12,9 +12,12 @@ cd "$1"
 . dependencies.sh
 cd "$original_dir"
 
-# If Bun is not present or older than BUN_VERSION, install using the official installer.
 NEED_BUN_INSTALL=0
+if [ -x "$HOME/.bun/bin/bun" ]; then
+	export PATH="$HOME/.bun/bin:$PATH"
+fi
 
+# If Bun is not present or older than BUN_VERSION, install using the official installer.
 if ! command -v bun >/dev/null 2>&1; then
 	NEED_BUN_INSTALL=1
 else

--- a/tools/tgs_scripts/PreCompile.sh
+++ b/tools/tgs_scripts/PreCompile.sh
@@ -12,6 +12,33 @@ cd "$1"
 . dependencies.sh
 cd "$original_dir"
 
+# If Bun is not present or older than BUN_VERSION, install using the official installer.
+NEED_BUN_INSTALL=0
+
+if ! command -v bun >/dev/null 2>&1; then
+	NEED_BUN_INSTALL=1
+else
+	INSTALLED_BUN_VERSION=$(bun --version)
+	if [ "$(printf '%s\n' "$BUN_VERSION" "$INSTALLED_BUN_VERSION" | sort -V | head -n1)" != "$BUN_VERSION" ]; then
+		NEED_BUN_INSTALL=1
+	fi
+fi
+
+if [ "$NEED_BUN_INSTALL" = "1" ]; then
+	echo "Installing Bun $BUN_VERSION..."
+	curl -fsSL https://bun.sh/install | bash
+
+	if [ -x "$HOME/.bun/bin/bun" ]; then
+		export PATH="$HOME/.bun/bin:$PATH"
+	else
+		echo "ERROR: Bun installation failed; $HOME/.bun/bin/bun not found"
+		exit 1
+	fi
+fi
+
+INSTALLED_BUN_VERSION=$(bun --version)
+
+echo "Using bun $INSTALLED_BUN_VERSION (minimum required: $BUN_VERSION)"
 
 # update rust-g
 if [ ! -d "rust-g" ]; then


### PR DESCRIPTION
## About The Pull Request

Turns out the version we are using has a memory segmentation issue that has been fixed in later versions.

https://github.com/oven-sh/bun/issues/23240

For server ops: remember to update your PreCompile.sh

## Why It's Good For The Game

Improved stability, probably fixes some CI flakiness

## Changelog

:cl:
server: updates bun version to 1.3.5, and adds automated validation for tgs
/:cl:
