### PR TITLE
Batons target the chest, respecting chest armor rather than averaging the armor from all body parts

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -260,7 +260,7 @@
 			var/mob/living/carbon/human/human_target = target
 			if(prob(force_say_chance))
 				human_target.force_say()
-		var/armour_block = target.run_armor_check(null, armour_type_against_stun, null, null, stun_armour_penetration)
+		var/armour_block = target.run_armor_check(BODY_ZONE_CHEST, armour_type_against_stun, null, null, stun_armour_penetration)
 		target.apply_damage(stamina_damage, STAMINA, blocked = armour_block)
 		if(!trait_check)
 			target.Knockdown((isnull(stun_override) ? knockdown_time : stun_override))


### PR DESCRIPTION
## About The Pull Request

This behaviour was changed in https://github.com/tgstation/tgstation/pull/88830 but as it turns out, most limbs not having armor means this gets divided to borderline 0 after AP is applied, meaning that the only armors that were meaningfully stopping batons this whole time were full body suits. Like antag armor, mining armor and the magnate armor.

This isn't intended, and since it was a last minute review, wasn't thoroughly tested. Oops.

## Why It's Good For The Game

I want to formally apologize to every security officer wearing only the dinky normal vest, you were so fucked over.

## Changelog
:cl:
fix: Batons respect chest armor specifically once again.
/:cl:
