### PR TITLE
Fix autowiki by changing to new URL

### DIFF
--- a/tools/autowiki/autowiki.js
+++ b/tools/autowiki/autowiki.js
@@ -38,7 +38,7 @@ async function main() {
   const bot = new MWBot();
 
   await bot.loginGetEditToken({
-    apiUrl: "https://tgstation13.org/wiki/api.php",
+    apiUrl: "https://wiki.tgstation13.org/api.php",
     username: USERNAME,
     password: PASSWORD,
   });


### PR DESCRIPTION
This broke in January. It's not good that this failing still results in green checkmark