### PR TITLE
Spaceacillin doesn't get rid of good viruses anymore

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -135,7 +135,7 @@
 		switch(severity)
 			if(DISEASE_SEVERITY_POSITIVE) //good viruses don't go anywhere after hitting max stage - you can try to get rid of them by sleeping earlier
 				cycles_to_beat = max(DISEASE_RECOVERY_SCALING, DISEASE_CYCLES_POSITIVE) //because of the way we later check for recovery_prob, we need to floor this at least equal to the scaling to avoid infinitely getting less likely to cure
-				if(((HAS_TRAIT(affected_mob, TRAIT_NOHUNGER)) || ((affected_mob.nutrition > NUTRITION_LEVEL_STARVING) && (affected_mob.satiety >= 0))) && slowdown == 1) //any sort of malnourishment/immunosuppressant opens you to losing a good virus
+				if(((HAS_TRAIT(affected_mob, TRAIT_NOHUNGER)) || ((affected_mob.nutrition > NUTRITION_LEVEL_STARVING) && (affected_mob.satiety >= 0))) && ((bad_immune == 1 || slowdown <= 1) || prob(50))) //any sort of malnourishment/immunosuppressant opens you to losing a good virus
 					return TRUE
 			if(DISEASE_SEVERITY_NONTHREAT)
 				cycles_to_beat = max(DISEASE_RECOVERY_SCALING, DISEASE_CYCLES_NONTHREAT)


### PR DESCRIPTION
## About The Pull Request

_This is a salt PR, I took spaceacillin to slow down an alien embryo and lost my thermoregulation because of it. I didn't like, freeze to death later on or anything but it was still pretty annoying._

Basically, this PR makes it so that spaceacillin doesn't cause you to start naturally recovering from good viruses. 

The code comment there said that malnourishment or immunosuppressants would cause your good disease to go away, so instead of spaceacillin causing your good virus to go away, immunodeficiency does. Specifically, you need to be immunodeficient and off your meds and even then you only have half the normal chance to naturally recover because I'm not trying to make life harder for immunodeficient people.

## Why It's Good For The Game

You need spaceacillin for stuff like curing simple diseases, protecting yourself from zombies, and slowing down alien embryos. Also, how often are you trying to get rid of a good disease anyways? If you really need to you can starve or something but I don't often see people hurrying into medbay because they gained the ability to heal while in darkness and they _really_ want to die in maints.

## Changelog

:cl:
balance: spaceacillin no longer gets rid of good viruses
balance: immunodeficiency gets rid of good viruses, but only half as much as spaceacillin did and only if it's untreated
/:cl: