### PR TITLE
Changes Coveroli in Albuterol's recipe to standard Convermol

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -159,7 +159,7 @@
 
 /datum/chemical_reaction/medicine/albuterol_creation
 	results = list(/datum/reagent/medicine/albuterol = 15)
-	required_reagents = list(/datum/reagent/lithium = 3, /datum/reagent/aluminium = 3, /datum/reagent/bromine = 3, /datum/reagent/inverse/healing/convermol = 1)
+	required_reagents = list(/datum/reagent/lithium = 3, /datum/reagent/aluminium = 3, /datum/reagent/bromine = 3, /datum/reagent/medicine/c2/convermol = 1)
 	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_ORGAN | REACTION_TAG_OTHER
 	required_temp = 400
 	optimal_temp = 600
@@ -187,8 +187,8 @@
 	overheat_temp = 800
 	mix_message = "The solution breaks apart, turning a deeper blue."
 
-/datum/chemical_reaction/medicine/albuterol_to_inverse_convermol
-	results = list(/datum/reagent/inverse/healing/convermol = 1, /datum/reagent/lithium = 3, /datum/reagent/aluminium = 3, /datum/reagent/bromine = 3)
+/datum/chemical_reaction/medicine/albuterol_to_convermol
+	results = list(/datum/reagent/medicine/c2/convermol = 1, /datum/reagent/lithium = 3, /datum/reagent/aluminium = 3, /datum/reagent/bromine = 3)
 	required_catalysts = list(/datum/reagent/toxin/acid/fluacid = 1)
 	required_reagents = list(/datum/reagent/medicine/albuterol = 5)
 	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_ORGAN | REACTION_TAG_OTHER | REACTION_TAG_ACTIVE
@@ -198,7 +198,7 @@
 	thermic_constant = 25
 	mix_message = "The solution rapidly breaks apart, turning a mix of colors."
 
-/datum/chemical_reaction/medicine/albuterol_to_inverse_convermol/overheated(datum/reagents/holder, datum/equilibrium/equilibrium, impure = FALSE)
+/datum/chemical_reaction/medicine/albuterol_to_convermol/overheated(datum/reagents/holder, datum/equilibrium/equilibrium, impure = FALSE)
 	var/bonus = impure ? 2 : 1
 	explode_smoke(holder, equilibrium, 7.5 * bonus, TRUE, TRUE)
 


### PR DESCRIPTION

## About The Pull Request

Replaces Coveroli (Convermol's inverse) in Albuterol's recipe, and the reversal recipe, to its base form.
Closes #94574

## Why It's Good For The Game

Despite it not being a bug, LT3 brought up a good point in #94574 about the requirements being overly harsh. It doesn't make much sense for a somewhat mediocre drug whose only purpose outside of niche interactions with nitrium and alike is to cure asthma to require inverse chemicals. We already have a design document to retire fermichem as-is, and forcing obscure mechanics onto players as a requirement for rather basic medicines is not a good idea, especially considering none of our in-game guides (nor the wiki) explain inverse recipes either. 

## Changelog
:cl:
balance: Changed Coveroli in Albuterol's recipe to standard Convermol
/:cl:
