### PR TITLE
[NO GBP] Fixes an oversight with tablesmash element

### DIFF
--- a/code/datums/elements/table_smash.dm
+++ b/code/datums/elements/table_smash.dm
@@ -198,6 +198,6 @@
 	after_smash(target)
 	return COMSIG_LIVING_SHOVE_HANDLED
 
-/// Called after someone is harmfully smashed into us
+/// Called after someone is harmfully smashed onto us
 /obj/structure/proc/after_smash(mob/living/smashed_onto)
 	return // This is mostly for our children

--- a/code/datums/elements/table_smash.dm
+++ b/code/datums/elements/table_smash.dm
@@ -4,21 +4,24 @@
 	argument_hash_start_idx = 2
 	/// If true, mobs will be placed gently on the table even if they're in an aggressive grab
 	var/gentle_push
+	/// Passed proc call path for what to do after smashing harmfully into our 'table'-like obj
+	var/after_smash_proccall
 
-/datum/element/table_smash/Attach(datum/target, gentle_push = FALSE)
+/datum/element/table_smash/Attach(datum/target, gentle_push = FALSE, after_smash_proccall)
 	. = ..()
 	if (!isobj(target))
 		return ELEMENT_INCOMPATIBLE
 
 	src.gentle_push = gentle_push
+	src.after_smash_proccall = after_smash_proccall
 
 	RegisterSignal(target, COMSIG_ATOM_ATTACK_HAND, PROC_REF(on_interaction))
 	RegisterSignal(target, COMSIG_ATOM_ITEM_INTERACTION, PROC_REF(on_item_interaction))
 
 	var/static/list/loc_connections = list(
-		COMSIG_LIVING_DISARM_COLLIDE = TYPE_PROC_REF(/obj/structure/table, on_pushed_into),
+		COMSIG_LIVING_DISARM_COLLIDE = TYPE_PROC_REF(/obj/structure, on_disarm_shoved_into),
 	)
-	target.AddComponent(/datum/component/connect_loc_behalf, target, loc_connections)
+	target.AddElement(/datum/element/connect_loc, loc_connections)
 
 /datum/element/table_smash/Detach(datum/source, ...)
 	. = ..()
@@ -159,7 +162,8 @@
 	log_combat(user, pushed_mob, "tabled", null, "onto [table]")
 	pushed_mob.add_mood_event("table", /datum/mood_event/table)
 	SEND_SIGNAL(user, COMSIG_LIVING_TABLE_SLAMMING, pushed_mob, table)
-	table.after_smash(pushed_mob)
+	if(after_smash_proccall)
+		call(table, after_smash_proccall)(pushed_mob)
 
 /// Even more aggressively smash a single part of a mob onto the table
 /datum/element/table_smash/proc/tablelimbsmash(mob/living/user, mob/living/pushed_mob, obj/structure/table/table)
@@ -177,10 +181,11 @@
 	pushed_mob.add_mood_event("table", /datum/mood_event/table_limbsmash, banged_limb)
 	table.take_damage(50)
 	SEND_SIGNAL(user, COMSIG_LIVING_TABLE_LIMB_SLAMMING, pushed_mob, table)
-	table.after_smash(pushed_mob)
+	if(after_smash_proccall)
+		call(table, after_smash_proccall)(pushed_mob)
 
 /// Called when someone is shoved into our tile
-/obj/structure/table/proc/on_pushed_into(datum/source, mob/living/shover, mob/living/target, shove_flags, obj/item/weapon)
+/obj/structure/proc/on_disarm_shoved_into(datum/source, mob/living/shover, mob/living/target, shove_flags, obj/item/weapon)
 	SIGNAL_HANDLER
 	if((shove_flags & SHOVE_KNOCKDOWN_BLOCKED) || !(shove_flags & SHOVE_BLOCKED))
 		return
@@ -193,6 +198,6 @@
 	after_smash(target)
 	return COMSIG_LIVING_SHOVE_HANDLED
 
-/// What happens after something gets smashed onto this table
-/obj/structure/table/proc/after_smash(mob/living/smashed_onto)
-	return
+/// Called after someone is harmfully smashed into us
+/obj/structure/proc/after_smash(mob/living/smashed_onto)
+	return // This is mostly for our children

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -91,11 +91,7 @@
 	make_climbable()
 	AddElement(/datum/element/give_turf_traits, string_list(turf_traits))
 	AddElement(/datum/element/footstep_override, priority = STEP_SOUND_TABLE_PRIORITY)
-	AddElement(/datum/element/table_smash, gentle_push = slam_gently)
-
-/// Called after someone is harmfully smashed into us
-/obj/structure/table/after_smash(mob/living/smashed_onto)
-	return // This is mostly for our children
+	AddElement(/datum/element/table_smash, gentle_push = slam_gently, after_smash_proccall = PROC_REF(after_smash))
 
 /// Applies additional properties based on the frame used to construct this table.
 /obj/structure/table/proc/apply_frame_properties(obj/structure/table_frame/frame_used)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -800,7 +800,7 @@
 			if(obj_content.flags_1 & ON_BORDER_1 && obj_content.dir == shove_dir && obj_content.density)
 				shove_flags |= SHOVE_DIRECTIONAL_BLOCKED
 				break
-		if(target_turf != target_shove_turf && !(shove_flags && SHOVE_DIRECTIONAL_BLOCKED)) //Make sure that we don't run the exact same check twice on the same tile
+		if(target_turf != target_shove_turf && !(shove_flags & SHOVE_DIRECTIONAL_BLOCKED)) //Make sure that we don't run the exact same check twice on the same tile
 			for(var/obj/obj_content in target_shove_turf)
 				if(obj_content.flags_1 & ON_BORDER_1 && obj_content.dir == REVERSE_DIR(shove_dir) && obj_content.density)
 					shove_flags |= SHOVE_DIRECTIONAL_BLOCKED


### PR DESCRIPTION
## About The Pull Request

I neglected platforms, whoops. Also, while we are at it refactors to use the connect_loc element further reducing instances of connect_loc_behalf components, and fixes a bug in disarm code with checking for a flag using && instead of & that I randomly stumbled upon

<details> <summary> Working </summary>

<img width="1461" height="804" alt="image" src="https://github.com/user-attachments/assets/fa6fc773-94a8-488e-840d-d1d3d2070a29" />

</details>

## Why It's Good For The Game

Fixes a runtime

## Changelog

:cl:
fix: fixes tablesmashing onto platforms
/:cl: