### PR TITLE
Fixes problems with the giantslayer spear

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -298,14 +298,14 @@
  * "WHERES MY DRAGONATOR?!"
  */
 /obj/item/spear/dragonator
+	name = "giantslayer spear"
+	desc = "An oversized multi-bladed spear designed to kill large hostile xenoforms such as space dragons or the creatures of Indecipheres. Capable of being launched from a ballista."
 	icon = 'icons/obj/weapons/48x.dmi'
 	icon_state = "speardragon0"
 	icon_prefix = "speardragon"
-	base_icon_state = "speardragon0"
+	base_icon_state = "speardragon"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
-	name = "Giantslayer Spear"
-	desc = "An oversized multi-bladed spear designed to kill large hostile xenoforms such as space dragons or the creatures of lavaland. Capable of being launched from a ballista."
 	demolition_mod = 0.5
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	force = 13
@@ -317,6 +317,7 @@
 	force_unwielded = 13
 	force_wielded = 21
 	armour_penetration = 15
+	improvised_construction = FALSE
 	custom_materials =  list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 42,
 		/datum/material/alloy/plasteel = SHEET_MATERIAL_AMOUNT * 15,
@@ -330,14 +331,12 @@
  * Untreated Giantslayer , needs to be thrown into lava
  */
 /obj/item/spear/dragonator_untreated
+	name = "unfired giantslayer spear"
+	desc = "A half-finished giantslayer spear, needs to be thrown in lava to forge the metals to a killing edge."
 	icon = 'icons/obj/weapons/48x.dmi'
 	icon_state = "speardragonraw0"
 	icon_prefix = "speardragonraw"
-	base_icon_state = "speardragonraw0"
-	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
-	name = "Unfired Giantslayer Spear"
-	desc = "A half-finished giantslayer spear, needs to be thrown in lava to forge the metals to a killing edge."
+	base_icon_state = "speardragonraw"
 	demolition_mod = 0.5
 	wound_bonus = 0
 	exposed_wound_bonus = 0
@@ -353,7 +352,6 @@
 	var/obj/item/spear/dragonator/dragonator = new(loc)
 	playsound(dragonator.loc, 'sound/effects/magic/staff_change.ogg',5)
 	qdel(src)
-
 
 /*
  * Bone Spear


### PR DESCRIPTION

## About The Pull Request

Cleans up some of the code and grammar for the giantslayer spears.

Makes them not improvised, which is almost certainly an oversight given they're not improvised weapons.

## Why It's Good For The Game

Code cleaning.

## Changelog
:cl:
code: Fixes up some of the code and grammar for the giantslayer spears.
fix: Giantslayer spears are not improvised and therefore do not break when used to attack things.
/:cl:
