### PR TITLE
Sanity checks the iconoclast's repeater

### DIFF
--- a/code/game/objects/structures/cannons/mounted_guns/mounted_gun.dm
+++ b/code/game/objects/structures/cannons/mounted_guns/mounted_gun.dm
@@ -236,7 +236,7 @@
 	shots_in_gun = 12
 	fire_sound = 'sound/items/weapons/thermalpistol.ogg'
 	last_fire_sound = 'sound/items/weapons/thermalpistol.ogg'
-	projectile_type = /obj/projectile/beam/laser/musket/repeater
+	projectile_type = /obj/projectile/beam/laser/repeater
 	loaded_gun = TRUE
 	fully_loaded_gun = TRUE
 	fire_delay = 1

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -62,7 +62,7 @@
 	variance = 10
 
 /obj/item/ammo_casing/energy/laser/musket/repeater
-	projectile_type = /obj/projectile/beam/laser/musket/repeater
+	projectile_type = /obj/projectile/beam/laser/repeater
 	pellets = 2
 	variance = 10
 	fire_sound = 'sound/items/weapons/thermalpistol.ogg'

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -68,6 +68,10 @@
 	fire_sound = 'sound/items/weapons/thermalpistol.ogg'
 	e_cost = LASER_SHOTS(6, STANDARD_CELL_CHARGE)
 
+/obj/item/ammo_casing/energy/laser/musket/repeater/handheld
+	pellets = 1
+	e_cost = LASER_SHOTS(12, STANDARD_CELL_CHARGE)
+
 /obj/item/ammo_casing/energy/laser/practice
 	projectile_type = /obj/projectile/beam/practice
 	select_name = "practice"

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -7,6 +7,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/musket)
 	slot_flags = ITEM_SLOT_BACK
 	obj_flags = UNIQUE_RENAME
+	weapon_weight = WEAPON_HEAVY
 	custom_materials = list(/datum/material/wood = SHEET_MATERIAL_AMOUNT * 8, /datum/material/glass = SHEET_MATERIAL_AMOUNT * 1.2, /datum/material/iron = SHEET_MATERIAL_AMOUNT * 1.2)
 	light_color = COLOR_PURPLE
 
@@ -164,7 +165,6 @@
 	spread = 20
 	charge_sections = 1
 	item_flags = SLOWS_WHILE_IN_HAND | IMMUTABLE_SLOW
-	weapon_weight = WEAPON_HEAVY
 	custom_materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5.25,
 		/datum/material/bronze = SHEET_MATERIAL_AMOUNT * 5,

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -152,16 +152,19 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/nanite/cryo)
 
 /obj/item/gun/energy/laser/musket/repeater
-	name = "Iconoclast's Repeater"
+	name = "iconoclast's repeater"
 	desc = "A weapon of incredible bulk, this ratvarian repeater has been permanently severed from its stand to be carried by hand. Cumbersome, Yes - but powerful."
 	icon_state = "repeater"
 	inhand_icon_state = "repeater"
 	slowdown = 1
+	burst_size = 2
+	fire_delay = 0.5
 	w_class = WEIGHT_CLASS_HUGE
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/musket/repeater)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/musket/repeater/handheld)
 	spread = 20
 	charge_sections = 1
 	item_flags = SLOWS_WHILE_IN_HAND | IMMUTABLE_SLOW
+	weapon_weight = WEAPON_HEAVY
 	custom_materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5.25,
 		/datum/material/bronze = SHEET_MATERIAL_AMOUNT * 5,
@@ -173,13 +176,16 @@
 	AddComponent( \
 		/datum/component/crank_recharge, \
 		charging_cell = get_cell(), \
-		charge_amount = STANDARD_CELL_CHARGE, \
-		cooldown_time = 3 SECONDS, \
+		charge_amount = LASER_SHOTS(6, STANDARD_CELL_CHARGE), \
+		cooldown_time = 0.4 SECONDS, \
 		charge_sound = 'sound/machines/clockcult/integration_cog_install.ogg', \
 		charge_sound_cooldown_time = 3 SECONDS, \
-		charge_move = IGNORE_USER_LOC_CHANGE, \
 	)
 	AddComponent(/datum/component/automatic_fire, 0.5 SECONDS)
+
+/obj/item/gun/energy/laser/musket/repeater/add_deep_lore()
+	return
+
 // The Deep Lore //
 
 // Laser Musket

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -122,9 +122,8 @@
 	name = "clockwork laser"
 	icon_state = "laser_repeater"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/yellow_laser
-	damage = 28
-	stamina = 35
-	weak_against_armour = TRUE
+	damage = 15
+	stamina = 20
 	light_color = COLOR_DARK_ORANGE
 
 /obj/projectile/beam/weak

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -118,12 +118,13 @@
 	stamina = 20
 	weak_against_armour = FALSE
 
-/obj/projectile/beam/laser/musket/repeater
+/obj/projectile/beam/laser/repeater
 	name = "clockwork laser"
 	icon_state = "laser_repeater"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/yellow_laser
 	damage = 15
 	light_color = COLOR_DARK_ORANGE
+	weak_against_armour = TRUE
 
 /obj/projectile/beam/weak
 	damage = 15

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -123,7 +123,6 @@
 	icon_state = "laser_repeater"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/yellow_laser
 	damage = 15
-	stamina = 20
 	light_color = COLOR_DARK_ORANGE
 
 /obj/projectile/beam/weak


### PR DESCRIPTION
## About The Pull Request

Alternative to https://github.com/tgstation/tgstation/pull/94613

The iconoclast repeater, the handheld version, no longer fires two pellets but instead fires in a two round burst.

The iconoclast repeater now charges two shots (one trigger pull) every crank, and the crank takes 0.4 seconds (letting you outpace your shot rate). However, you cannot charge the gun while moving.

Reduces the damage of the repeater's shots. Now it does 15 lethal force. Since this is coming out in bursts of two, this means that it deals 30 lethal force in a single pull.

https://github.com/tgstation/tgstation/pull/86867 removed the wielding requirement but didn't make the weapon heavy. I suspect this was an oversight so I'm treating it as a fix given the weapon visually appears to be held in two hands.

Cleans up some repeat variables and nouns.

## Why It's Good For The Game

The repeater has some pretty egregious statistics that put it pretty soundly above other improvised weapons, but also a lot of manufactured weapons as well. It has existing downsides, but they're not necessarily able to be felt because of other oversights to the weapon's design.

This will make sure that the weaknesses are felt while still being a relatively useful weapon. Pointedly, the gun still kills people pretty fast if you're in line of fire, but actually pursuing someone while firing is going to be very difficult. It can still run down unarmored targets with the amount of shots in the gun, but it can't be used to go Rambo down the halls, wiping everyone out with your effective machine gun. 

## Changelog
:cl:
balance: The iconoclast repeater, the handheld version, no longer fires two pellets but instead fires in a two round burst.
balance: The iconoclast repeater now charges two shots (one trigger pull) every crank, and the crank takes 0.4 seconds (letting you outpace your shot rate). However, you cannot charge the gun while moving.
balance: Reduces the damage of the repeater's shots (both versions). Now it does 15 lethal force per shot. Since this is coming out in bursts of two, this means that it deals 30 lethal force in a single pull.
fix: Laser musket type weapons are now heavy weapons.
code: Cleans up some of the code and grammar on the repeater.
/:cl:
