### PR TITLE
Fixes cake dough recipe on sugar sack

### DIFF
--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -98,6 +98,7 @@
 				\
 				<b>Dough:</b> 10u water + 15u flour for simple dough.<br>\
 				6u egg yolk + 12 egg white + 15u flour + 5u sugar for cake batter.<br>\
+				(15u soy milk can be substituted for the eggs.)<br>\
 				Doughs can be transformed by using a knife and rolling pin.<br>\
 				All doughs can be baked.<br>\
 				<b>Bowl:</b> Add recipe ingredients and liquid to make soups.<br>\

--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -124,11 +124,14 @@
 
 /obj/item/reagent_containers/condiment/sugar/examine(mob/user)
 	. = ..()
-	var/datum/chemical_reaction/recipe = GLOB.chemical_reactions_list[/datum/chemical_reaction/food/cakebatter]
-	var/flour_required = recipe.required_reagents[/datum/reagent/consumable/flour]
-	var/eggyolk_required = recipe.required_reagents[/datum/reagent/consumable/eggyolk]
-	var/sugar_required = recipe.required_reagents[/datum/reagent/consumable/sugar]
-	. += span_notice("[flour_required] flour, [eggyolk_required] egg yolk (or soy milk), [sugar_required] sugar makes cake dough. You can make pie dough from it.")
+	var/datum/chemical_reaction/standard_recipe = GLOB.chemical_reactions_list[/datum/chemical_reaction/food/cakebatter]
+	var/datum/chemical_reaction/alt_recipe = GLOB.chemical_reactions_list[/datum/chemical_reaction/food/cakebatter/vegan]
+	var/flour_required = standard_recipe.required_reagents[/datum/reagent/consumable/flour]
+	var/eggyolk_required = standard_recipe.required_reagents[/datum/reagent/consumable/eggyolk]
+	var/eggwhite_required = standard_recipe.required_reagents[/datum/reagent/consumable/eggwhite]
+	var/sugar_required = standard_recipe.required_reagents[/datum/reagent/consumable/sugar]
+	var/soymilk_required = alt_recipe.required_reagents[/datum/reagent/consumable/soymilk]
+	. += span_notice("[flour_required] flour, [sugar_required] sugar, and either [eggyolk_required] egg yolk + [eggwhite_required] egg white or [soymilk_required] soy milk yields a cake dough. You can make pie dough from it.")
 
 /obj/item/reagent_containers/condiment/saltshaker //Separate from above since it's a small shaker rather then
 	name = "salt shaker" // a large one.


### PR DESCRIPTION
## About The Pull Request

Fixes the cake dough recipe printed on the sugar sack, egg white is also required. Also clarifies the amount of soy milk required, if used.

## Why It's Good For The Game

Less sad chef trying to bake a cake

## Changelog

:cl: LT3
fix: Sugar sack now has the correct recipe for cake batter
/:cl: