### PR TITLE
Fix inverted moth wing repair check

### DIFF
--- a/code/modules/surgery/operations/operation_virus.dm
+++ b/code/modules/surgery/operations/operation_virus.dm
@@ -27,7 +27,7 @@
 	. = ..()
 	. += "the patient must have a virus to bond"
 	for(var/datum/reagent/chem as anything in required_chems)
-		. += "the patient must be dosed with >1u [chem::name]"
+		. += "the patient must be dosed with >=1u [chem::name]"
 
 /datum/surgery_operation/basic/viral_bonding/get_default_radial_image()
 	return image(/obj/item/clothing/mask/surgical)

--- a/code/modules/surgery/operations/operation_wing_repair.dm
+++ b/code/modules/surgery/operations/operation_wing_repair.dm
@@ -12,12 +12,13 @@
 	time = 20 SECONDS
 	target_type = /obj/item/organ/wings/moth
 	all_surgery_states_required = SURGERY_SKIN_OPEN|SURGERY_VESSELS_CLAMPED
+	required_organ_flag = NONE
 
 /datum/surgery_operation/organ/fix_wings/get_default_radial_image()
 	return image(icon = 'icons/mob/human/species/moth/moth_wings.dmi', icon_state = "m_moth_wings_monarch_BEHIND")
 
 /datum/surgery_operation/organ/fix_wings/all_required_strings()
-	return ..() + list("the wings must be burnt", "the patient must be dosed with >5u [/datum/reagent/medicine/c2/synthflesh::name]")
+	return ..() + list("the wings must be burnt", "the patient must be dosed with >=5u [/datum/reagent/medicine/c2/synthflesh::name]")
 
 /datum/surgery_operation/organ/fix_wings/all_blocked_strings()
 	return ..() + list("if the limb has bones, they must be intact")
@@ -26,7 +27,7 @@
 	if(!organ.burnt)
 		return FALSE
 	// If bones are sawed, prevent the operation (unless we're operating on a limb with no bones)
-	if(!LIMB_HAS_ANY_SURGERY_STATE(organ.bodypart_owner, SURGERY_BONE_DRILLED|SURGERY_BONE_SAWED) && LIMB_HAS_BONES(organ.bodypart_owner))
+	if(LIMB_HAS_ANY_SURGERY_STATE(organ.bodypart_owner, SURGERY_BONE_DRILLED|SURGERY_BONE_SAWED) && LIMB_HAS_BONES(organ.bodypart_owner))
 		return FALSE
 	if(organ.owner.reagents?.get_reagent_amount(/datum/reagent/medicine/c2/synthflesh) < 5)
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

The instructions state `if the limb has bones, they must be intact` 
But the code checked `if the limb has bones, they must be be sawed`

Also removed the organ flag requirement (it's redundant)
Also updated some wording

## Changelog

:cl: Melbert
fix: Moth wing repair surgery correctly checks that bones are intact rather than bones are sawed
/:cl:
