### PR TITLE
Fixing a singular, tiny grammatical error in asthma.dm

### DIFF
--- a/code/datums/quirks/negative_quirks/asthma.dm
+++ b/code/datums/quirks/negative_quirks/asthma.dm
@@ -1,6 +1,6 @@
 /datum/quirk/item_quirk/asthma
 	name = "Asthma"
-	desc = "You suffer from asthma, a inflammatory disorder that causes your airpipe to squeeze shut! Be careful around smoke!"
+	desc = "You suffer from asthma, an inflammatory disorder that causes your airpipe to squeeze shut! Be careful around smoke!"
 	icon = FA_ICON_LUNGS_VIRUS
 	value = -4 // trivialized by NOBREATH but still quite dangerous
 	gain_text = span_danger("You have a harder time breathing.")


### PR DESCRIPTION
Fixes 1 single grammatical error. Feels pretentious but grammar good mmm.

## About The Pull Request

This pull request converts a singular "a" into "an" in the asthma.dm file to change the phrase that is visible during quirk selection. Converting the phrase:


## Why It's Good For The Game

While the grammar mistake is relatively small, and hence this has incredibly low priority, it is still a SPaG error that should probably be corrected. It may improve the sentence's flow/readability by a tiny amount as well.

## Changelog

:cl:
spellcheck: fixed asthma.dm typo
/:cl:

