### PR TITLE
Readds soul to shocks

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -280,11 +280,17 @@
 			C.electrocute_act(shock_damage*0.75, src, 1, flags, jitter_time, stutter_time, stun_duration)
 	//Stun
 	var/should_stun = (!(flags & SHOCK_TESLA) || siemens_coeff > 0.5) && !(flags & SHOCK_NOSTUN)
-	var/paralyze = !(flags & SHOCK_KNOCKDOWN)
+	var/stun = !(flags & SHOCK_KNOCKDOWN)
 	var/immediately_stun = should_stun && !(flags & SHOCK_DELAY_STUN)
 	if (immediately_stun)
-		if (paralyze)
-			Paralyze(stun_duration)
+		if (stun)
+			// intended effect here is to floor you immediately if you are shocked twice in quick succession
+			// or to keep you floored if you are already incapacitated otherwise
+			if(incapacitated)
+				Paralyze(stun_duration)
+			// otherwise it just stuns you upright - until the second shock, which floors you
+			else
+				Stun(stun_duration)
 		else
 			Knockdown(stun_duration)
 	//Jitter and other fluff.
@@ -292,12 +298,12 @@
 	adjust_jitter(jitter_time)
 	adjust_stutter(stutter_time)
 	if (should_stun)
-		addtimer(CALLBACK(src, PROC_REF(secondary_shock), paralyze, stun_duration * 1.5), 2 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(secondary_shock), stun, stun_duration * 1.5), 2 SECONDS)
 	return shock_damage
 
 ///Called slightly after electrocute act to apply a secondary stun.
-/mob/living/carbon/proc/secondary_shock(paralyze, stun_duration)
-	if (paralyze)
+/mob/living/carbon/proc/secondary_shock(stun, stun_duration)
+	if (stun)
 		Paralyze(stun_duration)
 	else
 		Knockdown(stun_duration)


### PR DESCRIPTION
## About The Pull Request

Replaces the `Paralyze` after being shocked with a `Stun`.
(For those unaware the only difference between these effects is `Paralyze` forces you to the floor, `Stun` does not.)
You still get `Paralyze`d after a few seconds, which forces you to the floor.

If you play with RDS, you may be familiar with the shock hallucination that keeps you upright for a bit before flooring you.
That's what normal shocking looks like now. 

I also added some extra logic to revert back to using a `Paralyze` if you are already stunned, so two shocks in quick succession floors you faster.

## Why It's Good For The Game

Functionally it is largely identical, so this ultimately isn't a major change.
I think this is how shocking was supposed to look, before the PR that added `Paralyze()` and friends?
Either way I just think it looks more fun.

## Changelog

:cl: Melbert
balance: When you are shocked, you remain standing for a short period of time before being forced to the ground. You are still stunned for the duration of this effect, that remains unchanged.
/:cl:
