### PR TITLE
Suit sensor runtime & logging

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -293,6 +293,8 @@
 		return
 
 	var/mob/living/carbon/human/wearer = loc
+	if(wearer.get_item_by_slot(ITEM_SLOT_ICLOTHING) != src)
+		return
 
 	if(has_sensor >= HAS_SENSORS && sensor_mode >= SENSOR_LIVING)
 		GLOB.suit_sensors_list |= wearer

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -106,8 +106,8 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 		"[SENSOR_COORDS]" = "Tracking",
 	)
 
-	var/new_mode = tgui_input_list(user, "Adjust suit sensors", "Adjust Sensors", sensor_mode_text_to_num, senor_mode_num_to_text["[jumpsuit.sensor_mode]"])
-	new_mode = sensor_mode_text_to_num[new_mode]
+	var/new_mode_str = tgui_input_list(user, "Adjust suit sensors", "Adjust Sensors", sensor_mode_text_to_num, senor_mode_num_to_text["[jumpsuit.sensor_mode]"])
+	var/new_mode = sensor_mode_text_to_num[new_mode_str]
 	if(isnull(new_mode)) // also catches returning null
 		return
 
@@ -121,6 +121,8 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 		return
 	source.balloon_alert(user, "changed sensors")
 	to_chat(source, span_notice("[user] successfully adjusted your [jumpsuit.name]'s sensor."))
+	user.log_message("changed suit sensors of [key_name(source)] to [new_mode_str]", LOG_ATTACK, color="red")
+	source.log_message("suit sensors changed to [new_mode_str] by [key_name(user)]", LOG_VICTIM, color="orange", log_globally=FALSE)
 
 /datum/strippable_item/mob_item_slot/jumpsuit/proc/do_strip_accessory(atom/source, mob/user, obj/item/clothing/under/jumpsuit)
 	var/list/accessory_choices = list()


### PR DESCRIPTION

## About The Pull Request
Fixes that a mob's state in the suit sensor list could be disconnected from the state of their worn suit sensors, because unequipped suits were considered during sensor updates
(eg pick up a suit, turn on its sensors while its in your hand, drop it, get added to GLOB.suit_sensors_list even if your worn sensors are disabled)

Also adds logging for toggling the suit sensors of a corpse, because logging is good and that can be important information
## Why It's Good For The Game
Fix log bug good 
## Changelog
:cl:
admin: Changing suit sensors from the strip menu is now logged
fix: Fixed a case where your suit sensor status could be desynced from what your suit sensors appear to be set to
/:cl:
