### PR TITLE
Chameleon clothing contribute to sleeping carp style adherence. Fixes carp masks not contributing to style.

### DIFF
--- a/code/modules/clothing/chameleon/generic_chameleon_clothing.dm
+++ b/code/modules/clothing/chameleon/generic_chameleon_clothing.dm
@@ -30,6 +30,7 @@ do { \
 	sensor_mode = SENSOR_OFF //Hey who's this guy on the Syndicate Shuttle??
 	random_sensor = FALSE
 	resistance_flags = NONE
+	clothing_flags = CARP_STYLE_FACTOR
 	can_adjust = FALSE
 	armor_type = /datum/armor/clothing_under/chameleon
 	actions_types = list(/datum/action/item_action/chameleon/change/jumpsuit)
@@ -58,6 +59,7 @@ do { \
 	inhand_icon_state = "armor"
 	blood_overlay_type = "armor"
 	resistance_flags = NONE
+	clothing_flags = CARP_STYLE_FACTOR
 	armor_type = /datum/armor/suit_chameleon
 	actions_types = list(/datum/action/item_action/chameleon/change/suit)
 	action_slots = ALL
@@ -87,6 +89,7 @@ do { \
 	icon_state = "meson"
 	inhand_icon_state = "meson"
 	resistance_flags = NONE
+	clothing_flags = CARP_STYLE_FACTOR
 	armor_type = /datum/armor/glasses_chameleon
 	actions_types = list(/datum/action/item_action/chameleon/change/glasses)
 	action_slots = ALL
@@ -106,13 +109,14 @@ do { \
 	acid = 50
 
 /obj/item/clothing/gloves/chameleon
-	desc = "These gloves provide protection against electric shock."
 	name = "insulated gloves"
+	desc = "These gloves provide protection against electric shock."
 	icon_state = "yellow"
 	inhand_icon_state = "ygloves"
 	greyscale_colors = null
 
 	resistance_flags = NONE
+	clothing_flags = CARP_STYLE_FACTOR
 	body_parts_covered = HANDS|ARMS
 	armor_type = /datum/armor/gloves_chameleon
 	actions_types = list(/datum/action/item_action/chameleon/change/gloves)
@@ -140,6 +144,7 @@ do { \
 	worn_icon = 'icons/mob/clothing/head/hats.dmi'
 	icon_state = "greysoft"
 	resistance_flags = NONE
+	clothing_flags = CARP_STYLE_FACTOR
 	armor_type = /datum/armor/head_chameleon
 	actions_types = list(/datum/action/item_action/chameleon/change/hat)
 	action_slots = ALL
@@ -179,7 +184,7 @@ do { \
 	inhand_icon_state = "gas_alt"
 	resistance_flags = NONE
 	armor_type = /datum/armor/mask_chameleon
-	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
+	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS | CARP_STYLE_FACTOR
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
 	w_class = WEIGHT_CLASS_SMALL
@@ -240,6 +245,7 @@ do { \
 	greyscale_config_inhand_right = /datum/greyscale_config/sneakers/inhand_right
 	greyscale_colors = "#545454#ffffff"
 	resistance_flags = NONE
+	clothing_flags = CARP_STYLE_FACTOR
 	armor_type = /datum/armor/shoes_chameleon
 	actions_types = list(/datum/action/item_action/chameleon/change/shoes)
 	action_slots = ALL

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -446,6 +446,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	icon_state = "carp_mask"
 	inhand_icon_state = null
 	flags_cover = MASKCOVERSEYES
+	clothing_flags = CARP_STYLE_FACTOR
 	fishing_modifier = -4
 
 /obj/item/clothing/mask/gas/tiki_mask


### PR DESCRIPTION
## About The Pull Request

Chameleon clothing now contribute to sleeping carp style. This includes chameleon no slips.

Carp masks were supposed to contribute as well, but were missing the flag. I've included the flag here.

## Why It's Good For The Game

Chameleon outfits are for two purposes; dressing up to look cool, or disguises. They're otherwise extremely minor in terms of actual functional benefit, and already could be providing misleading information as to the protectiveness of the clothing worn. This allows chameleon kits to synergy with sleeping carp in a unique way, while also allowing the carp user to wear no slip chameleon shoes without compromising their defenses unnecessarily.

Chameleon items do come with some level of armor, so they're not perfect for the slot they occupy as they will have less protectiveness than some other options in that slot. We can probably think of that as a drawback for their deceptive nature.

## Changelog
:cl:
balance: Chameleon outfits now contribute to sleeping carp style factor. Most items are armored, so they're a bit less useful than other options.
fix: Carp masks actually contribute to sleeping carp style factor.
/:cl:
