### PR TITLE
Makes unconcious people no longer pick up ores

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -161,6 +161,8 @@
 	INVOKE_ASYNC(src, PROC_REF(handle_move), user)
 
 /obj/item/storage/bag/ore/proc/handle_move(mob/living/user)
+	if(user.stat != CONSCIOUS)
+		return
 	var/turf/tile = get_turf(user)
 	var/obj/structure/ore_box/box = null
 	if(istype(user.pulling, /obj/structure/ore_box))


### PR DESCRIPTION

## About The Pull Request

Adds a check for `CONCIOUS` in the ore bag move handling where it picks up ores.

## Why It's Good For The Game

Dead people continuing to work has been described by many as unlikely.

## Changelog
:cl:

fix: Miners are no longer so dedicated they will pick up ores while dead

/:cl:
