### PR TITLE
Adds midround clownops to antag preferences menu

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/clownoperativemidround.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/clownoperativemidround.ts
@@ -1,0 +1,18 @@
+import { type Antagonist, Category } from '../base';
+import { OPERATIVE_MECHANICAL_DESCRIPTION } from './operative';
+
+const ClownoOperativeMidround: Antagonist = {
+  key: 'clownoperativemidround',
+  name: 'Clown Ass-ailant',
+  description: [
+    `
+     A form of clown operative that is offered to ghosts in the middle
+     of the shift.
+    `,
+
+    OPERATIVE_MECHANICAL_DESCRIPTION,
+  ],
+  category: Category.Midround,
+};
+
+export default ClownoOperativeMidround;


### PR DESCRIPTION

## About The Pull Request
Closes https://github.com/tgstation/tgstation/issues/94591. Adds the Clown Ass-ailant, midround clownops, to the antag preference menu, allowing players to enable the antag and sign up for it when spawned.
## Why It's Good For The Game
Nobody could sign up for it because we didn't give the option to enable it.
<img width="765" height="129" alt="Screenshot 2025-12-23 193313" src="https://github.com/user-attachments/assets/b0efd70a-4d1e-4bf3-a192-5a8ff99b0f11" />
## Changelog
:cl:
fix: Adds midround clownops to the antag pref
/:cl:
