### PR TITLE
Fixes everything that should care if they don't have enough power not caring if they don't have enough power

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -177,7 +177,7 @@
 	if((amount > grid_used) && !ignore_apc && !QDELETED(local_apc.cell)) // Use from the APC's cell if there isn't enough energy from the grid.
 		apc_used = local_apc.cell.use(amount - grid_used, force = force)
 
-	if(!force && (amount < grid_used + apc_used)) // If we aren't forcing it and there isn't enough energy to supply demand, return nothing.
+	if(!force && (amount > grid_used + apc_used)) // If we aren't forcing it and there isn't enough energy to supply demand, return nothing.
 		return FALSE
 
 	// Use the grid's and APC's energy.


### PR DESCRIPTION

## About The Pull Request

[cost of operation] < [available consumed power] is a check that will never succeed, because it'll never have consumed more power than `amount`. Currently, this doesn't cause any issues when there is enough power because it's < and not <=. But it does mean that machines that check if use_energy() succeeded will never fail. Unless there's no APC.

## Why It's Good For The Game

Checks checking for what they're checking for is generally a positive for the utility of said checks

## Changelog
:cl:

fix: Things that are supposed to be able to fail to draw enough power to operate are actually able to do so.

/:cl:
