### PR TITLE
[NO GBP] Extends meteor deflection interactions to meteor gun meteors

### DIFF
--- a/code/modules/meteors/meteor_deflection.dm
+++ b/code/modules/meteors/meteor_deflection.dm
@@ -1,0 +1,74 @@
+/**
+ * Component for meteors and meteor imitators that handles punching them, mining them, & examining them
+ */
+
+
+/datum/component/meteor_combat
+    ///If the parent object can give the meteor punching achievement
+    var/achievement_enabled
+    ///Callback for the parent object's deflection logic
+    var/datum/callback/redirection_proc
+    ///Callback for the parent object's destruction logic
+    var/datum/callback/destruction_proc
+
+/datum/component/meteor_combat/Initialize(datum/callback/redirection_callback, datum/callback/destruction_callback, achievement_on = FALSE)
+    redirection_proc = redirection_callback
+    destruction_proc = destruction_callback
+    achievement_enabled = achievement_on
+    RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, PROC_REF(on_attacked))
+    RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, PROC_REF(on_punched))
+
+/datum/component/meteor_combat/UnregisterFromParent()
+    UnregisterSignal(parent, COMSIG_ATOM_ATTACKBY)
+    UnregisterSignal(parent, COMSIG_ATOM_ATTACK_HAND)
+
+/datum/component/meteor_combat/proc/on_attacked(atom/owner, obj/item/attacking_item, mob/user, list/modifiers)
+	SIGNAL_HANDLER
+	. = FALSE
+	if(attacking_item.tool_behaviour == TOOL_MINING)
+		destruction_proc?.Invoke()
+		playsound(parent, 'sound/effects/pickaxe/picaxe1.ogg', 50, TRUE)
+		qdel(parent)
+		return TRUE
+
+	else if	(istype(attacking_item, /obj/item/melee/baseball_bat))
+		if(user.mind?.get_skill_level(/datum/skill/athletics) < SKILL_LEVEL_EXPERT)
+			to_chat(user, span_warning("\The [parent] is too heavy for you!"))
+			return
+		playsound(parent, 'sound/items/baseballhit.ogg', 100, TRUE)
+		redirection_proc.Invoke(user)
+		return TRUE
+
+	else if (istype(attacking_item, /obj/item/melee/powerfist))
+		var/obj/item/melee/powerfist/fist = attacking_item
+		if(!fist.tank)
+			to_chat(user, span_warning("\The [fist] has no gas tank!"))
+			return
+		var/datum/gas_mixture/gas_used = fist.tank.remove_air(fist.gas_per_fist * 3) // 3 is HIGH_PRESSURE setting on powerfist.
+		if(!gas_used || !molar_cmp_equals(gas_used.total_moles(), fist.gas_per_fist * 3))
+			to_chat(user, span_warning("\The [fist] didn't have enough gas to budge \the [parent]!"))
+			return
+		playsound(parent, 'sound/items/weapons/resonator_blast.ogg', 50, TRUE)
+		redirection_proc.Invoke(user)
+		return TRUE
+
+	return
+
+/datum/component/meteor_combat/proc/on_punched(atom/owner, mob/user, list/modifiers)
+	SIGNAL_HANDLER
+	. = FALSE
+	if(!isliving(user))
+		return
+	var/mob/living/livinguser = user
+
+	if(livinguser.combat_mode && livinguser.mind?.get_skill_level(/datum/skill/athletics) >= SKILL_LEVEL_LEGENDARY)
+		check_punch_award(livinguser)
+		playsound(parent, SFX_PUNCH, 50, TRUE)
+		redirection_proc.Invoke(livinguser)
+		return TRUE
+
+	return
+
+/datum/component/meteor_combat/proc/check_punch_award(mob/user)
+	if(achievement_enabled && !(astype(parent, /atom).flags_1 & ADMIN_SPAWNED_1) && isliving(user))
+		user.client.give_award(/datum/award/achievement/misc/meteor_punch, user)

--- a/code/modules/meteors/meteor_deflection.dm
+++ b/code/modules/meteors/meteor_deflection.dm
@@ -23,41 +23,39 @@
 
 /datum/component/meteor_combat/proc/on_attacked(atom/owner, obj/item/attacking_item, mob/user, list/modifiers)
 	SIGNAL_HANDLER
-	. = FALSE
 	if(attacking_item.tool_behaviour == TOOL_MINING)
 		destruction_proc?.Invoke()
 		playsound(parent, 'sound/effects/pickaxe/picaxe1.ogg', 50, TRUE)
 		qdel(parent)
 		return TRUE
 
-	else if	(istype(attacking_item, /obj/item/melee/baseball_bat))
+	if(istype(attacking_item, /obj/item/melee/baseball_bat))
 		if(user.mind?.get_skill_level(/datum/skill/athletics) < SKILL_LEVEL_EXPERT)
 			to_chat(user, span_warning("\The [parent] is too heavy for you!"))
-			return
+			return FALSE
 		playsound(parent, 'sound/items/baseballhit.ogg', 100, TRUE)
 		redirection_proc.Invoke(user)
 		return TRUE
 
-	else if (istype(attacking_item, /obj/item/melee/powerfist))
+	if (istype(attacking_item, /obj/item/melee/powerfist))
 		var/obj/item/melee/powerfist/fist = attacking_item
 		if(!fist.tank)
 			to_chat(user, span_warning("\The [fist] has no gas tank!"))
-			return
+			return FALSE
 		var/datum/gas_mixture/gas_used = fist.tank.remove_air(fist.gas_per_fist * 3) // 3 is HIGH_PRESSURE setting on powerfist.
 		if(!gas_used || !molar_cmp_equals(gas_used.total_moles(), fist.gas_per_fist * 3))
 			to_chat(user, span_warning("\The [fist] didn't have enough gas to budge \the [parent]!"))
-			return
+			return FALSE
 		playsound(parent, 'sound/items/weapons/resonator_blast.ogg', 50, TRUE)
 		redirection_proc.Invoke(user)
 		return TRUE
 
-	return
+	return FALSE
 
 /datum/component/meteor_combat/proc/on_punched(atom/owner, mob/user, list/modifiers)
 	SIGNAL_HANDLER
-	. = FALSE
 	if(!isliving(user))
-		return
+		return FALSE
 	var/mob/living/livinguser = user
 
 	if(livinguser.combat_mode && livinguser.mind?.get_skill_level(/datum/skill/athletics) >= SKILL_LEVEL_LEGENDARY)
@@ -66,7 +64,7 @@
 		redirection_proc.Invoke(livinguser)
 		return TRUE
 
-	return
+	return FALSE
 
 /datum/component/meteor_combat/proc/check_punch_award(mob/user)
 	if(achievement_enabled && !(astype(parent, /atom).flags_1 & ADMIN_SPAWNED_1) && isliving(user))

--- a/code/modules/meteors/meteor_deflection.dm
+++ b/code/modules/meteors/meteor_deflection.dm
@@ -2,25 +2,24 @@
  * Component for meteors and meteor imitators that handles punching them, mining them, & examining them
  */
 
-
 /datum/component/meteor_combat
-    ///If the parent object can give the meteor punching achievement
-    var/achievement_enabled
-    ///Callback for the parent object's deflection logic
-    var/datum/callback/redirection_proc
-    ///Callback for the parent object's destruction logic
-    var/datum/callback/destruction_proc
+	///If the parent object can give the meteor punching achievement
+	var/achievement_enabled
+	///Callback for the parent object's deflection logic
+	var/datum/callback/redirection_proc
+	///Callback for the parent object's destruction logic
+	var/datum/callback/destruction_proc
 
 /datum/component/meteor_combat/Initialize(datum/callback/redirection_callback, datum/callback/destruction_callback, achievement_on = FALSE)
-    redirection_proc = redirection_callback
-    destruction_proc = destruction_callback
-    achievement_enabled = achievement_on
-    RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, PROC_REF(on_attacked))
-    RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, PROC_REF(on_punched))
+	redirection_proc = redirection_callback
+	destruction_proc = destruction_callback
+	achievement_enabled = achievement_on
+	RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, PROC_REF(on_attacked))
+	RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, PROC_REF(on_punched))
 
 /datum/component/meteor_combat/UnregisterFromParent()
-    UnregisterSignal(parent, COMSIG_ATOM_ATTACKBY)
-    UnregisterSignal(parent, COMSIG_ATOM_ATTACK_HAND)
+	UnregisterSignal(parent, COMSIG_ATOM_ATTACKBY)
+	UnregisterSignal(parent, COMSIG_ATOM_ATTACK_HAND)
 
 /datum/component/meteor_combat/proc/on_attacked(atom/owner, obj/item/attacking_item, mob/user, list/modifiers)
 	SIGNAL_HANDLER

--- a/code/modules/meteors/meteor_types.dm
+++ b/code/modules/meteors/meteor_types.dm
@@ -42,7 +42,12 @@
 	SSaugury.register_doom(src, threat)
 	SpinAnimation()
 	chase_target(target)
-	AddComponent(/datum/component/meteor_combat, CALLBACK(src, PROC_REF(redirect)), CALLBACK(src, PROC_REF(make_debris)), achievement_on = !istype(src, /obj/effect/meteor/sand))
+	AddComponent(
+		/datum/component/meteor_combat, \
+		CALLBACK(src, PROC_REF(redirect)), \
+		CALLBACK(src, PROC_REF(make_debris)), \
+		achievement_on = !istype(src, /obj/effect/meteor/sand), \
+	)
 
 /obj/effect/meteor/Destroy()
 	GLOB.meteor_list -= src
@@ -122,6 +127,7 @@
 		. += span_notice("On second thought, it doesn't look too tough.")
 	check_examine_award(user)
 
+///Called by component/meteor_combat to send us moving to the edge of the map away from whoever punched us
 /obj/effect/meteor/proc/redirect(mob/athlete)
 	dest = spaceDebrisStartLoc(get_cardinal_dir(athlete, src), z)
 	chase_target(dest)

--- a/code/modules/meteors/meteor_types.dm
+++ b/code/modules/meteors/meteor_types.dm
@@ -42,6 +42,7 @@
 	SSaugury.register_doom(src, threat)
 	SpinAnimation()
 	chase_target(target)
+	AddComponent(/datum/component/meteor_combat, CALLBACK(src, PROC_REF(redirect)), CALLBACK(src, PROC_REF(make_debris)), achievement_on = !istype(src, /obj/effect/meteor/sand))
 
 /obj/effect/meteor/Destroy()
 	GLOB.meteor_list -= src
@@ -121,47 +122,6 @@
 		. += span_notice("On second thought, it doesn't look too tough.")
 	check_examine_award(user)
 
-/obj/effect/meteor/attack_hand(mob/user, list/modifiers)
-	if(!isliving(user))
-		return ..()
-	var/mob/living/livinguser = user
-
-	if(livinguser.combat_mode && livinguser.mind?.get_skill_level(/datum/skill/athletics) >= SKILL_LEVEL_LEGENDARY)
-		check_punch_award(livinguser)
-		playsound(loc, SFX_PUNCH, 50, TRUE)
-		redirect(livinguser)
-		return TRUE
-
-	return ..()
-
-/obj/effect/meteor/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
-	if(attacking_item.tool_behaviour == TOOL_MINING)
-		make_debris()
-		qdel(src)
-		return TRUE
-
-	else if	(istype(attacking_item, /obj/item/melee/baseball_bat))
-		if(user.mind?.get_skill_level(/datum/skill/athletics) >= SKILL_LEVEL_EXPERT)
-			playsound(src, 'sound/items/baseballhit.ogg', 100, TRUE)
-			redirect(user)
-			return TRUE
-		to_chat(user, span_warning("\The [src] is too heavy for you!"))
-
-	else if (istype(attacking_item, /obj/item/melee/powerfist))
-		var/obj/item/melee/powerfist/fist = attacking_item
-		if(!fist.tank)
-			to_chat(user, span_warning("\The [fist] has no gas tank!"))
-			return ..()
-		var/datum/gas_mixture/gas_used = fist.tank.remove_air(fist.gas_per_fist * 3) // 3 is HIGH_PRESSURE setting on powerfist.
-		if(!gas_used || !molar_cmp_equals(gas_used.total_moles(), fist.gas_per_fist * 3))
-			to_chat(user, span_warning("\The [fist] didn't have enough gas to budge \the [src]!"))
-			return ..()
-		playsound(src, 'sound/items/weapons/resonator_blast.ogg', 50, TRUE)
-		redirect(user)
-		return TRUE
-
-	return ..()
-
 /obj/effect/meteor/proc/redirect(mob/athlete)
 	dest = spaceDebrisStartLoc(get_cardinal_dir(athlete, src), z)
 	chase_target(dest)
@@ -200,10 +160,6 @@
 	if(!(flags_1 & ADMIN_SPAWNED_1) && isliving(user))
 		user.client.give_award(/datum/award/achievement/misc/meteor_examine, user)
 
-
-/obj/effect/meteor/proc/check_punch_award(mob/user)
-	if(!(flags_1 & ADMIN_SPAWNED_1) && isliving(user))
-		user.client.give_award(/datum/award/achievement/misc/meteor_punch, user)
 
 /**
  * Handles the meteor's interaction with meteor shields.
@@ -247,9 +203,6 @@
 	return ..()
 
 /obj/effect/meteor/sand/check_examine_award(mob/user) //Too insignificant and predictable to warrant an award.
-	return
-
-/obj/effect/meteor/sand/check_punch_award(mob/user)
 	return
 
 //Dust

--- a/code/modules/meteors/meteor_types.dm
+++ b/code/modules/meteors/meteor_types.dm
@@ -138,6 +138,7 @@
 	if(attacking_item.tool_behaviour == TOOL_MINING)
 		make_debris()
 		qdel(src)
+		return TRUE
 
 	else if	(istype(attacking_item, /obj/item/melee/baseball_bat))
 		if(user.mind?.get_skill_level(/datum/skill/athletics) >= SKILL_LEVEL_EXPERT)

--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -8,6 +8,7 @@
 	armour_penetration = 100
 	damage_type = BRUTE
 	armor_flag = BULLET
+	mouse_opacity = MOUSE_OPACITY_ICON
 
 /obj/projectile/meteor/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
@@ -28,3 +29,45 @@
 		if(!onlookers_in_range.stat)
 			shake_camera(onlookers_in_range, 3, 1)
 	qdel(src)
+
+/obj/projectile/meteor/attack_hand(mob/user, list/modifiers)
+	if(!isliving(user))
+		return ..()
+	var/mob/living/livinguser = user
+
+	if(livinguser.combat_mode && livinguser.mind?.get_skill_level(/datum/skill/athletics) >= SKILL_LEVEL_LEGENDARY)
+		playsound(loc, SFX_PUNCH, 50, TRUE)
+		deflect(livinguser)
+		return TRUE
+
+	return ..()
+
+/obj/projectile/meteor/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+	if(attacking_item.tool_behaviour == TOOL_MINING)
+		qdel(src)
+
+	else if	(istype(attacking_item, /obj/item/melee/baseball_bat))
+		if(user.mind?.get_skill_level(/datum/skill/athletics) >= SKILL_LEVEL_EXPERT)
+			playsound(src, 'sound/items/baseballhit.ogg', 100, TRUE)
+			deflect(user)
+			return TRUE
+		to_chat(user, span_warning("\The [src] is too heavy for you!"))
+
+	else if (istype(attacking_item, /obj/item/melee/powerfist))
+		var/obj/item/melee/powerfist/fist = attacking_item
+		if(!fist.tank)
+			to_chat(user, span_warning("\The [fist] has no gas tank!"))
+			return ..()
+		var/datum/gas_mixture/gas_used = fist.tank.remove_air(fist.gas_per_fist * 3) // 3 is HIGH_PRESSURE setting on powerfist.
+		if(!gas_used || !molar_cmp_equals(gas_used.total_moles(), fist.gas_per_fist * 3))
+			to_chat(user, span_warning("\The [fist] didn't have enough gas to budge \the [src]!"))
+			return ..()
+		playsound(src, 'sound/items/weapons/resonator_blast.ogg', 50, TRUE)
+		deflect(user)
+		return TRUE
+
+	return ..()
+
+/obj/projectile/meteor/proc/deflect(mob/user)
+	firer = user
+	set_angle(get_angle(user, src) + rand(-45, 45))

--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -9,6 +9,11 @@
 	damage_type = BRUTE
 	armor_flag = BULLET
 	mouse_opacity = MOUSE_OPACITY_ICON
+	obj_flags = NONE
+
+/obj/projectile/meteor/Initialize()
+	. = ..()
+	AddComponent(/datum/component/meteor_combat, CALLBACK(src, PROC_REF(deflect)))
 
 /obj/projectile/meteor/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
@@ -29,45 +34,6 @@
 		if(!onlookers_in_range.stat)
 			shake_camera(onlookers_in_range, 3, 1)
 	qdel(src)
-
-/obj/projectile/meteor/attack_hand(mob/user, list/modifiers)
-	if(!isliving(user))
-		return ..()
-	var/mob/living/livinguser = user
-
-	if(livinguser.combat_mode && livinguser.mind?.get_skill_level(/datum/skill/athletics) >= SKILL_LEVEL_LEGENDARY)
-		playsound(loc, SFX_PUNCH, 50, TRUE)
-		deflect(livinguser)
-		return TRUE
-
-	return ..()
-
-/obj/projectile/meteor/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
-	if(attacking_item.tool_behaviour == TOOL_MINING)
-		qdel(src)
-		return TRUE
-
-	else if	(istype(attacking_item, /obj/item/melee/baseball_bat))
-		if(user.mind?.get_skill_level(/datum/skill/athletics) >= SKILL_LEVEL_EXPERT)
-			playsound(src, 'sound/items/baseballhit.ogg', 100, TRUE)
-			deflect(user)
-			return TRUE
-		to_chat(user, span_warning("\The [src] is too heavy for you!"))
-
-	else if (istype(attacking_item, /obj/item/melee/powerfist))
-		var/obj/item/melee/powerfist/fist = attacking_item
-		if(!fist.tank)
-			to_chat(user, span_warning("\The [fist] has no gas tank!"))
-			return ..()
-		var/datum/gas_mixture/gas_used = fist.tank.remove_air(fist.gas_per_fist * 3) // 3 is HIGH_PRESSURE setting on powerfist.
-		if(!gas_used || !molar_cmp_equals(gas_used.total_moles(), fist.gas_per_fist * 3))
-			to_chat(user, span_warning("\The [fist] didn't have enough gas to budge \the [src]!"))
-			return ..()
-		playsound(src, 'sound/items/weapons/resonator_blast.ogg', 50, TRUE)
-		deflect(user)
-		return TRUE
-
-	return ..()
 
 /obj/projectile/meteor/proc/deflect(mob/user)
 	firer = user

--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -45,6 +45,7 @@
 /obj/projectile/meteor/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	if(attacking_item.tool_behaviour == TOOL_MINING)
 		qdel(src)
+		return TRUE
 
 	else if	(istype(attacking_item, /obj/item/melee/baseball_bat))
 		if(user.mind?.get_skill_level(/datum/skill/athletics) >= SKILL_LEVEL_EXPERT)

--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -11,7 +11,7 @@
 	mouse_opacity = MOUSE_OPACITY_ICON
 	obj_flags = NONE
 
-/obj/projectile/meteor/Initialize()
+/obj/projectile/meteor/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/meteor_combat, CALLBACK(src, PROC_REF(deflect)))
 

--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -35,6 +35,7 @@
 			shake_camera(onlookers_in_range, 3, 1)
 	qdel(src)
 
+///Called by component/meteor_combat to direct us away from whatever has punched us.
 /obj/projectile/meteor/proc/deflect(mob/user)
 	firer = user
 	set_angle(get_angle(user, src) + rand(-45, 45))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4933,6 +4933,7 @@
 #include "code\modules\mapping\space_management\zlevel_manager.dm"
 #include "code\modules\meteors\meteor_changeling.dm"
 #include "code\modules\meteors\meteor_dark_matteor.dm"
+#include "code\modules\meteors\meteor_deflection.dm"
 #include "code\modules\meteors\meteor_mode_controller.dm"
 #include "code\modules\meteors\meteor_spawning.dm"
 #include "code\modules\meteors\meteor_types.dm"


### PR DESCRIPTION
## About The Pull Request

Turns the meteor deflection interaction previously added into a components and gives it to both meteors and meteor gun "meteors".

## Why It's Good For The Game

fixes #94542

## Changelog
:cl:

fix: Meteor gun projectile meteors can now be smacked, whacked, walloped and cracked just as normal meteors can.

/:cl:
