### PR TITLE
Escaped glitches distort when interacted with

### DIFF
--- a/code/datums/components/holographic_nature.dm
+++ b/code/datums/components/holographic_nature.dm
@@ -19,12 +19,15 @@
 /datum/component/holographic_nature/RegisterWithParent()
 	AddComponent(/datum/component/connect_loc_behalf, parent, loc_connections)
 	if(isliving(parent))
+		RegisterSignal(parent, COMSIG_LIVING_MOB_BUMP, PROC_REF(on_bumped))
+		RegisterSignal(parent, COMSIG_LIVING_MOB_BUMPED, PROC_REF(on_bumped))
 		RegisterSignal(parent, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(on_mob_damaged))
 		return
 
 	var/atom/atom_parent = parent
 	if(isobj(atom_parent) && atom_parent.uses_integrity)
 		RegisterSignal(parent, COMSIG_ATOM_TAKE_DAMAGE, PROC_REF(on_object_damaged))
+
 
 /datum/component/holographic_nature/proc/on_mob_damaged(mob/living/source, damage_amount, damagetype, def_zone, blocked, wound_bonus, exposed_wound_bonus, sharpness, attack_direction, attacking_item)
 	SIGNAL_HANDLER
@@ -43,6 +46,10 @@
 		return
 	if(isprojectile(thing) || thing.density)
 		apply_effects()
+
+/datum/component/holographic_nature/proc/on_bumped(atom/movable/source, mob/living/crossing_mob)
+	SIGNAL_HANDLER
+	apply_effects()
 
 /datum/component/holographic_nature/proc/apply_effects()
 	if(!COOLDOWN_FINISHED(src, glitch_cooldown))

--- a/code/modules/bitrunning/components/glitch.dm
+++ b/code/modules/bitrunning/components/glitch.dm
@@ -1,38 +1,36 @@
 /datum/component/glitch
 	/// Ref of the spawning forge
 	var/datum/weakref/forge_ref
+	var/datum/weakref/distort_component
 
 /datum/component/glitch/Initialize(obj/machinery/quantum_server/server, obj/machinery/byteforge/forge)
 	if(!isliving(parent))
 		return COMPONENT_INCOMPATIBLE
 
-	RegisterSignal(forge, COMSIG_MACHINERY_POWER_RESTORED, PROC_REF(on_forge_power_restored))
-	RegisterSignals(forge, list(COMSIG_MACHINERY_BROKEN, COMSIG_MACHINERY_POWER_LOST), PROC_REF(on_forge_broken))
-	forge_ref = WEAKREF(forge)
-
 	var/mob/living/owner = parent
-	server.remove_threat(owner) // so the server doesn't dust us
+	var/health_boost = 0
+
+	if (forge)
+		RegisterSignal(forge, COMSIG_MACHINERY_POWER_RESTORED, PROC_REF(on_forge_power_restored))
+		RegisterSignals(forge, list(COMSIG_MACHINERY_BROKEN, COMSIG_MACHINERY_POWER_LOST), PROC_REF(on_forge_broken))
+		forge_ref = WEAKREF(forge)
+		server.remove_threat(owner) // so the server doesn't dust us
+		health_boost = ROUND_UP(server.threat * 0.2)
 
 	owner.faction.Cut()
 	owner.faction += list(ROLE_GLITCH)
 
-	var/current_max = owner.maxHealth + ROUND_UP(server.threat * 0.2)
-	owner.maxHealth = clamp(current_max, 200, 500)
+	owner.maxHealth = clamp(owner.maxHealth + health_boost, 200, 500)
 	owner.fully_heal()
-
-	var/atom/thing = owner
-	thing.create_digital_aura()
+	owner.create_digital_aura()
 
 /datum/component/glitch/RegisterWithParent()
-	parent.AddComponent(/datum/component/holographic_nature)
+	RegisterSignal(parent, COMSIG_LIVING_DEATH, PROC_REF(on_death))
+	distort_component = WEAKREF(parent.AddComponent(/datum/component/holographic_nature))
 
-/// Sakujo
-/datum/component/glitch/proc/dust_mob()
-	if(QDELETED(parent))
-		return
-
-	var/mob/living/owner = parent
-	owner.dust()
+/datum/component/glitch/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_LIVING_DEATH)
+	QDEL_NULL(distort_component)
 
 /// We don't want digital entities just lingering around as corpses.
 /datum/component/glitch/proc/on_death()
@@ -44,10 +42,10 @@
 	var/mob/living/owner = parent
 	to_chat(owner, span_userdanger("You feel a strange sensation..."))
 
-	var/obj/machinery/byteforge/forge = forge_ref.resolve()
+	var/obj/machinery/byteforge/forge = forge_ref?.resolve()
 	forge?.setup_particles()
 
-	addtimer(CALLBACK(src, PROC_REF(dust_mob)), 2 SECONDS, TIMER_UNIQUE|TIMER_DELETE_ME|TIMER_STOPPABLE)
+	owner.fade_into_nothing(3 SECONDS, 2 SECONDS)
 
 /// If the forge breaks, we take a massive slowdown
 /datum/component/glitch/proc/on_forge_broken(datum/source)

--- a/code/modules/bitrunning/components/glitch.dm
+++ b/code/modules/bitrunning/components/glitch.dm
@@ -23,6 +23,9 @@
 	var/atom/thing = owner
 	thing.create_digital_aura()
 
+/datum/component/glitch/RegisterWithParent()
+	parent.AddComponent(/datum/component/holographic_nature)
+
 /// Sakujo
 /datum/component/glitch/proc/dust_mob()
 	if(QDELETED(parent))


### PR DESCRIPTION
## About The Pull Request

This PR adds the hologram distortion component from #89689 to Bitrunning glitches
It also extends the hologram distortion component to also work with mob bumps because it felt like that should trigger the effect

https://github.com/user-attachments/assets/efdead46-4aae-4d71-8353-e391e48d6c7c

Finally, this fixes a bug where the bitrunning glitch component had a proc for dusting dead mobs but forgot to actually attach it to the signal
I replaced the dusting with the "fade into nothing" proc because I think it looks cooler for a hologram to do that

## Why It's Good For The Game

We have a cool visual for holograms and didn't give it to this form of hologram
It also makes it a little more obvious that you're fighting some kind of matrix guy, in case the greentext wasn't enough

## Changelog

:cl:
add: Escaped bitrunning glitches will visually distort when interacted with
fix: Escaped bitrunning glitches will not stick around as holographic corpses after they die
/:cl:
