### PR TITLE
Gateway progression skip fix

### DIFF
--- a/_maps/RandomZLevels/heretic.dmm
+++ b/_maps/RandomZLevels/heretic.dmm
@@ -3102,6 +3102,8 @@
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/puzzle/keycard/heretic_entrance,
+/obj/effect/mapping_helpers/airlock/access/all/supply,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory)
 "qn" = (
@@ -6152,6 +6154,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/iron,
+/area/awaymission/caves/heretic_laboratory)
+"Gk" = (
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/puzzle/keycard/heretic_entrance,
+/obj/effect/mapping_helpers/airlock/access/all/supply,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory)
 "Gm" = (
@@ -15448,7 +15456,7 @@ KB
 bl
 Ii
 DN
-Az
+Ka
 wn
 wh
 wn
@@ -15705,7 +15713,7 @@ KB
 Ii
 wn
 wn
-Az
+Ka
 wn
 wh
 wn
@@ -15962,7 +15970,7 @@ KB
 wn
 wn
 wn
-Az
+Ka
 wn
 wh
 wn
@@ -16219,7 +16227,7 @@ KB
 wn
 wn
 ji
-Az
+Ka
 wn
 wh
 wn
@@ -16476,7 +16484,7 @@ KB
 wn
 TL
 Oc
-Az
+Ka
 wn
 wh
 wn
@@ -16733,7 +16741,7 @@ KB
 wn
 wn
 AZ
-Az
+Ka
 wn
 wh
 wn
@@ -16990,7 +16998,7 @@ KB
 wn
 wn
 wn
-Az
+Ka
 wn
 wh
 wn
@@ -17247,7 +17255,7 @@ KB
 wn
 wn
 wn
-Az
+Ka
 wn
 wh
 wn
@@ -17504,7 +17512,7 @@ KB
 wn
 wn
 wn
-Az
+Ka
 wn
 wh
 wn
@@ -18254,7 +18262,7 @@ KB
 KB
 KB
 qm
-Xh
+Gk
 KB
 KB
 KB


### PR DESCRIPTION
Just adds some stuff to stop people from progressing in an un-attended way.

:cl:
fix: fixed being able to skip the first puzzle in the new gateway
/:cl: