### PR TITLE
Axes grind & juice vars into procs

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -528,7 +528,6 @@
 	organ_traits = list(TRAIT_TETRODOTOXIN_HEALING, TRAIT_ALCOHOL_TOLERANCE) //drink like a fish :^)
 	liver_resistance = parent_type::liver_resistance * 1.5
 	food_reagents = list(/datum/reagent/consumable/nutriment/organ_tissue = 5, /datum/reagent/iron = 5, /datum/reagent/toxin/tetrodotoxin = 5)
-	grind_results = list(/datum/reagent/consumable/nutriment/peptides = 5, /datum/reagent/toxin/tetrodotoxin = 5)
 
 	// Seafood instead of meat, because it's a fish organ
 	foodtype_flags = RAW | SEAFOOD | GORE
@@ -538,6 +537,9 @@
 /obj/item/organ/liver/fish/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/fish)
+
+/obj/item/organ/liver/fish/grind_results()
+	return list(/datum/reagent/consumable/nutriment/peptides = 5, /datum/reagent/toxin/tetrodotoxin = 5)
 
 #undef FISH_ORGAN_COLOR
 #undef FISH_SCLERA_COLOR

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -225,11 +225,6 @@
 	///What dye registry should be looked at when dying this item; see washing_machine.dm
 	var/dying_key
 
-	/// A lazy reagent list containing the reagents this item produces when ground up in a grinder
-	var/list/grind_results
-	///A reagent the nutriments are converted into when the item is juiced.
-	var/datum/reagent/consumable/juice_typepath
-
 	/// Used in obj/item/examine to give additional notes on what the weapon does, separate from the predetermined output variables
 	var/offensive_notes
 	/// Used in obj/item/examine to determines whether or not to detail an item's statistics even if it does not meet the force requirements
@@ -1025,6 +1020,12 @@
 /obj/item/proc/blend_requirements(obj/machinery/reagentgrinder/R)
 	return TRUE
 
+///Returns a reagent list containing the reagents this item produces when ground up in a grinder
+/obj/item/proc/grind_results()
+	RETURN_TYPE(/list/datum/reagent)
+
+	return list()
+
 ///Called BEFORE the object is ground up - use this to change grind results based on conditions. Return "-1" to prevent the grinding from occurring
 /obj/item/proc/on_grind()
 	PROTECTED_PROC(TRUE)
@@ -1058,18 +1059,26 @@
 /obj/item/proc/grind_atom(datum/reagents/target_holder, mob/user)
 	PROTECTED_PROC(TRUE)
 
+	var/list/datum/reagent/grind_reagents = grind_results()
+
 	. = FALSE
-	if(LAZYLEN(grind_results))
-		target_holder.add_reagent_list(grind_results)
+	if(length(grind_reagents))
+		target_holder.add_reagent_list(grind_reagents)
 		. = TRUE
 	if(reagents?.trans_to(target_holder, reagents.total_volume, transferred_by = user))
 		. = TRUE
+
+///Returns A reagent the nutriments are converted into when the item is juiced.
+/obj/item/proc/juice_typepath()
+	RETURN_TYPE(/datum/reagent)
+
+	return null
 
 ///Called BEFORE the object is ground up - use this to change grind results based on conditions. Return "-1" to prevent the grinding from occurring
 /obj/item/proc/on_juice()
 	PROTECTED_PROC(TRUE)
 
-	if(!juice_typepath)
+	if(!juice_typepath())
 		return -1
 
 	return SEND_SIGNAL(src, COMSIG_ITEM_ON_JUICE)
@@ -1103,9 +1112,11 @@
 
 	. = FALSE
 
-	if(ispath(juice_typepath))
-		reagents.convert_reagent(/datum/reagent/consumable/nutriment, juice_typepath, include_source_subtypes = FALSE)
-		reagents.convert_reagent(/datum/reagent/consumable/nutriment/vitamin, juice_typepath, include_source_subtypes = FALSE)
+	var/juice_result = juice_typepath()
+
+	if(ispath(juice_result))
+		reagents.convert_reagent(/datum/reagent/consumable/nutriment, juice_result, include_source_subtypes = FALSE)
+		reagents.convert_reagent(/datum/reagent/consumable/nutriment/vitamin, juice_result, include_source_subtypes = FALSE)
 		. = TRUE
 
 	if(!QDELETED(target_holder))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1024,7 +1024,7 @@
 /obj/item/proc/grind_results()
 	RETURN_TYPE(/list/datum/reagent)
 
-	return list()
+	return null
 
 ///Called BEFORE the object is ground up - use this to change grind results based on conditions. Return "-1" to prevent the grinding from occurring
 /obj/item/proc/on_grind()

--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -22,7 +22,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	base_icon_state = "match"
 	w_class = WEIGHT_CLASS_TINY
 	heat = 1000
-	grind_results = list(/datum/reagent/phosphorus = 2)
 	/// Whether this match has been lit.
 	var/lit = FALSE
 	/// Whether this match has burnt out.
@@ -31,6 +30,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/smoketime = 10 SECONDS
 	/// If the match is broken
 	var/broken = FALSE
+
+/obj/item/match/grind_results()
+	return list(/datum/reagent/phosphorus = 2)
 
 /obj/item/match/process(seconds_per_tick)
 	smoketime -= seconds_per_tick * (1 SECONDS)
@@ -164,7 +166,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "An unlit firebrand. It makes you wonder why it's not just called a stick."
 	smoketime = 40 SECONDS
 	custom_materials = list(/datum/material/wood = SHEET_MATERIAL_AMOUNT * 2)
-	grind_results = list(/datum/reagent/carbon = 2)
+
+/obj/item/match/firebrand/grind_results()
+	return list(/datum/reagent/carbon = 2)
 
 /obj/item/match/firebrand/Initialize(mapload)
 	. = ..()
@@ -908,7 +912,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "cigbutt"
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 0
-	grind_results = list(/datum/reagent/carbon = 2)
+
+/obj/item/cigbutt/grind_results()
+	return list(/datum/reagent/carbon = 2)
 
 /obj/item/cigbutt/cigarbutt
 	name = "cigar butt"

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -15,7 +15,6 @@
 	abstract_type = /obj/item/circuitboard
 	custom_materials = list(/datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT)
 	w_class = WEIGHT_CLASS_SMALL
-	grind_results = list(/datum/reagent/silicon = 20)
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	var/build_path = null
 	/// whether or not the circuit board will build into a vendor whose products cost nothing (used for offstation vending machines mostly)
@@ -29,6 +28,9 @@
 	if(icon_state == "circuit_map") // some circuitboards have cool custom sprites
 		set_greyscale(new_config = /datum/greyscale_config/circuit)
 	return ..()
+
+/obj/item/circuitboard/grind_results()
+	return list(/datum/reagent/silicon = 20)
 
 /obj/item/circuitboard/proc/apply_default_parts(obj/machinery/machine)
 	if(LAZYLEN(machine.component_parts))

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -114,7 +114,18 @@
 	uses = 800 //In the Greek numeric system, Omega has a value of 800
 
 /obj/item/soap/omega/grind_results()
-	return list(/datum/reagent/consumable/potato_juice = 9, /datum/reagent/consumable/ethanol/lizardwine = 9, /datum/reagent/monkey_powder = 9, /datum/reagent/drug/krokodil = 9, /datum/reagent/toxin/acid/nitracid = 9, /datum/reagent/baldium = 9, /datum/reagent/consumable/ethanol/hooch = 9, /datum/reagent/bluespace = 9, /datum/reagent/drug/pumpup = 9, /datum/reagent/consumable/space_cola = 9)
+	return list(
+		/datum/reagent/consumable/potato_juice = 9,
+		/datum/reagent/consumable/ethanol/lizardwine = 9,
+		/datum/reagent/monkey_powder = 9,
+		/datum/reagent/drug/krokodil = 9,
+		/datum/reagent/toxin/acid/nitracid = 9,
+		/datum/reagent/baldium = 9,
+		/datum/reagent/consumable/ethanol/hooch = 9,
+		/datum/reagent/bluespace = 9,
+		/datum/reagent/drug/pumpup = 9,
+		/datum/reagent/consumable/space_cola = 9
+	)
 
 /obj/item/soap/omega/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is using [src] to scrub themselves from the timeline! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -25,7 +25,6 @@
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 7
-	grind_results = list(/datum/reagent/lye = 10)
 	var/cleanspeed = 3.5 SECONDS //slower than mop
 	force_string = "robust... against germs"
 	var/uses = 100
@@ -34,6 +33,9 @@
 	. = ..()
 	AddComponent(/datum/component/slippery, 80)
 	AddComponent(/datum/component/cleaner, cleanspeed, 0.1, pre_clean_callback=CALLBACK(src, PROC_REF(should_clean)), on_cleaned_callback=CALLBACK(src, PROC_REF(decreaseUses))) //less scaling for soapies
+
+/obj/item/soap/grind_results()
+	return list(/datum/reagent/lye = 10)
 
 /obj/item/soap/examine(mob/user)
 	. = ..()
@@ -56,36 +58,44 @@
 
 /obj/item/soap/homemade
 	desc = "A homemade bar of soap. Smells of... well...."
-	grind_results = list(/datum/reagent/consumable/liquidgibs = 9, /datum/reagent/lye = 9)
 	icon_state = "soapgibs"
 	inhand_icon_state = "soapgibs"
 	worn_icon_state = "soapgibs"
 	cleanspeed = 3 SECONDS // faster than base soap to reward chemists for going to the effort
 
+/obj/item/soap/homemade/grind_results()
+	return list(/datum/reagent/consumable/liquidgibs = 9, /datum/reagent/lye = 9)
+
 /obj/item/soap/nanotrasen
 	desc = "A heavy duty bar of Nanotrasen brand soap. Smells of plasma."
-	grind_results = list(/datum/reagent/toxin/plasma = 10, /datum/reagent/lye = 10)
 	icon_state = "soapnt"
 	inhand_icon_state = "soapnt"
 	worn_icon_state = "soapnt"
 	cleanspeed = 2.8 SECONDS //janitor gets this
 	uses = 300
 
+/obj/item/soap/nanotrasen/grind_results()
+	return list(/datum/reagent/toxin/plasma = 10, /datum/reagent/lye = 10)
+
 /obj/item/soap/deluxe
 	desc = "A deluxe Waffle Corporation brand bar of soap. Smells of high-class luxury."
-	grind_results = list(/datum/reagent/consumable/aloejuice = 10, /datum/reagent/lye = 10)
 	icon_state = "soapdeluxe"
 	inhand_icon_state = "soapdeluxe"
 	worn_icon_state = "soapdeluxe"
 	cleanspeed = 2 SECONDS //captain gets one of these
 
+/obj/item/soap/deluxe/grind_results()
+	return list(/datum/reagent/consumable/aloejuice = 10, /datum/reagent/lye = 10)
+
 /obj/item/soap/syndie
 	desc = "An untrustworthy bar of soap made of strong chemical agents that dissolve blood faster."
-	grind_results = list(/datum/reagent/toxin/acid = 10, /datum/reagent/lye = 10)
 	icon_state = "soapsyndie"
 	inhand_icon_state = "soapsyndie"
 	worn_icon_state = "soapsyndie"
 	cleanspeed = 0.5 SECONDS //faster than mops so it's useful for traitors who want to clean crime scenes
+
+/obj/item/soap/syndie/grind_results()
+	return list(/datum/reagent/toxin/acid = 10, /datum/reagent/lye = 10)
 
 /obj/item/soap/drone
 	name = "\improper integrated soap module"
@@ -97,12 +107,14 @@
 /obj/item/soap/omega
 	name = "\improper Omega soap"
 	desc = "The most advanced soap known to mankind. The beginning of the end for germs."
-	grind_results = list(/datum/reagent/consumable/potato_juice = 9, /datum/reagent/consumable/ethanol/lizardwine = 9, /datum/reagent/monkey_powder = 9, /datum/reagent/drug/krokodil = 9, /datum/reagent/toxin/acid/nitracid = 9, /datum/reagent/baldium = 9, /datum/reagent/consumable/ethanol/hooch = 9, /datum/reagent/bluespace = 9, /datum/reagent/drug/pumpup = 9, /datum/reagent/consumable/space_cola = 9)
 	icon_state = "soapomega"
 	inhand_icon_state = "soapomega"
 	worn_icon_state = "soapomega"
 	cleanspeed = 0.3 SECONDS //Only the truest of mind soul and body get one of these
 	uses = 800 //In the Greek numeric system, Omega has a value of 800
+
+/obj/item/soap/omega/grind_results()
+	return list(/datum/reagent/consumable/potato_juice = 9, /datum/reagent/consumable/ethanol/lizardwine = 9, /datum/reagent/monkey_powder = 9, /datum/reagent/drug/krokodil = 9, /datum/reagent/toxin/acid/nitracid = 9, /datum/reagent/baldium = 9, /datum/reagent/consumable/ethanol/hooch = 9, /datum/reagent/bluespace = 9, /datum/reagent/drug/pumpup = 9, /datum/reagent/consumable/space_cola = 9)
 
 /obj/item/soap/omega/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is using [src] to scrub themselves from the timeline! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -447,7 +447,6 @@
 	light_color = LIGHT_COLOR_FLARE
 	light_system = OVERLAY_LIGHT
 	light_power = 2
-	grind_results = list(/datum/reagent/sulfur = 15)
 	sound_on = 'sound/items/match_strike.ogg'
 	toggle_context = FALSE
 	has_closed_handle = FALSE
@@ -478,6 +477,9 @@
 		force = on_damage
 		damtype = BURN
 		update_brightness()
+
+/obj/item/flashlight/flare/grind_results()
+	return list(/datum/reagent/sulfur = 15)
 
 /obj/item/flashlight/flare/init_slapcrafting()
 	return
@@ -864,7 +866,6 @@
 	base_icon_state = "glowstick"
 	inhand_icon_state = null
 	worn_icon_state = "lightstick"
-	grind_results = list(/datum/reagent/phenol = 15, /datum/reagent/hydrogen = 10, /datum/reagent/oxygen = 5) //Meth-in-a-stick
 	sound_on = 'sound/effects/wounds/crack2.ogg' // the cracking sound isn't just for wounds silly
 	toggle_context = FALSE
 	ignore_base_color = TRUE
@@ -897,6 +898,11 @@
 		bite_consumption = round(reagents.total_volume / (rand(20, 30) * 0.1)),\
 	)
 	RegisterSignal(reagents, COMSIG_REAGENTS_HOLDER_UPDATED, PROC_REF(on_reagent_change))
+
+/obj/item/flashlight/glowstick/grind_results()
+	. = list(/datum/reagent/phenol = 15, /datum/reagent/hydrogen = 10)
+	if(!light_on)
+		.[/datum/reagent/oxygen] = 5
 
 /obj/item/flashlight/glowstick/proc/get_fuel()
 	return reagents.get_reagent_amount(fuel_type)
@@ -937,7 +943,6 @@
 
 /obj/item/flashlight/glowstick/proc/turn_on()
 	reagents.add_reagent(/datum/reagent/oxygen, oxygen_added)
-	grind_results -= /datum/reagent/oxygen
 	set_light_on(TRUE) // Just in case
 	var/datum/action/toggle = locate(/datum/action/item_action/toggle_light) in actions
 	// No sense having a toggle light action that we don't use eh?

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -16,7 +16,6 @@
 	throw_range = 7
 	tool_behaviour = TOOL_ANALYZER
 	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT * 0.3, /datum/material/glass=SMALL_MATERIAL_AMOUNT * 0.2)
-	grind_results = list(/datum/reagent/mercury = 5, /datum/reagent/iron = 5, /datum/reagent/silicon = 5)
 	interaction_flags_click = NEED_LITERACY|NEED_LIGHT|ALLOW_RESTING
 	pickup_sound = 'sound/items/handling/gas_analyzer/gas_analyzer_pickup.ogg'
 	drop_sound = 'sound/items/handling/gas_analyzer/gas_analyzer_drop.ogg'
@@ -43,6 +42,9 @@
 		/datum/element/slapcrafting,\
 		slapcraft_recipes = slapcraft_recipe_list,\
 	)
+
+/obj/item/analyzer/grind_results()
+	return list(/datum/reagent/mercury = 5, /datum/reagent/iron = 5, /datum/reagent/silicon = 5)
 
 /obj/item/analyzer/equipped(mob/user, slot, initial)
 	. = ..()
@@ -234,5 +236,7 @@
 	worn_icon_state = "analyzer"
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 0.2, /datum/material/gold = SMALL_MATERIAL_AMOUNT*3, /datum/material/bluespace=SMALL_MATERIAL_AMOUNT*2)
-	grind_results = list(/datum/reagent/mercury = 5, /datum/reagent/iron = 5, /datum/reagent/silicon = 5)
 	ranged_scan_distance = 15
+
+/obj/item/analyzer/ranged/grind_results()
+	return list(/datum/reagent/mercury = 5, /datum/reagent/iron = 5, /datum/reagent/silicon = 5)

--- a/code/game/objects/items/devices/scanners/plant_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/plant_analyzer.dm
@@ -326,11 +326,11 @@
 			product_grinder_results[seed.product] = list()
 			var/obj/item/food/grown/product = new seed.product
 			var/datum/reagent/product_distill_reagent = product.distill_reagent
-			var/datum/reagent/product_juice_typepath = product.juice_typepath
+			var/datum/reagent/product_juice_typepath = product.juice_typepath()
 			product_grinder_results[seed.product]["distill_reagent"] = initial(product_distill_reagent.name)
 			product_grinder_results[seed.product]["juice_name"] = initial(product_juice_typepath.name)
 			product_grinder_results[seed.product]["grind_results"] = list()
-			for(var/datum/reagent/reagent as anything in product.grind_results)
+			for(var/datum/reagent/reagent as anything in product.grind_results())
 				product_grinder_results[seed.product]["grind_results"] += initial(reagent.name)
 			qdel(product)
 		seed_data["distill_reagent"] = product_grinder_results[seed.product]["distill_reagent"]

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -13,8 +13,10 @@
 	tastes = list("watermelon" = 1)
 	foodtypes = FRUIT
 	food_flags = FOOD_FINGER_FOOD
-	juice_typepath = /datum/reagent/consumable/watermelonjuice
 	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/food/watermelonslice/juice_typepath()
+	return /datum/reagent/consumable/watermelonjuice
 
 /obj/item/food/watermelonmush
 	name = "watermelon mush"
@@ -29,8 +31,10 @@
 	tastes = list("watermelon" = 1)
 	foodtypes = FRUIT
 	food_flags = FOOD_FINGER_FOOD
-	juice_typepath = /datum/reagent/consumable/watermelonjuice
 	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/food/watermelonmush/juice_typepath()
+	return /datum/reagent/consumable/watermelonjuice
 
 /obj/item/food/holymelonslice
 	name = "holymelon slice"
@@ -45,8 +49,10 @@
 	tastes = list("holymelon" = 1)
 	foodtypes = FRUIT
 	food_flags = FOOD_FINGER_FOOD
-	juice_typepath = /datum/reagent/water/holywater
 	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/food/holymelonslice/juice_typepath()
+	return /datum/reagent/water/holywater
 
 /obj/item/food/holymelonmush
 	name = "holymelon mush"
@@ -61,8 +67,10 @@
 	tastes = list("holymelon" = 1)
 	foodtypes = FRUIT
 	food_flags = FOOD_FINGER_FOOD
-	juice_typepath = /datum/reagent/water/holywater
 	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/food/holymelonmush/juice_typepath()
+	return /datum/reagent/water/holywater
 
 /obj/item/food/barrelmelonslice
 	name = "barrelmelon slice"
@@ -77,8 +85,10 @@
 	tastes = list("beer" = 1)
 	foodtypes = FRUIT
 	food_flags = FOOD_FINGER_FOOD
-	juice_typepath = /datum/reagent/consumable/ethanol/beer
 	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/food/barrelmelonslice/juice_typepath()
+	return /datum/reagent/consumable/ethanol/beer
 
 /obj/item/food/barrelmelonmush
 	name = "barrelmelon mush"
@@ -93,9 +103,10 @@
 	tastes = list("beer" = 1)
 	foodtypes = FRUIT
 	food_flags = FOOD_FINGER_FOOD
-	juice_typepath = /datum/reagent/consumable/ethanol/beer
 	w_class = WEIGHT_CLASS_SMALL
 
+/obj/item/food/barrelmelonmush/juice_typepath()
+	return /datum/reagent/consumable/ethanol/beer
 
 /obj/item/food/appleslice
 	name = "apple slice"
@@ -110,8 +121,10 @@
 	tastes = list("apple" = 1)
 	foodtypes = FRUIT
 	food_flags = FOOD_FINGER_FOOD
-	juice_typepath = /datum/reagent/consumable/applejuice
 	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/food/appleslice/juice_typepath()
+	return /datum/reagent/consumable/applejuice
 
 /obj/item/food/hugemushroomslice
 	name = "huge mushroom slice"
@@ -431,10 +444,12 @@
 	name = "pineapple slice"
 	desc = "A sliced piece of juicy pineapple."
 	icon_state = "pineapple_slice"
-	juice_typepath = /datum/reagent/consumable/pineapplejuice
 	tastes = list("pineapple" = 1)
 	foodtypes = FRUIT | PINEAPPLE
 	w_class = WEIGHT_CLASS_TINY
+
+/obj/item/food/pineappleslice/juice_typepath()
+	return /datum/reagent/consumable/pineapplejuice
 
 /obj/item/food/crab_rangoon
 	name = "crab rangoon"
@@ -619,9 +634,11 @@
 		/datum/reagent/medicine/antihol = 2,
 	)
 	tastes = list("pickle" = 1, "spices" = 1, "salt water" = 2)
-	juice_typepath = /datum/reagent/consumable/pickle
 	foodtypes = VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/food/pickle/juice_typepath()
+	return /datum/reagent/consumable/pickle
 
 /obj/item/food/pickle/make_edible()
 	. = ..()

--- a/code/game/objects/items/food/snacks.dm
+++ b/code/game/objects/items/food/snacks.dm
@@ -230,8 +230,10 @@
 	custom_price = PAYCHECK_CREW * 0.8 //nuts are expensive in real life, and this is the best food in the vendor.
 	junkiness = 10 //less junky than other options, since peanuts are a decently healthy snack option
 	w_class = WEIGHT_CLASS_SMALL
-	grind_results = list(/datum/reagent/consumable/peanut_butter = 5, /datum/reagent/consumable/nutriment/fat/oil = 2)
 	var/safe_for_consumption = TRUE
+
+/obj/item/food/peanuts/grind_results()
+	return list(/datum/reagent/consumable/peanut_butter = 5, /datum/reagent/consumable/nutriment/fat/oil = 2)
 
 /obj/item/food/peanuts/salted
 	name = "\improper Gallery's salt reserves peanuts"
@@ -397,7 +399,9 @@ GLOBAL_LIST_INIT(safe_peanut_types, populate_safe_peanut_types())
 	custom_price = PAYCHECK_CREW//pistachios are even more expensive.
 	junkiness = 10 //on par with peanuts
 	w_class = WEIGHT_CLASS_SMALL
-	grind_results = list(/datum/reagent/consumable/peanut_butter = 5, /datum/reagent/consumable/nutriment/fat/oil = 2)
+
+/obj/item/food/pistachios/grind_results()
+	return list(/datum/reagent/consumable/peanut_butter = 5, /datum/reagent/consumable/nutriment/fat/oil = 2)
 
 /obj/item/food/semki
 	name = "\improper Semki Sunflower Seeds"
@@ -538,7 +542,9 @@ GLOBAL_LIST_INIT(safe_peanut_types, populate_safe_peanut_types())
 	foodtypes = JUNKFOOD | SUGAR | NUTS
 	junkiness = 25
 	w_class = WEIGHT_CLASS_SMALL
-	grind_results = list(/datum/reagent/consumable/nutriment/fat/oil = 3, /datum/reagent/consumable/caramel = 2)
+
+/obj/item/food/hot_shots/grind_results()
+	return list(/datum/reagent/consumable/nutriment/fat/oil = 3, /datum/reagent/consumable/caramel = 2)
 
 /obj/item/food/sticko
 	name = "\improper Sticko Classic"

--- a/code/game/objects/items/inspector.dm
+++ b/code/game/objects/items/inspector.dm
@@ -459,8 +459,10 @@
  * If it is ground, it will turn into 5u water.
  */
 /obj/item/paper/fake_report/water
-	grind_results = list(/datum/reagent/water = 5)
 	interaction_flags_click = NEED_DEXTERITY|NEED_HANDS|ALLOW_RESTING
+
+/obj/item/paper/fake_report/water/grind_results()
+	return list(/datum/reagent/water = 5)
 
 /obj/item/paper/fake_report/water/click_alt(mob/living/user)
 	var/datum/action/innate/origami/origami_action = locate() in user.actions

--- a/code/game/objects/items/lighter.dm
+++ b/code/game/objects/items/lighter.dm
@@ -9,7 +9,6 @@
 	obj_flags = CONDUCTS_ELECTRICITY
 	slot_flags = ITEM_SLOT_BELT
 	resistance_flags = FIRE_PROOF
-	grind_results = list(/datum/reagent/iron = 1, /datum/reagent/fuel = 5, /datum/reagent/fuel/oil = 5)
 	custom_price = PAYCHECK_CREW * 1.1
 	light_system = OVERLAY_LIGHT
 	light_range = 2
@@ -54,6 +53,9 @@
 		on_intercepted = CALLBACK(src, PROC_REF(on_intercepted_bullet)),\
 	)
 	update_appearance()
+
+/obj/item/lighter/grind_results()
+	return list(/datum/reagent/iron = 1, /datum/reagent/fuel = 5, /datum/reagent/fuel/oil = 5)
 
 /obj/item/lighter/examine(mob/user)
 	. = ..()
@@ -315,7 +317,9 @@
 	heat_while_on = parent_type::heat_while_on + 1000 //Blue flame is hotter, this means this does act as a welding tool.
 	light_color = LIGHT_COLOR_CYAN
 	overlay_state = "slime"
-	grind_results = list(/datum/reagent/iron = 1, /datum/reagent/fuel = 5, /datum/reagent/medicine/pyroxadone = 5)
+
+/obj/item/lighter/slime/grind_results()
+	return list(/datum/reagent/iron = 1, /datum/reagent/fuel = 5, /datum/reagent/medicine/pyroxadone = 5)
 
 /obj/item/lighter/skull
 	name = "badass zippo"
@@ -329,10 +333,12 @@
 	light_color = LIGHT_COLOR_HALOGEN
 	heat_while_on = TCMB //I swear it's a real lighter dude you just can't see the flame dude I promise
 	overlay_state = "mime"
-	grind_results = list(/datum/reagent/iron = 1, /datum/reagent/toxin/mutetoxin = 5, /datum/reagent/consumable/nothing = 10)
 	light_range = 0
 	light_power = 0
 	fancy = FALSE
+
+/obj/item/lighter/mime/grind_results()
+	return list(/datum/reagent/iron = 1, /datum/reagent/toxin/mutetoxin = 5, /datum/reagent/consumable/nothing = 10)
 
 /obj/item/lighter/mime/ignition_effect(atom/A, mob/user)
 	. = span_infoplain("[user] lifts \the [src] to the [A], which miraculously lights!")
@@ -343,10 +349,12 @@
 	icon_state = "slighter"
 	light_color = LIGHT_COLOR_ELECTRIC_CYAN
 	overlay_state = "bright"
-	grind_results = list(/datum/reagent/iron = 1, /datum/reagent/flash_powder = 10)
 	light_range = 8
 	light_power = 3 //Irritatingly bright and large enough to cover a small room.
 	fancy = FALSE
+
+/obj/item/lighter/bright/grind_results()
+	return list(/datum/reagent/iron = 1, /datum/reagent/flash_powder = 10)
 
 /obj/item/lighter/bright/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/maintenance_loot.dm
+++ b/code/game/objects/items/maintenance_loot.dm
@@ -21,11 +21,13 @@
 	w_class = WEIGHT_CLASS_BULKY
 	wound_bonus = 20
 	demolition_mod = 1.25
-	grind_results = list(/datum/reagent/lead = 20)
 	pickup_sound = 'sound/items/handling/lead_pipe/lead_pipe_pickup.ogg'
 	drop_sound = 'sound/items/handling/materials/metal_drop.ogg'
 	throw_drop_sound = 'sound/items/handling/lead_pipe/lead_pipe_drop.ogg'
 	hitsound = 'sound/items/lead_pipe_hit.ogg'
+
+/obj/item/lead_pipe/grind_results()
+	return list(/datum/reagent/lead = 20)
 
 //A good battery early in the shift. Source of lead & sulfuric acid reagents.
 //Add lead material to this once implemented.
@@ -42,7 +44,9 @@
 	emp_damage_modifier = 4 // 15 shots.
 	charge_light_type = null
 	connector_type = "leadacid"
-	grind_results = list(/datum/reagent/lead = 15, /datum/reagent/toxin/acid = 15, /datum/reagent/water = 20)
+
+/obj/item/stock_parts/power_store/cell/lead/grind_results()
+	return list(/datum/reagent/lead = 15, /datum/reagent/toxin/acid = 15, /datum/reagent/water = 20)
 
 //starts partially discharged
 /obj/item/stock_parts/power_store/cell/lead/Initialize(mapload)

--- a/code/game/objects/items/stacks/ammonia_crystals.dm
+++ b/code/game/objects/items/stacks/ammonia_crystals.dm
@@ -6,5 +6,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	max_amount = 50
-	grind_results = list(/datum/reagent/ammonia = 10)
 	merge_type = /obj/item/stack/ammonia_crystals
+
+/obj/item/stack/ammonia_crystals/grind_results()
+	return list(/datum/reagent/ammonia = 10)

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -10,11 +10,13 @@
 	mats_per_unit = list(/datum/material/bluespace=SHEET_MATERIAL_AMOUNT)
 	points = 50
 	refined_type = /obj/item/stack/sheet/bluespace_crystal
-	grind_results = list(/datum/reagent/bluespace = 20)
 	scan_state = "rock_bscrystal"
 	merge_type = /obj/item/stack/ore/bluespace_crystal
 	/// The teleport range when crushed/thrown at someone.
 	var/blink_range = 8
+
+/obj/item/stack/ore/bluespace_crystal/grind_results()
+	return list(/datum/reagent/bluespace = 20)
 
 /obj/item/stack/ore/bluespace_crystal/refined
 	name = "refined bluespace crystal"
@@ -61,10 +63,12 @@
 	blink_range = 4 // Not as good as the organic stuff!
 	points = 0 //nice try
 	refined_type = null
-	grind_results = list(/datum/reagent/bluespace = 10, /datum/reagent/silicon = 20)
 	merge_type = /obj/item/stack/ore/bluespace_crystal/artificial
 	drop_sound = null //till I make a better one
 	pickup_sound = null
+
+/obj/item/stack/ore/bluespace_crystal/artificial/grind_results()
+	return list(/datum/reagent/bluespace = 10, /datum/reagent/silicon = 20)
 
 //Polycrystals, aka stacks
 /obj/item/stack/sheet/bluespace_crystal
@@ -79,11 +83,12 @@
 	attack_verb_continuous = list("bluespace polybashes", "bluespace polybatters", "bluespace polybludgeons", "bluespace polythrashes", "bluespace polysmashes")
 	attack_verb_simple = list("bluespace polybash", "bluespace polybatter", "bluespace polybludgeon", "bluespace polythrash", "bluespace polysmash")
 	novariants = TRUE
-	grind_results = list(/datum/reagent/bluespace = 20)
 	merge_type = /obj/item/stack/sheet/bluespace_crystal
 	material_type = /datum/material/bluespace
 	var/crystal_type = /obj/item/stack/ore/bluespace_crystal/refined
 
+/obj/item/stack/sheet/bluespace_crystal/grind_results()
+	return list(/datum/reagent/bluespace = 20)
 
 /obj/item/stack/sheet/bluespace_crystal/attack_self(mob/user)// to prevent the construction menu from ever happening
 	to_chat(user, span_warning("You cannot crush the polycrystal in-hand, try breaking one off."))

--- a/code/game/objects/items/stacks/cash.dm
+++ b/code/game/objects/items/stacks/cash.dm
@@ -13,12 +13,14 @@
 	full_w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	var/value = 0
-	grind_results = list(/datum/reagent/cellulose = 10)
 
 /obj/item/stack/spacecash/Initialize(mapload, new_amount, merge = TRUE, list/mat_override=null, mat_amt=1)
 	. = ..()
 	add_traits(list(TRAIT_FISHING_BAIT, TRAIT_BAIT_ALLOW_FISHING_DUD), INNATE_TRAIT)
 	update_desc()
+
+/obj/item/stack/spacecash/grind_results()
+	return list(/datum/reagent/cellulose = 10)
 
 /obj/item/stack/spacecash/update_desc()
 	. = ..()

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -359,9 +359,11 @@
 	heal_brute = 40
 	self_delay = 4 SECONDS
 	other_delay = 2 SECONDS
-	grind_results = list(/datum/reagent/medicine/c2/libital = 10)
 	merge_type = /obj/item/stack/medical/bruise_pack
 	apply_verb = "applying to"
+
+/obj/item/stack/medical/bruise_pack/grind_results()
+	return list(/datum/reagent/medicine/c2/libital = 10)
 
 /obj/item/stack/medical/bruise_pack/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is bludgeoning [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -377,7 +379,6 @@
 	other_delay = 2 SECONDS
 	max_amount = 12
 	amount = 6
-	grind_results = list(/datum/reagent/cellulose = 2)
 	custom_price = PAYCHECK_CREW * 2
 	absorption_rate = 0.125
 	absorption_capacity = 5
@@ -397,6 +398,9 @@
 /obj/item/stack/medical/gauze/Initialize(mapload, new_amount, merge, list/mat_override, mat_amt)
 	. = ..()
 	register_context()
+
+/obj/item/stack/medical/gauze/grind_results()
+	return list(/datum/reagent/cellulose = 2)
 
 /obj/item/stack/medical/gauze/Destroy(force)
 	. = ..()
@@ -560,7 +564,6 @@
 	repeating = TRUE
 	heal_brute = 10
 	stop_bleeding = 0.5
-	grind_results = list(/datum/reagent/medicine/spaceacillin = 2)
 	merge_type = /obj/item/stack/medical/suture
 	apply_verb = "suturing"
 	drop_sound = SFX_SUTURE_DROP
@@ -569,14 +572,19 @@
 	heal_continuous_sound = SFX_SUTURE_CONTINUOUS
 	heal_end_sound = SFX_SUTURE_END
 
+/obj/item/stack/medical/suture/grind_results()
+	return list(/datum/reagent/medicine/spaceacillin = 2)
+
 /obj/item/stack/medical/suture/medicated
 	name = "medicated suture"
 	icon_state = "suture_purp"
 	desc = "A suture infused with drugs that speed up wound healing of the treated laceration."
 	heal_brute = 15
 	stop_bleeding = 0.75
-	grind_results = list(/datum/reagent/medicine/polypyr = 1)
 	merge_type = /obj/item/stack/medical/suture/medicated
+
+/obj/item/stack/medical/suture/medicated/grind_results()
+	return list(/datum/reagent/medicine/polypyr = 1)
 
 /obj/item/stack/medical/ointment
 	name = "ointment"
@@ -590,13 +598,14 @@
 	max_amount = 8
 	self_delay = 4 SECONDS
 	other_delay = 2 SECONDS
-
 	heal_burn = 5
 	flesh_regeneration = 2.5
 	sanitization = 0.25
-	grind_results = list(/datum/reagent/medicine/c2/lenturi = 10)
 	merge_type = /obj/item/stack/medical/ointment
 	apply_verb = "applying to"
+
+/obj/item/stack/medical/ointment/grind_results()
+	return list(/datum/reagent/medicine/c2/lenturi = 10)
 
 /obj/item/stack/medical/ointment/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is squeezing [src] into [user.p_their()] mouth! [user.p_do(TRUE)]n't [user.p_they()] know that stuff is toxic?"))
@@ -621,16 +630,19 @@
 	heal_begin_sound = SFX_REGEN_MESH_BEGIN
 	heal_continuous_sound = SFX_REGEN_MESH_CONTINUOUS
 	heal_end_sound = SFX_REGEN_MESH_END
-
-	var/is_open = TRUE ///This var determines if the sterile packaging of the mesh has been opened.
-	grind_results = list(/datum/reagent/medicine/spaceacillin = 2)
 	merge_type = /obj/item/stack/medical/mesh
+
+	///This var determines if the sterile packaging of the mesh has been opened.
+	var/is_open = TRUE
 
 /obj/item/stack/medical/mesh/Initialize(mapload, new_amount, merge = TRUE, list/mat_override=null, mat_amt=1)
 	. = ..()
 	if(amount == max_amount)  //only seal full mesh packs
 		is_open = FALSE
 		update_appearance()
+
+/obj/item/stack/medical/mesh/grind_results()
+	return list(/datum/reagent/medicine/spaceacillin = 2)
 
 /obj/item/stack/medical/mesh/update_icon_state()
 	if(is_open)
@@ -668,14 +680,15 @@
 /obj/item/stack/medical/mesh/advanced
 	name = "advanced regenerative mesh"
 	desc = "An advanced mesh made with aloe extracts and sterilizing chemicals, used to treat burns."
-
 	gender = PLURAL
 	icon_state = "aloe_mesh"
 	heal_burn = 15
 	sanitization = 1.25
 	flesh_regeneration = 3.5
-	grind_results = list(/datum/reagent/consumable/aloejuice = 1)
 	merge_type = /obj/item/stack/medical/mesh/advanced
+
+/obj/item/stack/medical/mesh/advanced/grind_results()
+	return list(/datum/reagent/consumable/aloejuice = 1)
 
 /obj/item/stack/medical/mesh/advanced/update_icon_state()
 	if(is_open)
@@ -685,7 +698,6 @@
 /obj/item/stack/medical/aloe
 	name = "aloe cream"
 	desc = "A healing paste for minor cuts and burns."
-
 	gender = PLURAL
 	singular_name = "aloe cream"
 	icon_state = "aloe_paste"
@@ -697,13 +709,15 @@
 	repeating = TRUE
 	heal_brute = 3
 	heal_burn = 3
-	grind_results = list(/datum/reagent/consumable/aloejuice = 1)
 	merge_type = /obj/item/stack/medical/aloe
 	apply_verb = "applying to"
 
 /obj/item/stack/medical/aloe/Initialize(mapload, new_amount, merge, list/mat_override, mat_amt)
 	. = ..()
 	AddComponent(/datum/component/bakeable, /obj/item/food/badrecipe, rand(10 SECONDS, 15 SECONDS), FALSE)
+
+/obj/item/stack/medical/aloe/grind_results()
+	return list(/datum/reagent/consumable/aloejuice = 1)
 
 /obj/item/stack/medical/aloe/fresh
 	amount = 2
@@ -712,19 +726,19 @@
 	name = "bone gel"
 	singular_name = "bone gel"
 	desc = "A potent medical gel that, when applied to a damaged bone in a proper surgical setting, triggers an intense melding reaction to repair the wound. Can be directly applied alongside surgical sticky tape to a broken bone in dire circumstances, though this is very harmful to the patient and not recommended."
-
 	icon = 'icons/obj/medical/surgery_tools.dmi'
 	icon_state = "bone-gel"
 	inhand_icon_state = "bone-gel"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-
 	amount = 5
 	self_delay = 20
-	grind_results = list(/datum/reagent/bone_dust = 10, /datum/reagent/carbon = 10)
 	novariants = TRUE
 	merge_type = /obj/item/stack/medical/bone_gel
 	apply_verb = "applying to"
+
+/obj/item/stack/medical/bone_gel/grind_results()
+	return list(/datum/reagent/bone_dust = 10, /datum/reagent/carbon = 10)
 
 /obj/item/stack/medical/bone_gel/get_surgery_tool_overlay(tray_extended)
 	return "gel" + (tray_extended ? "" : "_out")
@@ -799,10 +813,11 @@
 	stop_bleeding = 0.2
 	self_delay = 3 SECONDS
 	other_delay = 1 SECONDS
-	grind_results = list(/datum/reagent/medicine/c2/libital = 2)
 	apply_verb = "applying to"
 	pickup_sound = SFX_CLOTH_PICKUP
-	// add a better drop sound more fitting for a lil' itty bitty band-aid
+
+/obj/item/stack/medical/bandage/grind_results()
+	return list(/datum/reagent/medicine/c2/libital = 2)
 
 /obj/item/stack/medical/bandage/makeshift
 	name = "makeshift bandage"

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -25,7 +25,6 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 	armor_type = /datum/armor/sheet_glass
 	resistance_flags = ACID_PROOF
 	merge_type = /obj/item/stack/sheet/glass
-	grind_results = list(/datum/reagent/silicon = 20)
 	material_type = /datum/material/glass
 	table_type = /obj/structure/table/glass
 	matter_amount = 4
@@ -38,6 +37,9 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 /datum/armor/sheet_glass
 	fire = 50
 	acid = 100
+
+/obj/item/stack/sheet/glass/grind_results()
+	return list(/datum/reagent/silicon = 20)
 
 /obj/item/stack/sheet/glass/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins to slice [user.p_their()] neck with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -101,11 +103,13 @@ GLOBAL_LIST_INIT(pglass_recipes, list ( \
 	armor_type = /datum/armor/sheet_plasmaglass
 	resistance_flags = ACID_PROOF
 	merge_type = /obj/item/stack/sheet/plasmaglass
-	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/toxin/plasma = 10)
 	material_flags = NONE
 	table_type = /obj/structure/table/glass/plasmaglass
 	pickup_sound = 'sound/items/handling/materials/glass_pick_up.ogg'
 	drop_sound = 'sound/items/handling/materials/glass_drop.ogg'
+
+/obj/item/stack/sheet/plasmaglass/grind_results()
+	return list(/datum/reagent/silicon = 20, /datum/reagent/toxin/plasma = 10)
 
 /obj/item/stack/sheet/plasmaglass/fifty
 	amount = 50
@@ -161,11 +165,13 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list ( \
 	armor_type = /datum/armor/sheet_rglass
 	resistance_flags = ACID_PROOF
 	merge_type = /obj/item/stack/sheet/rglass
-	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/iron = 10)
 	matter_amount = 6
 	table_type = /obj/structure/table/reinforced/rglass
 	pickup_sound = 'sound/items/handling/materials/glass_pick_up.ogg'
 	drop_sound = 'sound/items/handling/materials/glass_drop.ogg'
+
+/obj/item/stack/sheet/rglass/grind_results()
+	return list(/datum/reagent/silicon = 20, /datum/reagent/iron = 10)
 
 /obj/item/stack/sheet/rglass/fifty
 	amount = 50
@@ -200,12 +206,14 @@ GLOBAL_LIST_INIT(prglass_recipes, list ( \
 	resistance_flags = ACID_PROOF
 	material_flags = NONE
 	merge_type = /obj/item/stack/sheet/plasmarglass
-	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/toxin/plasma = 10, /datum/reagent/iron = 10)
 	gulag_valid = TRUE
 	matter_amount = 8
 	table_type = /obj/structure/table/reinforced/plasmarglass
 	pickup_sound = 'sound/items/handling/materials/glass_pick_up.ogg'
 	drop_sound = 'sound/items/handling/materials/glass_drop.ogg'
+
+/obj/item/stack/sheet/plasmarglass/grind_results()
+	return list(/datum/reagent/silicon = 20, /datum/reagent/toxin/plasma = 10, /datum/reagent/iron = 10)
 
 /datum/armor/sheet_plasmarglass
 	melee = 20

--- a/code/game/objects/items/stacks/sheets/hot_ice.dm
+++ b/code/game/objects/items/stacks/sheets/hot_ice.dm
@@ -5,9 +5,11 @@
 	singular_name = "hot ice piece"
 	icon = 'icons/obj/stack_objects.dmi'
 	mats_per_unit = list(/datum/material/hot_ice=SHEET_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/toxin/hot_ice = 25)
 	material_type = /datum/material/hot_ice
 	merge_type = /obj/item/stack/sheet/hot_ice
+
+/obj/item/stack/sheet/hot_ice/grind_results()
+	return list(/datum/reagent/toxin/hot_ice = 25)
 
 /obj/item/stack/sheet/hot_ice/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins licking \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/game/objects/items/stacks/sheets/light.dm
+++ b/code/game/objects/items/stacks/sheets/light.dm
@@ -11,9 +11,11 @@
 	throw_range = 7
 	obj_flags = CONDUCTS_ELECTRICITY
 	max_amount = 60
-	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/copper = 5)
 	mats_per_unit = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 1.05, /datum/material/glass = SHEET_MATERIAL_AMOUNT * 1.05)
 	merge_type = /obj/item/stack/light_w
+
+/obj/item/stack/light_w/grind_results()
+	return list(/datum/reagent/silicon = 20, /datum/reagent/copper = 5)
 
 /obj/item/stack/light_w/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -104,7 +104,6 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	singular_name = "diamond"
 	construction_path_type = "diamond"
 	mats_per_unit = list(/datum/material/diamond=SHEET_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/carbon = 20)
 	gulag_valid = TRUE
 	merge_type = /obj/item/stack/sheet/mineral/diamond
 	material_type = /datum/material/diamond
@@ -114,6 +113,9 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 	new/datum/stack_recipe("diamond door", /obj/structure/mineral_door/transparent/diamond, 10, time = 5 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND, category = CAT_DOORS), \
 	new/datum/stack_recipe("diamond tile", /obj/item/stack/tile/mineral/diamond, 1, 4, 20, crafting_flags = NONE, category = CAT_TILES),  \
 	))
+
+/obj/item/stack/sheet/mineral/diamond/grind_results()
+	return list(/datum/reagent/carbon = 20)
 
 /obj/item/stack/sheet/mineral/diamond/get_main_recipes()
 	. = ..()
@@ -135,7 +137,6 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 	singular_name = "uranium sheet"
 	construction_path_type = "uranium"
 	mats_per_unit = list(/datum/material/uranium=SHEET_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/uranium = 20)
 	gulag_valid = TRUE
 	merge_type = /obj/item/stack/sheet/mineral/uranium
 	material_type = /datum/material/uranium
@@ -146,6 +147,9 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 	new/datum/stack_recipe("depleted uranium platform", /obj/structure/platform/uranium, 2, time = 3 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND, trait_booster = TRAIT_QUICK_BUILD, trait_modifier = 0.75, category = CAT_STRUCTURE), \
 	new/datum/stack_recipe("uranium tile", /obj/item/stack/tile/mineral/uranium, 1, 4, 20, crafting_flags = NONE, category = CAT_TILES), \
 	))
+
+/obj/item/stack/sheet/mineral/uranium/grind_results()
+	return list(/datum/reagent/uranium = 20)
 
 /obj/item/stack/sheet/mineral/uranium/get_main_recipes()
 	. = ..()
@@ -172,11 +176,13 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
 	mats_per_unit = list(/datum/material/plasma=SHEET_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/toxin/plasma = 20)
 	gulag_valid = TRUE
 	merge_type = /obj/item/stack/sheet/mineral/plasma
 	material_type = /datum/material/plasma
 	walltype = /turf/closed/wall/mineral/plasma
+
+/obj/item/stack/sheet/mineral/plasma/grind_results()
+	return list(/datum/reagent/toxin/plasma = 20)
 
 /obj/item/stack/sheet/mineral/plasma/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins licking \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -210,7 +216,6 @@ GLOBAL_LIST_INIT(plasma_recipes, list ( \
 	singular_name = "gold bar"
 	construction_path_type = "gold"
 	mats_per_unit = list(/datum/material/gold=SHEET_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/gold = 20)
 	gulag_valid = TRUE
 	merge_type = /obj/item/stack/sheet/mineral/gold
 	material_type = /datum/material/gold
@@ -223,6 +228,9 @@ GLOBAL_LIST_INIT(gold_recipes, list ( \
 	new/datum/stack_recipe("blank plaque", /obj/item/plaque, 1, crafting_flags = NONE, category = CAT_FURNITURE), \
 	new/datum/stack_recipe("Simple Crown", /obj/item/clothing/head/costume/crown, 5, crafting_flags = NONE, category = CAT_CLOTHING), \
 	))
+
+/obj/item/stack/sheet/mineral/gold/grind_results()
+	return list(/datum/reagent/gold = 20)
 
 /obj/item/stack/sheet/mineral/gold/get_main_recipes()
 	. = ..()
@@ -241,7 +249,6 @@ GLOBAL_LIST_INIT(gold_recipes, list ( \
 	singular_name = "silver bar"
 	construction_path_type = "silver"
 	mats_per_unit = list(/datum/material/silver=SHEET_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/silver = 20)
 	gulag_valid = TRUE
 	merge_type = /obj/item/stack/sheet/mineral/silver
 	material_type = /datum/material/silver
@@ -253,6 +260,9 @@ GLOBAL_LIST_INIT(silver_recipes, list ( \
 	new/datum/stack_recipe("silver platform", /obj/structure/platform/silver, 2, time = 3 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND, trait_booster = TRAIT_QUICK_BUILD, trait_modifier = 0.75, category = CAT_STRUCTURE), \
 	new/datum/stack_recipe("silver tile", /obj/item/stack/tile/mineral/silver, 1, 4, 20, crafting_flags = NONE, category = CAT_TILES), \
 	))
+
+/obj/item/stack/sheet/mineral/silver/grind_results()
+	return list(/datum/reagent/silver = 20)
 
 /obj/item/stack/sheet/mineral/silver/get_main_recipes()
 	. = ..()
@@ -271,7 +281,6 @@ GLOBAL_LIST_INIT(silver_recipes, list ( \
 	singular_name = "bananium sheet"
 	construction_path_type = "bananium"
 	mats_per_unit = list(/datum/material/bananium=SHEET_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/consumable/banana = 20)
 	gulag_valid = TRUE
 	merge_type = /obj/item/stack/sheet/mineral/bananium
 	material_type = /datum/material/bananium
@@ -280,6 +289,9 @@ GLOBAL_LIST_INIT(silver_recipes, list ( \
 GLOBAL_LIST_INIT(bananium_recipes, list ( \
 	new/datum/stack_recipe("bananium tile", /obj/item/stack/tile/mineral/bananium, 1, 4, 20, crafting_flags = NONE, category = CAT_TILES), \
 	))
+
+/obj/item/stack/sheet/mineral/bananium/grind_results()
+	return list(/datum/reagent/consumable/banana = 20)
 
 /obj/item/stack/sheet/mineral/bananium/get_main_recipes()
 	. = ..()
@@ -385,7 +397,6 @@ GLOBAL_LIST_INIT(plastitanium_recipes, list ( \
 	singular_name = "snow block"
 	force = 1
 	throwforce = 2
-	grind_results = list(/datum/reagent/consumable/ice = 20)
 	merge_type = /obj/item/stack/sheet/mineral/snow
 	walltype = /turf/closed/wall/mineral/snow
 	material_type = /datum/material/snow
@@ -402,6 +413,9 @@ GLOBAL_LIST_INIT(snow_recipes, list ( \
 /obj/item/stack/sheet/mineral/snow/Initialize(mapload, new_amount, merge, list/mat_override, mat_amt)
 	. = ..()
 	AddComponent(/datum/component/storm_hating)
+
+/obj/item/stack/sheet/mineral/snow/grind_results()
+	return list(/datum/reagent/consumable/ice = 20)
 
 /obj/item/stack/sheet/mineral/snow/get_main_recipes()
 	. = ..()
@@ -497,8 +511,10 @@ GLOBAL_LIST_INIT(abductor_recipes, list ( \
 	icon_state = "slag"
 	singular_name = "coal lump"
 	merge_type = /obj/item/stack/sheet/mineral/coal
-	grind_results = list(/datum/reagent/carbon = 20)
 	novariants = TRUE
+
+/obj/item/stack/sheet/mineral/coal/grind_results()
+	return list(/datum/reagent/carbon = 20)
 
 /obj/item/stack/sheet/mineral/coal/attackby(obj/item/W, mob/user, list/modifiers, list/attack_modifiers)
 	if(W.get_temperature() > 300)//If the temperature of the object is over 300, then ignite

--- a/code/game/objects/items/stacks/sheets/runed_metal.dm
+++ b/code/game/objects/items/stacks/sheets/runed_metal.dm
@@ -77,10 +77,12 @@ GLOBAL_LIST_INIT(runed_metal_recipes, list( \
 	mats_per_unit = list(/datum/material/runedmetal = SHEET_MATERIAL_AMOUNT)
 	construction_path_type = "runed"
 	merge_type = /obj/item/stack/sheet/runed_metal
-	grind_results = list(/datum/reagent/iron = 5, /datum/reagent/blood = 15)
 	material_type = /datum/material/runedmetal
 	has_unique_girder = TRUE
 	use_radial = TRUE
+
+/obj/item/stack/sheet/runed_metal/grind_results()
+	return list(/datum/reagent/iron = 5, /datum/reagent/blood = 15)
 
 /obj/item/stack/sheet/runed_metal/interact(mob/user)
 	if(!IS_CULTIST(user))

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -169,7 +169,6 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	obj_flags = CONDUCTS_ELECTRICITY
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/iron
-	grind_results = list(/datum/reagent/iron = 20)
 	gulag_valid = TRUE
 	table_type = /obj/structure/table
 	material_type = /datum/material/iron
@@ -188,6 +187,9 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 		),
 	)
 	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
+
+/obj/item/stack/sheet/iron/grind_results()
+	return list(/datum/reagent/iron = 20)
 
 /obj/item/stack/sheet/iron/examine(mob/user)
 	. = ..()
@@ -317,7 +319,6 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	armor_type = /datum/armor/sheet_plasteel
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/plasteel
-	grind_results = list(/datum/reagent/iron = 20, /datum/reagent/toxin/plasma = 20)
 	gulag_valid = TRUE
 	table_type = /obj/structure/table/reinforced
 	material_flags = NONE
@@ -326,6 +327,9 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 /datum/armor/sheet_plasteel
 	fire = 100
 	acid = 80
+
+/obj/item/stack/sheet/plasteel/grind_results()
+	return list(/datum/reagent/iron = 20, /datum/reagent/toxin/plasma = 20)
 
 /obj/item/stack/sheet/plasteel/get_main_recipes()
 	. = ..()
@@ -415,7 +419,6 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/sheet/mineral/wood
 	material_type = /datum/material/wood
-	grind_results = list(/datum/reagent/cellulose = 20) //no lignocellulose or lignin reagents yet,
 	walltype = /turf/closed/wall/mineral/wood
 	stairs_type = /obj/structure/stairs/wood
 	pickup_sound = 'sound/items/handling/materials/wood_pick_up.ogg'
@@ -423,6 +426,9 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 
 /datum/armor/mineral_wood
 	fire = 50
+
+/obj/item/stack/sheet/mineral/wood/grind_results()
+	return list(/datum/reagent/cellulose = 20)
 
 /obj/item/stack/sheet/mineral/wood/get_main_recipes()
 	. = ..()
@@ -481,7 +487,6 @@ GLOBAL_LIST_INIT(bamboo_recipes, list ( \
 	armor_type = /datum/armor/mineral_bamboo
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/sheet/mineral/bamboo
-	grind_results = list(/datum/reagent/cellulose = 10)
 	material_type = /datum/material/bamboo
 	walltype = /turf/closed/wall/mineral/bamboo
 	drop_sound = null
@@ -489,6 +494,9 @@ GLOBAL_LIST_INIT(bamboo_recipes, list ( \
 
 /datum/armor/mineral_bamboo
 	fire = 50
+
+/obj/item/stack/sheet/mineral/bamboo/grind_results()
+	return list(/datum/reagent/cellulose = 10)
 
 /obj/item/stack/sheet/mineral/bamboo/get_main_recipes()
 	. = ..()
@@ -551,9 +559,11 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/cloth
 	drop_sound = 'sound/items/handling/cloth/cloth_drop1.ogg'
 	pickup_sound = 'sound/items/handling/cloth/cloth_pickup1.ogg'
-	grind_results = list(/datum/reagent/cellulose = 20)
 	pickup_sound = SFX_CLOTH_PICKUP
 	drop_sound = SFX_CLOTH_DROP
+
+/obj/item/stack/sheet/cloth/grind_results()
+	return list(/datum/reagent/cellulose = 20)
 
 /obj/item/stack/sheet/cloth/get_main_recipes()
 	. = ..()
@@ -611,15 +621,18 @@ GLOBAL_LIST_INIT(durathread_recipes, list ( \
 	force = 0
 	throwforce = 0
 	merge_type = /obj/item/stack/sheet/cotton
-	grind_results = list(/datum/reagent/cellulose = 20)
-	var/loom_result = /obj/item/stack/sheet/cloth
-	var/loom_time = 1 SECONDS
 	drop_sound = 'sound/items/handling/cloth/cloth_drop1.ogg'
 	pickup_sound = 'sound/items/handling/cloth/cloth_pickup1.ogg'
+
+	var/loom_result = /obj/item/stack/sheet/cloth
+	var/loom_time = 1 SECONDS
 
 /obj/item/stack/sheet/cotton/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/loomable, resulting_atom = loom_result, loom_time = loom_time)
+
+/obj/item/stack/sheet/cotton/grind_results()
+	return list(/datum/reagent/cellulose = 20)
 
 /obj/item/stack/sheet/cotton/durathread
 	name = "raw durathread bundle"
@@ -707,7 +720,7 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	null, \
 ))
 
-/obj/item/stack/sheet/cardboard //BubbleWrap //it's cardboard you fuck
+/obj/item/stack/sheet/cardboard
 	name = "cardboard"
 	desc = "Large sheets of card, like boxes folded flat."
 	singular_name = "cardboard sheet"
@@ -718,7 +731,6 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	force = 0
 	throwforce = 0
 	merge_type = /obj/item/stack/sheet/cardboard
-	grind_results = list(/datum/reagent/cellulose = 10)
 	material_type = /datum/material/cardboard
 	pickup_sound = 'sound/items/handling/materials/cardboard_pick_up.ogg'
 	drop_sound = 'sound/items/handling/materials/cardboard_drop.ogg'
@@ -731,6 +743,9 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 		/datum/element/slapcrafting,\
 		slapcraft_recipes = slapcraft_recipe_list,\
 	)
+
+/obj/item/stack/sheet/cardboard/grind_results()
+	return list(/datum/reagent/cellulose = 10)
 
 /obj/item/stack/sheet/cardboard/get_main_recipes()
 	. = ..()
@@ -794,12 +809,14 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	throw_speed = 1
 	throw_range = 3
 	novariants = FALSE
-	grind_results = list(/datum/reagent/iron = 20, /datum/reagent/copper = 12) //we have no "tin" reagent so this is the closest thing
 	merge_type = /obj/item/stack/sheet/bronze
 	table_type = /obj/structure/table/bronze
 	material_type = /datum/material/bronze
 	walltype = /turf/closed/wall/mineral/bronze
 	has_unique_girder = TRUE
+
+/obj/item/stack/sheet/bronze/grind_results()
+	return list(/datum/reagent/iron = 20, /datum/reagent/copper = 12)
 
 /obj/item/stack/sheet/bronze/get_main_recipes()
 	. = ..()
@@ -846,7 +863,6 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 1
 	throw_range = 3
-	grind_results = list(/datum/reagent/carbon = 10)
 	merge_type = /obj/item/stack/sheet/bone
 	material_type = /datum/material/bone
 	drop_sound = null
@@ -871,6 +887,10 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 		/datum/element/slapcrafting,\
 		slapcraft_recipes = slapcraft_recipe_list,\
 	)
+
+/obj/item/stack/sheet/bone/grind_results()
+	return list(/datum/reagent/carbon = 10)
+
 GLOBAL_LIST_INIT(plastic_recipes, list(
 	new /datum/stack_recipe("plastic floor tile", /obj/item/stack/tile/plastic, 1, 4, 20, time = 2 SECONDS, crafting_flags = NONE, category = CAT_TILES), \
 	new /datum/stack_recipe("light tram tile", /obj/item/stack/thermoplastic/light, 1, 4, 20, time = 2 SECONDS, crafting_flags = NONE, category = CAT_TILES), \
@@ -926,10 +946,12 @@ GLOBAL_LIST_INIT(paperframe_recipes, list(
 	mats_per_unit = list(/datum/material/paper = SHEET_MATERIAL_AMOUNT)
 	merge_type = /obj/item/stack/sheet/paperframes
 	resistance_flags = FLAMMABLE
-	grind_results = list(/datum/reagent/cellulose = 20)
 	material_type = /datum/material/paper
 	drop_sound = null
 	pickup_sound = null
+
+/obj/item/stack/sheet/paperframes/grind_results()
+	return list(/datum/reagent/cellulose = 20)
 
 /obj/item/stack/sheet/paperframes/get_main_recipes()
 	. = ..()
@@ -998,7 +1020,9 @@ GLOBAL_LIST_INIT(pizza_sheet_recipes, list(
 	merge_type = /obj/item/stack/sheet/hauntium
 	material_type = /datum/material/hauntium
 	material_modifier = 1 //None of that wussy stuff
-	grind_results = list(/datum/reagent/hauntium = 20)
+
+/obj/item/stack/sheet/hauntium/grind_results()
+	return list(/datum/reagent/hauntium = 20)
 
 /obj/item/stack/sheet/hauntium/fifty
 	amount = 50

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -176,14 +176,16 @@
 	if(current_amount <= 0 || QDELETED(src)) //just to get rid of this 0 amount/deleted stack we return success
 		return TRUE
 
+	var/list/grind_reagents = grind_results()
+
 	if(reagents)
 		reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
 	var/available_volume = target_holder.maximum_volume - target_holder.total_volume
 
 	//compute total volume of reagents that will be occupied by grind_results
 	var/total_volume = 0
-	for(var/reagent in grind_results)
-		total_volume += grind_results[reagent]
+	for(var/reagent in grind_reagents)
+		total_volume += grind_reagents[reagent]
 
 	//compute number of pieces(or sheets) from available_volume
 	var/available_amount = min(current_amount, round(available_volume / total_volume))
@@ -191,7 +193,6 @@
 		return FALSE
 
 	//Now transfer the grind results scaled by available_amount
-	var/list/grind_reagents = LAZYCOPY(grind_results)
 	for(var/reagent in grind_reagents)
 		grind_reagents[reagent] *= available_amount
 	target_holder.add_reagent_list(grind_reagents)

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -12,20 +12,23 @@
 	amount = 5
 	max_amount = 5
 	resistance_flags = FLAMMABLE
-	grind_results = list(/datum/reagent/cellulose = 5)
 	splint_factor = 0.65
 	merge_type = /obj/item/stack/sticky_tape
+	greyscale_config = /datum/greyscale_config/tape
+	greyscale_colors = "#B2B2B2#BD6A62"
+
 	var/conferred_embed = /datum/embedding/sticky_tape
 	///The tape type you get when ripping off a piece of tape.
 	var/obj/tape_gag = /obj/item/clothing/mask/muzzle/tape
-	greyscale_config = /datum/greyscale_config/tape
-	greyscale_colors = "#B2B2B2#BD6A62"
 
 /datum/embedding/sticky_tape
 	pain_mult = 0
 	jostle_pain_mult = 0
 	ignore_throwspeed_threshold = TRUE
 	immune_traits = null
+
+/obj/item/stack/sticky_tape/grind_results()
+	return list(/datum/reagent/cellulose = 5)
 
 /obj/item/stack/sticky_tape/attack_hand(mob/user, list/modifiers)
 	if(user.get_inactive_held_item() == src)

--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -93,8 +93,10 @@
 	amount = 25
 	max_amount = 25
 	resistance_flags = FLAMMABLE
-	grind_results = list(/datum/reagent/cellulose = 5)
 	merge_type = /obj/item/stack/package_wrap
+
+/obj/item/stack/package_wrap/grind_results()
+	return list(/datum/reagent/cellulose = 5)
 
 /obj/item/stack/package_wrap/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins wrapping [user.p_them()]self in \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/game/objects/items/storage/boxes/food_boxes.dm
+++ b/code/game/objects/items/storage/boxes/food_boxes.dm
@@ -379,7 +379,6 @@
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	item_flags = NOBLUDGEON|SKIP_FANTASY_ON_SPAWN
-	grind_results = list(/datum/reagent/aluminium = 1)
 
 	///The typepath of the type of gum that will spawn in our PopulateContents,
 	///this is set in Initialize by the gum box if there is one.
@@ -393,6 +392,9 @@
 	atom_storage.max_slots = 1
 	atom_storage.display_contents = FALSE
 	update_appearance(UPDATE_OVERLAYS)
+
+/obj/item/storage/bubblegum_wrapper/grind_results()
+	return list(/datum/reagent/aluminium = 1)
 
 /obj/item/storage/bubblegum_wrapper/PopulateContents()
 	new gum_to_spawn(src)

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -319,8 +319,10 @@
 	desc = "May or may not contain traces of lead."
 	icon_state = "medkit_tactical_premium"
 	inhand_icon_state = "medkit-tactical-premium"
-	grind_results = list(/datum/reagent/lead = 10)
 	storage_type = /datum/storage/medkit/tactical/premium
+
+/obj/item/storage/medkit/tactical/premium/grind_results()
+	return list(/datum/reagent/lead = 10)
 
 /obj/item/storage/medkit/tactical/premium/PopulateContents()
 	if(empty)

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -46,7 +46,9 @@
 /obj/item/trash/boritos
 	name = "boritos bag"
 	icon_state = "boritos"
-	grind_results = list(/datum/reagent/aluminium = 1) //from the mylar bag
+
+/obj/item/trash/boritos/grind_results()
+	return list(/datum/reagent/aluminium = 1)
 
 /obj/item/trash/boritos/green
 	icon_state = "boritosgreen"
@@ -130,8 +132,10 @@
 	name = "crushed can"
 	icon_state = "cola"
 	resistance_flags = NONE
-	grind_results = list(/datum/reagent/aluminium = 10)
 	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*2)
+
+/obj/item/trash/can/grind_results()
+	return list(/datum/reagent/aluminium = 10)
 
 /obj/item/trash/can/food
 	icon = 'icons/obj/food/canned.dmi'

--- a/code/game/objects/items/wall_mounted.dm
+++ b/code/game/objects/items/wall_mounted.dm
@@ -118,8 +118,10 @@
 	obj_flags = CONDUCTS_ELECTRICITY
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron= SMALL_MATERIAL_AMOUNT * 0.5, /datum/material/glass= SMALL_MATERIAL_AMOUNT * 0.5)
-	grind_results = list(/datum/reagent/iron = 10, /datum/reagent/silicon = 10)
 	custom_price = PAYCHECK_CREW * 0.5
 	sound_vary = TRUE
 	pickup_sound = SFX_GENERIC_DEVICE_PICKUP
 	drop_sound = SFX_GENERIC_DEVICE_DROP
+
+/obj/item/electronics/grind_results()
+	return list(/datum/reagent/iron = 10, /datum/reagent/silicon = 10)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -849,7 +849,9 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	gender = PLURAL
 	icon = 'icons/effects/magic.dmi'
 	icon_state = "ectoplasm"
-	grind_results = list(/datum/reagent/hauntium = 25) //can be ground into hauntium
+
+/obj/item/ectoplasm/grind_results()
+	return list(/datum/reagent/hauntium = 25)
 
 /obj/item/ectoplasm/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is inhaling [src]! It looks like [user.p_theyre()] trying to visit the astral plane!"))

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -24,7 +24,6 @@
 	var/theme = THEME_CULT
 	/// Role check, if any needed
 	var/required_role = /datum/antagonist/cult
-	grind_results = list(/datum/reagent/hauntium = 25, /datum/reagent/silicon = 10) //can be ground into hauntium
 
 /obj/item/soulstone/Initialize(mapload)
 	. = ..()
@@ -32,6 +31,9 @@
 		RegisterSignal(src, COMSIG_BIBLE_SMACKED, PROC_REF(on_bible_smacked))
 	if(!base_name)
 		base_name = initial(name)
+
+/obj/item/soulstone/grind_results()
+	return list(/datum/reagent/hauntium = 25, /datum/reagent/silicon = 10) //can be ground into hauntium
 
 /obj/item/soulstone/update_appearance(updates)
 	. = ..()

--- a/code/modules/economy/poker_chips.dm
+++ b/code/modules/economy/poker_chips.dm
@@ -5,9 +5,11 @@
 	icon_state = "pokerchip_white_black"
 	w_class = WEIGHT_CLASS_TINY
 	custom_materials = list(/datum/material/plastic = COIN_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/plastic_polymers = COIN_MATERIAL_AMOUNT * 0.2)
 	///How much credit this chip is worth when redeemed
 	var/redeem_value = 0
+
+/obj/item/poker_chip/grind_results()
+	return list(/datum/reagent/plastic_polymers = COIN_MATERIAL_AMOUNT * 0.2)
 
 /obj/item/poker_chip/get_item_credit_value()
 	return redeem_value

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -249,6 +249,20 @@ GLOBAL_LIST_INIT(fish_compatible_fluid_types, list(
 		stack_trace("[type] has a stable_population of [stable_population] but has neither of these traits: [english_list(pick_one)]. \
 			Either increase its stable population or add one of these traits to it.")
 
+/obj/item/fish/grind_results()
+	SHOULD_NOT_OVERRIDE(TRUE)
+
+	var/list/grind_results = fish_grind_results()
+	for(var/reagent_type in grind_results)
+		grind_results[reagent_type] *= max(FLOOR(weight/FISH_GRIND_RESULTS_WEIGHT_DIVISOR, 0.1), 0.1)
+
+	return grind_results
+
+/obj/item/fish/proc/fish_grind_results()
+	RETURN_TYPE(/list/datum/reagent)
+
+	return list()
+
 /obj/item/fish/suicide_act(mob/living/user)
 	if(force == 0)
 		user.visible_message(span_suicide("[user] slaps [user.p_them()]self with [src], but nothing happens!"))
@@ -651,8 +665,6 @@ GLOBAL_LIST_INIT(fish_compatible_fluid_types, list(
 
 	var/make_edible = !weight
 	if(weight)
-		for(var/reagent_type in grind_results)
-			grind_results[reagent_type] /= max(FLOOR(weight/FISH_GRIND_RESULTS_WEIGHT_DIVISOR, 0.1), 0.1)
 		if(reagents) //This fish has reagents. Adjust the maximum volume of the reagent holder and do some math to adjut the reagents too.
 			var/new_weight_ratio = new_weight / weight
 			var/volume_diff = reagents.maximum_volume * new_weight_ratio - reagents.maximum_volume
@@ -683,9 +695,6 @@ GLOBAL_LIST_INIT(fish_compatible_fluid_types, list(
 	if(ismob(loc))
 		var/mob/mob = loc
 		mob.update_equipment_speed_mods()
-
-	for(var/reagent_type in grind_results)
-		grind_results[reagent_type] *= max(FLOOR(weight/FISH_GRIND_RESULTS_WEIGHT_DIVISOR, 0.1), 0.1)
 
 	var/mats_len = length(custom_materials)
 	if(update_materials && mats_len)

--- a/code/modules/fishing/fish/types/air_space.dm
+++ b/code/modules/fishing/fish/types/air_space.dm
@@ -87,7 +87,6 @@
 	safe_air_limits = null
 	min_pressure = 0
 	max_pressure = INFINITY
-	grind_results = list(/datum/reagent/bluespace = 10)
 	fillet_type = null
 	fish_traits = list(/datum/fish_trait/antigrav, /datum/fish_trait/mixotroph)
 	compatible_types = list(/obj/item/fish/starfish/chrystarfish)
@@ -96,6 +95,9 @@
 /obj/item/fish/starfish/Initialize(mapload, apply_qualities = TRUE)
 	. = ..()
 	update_appearance(UPDATE_OVERLAYS)
+
+/obj/item/fish/starfish/fish_grind_results()
+	return list(/datum/reagent/bluespace = 10)
 
 /obj/item/fish/starfish/update_overlays()
 	. = ..()

--- a/code/modules/fishing/fish/types/mining.dm
+++ b/code/modules/fishing/fish/types/mining.dm
@@ -126,7 +126,6 @@
 	min_pressure = HAZARD_LOW_PRESSURE
 	max_integrity = 300
 	stable_population = 3
-	grind_results = list(/datum/reagent/bone_dust = 10)
 	fillet_type = /obj/item/stack/sheet/bone
 	num_fillets = 2
 	fish_traits = list(/datum/fish_trait/revival, /datum/fish_trait/carnivore)
@@ -139,6 +138,9 @@
 /obj/item/fish/boned/Initialize(mapload, apply_qualities = TRUE)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_FISH_MADE_OF_BONE, INNATE_TRAIT)
+
+/obj/item/fish/boned/fish_grind_results()
+	return list(/datum/reagent/bone_dust = 10)
 
 /obj/item/fish/boned/make_edible(weight_val)
 	return //it's all bones and no meat.

--- a/code/modules/fishing/fish/types/ruins.dm
+++ b/code/modules/fishing/fish/types/ruins.dm
@@ -16,7 +16,6 @@
 	min_pressure = HAZARD_LOW_PRESSURE
 	max_integrity = 600
 	stable_population = 2
-	grind_results = list(/datum/reagent/bone_dust = 5, /datum/reagent/consumable/liquidgibs = 5)
 	fillet_type = /obj/item/stack/sheet/bone
 	num_fillets = 2
 	feeding_frequency = 2 MINUTES
@@ -30,6 +29,9 @@
 /obj/item/fish/mastodon/Initialize(mapload, apply_qualities = TRUE)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_FISH_MADE_OF_BONE, INNATE_TRAIT)
+
+/obj/item/fish/mastodon/fish_grind_results()
+	return list(/datum/reagent/bone_dust = 5, /datum/reagent/consumable/liquidgibs = 5)
 
 /obj/item/fish/mastodon/make_edible(weight_val)
 	return //it's all bones and gibs.

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -142,6 +142,8 @@
 
 /obj/item/food/grown/grind_atom(datum/reagents/target_holder, mob/user)
 	var/list/grind_reagents = grind_results()
+	for(var/datum/reagent/result as anything in grind_reagents)
+		grind_reagents[result] = round(seed.potency)
 
 	var/grind_results_num = length(grind_reagents)
 	if(grind_results_num)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -141,13 +141,15 @@
 		reagents.del_reagent(reagent.type)
 
 /obj/item/food/grown/grind_atom(datum/reagents/target_holder, mob/user)
-	var/grind_results_num = LAZYLEN(grind_results)
+	var/list/grind_reagents = grind_results()
+
+	var/grind_results_num = length(grind_reagents)
 	if(grind_results_num)
 		var/average_purity = reagents.get_average_purity()
 		var/total_nutriment_amount = reagents.get_reagent_amount(/datum/reagent/consumable/nutriment, type_check = REAGENT_SUB_TYPE)
 		var/single_reagent_amount = grind_results_num > 1 ? round(total_nutriment_amount / grind_results_num, CHEMICAL_QUANTISATION_LEVEL) : total_nutriment_amount
 		reagents.remove_reagent(/datum/reagent/consumable/nutriment, total_nutriment_amount, include_subtypes = TRUE)
-		for(var/reagent in grind_results)
+		for(var/reagent in grind_reagents)
 			reagents.add_reagent(reagent, single_reagent_amount, added_purity = average_purity)
 
 	return reagents?.trans_to(target_holder, reagents.total_volume, transferred_by = user)

--- a/code/modules/hydroponics/grown/aloe.dm
+++ b/code/modules/hydroponics/grown/aloe.dm
@@ -23,8 +23,10 @@
 	icon_state = "aloe"
 	bite_consumption_mod = 3
 	foodtypes = VEGETABLES
-	juice_typepath = /datum/reagent/consumable/aloejuice
 	distill_reagent = /datum/reagent/consumable/ethanol/tequila
+
+/obj/item/food/grown/aloe/juice_typepath()
+	return /datum/reagent/consumable/aloejuice
 
 /obj/item/food/grown/aloe/make_bakeable()
 	AddComponent(/datum/component/bakeable, /obj/item/stack/medical/aloe/fresh, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE)

--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -22,9 +22,11 @@
 	desc = "It's a little piece of Eden."
 	icon_state = "apple"
 	foodtypes = FRUIT
-	juice_typepath = /datum/reagent/consumable/applejuice
 	tastes = list("apple" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/hcider
+
+/obj/item/food/grown/apple/juice_typepath()
+	return /datum/reagent/consumable/applejuice
 
 /obj/item/food/grown/apple/make_processable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/appleslice, 5, 20, screentip_verb = "Slice", sound_to_play = SFX_KNIFE_SLICE)

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -25,8 +25,10 @@
 	trash_type = /obj/item/grown/bananapeel
 	bite_consumption_mod = 3
 	foodtypes = FRUIT
-	juice_typepath = /datum/reagent/consumable/banana
 	distill_reagent = /datum/reagent/consumable/ethanol/bananahonk
+
+/obj/item/food/grown/banana/juice_typepath()
+	return /datum/reagent/consumable/banana
 
 /obj/item/food/grown/banana/make_edible()
 	. = ..()
@@ -42,12 +44,6 @@
 	var/obj/item/organ/liver/liver = consumer.get_organ_slot(ORGAN_SLOT_LIVER)
 	if (!HAS_TRAIT(consumer, TRAIT_AGEUSIA) && liver && HAS_TRAIT(liver, TRAIT_COMEDY_METABOLISM))
 		return FOOD_LIKED
-
-/obj/item/food/grown/banana/generate_trash(atom/location)
-	. = ..()
-	var/obj/item/grown/bananapeel/peel = .
-	if(istype(peel))
-		peel.grind_results = list(/datum/reagent/medicine/coagulant/banana_peel = peel.seed.potency * 0.2)
 
 /obj/item/food/grown/banana/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is aiming [src] at [user.p_them()]self! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -83,6 +79,9 @@
 			icon_state = "[icon_state]_2"
 		else
 			icon_state = "[icon_state]_3"
+
+/obj/item/grown/bananapeel/grind_results()
+	return list(/datum/reagent/medicine/coagulant/banana_peel = seed.potency * 0.2)
 
 /obj/item/grown/bananapeel/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is deliberately slipping on [src]! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/hydroponics/grown/beans.dm
+++ b/code/modules/hydroponics/grown/beans.dm
@@ -24,9 +24,11 @@
 	gender = PLURAL
 	icon_state = "soybeans"
 	foodtypes = VEGETABLES
-	juice_typepath = /datum/reagent/consumable/soymilk
 	tastes = list("soy" = 1)
 	distill_reagent = /datum/reagent/consumable/soysauce
+
+/obj/item/food/grown/soybeans/juice_typepath()
+	return /datum/reagent/consumable/soymilk
 
 // Koibean
 /obj/item/seeds/soya/koi

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -25,9 +25,11 @@
 	icon_state = "berrypile"
 	gender = PLURAL
 	foodtypes = FRUIT
-	juice_typepath = /datum/reagent/consumable/berryjuice
 	tastes = list("berry" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/gin
+
+/obj/item/food/grown/berries/juice_typepath()
+	return /datum/reagent/consumable/berryjuice
 
 // Poison Berries
 /obj/item/seeds/berry/poison
@@ -48,10 +50,12 @@
 	icon_state = "poisonberrypile"
 	bite_consumption_mod = 3
 	foodtypes = FRUIT | TOXIC
-	juice_typepath = /datum/reagent/consumable/poisonberryjuice
 	tastes = list("poison-berry" = 1)
 	distill_reagent = null
 	wine_power = 35
+
+/obj/item/food/grown/berries/poison/juice_typepath()
+	return /datum/reagent/consumable/poisonberryjuice
 
 // Death Berries
 /obj/item/seeds/berry/death
@@ -74,10 +78,12 @@
 	icon_state = "deathberrypile"
 	bite_consumption_mod = 3
 	foodtypes = FRUIT | TOXIC
-	juice_typepath = /datum/reagent/consumable/poisonberryjuice
 	tastes = list("death-berry" = 1)
 	distill_reagent = null
 	wine_power = 50
+
+/obj/item/food/grown/berries/death/juice_typepath()
+	return /datum/reagent/consumable/poisonberryjuice
 
 // Glow Berries
 /obj/item/seeds/berry/glow
@@ -134,9 +140,11 @@
 	icon_state = "grapes"
 	bite_consumption_mod = 2
 	foodtypes = FRUIT
-	juice_typepath = /datum/reagent/consumable/grapejuice
 	tastes = list("grape" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/wine
+
+/obj/item/food/grown/grapes/juice_typepath()
+	return /datum/reagent/consumable/grapejuice
 
 /obj/item/food/grown/grapes/make_dryable()
 	AddElement(/datum/element/dryable, /obj/item/food/no_raisin/healthy)
@@ -185,9 +193,11 @@
 	desc = "A branch with töchtaüse berries on it. They're a favourite on the Mothic Fleet, but not in this form."
 	icon_state = "toechtauese_branch"
 	foodtypes = FRUIT
-	juice_typepath = /datum/reagent/consumable/toechtauese_juice
 	tastes = list("fiery itchy pain" = 1)
 	distill_reagent = /datum/reagent/toxin/itching_powder
+
+/obj/item/food/grown/toechtauese/juice_typepath()
+	return /datum/reagent/consumable/toechtauese_juice
 
 /obj/item/seeds/lanternfruit
 	name = "lanternfruit seed pack"

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -22,11 +22,13 @@
 	icon_state = "wheat"
 	bite_consumption_mod = 0.5 // Chewing on wheat grains?
 	foodtypes = GRAIN
-	grind_results = list(/datum/reagent/consumable/flour = 0)
 	tastes = list("wheat" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/beer
 	slot_flags = ITEM_SLOT_MASK
 	worn_icon = 'icons/mob/clothing/head/hydroponics.dmi'
+
+/obj/item/food/grown/wheat/grind_results()
+	return list(/datum/reagent/consumable/flour = 0)
 
 // Oat
 /obj/item/seeds/wheat/oat
@@ -46,9 +48,11 @@
 	icon_state = "oat"
 	bite_consumption_mod = 0.5
 	foodtypes = GRAIN
-	grind_results = list(/datum/reagent/consumable/flour = 0)
 	tastes = list("oat" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/ale
+
+/obj/item/food/grown/oat/grind_results()
+	return list(/datum/reagent/consumable/flour = 0)
 
 // Rice
 /obj/item/seeds/wheat/rice
@@ -72,9 +76,11 @@
 	icon_state = "rice"
 	bite_consumption_mod = 0.5
 	foodtypes = GRAIN
-	grind_results = list(/datum/reagent/consumable/rice = 0)
 	tastes = list("rice" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/sake
+
+/obj/item/food/grown/rice/grind_results()
+	return list(/datum/reagent/consumable/rice = 0)
 
 //Meatwheat - grows into synthetic meat
 /obj/item/seeds/wheat/meat
@@ -94,11 +100,13 @@
 	bite_consumption_mod = 0.5
 	seed = /obj/item/seeds/wheat/meat
 	foodtypes = MEAT
-	grind_results = list(/datum/reagent/consumable/flour = 0, /datum/reagent/blood = 0)
 	tastes = list("meatwheat" = 1)
 	can_distill = FALSE
 	slot_flags = ITEM_SLOT_MASK
 	worn_icon = 'icons/mob/clothing/head/hydroponics.dmi'
+
+/obj/item/food/grown/meatwheat/grind_results()
+	return list(/datum/reagent/consumable/flour = 0, /datum/reagent/blood = 0)
 
 /obj/item/food/grown/meatwheat/attack_self(mob/living/user)
 	user.visible_message(span_notice("[user] crushes [src] into meat."), span_notice("You crush [src] into something that resembles meat."))

--- a/code/modules/hydroponics/grown/cherries.dm
+++ b/code/modules/hydroponics/grown/cherries.dm
@@ -28,9 +28,11 @@
 	gender = PLURAL
 	bite_consumption_mod = 2
 	foodtypes = FRUIT
-	grind_results = list(/datum/reagent/consumable/cherryjelly = 0)
 	tastes = list("cherry" = 1)
 	wine_power = 30
+
+/obj/item/food/grown/cherries/grind_results()
+	return list(/datum/reagent/consumable/cherryjelly = 0)
 
 // Blue Cherries
 /obj/item/seeds/cherry/blue
@@ -51,9 +53,11 @@
 	icon_state = "bluecherry"
 	bite_consumption_mod = 2
 	foodtypes = FRUIT
-	grind_results = list(/datum/reagent/consumable/bluecherryjelly = 0)
 	tastes = list("blue cherry" = 1)
 	wine_power = 50
+
+/obj/item/food/grown/bluecherries/grind_results()
+	return list(/datum/reagent/consumable/bluecherryjelly = 0)
 
 //Cherry Bulbs
 /obj/item/seeds/cherry/bulb
@@ -76,9 +80,11 @@
 	icon_state = "cherry_bulb"
 	bite_consumption_mod = 2
 	foodtypes = FRUIT
-	grind_results = list(/datum/reagent/consumable/cherryjelly = 0)
 	tastes = list("cherry" = 1)
 	wine_power = 50
+
+/obj/item/food/grown/cherrybulbs/grind_results()
+	return list(/datum/reagent/consumable/cherryjelly = 0)
 
 //Cherry Bombs
 /obj/item/seeds/cherry/bomb

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -30,7 +30,9 @@
 	name = "lime"
 	desc = "It's so sour, your face will twist."
 	icon_state = "lime"
-	juice_typepath = /datum/reagent/consumable/limejuice
+
+/obj/item/food/grown/citrus/lime/juice_typepath()
+	return /datum/reagent/consumable/limejuice
 
 // Orange
 /obj/item/seeds/orange
@@ -57,8 +59,10 @@
 	desc = "It's a tangy fruit."
 	icon_state = "orange"
 	foodtypes = ORANGES | FRUIT
-	juice_typepath = /datum/reagent/consumable/orangejuice
 	distill_reagent = /datum/reagent/consumable/ethanol/triple_sec
+
+/obj/item/food/grown/citrus/orange/juice_typepath()
+	return /datum/reagent/consumable/orangejuice
 
 // Lemon
 /obj/item/seeds/lemon
@@ -83,7 +87,9 @@
 	name = "lemon"
 	desc = "When life gives you lemons, make lemonade."
 	icon_state = "lemon"
-	juice_typepath = /datum/reagent/consumable/lemonjuice
+
+/obj/item/food/grown/citrus/lemon/juice_typepath()
+	return /datum/reagent/consumable/lemonjuice
 
 // Combustible lemon
 /obj/item/seeds/firelemon //combustible lemon is too long so firelemon
@@ -138,9 +144,11 @@
 	foodtypes = ORANGES
 	alt_icon = "orange"
 	bite_consumption_mod = 2
-	juice_typepath = /datum/reagent/consumable/orangejuice
 	distill_reagent = /datum/reagent/toxin/mindbreaker
 	tastes = list("polygons" = 1, "bluespace" = 1, "the true nature of reality" = 1)
+
+/obj/item/food/grown/citrus/orange_3d/juice_typepath()
+	return /datum/reagent/consumable/orangejuice
 
 /obj/item/food/grown/citrus/orange_3d/pickup(mob/user)
 	. = ..()

--- a/code/modules/hydroponics/grown/cocoa_vanilla.dm
+++ b/code/modules/hydroponics/grown/cocoa_vanilla.dm
@@ -80,9 +80,11 @@
 	bite_consumption_mod = 2
 	trash_type = /obj/item/food/grown/bungopit
 	foodtypes = FRUIT
-	juice_typepath = /datum/reagent/consumable/bungojuice
 	tastes = list("bungo" = 2, "tropical fruitiness" = 1)
 	distill_reagent = null
+
+/obj/item/food/grown/bungofruit/juice_typepath()
+	return /datum/reagent/consumable/bungojuice
 
 /obj/item/food/grown/bungopit
 	seed = /obj/item/seeds/cocoapod/bungotree

--- a/code/modules/hydroponics/grown/corn.dm
+++ b/code/modules/hydroponics/grown/corn.dm
@@ -24,10 +24,14 @@
 	trash_type = /obj/item/grown/corncob
 	bite_consumption_mod = 2
 	foodtypes = VEGETABLES
-	grind_results = list(/datum/reagent/consumable/cornmeal = 0, /datum/reagent/consumable/nutriment/fat/oil/corn = 0)
-	juice_typepath = /datum/reagent/consumable/corn_starch
 	tastes = list("corn" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/whiskey
+
+/obj/item/food/grown/corn/grind_results()
+	return list(/datum/reagent/consumable/cornmeal = 0, /datum/reagent/consumable/nutriment/fat/oil/corn = 0)
+
+/obj/item/food/grown/corn/juice_typepath()
+	return /datum/reagent/consumable/corn_starch
 
 /obj/item/food/grown/corn/make_bakeable()
 	AddComponent(/datum/component/bakeable, /obj/item/food/oven_baked_corn, rand(15 SECONDS, 25 SECONDS), TRUE, TRUE)
@@ -45,7 +49,9 @@
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 7
-	grind_results = list(/datum/reagent/cellulose = 10) //really partially hemicellulose
+
+/obj/item/grown/corncob/grind_results()
+	return list(/datum/reagent/cellulose = 10)
 
 /obj/item/grown/corncob/attackby(obj/item/grown/W, mob/user, list/modifiers, list/attack_modifiers)
 	if(W.get_sharpness())
@@ -116,8 +122,10 @@
 	icon_state = "peppercorn"
 	trash_type = /obj/item/grown/corncob/pepper
 	foodtypes = VEGETABLES
-	grind_results = list(/datum/reagent/consumable/blackpepper = 0)
 	tastes = list("pepper" = 1, "sneezing" = 1)
+
+/obj/item/food/grown/peppercorn/grind_results()
+	return list(/datum/reagent/consumable/blackpepper = 0)
 
 /obj/item/grown/corncob/pepper
 	seed = /obj/item/seeds/corn/pepper

--- a/code/modules/hydroponics/grown/cucumber.dm
+++ b/code/modules/hydroponics/grown/cucumber.dm
@@ -22,5 +22,7 @@
 	desc = "Oblong and green, with pimples, the standard of salads."
 	icon_state = "cucumber"
 	foodtypes = VEGETABLES
-	juice_typepath = /datum/reagent/consumable/cucumberjuice
 	tastes = list("cucumber" = 1)
+
+/obj/item/food/grown/cucumber/juice_typepath()
+	return /datum/reagent/consumable/cucumberjuice

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -261,7 +261,9 @@
 	throw_range = 3
 	attack_verb_continuous = list("roasts", "scorches", "burns")
 	attack_verb_simple = list("roast", "scorch", "burn")
-	grind_results = list(/datum/reagent/consumable/capsaicin = 0, /datum/reagent/consumable/condensedcapsaicin = 0)
+
+/obj/item/grown/novaflower/grind_results()
+	return list(/datum/reagent/consumable/capsaicin = 0, /datum/reagent/consumable/condensedcapsaicin = 0)
 
 // Rose
 /obj/item/seeds/rose

--- a/code/modules/hydroponics/grown/herbs.dm
+++ b/code/modules/hydroponics/grown/herbs.dm
@@ -21,7 +21,11 @@
 	desc = "A bundle of various herbs. Somehow, you're always able to pick what you need out."
 	icon_state = "herbs"
 	foodtypes = VEGETABLES
-	grind_results = list(/datum/reagent/consumable/nutriment = 0)
-	juice_typepath = /datum/reagent/consumable/nutriment
 	tastes = list("nondescript herbs" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/fernet
+
+/obj/item/food/grown/herbs/grind_results()
+	return list(/datum/reagent/consumable/nutriment = 0)
+
+/obj/item/food/grown/herbs/juice_typepath()
+	return /datum/reagent/consumable/nutriment

--- a/code/modules/hydroponics/grown/korta_nut.dm
+++ b/code/modules/hydroponics/grown/korta_nut.dm
@@ -22,10 +22,14 @@
 	desc = "A little nut of great importance. Has a peppery shell which can be ground into flour and a soft, pulpy interior that produces a milky fluid when juiced. Or you can eat them whole, as a quick snack."
 	icon_state = "korta_nut"
 	foodtypes = NUTS
-	grind_results = list(/datum/reagent/consumable/korta_flour = 0)
-	juice_typepath = /datum/reagent/consumable/korta_milk
 	tastes = list("peppery heat" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/kortara
+
+/obj/item/food/grown/korta_nut/grind_results()
+	return list(/datum/reagent/consumable/korta_flour = 0)
+
+/obj/item/food/grown/korta_nut/juice_typepath()
+	return /datum/reagent/consumable/korta_milk
 
 //Sweet Korta Nut
 /obj/item/seeds/korta_nut/sweet
@@ -46,7 +50,11 @@
 	name = "sweet korta nut"
 	desc = "A sweet treat lizards love to eat."
 	icon_state = "korta_nut"
-	grind_results = list(/datum/reagent/consumable/korta_flour = 0)
-	juice_typepath = /datum/reagent/consumable/korta_nectar
 	tastes = list("peppery sweet" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/kortara
+
+/obj/item/food/grown/korta_nut/sweet/grind_results()
+	return list(/datum/reagent/consumable/korta_flour = 0)
+
+/obj/item/food/grown/korta_nut/sweet/juice_typepath()
+	return /datum/reagent/consumable/korta_nectar

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -31,8 +31,10 @@
 	bite_consumption_mod = 2
 	w_class = WEIGHT_CLASS_NORMAL
 	foodtypes = FRUIT
-	juice_typepath = /datum/reagent/consumable/watermelonjuice
 	wine_power = 40
+
+/obj/item/food/grown/watermelon/juice_typepath()
+	return /datum/reagent/consumable/watermelonjuice
 
 /obj/item/food/grown/watermelon/make_processable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/watermelonslice, 5, 20, screentip_verb = "Slice", sound_to_play = SFX_KNIFE_SLICE)
@@ -95,9 +97,11 @@
 	bite_consumption_mod = 2
 	w_class = WEIGHT_CLASS_NORMAL
 	foodtypes = FRUIT
-	juice_typepath = /datum/reagent/water/holywater
 	wine_power = 70 //Water to wine, baby.
 	wine_flavor = "divinity"
+
+/obj/item/food/grown/holymelon/juice_typepath()
+	return /datum/reagent/water/holywater
 
 /obj/item/food/grown/holymelon/make_processable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/holymelonslice, 5, 20, screentip_verb = "Slice", sound_to_play = SFX_KNIFE_SLICE)

--- a/code/modules/hydroponics/grown/olive.dm
+++ b/code/modules/hydroponics/grown/olive.dm
@@ -22,6 +22,7 @@
 	desc = "A small cylindrical salty fruit closely related to mangoes. Can be ground into a paste and mixed with water to make quality oil."
 	icon_state = "olive"
 	foodtypes = FRUIT
-	grind_results = list(/datum/reagent/consumable/olivepaste = 0)
 	tastes = list("olive" = 1)
 
+/obj/item/food/grown/olive/grind_results()
+	return list(/datum/reagent/consumable/olivepaste = 0)

--- a/code/modules/hydroponics/grown/peanut.dm
+++ b/code/modules/hydroponics/grown/peanut.dm
@@ -21,5 +21,7 @@
 	desc = "A tasty pair of groundnuts concealed in a tough shell."
 	icon_state = "peanut"
 	foodtypes = NUTS
-	grind_results = list(/datum/reagent/consumable/peanut_butter = 0)
 	tastes = list("peanuts" = 1)
+
+/obj/item/food/grown/peanut/grind_results()
+	return list(/datum/reagent/consumable/peanut_butter = 0)

--- a/code/modules/hydroponics/grown/peas.dm
+++ b/code/modules/hydroponics/grown/peas.dm
@@ -54,10 +54,12 @@
 	desc = "Ridens Cicer, guaranteed to improve your mood dramatically upon consumption!"
 	icon_state = "laughpeas"
 	foodtypes = VEGETABLES
-	juice_typepath = /datum/reagent/consumable/laughsyrup
 	tastes = list ("a prancing rabbit" = 1) //Vib Ribbon sends her regards.. wherever she is.
 	wine_power = 90
 	wine_flavor = "a vector-graphic rabbit dancing on your tongue"
+
+/obj/item/food/grown/laugh/juice_typepath()
+	return /datum/reagent/consumable/laughsyrup
 
 // World Peas - Peace at last, peace at last...
 /obj/item/seeds/peas/laugh/peace

--- a/code/modules/hydroponics/grown/pineapple.dm
+++ b/code/modules/hydroponics/grown/pineapple.dm
@@ -30,10 +30,11 @@
 	throw_range = 5
 	w_class = WEIGHT_CLASS_NORMAL
 	foodtypes = FRUIT | PINEAPPLE
-	juice_typepath = /datum/reagent/consumable/pineapplejuice
 	tastes = list("pineapple" = 1)
 	wine_power = 40
 
-
 /obj/item/food/grown/pineapple/make_processable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pineappleslice, 3, 15, screentip_verb = "Cut")
+
+/obj/item/food/grown/pineapple/juice_typepath()
+	return /datum/reagent/consumable/pineapplejuice

--- a/code/modules/hydroponics/grown/plum.dm
+++ b/code/modules/hydroponics/grown/plum.dm
@@ -22,9 +22,11 @@
 	desc = "A poet's favorite fruit. Noice."
 	icon_state = "plum"
 	foodtypes = FRUIT
-	juice_typepath = /datum/reagent/consumable/plumjuice
 	tastes = list("plum" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/plumwine
+
+/obj/item/food/grown/plum/juice_typepath()
+	return /datum/reagent/consumable/plumjuice
 
 // Plumb
 /obj/item/seeds/plum/plumb

--- a/code/modules/hydroponics/grown/potato.dm
+++ b/code/modules/hydroponics/grown/potato.dm
@@ -25,8 +25,10 @@
 	desc = "Boil 'em! Mash 'em! Stick 'em in a stew!"
 	icon_state = "potato"
 	foodtypes = VEGETABLES
-	juice_typepath = /datum/reagent/consumable/potato_juice
 	distill_reagent = /datum/reagent/consumable/ethanol/vodka
+
+/obj/item/food/grown/potato/juice_typepath()
+	return /datum/reagent/consumable/potato_juice
 
 /obj/item/food/grown/potato/make_bakeable()
 	AddComponent(/datum/component/bakeable, /obj/item/food/baked_potato, rand(15 SECONDS, 25 SECONDS), TRUE, TRUE)

--- a/code/modules/hydroponics/grown/pumpkin.dm
+++ b/code/modules/hydroponics/grown/pumpkin.dm
@@ -24,10 +24,12 @@
 	icon_state = "pumpkin"
 	bite_consumption_mod = 2
 	foodtypes = VEGETABLES
-	juice_typepath = /datum/reagent/consumable/pumpkinjuice
 	wine_power = 20
 	///Which type of lantern this gourd produces when carved.
 	var/carved_type = /obj/item/clothing/head/utility/hardhat/pumpkinhead
+
+/obj/item/food/grown/pumpkin/juice_typepath()
+	return /datum/reagent/consumable/pumpkinjuice
 
 /obj/item/food/grown/pumpkin/attackby(obj/item/W as obj, mob/user as mob, list/modifiers, list/attack_modifiers)
 	if(W.get_sharpness())
@@ -56,6 +58,8 @@
 	desc = "The pumpkin's toxic sibling."
 	icon_state = "blumpkin"
 	bite_consumption_mod = 3
-	juice_typepath = /datum/reagent/consumable/blumpkinjuice
 	wine_power = 50
 	carved_type = /obj/item/clothing/head/utility/hardhat/pumpkinhead/blumpkin
+
+/obj/item/food/grown/pumpkin/blumpkin/juice_typepath()
+	return /datum/reagent/consumable/blumpkinjuice

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -23,8 +23,10 @@
 	icon_state = "carrot"
 	bite_consumption_mod = 2
 	foodtypes = VEGETABLES
-	juice_typepath = /datum/reagent/consumable/carrotjuice
 	wine_power = 30
+
+/obj/item/food/grown/carrot/juice_typepath()
+	return /datum/reagent/consumable/carrotjuice
 
 /obj/item/food/grown/carrot/attackby(obj/item/I, mob/user, list/modifiers, list/attack_modifiers)
 	if(!I.get_sharpness())
@@ -62,8 +64,10 @@
 	desc = "Closely related to carrots."
 	icon_state = "parsnip"
 	foodtypes = VEGETABLES
-	juice_typepath = /datum/reagent/consumable/parsnipjuice
 	wine_power = 35
+
+/obj/item/food/grown/parsnip/juice_typepath()
+	return /datum/reagent/consumable/parsnipjuice
 
 /obj/item/food/grown/parsnip/attackby(obj/item/I, mob/user, list/modifiers, list/attack_modifiers)
 	if(!I.get_sharpness())
@@ -107,9 +111,11 @@
 	desc = "Heavily modified version of terran carrot, originally made to survive the scarciest of environments by an enterprising scientist of Moth Flotilla, Cahn'Mang."
 	icon_state = "cahn'root"
 	foodtypes = VEGETABLES
-	juice_typepath = null
 	tastes = list("sweet dirt" = 1)
 	distill_reagent = /datum/reagent/consumable/rootbeer
+
+/obj/item/food/grown/cahnroot/juice_typepath()
+	return null
 
 /obj/item/food/grown/cahnroot/attackby(obj/item/I, mob/user, list/modifiers, list/attack_modifiers)
 	if(!I.get_sharpness())

--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -21,9 +21,11 @@
 	name = "Tea Aspera tips"
 	desc = "These aromatic tips of the tea plant can be dried to make tea."
 	icon_state = "tea_aspera_leaves"
-	grind_results = list(/datum/reagent/toxin/teapowder = 0)
 	dry_grind = TRUE
 	can_distill = FALSE
+
+/obj/item/food/grown/tea/grind_results()
+	return list(/datum/reagent/toxin/teapowder = 0)
 
 // Tea Astra
 /obj/item/seeds/tea/astra
@@ -41,8 +43,9 @@
 	name = "Tea Astra tips"
 	icon_state = "tea_astra_leaves"
 	bite_consumption_mod = 2
-	grind_results = list(/datum/reagent/toxin/teapowder = 0, /datum/reagent/medicine/salglu_solution = 0)
 
+/obj/item/food/grown/tea/astra/grind_results()
+	return list(/datum/reagent/toxin/teapowder = 0, /datum/reagent/medicine/salglu_solution = 0)
 
 // Coffee
 /obj/item/seeds/coffee
@@ -70,8 +73,10 @@
 	desc = "Dry them out to make coffee."
 	icon_state = "coffee_arabica"
 	dry_grind = TRUE
-	grind_results = list(/datum/reagent/toxin/coffeepowder = 0)
 	distill_reagent = /datum/reagent/consumable/ethanol/kahlua
+
+/obj/item/food/grown/coffee/grind_results()
+	return list(/datum/reagent/toxin/coffeepowder = 0)
 
 // Coffee Robusta
 /obj/item/seeds/coffee/robusta
@@ -90,4 +95,6 @@
 	name = "coffee robusta beans"
 	desc = "Increases robustness by 37 percent!"
 	icon_state = "coffee_robusta"
-	grind_results = list(/datum/reagent/toxin/coffeepowder = 0, /datum/reagent/medicine/morphine = 0)
+
+/obj/item/food/grown/coffee/robusta/grind_results()
+	return list(/datum/reagent/toxin/coffeepowder = 0, /datum/reagent/medicine/morphine = 0)

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -23,9 +23,13 @@
 	icon_state = "tomato"
 	splat_type = /obj/effect/decal/cleanable/food/tomato_smudge
 	foodtypes = VEGETABLES
-	grind_results = list(/datum/reagent/consumable/ketchup = 0)
-	juice_typepath = /datum/reagent/consumable/tomatojuice
 	distill_reagent = /datum/reagent/consumable/enzyme
+
+/obj/item/food/grown/tomato/grind_results()
+	return list(/datum/reagent/consumable/ketchup = 0)
+
+/obj/item/food/grown/tomato/juice_typepath()
+	return /datum/reagent/consumable/tomatojuice
 
 // Blood Tomato
 /obj/item/seeds/tomato/blood
@@ -47,8 +51,10 @@
 	bite_consumption_mod = 3
 	splat_type = /obj/effect/gibspawner/generic
 	foodtypes = VEGETABLES | GORE
-	grind_results = list(/datum/reagent/consumable/ketchup = 0, /datum/reagent/blood = 0)
 	distill_reagent = /datum/reagent/consumable/ethanol/bloody_mary
+
+/obj/item/food/grown/tomato/blood/grind_results()
+	return list(/datum/reagent/consumable/ketchup = 0, /datum/reagent/blood = 0)
 
 // Blue Tomato
 /obj/item/seeds/tomato/blue

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -53,8 +53,3 @@
 	if(reagents)
 		return TRUE
 	return FALSE
-
-/obj/item/grown/on_grind()
-	. = ..()
-	for(var/i in 1 to grind_results.len)
-		grind_results[grind_results[i]] = round(seed.potency)

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -214,10 +214,10 @@
 			var/obj/item/food/grown/product = new to_add.product
 			var/datum/reagent/product_distill_reagent = product.distill_reagent
 			seed_data["distill_reagent"] = initial(product_distill_reagent.name)
-			var/datum/reagent/product_juice_typepath = product.juice_typepath
+			var/datum/reagent/product_juice_typepath = product.juice_typepath()
 			seed_data["juice_name"] = initial(product_juice_typepath.name)
 			seed_data["grind_results"] = list()
-			for(var/datum/reagent/reagent as anything in product.grind_results)
+			for(var/datum/reagent/reagent as anything in product.grind_results())
 				seed_data["grind_results"] += initial(reagent.name)
 			qdel(product)
 

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -294,7 +294,7 @@
 			T.reagents.add_reagent(rid, amount, data, added_purity = reagent_purity)
 
 		//Handles the juicing trait, swaps nutriment and vitamins for that species various juices if they exist. Mutually exclusive with distilling.
-		if(get_gene(/datum/plant_gene/trait/juicing) && grown_edible.juice_typepath)
+		if(get_gene(/datum/plant_gene/trait/juicing) && grown_edible.juice_typepath())
 			grown_edible.juice(juicer = FALSE) //we pass FALSE & not null because Byond default args will subtitute it with the default value
 		else if(get_gene(/datum/plant_gene/trait/brewing))
 			grown_edible.ferment()

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -214,8 +214,8 @@
 	pixel_x = base_pixel_x + rand(-4, 4)
 	pixel_y = base_pixel_y + rand(-4, 4)
 
-/obj/item/food/grown/ash_flora/shavings //So we can't craft bowls from everything.
-	grind_results = list(/datum/reagent/toxin/mushroom_powder = 5)
+/obj/item/food/grown/ash_flora/shavings/grind_results()
+	return list(/datum/reagent/toxin/mushroom_powder = 5)
 
 /obj/item/food/grown/ash_flora/mushroom_leaf
 	name = "mushroom leaf"

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -632,7 +632,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	return list(/datum/reagent/ants = 2, /datum/reagent/consumable/eggyolk = 2)
 
 /obj/item/coin/iron/grind_results()
-	 return list(/datum/reagent/iron = 4)
+	return list(/datum/reagent/iron = 4)
 
 /obj/item/coin/gold/debug
 	custom_materials = list(/datum/material/gold = COIN_MATERIAL_AMOUNT)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -553,46 +553,66 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 
 /obj/item/coin/gold
 	custom_materials = list(/datum/material/gold = COIN_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/gold = 4)
+
+/obj/item/coin/gold/grind_results()
+	return list(/datum/reagent/gold = 4)
 
 /obj/item/coin/silver
 	custom_materials = list(/datum/material/silver = COIN_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/silver = 4)
+
+/obj/item/coin/silver/grind_results()
+	return list(/datum/reagent/silver = 4)
 
 /obj/item/coin/diamond
 	custom_materials = list(/datum/material/diamond = COIN_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/carbon = 4)
+
+/obj/item/coin/diamond/grind_results()
+	return list(/datum/reagent/carbon = 4)
 
 /obj/item/coin/plasma
 	custom_materials = list(/datum/material/plasma = COIN_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/toxin/plasma = 4)
+
+/obj/item/coin/plasma/grind_results()
+	return list(/datum/reagent/toxin/plasma = 4)
 
 /obj/item/coin/uranium
 	custom_materials = list(/datum/material/uranium = COIN_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/uranium = 4)
+
+/obj/item/coin/uranium/grind_results()
+	return list(/datum/reagent/uranium = 4)
 
 /obj/item/coin/titanium
 	custom_materials = list(/datum/material/titanium = COIN_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/flash_powder = 4)
+
+/obj/item/coin/titanium/grind_results()
+	return list(/datum/reagent/flash_powder = 4)
 
 /obj/item/coin/bananium
 	custom_materials = list(/datum/material/bananium = COIN_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/consumable/nutriment/soup/clown_tears = 4)
+
+/obj/item/coin/bananium/grind_results()
+	return list(/datum/reagent/consumable/nutriment/soup/clown_tears = 4)
 
 /obj/item/coin/adamantine
 	custom_materials = list(/datum/material/adamantine = COIN_MATERIAL_AMOUNT)
 
 /obj/item/coin/mythril
 	custom_materials = list(/datum/material/mythril = COIN_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/medicine/omnizine/godblood = 4)
+
+/obj/item/coin/mythril/grind_results()
+	return list(/datum/reagent/medicine/omnizine/godblood = 4)
 
 /obj/item/coin/plastic
 	custom_materials = list(/datum/material/plastic = COIN_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/plastic_polymers = 4)
+
+/obj/item/coin/plastic/grind_results()
+	return list(/datum/reagent/plastic_polymers = 4)
 
 /obj/item/coin/runite
 	custom_materials = list(/datum/material/runite = COIN_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/iron = 2, /datum/reagent/consumable/ethanol/ritual_wine = 2)
+
+/obj/item/coin/runite/grind_results()
+	return list(/datum/reagent/iron = 2, /datum/reagent/consumable/ethanol/ritual_wine = 2)
 
 /obj/item/coin/twoheaded
 	desc = "Hey, this coin's the same on both sides!"
@@ -607,15 +627,19 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	heads_name = "valid"
 	material_flags = NONE
 	override_material_worth = TRUE
-	grind_results = list(/datum/reagent/ants = 2, /datum/reagent/consumable/eggyolk = 2)
 
-/obj/item/coin/iron
-	grind_results = list(/datum/reagent/iron = 4)
+/obj/item/coin/antagtoken/grind_results()
+	return list(/datum/reagent/ants = 2, /datum/reagent/consumable/eggyolk = 2)
+
+/obj/item/coin/iron/grind_results()
+	 return list(/datum/reagent/iron = 4)
 
 /obj/item/coin/gold/debug
 	custom_materials = list(/datum/material/gold = COIN_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/gold/cursed = 4)
 	desc = "If you got this somehow, be aware that it will dust you. Almost certainly."
+
+/obj/item/coin/gold/debug/grind_results()
+	return list(/datum/reagent/gold/cursed = 4)
 
 /obj/item/coin/gold/debug/attack_self(mob/user)
 	if(cooldown < world.time)
@@ -657,9 +681,11 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	heads_name = "heretic"
 	has_action = TRUE
 	material_flags = NONE
-	grind_results = list(/datum/reagent/carbon = 5, /datum/reagent/toxin/plasma = 5, /datum/reagent/eldritch = 4)
 	/// The range at which airlocks are effected.
 	var/airlock_range = 5
+
+/obj/item/coin/eldritch/grind_results()
+	return list(/datum/reagent/carbon = 5, /datum/reagent/toxin/plasma = 5, /datum/reagent/eldritch = 4)
 
 /obj/item/coin/eldritch/heads_action(mob/user)
 	var/mob/living/living_user = user

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -342,7 +342,6 @@
 	eatverbs = list("devour")
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
 	foodtypes = GORE | MEAT | RAW
-	grind_results = list(/datum/reagent/blood = 20, /datum/reagent/consumable/liquidgibs = 5)
 	decomp_req_handle = TRUE
 	ant_attracting = FALSE
 	decomp_type = /obj/item/food/deadmouse/moldy
@@ -353,6 +352,9 @@
 	. = ..()
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOUSE, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 10)
 	RegisterSignal(src, COMSIG_ATOM_ON_LAZARUS_INJECTOR, PROC_REF(use_lazarus))
+
+/obj/item/food/deadmouse/grind_results()
+	return list(/datum/reagent/blood = 20, /datum/reagent/consumable/liquidgibs = 5)
 
 /// Copy properties from an imminently dead mouse
 /obj/item/food/deadmouse/proc/copy_corpse(mob/living/basic/mouse/dead_critter)
@@ -415,8 +417,10 @@
 	icon_state = "mouse_gray_dead"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/consumable/mold = 10)
 	foodtypes = GORE | MEAT | RAW | GROSS
-	grind_results = list(/datum/reagent/blood = 20, /datum/reagent/consumable/liquidgibs = 5, /datum/reagent/consumable/mold = 10)
 	preserved_food = TRUE
+
+/obj/item/food/deadmouse/moldy/grind_results()
+	return list(/datum/reagent/blood = 20, /datum/reagent/consumable/liquidgibs = 5, /datum/reagent/consumable/mold = 10)
 
 /// The mouse AI controller
 /datum/ai_controller/basic_controller/mouse

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -26,7 +26,6 @@
 	max_integrity = 50
 	drop_sound = 'sound/items/handling/paper_drop.ogg'
 	pickup_sound = 'sound/items/handling/paper_pickup.ogg'
-	grind_results = list(/datum/reagent/cellulose = 3)
 	custom_materials = list(/datum/material/paper = HALF_SHEET_MATERIAL_AMOUNT / 2)
 	color = COLOR_WHITE
 	item_flags = SKIP_FANTASY_ON_SPAWN
@@ -88,6 +87,9 @@
 	clear_paper()
 	LAZYREMOVE(SSpersistence.queued_message_bottles, src)
 	return ..()
+
+/obj/item/paper/grind_results()
+	return list(/datum/reagent/cellulose = 3)
 
 /obj/item/paper/custom_fire_overlay()
 	if (!custom_fire_overlay)

--- a/code/modules/paperwork/paper_cutter.dm
+++ b/code/modules/paperwork/paper_cutter.dm
@@ -190,7 +190,9 @@
 	inhand_icon_state = "silver_id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	grind_results = list(/datum/reagent/cellulose = 1.5) //It's a normal paper sheet divided in 2. 3 divided by 2 equals 1.5, this way you can't magically dupe cellulose
+
+/obj/item/paper/paperslip/grind_results()
+	return list(/datum/reagent/cellulose = 1.5)
 
 /obj/item/paper/paperslip/fortune
 	name = "fortune slip"
@@ -199,17 +201,20 @@
 	default_raw_text = pick(GLOB.wisdoms)
 	return ..()
 
-/obj/item/paper/paperslip/corporate //More fancy and sturdy paper slip which is a "plastic card", used for things like spare ID safe code
+///More fancy and sturdy paper slip which is a "plastic card", used for things like spare ID safe code
+/obj/item/paper/paperslip/corporate
 	name = "corporate plastic card"
 	desc = "A plastic card for confidential corporate matters. Can be written on with pen somehow."
 	icon_state = "corppaperslip"
-	grind_results = list(/datum/reagent/plastic_polymers = 1.5) //It's a plastic card after all
 	custom_materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT * 3, /datum/material/paper = HALF_SHEET_MATERIAL_AMOUNT / 2)
 	max_integrity = 130 //Slightly more sturdy because of being made out of a plastic
 	drop_sound = 'sound/items/handling/disk_drop.ogg'
 	pickup_sound = 'sound/items/handling/disk_pickup.ogg'
 	throw_range = 6
 	throw_speed = 2
+
+/obj/item/paper/paperslip/corporate/grind_results()
+	return list(/datum/reagent/plastic_polymers = 1.5)
 
 /obj/item/hatchet/cutterblade
 	name = "paper cutter blade"

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -25,7 +25,6 @@
 	throw_range = 7
 	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*0.1)
 	pressure_resistance = 2
-	grind_results = list(/datum/reagent/iron = 2, /datum/reagent/iodine = 1)
 	var/colour = COLOR_BLACK //what colour the ink is!
 	var/degrees = 0
 	var/font = PEN_FONT
@@ -57,6 +56,9 @@
 		return
 	create_transform_component()
 	RegisterSignal(src, COMSIG_TRANSFORMING_ON_TRANSFORM, PROC_REF(on_transform))
+
+/obj/item/pen/grind_results()
+	return list(/datum/reagent/iron = 2, /datum/reagent/iodine = 1)
 
 /// Proc that child classes can override to have custom transforms, like edaggers or pendrivers
 /obj/item/pen/proc/create_transform_component()
@@ -166,9 +168,11 @@
 	colour = "#696969"
 	font = CHARCOAL_FONT
 	custom_materials = list(/datum/material/wood = SHEET_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/ash = 5, /datum/reagent/cellulose = 10)
 	requires_gravity = FALSE // this is technically a pencil
 	can_click = FALSE
+
+/obj/item/pen/charcoal/grind_results()
+	return list(/datum/reagent/ash = 5, /datum/reagent/cellulose = 10)
 
 /datum/crafting_recipe/charcoal_stylus
 	name = "Charcoal Stylus"
@@ -482,7 +486,6 @@
 	w_class = WEIGHT_CLASS_TINY
 	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*0.1, /datum/material/diamond=SMALL_MATERIAL_AMOUNT, /datum/material/titanium = SMALL_MATERIAL_AMOUNT*0.1)
 	pressure_resistance = 2
-	grind_results = list(/datum/reagent/iron = 2, /datum/reagent/iodine = 1)
 	tool_behaviour = TOOL_MINING //For the classic "digging out of prison with a spoon but you're in space so this analogy doesn't work" situation.
 	toolspeed = 10 //You will never willingly choose to use one of these over a shovel.
 	font = FOUNTAIN_PEN_FONT
@@ -490,6 +493,9 @@
 	dart_insert_casing_icon_state = "overlay_survivalpen"
 	dart_insert_projectile_icon_state = "overlay_survivalpen_proj"
 	can_click = FALSE
+
+/obj/item/pen/survival/grind_results()
+	return list(/datum/reagent/iron = 2, /datum/reagent/iodine = 1)
 
 /obj/item/pen/survival/on_inserted_into_dart(datum/source, obj/item/ammo_casing/dart, mob/user)
 	. = ..()

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -871,9 +871,11 @@ GLOBAL_LIST_INIT(paper_blanks, init_paper_blanks())
 	icon = 'icons/obj/service/bureaucracy.dmi'
 	icon_state = "tonercartridge"
 	w_class = WEIGHT_CLASS_SMALL
-	grind_results = list(/datum/reagent/iodine = 40, /datum/reagent/iron = 10)
 	var/charges = 5
 	var/max_charges = 5
+
+/obj/item/toner/grind_results()
+	return list(/datum/reagent/iodine = 40, /datum/reagent/iron = 10)
 
 /obj/item/toner/examine(mob/user)
 	. = ..()
@@ -882,9 +884,11 @@ GLOBAL_LIST_INIT(paper_blanks, init_paper_blanks())
 /obj/item/toner/large
 	name = "large toner cartridge"
 	desc = "A hefty cartridge of Nanotrasen ValueBrand toner. Fits photocopiers and autopainters alike."
-	grind_results = list(/datum/reagent/iodine = 90, /datum/reagent/iron = 10)
 	charges = 25
 	max_charges = 25
+
+/obj/item/toner/large/grind_results()
+	return list(/datum/reagent/iodine = 90, /datum/reagent/iron = 10)
 
 /obj/item/toner/extreme
 	name = "extremely large toner cartridge"

--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -11,9 +11,11 @@
 	max_integrity = 50
 	drop_sound = 'sound/items/handling/paper_drop.ogg'
 	pickup_sound = 'sound/items/handling/paper_pickup.ogg'
-	grind_results = list(/datum/reagent/iodine = 4)
 	var/datum/picture/picture
 	var/scribble //Scribble on the back.
+
+/obj/item/photo/grind_results()
+	return LAZYACCESS(custom_materials, /datum/material/hauntium) ? list(/datum/reagent/hauntium = 20) : list(/datum/reagent/iodine = 4)
 
 /obj/item/photo/get_save_vars()
 	return ..() - NAMEOF(src, icon)
@@ -56,7 +58,6 @@
 		if(!isobserver(seen) && !isghostspecies(seen))
 			continue
 		set_custom_materials(list(/datum/material/hauntium =SHEET_MATERIAL_AMOUNT))
-		grind_results = list(/datum/reagent/hauntium = 20)
 		break
 
 /obj/item/photo/update_icon_state()

--- a/code/modules/plumbing/plumbers/grinder_chemical.dm
+++ b/code/modules/plumbing/plumbers/grinder_chemical.dm
@@ -103,11 +103,11 @@
 	INVOKE_ASYNC(src, PROC_REF(blend), AM)
 
 
-/obj/machinery/plumbing/grinder_chemical/blended(obj/item/blended_item, grinded)
+/obj/machinery/plumbing/grinder_chemical/blended(obj/item/slime_extract/blended_item, grinded)
 	//don't delete slime extracts
-	if(istype(blended_item, /obj/item/slime_extract))
+	if(istype(blended_item))
 		//so you can't regrind them for extra stuff
-		blended_item.grind_results = null
+		blended_item.can_grind = FALSE
 
 		blended_item.forceMove(drop_location())
 
@@ -135,7 +135,7 @@
 
 	if(!grinding)
 		item_to_blend.juice(reagents, usr, src)
-	else if(LAZYLEN(item_to_blend.grind_results) || item_to_blend.reagents?.total_volume)
+	else if(length(item_to_blend.grind_results()) || item_to_blend.reagents?.total_volume)
 		item_to_blend.grind(reagents, usr, src)
 
 	use_energy(active_power_usage)

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -13,10 +13,12 @@
 	throw_speed = 2
 	throw_range = 2
 	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*12, /datum/material/glass=SMALL_MATERIAL_AMOUNT*2)
-	grind_results = list(/datum/reagent/lithium = 60, /datum/reagent/iron = 10, /datum/reagent/silicon = 10)
 	rating_base = STANDARD_BATTERY_CHARGE
 	maxcharge = STANDARD_BATTERY_CHARGE
 	chargerate = STANDARD_BATTERY_RATE
+
+/obj/item/stock_parts/power_store/battery/grind_results()
+	return list(/datum/reagent/lithium = 60, /datum/reagent/iron = 10, /datum/reagent/silicon = 10)
 
 /obj/item/stock_parts/power_store/battery/empty
 	empty = TRUE

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -459,7 +459,6 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 	attack_verb_simple = list("whip", "lash", "discipline", "flog")
 	singular_name = "cable piece"
 	full_w_class = WEIGHT_CLASS_SMALL
-	grind_results = list(/datum/reagent/copper = 2) //2 copper per cable in the coil
 	usesound = 'sound/items/deconstruct.ogg'
 	cost = 1
 	source = /datum/robot_energy_storage/wire
@@ -475,6 +474,9 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 	update_appearance()
+
+/obj/item/stack/cable_coil/grind_results()
+	return list(/datum/reagent/copper = 2)
 
 /obj/item/stack/cable_coil/examine(mob/user)
 	. = ..()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -19,7 +19,6 @@
 	emp_damage_modifier = 1
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*7, /datum/material/glass=SMALL_MATERIAL_AMOUNT*0.5)
-	grind_results = list(/datum/reagent/lithium = 15, /datum/reagent/iron = 5, /datum/reagent/silicon = 5)
 
 /obj/item/stock_parts/power_store/cell/Initialize(mapload)
 	. = ..()
@@ -30,6 +29,9 @@
 		/datum/element/slapcrafting,\
 		slapcraft_recipes = slapcraft_recipe_list,\
 	)
+
+/obj/item/stock_parts/power_store/cell/grind_results()
+	return list(/datum/reagent/lithium = 15, /datum/reagent/iron = 5, /datum/reagent/silicon = 5)
 
 /* Cell variants*/
 /obj/item/stock_parts/power_store/cell/empty
@@ -245,7 +247,9 @@
 	charge_light_type = null
 	connector_type = "crystal"
 	custom_materials = null
-	grind_results = null
+
+/obj/item/stock_parts/power_store/cell/crystal_cell/grind_results()
+	return list()
 
 /obj/item/stock_parts/power_store/cell/ethereal
 	name = "ahelp it"
@@ -256,9 +260,11 @@
 	charge_light_type = null
 	connector_type = null
 	custom_materials = null
-	grind_results = null
 	emp_damage_modifier = 0
 	abstract_type = /obj/item/stock_parts/power_store/cell/ethereal
+
+/obj/item/stock_parts/power_store/cell/ethereal/grind_results()
+	return list()
 
 /obj/item/stock_parts/power_store/cell/ethereal/examine(mob/user)
 	. = ..()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -249,7 +249,7 @@
 	custom_materials = null
 
 /obj/item/stock_parts/power_store/cell/crystal_cell/grind_results()
-	return list()
+	return null
 
 /obj/item/stock_parts/power_store/cell/ethereal
 	name = "ahelp it"
@@ -264,7 +264,7 @@
 	abstract_type = /obj/item/stock_parts/power_store/cell/ethereal
 
 /obj/item/stock_parts/power_store/cell/ethereal/grind_results()
-	return list()
+	return null
 
 /obj/item/stock_parts/power_store/cell/ethereal/examine(mob/user)
 	. = ..()

--- a/code/modules/power/lighting/light_items.dm
+++ b/code/modules/power/lighting/light_items.dm
@@ -8,7 +8,6 @@
 	throwforce = 5
 	w_class = WEIGHT_CLASS_TINY
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/silicon = 5, /datum/reagent/nitrogen = 10) //Nitrogen is used as a cheaper alternative to argon in incandescent lighbulbs
 	///How much light it gives off
 	var/brightness = 2
 	///LIGHT_OK, LIGHT_BURNED or LIGHT_BROKEN
@@ -29,6 +28,9 @@
 	AddElement(/datum/element/connect_loc, loc_connections)
 	AddElement(/datum/element/update_icon_updates_onmob)
 	AddComponent(/datum/component/golem_food, golem_food_key = /obj/item/light, extra_validation = CALLBACK(src, PROC_REF(is_intact)))
+
+/obj/item/light/grind_results()
+	return list(/datum/reagent/silicon = 5, /datum/reagent/nitrogen = 10)
 
 /obj/item/light/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	. = ..()

--- a/code/modules/power/pipecleaners.dm
+++ b/code/modules/power/pipecleaners.dm
@@ -201,13 +201,15 @@ By design, d1 is the smallest direction and d2 is the highest
 	attack_verb_simple = list("whip", "lash", "discipline", "flog")
 	singular_name = "pipe cleaner piece"
 	full_w_class = WEIGHT_CLASS_SMALL
-	grind_results = list(/datum/reagent/copper = 2) //2 copper per pipe_cleaner in the coil
 	usesound = 'sound/items/deconstruct.ogg'
 	cost = 1
 	source = /datum/robot_energy_storage/pipe_cleaner
 	color = CABLE_HEX_COLOR_RED
 	///For updating inhand icons.
 	var/pipecleaner_color = CABLE_COLOR_RED
+
+/obj/item/stack/pipe_cleaner_coil/grind_results()
+	return list(/datum/reagent/copper = 2)
 
 /obj/item/stack/pipe_cleaner_coil/cyborg/attack_self(mob/user)
 	var/list/pipe_cleaner_colors = GLOB.cable_colors

--- a/code/modules/reagents/chemistry/holder/reactions.dm
+++ b/code/modules/reagents/chemistry/holder/reactions.dm
@@ -339,7 +339,7 @@
 				my_atom.visible_message(span_notice("[iconhtml] \The [my_atom]'s power is consumed in the reaction."))
 				extract.name = "used slime extract"
 				extract.desc = "This extract has been used up."
-				LAZYNULL(extract.grind_results)
+				extract.can_grind = FALSE
 
 	//finish the reaction
 	selected_reaction.on_reaction(src, null, multiplier)

--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -151,7 +151,6 @@
 	desc = "A small table size burner used for heating up beakers."
 	icon = 'icons/obj/medical/chemical.dmi'
 	icon_state = "burner"
-	grind_results = list(/datum/reagent/consumable/ethanol = 5, /datum/reagent/silicon = 10)
 	custom_materials = list(/datum/material/paper = HALF_SHEET_MATERIAL_AMOUNT / 2)
 	item_flags = NOBLUDGEON
 	resistance_flags = FLAMMABLE
@@ -169,6 +168,9 @@
 	create_reagents(max_volume, TRANSPARENT)//We have our own refillable - since we want to heat and pour
 	if(reagent_type)
 		reagents.add_reagent(reagent_type, 15)
+
+/obj/item/burner/grind_results()
+	return list(/datum/reagent/consumable/ethanol = 5, /datum/reagent/silicon = 10)
 
 /obj/item/burner/attackby(obj/item/I, mob/living/user, list/modifiers, list/attack_modifiers)
 	. = ..()
@@ -283,11 +285,15 @@
 
 /obj/item/burner/oil
 	reagent_type = /datum/reagent/fuel/oil
-	grind_results = list(/datum/reagent/fuel/oil = 5, /datum/reagent/silicon = 10)
+
+/obj/item/burner/oil/grind_results()
+	return list(/datum/reagent/fuel/oil = 5, /datum/reagent/silicon = 10)
 
 /obj/item/burner/fuel
 	reagent_type = /datum/reagent/fuel
-	grind_results = list(/datum/reagent/fuel = 5, /datum/reagent/silicon = 10)
+
+/obj/item/burner/fuel/grind_results()
+	return list(/datum/reagent/fuel = 5, /datum/reagent/silicon = 10)
 
 /obj/item/thermometer
 	name = "thermometer"
@@ -296,7 +302,6 @@
 	icon = 'icons/obj/medical/chemical.dmi'
 	item_flags = NOBLUDGEON
 	w_class = WEIGHT_CLASS_TINY
-	grind_results = list(/datum/reagent/mercury = 5)
 	custom_materials = list(/datum/material/glass = SHEET_MATERIAL_AMOUNT)
 	///The reagents datum that this object is attached to, so we know where we are when it's added to something.
 	var/datum/reagents/attached_to_reagents
@@ -304,6 +309,9 @@
 /obj/item/thermometer/Destroy()
 	attached_to_reagents = null
 	return ..()
+
+/obj/item/thermometer/grind_results()
+	return list(/datum/reagent/mercury = 5)
 
 /obj/item/thermometer/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(isnull(interacting_with.reagents))

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -182,7 +182,7 @@
 			continue
 
 		//Nothing would come from grinding or juicing
-		if(!length(ingredient.grind_results) && !ingredient.reagents.total_volume)
+		if(!length(ingredient.grind_results()) && !ingredient.reagents.total_volume)
 			to_chat(user, span_warning("You cannot grind/juice [ingredient] into reagents!"))
 			continue
 
@@ -253,7 +253,7 @@
 		return ITEM_INTERACT_SUCCESS
 
 	//add item directly
-	else if(length(tool.grind_results) || tool.reagents?.total_volume)
+	else if(length(tool.grind_results()) || tool.reagents?.total_volume)
 		if(tool.atom_storage && length(tool.contents)) //anything that has internal storage would be too much recursion for us to handle
 			to_chat(user, span_notice("Drag this item onto [src] to dump its contents, or empty it to grind the container."))
 			return ITEM_INTERACT_BLOCKING

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -464,7 +464,7 @@
 	if(!tool.blend_requirements(src))
 		to_chat(user, span_warning("Cannot grind this!"))
 		return ITEM_INTERACT_BLOCKING
-	if((length(tool.grind_results) || tool.reagents?.total_volume) && user.transferItemToLoc(tool, src))
+	if((length(tool.grind_results()) || tool.reagents?.total_volume) && user.transferItemToLoc(tool, src))
 		grinded = tool
 		return ITEM_INTERACT_SUCCESS
 	return NONE

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -10,7 +10,8 @@
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 6
-	grind_results = list(/datum/reagent/toxin/slimejelly = 20)
+	///Can this extract still be grinded
+	var/can_grind = TRUE
 	///uses before it goes inert
 	var/extract_uses = 1
 	///deletion timer, for delayed reactions
@@ -19,6 +20,9 @@
 	var/crossbreed_modification
 	///Reagents required for activation
 	var/recurring = FALSE
+
+/obj/item/slime_extract/grind_results()
+	return can_grind ? list(/datum/reagent/toxin/slimejelly = 20) : list()
 
 /obj/item/slime_extract/examine(mob/user)
 	. = ..()

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -21,7 +21,6 @@
 	///The color to multiply the greyscaled husk sprites by. Can be null. Old husk sprite chest color is #A6A6A6
 	var/husk_color = "#A6A6A6"
 	layer = BELOW_MOB_LAYER //so it isn't hidden behind objects when on the floor
-	grind_results = list(/datum/reagent/bone_dust = 10, /datum/reagent/consumable/liquidgibs = 5) // robotic bodyparts and chests/heads cannot be ground
 	/// The mob that "owns" this limb
 	/// DO NOT MODIFY DIRECTLY. Use update_owner()
 	var/mob/living/carbon/owner
@@ -255,9 +254,7 @@
 		texture_bodypart_overlay = new texture_bodypart_overlay()
 		add_bodypart_overlay(texture_bodypart_overlay, update = FALSE)
 
-	if(!IS_ORGANIC_LIMB(src))
-		grind_results = null
-	else
+	if(IS_ORGANIC_LIMB(src))
 		blood_dna_info = list("Unknown DNA" = get_blood_type(BLOOD_TYPE_O_PLUS))
 
 	var/innate_state = NONE
@@ -295,6 +292,9 @@
 	QDEL_LIST_ASSOC_VAL(feature_offsets)
 
 	return ..()
+
+/obj/item/bodypart/grind_results()
+	return IS_ORGANIC_LIMB(src) ? list() : list(/datum/reagent/bone_dust = 10, /datum/reagent/consumable/liquidgibs = 5)
 
 /obj/item/bodypart/ex_act(severity, target)
 	if(owner) //trust me bro you dont want this

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -105,7 +105,7 @@
 	return ..()
 
 /obj/item/bodypart/head/grind_results()
-	return list()
+	return null
 
 /obj/item/bodypart/head/examine(mob/user)
 	. = ..()

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -15,7 +15,6 @@
 	wound_resistance = 5
 	disabled_wound_penalty = 25
 	scars_covered_by_clothes = FALSE
-	grind_results = null
 	is_dimorphic = TRUE
 	unarmed_attack_verbs = list("bite", "chomp")
 	unarmed_attack_verbs_continuous = list("bites", "chomps")
@@ -104,6 +103,9 @@
 	QDEL_NULL(worn_head_offset)
 	QDEL_NULL(worn_face_offset)
 	return ..()
+
+/obj/item/bodypart/head/grind_results()
+	return list()
 
 /obj/item/bodypart/head/examine(mob/user)
 	. = ..()

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -37,7 +37,7 @@
 	var/list/wing_types = list(/obj/item/organ/wings/functional/angel)
 
 /obj/item/bodypart/chest/grind_results()
-	return list()
+	return null
 
 /obj/item/bodypart/chest/forced_removal(dismembered, special, move_to_floor)
 	var/mob/living/carbon/old_owner = owner

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -10,7 +10,6 @@
 	is_dimorphic = TRUE
 	px_x = 0
 	px_y = 0
-	grind_results = null
 	wound_resistance = 10
 	bodypart_trait_source = CHEST_TRAIT
 	///The bodyshape(s) allowed to attach to this chest.
@@ -36,6 +35,9 @@
 	var/datum/worn_feature_offset/worn_neck_offset
 	/// Which functional (i.e. flightpotion) wing types (if any) does this bodypart support? If count is >1 a radial menu is used to choose between all icons in list
 	var/list/wing_types = list(/obj/item/organ/wings/functional/angel)
+
+/obj/item/bodypart/chest/grind_results()
+	return list()
 
 /obj/item/bodypart/chest/forced_removal(dismembered, special, move_to_floor)
 	var/mob/living/carbon/old_owner = owner

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -26,7 +26,6 @@
 	///We cant hide this wings in suit
 	var/cant_hide = FALSE
 
-	// grind_results = list(/datum/reagent/flightpotion = 5)
 	food_reagents = list(/datum/reagent/flightpotion = 5)
 
 	var/drift_force = FUNCTIONAL_WING_FORCE
@@ -49,6 +48,9 @@
 /obj/item/organ/wings/functional/Destroy()
 	QDEL_NULL(fly)
 	return ..()
+
+/obj/item/organ/wings/functional/grind_results()
+	return list(/datum/reagent/flightpotion = 5)
 
 /obj/item/organ/wings/functional/on_mob_insert(mob/living/carbon/receiver, special, movement_flags)
 	. = ..()

--- a/code/modules/surgery/organs/internal/appendix/_appendix.dm
+++ b/code/modules/surgery/organs/internal/appendix/_appendix.dm
@@ -10,7 +10,6 @@
 	zone = BODY_ZONE_PRECISE_GROIN
 	slot = ORGAN_SLOT_APPENDIX
 	food_reagents = list(/datum/reagent/consumable/nutriment/organ_tissue = 5, /datum/reagent/toxin/bad_food = 5)
-	grind_results = list(/datum/reagent/toxin/bad_food = 5)
 	healing_factor = STANDARD_ORGAN_HEALING
 	decay_factor = STANDARD_ORGAN_DECAY
 
@@ -18,6 +17,9 @@
 	now_fixed = span_info("The pain in your abdomen has subsided.")
 
 	var/inflamation_stage = 0
+
+/obj/item/organ/appendix/grind_results()
+	return list(/datum/reagent/toxin/bad_food = 5)
 
 /obj/item/organ/appendix/update_name()
 	. = ..()

--- a/code/modules/surgery/organs/internal/liver/_liver.dm
+++ b/code/modules/surgery/organs/internal/liver/_liver.dm
@@ -16,7 +16,6 @@
 	decay_factor = STANDARD_ORGAN_DECAY // smack in the middle of decay times
 
 	food_reagents = list(/datum/reagent/consumable/nutriment/organ_tissue = 5, /datum/reagent/iron = 5)
-	grind_results = list(/datum/reagent/consumable/nutriment/peptides = 5)
 
 	cell_line = CELL_LINE_ORGAN_LIVER
 	cells_minimum = 1
@@ -37,6 +36,9 @@
 	// Don't think about it too much.
 	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_COMEDY_METABOLISM), PROC_REF(on_add_comedy_metabolism))
 	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_COMEDY_METABOLISM), PROC_REF(on_remove_comedy_metabolism))
+
+/obj/item/organ/liver/grind_results()
+	return list(/datum/reagent/consumable/nutriment/peptides = 5)
 
 /* Signal handler for the liver gaining the TRAIT_COMEDY_METABOLISM trait
  *

--- a/code/modules/unit_tests/fish_unit_tests.dm
+++ b/code/modules/unit_tests/fish_unit_tests.dm
@@ -137,7 +137,7 @@
 	var/expected_num_fillets = 0
 
 /obj/item/fish/testdummy/fish_grind_results()
-	return list()
+	return null
 
 /obj/item/fish/testdummy/small
 	// The parent type is too big to reproduce inside the more compact fish tank

--- a/code/modules/unit_tests/fish_unit_tests.dm
+++ b/code/modules/unit_tests/fish_unit_tests.dm
@@ -124,7 +124,6 @@
 
 ///dummy fish item used for the tests, as well with related subtypes and datums.
 /obj/item/fish/testdummy
-	grind_results = list()
 	average_weight = FISH_GRIND_RESULTS_WEIGHT_DIVISOR * 2
 	average_size = FISH_SIZE_BULKY_MAX
 	num_fillets = 2
@@ -133,7 +132,12 @@
 	breeding_timeout = 0
 	fish_flags = parent_type::fish_flags & ~(FISH_FLAG_SHOW_IN_CATALOG|FISH_FLAG_EXPERIMENT_SCANNABLE)
 	fish_id_redirect_path = /obj/item/fish/goldfish //Stops SSfishing from complaining
-	var/expected_num_fillets = 0 //used to know how many fillets should be gotten out of this fish
+
+	///used to know how many fillets should be gotten out of this fish
+	var/expected_num_fillets = 0
+
+/obj/item/fish/testdummy/fish_grind_results()
+	return list()
 
 /obj/item/fish/testdummy/small
 	// The parent type is too big to reproduce inside the more compact fish tank


### PR DESCRIPTION
## About The Pull Request
Inspired by #94233. `grind_results`(list) & `juice_typepath`(typepath) are only used when grinding & juicing after which the atom is deleted. This means if that object is not processed these vars occupy memory & don't do anything.

Now these values are only generated on demand by calling their respective procs. Considering how these vars are on the obj level the memory savings are quite significant

## Changelog
🆑
refactor: grinding & juicing have been refactored to occupy low memory. Report bugs on github
code: improved grinding & juicing code
/:cl:

