### PR TITLE
Reduces the Secondary Effects of Stun/Contractor Batons if you have Baton Resistance

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -452,8 +452,8 @@
 
 /obj/item/melee/baton/telescopic/contractor_baton/additional_effects_non_cyborg(mob/living/target, mob/living/user)
 	. = ..()
-	target.set_jitter_if_lower(40 SECONDS)
-	target.set_stutter_if_lower(40 SECONDS)
+	target.set_jitter_if_lower(40 SECONDS * (HAS_TRAIT(target, TRAIT_BATON_RESISTANCE) ? 0.5 : 1))
+	target.set_stutter_if_lower(40 SECONDS * (HAS_TRAIT(target, TRAIT_BATON_RESISTANCE) ? 0.5 : 1))
 
 /obj/item/melee/baton/security
 	name = "stun baton"
@@ -692,9 +692,9 @@
  * After a period of time, we then check to see what stun duration we give.
  */
 /obj/item/melee/baton/security/additional_effects_non_cyborg(mob/living/target, mob/living/user)
-	target.set_jitter_if_lower(40 SECONDS)
-	target.set_confusion_if_lower(10 SECONDS)
-	target.set_stutter_if_lower(16 SECONDS)
+	target.set_jitter_if_lower(40 SECONDS * (HAS_TRAIT(target, TRAIT_BATON_RESISTANCE) ? 0.5 : 1))
+	target.set_confusion_if_lower(10 SECONDS * (HAS_TRAIT(target, TRAIT_BATON_RESISTANCE) ? 0.5 : 1))
+	target.set_stutter_if_lower(16 SECONDS * (HAS_TRAIT(target, TRAIT_BATON_RESISTANCE) ? 0.5 : 1))
 
 	SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK)
 	addtimer(CALLBACK(src, PROC_REF(apply_stun_effect_end), target), 2 SECONDS)

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -1020,7 +1020,7 @@
 
 /obj/item/mod/module/shock_absorber
 	name = "MOD shock absorption module"
-	desc = "A module that makes the user resistant to the knockdown inflicted by Stun Batons."
+	desc = "A module that makes the user resistant to the knockdown and CNS disruption inflicted by Stun Batons."
 	icon_state = "no_baton"
 	complexity = 1
 	use_energy_cost = DEFAULT_CHARGE_DRAIN


### PR DESCRIPTION
## About The Pull Request

As on tin. Checks if you have baton resistance and reduces the duration of jitter, confusion (exclusive to the stun baton), and stutter by half. This applies to both the stun and contractor baton, since they are the only two to possess these effects. Updates the shock absorber module description accordingly.

## Why It's Good For The Game

Baton resistance is limited to only preventing knockdown in most use cases, while allowing the other detrimental effects to slip by. With how few sources there are of this trait, next to half of which are temporary, the investment in procuring this is moot if confusion decides you should run into a wall for most of the ten whole seconds it is active after taking a hit from a stun baton. This mitigates that by allowing those who've prepared (or should rightly be harder to subdue, like nukies with a shock absorber module) to fight or flee from combat with security somewhat more easily, while slightly improving quality of life thematically, in line with the spirit of the trait. Extends it to the contractor baton as it uses the same effects, method of stunning in lore, and already resists the knockdown there.

## Changelog
:cl:
balance: Baton resistance now reduces the jitter, confusion, and stutter of electric baton strikes by half.
/:cl:
