### PR TITLE
Makes the BSA (always) cost power to fire

### DIFF
--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -298,7 +298,7 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 		if("fire")
 			var/obj/machinery/bsa/full/cannon = cannon_ref.resolve()
 			if(cannon.use_energy(cannon.power_used_per_shot, force = FALSE))
-				fire(usr)
+				fire(ui.user)
 			else
 				to_chat(ui.user, span_warning("Insufficient power!"))
 			. = TRUE

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -143,7 +143,6 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	var/static/mutable_appearance/top_layer
 	var/ex_power = 3
 	var/power_used_per_shot = 2000000 //enough to kil standard apc - todo : make this use wires instead and scale explosion power with it
-	var/ready
 	pixel_y = -32
 	pixel_x = -192
 	bound_width = 352
@@ -189,7 +188,6 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 			bound_x = -128
 			icon_state = "cannon_east"
 	get_layer()
-	reload()
 
 /obj/machinery/bsa/full/proc/get_layer()
 	top_layer = mutable_appearance(icon, layer = ABOVE_MOB_LAYER)
@@ -208,8 +206,6 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	return ..()
 
 /obj/machinery/bsa/full/proc/fire(mob/user, turf/bullseye)
-	reload()
-
 	var/turf/point = get_front_turf()
 	var/turf/target = get_target_turf()
 	var/atom/blocker
@@ -245,15 +241,6 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	else
 		message_admins("[ADMIN_LOOKUPFLW(user)] has launched a bluespace artillery strike targeting [ADMIN_VERBOSEJMP(bullseye)] but it was blocked by [blocker] at [ADMIN_VERBOSEJMP(target)].")
 		user.log_message("has launched a bluespace artillery strike targeting [AREACOORD(bullseye)] but it was blocked by [blocker] at [AREACOORD(target)].", LOG_GAME)
-
-
-/obj/machinery/bsa/full/proc/reload()
-	ready = FALSE
-	use_energy(power_used_per_shot)
-	addtimer(CALLBACK(src,"ready_cannon"), 1 MINUTES)
-
-/obj/machinery/bsa/full/proc/ready_cannon()
-	ready = TRUE
 
 /obj/structure/filler
 	name = "big machinery part"
@@ -292,7 +279,6 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 /obj/machinery/computer/bsa_control/ui_data()
 	var/obj/machinery/bsa/full/cannon = cannon_ref?.resolve()
 	var/list/data = list()
-	data["ready"] = cannon ? cannon.ready : FALSE
 	data["connected"] = cannon
 	data["notice"] = notice
 	data["unlocked"] = GLOB.bsa_unlock
@@ -310,7 +296,11 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 			cannon_ref = WEAKREF(deploy())
 			. = TRUE
 		if("fire")
-			fire(usr)
+			var/obj/machinery/bsa/full/cannon = cannon_ref.resolve()
+			if(cannon.use_energy(cannon.power_used_per_shot, force = FALSE))
+				fire(usr)
+			else
+				to_chat(ui.user, span_warning("Insufficient power!"))
 			. = TRUE
 		if("recalibrate")
 			calibrate(usr)


### PR DESCRIPTION

## About The Pull Request

Removes what appears to have been an attempt at making a cooldown from the BSA's code(it did nothing) and adds a check to right before you fire that ensures the full cost of the shot has been paid before firing. Reliant on #94576 merging to do anything.

## Why It's Good For The Game

You can currently fire the bsa so fast the only restriction on firerate is getting rate limited from clicking FIRE too fast, and it costs jack shit. You could make it cost even less by making an apc that has a AA battery for a cell. I think this is stupid, and that the BSA should require a consistent and gargantuan amount of power to fire. Every shot should be valuable, and currently, they're not.

## Changelog
:cl:

balance: The BSA now always requires its full power cost paid in order to fire

/:cl:
