### PR TITLE
Adds the AI_COMPATIBLE flag to the Mauler exosuit

### DIFF
--- a/code/modules/vehicles/mecha/combat/marauder.dm
+++ b/code/modules/vehicles/mecha/combat/marauder.dm
@@ -133,7 +133,7 @@
 	armor_type = /datum/armor/mecha_mauler
 	accesses = list(ACCESS_SYNDICATE)
 	wreckage = /obj/structure/mecha_wreckage/mauler
-	mecha_flags = ID_LOCK_ON | CAN_STRAFE | IS_ENCLOSED | HAS_LIGHTS | MMI_COMPATIBLE
+	mecha_flags = ID_LOCK_ON | CAN_STRAFE | IS_ENCLOSED | HAS_LIGHTS | MMI_COMPATIBLE | AI_COMPATIBLE
 	max_equip_by_category = list(
 		MECHA_L_ARM = 1,
 		MECHA_R_ARM = 1,


### PR DESCRIPTION
## About The Pull Request

Just a very simple PR to fix an oversight where the Mauler exosuit doesn't have the AI_COMPATIBLE flag, meaning as well as being unable to be beaconed - which is intended - you also couldn't use an intellicard to manually install an AI into it.
## Why It's Good For The Game

If a squad of nukies wants to shove an AI into their Mauler, then why not? The base Marauder model which the Mauler is based on has AI compatibility, so does the Seraph! Also brings parity with the Dark Gygax which currently _can_ have an AI installed.
## Changelog
:cl:
fix: Fixed the inability to shove an intellicarded AI into a Mauler-type exosuit.
/:cl:
