### PR TITLE
Make fade_into_nothing more sensible

### DIFF
--- a/code/__HELPERS/fade_into_nothing.dm
+++ b/code/__HELPERS/fade_into_nothing.dm
@@ -1,8 +1,13 @@
 /// Deletes the atom with a little fading out animation after a specified time
 /atom/proc/fade_into_nothing(life_time = 5 SECONDS, fade_time = 3 SECONDS)
 	QDEL_IN(src, life_time)
-	if (life_time > fade_time && fade_time > 0)
+	if (fade_time <= 0)
+		return
+
+	if (life_time > fade_time)
 		addtimer(CALLBACK(src, PROC_REF(fade_into_nothing_animate), fade_time), life_time - fade_time, TIMER_DELETE_ME)
+	else
+		fade_into_nothing_animate(fade_time)
 
 /// Actually does the fade out, used by fade_into_nothing()
 /atom/proc/fade_into_nothing_animate(fade_time)


### PR DESCRIPTION
## About The Pull Request

For some reason when we (read: I) added the code that this was originally I put in this "sanity check" which really just causes more problems than it solves.
There's no reason you shouldn't be able to set the life time and fade time to the same number, and if you wanted to only have it fade half way before disappearing that would look weird but I'm not your mum.

## Why It's Good For The Game

I occasionally try to use this proc this way and wonder why it doesn't work, I assume other people also have done this

## Changelog

not player facing