### PR TITLE
Ratvarian_Repeater no longer can be unwelded - Balance fix

### DIFF
--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -345,17 +345,6 @@
 	category = CAT_WEAPON_RANGED
 	crafting_flags = CRAFT_CHECK_DENSITY
 
-/datum/crafting_recipe/Detached_Ratvarian_Repeater
-	name = "Iconoclast's Repeater"
-	tool_behaviors = list(TOOL_WELDER)
-	result = /obj/item/gun/energy/laser/musket/repeater
-	structures = list(
-		/obj/structure/mounted_gun/ratvarian_repeater = CRAFTING_STRUCTURE_CONSUME,
-	)
-	time = 10 SECONDS
-	category = CAT_WEAPON_RANGED
-	crafting_flags = CRAFT_CHECK_DENSITY
-
 
 /datum/crafting_recipe/large_ballista
 	name = "Improvised Ballista"


### PR DESCRIPTION

## Removes the ability for the bulky turret to be carried as a stand alone weapon
## Why It's Good For The Game

Many layers of balancing considerations have been missed from this PR - Currently the most powerful infinite ammo weapon in the game, plus the fact you can re-load while firing is broken, along with any mounted vehicle can eliminate the slowdown from it.

Expectation is this is a temporary change until the original author can re-balance the weapon properly.

Original PR is = #94102 
## Changelog
:cl:
balance: Stops Ratvar Repeater from being unwelded, Temp removal of Ironclast Repeater as craftable item
/:cl:
