### PR TITLE
The Roboticist arm implanted gun can copy projectiles

### DIFF
--- a/code/__DEFINES/projectiles.dm
+++ b/code/__DEFINES/projectiles.dm
@@ -103,3 +103,6 @@
 
 /// For how long projectile tracers linger
 #define PROJECTILE_TRACER_DURATION 0.3 SECONDS
+
+///This energy casing can't be copied by the mounted arm laser.
+#define PROJECTILE_CANT_COPY (1<<0)

--- a/code/modules/capture_the_flag/ctf_equipment.dm
+++ b/code/modules/capture_the_flag/ctf_equipment.dm
@@ -173,6 +173,7 @@
 	e_cost = 0 // Not possible to use the macro
 	select_name = "DESTROY"
 	muzzle_flash_color = LIGHT_COLOR_BLUE
+	energy_projectile_flags = PROJECTILE_CANT_COPY
 
 /obj/projectile/beam/instakill
 	name = "instagib laser"

--- a/code/modules/clothing/chameleon/chameleon_gun.dm
+++ b/code/modules/clothing/chameleon/chameleon_gun.dm
@@ -51,6 +51,7 @@
 
 	fire_sound = gun_to_set.fire_sound
 	burst_size = gun_to_set.burst_size
+	burst_delay = gun_to_set.burst_delay
 	fire_delay = gun_to_set.fire_delay
 	inhand_x_dimension = gun_to_set.inhand_x_dimension
 	inhand_y_dimension = gun_to_set.inhand_y_dimension

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -101,6 +101,10 @@
 	name = "laser pistol power cell"
 	chargerate = STANDARD_CELL_RATE * 0.15
 
+/obj/item/stock_parts/power_store/cell/meteor_gun
+	name = "meteor gun power cell"
+	maxcharge = STANDARD_CELL_CHARGE * 1.5
+
 /obj/item/stock_parts/power_store/cell/ninja
 	name = "black power cell"
 	icon_state = "bscell"

--- a/code/modules/projectiles/ammunition/energy/_energy.dm
+++ b/code/modules/projectiles/ammunition/energy/_energy.dm
@@ -4,9 +4,13 @@
 	caliber = ENERGY
 	projectile_type = /obj/projectile/energy
 	slot_flags = null
-	var/e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE) //The amount of energy a cell needs to expend to create this shot.
-	var/select_name = CALIBER_ENERGY
 	fire_sound = 'sound/items/weapons/laser.ogg'
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/red
 	newtonian_force = 0.5
 	muzzle_flash_color = LIGHT_COLOR_CYAN
+
+	///The amount of energy a cell needs to expend to create this shot.
+	var/e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE)
+	var/select_name = CALIBER_ENERGY
+	///Energy casing specific flags: (PROJECTILE_CANT_COPY)
+	var/energy_projectile_flags = NONE

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -77,6 +77,7 @@
 	projectile_type = /obj/projectile/energy/chameleon
 	e_cost = 0 // Can't really use the macro here, unfortunately
 	harmful = FALSE
+	energy_projectile_flags = PROJECTILE_CANT_COPY
 	var/projectile_vars = list()
 
 /obj/item/ammo_casing/energy/chameleon/ready_proj()

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -50,6 +50,7 @@
 	projectile_type = /obj/projectile/meteor
 	select_name = "goddamn meteor"
 	newtonian_force = 3
+	e_cost = LASER_SHOTS(2, STANDARD_CELL_CHARGE)
 
 /obj/item/ammo_casing/energy/scatter
 	projectile_type = /obj/projectile/beam/disabler/scatter

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -6,6 +6,7 @@
 	harmful = FALSE
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect
 	muzzle_flash_color = LIGHT_COLOR_DIM_YELLOW
+	energy_projectile_flags = PROJECTILE_CANT_COPY
 
 /obj/item/ammo_casing/energy/electrode/spec
 	e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE)

--- a/code/modules/projectiles/guns/energy/beam_rifle.dm
+++ b/code/modules/projectiles/guns/energy/beam_rifle.dm
@@ -49,6 +49,13 @@
 	e_cost = LASER_SHOTS(1, STANDARD_CELL_CHARGE)
 	fire_sound = 'sound/items/weapons/beam_sniper.ogg'
 
+/obj/item/ammo_casing/energy/event_horizon/throw_proj(atom/target, turf/targloc, mob/living/user, params, spread, atom/fired_from)
+	. = ..()
+	if(fired_from && !istype(fired_from, /obj/item/gun/energy/event_horizon))
+		fired_from.visible_message("[fired_from] bursts as it fires under the weight of the projectile!")
+		explosion(fired_from, light_impact_range = 1, smoke = FALSE, explosion_cause = "[user]'s [fired_from]")
+		qdel(fired_from)
+
 /obj/projectile/beam/event_horizon
 	name = "anti-existential beam"
 	icon_state = null

--- a/code/modules/projectiles/guns/energy/beam_rifle.dm
+++ b/code/modules/projectiles/guns/energy/beam_rifle.dm
@@ -52,7 +52,7 @@
 /obj/item/ammo_casing/energy/event_horizon/throw_proj(atom/target, turf/targloc, mob/living/user, params, spread, atom/fired_from)
 	. = ..()
 	if(fired_from && !istype(fired_from, /obj/item/gun/energy/event_horizon))
-		fired_from.visible_message("[fired_from] bursts as it fires under the weight of the projectile!")
+		fired_from.visible_message("[fired_from] bursts under the weight of the bullet!")
 		explosion(fired_from, light_impact_range = 1, smoke = FALSE, explosion_cause = "[user]'s [fired_from]")
 		qdel(fired_from)
 

--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -294,6 +294,7 @@
 /obj/item/ammo_casing/energy/duel
 	e_cost = 0 // Can't use the macro
 	projectile_type = /obj/projectile/energy/duel
+	energy_projectile_flags = PROJECTILE_CANT_COPY
 	var/setting
 
 /obj/item/ammo_casing/energy/duel/ready_proj(atom/target, mob/living/user, quiet, zone_override)

--- a/code/modules/projectiles/guns/energy/mounted.dm
+++ b/code/modules/projectiles/guns/energy/mounted.dm
@@ -47,6 +47,9 @@
 	if(copied_projectile.energy_projectile_flags & PROJECTILE_CANT_COPY)
 		user.balloon_alert(user, "can't copy!")
 		return ..()
+	user.balloon_alert(user, "copying schematics...")
+	if(!do_after(user, 3 SECONDS, tool))
+		return
 	ammo_type = list(copied_projectile)
 	fire_sound = energy_gun.fire_sound
 	burst_size = energy_gun.burst_size
@@ -54,7 +57,7 @@
 	fire_delay = energy_gun.fire_delay
 	QDEL_NULL(chambered)
 	recharge_newshot(TRUE)
-	user.balloon_alert(user, "projectile copied")
+	user.balloon_alert(user, "schematics copied")
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/gun/energy/laser/mounted/add_deep_lore()

--- a/code/modules/projectiles/guns/energy/mounted.dm
+++ b/code/modules/projectiles/guns/energy/mounted.dm
@@ -24,7 +24,3 @@
 
 /obj/item/gun/energy/laser/mounted/add_deep_lore()
 	return
-
-/obj/item/gun/energy/laser/mounted/augment
-	icon = 'icons/obj/medical/organs/organs.dmi'
-	icon_state = "arm_laser"

--- a/code/modules/projectiles/guns/energy/mounted.dm
+++ b/code/modules/projectiles/guns/energy/mounted.dm
@@ -22,19 +22,36 @@
 	selfcharge = 1
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 
+/obj/item/gun/energy/laser/mounted/examine(mob/user)
+	. = ..()
+	. += span_notice("[src] can copy other gun projectiles by using a gun on it, and reset back to the default with [EXAMINE_HINT("right-click.")]")
+
 /obj/item/gun/energy/laser/mounted/attack_self_secondary(mob/user, modifiers)
 	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
 	user.balloon_alert(user, "projectile reset")
-	ammo_type = initial(ammo_type)
+	ammo_type = /obj/item/gun/energy/laser/mounted::ammo_type
+	burst_size = initial(burst_size)
+	burst_delay = initial(burst_delay)
 	update_ammo_types()
+	QDEL_NULL(chambered)
+	recharge_newshot(TRUE)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/gun/energy/laser/mounted/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(!istype(tool, /obj/item/gun/energy))
 		return ..()
 	user.balloon_alert(user, "projectile copied")
 	var/obj/item/gun/energy/energy_gun = tool
-	ammo_type = energy_gun.ammo_type[energy_gun.select]
-	update_ammo_types()
+	ammo_type = list(energy_gun.ammo_type[energy_gun.select])
+	fire_sound = energy_gun.fire_sound
+	burst_size = energy_gun.burst_size
+	burst_delay = energy_gun.burst_delay
+	fire_delay = energy_gun.fire_delay
+	QDEL_NULL(chambered)
+	recharge_newshot(TRUE)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/gun/energy/laser/mounted/add_deep_lore()
 	return

--- a/code/modules/projectiles/guns/energy/mounted.dm
+++ b/code/modules/projectiles/guns/energy/mounted.dm
@@ -50,7 +50,7 @@
 	user.balloon_alert(user, "copying schematics...")
 	if(!do_after(user, 3 SECONDS, tool))
 		return
-	ammo_type = list(copied_projectile)
+	ammo_type = list(new copied_projectile.type)
 	fire_sound = energy_gun.fire_sound
 	burst_size = energy_gun.burst_size
 	burst_delay = energy_gun.burst_delay

--- a/code/modules/projectiles/guns/energy/mounted.dm
+++ b/code/modules/projectiles/guns/energy/mounted.dm
@@ -42,15 +42,19 @@
 /obj/item/gun/energy/laser/mounted/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(!istype(tool, /obj/item/gun/energy))
 		return ..()
-	user.balloon_alert(user, "projectile copied")
 	var/obj/item/gun/energy/energy_gun = tool
-	ammo_type = list(energy_gun.ammo_type[energy_gun.select])
+	var/obj/item/ammo_casing/energy/copied_projectile = energy_gun.ammo_type[energy_gun.select]
+	if(copied_projectile.energy_projectile_flags & PROJECTILE_CANT_COPY)
+		user.balloon_alert(user, "can't copy!")
+		return ..()
+	ammo_type = list(copied_projectile)
 	fire_sound = energy_gun.fire_sound
 	burst_size = energy_gun.burst_size
 	burst_delay = energy_gun.burst_delay
 	fire_delay = energy_gun.fire_delay
 	QDEL_NULL(chambered)
 	recharge_newshot(TRUE)
+	user.balloon_alert(user, "projectile copied")
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/gun/energy/laser/mounted/add_deep_lore()

--- a/code/modules/projectiles/guns/energy/mounted.dm
+++ b/code/modules/projectiles/guns/energy/mounted.dm
@@ -22,5 +22,19 @@
 	selfcharge = 1
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 
+/obj/item/gun/energy/laser/mounted/attack_self_secondary(mob/user, modifiers)
+	. = ..()
+	user.balloon_alert(user, "projectile reset")
+	ammo_type = initial(ammo_type)
+	update_ammo_types()
+
+/obj/item/gun/energy/laser/mounted/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/gun/energy))
+		return ..()
+	user.balloon_alert(user, "projectile copied")
+	var/obj/item/gun/energy/energy_gun = tool
+	ammo_type = energy_gun.ammo_type[energy_gun.select]
+	update_ammo_types()
+
 /obj/item/gun/energy/laser/mounted/add_deep_lore()
 	return

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -54,8 +54,8 @@
 	inhand_icon_state = "c20r"
 	w_class = WEIGHT_CLASS_BULKY
 	ammo_type = list(/obj/item/ammo_casing/energy/meteor)
-	cell_type = /obj/item/stock_parts/power_store/cell/potato
-	clumsy_check = 0 //Admin spawn only, might as well let clowns use it.
+	cell_type = /obj/item/stock_parts/power_store/cell/meteor_gun
+	clumsy_check = FALSE //Admin spawn only, might as well let clowns use it.
 	selfcharge = 1
 	automatic_charge_overlays = FALSE
 

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -167,7 +167,8 @@
 	ADD_TRAIT(src, TRAIT_CONTRABAND, INNATE_TRAIT)
 
 /obj/item/autosurgeon/syndicate/laser_arm
-	desc = "A single use autosurgeon that contains a combat arms-up laser augment. A screwdriver can be used to remove it, but implants can't be placed back in."
+	desc = "A single use autosurgeon that contains a combat arms-up laser augment. \
+		A screwdriver can be used to remove it, but implants can't be placed back in."
 	uses = 1
 	starting_organ = /obj/item/organ/cyberimp/arm/toolkit/gun/laser
 

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -250,8 +250,7 @@
 /obj/item/organ/cyberimp/arm/toolkit/gun/laser
 	name = "arm-mounted laser implant"
 	desc = "A variant of the arm cannon implant that fires lethal laser beams. The cannon emerges from the subject's arm and remains inside when not in use."
-	icon = 'icons/obj/items_cyborg.dmi'
-	icon_state = "laser_cyborg"
+	icon_state = "arm_laser"
 	items_to_create = list(/obj/item/gun/energy/laser/mounted)
 
 /obj/item/organ/cyberimp/arm/toolkit/gun/taser

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -112,7 +112,10 @@
 
 	if(active_item == source)
 		Retract()
-	items_list -= WEAKREF(source)
+	for(var/datum/weakref/ref in items_list)
+		var/obj/item/to_del = ref.resolve()
+		if(QDELETED(to_del))
+			items_list -= ref
 
 /obj/item/organ/cyberimp/arm/toolkit/emp_act(severity)
 	. = ..()

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -262,7 +262,8 @@
 
 /obj/item/organ/cyberimp/arm/toolkit/gun/laser
 	name = "arm-mounted laser implant"
-	desc = "A variant of the arm cannon implant that fires lethal laser beams. The cannon emerges from the subject's arm and remains inside when not in use."
+	desc = "A variant of the arm cannon implant that fires lethal laser beams, or custom ones if copying another gun's bullet properties. \
+		The cannon emerges from the subject's arm and remains inside when not in use."
 	icon_state = "arm_laser"
 	items_to_create = list(/obj/item/gun/energy/laser/mounted)
 

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -250,8 +250,9 @@
 /obj/item/organ/cyberimp/arm/toolkit/gun/laser
 	name = "arm-mounted laser implant"
 	desc = "A variant of the arm cannon implant that fires lethal laser beams. The cannon emerges from the subject's arm and remains inside when not in use."
-	icon_state = "arm_laser"
-	items_to_create = list(/obj/item/gun/energy/laser/mounted/augment)
+	icon = 'icons/obj/items_cyborg.dmi'
+	icon_state = "laser_cyborg"
+	items_to_create = list(/obj/item/gun/energy/laser/mounted)
 
 /obj/item/organ/cyberimp/arm/toolkit/gun/taser
 	name = "arm-mounted taser implant"

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -63,10 +63,12 @@
 	if(ispath(active_item))
 		active_item = new active_item(src)
 		items_list += WEAKREF(active_item)
+		RegisterSignal(active_item, COMSIG_QDELETING, PROC_REF(on_item_deleted))
 
 	for(var/typepath in items_to_create)
 		var/atom/new_item = new typepath(src)
 		items_list += WEAKREF(new_item)
+		RegisterSignal(new_item, COMSIG_QDELETING, PROC_REF(on_item_deleted))
 
 /obj/item/organ/cyberimp/arm/toolkit/Destroy()
 	hand = null
@@ -103,6 +105,14 @@
 /obj/item/organ/cyberimp/arm/toolkit/proc/on_item_attack_self()
 	SIGNAL_HANDLER
 	INVOKE_ASYNC(src, PROC_REF(ui_action_click))
+
+///If somehow your implant gets destroyed, it's gone.
+/obj/item/organ/cyberimp/arm/toolkit/proc/on_item_deleted(atom/source)
+	SIGNAL_HANDLER
+
+	if(active_item == source)
+		Retract()
+	items_list -= WEAKREF(source)
 
 /obj/item/organ/cyberimp/arm/toolkit/emp_act(severity)
 	. = ..()

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -241,7 +241,8 @@
 
 /datum/uplink_item/role_restricted/laser_arm
 	name = "Laser Arm Implant"
-	desc = "An implant that grants you a recharging laser gun inside your arm. Weak to EMPs. Comes in a syndicate autosurgeon for immediate self-application."
+	desc = "An implant that grants you a recharging laser gun inside your arm, which can also steal bullet types of other guns. Weak to EMPs. \
+		Comes in a syndicate autosurgeon for immediate self-application."
 	cost = 10
 	item = /obj/item/autosurgeon/syndicate/laser_arm
 	restricted_roles = list(JOB_ROBOTICIST, JOB_RESEARCH_DIRECTOR)

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -241,7 +241,7 @@
 
 /datum/uplink_item/role_restricted/laser_arm
 	name = "Laser Arm Implant"
-	desc = "An implant that grants you a recharging laser gun inside your arm. Weak to EMPs. Comes with a syndicate autosurgeon for immediate self-application."
+	desc = "An implant that grants you a recharging laser gun inside your arm. Weak to EMPs. Comes in a syndicate autosurgeon for immediate self-application."
 	cost = 10
 	item = /obj/item/autosurgeon/syndicate/laser_arm
 	restricted_roles = list(JOB_ROBOTICIST, JOB_RESEARCH_DIRECTOR)


### PR DESCRIPTION
## About The Pull Request

Using the arm-implanted gun on another *energy* gun will copy its projectile, you can right click it to reset it back to the default.

https://github.com/user-attachments/assets/b143d3d2-a829-493c-b1f0-e35c01b49631

https://github.com/user-attachments/assets/49bba50b-b998-4696-82c9-1f0546687698

Event horizon projectiles are one-time use if fired by any gun that isn't the event horizon rifle.

https://github.com/user-attachments/assets/c3703915-88d7-4e7c-ad3c-226a197c17a2


##### Code bounty by Ezel/Improvedname

## Why It's Good For The Game

The arm implant is essentially just a laser gun limited to the Roboticist that you have to wait a long ass time to recharge as it cannot go into rechargers itself. This hopes to add some more to it as a way of 'stealing' projectiles of sorts. Set it to ion mode, or non-lethal if you wish to kidnap, etc.
Electrode blacklist was added by request.

## Changelog

:cl:
balance: The roboticst's arm implanted gun (traitor item) can now copy projectiles of energy guns by using a gun you wish to copy onto it.
/:cl: