### PR TITLE
Replaces micro dosing with volumetric dosing

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -479,7 +479,7 @@
 /// How much nutrition eating clothes as moth gives and drains
 #define CLOTHING_NUTRITION_GAIN 15
 #define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.
-#define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4) // By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism
+#define REAGENTS_EFFECT_MULTIPLIER (1 / (REAGENTS_METABOLISM * SSMOBS_DT)) // When multiplied with the volume of reagent metabolized you get an value from 0->1 to scale all reagent affects
 #define REM REAGENTS_EFFECT_MULTIPLIER //! Shorthand for the above define for ease of use in equations and the like
 
 // Eye protection

--- a/code/__HELPERS/reagents.dm
+++ b/code/__HELPERS/reagents.dm
@@ -1,8 +1,3 @@
-///Helper to ensure an reagent affect operates at a constant 100% even with varying metabolization rates
-///Use for parent reagent types when subtypes alter metabolization rates
-///This constant is still dependent on the mobs metabolziation rate & the volume of reagent available
-#define METABOLIZE_FREE_CONSTANT(value)((value * REAGENTS_METABOLISM) / metabolization_rate)
-
 /proc/chem_recipes_do_conflict(datum/chemical_reaction/r1, datum/chemical_reaction/r2)
 	//We have to check to see if either is competitive so can ignore it (competitive reagents are supposed to conflict)
 	if((r1.reaction_flags & REACTION_COMPETITIVE) || (r2.reaction_flags & REACTION_COMPETITIVE))

--- a/code/__HELPERS/reagents.dm
+++ b/code/__HELPERS/reagents.dm
@@ -1,6 +1,5 @@
-///Helper to ensure an reagent affect operates at a constant 100% even with varying metabolization rates
+///Helper to ensure a constant is applied regardless of reagent metabolization rate to get 100% effect
 ///Use for parent reagent types when subtypes alter metabolization rates
-///This constant is still dependent on the mobs metabolziation rate & the volume of reagent available
 #define METABOLIZE_FREE_CONSTANT(value)((value * REAGENTS_METABOLISM) / metabolization_rate)
 
 /proc/chem_recipes_do_conflict(datum/chemical_reaction/r1, datum/chemical_reaction/r2)

--- a/code/__HELPERS/reagents.dm
+++ b/code/__HELPERS/reagents.dm
@@ -1,3 +1,8 @@
+///Helper to ensure an reagent affect operates at a constant 100% even with varying metabolization rates
+///Use for parent reagent types when subtypes alter metabolization rates
+///This constant is still dependent on the mobs metabolziation rate & the volume of reagent available
+#define METABOLIZE_FREE_CONSTANT(value)((value * REAGENTS_METABOLISM) / metabolization_rate)
+
 /proc/chem_recipes_do_conflict(datum/chemical_reaction/r1, datum/chemical_reaction/r2)
 	//We have to check to see if either is competitive so can ignore it (competitive reagents are supposed to conflict)
 	if((r1.reaction_flags & REACTION_COMPETITIVE) || (r2.reaction_flags & REACTION_COMPETITIVE))

--- a/code/modules/antagonists/blob/blobstrains/cryogenic_poison.dm
+++ b/code/modules/antagonists/blob/blobstrains/cryogenic_poison.dm
@@ -25,11 +25,11 @@
 		exposed_mob.reagents.add_reagent(/datum/reagent/blob/cryogenic_poison, 0.3*reac_volume)
 	exposed_mob.apply_damage(0.2*reac_volume, BRUTE, wound_bonus=CANT_WOUND)
 
-/datum/reagent/blob/cryogenic_poison/on_mob_life(mob/living/carbon/exposed_mob, seconds_per_tick)
+/datum/reagent/blob/cryogenic_poison/on_mob_life(mob/living/carbon/exposed_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = exposed_mob.adjust_brute_loss(0.5 * REM * seconds_per_tick, updating_health = FALSE)
-	need_mob_update += exposed_mob.adjust_fire_loss(0.5 * REM * seconds_per_tick, updating_health = FALSE)
-	need_mob_update += exposed_mob.adjust_tox_loss(0.5 * REM * seconds_per_tick, updating_health = FALSE)
+	need_mob_update = exposed_mob.adjust_brute_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+	need_mob_update += exposed_mob.adjust_fire_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+	need_mob_update += exposed_mob.adjust_tox_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH

--- a/code/modules/antagonists/blob/blobstrains/cryogenic_poison.dm
+++ b/code/modules/antagonists/blob/blobstrains/cryogenic_poison.dm
@@ -25,11 +25,11 @@
 		exposed_mob.reagents.add_reagent(/datum/reagent/blob/cryogenic_poison, 0.3*reac_volume)
 	exposed_mob.apply_damage(0.2*reac_volume, BRUTE, wound_bonus=CANT_WOUND)
 
-/datum/reagent/blob/cryogenic_poison/on_mob_life(mob/living/carbon/exposed_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/blob/cryogenic_poison/on_mob_life(mob/living/carbon/exposed_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = exposed_mob.adjust_brute_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-	need_mob_update += exposed_mob.adjust_fire_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-	need_mob_update += exposed_mob.adjust_tox_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+	need_mob_update = exposed_mob.adjust_brute_loss(0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+	need_mob_update += exposed_mob.adjust_fire_loss(0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+	need_mob_update += exposed_mob.adjust_tox_loss(0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH

--- a/code/modules/antagonists/blob/blobstrains/regenerative_materia.dm
+++ b/code/modules/antagonists/blob/blobstrains/regenerative_materia.dm
@@ -26,9 +26,9 @@
 		exposed_mob.reagents.add_reagent(/datum/reagent/toxin/spore, 0.2*reac_volume)
 	exposed_mob.apply_damage(0.7*reac_volume, TOX)
 
-/datum/reagent/blob/regenerative_materia/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick)
+/datum/reagent/blob/regenerative_materia/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(metabolizer.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE))
+	if(metabolizer.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/blob/regenerative_materia/on_mob_metabolize(mob/living/metabolizer)

--- a/code/modules/antagonists/blob/blobstrains/regenerative_materia.dm
+++ b/code/modules/antagonists/blob/blobstrains/regenerative_materia.dm
@@ -26,9 +26,9 @@
 		exposed_mob.reagents.add_reagent(/datum/reagent/toxin/spore, 0.2*reac_volume)
 	exposed_mob.apply_damage(0.7*reac_volume, TOX)
 
-/datum/reagent/blob/regenerative_materia/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolized_volume)
+/datum/reagent/blob/regenerative_materia/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(metabolizer.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+	if(metabolizer.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/blob/regenerative_materia/on_mob_metabolize(mob/living/metabolizer)

--- a/code/modules/antagonists/changeling/powers/_biodegrade_bioacid.dm
+++ b/code/modules/antagonists/changeling/powers/_biodegrade_bioacid.dm
@@ -19,7 +19,7 @@
 	exposed_mob.adjust_fire_loss(round(reac_volume * min(1 - touch_protection), 0.1) * 3, required_bodytype = BODYTYPE_ORGANIC) // full bio protection = 100% damage reduction
 	exposed_mob.acid_act(10, 50)
 
-/datum/reagent/toxin/acid/bio_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/acid/bio_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(50, seconds_per_tick))
 		affected_mob.emote(pick("screech", "cry"))

--- a/code/modules/antagonists/changeling/powers/_biodegrade_bioacid.dm
+++ b/code/modules/antagonists/changeling/powers/_biodegrade_bioacid.dm
@@ -19,7 +19,7 @@
 	exposed_mob.adjust_fire_loss(round(reac_volume * min(1 - touch_protection), 0.1) * 3, required_bodytype = BODYTYPE_ORGANIC) // full bio protection = 100% damage reduction
 	exposed_mob.acid_act(10, 50)
 
-/datum/reagent/toxin/acid/bio_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/acid/bio_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(50, seconds_per_tick))
 		affected_mob.emote(pick("screech", "cry"))

--- a/code/modules/antagonists/heretic/items/heretic_grenade.dm
+++ b/code/modules/antagonists/heretic/items/heretic_grenade.dm
@@ -113,7 +113,7 @@
 	. = ..()
 	exposed_turf.rust_turf()
 
-/datum/reagent/heretic_rust/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/heretic_rust/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!holder.has_reagent(/datum/reagent/consumable/milk))
 		if(SPT_PROB(5, seconds_per_tick))

--- a/code/modules/antagonists/heretic/items/heretic_grenade.dm
+++ b/code/modules/antagonists/heretic/items/heretic_grenade.dm
@@ -113,7 +113,7 @@
 	. = ..()
 	exposed_turf.rust_turf()
 
-/datum/reagent/heretic_rust/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/heretic_rust/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!holder.has_reagent(/datum/reagent/consumable/milk))
 		if(SPT_PROB(5, seconds_per_tick))

--- a/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
+++ b/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
@@ -537,7 +537,8 @@
 	// Heals blood loss
 	source.adjust_blood_volume(2.5 * delta_time, maximum = BLOOD_VOLUME_NORMAL)
 	for(var/datum/reagent/reagent as anything in source.reagents.reagent_list)
-		source.reagents.remove_reagent(reagent.type, reagent.purge_multiplier * seconds_per_tick)
+		reagent.volume -= 1 * reagent.purge_multiplier * seconds_per_tick
+	source.reagents.update_total()
 
 	if(!iscarbon(source))
 		return

--- a/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
+++ b/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
@@ -537,7 +537,7 @@
 	// Heals blood loss
 	source.adjust_blood_volume(2.5 * delta_time, maximum = BLOOD_VOLUME_NORMAL)
 	for(var/datum/reagent/reagent as anything in source.reagents.reagent_list)
-		source.reagents.remove_reagent(reagent.type, 2 * reagent.purge_multiplier * REM * seconds_per_tick)
+		source.reagents.remove_reagent(reagent.type, reagent.purge_multiplier * seconds_per_tick)
 
 	if(!iscarbon(source))
 		return

--- a/code/modules/mob/living/basic/jungle/leaper/leaper_abilities.dm
+++ b/code/modules/mob/living/basic/jungle/leaper/leaper_abilities.dm
@@ -62,11 +62,11 @@
 	taste_description = "french cuisine"
 	taste_mult = 1.3
 
-/datum/reagent/toxin/leaper_venom/on_mob_life(mob/living/carbon/poisoned_mob, seconds_per_tick)
+/datum/reagent/toxin/leaper_venom/on_mob_life(mob/living/carbon/poisoned_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(volume <= 5)
 		return
-	if(poisoned_mob.adjust_tox_loss(2.5 * REM * seconds_per_tick, updating_health = FALSE))
+	if(poisoned_mob.adjust_tox_loss(1.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 // bubble ability structure

--- a/code/modules/mob/living/basic/jungle/leaper/leaper_abilities.dm
+++ b/code/modules/mob/living/basic/jungle/leaper/leaper_abilities.dm
@@ -62,11 +62,11 @@
 	taste_description = "french cuisine"
 	taste_mult = 1.3
 
-/datum/reagent/toxin/leaper_venom/on_mob_life(mob/living/carbon/poisoned_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/leaper_venom/on_mob_life(mob/living/carbon/poisoned_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(volume <= 5)
 		return
-	if(poisoned_mob.adjust_tox_loss(1.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+	if(poisoned_mob.adjust_tox_loss(1.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 // bubble ability structure

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
@@ -172,7 +172,7 @@
 		return
 	to_chat(affected_mob, span_notice("This food has a funny taste!"))
 
-/datum/reagent/rat_spit/overdose_start(mob/living/affected_mob, metabolized_volume)
+/datum/reagent/rat_spit/overdose_start(mob/living/affected_mob, metabolization_ratio)
 	. = ..()
 	var/mob/living/carbon/victim = affected_mob
 	if (istype(victim) && !(FACTION_RAT in victim.faction))
@@ -181,7 +181,7 @@
 		victim.vomit(VOMIT_CATEGORY_DEFAULT)
 	metabolization_rate = 10 * REAGENTS_METABOLISM
 
-/datum/reagent/rat_spit/on_mob_life(mob/living/carbon/affected_mob, metabolized_volume)
+/datum/reagent/rat_spit/on_mob_life(mob/living/carbon/affected_mob, metabolization_ratio)
 	. = ..()
 	if(prob(15))
 		to_chat(affected_mob, span_notice("You feel queasy!"))

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
@@ -172,7 +172,7 @@
 		return
 	to_chat(affected_mob, span_notice("This food has a funny taste!"))
 
-/datum/reagent/rat_spit/overdose_start(mob/living/affected_mob)
+/datum/reagent/rat_spit/overdose_start(mob/living/affected_mob, metabolized_volume)
 	. = ..()
 	var/mob/living/carbon/victim = affected_mob
 	if (istype(victim) && !(FACTION_RAT in victim.faction))
@@ -181,7 +181,7 @@
 		victim.vomit(VOMIT_CATEGORY_DEFAULT)
 	metabolization_rate = 10 * REAGENTS_METABOLISM
 
-/datum/reagent/rat_spit/on_mob_life(mob/living/carbon/affected_mob)
+/datum/reagent/rat_spit/on_mob_life(mob/living/carbon/affected_mob, metabolized_volume)
 	. = ..()
 	if(prob(15))
 		to_chat(affected_mob, span_notice("You feel queasy!"))

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -187,7 +187,7 @@
 					losebreath += 0.5 * determined_mod * seconds_per_tick
 				else if(get_stamina_loss() < 25 * determined_mod)
 					to_chat(src, span_danger("You feel [word]. It's getting a bit hard to focus."))
-					adjust_stamina_loss(10 * determined_mod * REM * seconds_per_tick)
+					adjust_stamina_loss(5 * determined_mod * seconds_per_tick)
 		// Pretty low blood, getting dangerous!
 		if(BLOOD_VOLUME_RISKY to BLOOD_VOLUME_OKAY)
 			if(SPT_PROB(5, seconds_per_tick))
@@ -198,7 +198,7 @@
 					losebreath += 1 * determined_mod * seconds_per_tick
 				else if(get_stamina_loss() < 40 * determined_mod)
 					to_chat(src, span_bolddanger("You feel very [word]. It's getting hard to stay awake!"))
-					adjust_stamina_loss(15 * determined_mod * REM * seconds_per_tick)
+					adjust_stamina_loss(7.5 * determined_mod * seconds_per_tick)
 		// Very low blood, danger!!
 		if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_RISKY)
 			if(SPT_PROB(5, seconds_per_tick))
@@ -209,7 +209,7 @@
 					losebreath += 1.5 * determined_mod * seconds_per_tick
 				else if(get_stamina_loss() < 80 * determined_mod)
 					to_chat(src, span_userdanger("You feel extremely [word]! It's getting very hard to stay awake!"))
-					adjust_stamina_loss(20 * determined_mod * REM * seconds_per_tick)
+					adjust_stamina_loss(10 * determined_mod * seconds_per_tick)
 		// Critically low blood, death is near! Adrenaline won't help you here.
 		if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_BAD)
 			if(SPT_PROB(7.5, seconds_per_tick))

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -195,10 +195,10 @@
 				set_dizzy_if_lower(2 SECONDS * determined_mod)
 				if(prob(50))
 					to_chat(src, span_bolddanger("You feel very [word]. It's getting hard to breathe!"))
-					losebreath += 1 * determined_mod * seconds_per_tick
+					losebreath += 1 * determined_mod
 				else if(get_stamina_loss() < 40 * determined_mod)
 					to_chat(src, span_bolddanger("You feel very [word]. It's getting hard to stay awake!"))
-					adjust_stamina_loss(7.5 * determined_mod * seconds_per_tick)
+					adjust_stamina_loss(7.5 * determined_mod)
 		// Very low blood, danger!!
 		if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_RISKY)
 			if(SPT_PROB(5, seconds_per_tick))
@@ -206,10 +206,10 @@
 				set_dizzy_if_lower(4 SECONDS * determined_mod)
 				if(prob(50))
 					to_chat(src, span_userdanger("You feel extremely [word]! It's getting very hard to breathe!"))
-					losebreath += 1.5 * determined_mod * seconds_per_tick
+					losebreath += 1.5 * determined_mod
 				else if(get_stamina_loss() < 80 * determined_mod)
 					to_chat(src, span_userdanger("You feel extremely [word]! It's getting very hard to stay awake!"))
-					adjust_stamina_loss(10 * determined_mod * seconds_per_tick)
+					adjust_stamina_loss(10 * determined_mod)
 		// Critically low blood, death is near! Adrenaline won't help you here.
 		if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_BAD)
 			if(SPT_PROB(7.5, seconds_per_tick))

--- a/code/modules/reagents/chemistry/holder/mob_life.dm
+++ b/code/modules/reagents/chemistry/holder/mob_life.dm
@@ -124,7 +124,7 @@
 		need_mob_update += reagent.on_mob_dead(owner, seconds_per_tick, metabolization_ratio)
 
 	if(!QDELETED(owner) && !QDELETED(reagent) && !(tick_return & COMSIG_MOB_STOP_REAGENT_METABOLISM))
-		reagent.metabolize_reagent(owner, seconds_per_tick, metabolization_ratio)
+		reagent.metabolize_reagent(owner, seconds_per_tick, metabolized_volume)
 
 	return need_mob_update
 

--- a/code/modules/reagents/chemistry/holder/mob_life.dm
+++ b/code/modules/reagents/chemistry/holder/mob_life.dm
@@ -103,30 +103,28 @@
 		return FALSE
 
 	var/need_mob_update = FALSE
-	if(!reagent.metabolizing)
-		reagent.metabolizing = TRUE
-		reagent.on_mob_metabolize(owner)
 
+	var/metabolized_volume = reagent.compute_metabolization(owner, seconds_per_tick)
 	if(can_overdose && !HAS_TRAIT(owner, TRAIT_OVERDOSEIMMUNE))
 		if(reagent.overdose_threshold && reagent.volume >= reagent.overdose_threshold && !reagent.overdosed)
 			reagent.overdosed = TRUE
-			need_mob_update += reagent.overdose_start(owner)
+			need_mob_update += reagent.overdose_start(owner, metabolized_volume)
 			owner.log_message("has started overdosing on [reagent.name] at [reagent.volume] units.", LOG_GAME)
 
 		for(var/addiction in reagent.addiction_types)
 			owner.mind?.add_addiction_points(addiction, reagent.addiction_types[addiction] * REAGENTS_METABOLISM)
 
 		if(reagent.overdosed)
-			need_mob_update += reagent.overdose_process(owner, seconds_per_tick)
+			need_mob_update += reagent.overdose_process(owner, seconds_per_tick, metabolized_volume)
 
 	reagent.current_cycle++
-	need_mob_update += reagent.on_mob_life(owner, seconds_per_tick)
+	need_mob_update += reagent.on_mob_life(owner, seconds_per_tick, metabolized_volume)
 
 	if(dead && !QDELETED(owner) && !QDELETED(reagent))
-		need_mob_update += reagent.on_mob_dead(owner, seconds_per_tick)
+		need_mob_update += reagent.on_mob_dead(owner, seconds_per_tick, metabolized_volume)
 
 	if(!QDELETED(owner) && !QDELETED(reagent) && !(tick_return & COMSIG_MOB_STOP_REAGENT_METABOLISM))
-		reagent.metabolize_reagent(owner, seconds_per_tick)
+		reagent.metabolize_reagent(owner, seconds_per_tick, metabolized_volume)
 
 	return need_mob_update
 

--- a/code/modules/reagents/chemistry/holder/mob_life.dm
+++ b/code/modules/reagents/chemistry/holder/mob_life.dm
@@ -103,28 +103,28 @@
 		return FALSE
 
 	var/need_mob_update = FALSE
-
 	var/metabolized_volume = reagent.compute_metabolization(owner, seconds_per_tick)
+	var/metabolization_ratio = REM * metabolized_volume
 	if(can_overdose && !HAS_TRAIT(owner, TRAIT_OVERDOSEIMMUNE))
 		if(reagent.overdose_threshold && reagent.volume >= reagent.overdose_threshold && !reagent.overdosed)
 			reagent.overdosed = TRUE
-			need_mob_update += reagent.overdose_start(owner, metabolized_volume)
+			need_mob_update += reagent.overdose_start(owner, metabolization_ratio)
 			owner.log_message("has started overdosing on [reagent.name] at [reagent.volume] units.", LOG_GAME)
 
 		for(var/addiction in reagent.addiction_types)
 			owner.mind?.add_addiction_points(addiction, reagent.addiction_types[addiction] * REAGENTS_METABOLISM)
 
 		if(reagent.overdosed)
-			need_mob_update += reagent.overdose_process(owner, seconds_per_tick, metabolized_volume)
+			need_mob_update += reagent.overdose_process(owner, seconds_per_tick, metabolization_ratio)
 
 	reagent.current_cycle++
-	need_mob_update += reagent.on_mob_life(owner, seconds_per_tick, metabolized_volume)
+	need_mob_update += reagent.on_mob_life(owner, seconds_per_tick, metabolization_ratio)
 
 	if(dead && !QDELETED(owner) && !QDELETED(reagent))
-		need_mob_update += reagent.on_mob_dead(owner, seconds_per_tick, metabolized_volume)
+		need_mob_update += reagent.on_mob_dead(owner, seconds_per_tick, metabolization_ratio)
 
 	if(!QDELETED(owner) && !QDELETED(reagent) && !(tick_return & COMSIG_MOB_STOP_REAGENT_METABOLISM))
-		reagent.metabolize_reagent(owner, seconds_per_tick, metabolized_volume)
+		reagent.metabolize_reagent(owner, seconds_per_tick, metabolization_ratio)
 
 	return need_mob_update
 

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -179,14 +179,14 @@
  * * times_fired - the number of times the owner's Life() tick has been called aka The number of times SSmobs has fired
  *
  */
-/datum/reagent/proc/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/proc/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	SHOULD_CALL_PARENT(TRUE)
 
 ///Metabolizes a portion of the reagent after on_mob_life() is called
-/datum/reagent/proc/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/proc/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	if(isnull(holder))
 		return
-	holder.remove_reagent(type, metabolized_volume)
+	holder.remove_reagent(type, metabolization_ratio)
 
 
 /// Called in burns.dm *if* the reagent has the REAGENT_AFFECTS_WOUNDS process flag
@@ -225,7 +225,7 @@
 		affected_mob.add_traits(metabolized_traits, "metabolize:[type]")
 
 /// Called when this reagent stops being metabolized by a liver
-/datum/reagent/proc/on_mob_end_metabolize(mob/living/affected_mob, metabolized_volume)
+/datum/reagent/proc/on_mob_end_metabolize(mob/living/affected_mob, metabolization_ratio)
 	SHOULD_CALL_PARENT(TRUE)
 	REMOVE_TRAITS_IN(affected_mob, "metabolize:[type]")
 
@@ -253,11 +253,11 @@
 	SEND_SIGNAL(src, COMSIG_REAGENT_ON_MERGE, mix_data, amount)
 
 /// Called if the reagent has passed the overdose threshold and is set to be triggering overdose effects. Returning UPDATE_MOB_HEALTH will cause updatehealth() to be called on the holder mob by /datum/reagents/proc/metabolize.
-/datum/reagent/proc/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/proc/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	return
 
 /// Called when an overdose starts. Returning UPDATE_MOB_HEALTH will cause updatehealth() to be called on the holder mob by /datum/reagents/proc/metabolize.
-/datum/reagent/proc/overdose_start(mob/living/affected_mob, metabolized_volume)
+/datum/reagent/proc/overdose_start(mob/living/affected_mob, metabolization_ratio)
 	to_chat(affected_mob, span_userdanger("You feel like you took too much of [name]!"))
 	affected_mob.add_mood_event("[type]_overdose", /datum/mood_event/overdose, name)
 	return

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -186,8 +186,8 @@
 /datum/reagent/proc/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(isnull(holder))
 		return
-	holder.remove_reagent(type, metabolized_volume)
-
+	volume -= metabolized_volume
+	holder.update_total()
 
 /// Called in burns.dm *if* the reagent has the REAGENT_AFFECTS_WOUNDS process flag
 /datum/reagent/proc/on_burn_wound_processing(datum/wound/burn/flesh/burn_wound)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -183,10 +183,10 @@
 	SHOULD_CALL_PARENT(TRUE)
 
 ///Metabolizes a portion of the reagent after on_mob_life() is called
-/datum/reagent/proc/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+/datum/reagent/proc/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(isnull(holder))
 		return
-	holder.remove_reagent(type, metabolization_ratio)
+	holder.remove_reagent(type, metabolized_volume)
 
 
 /// Called in burns.dm *if* the reagent has the REAGENT_AFFECTS_WOUNDS process flag

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -149,7 +149,7 @@
 	return
 
 
-/// Called to begin metabolization and return the volume of reagent to metabolize
+///Called to begin metabolization and return the volume of reagent to metabolize
 /datum/reagent/proc/compute_metabolization(mob/living/carbon/affected_mob, seconds_per_tick)
 	var/metabolizing_out = metabolization_rate * seconds_per_tick
 	if(!(chemical_flags & REAGENT_UNAFFECTED_BY_METABOLISM))

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -148,6 +148,22 @@
 /datum/reagent/proc/burn(datum/reagents/holder)
 	return
 
+
+/// Called to begin metabolization and return the volume of reagent to metabolize
+/datum/reagent/proc/compute_metabolization(mob/living/carbon/affected_mob, seconds_per_tick)
+	var/metabolizing_out = metabolization_rate * seconds_per_tick
+	if(!(chemical_flags & REAGENT_UNAFFECTED_BY_METABOLISM))
+		if(chemical_flags & REAGENT_REVERSE_METABOLISM)
+			metabolizing_out /= affected_mob.metabolism_efficiency
+		else
+			metabolizing_out *= affected_mob.metabolism_efficiency
+
+	if(!metabolizing)
+		metabolizing = TRUE
+		on_mob_metabolize(affected_mob)
+
+	return min(metabolizing_out, volume)
+
 /**
  * Ticks on mob Life() for as long as the reagent remains in the mob's reagents.
  *
@@ -163,22 +179,14 @@
  * * times_fired - the number of times the owner's Life() tick has been called aka The number of times SSmobs has fired
  *
  */
-/datum/reagent/proc/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/proc/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	SHOULD_CALL_PARENT(TRUE)
 
 ///Metabolizes a portion of the reagent after on_mob_life() is called
-/datum/reagent/proc/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/proc/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(isnull(holder))
 		return
-
-	var/metabolizing_out = metabolization_rate * seconds_per_tick
-	if(!(chemical_flags & REAGENT_UNAFFECTED_BY_METABOLISM))
-		if(chemical_flags & REAGENT_REVERSE_METABOLISM)
-			metabolizing_out /= affected_mob.metabolism_efficiency
-		else
-			metabolizing_out *= affected_mob.metabolism_efficiency
-
-	holder.remove_reagent(type, metabolizing_out)
+	holder.remove_reagent(type, metabolized_volume)
 
 
 /// Called in burns.dm *if* the reagent has the REAGENT_AFFECTS_WOUNDS process flag
@@ -217,7 +225,7 @@
 		affected_mob.add_traits(metabolized_traits, "metabolize:[type]")
 
 /// Called when this reagent stops being metabolized by a liver
-/datum/reagent/proc/on_mob_end_metabolize(mob/living/affected_mob)
+/datum/reagent/proc/on_mob_end_metabolize(mob/living/affected_mob, metabolized_volume)
 	SHOULD_CALL_PARENT(TRUE)
 	REMOVE_TRAITS_IN(affected_mob, "metabolize:[type]")
 
@@ -245,11 +253,11 @@
 	SEND_SIGNAL(src, COMSIG_REAGENT_ON_MERGE, mix_data, amount)
 
 /// Called if the reagent has passed the overdose threshold and is set to be triggering overdose effects. Returning UPDATE_MOB_HEALTH will cause updatehealth() to be called on the holder mob by /datum/reagents/proc/metabolize.
-/datum/reagent/proc/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/proc/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	return
 
 /// Called when an overdose starts. Returning UPDATE_MOB_HEALTH will cause updatehealth() to be called on the holder mob by /datum/reagents/proc/metabolize.
-/datum/reagent/proc/overdose_start(mob/living/affected_mob)
+/datum/reagent/proc/overdose_start(mob/living/affected_mob, metabolized_volume)
 	to_chat(affected_mob, span_userdanger("You feel like you took too much of [name]!"))
 	affected_mob.add_mood_event("[type]_overdose", /datum/mood_event/overdose, name)
 	return

--- a/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
@@ -1,7 +1,7 @@
 /datum/reagent/freon
 	name = "Freon"
 	description = "A powerful heat absorbent."
-	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because nitrium/freon/hypernoblium are handled through gas breathing, metabolism must be lower for breathcode to keep up
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM  // Because nitrium/freon/hypernoblium are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "90560B"
 	taste_description = "burning"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
@@ -17,7 +17,7 @@
 /datum/reagent/halon
 	name = "Halon"
 	description = "A fire suppression gas that removes oxygen and cools down the area"
-	metabolization_rate = REAGENTS_METABOLISM * 0.5
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	color = "90560B"
 	taste_description = "minty"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
@@ -34,7 +34,7 @@
 /datum/reagent/healium
 	name = "Healium"
 	description = "A powerful sleeping agent with healing properties"
-	metabolization_rate = REAGENTS_METABOLISM * 0.5
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	color = "90560B"
 	taste_description = "rubbery"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
@@ -56,7 +56,7 @@
 /datum/reagent/hypernoblium
 	name = "Hyper-Noblium"
 	description = "A suppressive gas that stops gas reactions on those who inhale it."
-	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because nitrium/freon/hyper-nob are handled through gas breathing, metabolism must be lower for breathcode to keep up
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM // Because nitrium/freon/hyper-nob are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "90560B"
 	taste_description = "searingly cold"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
@@ -69,7 +69,7 @@
 /datum/reagent/nitrium_high_metabolization
 	name = "Nitrosyl plasmide"
 	description = "A highly reactive byproduct that stops you from sleeping, while dealing increasing toxin damage over time."
-	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because nitrium/freon/hypernoblium are handled through gas breathing, metabolism must be lower for breathcode to keep up
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM  // Because nitrium/freon/hypernoblium are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "E1A116"
 	taste_description = "sourness"
 	ph = 1.8
@@ -88,7 +88,7 @@
 /datum/reagent/nitrium_low_metabolization
 	name = "Nitrium"
 	description = "A highly reactive gas that makes you feel faster."
-	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because nitrium/freon/hypernoblium are handled through gas breathing, metabolism must be lower for breathcode to keep up
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM // Because nitrium/freon/hypernoblium are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "90560B"
 	taste_description = "burning"
 	ph = 2
@@ -105,7 +105,7 @@
 /datum/reagent/pluoxium
 	name = "Pluoxium"
 	description = "A gas that is eight times more efficient than O2 at lung diffusion with organ healing properties on sleeping patients."
-	metabolization_rate = REAGENTS_METABOLISM * 0.5
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	color = COLOR_GRAY
 	taste_description = "irradiated air"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
@@ -125,7 +125,7 @@
 /datum/reagent/zauker
 	name = "Zauker"
 	description = "An unstable gas that is toxic to all living beings."
-	metabolization_rate = REAGENTS_METABOLISM * 0.5
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	color = "90560B"
 	taste_description = "bitter"
 	chemical_flags = REAGENT_NO_RANDOM_RECIPE

--- a/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
@@ -43,13 +43,13 @@
 	. = ..()
 	breather.SetSleeping(1 SECONDS)
 
-/datum/reagent/healium/on_mob_life(mob/living/breather, seconds_per_tick, metabolized_volume)
+/datum/reagent/healium/on_mob_life(mob/living/breather, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	breather.SetSleeping(30 SECONDS)
 	var/need_mob_update
-	need_mob_update = breather.adjust_fire_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += breather.adjust_tox_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += breather.adjust_brute_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = breather.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += breather.adjust_tox_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += breather.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -61,10 +61,10 @@
 	taste_description = "searingly cold"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/hypernoblium/on_mob_life(mob/living/carbon/breather, seconds_per_tick, metabolized_volume)
+/datum/reagent/hypernoblium/on_mob_life(mob/living/carbon/breather, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(isplasmaman(breather))
-		breather.set_timed_status_effect(5 SECONDS * REM * metabolized_volume * seconds_per_tick, /datum/status_effect/hypernob_protection)
+		breather.set_timed_status_effect(5 SECONDS * metabolization_ratio * seconds_per_tick, /datum/status_effect/hypernob_protection)
 
 /datum/reagent/nitrium_high_metabolization
 	name = "Nitrosyl plasmide"
@@ -77,11 +77,11 @@
 	addiction_types = list(/datum/addiction/stimulants = 14)
 	metabolized_traits = list(TRAIT_SLEEPIMMUNE)
 
-/datum/reagent/nitrium_high_metabolization/on_mob_life(mob/living/carbon/breather, seconds_per_tick, metabolized_volume)
+/datum/reagent/nitrium_high_metabolization/on_mob_life(mob/living/carbon/breather, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = breather.adjust_stamina_loss(-2 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	need_mob_update += breather.adjust_tox_loss(0.05 * (current_cycle-1) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) // 1 toxin damage per cycle at cycle 10
+	need_mob_update = breather.adjust_stamina_loss(-2 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += breather.adjust_tox_loss(0.05 * (current_cycle-1) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) // 1 toxin damage per cycle at cycle 10
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -110,7 +110,7 @@
 	taste_description = "irradiated air"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/pluoxium/on_mob_life(mob/living/carbon/breather, seconds_per_tick, metabolized_volume)
+/datum/reagent/pluoxium/on_mob_life(mob/living/carbon/breather, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!HAS_TRAIT(breather, TRAIT_KNOCKEDOUT))
 		return
@@ -119,7 +119,7 @@
 		if(!organ_being_healed.damage)
 			continue
 
-		if(organ_being_healed.apply_organ_damage(-0.5 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = ORGAN_ORGANIC))
+		if(organ_being_healed.apply_organ_damage(-0.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = ORGAN_ORGANIC))
 			. = UPDATE_MOB_HEALTH
 
 /datum/reagent/zauker
@@ -132,12 +132,12 @@
 	affected_biotype = MOB_ORGANIC | MOB_MINERAL | MOB_PLANT // "toxic to all living beings"
 	affected_respiration_type = ALL
 
-/datum/reagent/zauker/on_mob_life(mob/living/breather, seconds_per_tick, metabolized_volume)
+/datum/reagent/zauker/on_mob_life(mob/living/breather, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = breather.adjust_brute_loss(3 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += breather.adjust_oxy_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += breather.adjust_fire_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += breather.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = breather.adjust_brute_loss(3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += breather.adjust_oxy_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += breather.adjust_fire_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += breather.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH

--- a/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
@@ -47,9 +47,9 @@
 	. = ..()
 	breather.SetSleeping(30 SECONDS)
 	var/need_mob_update
-	need_mob_update = breather.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += breather.adjust_tox_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += breather.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = breather.adjust_fire_loss(-2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += breather.adjust_tox_loss(-5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += breather.adjust_brute_loss(-2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -64,7 +64,7 @@
 /datum/reagent/hypernoblium/on_mob_life(mob/living/carbon/breather, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(isplasmaman(breather))
-		breather.set_timed_status_effect(5 SECONDS * metabolization_ratio * seconds_per_tick, /datum/status_effect/hypernob_protection)
+		breather.set_timed_status_effect(10 SECONDS * metabolization_ratio * seconds_per_tick, /datum/status_effect/hypernob_protection)
 
 /datum/reagent/nitrium_high_metabolization
 	name = "Nitrosyl plasmide"
@@ -80,8 +80,8 @@
 /datum/reagent/nitrium_high_metabolization/on_mob_life(mob/living/carbon/breather, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = breather.adjust_stamina_loss(-2 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	need_mob_update += breather.adjust_tox_loss(0.05 * (current_cycle-1) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) // 1 toxin damage per cycle at cycle 10
+	need_mob_update = breather.adjust_stamina_loss(-4 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += breather.adjust_tox_loss(0.1 * (current_cycle-1) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) // 1 toxin damage per cycle at cycle 10
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -119,7 +119,7 @@
 		if(!organ_being_healed.damage)
 			continue
 
-		if(organ_being_healed.apply_organ_damage(-0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = ORGAN_ORGANIC))
+		if(organ_being_healed.apply_organ_damage(-0.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = ORGAN_ORGANIC))
 			. = UPDATE_MOB_HEALTH
 
 /datum/reagent/zauker
@@ -135,9 +135,9 @@
 /datum/reagent/zauker/on_mob_life(mob/living/breather, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = breather.adjust_brute_loss(3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += breather.adjust_oxy_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += breather.adjust_fire_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += breather.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = breather.adjust_brute_loss(6 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += breather.adjust_oxy_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += breather.adjust_fire_loss(2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += breather.adjust_tox_loss(2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH

--- a/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
@@ -119,7 +119,7 @@
 		if(!organ_being_healed.damage)
 			continue
 
-		if(organ_being_healed.apply_organ_damage(-0.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = ORGAN_ORGANIC))
+		if(organ_being_healed.apply_organ_damage(-0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = ORGAN_ORGANIC))
 			. = UPDATE_MOB_HEALTH
 
 /datum/reagent/zauker

--- a/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
@@ -43,13 +43,13 @@
 	. = ..()
 	breather.SetSleeping(1 SECONDS)
 
-/datum/reagent/healium/on_mob_life(mob/living/breather, seconds_per_tick)
+/datum/reagent/healium/on_mob_life(mob/living/breather, seconds_per_tick, metabolized_volume)
 	. = ..()
 	breather.SetSleeping(30 SECONDS)
 	var/need_mob_update
-	need_mob_update = breather.adjust_fire_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += breather.adjust_tox_loss(-5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += breather.adjust_brute_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = breather.adjust_fire_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += breather.adjust_tox_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += breather.adjust_brute_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -61,10 +61,10 @@
 	taste_description = "searingly cold"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/hypernoblium/on_mob_life(mob/living/carbon/breather, seconds_per_tick)
+/datum/reagent/hypernoblium/on_mob_life(mob/living/carbon/breather, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(isplasmaman(breather))
-		breather.set_timed_status_effect(10 SECONDS * REM * seconds_per_tick, /datum/status_effect/hypernob_protection)
+		breather.set_timed_status_effect(5 SECONDS * REM * metabolized_volume * seconds_per_tick, /datum/status_effect/hypernob_protection)
 
 /datum/reagent/nitrium_high_metabolization
 	name = "Nitrosyl plasmide"
@@ -77,11 +77,11 @@
 	addiction_types = list(/datum/addiction/stimulants = 14)
 	metabolized_traits = list(TRAIT_SLEEPIMMUNE)
 
-/datum/reagent/nitrium_high_metabolization/on_mob_life(mob/living/carbon/breather, seconds_per_tick)
+/datum/reagent/nitrium_high_metabolization/on_mob_life(mob/living/carbon/breather, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = breather.adjust_stamina_loss(-4 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	need_mob_update += breather.adjust_tox_loss(0.1 * (current_cycle-1) * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) // 1 toxin damage per cycle at cycle 10
+	need_mob_update = breather.adjust_stamina_loss(-2 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += breather.adjust_tox_loss(0.05 * (current_cycle-1) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) // 1 toxin damage per cycle at cycle 10
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -110,7 +110,7 @@
 	taste_description = "irradiated air"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/pluoxium/on_mob_life(mob/living/carbon/breather, seconds_per_tick)
+/datum/reagent/pluoxium/on_mob_life(mob/living/carbon/breather, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!HAS_TRAIT(breather, TRAIT_KNOCKEDOUT))
 		return
@@ -119,7 +119,7 @@
 		if(!organ_being_healed.damage)
 			continue
 
-		if(organ_being_healed.apply_organ_damage(-0.5 * REM * seconds_per_tick, required_organ_flag = ORGAN_ORGANIC))
+		if(organ_being_healed.apply_organ_damage(-0.5 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = ORGAN_ORGANIC))
 			. = UPDATE_MOB_HEALTH
 
 /datum/reagent/zauker
@@ -132,12 +132,12 @@
 	affected_biotype = MOB_ORGANIC | MOB_MINERAL | MOB_PLANT // "toxic to all living beings"
 	affected_respiration_type = ALL
 
-/datum/reagent/zauker/on_mob_life(mob/living/breather, seconds_per_tick)
+/datum/reagent/zauker/on_mob_life(mob/living/breather, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = breather.adjust_brute_loss(6 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += breather.adjust_oxy_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += breather.adjust_fire_loss(2 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += breather.adjust_tox_loss(2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = breather.adjust_brute_loss(3 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += breather.adjust_oxy_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += breather.adjust_fire_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += breather.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -33,15 +33,15 @@
 	switch(affected_mob.stat)
 		if(CONSCIOUS) //bad
 			thou_shall_heal = max(death_is_coming/20, 3)
-			need_mob_update += affected_mob.adjust_oxy_loss(1 * metabolization_ratio * seconds_per_tick, TRUE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_oxy_loss(2 * metabolization_ratio * seconds_per_tick, TRUE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 		if(SOFT_CRIT) //meh convert
 			thou_shall_heal = round(death_is_coming/13,0.1)
-			need_mob_update += affected_mob.adjust_oxy_loss(0.5 * metabolization_ratio * seconds_per_tick, TRUE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_oxy_loss(1 * metabolization_ratio * seconds_per_tick, TRUE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 			good_kind_of_healing = TRUE
 		else //no convert
 			thou_shall_heal = round(death_is_coming/10, 0.1)
 			good_kind_of_healing = TRUE
-	need_mob_update += affected_mob.adjust_brute_loss(-0.5 * thou_shall_heal * metabolization_ratio * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_brute_loss(-1 * thou_shall_heal * metabolization_ratio * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH
 
@@ -110,8 +110,8 @@
 /datum/reagent/medicine/c2/libital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.15 * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_brute_loss(-1.5 * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.3 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_brute_loss(-3 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -128,7 +128,7 @@
 /datum/reagent/medicine/c2/probital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-1.5 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_brute_loss(-3 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	var/ooo_youaregettingsleepy = 3.5
 	switch(round(affected_mob.get_stamina_loss()))
 		if(10 to 40)
@@ -137,16 +137,16 @@
 			ooo_youaregettingsleepy = 2.5
 		if(61 to 200) //you really can only go to 120
 			ooo_youaregettingsleepy = 2
-	need_mob_update += affected_mob.adjust_stamina_loss(0.5 * ooo_youaregettingsleepy * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
+	need_mob_update += affected_mob.adjust_stamina_loss(1 * ooo_youaregettingsleepy * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/c2/probital/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(1.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
+	need_mob_update = affected_mob.adjust_stamina_loss(3 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 	if(affected_mob.get_stamina_loss() >= 80)
-		affected_mob.adjust_drowsiness(1 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_drowsiness(2 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.get_stamina_loss() >= 100)
 		to_chat(affected_mob,span_warning("You feel more tired than you usually do, perhaps if you rest your eyes for a bit..."))
 		need_mob_update += affected_mob.adjust_stamina_loss(-100, updating_stamina = FALSE) // Don't add the biotype parameter here as it results in infinite sleep and chat spam.
@@ -170,8 +170,6 @@
 	description = "Used to treat burns. Applies stomach damage when it leaves your system."
 	color = "#6171FF"
 	ph = 4.7
-	var/resetting_probability = 0 //What are these for?? Can I remove them?
-	var/spammer = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	inverse_chem_val = 0.4
 	inverse_chem = /datum/reagent/inverse/lentslurri
@@ -179,8 +177,8 @@
 /datum/reagent/medicine/c2/lenturi/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_fire_loss(-1.875 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, 0.2 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_fire_loss(-3.75 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, 0.4 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -189,8 +187,6 @@
 	description = "Used to treat burns. Does minor eye damage."
 	color = "#8C93FF"
 	ph = 4
-	var/resetting_probability = 0 //same with this? Old legacy vars that should be removed?
-	var/message_cd = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	inverse_chem_val = 0.35
 	inverse_chem = /datum/reagent/inverse/aiuri
@@ -198,8 +194,8 @@
 /datum/reagent/medicine/c2/aiuri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_fire_loss(-1 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, 0.125 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_fire_loss(-2 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, 0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -218,15 +214,15 @@
 	. = ..()
 	var/need_mob_update
 	if(affected_mob.get_fire_loss() > 50)
-		need_mob_update = affected_mob.adjust_fire_loss(-1.5 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_fire_loss(-3 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
 	else
-		need_mob_update = affected_mob.adjust_fire_loss(-1.125 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_fire_loss(-2.25 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
 	affected_mob.adjust_bodytemperature(0.5 * rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50)
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/humi = affected_mob
-		humi.adjust_coretemperature(0.5 * rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50)
-	affected_mob.reagents?.chem_temp += (-5 * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_fire_stacks(-0.5 * metabolization_ratio * seconds_per_tick)
+		humi.adjust_coretemperature(1 * rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50)
+	affected_mob.reagents?.chem_temp += (-10 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_fire_stacks(-1 * metabolization_ratio * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -242,10 +238,10 @@
 
 /datum/reagent/medicine/c2/hercuri/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50) //chilly chilly
+	affected_mob.adjust_bodytemperature(-10 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50) //chilly chilly
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/humi = affected_mob
-		humi.adjust_coretemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50)
+		humi.adjust_coretemperature(-10 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50)
 
 
 /******OXY******/
@@ -264,12 +260,12 @@
 
 /datum/reagent/medicine/c2/convermol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	var/oxycalc = 1.25 * metabolization_ratio * (current_cycle-1)
+	var/oxycalc = 2.5 * metabolization_ratio * (current_cycle-1)
 	if(!overdosed)
 		oxycalc = min(oxycalc, affected_mob.get_oxy_loss() + 0.5) //if NOT overdosing, we lower our toxdamage to only the damage we actually healed with a minimum of 0.1*current_cycle. IE if we only heal 10 oxygen damage but we COULD have healed 20, we will only take toxdamage for the 10. We would take the toxdamage for the extra 10 if we were overdosing.
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_oxy_loss(-oxycalc * seconds_per_tick * normalise_creation_purity(), FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_tox_loss(oxycalc * seconds_per_tick / CONVERMOL_RATIO, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_oxy_loss(-2 * oxycalc * normalise_creation_purity() * metabolization_ratio * seconds_per_tick , FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_tox_loss(2 * oxycalc * metabolization_ratio * seconds_per_tick / CONVERMOL_RATIO, updating_health = FALSE, required_biotype = affected_biotype)
 	if(SPT_PROB((current_cycle-1) / 2, seconds_per_tick) && affected_mob.losebreath)
 		affected_mob.losebreath--
 		need_mob_update = TRUE
@@ -297,8 +293,8 @@
 /datum/reagent/medicine/c2/tirimol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_oxy_loss(-2.25 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_stamina_loss(1 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_oxy_loss(-4.5 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_stamina_loss(2 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 	if(drowsycd && COOLDOWN_FINISHED(src, drowsycd))
 		affected_mob.adjust_drowsiness(20 SECONDS)
 		COOLDOWN_START(src, drowsycd, 45 SECONDS)
@@ -337,14 +333,14 @@
 	var/healypoints = 0 //5 healypoints = 1 heart damage; 5 rads = 1 tox damage healed for the purpose of healypoints
 
 	//you're hot
-	var/toxcalc = min(0.5 * round(5 + ((chemtemp-1000)/175), 0.1), 5) * metabolization_ratio * seconds_per_tick * normalise_creation_purity() //max 2.5 tox healing per second
+	var/toxcalc = min(1 * round(5 + ((chemtemp-1000)/175), 0.1), 5) * metabolization_ratio * seconds_per_tick * normalise_creation_purity() //max 2.5 tox healing per second
 	var/need_mob_update
 	if(toxcalc > 0)
 		need_mob_update = affected_mob.adjust_tox_loss(-toxcalc, updating_health = FALSE, required_biotype = affected_biotype)
 		healypoints += toxcalc
 
 	//and you're cold
-	var/radcalc = 0.5 * round((T0C-chemtemp) / 6, 0.1) * metabolization_ratio * seconds_per_tick //max ~45 rad loss unless you've hit below 0K. if so, wow.
+	var/radcalc = 1 * round((T0C-chemtemp) / 6, 0.1) * metabolization_ratio * seconds_per_tick //max ~45 rad loss unless you've hit below 0K. if so, wow.
 	if(radcalc > 0 && HAS_TRAIT(affected_mob, TRAIT_IRRADIATED))
 		radcalc *= normalise_creation_purity()
 		// extra rad healing if you are SUPER cold
@@ -378,15 +374,15 @@
 	if(creation_purity >= 1) //Perfectly pure multivers gives a bonus of 2!
 		medibonus += 1
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(-0.25 * min(medibonus, 3 * normalise_creation_purity()) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //not great at healing but if you have nothing else it will work
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags) //kills at 40u
+	need_mob_update = affected_mob.adjust_tox_loss(-0.25 * min(medibonus, 6 * normalise_creation_purity()) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //not great at healing but if you have nothing else it will work
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags) //kills at 40u
 	if(!holder.has_reagent(/datum/reagent/toxin/anacea))
 		for(var/datum/reagent/second_reagent as anything in affected_mob.reagents.reagent_list)
 			if(second_reagent == src)
 				continue
 			if(medibonus >= 3 && istype(second_reagent, /datum/reagent/medicine)) //3 unique meds (2+multiver) | (1 + pure multiver) will make it not purge medicines
 				continue
-			affected_mob.reagents.remove_reagent(second_reagent.type, 1.5 * second_reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
+			affected_mob.reagents.remove_reagent(second_reagent.type, 3 * second_reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -403,8 +399,8 @@
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 	overdose_threshold = 6
 	ph = 8.6
-	var/conversion_amount
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	var/conversion_amount
 
 /datum/reagent/medicine/c2/syriniver/expose_mob(mob/living/carbon/exposed_mob, methods, trans_volume, show_message, touch_protection)
 	. = ..()
@@ -425,22 +421,22 @@
 /datum/reagent/medicine/c2/syriniver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.4 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.54 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_tox_loss(-1.34 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	for(var/datum/reagent/R in affected_mob.reagents.reagent_list)
 		if(issyrinormusc(R))
 			continue
-		affected_mob.reagents.remove_reagent(R.type, 0.2 * metabolization_ratio * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(R.type, 0.27 * metabolization_ratio * seconds_per_tick)
 
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/c2/syriniver/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.75 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 1 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_disgust(1.5 * metabolization_ratio * seconds_per_tick)
-	affected_mob.reagents.add_reagent(/datum/reagent/medicine/c2/musiver, 0.1125 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_disgust(2 * metabolization_ratio * seconds_per_tick)
+	affected_mob.reagents.add_reagent(/datum/reagent/medicine/c2/musiver, 0.15 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/c2/musiver //MUScles
 	name = "Musiver"
@@ -455,12 +451,12 @@
 /datum/reagent/medicine/c2/musiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.05 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_tox_loss(-0.75 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.2 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_tox_loss(-3 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	for(var/datum/reagent/reagent as anything in affected_mob.reagents.reagent_list)
 		if(issyrinormusc(reagent))
 			continue
-		affected_mob.reagents.remove_reagent(reagent.type, 0.1 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(reagent.type, 0.4 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -476,9 +472,9 @@
 
 /datum/reagent/medicine/c2/musiver/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.75 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 3 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_disgust(1.5 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_disgust(6 * metabolization_ratio * seconds_per_tick)
 
 #undef issyrinormusc
 /******COMBOS******/
@@ -597,20 +593,20 @@
 /datum/reagent/medicine/c2/penthrite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, 0.125 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, 0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(affected_mob.health <= HEALTH_THRESHOLD_CRIT && affected_mob.health > (affected_mob.crit_threshold + HEALTH_THRESHOLD_FULLCRIT * (2 * normalise_creation_purity()))) //we cannot save someone below our lowered crit threshold.
 
-		need_mob_update += affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += affected_mob.adjust_tox_loss(-2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-6 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 
 		affected_mob.losebreath = 0
 
-		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.5 * max(volume/10, 1) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags) // your heart is barely keeping up!
+		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 1 * max(volume/10, 1) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags) // your heart is barely keeping up!
 
-		affected_mob.set_jitter_if_lower(0.5 * rand(0 SECONDS, 4 SECONDS) * metabolization_ratio * seconds_per_tick)
-		affected_mob.set_dizzy_if_lower(0.5 * rand(0 SECONDS, 4 SECONDS) * metabolization_ratio * seconds_per_tick)
+		affected_mob.set_jitter_if_lower(1 * rand(0 SECONDS, 4 SECONDS) * metabolization_ratio * seconds_per_tick)
+		affected_mob.set_dizzy_if_lower(1 * rand(0 SECONDS, 4 SECONDS) * metabolization_ratio * seconds_per_tick)
 
 		if(SPT_PROB(18, seconds_per_tick))
 			to_chat(affected_mob,span_danger("Your body is trying to give up, but your heart is still beating!"))
@@ -635,8 +631,8 @@
 	. = ..()
 	REMOVE_TRAIT(affected_mob, TRAIT_STABLEHEART, type)
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_stamina_loss(10 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 10 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	need_mob_update += affected_mob.set_heartattack(TRUE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -24,7 +24,7 @@
 	var/reaping = FALSE
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/c2/helbital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/helbital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/death_is_coming = (affected_mob.get_tox_loss() + affected_mob.get_oxy_loss() + affected_mob.get_fire_loss() + affected_mob.get_brute_loss())*normalise_creation_purity()
 	var/thou_shall_heal = 0
@@ -33,15 +33,15 @@
 	switch(affected_mob.stat)
 		if(CONSCIOUS) //bad
 			thou_shall_heal = max(death_is_coming/20, 3)
-			need_mob_update += affected_mob.adjust_oxy_loss(1 * REM * metabolized_volume * seconds_per_tick, TRUE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_oxy_loss(1 * metabolization_ratio * seconds_per_tick, TRUE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 		if(SOFT_CRIT) //meh convert
 			thou_shall_heal = round(death_is_coming/13,0.1)
-			need_mob_update += affected_mob.adjust_oxy_loss(0.5 * REM * metabolized_volume * seconds_per_tick, TRUE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_oxy_loss(0.5 * metabolization_ratio * seconds_per_tick, TRUE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 			good_kind_of_healing = TRUE
 		else //no convert
 			thou_shall_heal = round(death_is_coming/10, 0.1)
 			good_kind_of_healing = TRUE
-	need_mob_update += affected_mob.adjust_brute_loss(0.5 * -thou_shall_heal * REM * metabolized_volume * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_brute_loss(0.5 * -thou_shall_heal * metabolization_ratio * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH
 
@@ -80,7 +80,7 @@
 				holder.del_reagent(type)
 				return
 
-/datum/reagent/medicine/c2/helbital/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/helbital/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!helbent)
 		affected_mob.apply_necropolis_curse(CURSE_WASTING | CURSE_BLINDING)
@@ -107,7 +107,7 @@
 	inverse_chem = /datum/reagent/inverse/libitoil
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/c2/libital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/libital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.15 * seconds_per_tick, required_organ_flag = affected_organ_flags)
@@ -125,10 +125,10 @@
 	inverse_chem = /datum/reagent/medicine/metafactor //Seems thematically intact
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/c2/probital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/probital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-1.5 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_brute_loss(-1.5 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	var/ooo_youaregettingsleepy = 3.5
 	switch(round(affected_mob.get_stamina_loss()))
 		if(10 to 40)
@@ -137,16 +137,16 @@
 			ooo_youaregettingsleepy = 2.5
 		if(61 to 200) //you really can only go to 120
 			ooo_youaregettingsleepy = 2
-	need_mob_update += affected_mob.adjust_stamina_loss(0.5 * ooo_youaregettingsleepy * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
+	need_mob_update += affected_mob.adjust_stamina_loss(0.5 * ooo_youaregettingsleepy * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/c2/probital/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/probital/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(1.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
+	need_mob_update = affected_mob.adjust_stamina_loss(1.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 	if(affected_mob.get_stamina_loss() >= 80)
-		affected_mob.adjust_drowsiness(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_drowsiness(1 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.get_stamina_loss() >= 100)
 		to_chat(affected_mob,span_warning("You feel more tired than you usually do, perhaps if you rest your eyes for a bit..."))
 		need_mob_update += affected_mob.adjust_stamina_loss(-100, updating_stamina = FALSE) // Don't add the biotype parameter here as it results in infinite sleep and chat spam.
@@ -176,11 +176,11 @@
 	inverse_chem_val = 0.4
 	inverse_chem = /datum/reagent/inverse/lentslurri
 
-/datum/reagent/medicine/c2/lenturi/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/lenturi/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_fire_loss(-1.875 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, 0.2 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_fire_loss(-1.875 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, 0.2 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -195,11 +195,11 @@
 	inverse_chem_val = 0.35
 	inverse_chem = /datum/reagent/inverse/aiuri
 
-/datum/reagent/medicine/c2/aiuri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/aiuri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_fire_loss(-1 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, 0.125 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_fire_loss(-1 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, 0.125 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -214,19 +214,19 @@
 	inverse_chem_val = 0.3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/c2/hercuri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/hercuri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	if(affected_mob.get_fire_loss() > 50)
-		need_mob_update = affected_mob.adjust_fire_loss(-1.5 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_fire_loss(-1.5 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
 	else
-		need_mob_update = affected_mob.adjust_fire_loss(-1.125 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
-	affected_mob.adjust_bodytemperature(0.5 * rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 50)
+		need_mob_update = affected_mob.adjust_fire_loss(-1.125 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
+	affected_mob.adjust_bodytemperature(0.5 * rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50)
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/humi = affected_mob
-		humi.adjust_coretemperature(0.5 * rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 50)
-	affected_mob.reagents?.chem_temp += (-5 * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_fire_stacks(-0.5 * REM * metabolized_volume * seconds_per_tick)
+		humi.adjust_coretemperature(0.5 * rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50)
+	affected_mob.reagents?.chem_temp += (-5 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_fire_stacks(-0.5 * metabolization_ratio * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -240,12 +240,12 @@
 	if(reac_volume >= metabolization_rate)
 		exposed_mob.extinguish_mob()
 
-/datum/reagent/medicine/c2/hercuri/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/hercuri/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 50) //chilly chilly
+	affected_mob.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50) //chilly chilly
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/humi = affected_mob
-		humi.adjust_coretemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 50)
+		humi.adjust_coretemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50)
 
 
 /******OXY******/
@@ -262,9 +262,9 @@
 	inverse_chem = /datum/reagent/inverse/healing/convermol
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/c2/convermol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/convermol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	var/oxycalc = 1.25 * REM * metabolized_volume * (current_cycle-1)
+	var/oxycalc = 1.25 * metabolization_ratio * (current_cycle-1)
 	if(!overdosed)
 		oxycalc = min(oxycalc, affected_mob.get_oxy_loss() + 0.5) //if NOT overdosing, we lower our toxdamage to only the damage we actually healed with a minimum of 0.1*current_cycle. IE if we only heal 10 oxygen damage but we COULD have healed 20, we will only take toxdamage for the 10. We would take the toxdamage for the extra 10 if we were overdosing.
 	var/need_mob_update
@@ -276,7 +276,7 @@
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/c2/convermol/overdose_process(mob/living/carbon/human/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/convermol/overdose_process(mob/living/carbon/human/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	metabolization_rate += 2.5 * REAGENTS_METABOLISM
 
@@ -294,11 +294,11 @@
 	/// A cooldown for spacing bursts of stamina damage
 	COOLDOWN_DECLARE(drowsycd)
 
-/datum/reagent/medicine/c2/tirimol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/tirimol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_oxy_loss(-2.25 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_stamina_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_oxy_loss(-2.25 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_stamina_loss(1 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 	if(drowsycd && COOLDOWN_FINISHED(src, drowsycd))
 		affected_mob.adjust_drowsiness(20 SECONDS)
 		COOLDOWN_START(src, drowsycd, 45 SECONDS)
@@ -330,21 +330,21 @@
 	. = ..()
 	rads_heal_threshold = rand(rads_heal_threshold - 50, rads_heal_threshold + 50) // Basically this means 50K and below will always give the radiation heal, and upto 150K could. Calculated once.
 
-/datum/reagent/medicine/c2/seiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/seiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/chemtemp = min(holder.chem_temp, 1000)
 	chemtemp = chemtemp ? chemtemp : T0C //why do you have null sweaty
 	var/healypoints = 0 //5 healypoints = 1 heart damage; 5 rads = 1 tox damage healed for the purpose of healypoints
 
 	//you're hot
-	var/toxcalc = min(0.5 * round(5 + ((chemtemp-1000)/175), 0.1), 5) * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity() //max 2.5 tox healing per second
+	var/toxcalc = min(0.5 * round(5 + ((chemtemp-1000)/175), 0.1), 5) * metabolization_ratio * seconds_per_tick * normalise_creation_purity() //max 2.5 tox healing per second
 	var/need_mob_update
 	if(toxcalc > 0)
 		need_mob_update = affected_mob.adjust_tox_loss(-toxcalc, updating_health = FALSE, required_biotype = affected_biotype)
 		healypoints += toxcalc
 
 	//and you're cold
-	var/radcalc = 0.5 * round((T0C-chemtemp) / 6, 0.1) * REM * metabolized_volume * seconds_per_tick //max ~45 rad loss unless you've hit below 0K. if so, wow.
+	var/radcalc = 0.5 * round((T0C-chemtemp) / 6, 0.1) * metabolization_ratio * seconds_per_tick //max ~45 rad loss unless you've hit below 0K. if so, wow.
 	if(radcalc > 0 && HAS_TRAIT(affected_mob, TRAIT_IRRADIATED))
 		radcalc *= normalise_creation_purity()
 		// extra rad healing if you are SUPER cold
@@ -368,7 +368,7 @@
 	ph = 9.2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/c2/multiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/multiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/medibonus = 0 //it will always have itself which makes it REALLY start @ 1
 	for(var/r in affected_mob.reagents.reagent_list)
@@ -378,15 +378,15 @@
 	if(creation_purity >= 1) //Perfectly pure multivers gives a bonus of 2!
 		medibonus += 1
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(-0.25 * min(medibonus, 3 * normalise_creation_purity()) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //not great at healing but if you have nothing else it will work
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.25 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags) //kills at 40u
+	need_mob_update = affected_mob.adjust_tox_loss(-0.25 * min(medibonus, 3 * normalise_creation_purity()) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //not great at healing but if you have nothing else it will work
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags) //kills at 40u
 	if(!holder.has_reagent(/datum/reagent/toxin/anacea))
 		for(var/datum/reagent/second_reagent as anything in affected_mob.reagents.reagent_list)
 			if(second_reagent == src)
 				continue
 			if(medibonus >= 3 && istype(second_reagent, /datum/reagent/medicine)) //3 unique meds (2+multiver) | (1 + pure multiver) will make it not purge medicines
 				continue
-			affected_mob.reagents.remove_reagent(second_reagent.type, 1.5 * second_reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.reagents.remove_reagent(second_reagent.type, 1.5 * second_reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -422,25 +422,25 @@
 	mob_reagents.remove_reagent(/datum/reagent/medicine/c2/syriniver, conversion_amount)
 	mob_reagents.add_reagent(/datum/reagent/medicine/c2/musiver, conversion_amount)
 
-/datum/reagent/medicine/c2/syriniver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/syriniver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.4 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.4 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	for(var/datum/reagent/R in affected_mob.reagents.reagent_list)
 		if(issyrinormusc(R))
 			continue
-		affected_mob.reagents.remove_reagent(R.type, 0.2 * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(R.type, 0.2 * metabolization_ratio * seconds_per_tick)
 
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/c2/syriniver/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/syriniver/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.75 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.75 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_disgust(1.5 * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.reagents.add_reagent(/datum/reagent/medicine/c2/musiver, 0.1125 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_disgust(1.5 * metabolization_ratio * seconds_per_tick)
+	affected_mob.reagents.add_reagent(/datum/reagent/medicine/c2/musiver, 0.1125 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/c2/musiver //MUScles
 	name = "Musiver"
@@ -452,19 +452,19 @@
 	var/datum/brain_trauma/mild/muscle_weakness/trauma
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/medicine/c2/musiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/musiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.05 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_tox_loss(-0.75 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.05 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_tox_loss(-0.75 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype)
 	for(var/datum/reagent/reagent as anything in affected_mob.reagents.reagent_list)
 		if(issyrinormusc(reagent))
 			continue
-		affected_mob.reagents.remove_reagent(reagent.type, 0.1 * reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(reagent.type, 0.1 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/c2/musiver/overdose_start(mob/living/carbon/affected_mob, metabolized_volume)
+/datum/reagent/medicine/c2/musiver/overdose_start(mob/living/carbon/affected_mob, metabolization_ratio)
 	. = ..()
 	trauma = new()
 	affected_mob.gain_trauma(trauma, TRAUMA_RESILIENCE_ABSOLUTE)
@@ -474,11 +474,11 @@
 	if(trauma)
 		QDEL_NULL(trauma)
 
-/datum/reagent/medicine/c2/musiver/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/musiver/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.75 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.75 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_disgust(1.5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_disgust(1.5 * metabolization_ratio * seconds_per_tick)
 
 #undef issyrinormusc
 /******COMBOS******/
@@ -594,23 +594,23 @@
 	send_alert(user)
 	user.add_traits(subject_traits, type)
 
-/datum/reagent/medicine/c2/penthrite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/penthrite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, 0.125 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, 0.125 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(affected_mob.health <= HEALTH_THRESHOLD_CRIT && affected_mob.health > (affected_mob.crit_threshold + HEALTH_THRESHOLD_FULLCRIT * (2 * normalise_creation_purity()))) //we cannot save someone below our lowered crit threshold.
 
-		need_mob_update += affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-3 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 
 		affected_mob.losebreath = 0
 
-		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.5 * max(volume/10, 1) * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags) // your heart is barely keeping up!
+		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.5 * max(volume/10, 1) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags) // your heart is barely keeping up!
 
-		affected_mob.set_jitter_if_lower(0.5 * rand(0 SECONDS, 4 SECONDS) * REM * metabolized_volume * seconds_per_tick)
-		affected_mob.set_dizzy_if_lower(0.5 * rand(0 SECONDS, 4 SECONDS) * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.set_jitter_if_lower(0.5 * rand(0 SECONDS, 4 SECONDS) * metabolization_ratio * seconds_per_tick)
+		affected_mob.set_dizzy_if_lower(0.5 * rand(0 SECONDS, 4 SECONDS) * metabolization_ratio * seconds_per_tick)
 
 		if(SPT_PROB(18, seconds_per_tick))
 			to_chat(affected_mob,span_danger("Your body is trying to give up, but your heart is still beating!"))
@@ -631,12 +631,12 @@
 	remove_alert(affected_mob)
 	affected_mob.remove_traits(subject_traits, type)
 
-/datum/reagent/medicine/c2/penthrite/overdose_process(mob/living/carbon/human/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/c2/penthrite/overdose_process(mob/living/carbon/human/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	REMOVE_TRAIT(affected_mob, TRAIT_STABLEHEART, type)
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 5 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_stamina_loss(5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	need_mob_update += affected_mob.set_heartattack(TRUE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -24,7 +24,7 @@
 	var/reaping = FALSE
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/c2/helbital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/helbital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/death_is_coming = (affected_mob.get_tox_loss() + affected_mob.get_oxy_loss() + affected_mob.get_fire_loss() + affected_mob.get_brute_loss())*normalise_creation_purity()
 	var/thou_shall_heal = 0
@@ -33,15 +33,15 @@
 	switch(affected_mob.stat)
 		if(CONSCIOUS) //bad
 			thou_shall_heal = max(death_is_coming/20, 3)
-			need_mob_update += affected_mob.adjust_oxy_loss(2 * REM * seconds_per_tick, TRUE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_oxy_loss(1 * REM * metabolized_volume * seconds_per_tick, TRUE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 		if(SOFT_CRIT) //meh convert
 			thou_shall_heal = round(death_is_coming/13,0.1)
-			need_mob_update += affected_mob.adjust_oxy_loss(1 * REM * seconds_per_tick, TRUE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_oxy_loss(0.5 * REM * metabolized_volume * seconds_per_tick, TRUE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 			good_kind_of_healing = TRUE
 		else //no convert
 			thou_shall_heal = round(death_is_coming/10, 0.1)
 			good_kind_of_healing = TRUE
-	need_mob_update += affected_mob.adjust_brute_loss(-thou_shall_heal * REM * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_brute_loss(0.5 * -thou_shall_heal * REM * metabolized_volume * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH
 
@@ -80,7 +80,7 @@
 				holder.del_reagent(type)
 				return
 
-/datum/reagent/medicine/c2/helbital/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/helbital/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!helbent)
 		affected_mob.apply_necropolis_curse(CURSE_WASTING | CURSE_BLINDING)
@@ -107,11 +107,11 @@
 	inverse_chem = /datum/reagent/inverse/libitoil
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/c2/libital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/libital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.3 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_brute_loss(-3 * REM * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.15 * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_brute_loss(-1.5 * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -125,10 +125,10 @@
 	inverse_chem = /datum/reagent/medicine/metafactor //Seems thematically intact
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/c2/probital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/probital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-3 * REM * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_brute_loss(-1.5 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	var/ooo_youaregettingsleepy = 3.5
 	switch(round(affected_mob.get_stamina_loss()))
 		if(10 to 40)
@@ -137,16 +137,16 @@
 			ooo_youaregettingsleepy = 2.5
 		if(61 to 200) //you really can only go to 120
 			ooo_youaregettingsleepy = 2
-	need_mob_update += affected_mob.adjust_stamina_loss(ooo_youaregettingsleepy * REM * seconds_per_tick, updating_stamina = FALSE)
+	need_mob_update += affected_mob.adjust_stamina_loss(0.5 * ooo_youaregettingsleepy * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/c2/probital/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/probital/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(3 * REM * seconds_per_tick, updating_stamina = FALSE)
+	need_mob_update = affected_mob.adjust_stamina_loss(1.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
 	if(affected_mob.get_stamina_loss() >= 80)
-		affected_mob.adjust_drowsiness(2 SECONDS * REM * seconds_per_tick)
+		affected_mob.adjust_drowsiness(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(affected_mob.get_stamina_loss() >= 100)
 		to_chat(affected_mob,span_warning("You feel more tired than you usually do, perhaps if you rest your eyes for a bit..."))
 		need_mob_update += affected_mob.adjust_stamina_loss(-100, updating_stamina = FALSE) // Don't add the biotype parameter here as it results in infinite sleep and chat spam.
@@ -176,11 +176,11 @@
 	inverse_chem_val = 0.4
 	inverse_chem = /datum/reagent/inverse/lentslurri
 
-/datum/reagent/medicine/c2/lenturi/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/lenturi/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_fire_loss(-3.75 * REM * normalise_creation_purity() * seconds_per_tick, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, 0.4 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_fire_loss(-1.875 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, 0.2 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -195,11 +195,11 @@
 	inverse_chem_val = 0.35
 	inverse_chem = /datum/reagent/inverse/aiuri
 
-/datum/reagent/medicine/c2/aiuri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/aiuri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_fire_loss(-2 * REM * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, 0.25 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_fire_loss(-1 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, 0.125 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -214,19 +214,19 @@
 	inverse_chem_val = 0.3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/c2/hercuri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/hercuri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	if(affected_mob.get_fire_loss() > 50)
-		need_mob_update = affected_mob.adjust_fire_loss(-3 * REM * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_fire_loss(-1.5 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
 	else
-		need_mob_update = affected_mob.adjust_fire_loss(-2.25 * REM * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
-	affected_mob.adjust_bodytemperature(rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick, 50)
+		need_mob_update = affected_mob.adjust_fire_loss(-1.125 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
+	affected_mob.adjust_bodytemperature(0.5 * rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 50)
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/humi = affected_mob
-		humi.adjust_coretemperature(rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick, 50)
-	affected_mob.reagents?.chem_temp += (-10 * REM * seconds_per_tick)
-	affected_mob.adjust_fire_stacks(-1 * REM * seconds_per_tick)
+		humi.adjust_coretemperature(0.5 * rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 50)
+	affected_mob.reagents?.chem_temp += (-5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_fire_stacks(-0.5 * REM * metabolized_volume * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -240,12 +240,12 @@
 	if(reac_volume >= metabolization_rate)
 		exposed_mob.extinguish_mob()
 
-/datum/reagent/medicine/c2/hercuri/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/hercuri/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-10 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick, 50) //chilly chilly
+	affected_mob.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 50) //chilly chilly
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/humi = affected_mob
-		humi.adjust_coretemperature(-10 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick, 50)
+		humi.adjust_coretemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 50)
 
 
 /******OXY******/
@@ -262,9 +262,9 @@
 	inverse_chem = /datum/reagent/inverse/healing/convermol
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/c2/convermol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/convermol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	var/oxycalc = 2.5 * REM * (current_cycle-1)
+	var/oxycalc = 1.25 * REM * metabolized_volume * (current_cycle-1)
 	if(!overdosed)
 		oxycalc = min(oxycalc, affected_mob.get_oxy_loss() + 0.5) //if NOT overdosing, we lower our toxdamage to only the damage we actually healed with a minimum of 0.1*current_cycle. IE if we only heal 10 oxygen damage but we COULD have healed 20, we will only take toxdamage for the 10. We would take the toxdamage for the extra 10 if we were overdosing.
 	var/need_mob_update
@@ -276,7 +276,7 @@
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/c2/convermol/overdose_process(mob/living/carbon/human/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/convermol/overdose_process(mob/living/carbon/human/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	metabolization_rate += 2.5 * REAGENTS_METABOLISM
 
@@ -294,11 +294,11 @@
 	/// A cooldown for spacing bursts of stamina damage
 	COOLDOWN_DECLARE(drowsycd)
 
-/datum/reagent/medicine/c2/tirimol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/tirimol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_oxy_loss(-4.5 * REM * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_stamina_loss(2 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_oxy_loss(-2.25 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_stamina_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 	if(drowsycd && COOLDOWN_FINISHED(src, drowsycd))
 		affected_mob.adjust_drowsiness(20 SECONDS)
 		COOLDOWN_START(src, drowsycd, 45 SECONDS)
@@ -330,21 +330,21 @@
 	. = ..()
 	rads_heal_threshold = rand(rads_heal_threshold - 50, rads_heal_threshold + 50) // Basically this means 50K and below will always give the radiation heal, and upto 150K could. Calculated once.
 
-/datum/reagent/medicine/c2/seiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/seiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/chemtemp = min(holder.chem_temp, 1000)
 	chemtemp = chemtemp ? chemtemp : T0C //why do you have null sweaty
 	var/healypoints = 0 //5 healypoints = 1 heart damage; 5 rads = 1 tox damage healed for the purpose of healypoints
 
 	//you're hot
-	var/toxcalc = min(round(5 + ((chemtemp-1000)/175), 0.1), 5) * REM * seconds_per_tick * normalise_creation_purity() //max 2.5 tox healing per second
+	var/toxcalc = min(0.5 * round(5 + ((chemtemp-1000)/175), 0.1), 5) * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity() //max 2.5 tox healing per second
 	var/need_mob_update
 	if(toxcalc > 0)
 		need_mob_update = affected_mob.adjust_tox_loss(-toxcalc, updating_health = FALSE, required_biotype = affected_biotype)
 		healypoints += toxcalc
 
 	//and you're cold
-	var/radcalc = round((T0C-chemtemp) / 6, 0.1) * REM * seconds_per_tick //max ~45 rad loss unless you've hit below 0K. if so, wow.
+	var/radcalc = 0.5 * round((T0C-chemtemp) / 6, 0.1) * REM * metabolized_volume * seconds_per_tick //max ~45 rad loss unless you've hit below 0K. if so, wow.
 	if(radcalc > 0 && HAS_TRAIT(affected_mob, TRAIT_IRRADIATED))
 		radcalc *= normalise_creation_purity()
 		// extra rad healing if you are SUPER cold
@@ -368,7 +368,7 @@
 	ph = 9.2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/c2/multiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/multiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/medibonus = 0 //it will always have itself which makes it REALLY start @ 1
 	for(var/r in affected_mob.reagents.reagent_list)
@@ -378,15 +378,15 @@
 	if(creation_purity >= 1) //Perfectly pure multivers gives a bonus of 2!
 		medibonus += 1
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(-0.5 * min(medibonus, 3 * normalise_creation_purity()) * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //not great at healing but if you have nothing else it will work
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.5 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags) //kills at 40u
+	need_mob_update = affected_mob.adjust_tox_loss(-0.25 * min(medibonus, 3 * normalise_creation_purity()) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //not great at healing but if you have nothing else it will work
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.25 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags) //kills at 40u
 	if(!holder.has_reagent(/datum/reagent/toxin/anacea))
 		for(var/datum/reagent/second_reagent as anything in affected_mob.reagents.reagent_list)
 			if(second_reagent == src)
 				continue
 			if(medibonus >= 3 && istype(second_reagent, /datum/reagent/medicine)) //3 unique meds (2+multiver) | (1 + pure multiver) will make it not purge medicines
 				continue
-			affected_mob.reagents.remove_reagent(second_reagent.type, 3 * second_reagent.purge_multiplier * REM * seconds_per_tick)
+			affected_mob.reagents.remove_reagent(second_reagent.type, 1.5 * second_reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -422,25 +422,25 @@
 	mob_reagents.remove_reagent(/datum/reagent/medicine/c2/syriniver, conversion_amount)
 	mob_reagents.add_reagent(/datum/reagent/medicine/c2/musiver, conversion_amount)
 
-/datum/reagent/medicine/c2/syriniver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/syriniver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.8 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_tox_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.4 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	for(var/datum/reagent/R in affected_mob.reagents.reagent_list)
 		if(issyrinormusc(R))
 			continue
-		affected_mob.reagents.remove_reagent(R.type, 0.4 * REM * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(R.type, 0.2 * REM * metabolized_volume * seconds_per_tick)
 
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/c2/syriniver/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/syriniver/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 1.5 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.75 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_disgust(3 * REM * seconds_per_tick)
-	affected_mob.reagents.add_reagent(/datum/reagent/medicine/c2/musiver, 0.225 * REM * seconds_per_tick)
+	affected_mob.adjust_disgust(1.5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.reagents.add_reagent(/datum/reagent/medicine/c2/musiver, 0.1125 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/medicine/c2/musiver //MUScles
 	name = "Musiver"
@@ -452,19 +452,19 @@
 	var/datum/brain_trauma/mild/muscle_weakness/trauma
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/medicine/c2/musiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/musiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.1 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_tox_loss(-1.5 * REM * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.05 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_tox_loss(-0.75 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype)
 	for(var/datum/reagent/reagent as anything in affected_mob.reagents.reagent_list)
 		if(issyrinormusc(reagent))
 			continue
-		affected_mob.reagents.remove_reagent(reagent.type, 0.2 * reagent.purge_multiplier * REM * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(reagent.type, 0.1 * reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/c2/musiver/overdose_start(mob/living/carbon/affected_mob)
+/datum/reagent/medicine/c2/musiver/overdose_start(mob/living/carbon/affected_mob, metabolized_volume)
 	. = ..()
 	trauma = new()
 	affected_mob.gain_trauma(trauma, TRAUMA_RESILIENCE_ABSOLUTE)
@@ -474,11 +474,11 @@
 	if(trauma)
 		QDEL_NULL(trauma)
 
-/datum/reagent/medicine/c2/musiver/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/musiver/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 1.5 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.75 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_disgust(3 * REM * seconds_per_tick)
+	affected_mob.adjust_disgust(1.5 * REM * metabolized_volume * seconds_per_tick)
 
 #undef issyrinormusc
 /******COMBOS******/
@@ -594,23 +594,23 @@
 	send_alert(user)
 	user.add_traits(subject_traits, type)
 
-/datum/reagent/medicine/c2/penthrite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/penthrite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, 0.25 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, 0.125 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(affected_mob.health <= HEALTH_THRESHOLD_CRIT && affected_mob.health > (affected_mob.crit_threshold + HEALTH_THRESHOLD_FULLCRIT * (2 * normalise_creation_purity()))) //we cannot save someone below our lowered crit threshold.
 
-		need_mob_update += affected_mob.adjust_tox_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-6 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-3 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 
 		affected_mob.losebreath = 0
 
-		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, max(volume/10, 1) * REM * seconds_per_tick, required_organ_flag = affected_organ_flags) // your heart is barely keeping up!
+		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.5 * max(volume/10, 1) * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags) // your heart is barely keeping up!
 
-		affected_mob.set_jitter_if_lower(rand(0 SECONDS, 4 SECONDS) * REM * seconds_per_tick)
-		affected_mob.set_dizzy_if_lower(rand(0 SECONDS, 4 SECONDS) * REM * seconds_per_tick)
+		affected_mob.set_jitter_if_lower(0.5 * rand(0 SECONDS, 4 SECONDS) * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.set_dizzy_if_lower(0.5 * rand(0 SECONDS, 4 SECONDS) * REM * metabolized_volume * seconds_per_tick)
 
 		if(SPT_PROB(18, seconds_per_tick))
 			to_chat(affected_mob,span_danger("Your body is trying to give up, but your heart is still beating!"))
@@ -631,12 +631,12 @@
 	remove_alert(affected_mob)
 	affected_mob.remove_traits(subject_traits, type)
 
-/datum/reagent/medicine/c2/penthrite/overdose_process(mob/living/carbon/human/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/c2/penthrite/overdose_process(mob/living/carbon/human/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	REMOVE_TRAIT(affected_mob, TRAIT_STABLEHEART, type)
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(10 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 10 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_stamina_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 5 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	need_mob_update += affected_mob.set_heartattack(TRUE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -217,7 +217,7 @@
 		need_mob_update = affected_mob.adjust_fire_loss(-3 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
 	else
 		need_mob_update = affected_mob.adjust_fire_loss(-2.25 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
-	affected_mob.adjust_bodytemperature(0.5 * rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50)
+	affected_mob.adjust_bodytemperature(rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50)
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/humi = affected_mob
 		humi.adjust_coretemperature(1 * rand(-25,-5) * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50)
@@ -374,7 +374,7 @@
 	if(creation_purity >= 1) //Perfectly pure multivers gives a bonus of 2!
 		medibonus += 1
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(-0.25 * min(medibonus, 6 * normalise_creation_purity()) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //not great at healing but if you have nothing else it will work
+	need_mob_update = affected_mob.adjust_tox_loss(-0.5 * min(medibonus, 6 * normalise_creation_purity()) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //not great at healing but if you have nothing else it will work
 	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags) //kills at 40u
 	if(!holder.has_reagent(/datum/reagent/toxin/anacea))
 		for(var/datum/reagent/second_reagent as anything in affected_mob.reagents.reagent_list)
@@ -426,7 +426,8 @@
 	for(var/datum/reagent/R in affected_mob.reagents.reagent_list)
 		if(issyrinormusc(R))
 			continue
-		affected_mob.reagents.remove_reagent(R.type, 0.27 * metabolization_ratio * seconds_per_tick)
+		R.volume -= 0.27 * metabolization_ratio * seconds_per_tick
+	affected_mob.reagents.update_total()
 
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -41,7 +41,7 @@
 		else //no convert
 			thou_shall_heal = round(death_is_coming/10, 0.1)
 			good_kind_of_healing = TRUE
-	need_mob_update += affected_mob.adjust_brute_loss(0.5 * -thou_shall_heal * metabolization_ratio * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_brute_loss(-0.5 * thou_shall_heal * metabolization_ratio * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH
 

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -157,7 +157,7 @@
 
 /datum/reagent/consumable/ethanol/beer/green/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	metabolization_rate = 1 * REAGENTS_METABOLISM
+	metabolization_rate = REAGENTS_METABOLISM
 
 	if(!ishuman(affected_mob))
 		return
@@ -756,7 +756,7 @@
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_metabolize(mob/living/carbon/drinker)
 	. = ..()
 	if(HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
-		metabolization_rate = 0.8
+		metabolization_rate = 4 * REAGENTS_METABOLISM
 	// if you don't have a liver, or your liver isn't an officer's liver
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(!liver || !HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
@@ -1425,7 +1425,7 @@
 	boozepwr = 50
 	quality = DRINK_VERYGOOD
 	taste_description = "a numbing sensation"
-	metabolization_rate = 1 * REAGENTS_METABOLISM
+	metabolization_rate = REAGENTS_METABOLISM
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/consumable/ethanol/neurotoxin/proc/pick_paralyzed_limb()

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -302,7 +302,7 @@
 /datum/reagent/consumable/ethanol/bilk/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.get_brute_loss() && SPT_PROB(5, seconds_per_tick))
-		if(drinker.heal_bodypart_damage(brute = 1 * metabolization_ratio, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/threemileisland
@@ -1276,7 +1276,7 @@
 	. = ..()
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if((liver && HAS_TRAIT(liver, TRAIT_COMEDY_METABOLISM)) || is_simian(drinker))
-		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/silencer
@@ -1293,7 +1293,7 @@
 	. = ..()
 	if(ishuman(drinker) && HAS_MIND_TRAIT(drinker, TRAIT_MIMING))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
-		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/drunkenblumpkin
@@ -1587,7 +1587,7 @@
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/quintuple_sec
@@ -1605,7 +1605,7 @@
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		var/need_mob_update
-		need_mob_update = drinker.heal_bodypart_damage(1 * metabolization_ratio * seconds_per_tick, 2 * metabolization_ratio *  seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = drinker.heal_bodypart_damage(1 * metabolization_ratio * seconds_per_tick, 1 * metabolization_ratio *  seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		need_mob_update += drinker.adjust_stamina_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
@@ -1946,7 +1946,7 @@
 	. = ..()
 	if(ishuman(drinker) && HAS_MIND_TRAIT(drinker, TRAIT_MIMING))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
-		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/fruit_wine
@@ -2078,7 +2078,7 @@
 	//A healing drink similar to Quadruple Sec, Ling Stings, and Screwdrivers for the Wizznerds; the check is consistent with the changeling sting
 	if(drinker?.mind?.has_antag_datum(/datum/antagonist/wizard))
 		var/need_mob_update
-		need_mob_update = drinker.heal_bodypart_damage(0.5 * metabolization_ratio * seconds_per_tick, 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update = drinker.heal_bodypart_damage(0.5 * metabolization_ratio * seconds_per_tick, 0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
 		need_mob_update += drinker.adjust_oxy_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 		need_mob_update += drinker.adjust_tox_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 		need_mob_update += drinker.adjust_stamina_loss(-2.5  * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -74,7 +74,7 @@
 			booze_power *= (total_alcohol_volume / combined_dilute_volume)
 
 		// Volume, power, and server alcohol rate effect how quickly one gets drunk
-		drinker.adjust_drunk_effect(0.5 * sqrt(volume) * booze_power * ALCOHOL_RATE * metabolization_ratio * seconds_per_tick)
+		drinker.adjust_drunk_effect(1 * sqrt(volume) * booze_power * ALCOHOL_RATE * metabolization_ratio * seconds_per_tick)
 		if(boozepwr > 0)
 			var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 			var/heavy_drinker_multiplier = (HAS_TRAIT(drinker, TRAIT_HEAVY_DRINKER) ? 0.5 : 1)
@@ -1354,10 +1354,10 @@
 	. = ..()
 	if(drinker.health <= 0)
 		var/need_mob_update
-		need_mob_update = drinker.adjust_brute_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_fire_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_oxy_loss(-2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += drinker.adjust_tox_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = drinker.adjust_brute_loss(-3.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_fire_loss(-3.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_oxy_loss(-5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += drinker.adjust_tox_loss(-3.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -1477,34 +1477,34 @@
 
 /datum/reagent/consumable/ethanol/hippies_delight/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.set_slurring_if_lower(0.5 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.set_slurring_if_lower(2.5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	switch(current_cycle)
 		if(2 to 6)
-			drinker.set_dizzy_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
-			drinker.set_drugginess(30 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_dizzy_if_lower(20 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_drugginess(150 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(5, seconds_per_tick))
 				drinker.emote(pick("twitch","giggle"))
 		if(6 to 11)
-			drinker.set_jitter_if_lower(20 SECONDS * metabolization_ratio * seconds_per_tick)
-			drinker.set_dizzy_if_lower(20 SECONDS * metabolization_ratio * seconds_per_tick)
-			drinker.set_drugginess(45 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_jitter_if_lower(100 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_dizzy_if_lower(100 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_drugginess(225 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(10, seconds_per_tick))
 				drinker.emote(pick("twitch","giggle"))
 		if (11 to 201)
-			drinker.set_jitter_if_lower(40 SECONDS * metabolization_ratio * seconds_per_tick)
-			drinker.set_dizzy_if_lower(40 SECONDS * metabolization_ratio * seconds_per_tick)
-			drinker.set_drugginess(1 MINUTES * metabolization_ratio * seconds_per_tick)
+			drinker.set_jitter_if_lower(200 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_dizzy_if_lower(200 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_drugginess(5 MINUTES * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(16, seconds_per_tick))
 				drinker.emote(pick("twitch","giggle"))
 		if(201 to INFINITY)
-			drinker.set_jitter_if_lower(60 SECONDS * metabolization_ratio * seconds_per_tick)
-			drinker.set_dizzy_if_lower(60 SECONDS * metabolization_ratio * seconds_per_tick)
-			drinker.set_drugginess(1.25 MINUTES * metabolization_ratio * seconds_per_tick)
+			drinker.set_jitter_if_lower(300 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_dizzy_if_lower(300 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_drugginess(6.25 MINUTES * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(23, seconds_per_tick))
 				drinker.emote(pick("twitch","giggle"))
 			if(SPT_PROB(16, seconds_per_tick))
-				if(drinker.adjust_tox_loss(1 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
+				if(drinker.adjust_tox_loss(5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 					return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/eggnog
@@ -1663,11 +1663,11 @@
 	. = ..()
 	if(drinker.health > 0)
 		var/need_mob_update
-		need_mob_update = drinker.adjust_brute_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_fire_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_tox_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += drinker.adjust_oxy_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += drinker.adjust_stamina_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update = drinker.adjust_brute_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_fire_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_tox_loss(-0.125 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += drinker.adjust_oxy_loss(-0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += drinker.adjust_stamina_loss(-1.25 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -317,7 +317,7 @@
 
 /datum/reagent/consumable/ethanol/threemileisland/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.set_drugginess(10 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.set_drugginess(100 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/gin
 	name = "Gin"
@@ -671,7 +671,7 @@
 
 /datum/reagent/consumable/ethanol/bloody_mary/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_blood_volume(0.25 * (0.25 + round(2 * drinker.get_drunk_amount() / 40, 0.1)) * metabolization_ratio * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL) // Bloody Mary restores blood loss based on how drunk you are
+	drinker.adjust_blood_volume((0.25 + round(2 * drinker.get_drunk_amount() / 40, 0.1)) * metabolization_ratio * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL) // Bloody Mary restores blood loss based on how drunk you are
 
 /datum/reagent/consumable/ethanol/brave_bull
 	name = "Brave Bull"
@@ -1294,7 +1294,8 @@
 	. = ..()
 	if(ishuman(drinker) && HAS_MIND_TRAIT(drinker, TRAIT_MIMING))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
-		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
+		var/heal = 1 * metabolization_ratio * seconds_per_tick
+		if(drinker.heal_bodypart_damage(brute = heal, burn = heal, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/drunkenblumpkin

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -180,9 +180,9 @@
 
 /datum/reagent/consumable/ethanol/kahlua/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.set_dizzy_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
-	drinker.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
-	drinker.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.set_dizzy_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.adjust_drowsiness(-6 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.AdjustSleeping(-4 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(!HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
 		drinker.set_jitter_if_lower(10 SECONDS)
 
@@ -213,7 +213,7 @@
 /datum/reagent/consumable/ethanol/whiskey/candycorn/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
-		drinker.adjust_hallucinations(2 SECONDS * metabolization_ratio)
+		drinker.adjust_hallucinations(4 SECONDS * metabolization_ratio)
 
 /datum/reagent/consumable/ethanol/thirteenloko
 	name = "Thirteen Loko"
@@ -229,9 +229,9 @@
 
 /datum/reagent/consumable/ethanol/thirteenloko/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_drowsiness(-7 SECONDS * metabolization_ratio * seconds_per_tick)
-	drinker.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
-	drinker.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, drinker.get_body_temp_normal())
+	drinker.adjust_drowsiness(-14 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.AdjustSleeping(-4 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.adjust_bodytemperature(-5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, drinker.get_body_temp_normal())
 	if(!HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
 		drinker.set_jitter_if_lower(10 SECONDS)
 
@@ -261,7 +261,7 @@
 				eyes.forceMove(get_turf(drinker))
 				to_chat(drinker, span_userdanger("You double over in pain as you feel your eyeballs liquify in your head!"))
 				drinker.emote("scream")
-				if(drinker.adjust_brute_loss(7.5 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype))
+				if(drinker.adjust_brute_loss(15 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype))
 					. = UPDATE_MOB_HEALTH
 			else
 				to_chat(drinker, span_userdanger("You scream in terror as you go blind!"))
@@ -302,7 +302,7 @@
 /datum/reagent/consumable/ethanol/bilk/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.get_brute_loss() && SPT_PROB(5, seconds_per_tick))
-		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 1 * metabolization_ratio, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/threemileisland
@@ -317,7 +317,7 @@
 
 /datum/reagent/consumable/ethanol/threemileisland/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.set_drugginess(50 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.set_drugginess(10 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/gin
 	name = "Gin"
@@ -454,7 +454,7 @@
 /datum/reagent/consumable/ethanol/absinthe/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick) && !HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
-		drinker.adjust_hallucinations(4 SECONDS * metabolization_ratio)
+		drinker.adjust_hallucinations(8 SECONDS * metabolization_ratio)
 
 /datum/reagent/consumable/ethanol/hooch
 	name = "Hooch"
@@ -555,10 +555,10 @@
 	. = ..()
 	var/need_mob_update
 	if(cubano.mind && cubano.mind.has_antag_datum(/datum/antagonist/rev)) //Cuba Libre, the traditional drink of revolutions! Heals revolutionaries.
-		need_mob_update = cubano.adjust_brute_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += cubano.adjust_fire_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += cubano.adjust_tox_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += cubano.adjust_oxy_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update = cubano.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += cubano.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += cubano.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += cubano.adjust_oxy_loss(-5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -645,7 +645,7 @@
 	if(HAS_TRAIT(liver, TRAIT_ENGINEER_METABOLISM))
 		ADD_TRAIT(drinker, TRAIT_HALT_RADIATION_EFFECTS, "[type]")
 		if (HAS_TRAIT(drinker, TRAIT_IRRADIATED))
-			if(drinker.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			if(drinker.adjust_tox_loss(-2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/screwdrivercocktail/on_mob_end_metabolize(mob/living/drinker)
@@ -671,7 +671,7 @@
 
 /datum/reagent/consumable/ethanol/bloody_mary/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_blood_volume(0.5 * (0.25 + round(2 * drinker.get_drunk_amount() / 40, 0.1)) * metabolization_ratio * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL) // Bloody Mary restores blood loss based on how drunk you are
+	drinker.adjust_blood_volume(0.25 * (0.25 + round(2 * drinker.get_drunk_amount() / 40, 0.1)) * metabolization_ratio * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL) // Bloody Mary restores blood loss based on how drunk you are
 
 /datum/reagent/consumable/ethanol/brave_bull
 	name = "Brave Bull"
@@ -738,7 +738,7 @@
 
 /datum/reagent/consumable/ethanol/toxins_special/on_mob_life(mob/living/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_bodytemperature(7.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal() + 20) //310.15 is the normal bodytemp.
+	drinker.adjust_bodytemperature(15 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal() + 20) //310.15 is the normal bodytemp.
 
 /datum/reagent/consumable/ethanol/beepsky_smash
 	name = "Beepsky Smash"
@@ -769,7 +769,7 @@
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	// if you have a liver and that liver is an officer's liver
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		if(drinker.adjust_stamina_loss(-5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype))
+		if(drinker.adjust_stamina_loss(-4 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
 		if(SPT_PROB(10, seconds_per_tick))
 			drinker.cause_hallucination(get_random_valid_hallucination_subtype(/datum/hallucination/nearby_fake_item), name)
@@ -820,8 +820,8 @@
 	. = ..()
 	if(dorf_mode)
 		var/need_mob_update
-		need_mob_update = dwarf.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += dwarf.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = dwarf.adjust_brute_loss(-2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += dwarf.adjust_fire_loss(-2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -906,7 +906,7 @@
 
 /datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.set_drugginess(30 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.set_drugginess(1 MINUTES * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/whiskeysoda
 	name = "Whiskey Soda"
@@ -928,7 +928,7 @@
 
 /datum/reagent/consumable/ethanol/antifreeze/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_bodytemperature(10 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal() + 20) //310.15 is the normal bodytemp.
+	drinker.adjust_bodytemperature(20 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal() + 20) //310.15 is the normal bodytemp.
 
 /datum/reagent/consumable/ethanol/barefoot
 	name = "Barefoot"
@@ -944,7 +944,7 @@
 	if(ishuman(drinker)) //Barefoot causes the imbiber to quickly regenerate brute trauma if they're not wearing shoes.
 		var/mob/living/carbon/human/unshoed = drinker
 		if(!unshoed.shoes)
-			if(unshoed.adjust_brute_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+			if(unshoed.adjust_brute_loss(-3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/snowwhite
@@ -1108,7 +1108,7 @@
 
 /datum/reagent/consumable/ethanol/sbiten/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_bodytemperature(25 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, BODYTEMP_HEAT_DAMAGE_LIMIT) //310.15 is the normal bodytemp.
+	drinker.adjust_bodytemperature(50 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, BODYTEMP_HEAT_DAMAGE_LIMIT) //310.15 is the normal bodytemp.
 
 /datum/reagent/consumable/ethanol/red_mead
 	name = "Red Mead"
@@ -1139,7 +1139,7 @@
 
 /datum/reagent/consumable/ethanol/iced_beer/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_bodytemperature(-10 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, T0C) //310.15 is the normal bodytemp.
+	drinker.adjust_bodytemperature(-20 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, T0C) //310.15 is the normal bodytemp.
 
 /datum/reagent/consumable/ethanol/grog
 	name = "Grog"
@@ -1209,7 +1209,7 @@
 /datum/reagent/consumable/ethanol/changelingsting/on_mob_life(mob/living/carbon/target, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/datum/antagonist/changeling/changeling = IS_CHANGELING(target)
-	changeling?.adjust_chemicals(0.5 * metabolization_rate * metabolization_ratio * seconds_per_tick)
+	changeling?.adjust_chemicals(metabolization_rate * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/irishcarbomb
 	name = "Irish Car Bomb"
@@ -1276,7 +1276,8 @@
 	. = ..()
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if((liver && HAS_TRAIT(liver, TRAIT_COMEDY_METABOLISM)) || is_simian(drinker))
-		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
+		var/heal = 1 * metabolization_ratio * seconds_per_tick
+		if(drinker.heal_bodypart_damage(brute = heal, burn = heal, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/silencer
@@ -1381,17 +1382,17 @@
 
 /datum/reagent/consumable/ethanol/atomicbomb/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.set_drugginess(50 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.set_drugginess(100 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(!HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
-		drinker.adjust_confusion(1 SECONDS * metabolization_ratio * seconds_per_tick)
-	drinker.set_dizzy_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
-	drinker.adjust_slurring(3 SECONDS * metabolization_ratio * seconds_per_tick)
+		drinker.adjust_confusion(2 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.set_dizzy_if_lower(20 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.adjust_slurring(6 SECONDS * metabolization_ratio * seconds_per_tick)
 	switch(current_cycle)
 		if(52 to 201)
-			drinker.Sleeping(50 * metabolization_ratio * seconds_per_tick)
+			drinker.Sleeping(100 * metabolization_ratio * seconds_per_tick)
 		if(202 to INFINITY)
-			drinker.AdjustSleeping(2 SECONDS * metabolization_ratio * seconds_per_tick)
-			if(drinker.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			drinker.AdjustSleeping(4 SECONDS * metabolization_ratio * seconds_per_tick)
+			if(drinker.adjust_tox_loss(2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/gargle_blaster
@@ -1405,17 +1406,17 @@
 
 /datum/reagent/consumable/ethanol/gargle_blaster/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_dizzy(1.5 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.adjust_dizzy(3 SECONDS * metabolization_ratio * seconds_per_tick)
 	switch(current_cycle)
 		if(16 to 46)
-			drinker.adjust_slurring(1.5 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.adjust_slurring(3 SECONDS * metabolization_ratio * seconds_per_tick)
 		if(46 to 56)
 			if(SPT_PROB(30, seconds_per_tick))
-				drinker.adjust_confusion(1.5 SECONDS * metabolization_ratio)
+				drinker.adjust_confusion(3 SECONDS * metabolization_ratio)
 		if(56 to 201)
-			drinker.set_drugginess(55 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_drugginess(110 SECONDS * metabolization_ratio * seconds_per_tick)
 		if(201 to INFINITY)
-			if(drinker.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			if(drinker.adjust_tox_loss(2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/neurotoxin
@@ -1481,7 +1482,7 @@
 
 	switch(current_cycle)
 		if(2 to 6)
-			drinker.set_dizzy_if_lower(20 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_dizzy_if_lower(50 SECONDS * metabolization_ratio * seconds_per_tick)
 			drinker.set_drugginess(150 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(5, seconds_per_tick))
 				drinker.emote(pick("twitch","giggle"))
@@ -1538,8 +1539,8 @@
 
 /datum/reagent/consumable/ethanol/narsour/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_timed_status_effect(3 SECONDS * metabolization_ratio * seconds_per_tick, /datum/status_effect/speech/slurring/cult, max_duration = 6 SECONDS)
-	drinker.adjust_stutter_up_to(3 SECONDS * metabolization_ratio * seconds_per_tick, 6 SECONDS)
+	drinker.adjust_timed_status_effect(6 SECONDS * metabolization_ratio * seconds_per_tick, /datum/status_effect/speech/slurring/cult, max_duration = 6 SECONDS)
+	drinker.adjust_stutter_up_to(6 SECONDS * metabolization_ratio * seconds_per_tick, 6 SECONDS)
 
 /datum/reagent/consumable/ethanol/triple_sec
 	name = "Triple Sec"
@@ -1587,7 +1588,8 @@
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
+		var/heal = 1 * metabolization_ratio * seconds_per_tick
+		if(drinker.heal_bodypart_damage(brute = heal, burn = heal, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/quintuple_sec
@@ -1605,8 +1607,8 @@
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		var/need_mob_update
-		need_mob_update = drinker.heal_bodypart_damage(1 * metabolization_ratio * seconds_per_tick, 1 * metabolization_ratio *  seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_stamina_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update = drinker.heal_bodypart_damage(2 * metabolization_ratio * seconds_per_tick, 1 * metabolization_ratio *  seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_stamina_loss(-5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -1682,7 +1684,7 @@
 
 /datum/reagent/consumable/ethanol/squirt_cider/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.satiety += 2.5 * metabolization_ratio * seconds_per_tick //for context, vitamins give 15 satiety per second
+	drinker.satiety += 5 * metabolization_ratio * seconds_per_tick //for context, vitamins give 15 satiety per second
 
 /datum/reagent/consumable/ethanol/fringe_weaver
 	name = "Fringe Weaver"
@@ -1705,7 +1707,7 @@
 
 /datum/reagent/consumable/ethanol/sugar_rush/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.satiety -= 5 * metabolization_ratio * seconds_per_tick //junky as hell! a whole glass will keep you from being able to eat junk food
+	drinker.satiety -= 10 * metabolization_ratio * seconds_per_tick //junky as hell! a whole glass will keep you from being able to eat junk food
 
 /datum/reagent/consumable/ethanol/crevice_spike
 	name = "Crevice Spike"
@@ -1741,7 +1743,7 @@
 /datum/reagent/consumable/ethanol/peppermint_patty/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	drinker.apply_status_effect(/datum/status_effect/throat_soothed)
-	drinker.adjust_bodytemperature(2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal())
+	drinker.adjust_bodytemperature(5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 0, drinker.get_body_temp_normal())
 
 /datum/reagent/consumable/ethanol/alexander
 	name = "Alexander"
@@ -1822,13 +1824,13 @@
 	var/need_mob_update
 	if(drinker.get_brute_loss() && drinker.get_fire_loss()) //If you are damaged by both types, slightly increased healing but it only heals one. The more the merrier wink wink.
 		if(prob(50))
-			need_mob_update = drinker.adjust_brute_loss(-0.125 * metabolization_ratio * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
+			need_mob_update = drinker.adjust_brute_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
 		else
-			need_mob_update = drinker.adjust_fire_loss(-0.125 * metabolization_ratio * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
+			need_mob_update = drinker.adjust_fire_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
 	else if(drinker.get_brute_loss()) //If you have only one, it still heals but not as well.
-		need_mob_update = drinker.adjust_brute_loss(-0.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
+		need_mob_update = drinker.adjust_brute_loss(-0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
 	else if(drinker.get_fire_loss())
-		need_mob_update = drinker.adjust_fire_loss(-0.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = drinker.adjust_fire_loss(-0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1871,9 +1873,9 @@
 /datum/reagent/consumable/ethanol/fernet/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.nutrition <= NUTRITION_LEVEL_STARVING)
-		if(drinker.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(drinker.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	drinker.adjust_nutrition(-2.5 * metabolization_ratio * seconds_per_tick)
+	drinker.adjust_nutrition(-5 * metabolization_ratio * seconds_per_tick)
 	drinker.overeatduration = 0
 
 /datum/reagent/consumable/ethanol/fernet_cola
@@ -1888,9 +1890,9 @@
 /datum/reagent/consumable/ethanol/fernet_cola/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.nutrition <= NUTRITION_LEVEL_STARVING)
-		if(drinker.adjust_tox_loss(0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(drinker.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	drinker.adjust_nutrition(-1.5 * metabolization_ratio * seconds_per_tick)
+	drinker.adjust_nutrition(-3 * metabolization_ratio * seconds_per_tick)
 	drinker.overeatduration = 0
 
 /datum/reagent/consumable/ethanol/fanciulli
@@ -1905,7 +1907,7 @@
 
 /datum/reagent/consumable/ethanol/fanciulli/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_nutrition(-2.5 * metabolization_ratio * seconds_per_tick)
+	drinker.adjust_nutrition(-5 * metabolization_ratio * seconds_per_tick)
 	drinker.overeatduration = 0
 
 /datum/reagent/consumable/ethanol/fanciulli/on_mob_metabolize(mob/living/drinker)
@@ -1925,7 +1927,7 @@
 
 /datum/reagent/consumable/ethanol/branca_menta/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_bodytemperature(-10 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, T0C)
+	drinker.adjust_bodytemperature(-20 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, T0C)
 
 /datum/reagent/consumable/ethanol/branca_menta/on_mob_metabolize(mob/living/drinker)
 	. = ..()
@@ -1946,7 +1948,8 @@
 	. = ..()
 	if(ishuman(drinker) && HAS_MIND_TRAIT(drinker, TRAIT_MIMING))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
-		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
+		var/heal = 1 * metabolization_ratio * seconds_per_tick
+		if(drinker.heal_bodypart_damage(brute = heal, burn = heal, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/fruit_wine
@@ -1956,9 +1959,9 @@
 	boozepwr = 35
 	quality = DRINK_GOOD
 	taste_description = "bad coding"
+	ph = 4
 	var/list/names = list("null fruit" = 1) //Names of the fruits used. Associative list where name is key, value is the percentage of that fruit.
 	var/list/tastes = list("bad coding" = 1) //List of tastes. See above.
-	ph = 4
 
 /datum/reagent/consumable/ethanol/fruit_wine/on_new(list/data)
 	if(!data)
@@ -2078,10 +2081,10 @@
 	//A healing drink similar to Quadruple Sec, Ling Stings, and Screwdrivers for the Wizznerds; the check is consistent with the changeling sting
 	if(drinker?.mind?.has_antag_datum(/datum/antagonist/wizard))
 		var/need_mob_update
-		need_mob_update = drinker.heal_bodypart_damage(0.5 * metabolization_ratio * seconds_per_tick, 0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_oxy_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += drinker.adjust_tox_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += drinker.adjust_stamina_loss(-2.5  * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update = drinker.heal_bodypart_damage(1 * metabolization_ratio * seconds_per_tick, 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_oxy_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += drinker.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += drinker.adjust_stamina_loss(-5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -2102,7 +2105,7 @@
 /datum/reagent/consumable/ethanol/bug_spray/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	// Does some damage to bug biotypes
-	if(drinker.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(drinker.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
 		// Random chance of causing a screm if we did some damage
 		if(SPT_PROB(2, seconds_per_tick))
@@ -2138,7 +2141,7 @@
 	. = ..()
 	if(SPT_PROB(2, seconds_per_tick))
 		to_chat(drinker, span_notice("[pick("You feel disregard for the rule of law.", "You feel pumped!", "Your head is pounding.", "Your thoughts are racing..")]"))
-	if(drinker.adjust_stamina_loss(-0.25 * drinker.get_drunk_amount() * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype))
+	if(drinker.adjust_stamina_loss(-0.5 * drinker.get_drunk_amount() * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/old_timer
@@ -2198,10 +2201,10 @@
 /datum/reagent/consumable/ethanol/trappist/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.mind?.holy_role)
-		if(drinker.adjust_fire_loss(-1.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+		if(drinker.adjust_fire_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 			. = UPDATE_MOB_HEALTH
-		drinker.adjust_jitter(-1 SECONDS * metabolization_ratio * seconds_per_tick)
-		drinker.adjust_stutter(-1 SECONDS * metabolization_ratio * seconds_per_tick)
+		drinker.adjust_jitter(-2 SECONDS * metabolization_ratio * seconds_per_tick)
+		drinker.adjust_stutter(-2 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/blazaam
 	name = "Blazaam"
@@ -2242,9 +2245,9 @@
 /datum/reagent/consumable/ethanol/mauna_loa/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	// Heats the user up while the reagent is in the body. Occasionally makes you burst into flames.
-	drinker.adjust_bodytemperature(12.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick)
+	drinker.adjust_bodytemperature(25 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick)
 	if (SPT_PROB(2.5, seconds_per_tick))
-		drinker.adjust_fire_stacks(0.5 * metabolization_ratio)
+		drinker.adjust_fire_stacks(1 * metabolization_ratio)
 		drinker.ignite_mob()
 
 /datum/reagent/consumable/ethanol/painkiller
@@ -2297,7 +2300,7 @@
 
 /datum/reagent/consumable/ethanol/pruno/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_disgust(2.5 * metabolization_ratio * seconds_per_tick)
+	drinker.adjust_disgust(5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/ginger_amaretto
 	name = "Ginger Amaretto"
@@ -2339,7 +2342,7 @@
 /datum/reagent/consumable/ethanol/kortara/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
-		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, burn = 0, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 1 * metabolization_ratio, burn = 0, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/sea_breeze
@@ -2397,11 +2400,11 @@
 
 /datum/reagent/consumable/ethanol/protein_blend/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. =	..()
-	drinker.adjust_nutrition(1 * metabolization_ratio * seconds_per_tick)
+	drinker.adjust_nutrition(2 * metabolization_ratio * seconds_per_tick)
 	if(!islizard(drinker))
-		drinker.adjust_disgust(2.5 * metabolization_ratio * seconds_per_tick)
+		drinker.adjust_disgust(5 * metabolization_ratio * seconds_per_tick)
 	else
-		drinker.adjust_disgust(1 * metabolization_ratio * seconds_per_tick)
+		drinker.adjust_disgust(2 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/mushi_kombucha
 	name = "Mushi Kombucha"
@@ -2583,7 +2586,7 @@
 /datum/reagent/consumable/ethanol/helianthus/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
-		drinker.adjust_hallucinations_up_to(2 SECONDS * metabolization_ratio, 48 SECONDS)
+		drinker.adjust_hallucinations_up_to(4 SECONDS * metabolization_ratio, 48 SECONDS)
 
 /datum/reagent/consumable/ethanol/plumwine
 	name = "Plum wine"
@@ -2617,7 +2620,7 @@
 
 /datum/reagent/consumable/ethanol/gin_garden/on_mob_life(mob/living/carbon/doll, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	doll.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, doll.get_body_temp_normal())
+	doll.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, doll.get_body_temp_normal())
 
 /datum/reagent/consumable/ethanol/wine_voltaic
 	name = "Voltaic Yellow Wine"
@@ -2981,8 +2984,8 @@
 /datum/reagent/consumable/ethanol/suffering_bastard/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	affected_mob.apply_status_effect(/datum/status_effect/headache_soothed) //prevents headaches
-	affected_mob.adjust_disgust(-2.5 * metabolization_ratio * seconds_per_tick) //removes disgust, same with sol dry
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -0.25 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags)) //heals brain damage very slowly, about 12 damage per 5u
+	affected_mob.adjust_disgust(-5 * metabolization_ratio * seconds_per_tick) //removes disgust, same with sol dry
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -0.5 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags)) //heals brain damage very slowly, about 12 damage per 5u
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/blue_blazer
@@ -2996,7 +2999,7 @@
 
 /datum/reagent/consumable/ethanol/blue_blazer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(12.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(25 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/ethanol/hot_toddy
 	name = "Hot Toddy"
@@ -3010,7 +3013,7 @@
 
 /datum/reagent/consumable/ethanol/hot_toddy/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(12.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(25 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/ethanol/tizirian_sour
 	name = "Tizirian Sour"

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -51,7 +51,7 @@
 		LAZYSET(addiction_types, /datum/addiction/alcohol, 0.05 * boozepwr)
 	return ..()
 
-/datum/reagent/consumable/ethanol/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(drinker.get_drunk_amount() < volume * boozepwr * ALCOHOL_THRESHOLD_MODIFIER || boozepwr < 0)
 		var/booze_power = boozepwr
@@ -74,7 +74,7 @@
 			booze_power *= (total_alcohol_volume / combined_dilute_volume)
 
 		// Volume, power, and server alcohol rate effect how quickly one gets drunk
-		drinker.adjust_drunk_effect(sqrt(volume) * booze_power * ALCOHOL_RATE * REM * seconds_per_tick)
+		drinker.adjust_drunk_effect(0.5 * sqrt(volume) * booze_power * ALCOHOL_RATE * REM * metabolized_volume * seconds_per_tick)
 		if(boozepwr > 0)
 			var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 			var/heavy_drinker_multiplier = (HAS_TRAIT(drinker, TRAIT_HEAVY_DRINKER) ? 0.5 : 1)
@@ -146,7 +146,7 @@
 	ph = 6
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/beer/green/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/beer/green/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(drinker.color != color)
 		drinker.add_atom_colour(color, TEMPORARY_COLOUR_PRIORITY)
@@ -155,7 +155,7 @@
 	. = ..()
 	drinker.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, color)
 
-/datum/reagent/consumable/ethanol/beer/green/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/ethanol/beer/green/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 
@@ -178,11 +178,11 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/ethanol/kahlua/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/kahlua/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.set_dizzy_if_lower(10 SECONDS * REM * seconds_per_tick)
-	drinker.adjust_drowsiness(-6 SECONDS * REM * seconds_per_tick)
-	drinker.AdjustSleeping(-4 SECONDS * REM * seconds_per_tick)
+	drinker.set_dizzy_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(!HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
 		drinker.set_jitter_if_lower(10 SECONDS)
 
@@ -210,10 +210,10 @@
 	taste_description = "pancake syrup"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/whiskey/candycorn/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/whiskey/candycorn/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
-		drinker.adjust_hallucinations(4 SECONDS * REM * seconds_per_tick)
+		drinker.adjust_hallucinations(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/thirteenloko
 	name = "Thirteen Loko"
@@ -227,21 +227,21 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/ethanol/thirteenloko/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/thirteenloko/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.adjust_drowsiness(-14 SECONDS * REM * seconds_per_tick)
-	drinker.AdjustSleeping(-4 SECONDS * REM * seconds_per_tick)
-	drinker.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, drinker.get_body_temp_normal())
+	drinker.adjust_drowsiness(-7 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, drinker.get_body_temp_normal())
 	if(!HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
 		drinker.set_jitter_if_lower(10 SECONDS)
 
-/datum/reagent/consumable/ethanol/thirteenloko/overdose_start(mob/living/drinker)
+/datum/reagent/consumable/ethanol/thirteenloko/overdose_start(mob/living/drinker, metabolized_volume)
 	. = ..()
 	to_chat(drinker, span_userdanger("Your entire body violently jitters as you start to feel queasy. You really shouldn't have drank all of that [name]!"))
 	drinker.set_jitter_if_lower(40 SECONDS)
 	drinker.Stun(1.5 SECONDS)
 
-/datum/reagent/consumable/ethanol/thirteenloko/overdose_process(mob/living/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/thirteenloko/overdose_process(mob/living/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(3.5, seconds_per_tick) && iscarbon(drinker))
 		var/obj/item/held_item = drinker.get_active_held_item()
@@ -261,7 +261,7 @@
 				eyes.forceMove(get_turf(drinker))
 				to_chat(drinker, span_userdanger("You double over in pain as you feel your eyeballs liquify in your head!"))
 				drinker.emote("scream")
-				if(drinker.adjust_brute_loss(15 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+				if(drinker.adjust_brute_loss(7.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 					. = UPDATE_MOB_HEALTH
 			else
 				to_chat(drinker, span_userdanger("You scream in terror as you go blind!"))
@@ -299,10 +299,10 @@
 	taste_description = "desperation and lactate"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/bilk/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/bilk/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(drinker.get_brute_loss() && SPT_PROB(5, seconds_per_tick))
-		if(drinker.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/threemileisland
@@ -315,9 +315,9 @@
 	ph = 3.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/threemileisland/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/threemileisland/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.set_drugginess(100 SECONDS * REM * seconds_per_tick)
+	drinker.set_drugginess(50 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/gin
 	name = "Gin"
@@ -451,10 +451,10 @@
 	taste_description = "death and licorice"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/absinthe/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/absinthe/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick) && !HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
-		drinker.adjust_hallucinations(8 SECONDS * REM * seconds_per_tick)
+		drinker.adjust_hallucinations(4 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/hooch
 	name = "Hooch"
@@ -551,14 +551,14 @@
 	taste_description = "a refreshing marriage of citrus and rum"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/cuba_libre/on_mob_life(mob/living/carbon/cubano, seconds_per_tick)
+/datum/reagent/consumable/ethanol/cuba_libre/on_mob_life(mob/living/carbon/cubano, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	if(cubano.mind && cubano.mind.has_antag_datum(/datum/antagonist/rev)) //Cuba Libre, the traditional drink of revolutions! Heals revolutionaries.
-		need_mob_update = cubano.adjust_brute_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += cubano.adjust_fire_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += cubano.adjust_tox_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += cubano.adjust_oxy_loss(-5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update = cubano.adjust_brute_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += cubano.adjust_fire_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += cubano.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += cubano.adjust_oxy_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -639,13 +639,13 @@
 		drink.tool_behaviour = initial(drink.tool_behaviour)
 		drink.usesound = initial(drink.usesound)
 
-/datum/reagent/consumable/ethanol/screwdrivercocktail/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/screwdrivercocktail/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(HAS_TRAIT(liver, TRAIT_ENGINEER_METABOLISM))
 		ADD_TRAIT(drinker, TRAIT_HALT_RADIATION_EFFECTS, "[type]")
 		if (HAS_TRAIT(drinker, TRAIT_IRRADIATED))
-			if(drinker.adjust_tox_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			if(drinker.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/screwdrivercocktail/on_mob_end_metabolize(mob/living/drinker)
@@ -669,9 +669,9 @@
 	taste_description = "tomatoes with a hint of lime and liquid murder"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/bloody_mary/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/bloody_mary/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.adjust_blood_volume((0.25 + round(2 * drinker.get_drunk_amount() / 40, 0.1)) * REM * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL) // Bloody Mary restores blood loss based on how drunk you are
+	drinker.adjust_blood_volume(0.5 * (0.25 + round(2 * drinker.get_drunk_amount() / 40, 0.1)) * REM * metabolized_volume * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL) // Bloody Mary restores blood loss based on how drunk you are
 
 /datum/reagent/consumable/ethanol/brave_bull
 	name = "Brave Bull"
@@ -715,7 +715,7 @@
 	light_holder = new(drinker)
 	light_holder.set_light(3, 0.7, COLOR_TANGERINE_YELLOW) //Tequila Sunrise makes you radiate dim light, like a sunrise!
 
-/datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	if(QDELETED(light_holder))
 		holder.del_reagent(type) //If we lost our light object somehow, remove the reagent
 	else if(light_holder.loc != drinker)
@@ -736,9 +736,9 @@
 	taste_description = "spicy toxins"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/toxins_special/on_mob_life(mob/living/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/toxins_special/on_mob_life(mob/living/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.adjust_bodytemperature(15 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal() + 20) //310.15 is the normal bodytemp.
+	drinker.adjust_bodytemperature(7.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal() + 20) //310.15 is the normal bodytemp.
 
 /datum/reagent/consumable/ethanol/beepsky_smash
 	name = "Beepsky Smash"
@@ -763,13 +763,13 @@
 		beepsky_hallucination = new()
 		drinker.gain_trauma(beepsky_hallucination, TRAUMA_RESILIENCE_ABSOLUTE)
 
-/datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	drinker.set_jitter_if_lower(4 SECONDS)
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	// if you have a liver and that liver is an officer's liver
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		if(drinker.adjust_stamina_loss(-10 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype))
+		if(drinker.adjust_stamina_loss(-5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
 		if(SPT_PROB(10, seconds_per_tick))
 			drinker.cause_hallucination(get_random_valid_hallucination_subtype(/datum/hallucination/nearby_fake_item), name)
@@ -781,7 +781,7 @@
 	if(beepsky_hallucination)
 		QDEL_NULL(beepsky_hallucination)
 
-/datum/reagent/consumable/ethanol/beepsky_smash/overdose_start(mob/living/carbon/drinker)
+/datum/reagent/consumable/ethanol/beepsky_smash/overdose_start(mob/living/carbon/drinker, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	// if you don't have a liver, or your liver isn't an officer's liver
@@ -816,12 +816,12 @@
 			boozepwr = 50 // will still smash but not as much.
 			dorf_mode = TRUE
 
-/datum/reagent/consumable/ethanol/manly_dorf/on_mob_life(mob/living/carbon/dwarf, seconds_per_tick)
+/datum/reagent/consumable/ethanol/manly_dorf/on_mob_life(mob/living/carbon/dwarf, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(dorf_mode)
 		var/need_mob_update
-		need_mob_update = dwarf.adjust_brute_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += dwarf.adjust_fire_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = dwarf.adjust_brute_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += dwarf.adjust_fire_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -904,9 +904,9 @@
 	taste_description = "death, the destroyer of worlds"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.set_drugginess(1 MINUTES * REM * seconds_per_tick)
+	drinker.set_drugginess(30 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/whiskeysoda
 	name = "Whiskey Soda"
@@ -926,9 +926,9 @@
 	taste_description = "Jack Frost's piss"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/antifreeze/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/antifreeze/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.adjust_bodytemperature(20 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal() + 20) //310.15 is the normal bodytemp.
+	drinker.adjust_bodytemperature(10 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal() + 20) //310.15 is the normal bodytemp.
 
 /datum/reagent/consumable/ethanol/barefoot
 	name = "Barefoot"
@@ -939,12 +939,12 @@
 	taste_description = "creamy berries"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/barefoot/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/barefoot/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(ishuman(drinker)) //Barefoot causes the imbiber to quickly regenerate brute trauma if they're not wearing shoes.
 		var/mob/living/carbon/human/unshoed = drinker
 		if(!unshoed.shoes)
-			if(unshoed.adjust_brute_loss(-3 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+			if(unshoed.adjust_brute_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/snowwhite
@@ -1079,7 +1079,7 @@
 	. = ..()
 	drinker.remove_filter("singulo_rays")
 
-/datum/reagent/consumable/ethanol/singulo/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/singulo/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(2.5, seconds_per_tick))
 		// 20u = 1x1, 45u = 2x2, 80u = 3x3
@@ -1106,9 +1106,9 @@
 	taste_description = "hot and spice"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/sbiten/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/sbiten/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.adjust_bodytemperature(50 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, BODYTEMP_HEAT_DAMAGE_LIMIT) //310.15 is the normal bodytemp.
+	drinker.adjust_bodytemperature(25 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, BODYTEMP_HEAT_DAMAGE_LIMIT) //310.15 is the normal bodytemp.
 
 /datum/reagent/consumable/ethanol/red_mead
 	name = "Red Mead"
@@ -1137,9 +1137,9 @@
 	taste_description = "refreshingly cold"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/iced_beer/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/iced_beer/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.adjust_bodytemperature(-20 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, T0C) //310.15 is the normal bodytemp.
+	drinker.adjust_bodytemperature(-10 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, T0C) //310.15 is the normal bodytemp.
 
 /datum/reagent/consumable/ethanol/grog
 	name = "Grog"
@@ -1206,10 +1206,10 @@
 	taste_description = "your brain coming out your nose"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/changelingsting/on_mob_life(mob/living/carbon/target, seconds_per_tick)
+/datum/reagent/consumable/ethanol/changelingsting/on_mob_life(mob/living/carbon/target, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/datum/antagonist/changeling/changeling = IS_CHANGELING(target)
-	changeling?.adjust_chemicals(metabolization_rate * REM * seconds_per_tick)
+	changeling?.adjust_chemicals(0.5 * metabolization_rate * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/irishcarbomb
 	name = "Irish Car Bomb"
@@ -1229,7 +1229,7 @@
 	taste_description = "purified antagonism"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/syndicatebomb/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/syndicatebomb/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(2.5, seconds_per_tick))
 		playsound(get_turf(drinker), 'sound/effects/explosion/explosionfar.ogg', 100, TRUE)
@@ -1272,11 +1272,11 @@
 	taste_description = "a bad joke"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/bananahonk/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/bananahonk/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if((liver && HAS_TRAIT(liver, TRAIT_COMEDY_METABOLISM)) || is_simian(drinker))
-		if(drinker.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 1 * REM * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/silencer
@@ -1289,11 +1289,11 @@
 	taste_description = "a pencil eraser"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(ishuman(drinker) && HAS_MIND_TRAIT(drinker, TRAIT_MIMING))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
-		if(drinker.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 1 * REM * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/drunkenblumpkin
@@ -1333,7 +1333,7 @@
 	taste_description = "charged metal" // the same as teslium, honk honk.
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/fetching_fizz/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/fetching_fizz/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/turf/drinker_turf = get_turf(drinker)
 	for(var/obj/item/stack/ore/ore in orange(3, drinker))
@@ -1350,14 +1350,14 @@
 	taste_description = "bravado in the face of disaster"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/hearty_punch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/hearty_punch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(drinker.health <= 0)
 		var/need_mob_update
-		need_mob_update = drinker.adjust_brute_loss(-3 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_fire_loss(-3 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_oxy_loss(-4 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += drinker.adjust_tox_loss(-3 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = drinker.adjust_brute_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_fire_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_oxy_loss(-2 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += drinker.adjust_tox_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -1379,19 +1379,19 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_HIGH
 
-/datum/reagent/consumable/ethanol/atomicbomb/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/atomicbomb/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.set_drugginess(100 SECONDS * REM * seconds_per_tick)
+	drinker.set_drugginess(50 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(!HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
-		drinker.adjust_confusion(2 SECONDS * REM * seconds_per_tick)
-	drinker.set_dizzy_if_lower(20 SECONDS * REM * seconds_per_tick)
-	drinker.adjust_slurring(6 SECONDS * REM * seconds_per_tick)
+		drinker.adjust_confusion(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.set_dizzy_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.adjust_slurring(3 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	switch(current_cycle)
 		if(52 to 201)
-			drinker.Sleeping(100 * REM * seconds_per_tick)
+			drinker.Sleeping(50 * REM * metabolized_volume * seconds_per_tick)
 		if(202 to INFINITY)
-			drinker.AdjustSleeping(4 SECONDS * REM * seconds_per_tick)
-			if(drinker.adjust_tox_loss(2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			drinker.AdjustSleeping(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			if(drinker.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/gargle_blaster
@@ -1403,19 +1403,19 @@
 	taste_description = "your brains smashed out by a lemon wrapped around a gold brick"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/gargle_blaster/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/gargle_blaster/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.adjust_dizzy(3 SECONDS * REM * seconds_per_tick)
+	drinker.adjust_dizzy(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	switch(current_cycle)
 		if(16 to 46)
-			drinker.adjust_slurring(3 SECONDS * REM * seconds_per_tick)
+			drinker.adjust_slurring(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 		if(46 to 56)
 			if(SPT_PROB(30, seconds_per_tick))
-				drinker.adjust_confusion(3 SECONDS * REM * seconds_per_tick)
+				drinker.adjust_confusion(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 		if(56 to 201)
-			drinker.set_drugginess(110 SECONDS * REM * seconds_per_tick)
+			drinker.set_drugginess(55 SECONDS * REM * metabolized_volume * seconds_per_tick)
 		if(201 to INFINITY)
-			if(drinker.adjust_tox_loss(2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			if(drinker.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/neurotoxin
@@ -1431,23 +1431,23 @@
 /datum/reagent/consumable/ethanol/neurotoxin/proc/pick_paralyzed_limb()
 	return (pick(TRAIT_PARALYSIS_L_ARM,TRAIT_PARALYSIS_R_ARM,TRAIT_PARALYSIS_R_LEG,TRAIT_PARALYSIS_L_LEG))
 
-/datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.set_drugginess(100 SECONDS * REM * seconds_per_tick)
-	drinker.adjust_dizzy(4 SECONDS * REM * seconds_per_tick)
+	drinker.set_drugginess(50 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.adjust_dizzy(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	var/need_mob_update
-	need_mob_update = drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1 * REM * seconds_per_tick, 150, required_organ_flag = affected_organ_flags)
+	need_mob_update = drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * REM * metabolized_volume * seconds_per_tick, 150, required_organ_flag = affected_organ_flags)
 	if(SPT_PROB(10, seconds_per_tick))
-		need_mob_update += drinker.adjust_stamina_loss(10 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update += drinker.adjust_stamina_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		drinker.drop_all_held_items()
 		to_chat(drinker, span_notice("You cant feel your hands!"))
 	if(current_cycle > 6)
 		if(SPT_PROB(10, seconds_per_tick))
 			var/paralyzed_limb = pick_paralyzed_limb()
 			ADD_TRAIT(drinker, paralyzed_limb, type)
-			need_mob_update += drinker.adjust_stamina_loss(10 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+			need_mob_update += drinker.adjust_stamina_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(current_cycle > 31)
-			need_mob_update += drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+			need_mob_update += drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 			if(current_cycle > 51 && SPT_PROB(7.5, seconds_per_tick))
 				if(!drinker.undergoing_cardiac_arrest() && drinker.can_heartattack())
 					drinker.set_heartattack(TRUE)
@@ -1475,36 +1475,36 @@
 	taste_description = "giving peace a chance"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/hippies_delight/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/hippies_delight/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.set_slurring_if_lower(1 SECONDS * REM * seconds_per_tick)
+	drinker.set_slurring_if_lower(0.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 	switch(current_cycle)
 		if(2 to 6)
-			drinker.set_dizzy_if_lower(20 SECONDS * REM * seconds_per_tick)
-			drinker.set_drugginess(1 MINUTES * REM * seconds_per_tick)
+			drinker.set_dizzy_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			drinker.set_drugginess(30 SECONDS * REM * metabolized_volume * seconds_per_tick)
 			if(SPT_PROB(5, seconds_per_tick))
 				drinker.emote(pick("twitch","giggle"))
 		if(6 to 11)
-			drinker.set_jitter_if_lower(40 SECONDS * REM * seconds_per_tick)
-			drinker.set_dizzy_if_lower(40 SECONDS * REM * seconds_per_tick)
-			drinker.set_drugginess(1.5 MINUTES * REM * seconds_per_tick)
+			drinker.set_jitter_if_lower(20 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			drinker.set_dizzy_if_lower(20 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			drinker.set_drugginess(45 SECONDS * REM * metabolized_volume * seconds_per_tick)
 			if(SPT_PROB(10, seconds_per_tick))
 				drinker.emote(pick("twitch","giggle"))
 		if (11 to 201)
-			drinker.set_jitter_if_lower(80 SECONDS * REM * seconds_per_tick)
-			drinker.set_dizzy_if_lower(80 SECONDS * REM * seconds_per_tick)
-			drinker.set_drugginess(2 MINUTES * REM * seconds_per_tick)
+			drinker.set_jitter_if_lower(40 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			drinker.set_dizzy_if_lower(40 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			drinker.set_drugginess(1 MINUTES * REM * metabolized_volume * seconds_per_tick)
 			if(SPT_PROB(16, seconds_per_tick))
 				drinker.emote(pick("twitch","giggle"))
 		if(201 to INFINITY)
-			drinker.set_jitter_if_lower(120 SECONDS * REM * seconds_per_tick)
-			drinker.set_dizzy_if_lower(120 SECONDS * REM * seconds_per_tick)
-			drinker.set_drugginess(2.5 MINUTES * REM * seconds_per_tick)
+			drinker.set_jitter_if_lower(60 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			drinker.set_dizzy_if_lower(60 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			drinker.set_drugginess(1.25 MINUTES * REM * metabolized_volume * seconds_per_tick)
 			if(SPT_PROB(23, seconds_per_tick))
 				drinker.emote(pick("twitch","giggle"))
 			if(SPT_PROB(16, seconds_per_tick))
-				if(drinker.adjust_tox_loss(2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+				if(drinker.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 					return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/eggnog
@@ -1536,10 +1536,10 @@
 	taste_description = "bloody"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/narsour/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/narsour/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.adjust_timed_status_effect(6 SECONDS * REM * seconds_per_tick, /datum/status_effect/speech/slurring/cult, max_duration = 6 SECONDS)
-	drinker.adjust_stutter_up_to(6 SECONDS * REM * seconds_per_tick, 6 SECONDS)
+	drinker.adjust_timed_status_effect(3 SECONDS * REM * metabolized_volume * seconds_per_tick, /datum/status_effect/speech/slurring/cult, max_duration = 6 SECONDS)
+	drinker.adjust_stutter_up_to(3 SECONDS * REM * metabolized_volume * seconds_per_tick, 6 SECONDS)
 
 /datum/reagent/consumable/ethanol/triple_sec
 	name = "Triple Sec"
@@ -1582,12 +1582,12 @@
 	taste_description = "an invigorating bitter freshness which suffuses your being; no enemy of the station will go unrobusted this day"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/quadruple_sec/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/quadruple_sec/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		if(drinker.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 1 * REM * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/quintuple_sec
@@ -1599,14 +1599,14 @@
 	taste_description = "THE LAW"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/quintuple_sec/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/quintuple_sec/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes but STRONG..
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		var/need_mob_update
-		need_mob_update = drinker.heal_bodypart_damage(2 * REM * seconds_per_tick, 2 * REM *  seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_stamina_loss(-5 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update = drinker.heal_bodypart_damage(1 * REM * metabolized_volume * seconds_per_tick, 2 * REM * metabolized_volume *  seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_stamina_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -1659,15 +1659,15 @@
 	if(!drinker.stat && heal_points == 20) //brought us out of softcrit
 		drinker.visible_message(span_danger("[drinker] lurches to [drinker.p_their()] feet!"), span_boldnotice("Up and at 'em, kid."))
 
-/datum/reagent/consumable/ethanol/bastion_bourbon/on_mob_life(mob/living/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/bastion_bourbon/on_mob_life(mob/living/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(drinker.health > 0)
 		var/need_mob_update
-		need_mob_update = drinker.adjust_brute_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_fire_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_tox_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += drinker.adjust_oxy_loss(-3 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += drinker.adjust_stamina_loss(-5 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update = drinker.adjust_brute_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_fire_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_tox_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += drinker.adjust_oxy_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += drinker.adjust_stamina_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -1680,9 +1680,9 @@
 	nutriment_factor = 2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/squirt_cider/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/squirt_cider/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.satiety += 5 * REM * seconds_per_tick //for context, vitamins give 15 satiety per second
+	drinker.satiety += 2.5 * REM * metabolized_volume * seconds_per_tick //for context, vitamins give 15 satiety per second
 
 /datum/reagent/consumable/ethanol/fringe_weaver
 	name = "Fringe Weaver"
@@ -1703,9 +1703,9 @@
 	nutriment_factor = 2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/sugar_rush/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/sugar_rush/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.satiety -= 10 * REM * seconds_per_tick //junky as hell! a whole glass will keep you from being able to eat junk food
+	drinker.satiety -= 5 * REM * metabolized_volume * seconds_per_tick //junky as hell! a whole glass will keep you from being able to eat junk food
 
 /datum/reagent/consumable/ethanol/crevice_spike
 	name = "Crevice Spike"
@@ -1738,10 +1738,10 @@
 	quality = DRINK_GOOD
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/peppermint_patty/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/peppermint_patty/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	drinker.apply_status_effect(/datum/status_effect/throat_soothed)
-	drinker.adjust_bodytemperature(5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal())
+	drinker.adjust_bodytemperature(2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal())
 
 /datum/reagent/consumable/ethanol/alexander
 	name = "Alexander"
@@ -1763,7 +1763,7 @@
 			to_chat(the_human, span_notice("[the_shield] appears polished, although you don't recall polishing it."))
 			break
 
-/datum/reagent/consumable/ethanol/alexander/on_mob_life(mob/living/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/alexander/on_mob_life(mob/living/drinker, seconds_per_tick, metabolized_volume)
 	var/obj/item/shield/the_shield = mighty_shield?.resolve()
 	if(the_shield && !(the_shield in drinker.contents)) //If you had a shield and lose it, you lose the reagent as well. Otherwise this is just a normal drink.
 		holder.remove_reagent(type, volume)
@@ -1807,7 +1807,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_MEDIUM
 
-/datum/reagent/consumable/ethanol/between_the_sheets/on_mob_life(mob/living/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/between_the_sheets/on_mob_life(mob/living/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/is_between_the_sheets = FALSE
 	for(var/obj/item/bedsheet/bedsheet in range(drinker.loc, 0))
@@ -1822,13 +1822,13 @@
 	var/need_mob_update
 	if(drinker.get_brute_loss() && drinker.get_fire_loss()) //If you are damaged by both types, slightly increased healing but it only heals one. The more the merrier wink wink.
 		if(prob(50))
-			need_mob_update = drinker.adjust_brute_loss(-0.25 * REM * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
+			need_mob_update = drinker.adjust_brute_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
 		else
-			need_mob_update = drinker.adjust_fire_loss(-0.25 * REM * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
+			need_mob_update = drinker.adjust_fire_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
 	else if(drinker.get_brute_loss()) //If you have only one, it still heals but not as well.
-		need_mob_update = drinker.adjust_brute_loss(-0.2 * REM * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
+		need_mob_update = drinker.adjust_brute_loss(-0.1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
 	else if(drinker.get_fire_loss())
-		need_mob_update = drinker.adjust_fire_loss(-0.2 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = drinker.adjust_fire_loss(-0.1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1868,12 +1868,12 @@
 	taste_description = "utter bitterness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/fernet/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/fernet/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(drinker.nutrition <= NUTRITION_LEVEL_STARVING)
-		if(drinker.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(drinker.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	drinker.adjust_nutrition(-5 * REM * seconds_per_tick)
+	drinker.adjust_nutrition(-2.5 * REM * metabolized_volume * seconds_per_tick)
 	drinker.overeatduration = 0
 
 /datum/reagent/consumable/ethanol/fernet_cola
@@ -1885,12 +1885,12 @@
 	taste_description = "sweet relief"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/fernet_cola/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/fernet_cola/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(drinker.nutrition <= NUTRITION_LEVEL_STARVING)
-		if(drinker.adjust_tox_loss(0.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(drinker.adjust_tox_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	drinker.adjust_nutrition(-3 * REM * seconds_per_tick)
+	drinker.adjust_nutrition(-1.5 * REM * metabolized_volume * seconds_per_tick)
 	drinker.overeatduration = 0
 
 /datum/reagent/consumable/ethanol/fanciulli
@@ -1903,9 +1903,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_HIGH
 
-/datum/reagent/consumable/ethanol/fanciulli/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/fanciulli/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.adjust_nutrition(-5 * REM * seconds_per_tick)
+	drinker.adjust_nutrition(-2.5 * REM * metabolized_volume * seconds_per_tick)
 	drinker.overeatduration = 0
 
 /datum/reagent/consumable/ethanol/fanciulli/on_mob_metabolize(mob/living/drinker)
@@ -1923,9 +1923,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_MEDIUM
 
-/datum/reagent/consumable/ethanol/branca_menta/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/branca_menta/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.adjust_bodytemperature(-20 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, T0C)
+	drinker.adjust_bodytemperature(-10 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, T0C)
 
 /datum/reagent/consumable/ethanol/branca_menta/on_mob_metabolize(mob/living/drinker)
 	. = ..()
@@ -1942,11 +1942,11 @@
 	taste_description = "bubbling possibility"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(ishuman(drinker) && HAS_MIND_TRAIT(drinker, TRAIT_MIMING))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
-		if(drinker.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 1 * REM * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/fruit_wine
@@ -2073,15 +2073,15 @@
 	taste_description = "friendship! It is magic, after all"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/wizz_fizz/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/wizz_fizz/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	//A healing drink similar to Quadruple Sec, Ling Stings, and Screwdrivers for the Wizznerds; the check is consistent with the changeling sting
 	if(drinker?.mind?.has_antag_datum(/datum/antagonist/wizard))
 		var/need_mob_update
-		need_mob_update = drinker.heal_bodypart_damage(1 * REM * seconds_per_tick, 1 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_oxy_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += drinker.adjust_tox_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += drinker.adjust_stamina_loss(-5  * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update = drinker.heal_bodypart_damage(0.5 * REM * metabolized_volume * seconds_per_tick, 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_oxy_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += drinker.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += drinker.adjust_stamina_loss(-2.5  * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -2099,10 +2099,10 @@
 	. = ..()
 	AddElement(/datum/element/bugkiller_reagent)
 
-/datum/reagent/consumable/ethanol/bug_spray/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/bug_spray/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	// Does some damage to bug biotypes
-	if(drinker.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(drinker.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
 		// Random chance of causing a screm if we did some damage
 		if(SPT_PROB(2, seconds_per_tick))
@@ -2134,11 +2134,11 @@
 	taste_description = "the outlaw spirit"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/turbo/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/turbo/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(2, seconds_per_tick))
 		to_chat(drinker, span_notice("[pick("You feel disregard for the rule of law.", "You feel pumped!", "Your head is pounding.", "Your thoughts are racing..")]"))
-	if(drinker.adjust_stamina_loss(-0.5 * drinker.get_drunk_amount() * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype))
+	if(drinker.adjust_stamina_loss(-0.25 * drinker.get_drunk_amount() * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/old_timer
@@ -2150,7 +2150,7 @@
 	taste_description = "simpler times"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/old_timer/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/old_timer/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(10, seconds_per_tick) && ishuman(drinker))
 		var/mob/living/carbon/human/metabolizer = drinker
@@ -2195,13 +2195,13 @@
 	taste_description = "dried plums and malt"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/trappist/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/trappist/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(drinker.mind?.holy_role)
-		if(drinker.adjust_fire_loss(-2.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+		if(drinker.adjust_fire_loss(-1.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 			. = UPDATE_MOB_HEALTH
-		drinker.adjust_jitter(-2 SECONDS * REM * seconds_per_tick)
-		drinker.adjust_stutter(-2 SECONDS * REM * seconds_per_tick)
+		drinker.adjust_jitter(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		drinker.adjust_stutter(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/blazaam
 	name = "Blazaam"
@@ -2211,7 +2211,7 @@
 	taste_description = "alternate realities"
 	var/stored_teleports = 0
 
-/datum/reagent/consumable/ethanol/blazaam/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/blazaam/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(drinker.get_drunk_amount() > 40)
 		if(stored_teleports)
@@ -2239,12 +2239,12 @@
 	taste_description = "fiery, with an aftertaste of burnt flesh"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/mauna_loa/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/mauna_loa/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	// Heats the user up while the reagent is in the body. Occasionally makes you burst into flames.
-	drinker.adjust_bodytemperature(25 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick)
+	drinker.adjust_bodytemperature(12.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick)
 	if (SPT_PROB(2.5, seconds_per_tick))
-		drinker.adjust_fire_stacks(1 * REM * seconds_per_tick)
+		drinker.adjust_fire_stacks(0.5 * REM * metabolized_volume * seconds_per_tick)
 		drinker.ignite_mob()
 
 /datum/reagent/consumable/ethanol/painkiller
@@ -2273,7 +2273,7 @@
 	quality = DRINK_NICE
 	taste_description = "a horrible emulsion of pineapple and olive oil"
 
-/datum/reagent/consumable/ethanol/pina_olivada/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/pina_olivada/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(8, seconds_per_tick))
 		drinker.manual_emote(pick("coughs up some oil", "swallows the lump in [drinker.p_their()] throat", "gags", "chokes up a bit"))
@@ -2295,9 +2295,9 @@
 	taste_description = "your tastebuds being individually shanked"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/pruno/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/pruno/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
-	drinker.adjust_disgust(5 * REM * seconds_per_tick)
+	drinker.adjust_disgust(2.5 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/ginger_amaretto
 	name = "Ginger Amaretto"
@@ -2336,10 +2336,10 @@
 	taste_description = "sweet nectar"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/kortara/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/kortara/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(drinker.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
-		if(drinker.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 0, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/sea_breeze
@@ -2351,7 +2351,7 @@
 	taste_description = "mint choc chip"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/sea_breeze/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/sea_breeze/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	drinker.apply_status_effect(/datum/status_effect/throat_soothed)
 
@@ -2373,7 +2373,7 @@
 	taste_description = "sorrow"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/drunken_espatier/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/drunken_espatier/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	drinker.add_mood_event("numb", /datum/mood_event/narcotic_medium, name) //comfortably numb
 
@@ -2395,13 +2395,13 @@
 	nutriment_factor = 3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/protein_blend/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/protein_blend/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. =	..()
-	drinker.adjust_nutrition(2 * REM * seconds_per_tick)
+	drinker.adjust_nutrition(1 * REM * metabolized_volume * seconds_per_tick)
 	if(!islizard(drinker))
-		drinker.adjust_disgust(5 * REM * seconds_per_tick)
+		drinker.adjust_disgust(2.5 * REM * metabolized_volume * seconds_per_tick)
 	else
-		drinker.adjust_disgust(2 * REM * seconds_per_tick)
+		drinker.adjust_disgust(1 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/mushi_kombucha
 	name = "Mushi Kombucha"
@@ -2421,7 +2421,7 @@
 	taste_description = "victory"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/triumphal_arch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/triumphal_arch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(islizard(drinker))
 		drinker.add_mood_event("triumph", /datum/mood_event/memories_of_home, name)
@@ -2580,10 +2580,10 @@
 	var/hal_amt = 4
 	var/hal_cap = 24
 
-/datum/reagent/consumable/ethanol/helianthus/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/ethanol/helianthus/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
-		drinker.adjust_hallucinations_up_to(4 SECONDS * REM * seconds_per_tick, 48 SECONDS)
+		drinker.adjust_hallucinations_up_to(2 SECONDS * REM * metabolized_volume * seconds_per_tick, 48 SECONDS)
 
 /datum/reagent/consumable/ethanol/plumwine
 	name = "Plum wine"
@@ -2615,9 +2615,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_MEDIUM
 
-/datum/reagent/consumable/ethanol/gin_garden/on_mob_life(mob/living/carbon/doll, seconds_per_tick)
+/datum/reagent/consumable/ethanol/gin_garden/on_mob_life(mob/living/carbon/doll, seconds_per_tick, metabolized_volume)
 	. = ..()
-	doll.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, doll.get_body_temp_normal())
+	doll.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, doll.get_body_temp_normal())
 
 /datum/reagent/consumable/ethanol/wine_voltaic
 	name = "Voltaic Yellow Wine"
@@ -2978,11 +2978,11 @@
 	taste_description = "ginger-flavored recuperation"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/suffering_bastard/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/ethanol/suffering_bastard/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	affected_mob.apply_status_effect(/datum/status_effect/headache_soothed) //prevents headaches
-	affected_mob.adjust_disgust(-5 * REM * seconds_per_tick) //removes disgust, same with sol dry
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -0.5 * REM * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags)) //heals brain damage very slowly, about 12 damage per 5u
+	affected_mob.adjust_disgust(-2.5 * REM * metabolized_volume * seconds_per_tick) //removes disgust, same with sol dry
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -0.25 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags)) //heals brain damage very slowly, about 12 damage per 5u
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/blue_blazer
@@ -2994,9 +2994,9 @@
 	taste_description = "scorched sweet whiskey"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/blue_blazer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/ethanol/blue_blazer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_bodytemperature(25 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(12.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/ethanol/hot_toddy
 	name = "Hot Toddy"
@@ -3008,9 +3008,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_MEDIUM
 
-/datum/reagent/consumable/ethanol/hot_toddy/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/ethanol/hot_toddy/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_bodytemperature(25 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(12.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/ethanol/tizirian_sour
 	name = "Tizirian Sour"

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -51,7 +51,7 @@
 		LAZYSET(addiction_types, /datum/addiction/alcohol, 0.05 * boozepwr)
 	return ..()
 
-/datum/reagent/consumable/ethanol/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.get_drunk_amount() < volume * boozepwr * ALCOHOL_THRESHOLD_MODIFIER || boozepwr < 0)
 		var/booze_power = boozepwr
@@ -74,7 +74,7 @@
 			booze_power *= (total_alcohol_volume / combined_dilute_volume)
 
 		// Volume, power, and server alcohol rate effect how quickly one gets drunk
-		drinker.adjust_drunk_effect(0.5 * sqrt(volume) * booze_power * ALCOHOL_RATE * REM * metabolized_volume * seconds_per_tick)
+		drinker.adjust_drunk_effect(0.5 * sqrt(volume) * booze_power * ALCOHOL_RATE * metabolization_ratio * seconds_per_tick)
 		if(boozepwr > 0)
 			var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 			var/heavy_drinker_multiplier = (HAS_TRAIT(drinker, TRAIT_HEAVY_DRINKER) ? 0.5 : 1)
@@ -146,7 +146,7 @@
 	ph = 6
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/beer/green/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/beer/green/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.color != color)
 		drinker.add_atom_colour(color, TEMPORARY_COLOUR_PRIORITY)
@@ -155,7 +155,7 @@
 	. = ..()
 	drinker.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, color)
 
-/datum/reagent/consumable/ethanol/beer/green/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/beer/green/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 
@@ -178,11 +178,11 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/ethanol/kahlua/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/kahlua/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.set_dizzy_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	drinker.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	drinker.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.set_dizzy_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(!HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
 		drinker.set_jitter_if_lower(10 SECONDS)
 
@@ -210,10 +210,10 @@
 	taste_description = "pancake syrup"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/whiskey/candycorn/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/whiskey/candycorn/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
-		drinker.adjust_hallucinations(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		drinker.adjust_hallucinations(2 SECONDS * metabolization_ratio)
 
 /datum/reagent/consumable/ethanol/thirteenloko
 	name = "Thirteen Loko"
@@ -227,21 +227,21 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/ethanol/thirteenloko/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/thirteenloko/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_drowsiness(-7 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	drinker.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	drinker.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, drinker.get_body_temp_normal())
+	drinker.adjust_drowsiness(-7 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, drinker.get_body_temp_normal())
 	if(!HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
 		drinker.set_jitter_if_lower(10 SECONDS)
 
-/datum/reagent/consumable/ethanol/thirteenloko/overdose_start(mob/living/drinker, metabolized_volume)
+/datum/reagent/consumable/ethanol/thirteenloko/overdose_start(mob/living/drinker, metabolization_ratio)
 	. = ..()
 	to_chat(drinker, span_userdanger("Your entire body violently jitters as you start to feel queasy. You really shouldn't have drank all of that [name]!"))
 	drinker.set_jitter_if_lower(40 SECONDS)
 	drinker.Stun(1.5 SECONDS)
 
-/datum/reagent/consumable/ethanol/thirteenloko/overdose_process(mob/living/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/thirteenloko/overdose_process(mob/living/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(3.5, seconds_per_tick) && iscarbon(drinker))
 		var/obj/item/held_item = drinker.get_active_held_item()
@@ -261,7 +261,7 @@
 				eyes.forceMove(get_turf(drinker))
 				to_chat(drinker, span_userdanger("You double over in pain as you feel your eyeballs liquify in your head!"))
 				drinker.emote("scream")
-				if(drinker.adjust_brute_loss(7.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+				if(drinker.adjust_brute_loss(7.5 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype))
 					. = UPDATE_MOB_HEALTH
 			else
 				to_chat(drinker, span_userdanger("You scream in terror as you go blind!"))
@@ -299,10 +299,10 @@
 	taste_description = "desperation and lactate"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/bilk/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/bilk/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.get_brute_loss() && SPT_PROB(5, seconds_per_tick))
-		if(drinker.heal_bodypart_damage(brute = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 1 * metabolization_ratio, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/threemileisland
@@ -315,9 +315,9 @@
 	ph = 3.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/threemileisland/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/threemileisland/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.set_drugginess(50 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.set_drugginess(50 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/gin
 	name = "Gin"
@@ -451,10 +451,10 @@
 	taste_description = "death and licorice"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/absinthe/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/absinthe/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick) && !HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
-		drinker.adjust_hallucinations(4 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		drinker.adjust_hallucinations(4 SECONDS * metabolization_ratio)
 
 /datum/reagent/consumable/ethanol/hooch
 	name = "Hooch"
@@ -551,14 +551,14 @@
 	taste_description = "a refreshing marriage of citrus and rum"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/cuba_libre/on_mob_life(mob/living/carbon/cubano, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/cuba_libre/on_mob_life(mob/living/carbon/cubano, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	if(cubano.mind && cubano.mind.has_antag_datum(/datum/antagonist/rev)) //Cuba Libre, the traditional drink of revolutions! Heals revolutionaries.
-		need_mob_update = cubano.adjust_brute_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += cubano.adjust_fire_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += cubano.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += cubano.adjust_oxy_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update = cubano.adjust_brute_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += cubano.adjust_fire_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += cubano.adjust_tox_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += cubano.adjust_oxy_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -639,13 +639,13 @@
 		drink.tool_behaviour = initial(drink.tool_behaviour)
 		drink.usesound = initial(drink.usesound)
 
-/datum/reagent/consumable/ethanol/screwdrivercocktail/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/screwdrivercocktail/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(HAS_TRAIT(liver, TRAIT_ENGINEER_METABOLISM))
 		ADD_TRAIT(drinker, TRAIT_HALT_RADIATION_EFFECTS, "[type]")
 		if (HAS_TRAIT(drinker, TRAIT_IRRADIATED))
-			if(drinker.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			if(drinker.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/screwdrivercocktail/on_mob_end_metabolize(mob/living/drinker)
@@ -669,9 +669,9 @@
 	taste_description = "tomatoes with a hint of lime and liquid murder"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/bloody_mary/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/bloody_mary/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_blood_volume(0.5 * (0.25 + round(2 * drinker.get_drunk_amount() / 40, 0.1)) * REM * metabolized_volume * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL) // Bloody Mary restores blood loss based on how drunk you are
+	drinker.adjust_blood_volume(0.5 * (0.25 + round(2 * drinker.get_drunk_amount() / 40, 0.1)) * metabolization_ratio * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL) // Bloody Mary restores blood loss based on how drunk you are
 
 /datum/reagent/consumable/ethanol/brave_bull
 	name = "Brave Bull"
@@ -715,7 +715,7 @@
 	light_holder = new(drinker)
 	light_holder.set_light(3, 0.7, COLOR_TANGERINE_YELLOW) //Tequila Sunrise makes you radiate dim light, like a sunrise!
 
-/datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	if(QDELETED(light_holder))
 		holder.del_reagent(type) //If we lost our light object somehow, remove the reagent
 	else if(light_holder.loc != drinker)
@@ -736,9 +736,9 @@
 	taste_description = "spicy toxins"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/toxins_special/on_mob_life(mob/living/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/toxins_special/on_mob_life(mob/living/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_bodytemperature(7.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal() + 20) //310.15 is the normal bodytemp.
+	drinker.adjust_bodytemperature(7.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal() + 20) //310.15 is the normal bodytemp.
 
 /datum/reagent/consumable/ethanol/beepsky_smash
 	name = "Beepsky Smash"
@@ -763,13 +763,13 @@
 		beepsky_hallucination = new()
 		drinker.gain_trauma(beepsky_hallucination, TRAUMA_RESILIENCE_ABSOLUTE)
 
-/datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	drinker.set_jitter_if_lower(4 SECONDS)
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	// if you have a liver and that liver is an officer's liver
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		if(drinker.adjust_stamina_loss(-5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype))
+		if(drinker.adjust_stamina_loss(-5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
 		if(SPT_PROB(10, seconds_per_tick))
 			drinker.cause_hallucination(get_random_valid_hallucination_subtype(/datum/hallucination/nearby_fake_item), name)
@@ -781,7 +781,7 @@
 	if(beepsky_hallucination)
 		QDEL_NULL(beepsky_hallucination)
 
-/datum/reagent/consumable/ethanol/beepsky_smash/overdose_start(mob/living/carbon/drinker, metabolized_volume)
+/datum/reagent/consumable/ethanol/beepsky_smash/overdose_start(mob/living/carbon/drinker, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	// if you don't have a liver, or your liver isn't an officer's liver
@@ -816,12 +816,12 @@
 			boozepwr = 50 // will still smash but not as much.
 			dorf_mode = TRUE
 
-/datum/reagent/consumable/ethanol/manly_dorf/on_mob_life(mob/living/carbon/dwarf, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/manly_dorf/on_mob_life(mob/living/carbon/dwarf, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(dorf_mode)
 		var/need_mob_update
-		need_mob_update = dwarf.adjust_brute_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += dwarf.adjust_fire_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = dwarf.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += dwarf.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -904,9 +904,9 @@
 	taste_description = "death, the destroyer of worlds"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.set_drugginess(30 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.set_drugginess(30 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/whiskeysoda
 	name = "Whiskey Soda"
@@ -926,9 +926,9 @@
 	taste_description = "Jack Frost's piss"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/antifreeze/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/antifreeze/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_bodytemperature(10 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal() + 20) //310.15 is the normal bodytemp.
+	drinker.adjust_bodytemperature(10 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal() + 20) //310.15 is the normal bodytemp.
 
 /datum/reagent/consumable/ethanol/barefoot
 	name = "Barefoot"
@@ -939,12 +939,12 @@
 	taste_description = "creamy berries"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/barefoot/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/barefoot/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(ishuman(drinker)) //Barefoot causes the imbiber to quickly regenerate brute trauma if they're not wearing shoes.
 		var/mob/living/carbon/human/unshoed = drinker
 		if(!unshoed.shoes)
-			if(unshoed.adjust_brute_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+			if(unshoed.adjust_brute_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/snowwhite
@@ -1079,7 +1079,7 @@
 	. = ..()
 	drinker.remove_filter("singulo_rays")
 
-/datum/reagent/consumable/ethanol/singulo/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/singulo/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(2.5, seconds_per_tick))
 		// 20u = 1x1, 45u = 2x2, 80u = 3x3
@@ -1106,9 +1106,9 @@
 	taste_description = "hot and spice"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/sbiten/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/sbiten/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_bodytemperature(25 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, BODYTEMP_HEAT_DAMAGE_LIMIT) //310.15 is the normal bodytemp.
+	drinker.adjust_bodytemperature(25 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, BODYTEMP_HEAT_DAMAGE_LIMIT) //310.15 is the normal bodytemp.
 
 /datum/reagent/consumable/ethanol/red_mead
 	name = "Red Mead"
@@ -1137,9 +1137,9 @@
 	taste_description = "refreshingly cold"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/iced_beer/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/iced_beer/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_bodytemperature(-10 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, T0C) //310.15 is the normal bodytemp.
+	drinker.adjust_bodytemperature(-10 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, T0C) //310.15 is the normal bodytemp.
 
 /datum/reagent/consumable/ethanol/grog
 	name = "Grog"
@@ -1206,10 +1206,10 @@
 	taste_description = "your brain coming out your nose"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/changelingsting/on_mob_life(mob/living/carbon/target, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/changelingsting/on_mob_life(mob/living/carbon/target, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/datum/antagonist/changeling/changeling = IS_CHANGELING(target)
-	changeling?.adjust_chemicals(0.5 * metabolization_rate * REM * metabolized_volume * seconds_per_tick)
+	changeling?.adjust_chemicals(0.5 * metabolization_rate * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/irishcarbomb
 	name = "Irish Car Bomb"
@@ -1229,7 +1229,7 @@
 	taste_description = "purified antagonism"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/syndicatebomb/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/syndicatebomb/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(2.5, seconds_per_tick))
 		playsound(get_turf(drinker), 'sound/effects/explosion/explosionfar.ogg', 100, TRUE)
@@ -1272,11 +1272,11 @@
 	taste_description = "a bad joke"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/bananahonk/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/bananahonk/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if((liver && HAS_TRAIT(liver, TRAIT_COMEDY_METABOLISM)) || is_simian(drinker))
-		if(drinker.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/silencer
@@ -1289,11 +1289,11 @@
 	taste_description = "a pencil eraser"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(ishuman(drinker) && HAS_MIND_TRAIT(drinker, TRAIT_MIMING))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
-		if(drinker.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/drunkenblumpkin
@@ -1333,7 +1333,7 @@
 	taste_description = "charged metal" // the same as teslium, honk honk.
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/fetching_fizz/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/fetching_fizz/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/turf/drinker_turf = get_turf(drinker)
 	for(var/obj/item/stack/ore/ore in orange(3, drinker))
@@ -1350,14 +1350,14 @@
 	taste_description = "bravado in the face of disaster"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/hearty_punch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/hearty_punch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.health <= 0)
 		var/need_mob_update
-		need_mob_update = drinker.adjust_brute_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_fire_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_oxy_loss(-2 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += drinker.adjust_tox_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = drinker.adjust_brute_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_fire_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_oxy_loss(-2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += drinker.adjust_tox_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -1379,19 +1379,19 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_HIGH
 
-/datum/reagent/consumable/ethanol/atomicbomb/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/atomicbomb/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.set_drugginess(50 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.set_drugginess(50 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(!HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
-		drinker.adjust_confusion(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	drinker.set_dizzy_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	drinker.adjust_slurring(3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		drinker.adjust_confusion(1 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.set_dizzy_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.adjust_slurring(3 SECONDS * metabolization_ratio * seconds_per_tick)
 	switch(current_cycle)
 		if(52 to 201)
-			drinker.Sleeping(50 * REM * metabolized_volume * seconds_per_tick)
+			drinker.Sleeping(50 * metabolization_ratio * seconds_per_tick)
 		if(202 to INFINITY)
-			drinker.AdjustSleeping(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
-			if(drinker.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			drinker.AdjustSleeping(2 SECONDS * metabolization_ratio * seconds_per_tick)
+			if(drinker.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/gargle_blaster
@@ -1403,19 +1403,19 @@
 	taste_description = "your brains smashed out by a lemon wrapped around a gold brick"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/gargle_blaster/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/gargle_blaster/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_dizzy(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.adjust_dizzy(1.5 SECONDS * metabolization_ratio * seconds_per_tick)
 	switch(current_cycle)
 		if(16 to 46)
-			drinker.adjust_slurring(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			drinker.adjust_slurring(1.5 SECONDS * metabolization_ratio * seconds_per_tick)
 		if(46 to 56)
 			if(SPT_PROB(30, seconds_per_tick))
-				drinker.adjust_confusion(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+				drinker.adjust_confusion(1.5 SECONDS * metabolization_ratio)
 		if(56 to 201)
-			drinker.set_drugginess(55 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			drinker.set_drugginess(55 SECONDS * metabolization_ratio * seconds_per_tick)
 		if(201 to INFINITY)
-			if(drinker.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			if(drinker.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/neurotoxin
@@ -1431,23 +1431,23 @@
 /datum/reagent/consumable/ethanol/neurotoxin/proc/pick_paralyzed_limb()
 	return (pick(TRAIT_PARALYSIS_L_ARM,TRAIT_PARALYSIS_R_ARM,TRAIT_PARALYSIS_R_LEG,TRAIT_PARALYSIS_L_LEG))
 
-/datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.set_drugginess(50 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	drinker.adjust_dizzy(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.set_drugginess(50 SECONDS * metabolization_ratio * seconds_per_tick)
+	drinker.adjust_dizzy(2 SECONDS * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
-	need_mob_update = drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * REM * metabolized_volume * seconds_per_tick, 150, required_organ_flag = affected_organ_flags)
+	need_mob_update = drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * metabolization_ratio * seconds_per_tick, 150, required_organ_flag = affected_organ_flags)
 	if(SPT_PROB(10, seconds_per_tick))
-		need_mob_update += drinker.adjust_stamina_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update += drinker.adjust_stamina_loss(5 * metabolization_ratio, updating_stamina = FALSE, required_biotype = affected_biotype)
 		drinker.drop_all_held_items()
 		to_chat(drinker, span_notice("You cant feel your hands!"))
 	if(current_cycle > 6)
 		if(SPT_PROB(10, seconds_per_tick))
 			var/paralyzed_limb = pick_paralyzed_limb()
 			ADD_TRAIT(drinker, paralyzed_limb, type)
-			need_mob_update += drinker.adjust_stamina_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+			need_mob_update += drinker.adjust_stamina_loss(5 * metabolization_ratio, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(current_cycle > 31)
-			need_mob_update += drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+			need_mob_update += drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 			if(current_cycle > 51 && SPT_PROB(7.5, seconds_per_tick))
 				if(!drinker.undergoing_cardiac_arrest() && drinker.can_heartattack())
 					drinker.set_heartattack(TRUE)
@@ -1475,36 +1475,36 @@
 	taste_description = "giving peace a chance"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/hippies_delight/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/hippies_delight/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.set_slurring_if_lower(0.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	drinker.set_slurring_if_lower(0.5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	switch(current_cycle)
 		if(2 to 6)
-			drinker.set_dizzy_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
-			drinker.set_drugginess(30 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			drinker.set_dizzy_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_drugginess(30 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(5, seconds_per_tick))
 				drinker.emote(pick("twitch","giggle"))
 		if(6 to 11)
-			drinker.set_jitter_if_lower(20 SECONDS * REM * metabolized_volume * seconds_per_tick)
-			drinker.set_dizzy_if_lower(20 SECONDS * REM * metabolized_volume * seconds_per_tick)
-			drinker.set_drugginess(45 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			drinker.set_jitter_if_lower(20 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_dizzy_if_lower(20 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_drugginess(45 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(10, seconds_per_tick))
 				drinker.emote(pick("twitch","giggle"))
 		if (11 to 201)
-			drinker.set_jitter_if_lower(40 SECONDS * REM * metabolized_volume * seconds_per_tick)
-			drinker.set_dizzy_if_lower(40 SECONDS * REM * metabolized_volume * seconds_per_tick)
-			drinker.set_drugginess(1 MINUTES * REM * metabolized_volume * seconds_per_tick)
+			drinker.set_jitter_if_lower(40 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_dizzy_if_lower(40 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_drugginess(1 MINUTES * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(16, seconds_per_tick))
 				drinker.emote(pick("twitch","giggle"))
 		if(201 to INFINITY)
-			drinker.set_jitter_if_lower(60 SECONDS * REM * metabolized_volume * seconds_per_tick)
-			drinker.set_dizzy_if_lower(60 SECONDS * REM * metabolized_volume * seconds_per_tick)
-			drinker.set_drugginess(1.25 MINUTES * REM * metabolized_volume * seconds_per_tick)
+			drinker.set_jitter_if_lower(60 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_dizzy_if_lower(60 SECONDS * metabolization_ratio * seconds_per_tick)
+			drinker.set_drugginess(1.25 MINUTES * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(23, seconds_per_tick))
 				drinker.emote(pick("twitch","giggle"))
 			if(SPT_PROB(16, seconds_per_tick))
-				if(drinker.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+				if(drinker.adjust_tox_loss(1 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 					return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/eggnog
@@ -1536,10 +1536,10 @@
 	taste_description = "bloody"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/narsour/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/narsour/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_timed_status_effect(3 SECONDS * REM * metabolized_volume * seconds_per_tick, /datum/status_effect/speech/slurring/cult, max_duration = 6 SECONDS)
-	drinker.adjust_stutter_up_to(3 SECONDS * REM * metabolized_volume * seconds_per_tick, 6 SECONDS)
+	drinker.adjust_timed_status_effect(3 SECONDS * metabolization_ratio * seconds_per_tick, /datum/status_effect/speech/slurring/cult, max_duration = 6 SECONDS)
+	drinker.adjust_stutter_up_to(3 SECONDS * metabolization_ratio * seconds_per_tick, 6 SECONDS)
 
 /datum/reagent/consumable/ethanol/triple_sec
 	name = "Triple Sec"
@@ -1582,12 +1582,12 @@
 	taste_description = "an invigorating bitter freshness which suffuses your being; no enemy of the station will go unrobusted this day"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/quadruple_sec/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/quadruple_sec/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		if(drinker.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/quintuple_sec
@@ -1599,14 +1599,14 @@
 	taste_description = "THE LAW"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/quintuple_sec/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/quintuple_sec/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes but STRONG..
 	var/obj/item/organ/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		var/need_mob_update
-		need_mob_update = drinker.heal_bodypart_damage(1 * REM * metabolized_volume * seconds_per_tick, 2 * REM * metabolized_volume *  seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_stamina_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update = drinker.heal_bodypart_damage(1 * metabolization_ratio * seconds_per_tick, 2 * metabolization_ratio *  seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_stamina_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -1659,15 +1659,15 @@
 	if(!drinker.stat && heal_points == 20) //brought us out of softcrit
 		drinker.visible_message(span_danger("[drinker] lurches to [drinker.p_their()] feet!"), span_boldnotice("Up and at 'em, kid."))
 
-/datum/reagent/consumable/ethanol/bastion_bourbon/on_mob_life(mob/living/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/bastion_bourbon/on_mob_life(mob/living/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.health > 0)
 		var/need_mob_update
-		need_mob_update = drinker.adjust_brute_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_fire_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += drinker.adjust_tox_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += drinker.adjust_oxy_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += drinker.adjust_stamina_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update = drinker.adjust_brute_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_fire_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += drinker.adjust_tox_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += drinker.adjust_oxy_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += drinker.adjust_stamina_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -1680,9 +1680,9 @@
 	nutriment_factor = 2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/squirt_cider/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/squirt_cider/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.satiety += 2.5 * REM * metabolized_volume * seconds_per_tick //for context, vitamins give 15 satiety per second
+	drinker.satiety += 2.5 * metabolization_ratio * seconds_per_tick //for context, vitamins give 15 satiety per second
 
 /datum/reagent/consumable/ethanol/fringe_weaver
 	name = "Fringe Weaver"
@@ -1703,9 +1703,9 @@
 	nutriment_factor = 2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/sugar_rush/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/sugar_rush/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.satiety -= 5 * REM * metabolized_volume * seconds_per_tick //junky as hell! a whole glass will keep you from being able to eat junk food
+	drinker.satiety -= 5 * metabolization_ratio * seconds_per_tick //junky as hell! a whole glass will keep you from being able to eat junk food
 
 /datum/reagent/consumable/ethanol/crevice_spike
 	name = "Crevice Spike"
@@ -1738,10 +1738,10 @@
 	quality = DRINK_GOOD
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/peppermint_patty/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/peppermint_patty/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	drinker.apply_status_effect(/datum/status_effect/throat_soothed)
-	drinker.adjust_bodytemperature(2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal())
+	drinker.adjust_bodytemperature(2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, drinker.get_body_temp_normal())
 
 /datum/reagent/consumable/ethanol/alexander
 	name = "Alexander"
@@ -1763,7 +1763,7 @@
 			to_chat(the_human, span_notice("[the_shield] appears polished, although you don't recall polishing it."))
 			break
 
-/datum/reagent/consumable/ethanol/alexander/on_mob_life(mob/living/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/alexander/on_mob_life(mob/living/drinker, seconds_per_tick, metabolization_ratio)
 	var/obj/item/shield/the_shield = mighty_shield?.resolve()
 	if(the_shield && !(the_shield in drinker.contents)) //If you had a shield and lose it, you lose the reagent as well. Otherwise this is just a normal drink.
 		holder.remove_reagent(type, volume)
@@ -1807,7 +1807,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_MEDIUM
 
-/datum/reagent/consumable/ethanol/between_the_sheets/on_mob_life(mob/living/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/between_the_sheets/on_mob_life(mob/living/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/is_between_the_sheets = FALSE
 	for(var/obj/item/bedsheet/bedsheet in range(drinker.loc, 0))
@@ -1822,13 +1822,13 @@
 	var/need_mob_update
 	if(drinker.get_brute_loss() && drinker.get_fire_loss()) //If you are damaged by both types, slightly increased healing but it only heals one. The more the merrier wink wink.
 		if(prob(50))
-			need_mob_update = drinker.adjust_brute_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
+			need_mob_update = drinker.adjust_brute_loss(-0.125 * metabolization_ratio * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
 		else
-			need_mob_update = drinker.adjust_fire_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
+			need_mob_update = drinker.adjust_fire_loss(-0.125 * metabolization_ratio * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
 	else if(drinker.get_brute_loss()) //If you have only one, it still heals but not as well.
-		need_mob_update = drinker.adjust_brute_loss(-0.1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
+		need_mob_update = drinker.adjust_brute_loss(-0.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE,  required_bodytype = affected_bodytype)
 	else if(drinker.get_fire_loss())
-		need_mob_update = drinker.adjust_fire_loss(-0.1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = drinker.adjust_fire_loss(-0.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1868,12 +1868,12 @@
 	taste_description = "utter bitterness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/fernet/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/fernet/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.nutrition <= NUTRITION_LEVEL_STARVING)
-		if(drinker.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(drinker.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	drinker.adjust_nutrition(-2.5 * REM * metabolized_volume * seconds_per_tick)
+	drinker.adjust_nutrition(-2.5 * metabolization_ratio * seconds_per_tick)
 	drinker.overeatduration = 0
 
 /datum/reagent/consumable/ethanol/fernet_cola
@@ -1885,12 +1885,12 @@
 	taste_description = "sweet relief"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/fernet_cola/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/fernet_cola/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.nutrition <= NUTRITION_LEVEL_STARVING)
-		if(drinker.adjust_tox_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(drinker.adjust_tox_loss(0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	drinker.adjust_nutrition(-1.5 * REM * metabolized_volume * seconds_per_tick)
+	drinker.adjust_nutrition(-1.5 * metabolization_ratio * seconds_per_tick)
 	drinker.overeatduration = 0
 
 /datum/reagent/consumable/ethanol/fanciulli
@@ -1903,9 +1903,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_HIGH
 
-/datum/reagent/consumable/ethanol/fanciulli/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/fanciulli/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_nutrition(-2.5 * REM * metabolized_volume * seconds_per_tick)
+	drinker.adjust_nutrition(-2.5 * metabolization_ratio * seconds_per_tick)
 	drinker.overeatduration = 0
 
 /datum/reagent/consumable/ethanol/fanciulli/on_mob_metabolize(mob/living/drinker)
@@ -1923,9 +1923,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_MEDIUM
 
-/datum/reagent/consumable/ethanol/branca_menta/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/branca_menta/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_bodytemperature(-10 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, T0C)
+	drinker.adjust_bodytemperature(-10 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, T0C)
 
 /datum/reagent/consumable/ethanol/branca_menta/on_mob_metabolize(mob/living/drinker)
 	. = ..()
@@ -1942,11 +1942,11 @@
 	taste_description = "bubbling possibility"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(ishuman(drinker) && HAS_MIND_TRAIT(drinker, TRAIT_MIMING))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
-		if(drinker.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/fruit_wine
@@ -2073,15 +2073,15 @@
 	taste_description = "friendship! It is magic, after all"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/wizz_fizz/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/wizz_fizz/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	//A healing drink similar to Quadruple Sec, Ling Stings, and Screwdrivers for the Wizznerds; the check is consistent with the changeling sting
 	if(drinker?.mind?.has_antag_datum(/datum/antagonist/wizard))
 		var/need_mob_update
-		need_mob_update = drinker.heal_bodypart_damage(0.5 * REM * metabolized_volume * seconds_per_tick, 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_oxy_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += drinker.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += drinker.adjust_stamina_loss(-2.5  * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update = drinker.heal_bodypart_damage(0.5 * metabolization_ratio * seconds_per_tick, 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_oxy_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += drinker.adjust_tox_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += drinker.adjust_stamina_loss(-2.5  * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			return UPDATE_MOB_HEALTH
 
@@ -2099,10 +2099,10 @@
 	. = ..()
 	AddElement(/datum/element/bugkiller_reagent)
 
-/datum/reagent/consumable/ethanol/bug_spray/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/bug_spray/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	// Does some damage to bug biotypes
-	if(drinker.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(drinker.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
 		// Random chance of causing a screm if we did some damage
 		if(SPT_PROB(2, seconds_per_tick))
@@ -2134,11 +2134,11 @@
 	taste_description = "the outlaw spirit"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/turbo/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/turbo/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(2, seconds_per_tick))
 		to_chat(drinker, span_notice("[pick("You feel disregard for the rule of law.", "You feel pumped!", "Your head is pounding.", "Your thoughts are racing..")]"))
-	if(drinker.adjust_stamina_loss(-0.25 * drinker.get_drunk_amount() * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype))
+	if(drinker.adjust_stamina_loss(-0.25 * drinker.get_drunk_amount() * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/old_timer
@@ -2150,7 +2150,7 @@
 	taste_description = "simpler times"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/old_timer/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/old_timer/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(10, seconds_per_tick) && ishuman(drinker))
 		var/mob/living/carbon/human/metabolizer = drinker
@@ -2195,13 +2195,13 @@
 	taste_description = "dried plums and malt"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/trappist/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/trappist/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.mind?.holy_role)
-		if(drinker.adjust_fire_loss(-1.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+		if(drinker.adjust_fire_loss(-1.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 			. = UPDATE_MOB_HEALTH
-		drinker.adjust_jitter(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
-		drinker.adjust_stutter(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		drinker.adjust_jitter(-1 SECONDS * metabolization_ratio * seconds_per_tick)
+		drinker.adjust_stutter(-1 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/blazaam
 	name = "Blazaam"
@@ -2211,7 +2211,7 @@
 	taste_description = "alternate realities"
 	var/stored_teleports = 0
 
-/datum/reagent/consumable/ethanol/blazaam/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/blazaam/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.get_drunk_amount() > 40)
 		if(stored_teleports)
@@ -2239,12 +2239,12 @@
 	taste_description = "fiery, with an aftertaste of burnt flesh"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/mauna_loa/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/mauna_loa/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	// Heats the user up while the reagent is in the body. Occasionally makes you burst into flames.
-	drinker.adjust_bodytemperature(12.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick)
+	drinker.adjust_bodytemperature(12.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick)
 	if (SPT_PROB(2.5, seconds_per_tick))
-		drinker.adjust_fire_stacks(0.5 * REM * metabolized_volume * seconds_per_tick)
+		drinker.adjust_fire_stacks(0.5 * metabolization_ratio)
 		drinker.ignite_mob()
 
 /datum/reagent/consumable/ethanol/painkiller
@@ -2273,7 +2273,7 @@
 	quality = DRINK_NICE
 	taste_description = "a horrible emulsion of pineapple and olive oil"
 
-/datum/reagent/consumable/ethanol/pina_olivada/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/pina_olivada/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(8, seconds_per_tick))
 		drinker.manual_emote(pick("coughs up some oil", "swallows the lump in [drinker.p_their()] throat", "gags", "chokes up a bit"))
@@ -2295,9 +2295,9 @@
 	taste_description = "your tastebuds being individually shanked"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/pruno/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/pruno/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	drinker.adjust_disgust(2.5 * REM * metabolized_volume * seconds_per_tick)
+	drinker.adjust_disgust(2.5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/ginger_amaretto
 	name = "Ginger Amaretto"
@@ -2336,10 +2336,10 @@
 	taste_description = "sweet nectar"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/kortara/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/kortara/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(drinker.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
-		if(drinker.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, burn = 0, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/sea_breeze
@@ -2351,7 +2351,7 @@
 	taste_description = "mint choc chip"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/sea_breeze/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/sea_breeze/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	drinker.apply_status_effect(/datum/status_effect/throat_soothed)
 
@@ -2373,7 +2373,7 @@
 	taste_description = "sorrow"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/drunken_espatier/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/drunken_espatier/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	drinker.add_mood_event("numb", /datum/mood_event/narcotic_medium, name) //comfortably numb
 
@@ -2395,13 +2395,13 @@
 	nutriment_factor = 3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/protein_blend/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/protein_blend/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. =	..()
-	drinker.adjust_nutrition(1 * REM * metabolized_volume * seconds_per_tick)
+	drinker.adjust_nutrition(1 * metabolization_ratio * seconds_per_tick)
 	if(!islizard(drinker))
-		drinker.adjust_disgust(2.5 * REM * metabolized_volume * seconds_per_tick)
+		drinker.adjust_disgust(2.5 * metabolization_ratio * seconds_per_tick)
 	else
-		drinker.adjust_disgust(1 * REM * metabolized_volume * seconds_per_tick)
+		drinker.adjust_disgust(1 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/ethanol/mushi_kombucha
 	name = "Mushi Kombucha"
@@ -2421,7 +2421,7 @@
 	taste_description = "victory"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/triumphal_arch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/triumphal_arch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(islizard(drinker))
 		drinker.add_mood_event("triumph", /datum/mood_event/memories_of_home, name)
@@ -2580,10 +2580,10 @@
 	var/hal_amt = 4
 	var/hal_cap = 24
 
-/datum/reagent/consumable/ethanol/helianthus/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/helianthus/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
-		drinker.adjust_hallucinations_up_to(2 SECONDS * REM * metabolized_volume * seconds_per_tick, 48 SECONDS)
+		drinker.adjust_hallucinations_up_to(2 SECONDS * metabolization_ratio, 48 SECONDS)
 
 /datum/reagent/consumable/ethanol/plumwine
 	name = "Plum wine"
@@ -2615,9 +2615,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_MEDIUM
 
-/datum/reagent/consumable/ethanol/gin_garden/on_mob_life(mob/living/carbon/doll, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/gin_garden/on_mob_life(mob/living/carbon/doll, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	doll.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, doll.get_body_temp_normal())
+	doll.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, doll.get_body_temp_normal())
 
 /datum/reagent/consumable/ethanol/wine_voltaic
 	name = "Voltaic Yellow Wine"
@@ -2978,11 +2978,11 @@
 	taste_description = "ginger-flavored recuperation"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/suffering_bastard/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/suffering_bastard/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	affected_mob.apply_status_effect(/datum/status_effect/headache_soothed) //prevents headaches
-	affected_mob.adjust_disgust(-2.5 * REM * metabolized_volume * seconds_per_tick) //removes disgust, same with sol dry
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -0.25 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags)) //heals brain damage very slowly, about 12 damage per 5u
+	affected_mob.adjust_disgust(-2.5 * metabolization_ratio * seconds_per_tick) //removes disgust, same with sol dry
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -0.25 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags)) //heals brain damage very slowly, about 12 damage per 5u
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/ethanol/blue_blazer
@@ -2994,9 +2994,9 @@
 	taste_description = "scorched sweet whiskey"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/blue_blazer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/blue_blazer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(12.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(12.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/ethanol/hot_toddy
 	name = "Hot Toddy"
@@ -3008,9 +3008,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_MEDIUM
 
-/datum/reagent/consumable/ethanol/hot_toddy/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/hot_toddy/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(12.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(12.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/ethanol/tizirian_sour
 	name = "Tizirian Sour"

--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -502,11 +502,11 @@
 		ADD_TRAIT(affected_mob, TRAIT_DOUBLE_TAP, type)
 		effect_enabled = TRUE
 
-	affected_mob.set_jitter_if_lower(2 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(1 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(prob(50))
-		affected_mob.adjust_dizzy(1 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_dizzy(0.5 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(current_cycle > 10)
-		affected_mob.adjust_dizzy(1.5 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_dizzy(0.75 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/grey_bull
 	name = "Grey Bull"
@@ -1394,12 +1394,12 @@
 
 /datum/reagent/consumable/lean/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_jitter(1.25 SECONDS * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_stutter(1.125 SECONDS * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_drugginess(1 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_jitter(2.5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_stutter(2.25 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drugginess(2 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(SPT_PROB(15, seconds_per_tick))
 		affected_mob.emote(pick("taunt","twitch","shiver","laugh","moan","blush","stare"))
 	if(current_cycle > 16 && SPT_PROB(3.5, seconds_per_tick))
-		affected_mob.adjust_dizzy(7.5 SECONDS * metabolization_ratio)
-		affected_mob.adjust_drowsiness(3.25 SECONDS * metabolization_ratio)
+		affected_mob.adjust_dizzy(15 SECONDS * metabolization_ratio)
+		affected_mob.adjust_drowsiness(6.5 SECONDS * metabolization_ratio)
 		affected_mob.emote("drool")

--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -1390,7 +1390,7 @@
 	taste_description = "purple and a hint of opioid."
 	addiction_types = list(/datum/addiction/opioids = 6)
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	metabolization_rate = 0.1
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 
 /datum/reagent/consumable/lean/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -7,10 +7,10 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/orangejuice
 
-/datum/reagent/consumable/orangejuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/orangejuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.get_oxy_loss() && SPT_PROB(16, seconds_per_tick))
-		if(affected_mob.adjust_oxy_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, FALSE, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
+		if(affected_mob.adjust_oxy_loss(-0.5 * metabolization_ratio, FALSE, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/tomatojuice
@@ -21,10 +21,10 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/tomatojuice
 
-/datum/reagent/consumable/tomatojuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/tomatojuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.get_fire_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.heal_bodypart_damage(brute = 0, burn = 0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+		if(affected_mob.heal_bodypart_damage(brute = 0, burn = 0.5 * metabolization_ratio, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/limejuice
@@ -36,10 +36,10 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/limejuice
 
-/datum/reagent/consumable/limejuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/limejuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.get_tox_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/carrotjuice
@@ -49,17 +49,17 @@
 	taste_description = "carrots"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/carrotjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/carrotjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_eye_blur(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_temp_blindness(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_eye_blur(-1 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_temp_blindness(-1 SECONDS * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
 	switch(current_cycle)
 		if(21 to 110)
 			if(SPT_PROB(100 * (1 - (sqrt(110 - current_cycle) / 10)), seconds_per_tick))
-				need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, -1 * REM * metabolized_volume * seconds_per_tick)
+				need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, -1 * metabolization_ratio)
 		if(110 to INFINITY)
-			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, -1 * REM * metabolized_volume * seconds_per_tick)
+			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, -1 * metabolization_ratio * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -84,9 +84,9 @@
 	taste_description = "berries"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/poisonberryjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/poisonberryjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/watermelonjuice
@@ -111,11 +111,11 @@
 	taste_description = "banana"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/banana/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/banana/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if((liver && HAS_TRAIT(liver, TRAIT_COMEDY_METABOLISM)) || is_simian(affected_mob))
-		if(affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+		if(affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/nothing
@@ -128,11 +128,11 @@
 	required_drink_type = /datum/reagent/consumable/nothing
 	icon_state = "shotglass"
 
-/datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(ishuman(drinker) && HAS_MIND_TRAIT(drinker, TRAIT_MIMING))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
-		if(drinker.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/laughter
@@ -143,7 +143,7 @@
 	taste_description = "laughter"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/laughter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tic, metabolized_volume)
+/datum/reagent/consumable/laughter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tic, metabolization_ratio)
 	. = ..()
 	affected_mob.emote("laugh")
 	affected_mob.add_mood_event("chemical_laughter", /datum/mood_event/chemical_laughter)
@@ -156,7 +156,7 @@
 	taste_description = "laughter"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/superlaughter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/superlaughter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(16, seconds_per_tick))
 		affected_mob.visible_message(span_danger("[affected_mob] bursts out into a fit of uncontrollable laughter!"), span_userdanger("You burst out in a fit of uncontrollable laughter!"))
@@ -179,11 +179,11 @@
 	taste_description = "vinegar brine"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/pickle/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/pickle/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if((liver && HAS_TRAIT(liver, TRAIT_CORONER_METABOLISM)))
-		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/grapejuice
@@ -218,9 +218,9 @@
 		return
 	myseed.adjust_potency(-round(volume * 0.5))
 
-/datum/reagent/consumable/milk/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/milk/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	if(affected_mob.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0, updating_health = FALSE))
+		if(affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, burn = 0, updating_health = FALSE))
 			. = UPDATE_MOB_HEALTH
 	if(holder.has_reagent(/datum/reagent/consumable/capsaicin))
 		holder.remove_reagent(/datum/reagent/consumable/capsaicin, seconds_per_tick)
@@ -240,7 +240,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/condiment/soymilk
 
-/datum/reagent/consumable/soymilk/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/soymilk/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
 		if(affected_mob.heal_bodypart_damage(1, 0))
@@ -254,7 +254,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/cream
 
-/datum/reagent/consumable/cream/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/cream/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(10, seconds_per_tick) && affected_mob.heal_bodypart_damage(1, 0))
 		return UPDATE_MOB_HEALTH
@@ -270,19 +270,19 @@
 	glass_price = DRINK_PRICE_STOCK
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/coffee/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/coffee/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
 
-/datum/reagent/consumable/coffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/coffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_dizzy(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
 	//310.15 is the normal bodytemp.
-	affected_mob.adjust_bodytemperature(25 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(25 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 	if(holder.has_reagent(/datum/reagent/consumable/frostoil))
-		holder.remove_reagent(/datum/reagent/consumable/frostoil, 2.5 * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/consumable/frostoil, 2.5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/tea
 	name = "Tea"
@@ -295,16 +295,16 @@
 	default_container = /obj/item/reagent_containers/cup/glass/mug/tea
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/tea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/tea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_dizzy(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_jitter(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.AdjustSleeping(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_dizzy(-2 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-1 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_jitter(-3 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustSleeping(-1 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.get_tox_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_bodytemperature(10 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(10 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 
 	var/to_chatted = FALSE
 	for(var/datum/wound/iter_wound as anything in affected_mob.all_wounds)
@@ -354,7 +354,7 @@
 	taste_description = "bitter tea"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/tea/arnold_palmer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/tea/arnold_palmer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[pick("You remember to square your shoulders.","You remember to keep your head down.","You can't decide between squaring your shoulders and keeping your head down.","You remember to relax.","You think about how someday you'll get two strokes off your golf game.")]"))
@@ -369,16 +369,16 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/icecoffee/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/icecoffee/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
 
-/datum/reagent/consumable/icecoffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/icecoffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_dizzy(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/hot_ice_coffee
 	name = "Hot Ice Coffee"
@@ -390,17 +390,17 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/hot_ice_coffee/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/hot_ice_coffee/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
 
-/datum/reagent/consumable/hot_ice_coffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/hot_ice_coffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.AdjustSleeping(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-3.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
-	if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	affected_mob.adjust_dizzy(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustSleeping(-3 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-3.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	if(affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/icetea
@@ -412,15 +412,15 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/icetea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/icetea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_dizzy(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_dizzy(-2 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-1 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.get_tox_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/space_cola
 	name = "Cola"
@@ -429,10 +429,10 @@
 	taste_description = "cola"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/space_cola/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/space_cola/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_drowsiness(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_drowsiness(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/roy_rogers
 	name = "Roy Rogers"
@@ -442,10 +442,10 @@
 	taste_description = "fruity overlysweet cola"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/roy_rogers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
-	affected_mob.set_jitter_if_lower(6 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+/datum/reagent/consumable/roy_rogers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+	affected_mob.set_jitter_if_lower(6 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 	return ..()
 
 /datum/reagent/consumable/nuka_cola
@@ -464,14 +464,14 @@
 	. = ..()
 	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/nuka_cola)
 
-/datum/reagent/consumable/nuka_cola/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/nuka_cola/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_jitter_if_lower(20 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.set_drugginess(30 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_dizzy(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(20 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.set_drugginess(30 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_dizzy(1.5 SECONDS * metabolization_ratio * seconds_per_tick)
 	affected_mob.remove_status_effect(/datum/status_effect/drowsiness)
-	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 	if (SSradiation.can_irradiate_basic(affected_mob))
 		affected_mob.AddComponent(/datum/component/irradiated)
 
@@ -495,18 +495,18 @@
 		affected_mob.adjust_stamina_loss(min(80, current_cycle * 3), required_biotype = affected_biotype)
 		affected_mob.adjust_drowsiness((current_cycle-1) * 2 SECONDS)
 
-/datum/reagent/consumable/rootbeer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/rootbeer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 3 && !effect_enabled) // takes a few seconds for the bonus to kick in to prevent microdosing
 		to_chat(affected_mob, span_notice("You feel your trigger finger getting itchy..."))
 		ADD_TRAIT(affected_mob, TRAIT_DOUBLE_TAP, type)
 		effect_enabled = TRUE
 
-	affected_mob.set_jitter_if_lower(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(2 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(prob(50))
-		affected_mob.adjust_dizzy(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_dizzy(1 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(current_cycle > 10)
-		affected_mob.adjust_dizzy(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_dizzy(1.5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/grey_bull
 	name = "Grey Bull"
@@ -524,13 +524,13 @@
 		affected_atom.add_mood_event("maintenance_fun", /datum/mood_event/maintenance_high)
 		metabolization_rate *= 0.8
 
-/datum/reagent/consumable/grey_bull/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/grey_bull/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_jitter_if_lower(20 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_dizzy(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(20 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_dizzy(1 SECONDS * metabolization_ratio * seconds_per_tick)
 	affected_mob.remove_status_effect(/datum/status_effect/drowsiness)
-	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/spacemountainwind
 	name = "SM Wind"
@@ -540,12 +540,12 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/spacemountainwind/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/spacemountainwind/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_drowsiness(-7 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.AdjustSleeping(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
-	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-7 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustSleeping(-1 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.set_jitter_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/dr_gibb
 	name = "Dr. Gibb"
@@ -554,10 +554,10 @@
 	taste_description = "cherry soda" // FALSE ADVERTISING
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/dr_gibb/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/dr_gibb/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_drowsiness(-6 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_drowsiness(-6 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/space_up
 	name = "Space-Up"
@@ -566,9 +566,9 @@
 	taste_description = "cherry soda"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/space_up/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/space_up/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-4 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-4 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/lemon_lime
 	name = "Lemon Lime"
@@ -577,9 +577,9 @@
 	taste_description = "tangy lime and lemon soda"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/lemon_lime/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/lemon_lime/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-4 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-4 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/pwr_game
 	name = "Pwr Game"
@@ -595,9 +595,9 @@
 		to_chat(exposed_mob, span_nicegreen("As you imbibe the Pwr Game, your gamer third eye opens... \
 		You feel as though a great secret of the universe has been made known to you..."))
 
-/datum/reagent/consumable/pwr_game/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/pwr_game/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-4 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-4 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 	if(SPT_PROB(5, seconds_per_tick))
 		affected_mob.mind?.adjust_experience(/datum/skill/gaming, 5)
 
@@ -608,9 +608,9 @@
 	taste_description = "carbonated metallic soda"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/shamblers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/shamblers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-4 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-4 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/sodawater
 	name = "Soda Water"
@@ -625,11 +625,11 @@
 	mytray.adjust_waterlevel(round(volume))
 	mytray.adjust_plant_health(round(volume * 0.1))
 
-/datum/reagent/consumable/sodawater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/sodawater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_dizzy(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/tonic
 	name = "Tonic Water"
@@ -638,12 +638,12 @@
 	taste_description = "tart and fresh"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/tonic/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/tonic/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_dizzy(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/wellcheers
 	name = "Wellcheers"
@@ -652,17 +652,17 @@
 	taste_description = "grapes and the fresh open sea"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/wellcheers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/wellcheers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_drowsiness(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(1.5 SECONDS * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
 	switch(affected_mob.mob_mood.sanity_level)
 		if (SANITY_LEVEL_GREAT to SANITY_LEVEL_NEUTRAL)
-			need_mob_update = affected_mob.adjust_brute_loss(-0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+			need_mob_update = affected_mob.adjust_brute_loss(-0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
 		if (SANITY_LEVEL_DISTURBED to SANITY_LEVEL_UNSTABLE)
 			affected_mob.add_mood_event("wellcheers", /datum/mood_event/wellcheers)
 		if (SANITY_LEVEL_CRAZY to SANITY_LEVEL_INSANE)
-			need_mob_update = affected_mob.adjust_stamina_loss(1.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
+			need_mob_update = affected_mob.adjust_stamina_loss(1.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -675,13 +675,13 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/monkey_energy/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/monkey_energy/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_jitter_if_lower(40 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_dizzy(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(40 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_dizzy(1 SECONDS * metabolization_ratio * seconds_per_tick)
 	affected_mob.remove_status_effect(/datum/status_effect/drowsiness)
-	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/monkey_energy/on_mob_metabolize(mob/living/affected_mob)
 	. = ..()
@@ -692,7 +692,7 @@
 	. = ..()
 	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/monkey_energy)
 
-/datum/reagent/consumable/monkey_energy/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/monkey_energy/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(7.5, seconds_per_tick))
 		affected_mob.say(pick_list_replacements(BOOMER_FILE, "boomer"), forced = /datum/reagent/consumable/monkey_energy)
@@ -705,9 +705,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/cup/glass/ice
 
-/datum/reagent/consumable/ice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, FALSE, affected_mob.get_body_temp_normal()))
+	if(affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, FALSE, affected_mob.get_body_temp_normal()))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/soy_latte
@@ -721,19 +721,19 @@
 	glass_price = DRINK_PRICE_EASY
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/soy_latte/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/soy_latte/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
 
-/datum/reagent/consumable/soy_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/soy_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_dizzy(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
 	need_mob_update = affected_mob.SetSleeping(0)
-	affected_mob.adjust_bodytemperature(2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 	if(affected_mob.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
-		need_mob_update += affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0, updating_health = FALSE)
+		need_mob_update += affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, burn = 0, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -748,19 +748,19 @@
 	glass_price = DRINK_PRICE_EASY
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/cafe_latte/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/cafe_latte/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
 
-/datum/reagent/consumable/cafe_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/cafe_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-6 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_dizzy(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-6 SECONDS * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
 	need_mob_update = affected_mob.SetSleeping(0)
-	affected_mob.adjust_bodytemperature(2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 	if(affected_mob.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
-		need_mob_update += affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0, updating_health = FALSE)
+		need_mob_update += affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, burn = 0, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -772,18 +772,18 @@
 	taste_description = "homely fruit"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/doctor_delight/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/doctor_delight/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_tox_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update = affected_mob.adjust_brute_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_tox_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(affected_mob.nutrition && (affected_mob.nutrition - 2 > 0))
 		var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 		if(!(HAS_TRAIT(liver, TRAIT_MEDICAL_METABOLISM)))
 			// Drains the nutrition of the holder. Not medical doctors though, since it's the Doctor's Delight!
-			affected_mob.adjust_nutrition(-1 * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.adjust_nutrition(-1 * metabolization_ratio * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -795,9 +795,9 @@
 	taste_description = "sweet tangy fruit"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/cinderella/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/cinderella/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_disgust(-2.5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_disgust(-2.5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/cherryshake
 	name = "Cherry Shake"
@@ -879,19 +879,19 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/pumpkin_latte/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/pumpkin_latte/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
 
-/datum/reagent/consumable/pumpkin_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/pumpkin_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_dizzy(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
 	need_mob_update = affected_mob.SetSleeping(0)
-	affected_mob.adjust_bodytemperature(2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 	if(affected_mob.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
-		need_mob_update += affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0, updating_health = FALSE)
+		need_mob_update += affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, burn = 0, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -933,9 +933,9 @@
 	taste_description = "grape soda"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/grape_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/grape_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/milk/chocolate_milk
 	name = "Chocolate Milk"
@@ -953,13 +953,13 @@
 	taste_description = "creamy chocolate"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/hot_coco/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
-	affected_mob.adjust_bodytemperature(2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+/datum/reagent/consumable/hot_coco/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+	affected_mob.adjust_bodytemperature(2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 	if(affected_mob.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0, updating_health = FALSE))
+		if(affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, burn = 0, updating_health = FALSE))
 			. = UPDATE_MOB_HEALTH
 	if(holder.has_reagent(/datum/reagent/consumable/capsaicin))
-		holder.remove_reagent(/datum/reagent/consumable/capsaicin, 1 * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/consumable/capsaicin, 1 * metabolization_ratio * seconds_per_tick)
 	return ..() || .
 
 /datum/reagent/consumable/italian_coco
@@ -971,9 +971,9 @@
 	taste_description = "thick creamy chocolate"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/italian_coco/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/italian_coco/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/menthol
 	name = "Menthol"
@@ -983,7 +983,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/menthol
 
-/datum/reagent/consumable/menthol/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/menthol/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	affected_mob.apply_status_effect(/datum/status_effect/throat_soothed)
 
@@ -999,10 +999,10 @@
 	if(IS_REVOLUTIONARY(drinker))
 		to_chat(drinker, span_warning("Antioxidants are weakening your radical spirit!"))
 
-/datum/reagent/consumable/grenadine/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/grenadine/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(IS_REVOLUTIONARY(drinker))
-		drinker.set_dizzy_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		drinker.set_dizzy_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
 		if(drinker.get_stamina_loss() < 80)
 			drinker.adjust_stamina_loss(12, required_biotype = affected_biotype) //The pomegranate stops free radicals! Har har.
 
@@ -1036,9 +1036,9 @@
 	taste_description = "fizzy vanilla"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/cream_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/cream_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/sol_dry
 	name = "Sol Dry"
@@ -1048,9 +1048,9 @@
 	taste_description = "sweet ginger spice"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/sol_dry/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/sol_dry/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_disgust(-2.5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_disgust(-2.5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/shirley_temple
 	name = "Shirley Temple"
@@ -1060,8 +1060,8 @@
 	taste_description = "sweet cherry syrup and ginger spice"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/shirley_temple/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
-	affected_mob.adjust_disgust(-1.5 * REM * metabolized_volume * seconds_per_tick)
+/datum/reagent/consumable/shirley_temple/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+	affected_mob.adjust_disgust(-1.5 * metabolization_ratio * seconds_per_tick)
 	return ..()
 
 /datum/reagent/consumable/red_queen
@@ -1073,7 +1073,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	var/current_size = RESIZE_DEFAULT_SIZE
 
-/datum/reagent/consumable/red_queen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/red_queen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(50, seconds_per_tick))
 		return
@@ -1111,10 +1111,10 @@
 	taste_description = "vegetable"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/aloejuice/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/aloejuice/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.get_tox_loss() && SPT_PROB(16, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/agua_fresca
@@ -1125,11 +1125,11 @@
 	taste_description = "cool refreshing watermelon"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/agua_fresca/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/agua_fresca/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-4 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-4 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 	if(affected_mob.get_tox_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(-0.5, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/mushroom_tea
@@ -1140,10 +1140,10 @@
 	taste_description = "mushrooms"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/mushroom_tea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/mushroom_tea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(islizard(affected_mob))
-		if(affected_mob.adjust_oxy_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
+		if(affected_mob.adjust_oxy_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
 			return UPDATE_MOB_HEALTH
 
 //Moth Stuff
@@ -1227,11 +1227,11 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_HIGH
 
-/datum/reagent/consumable/cucumberlemonade/on_mob_life(mob/living/carbon/doll, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/cucumberlemonade/on_mob_life(mob/living/carbon/doll, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	doll.adjust_bodytemperature(-4 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, doll.get_body_temp_normal())
+	doll.adjust_bodytemperature(-4 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, doll.get_body_temp_normal())
 	if(doll.get_tox_loss() && SPT_PROB(10, seconds_per_tick))
-		if(doll.adjust_tox_loss(-0.5, updating_health = FALSE, required_biotype = affected_biotype))
+		if(doll.adjust_tox_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/mississippi_queen
@@ -1241,16 +1241,16 @@
 	taste_description = "sludge seeping down your throat"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/mississippi_queen/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/mississippi_queen/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	switch(current_cycle)
 		if(11 to 21)
-			drinker.adjust_dizzy(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			drinker.adjust_dizzy(2 SECONDS * metabolization_ratio * seconds_per_tick)
 		if(21 to 31)
 			if(SPT_PROB(15, seconds_per_tick))
-				drinker.adjust_confusion(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+				drinker.adjust_confusion(2 SECONDS * metabolization_ratio)
 		if(31 to 201)
-			drinker.adjust_hallucinations(30 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			drinker.adjust_hallucinations(30 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/t_letter
 	name = "T"
@@ -1260,15 +1260,15 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/t_letter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/t_letter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!HAS_MIND_TRAIT(affected_mob, TRAIT_MIMING))
 		return
 	affected_mob.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
-	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.get_tox_loss() && SPT_PROB(25, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-1 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/hakka_mate
@@ -1319,7 +1319,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	quality = DRINK_VERYGOOD
 
-/datum/reagent/consumable/fruit_punch/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/fruit_punch/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	var/found_valid_cooler = FALSE
@@ -1333,14 +1333,14 @@
 	if(found_valid_cooler)
 		affected_mob.clear_alert("punch_bad")
 		affected_mob.throw_alert("punch_good", /atom/movable/screen/alert/fruit_punch_good)
-		need_mob_update = affected_mob.adjust_tox_loss(-0.3 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update = affected_mob.adjust_brute_loss(-0.3 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update = affected_mob.adjust_fire_loss(-0.3 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update = affected_mob.adjust_tox_loss(-0.3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update = affected_mob.adjust_brute_loss(-0.3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update = affected_mob.adjust_fire_loss(-0.3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
 		affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/punch_punishment)
 	else
 		affected_mob.clear_alert("punch_good")
 		affected_mob.throw_alert("punch_bad", /atom/movable/screen/alert/fruit_punch_bad)
-		need_mob_update = affected_mob.apply_damage(0.75 * REM * metabolized_volume * seconds_per_tick, TOX)
+		need_mob_update = affected_mob.apply_damage(0.75 * metabolization_ratio * seconds_per_tick, TOX)
 		affected_mob.add_movespeed_modifier(/datum/movespeed_modifier/punch_punishment)
 		if(SPT_PROB(10, seconds_per_tick))
 			affected_mob.Knockdown(3 SECONDS, 6 SECONDS) //Gives daze effect. Using the cooler is a commitment and if you get jumped during it or have to run away to fight something, you should be vulnerable.
@@ -1378,9 +1378,9 @@
 	taste_description = "mild aromatics"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/bitters_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/ethanol/bitters_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_disgust(-2.5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_disgust(-2.5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/lean
 	name = "Lean"
@@ -1392,14 +1392,14 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolization_rate = 0.1
 
-/datum/reagent/consumable/lean/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/lean/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_jitter(1.25 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_stutter(1.125 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_drugginess(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_jitter(1.25 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_stutter(1.125 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drugginess(1 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(SPT_PROB(15, seconds_per_tick))
 		affected_mob.emote(pick("taunt","twitch","shiver","laugh","moan","blush","stare"))
 	if(current_cycle > 16 && SPT_PROB(3.5, seconds_per_tick))
-		affected_mob.adjust_dizzy(7.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-		affected_mob.adjust_drowsiness(3.25 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_dizzy(7.5 SECONDS * metabolization_ratio)
+		affected_mob.adjust_drowsiness(3.25 SECONDS * metabolization_ratio)
 		affected_mob.emote("drool")

--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -115,7 +115,7 @@
 	. = ..()
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if((liver && HAS_TRAIT(liver, TRAIT_COMEDY_METABOLISM)) || is_simian(affected_mob))
-		if(affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
+		if(affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/nothing
@@ -132,7 +132,7 @@
 	. = ..()
 	if(ishuman(drinker) && HAS_MIND_TRAIT(drinker, TRAIT_MIMING))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
-		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/laughter
@@ -280,7 +280,7 @@
 	affected_mob.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
 	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
 	//310.15 is the normal bodytemp.
-	affected_mob.adjust_bodytemperature(25 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(12.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 	if(holder.has_reagent(/datum/reagent/consumable/frostoil))
 		holder.remove_reagent(/datum/reagent/consumable/frostoil, 2.5 * metabolization_ratio * seconds_per_tick)
 
@@ -378,7 +378,7 @@
 	affected_mob.adjust_dizzy(-5 SECONDS * metabolization_ratio * seconds_per_tick)
 	affected_mob.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
 	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-2.5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/hot_ice_coffee
 	name = "Hot Ice Coffee"
@@ -420,7 +420,7 @@
 	if(affected_mob.get_tox_loss() && SPT_PROB(10, seconds_per_tick))
 		if(affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-2.5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/space_cola
 	name = "Cola"
@@ -432,7 +432,7 @@
 /datum/reagent/consumable/space_cola/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	affected_mob.adjust_drowsiness(-5 SECONDS * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-2.5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/roy_rogers
 	name = "Roy Rogers"
@@ -471,7 +471,7 @@
 	affected_mob.adjust_dizzy(1.5 SECONDS * metabolization_ratio * seconds_per_tick)
 	affected_mob.remove_status_effect(/datum/status_effect/drowsiness)
 	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-2.5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, affected_mob.get_body_temp_normal())
 	if (SSradiation.can_irradiate_basic(affected_mob))
 		affected_mob.AddComponent(/datum/component/irradiated)
 
@@ -629,7 +629,7 @@
 	. = ..()
 	affected_mob.adjust_dizzy(-5 SECONDS * metabolization_ratio * seconds_per_tick)
 	affected_mob.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-2.5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/tonic
 	name = "Tonic Water"
@@ -643,7 +643,7 @@
 	affected_mob.adjust_dizzy(-5 SECONDS * metabolization_ratio * seconds_per_tick)
 	affected_mob.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
 	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-2.5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/wellcheers
 	name = "Wellcheers"
@@ -681,7 +681,7 @@
 	affected_mob.adjust_dizzy(1 SECONDS * metabolization_ratio * seconds_per_tick)
 	affected_mob.remove_status_effect(/datum/status_effect/drowsiness)
 	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-2.5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/monkey_energy/on_mob_metabolize(mob/living/affected_mob)
 	. = ..()
@@ -707,7 +707,7 @@
 
 /datum/reagent/consumable/ice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_bodytemperature(-2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, FALSE, affected_mob.get_body_temp_normal()))
+	if(affected_mob.adjust_bodytemperature(-2.5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, FALSE, affected_mob.get_body_temp_normal()))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/soy_latte
@@ -731,7 +731,7 @@
 	affected_mob.adjust_drowsiness(-3 SECONDS * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
 	need_mob_update = affected_mob.SetSleeping(0)
-	affected_mob.adjust_bodytemperature(2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(2.5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 	if(affected_mob.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
 		need_mob_update += affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, burn = 0, updating_health = FALSE)
 	if(need_mob_update)
@@ -973,7 +973,7 @@
 
 /datum/reagent/consumable/italian_coco/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(2.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(2.5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/menthol
 	name = "Menthol"
@@ -1129,7 +1129,7 @@
 	. = ..()
 	affected_mob.adjust_bodytemperature(-4 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 	if(affected_mob.get_tox_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.25 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/mushroom_tea
@@ -1231,7 +1231,7 @@
 	. = ..()
 	doll.adjust_bodytemperature(-4 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, doll.get_body_temp_normal())
 	if(doll.get_tox_loss() && SPT_PROB(10, seconds_per_tick))
-		if(doll.adjust_tox_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
+		if(doll.adjust_tox_loss(-0.25 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/mississippi_queen

--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -7,10 +7,10 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/orangejuice
 
-/datum/reagent/consumable/orangejuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/orangejuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.get_oxy_loss() && SPT_PROB(16, seconds_per_tick))
-		if(affected_mob.adjust_oxy_loss(-1 * REM * seconds_per_tick, FALSE, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
+		if(affected_mob.adjust_oxy_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, FALSE, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/tomatojuice
@@ -21,10 +21,10 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/tomatojuice
 
-/datum/reagent/consumable/tomatojuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/tomatojuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.get_fire_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.heal_bodypart_damage(brute = 0, burn = 1 * REM * seconds_per_tick, updating_health = FALSE))
+		if(affected_mob.heal_bodypart_damage(brute = 0, burn = 0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/limejuice
@@ -36,10 +36,10 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/limejuice
 
-/datum/reagent/consumable/limejuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/limejuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.get_tox_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/carrotjuice
@@ -49,17 +49,17 @@
 	taste_description = "carrots"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/carrotjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/carrotjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_eye_blur(-2 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_temp_blindness(-2 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_eye_blur(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_temp_blindness(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	var/need_mob_update
 	switch(current_cycle)
 		if(21 to 110)
 			if(SPT_PROB(100 * (1 - (sqrt(110 - current_cycle) / 10)), seconds_per_tick))
-				need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, -2 * REM * seconds_per_tick)
+				need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, -1 * REM * metabolized_volume * seconds_per_tick)
 		if(110 to INFINITY)
-			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, -2 * REM * seconds_per_tick)
+			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, -1 * REM * metabolized_volume * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -84,9 +84,9 @@
 	taste_description = "berries"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/poisonberryjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/poisonberryjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/watermelonjuice
@@ -111,11 +111,11 @@
 	taste_description = "banana"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/banana/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/banana/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if((liver && HAS_TRAIT(liver, TRAIT_COMEDY_METABOLISM)) || is_simian(affected_mob))
-		if(affected_mob.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 1 * REM * seconds_per_tick, updating_health = FALSE))
+		if(affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/nothing
@@ -128,11 +128,11 @@
 	required_drink_type = /datum/reagent/consumable/nothing
 	icon_state = "shotglass"
 
-/datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(ishuman(drinker) && HAS_MIND_TRAIT(drinker, TRAIT_MIMING))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
-		if(drinker.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 1 * REM * seconds_per_tick, updating_health = FALSE))
+		if(drinker.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/laughter
@@ -143,7 +143,7 @@
 	taste_description = "laughter"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/laughter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/laughter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tic, metabolized_volume)
 	. = ..()
 	affected_mob.emote("laugh")
 	affected_mob.add_mood_event("chemical_laughter", /datum/mood_event/chemical_laughter)
@@ -156,7 +156,7 @@
 	taste_description = "laughter"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/superlaughter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/superlaughter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(16, seconds_per_tick))
 		affected_mob.visible_message(span_danger("[affected_mob] bursts out into a fit of uncontrollable laughter!"), span_userdanger("You burst out in a fit of uncontrollable laughter!"))
@@ -179,11 +179,11 @@
 	taste_description = "vinegar brine"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/pickle/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/pickle/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if((liver && HAS_TRAIT(liver, TRAIT_CORONER_METABOLISM)))
-		if(affected_mob.adjust_tox_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/grapejuice
@@ -218,9 +218,9 @@
 		return
 	myseed.adjust_potency(-round(volume * 0.5))
 
-/datum/reagent/consumable/milk/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/milk/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(affected_mob.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 0, updating_health = FALSE))
+		if(affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0, updating_health = FALSE))
 			. = UPDATE_MOB_HEALTH
 	if(holder.has_reagent(/datum/reagent/consumable/capsaicin))
 		holder.remove_reagent(/datum/reagent/consumable/capsaicin, seconds_per_tick)
@@ -240,7 +240,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/condiment/soymilk
 
-/datum/reagent/consumable/soymilk/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/soymilk/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
 		if(affected_mob.heal_bodypart_damage(1, 0))
@@ -254,7 +254,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/cream
 
-/datum/reagent/consumable/cream/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/cream/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(10, seconds_per_tick) && affected_mob.heal_bodypart_damage(1, 0))
 		return UPDATE_MOB_HEALTH
@@ -270,19 +270,19 @@
 	glass_price = DRINK_PRICE_STOCK
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/coffee/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/coffee/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.set_jitter_if_lower(10 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
-/datum/reagent/consumable/coffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/coffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_dizzy(-10 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-6 SECONDS * REM * seconds_per_tick)
-	affected_mob.AdjustSleeping(-4 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	//310.15 is the normal bodytemp.
-	affected_mob.adjust_bodytemperature(25 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(25 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 	if(holder.has_reagent(/datum/reagent/consumable/frostoil))
-		holder.remove_reagent(/datum/reagent/consumable/frostoil, 5 * REM * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/consumable/frostoil, 2.5 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/tea
 	name = "Tea"
@@ -295,16 +295,16 @@
 	default_container = /obj/item/reagent_containers/cup/glass/mug/tea
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/tea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/tea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_dizzy(-4 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-2 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_jitter(-6 SECONDS * REM * seconds_per_tick)
-	affected_mob.AdjustSleeping(-2 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_dizzy(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_jitter(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.AdjustSleeping(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(affected_mob.get_tox_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_bodytemperature(20 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(10 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 
 	var/to_chatted = FALSE
 	for(var/datum/wound/iter_wound as anything in affected_mob.all_wounds)
@@ -354,7 +354,7 @@
 	taste_description = "bitter tea"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/tea/arnold_palmer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/tea/arnold_palmer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[pick("You remember to square your shoulders.","You remember to keep your head down.","You can't decide between squaring your shoulders and keeping your head down.","You remember to relax.","You think about how someday you'll get two strokes off your golf game.")]"))
@@ -369,16 +369,16 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/icecoffee/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/icecoffee/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.set_jitter_if_lower(10 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
-/datum/reagent/consumable/icecoffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/icecoffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_dizzy(-10 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-6 SECONDS * REM * seconds_per_tick)
-	affected_mob.AdjustSleeping(-4 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/hot_ice_coffee
 	name = "Hot Ice Coffee"
@@ -390,17 +390,17 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/hot_ice_coffee/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/hot_ice_coffee/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.set_jitter_if_lower(10 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
-/datum/reagent/consumable/hot_ice_coffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/hot_ice_coffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_dizzy(-10 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-6 SECONDS * REM * seconds_per_tick)
-	affected_mob.AdjustSleeping(-6 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-7 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
-	if(affected_mob.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.AdjustSleeping(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-3.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/icetea
@@ -412,15 +412,15 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/icetea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/icetea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_dizzy(-4 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-2 SECONDS * REM * seconds_per_tick)
-	affected_mob.AdjustSleeping(-4 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_dizzy(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(affected_mob.get_tox_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/space_cola
 	name = "Cola"
@@ -429,10 +429,10 @@
 	taste_description = "cola"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/space_cola/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/space_cola/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_drowsiness(-10 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_drowsiness(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/roy_rogers
 	name = "Roy Rogers"
@@ -442,10 +442,10 @@
 	taste_description = "fruity overlysweet cola"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/roy_rogers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
-	affected_mob.set_jitter_if_lower(12 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-10 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+/datum/reagent/consumable/roy_rogers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+	affected_mob.set_jitter_if_lower(6 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 	return ..()
 
 /datum/reagent/consumable/nuka_cola
@@ -464,14 +464,14 @@
 	. = ..()
 	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/nuka_cola)
 
-/datum/reagent/consumable/nuka_cola/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/nuka_cola/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.set_jitter_if_lower(40 SECONDS * REM * seconds_per_tick)
-	affected_mob.set_drugginess(1 MINUTES * REM * seconds_per_tick)
-	affected_mob.adjust_dizzy(3 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(20 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_drugginess(30 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_dizzy(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	affected_mob.remove_status_effect(/datum/status_effect/drowsiness)
-	affected_mob.AdjustSleeping(-4 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 	if (SSradiation.can_irradiate_basic(affected_mob))
 		affected_mob.AddComponent(/datum/component/irradiated)
 
@@ -495,18 +495,18 @@
 		affected_mob.adjust_stamina_loss(min(80, current_cycle * 3), required_biotype = affected_biotype)
 		affected_mob.adjust_drowsiness((current_cycle-1) * 2 SECONDS)
 
-/datum/reagent/consumable/rootbeer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/rootbeer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(current_cycle > 3 && !effect_enabled) // takes a few seconds for the bonus to kick in to prevent microdosing
 		to_chat(affected_mob, span_notice("You feel your trigger finger getting itchy..."))
 		ADD_TRAIT(affected_mob, TRAIT_DOUBLE_TAP, type)
 		effect_enabled = TRUE
 
-	affected_mob.set_jitter_if_lower(4 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(prob(50))
-		affected_mob.adjust_dizzy(2 SECONDS * REM * seconds_per_tick)
+		affected_mob.adjust_dizzy(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(current_cycle > 10)
-		affected_mob.adjust_dizzy(3 SECONDS * REM * seconds_per_tick)
+		affected_mob.adjust_dizzy(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/grey_bull
 	name = "Grey Bull"
@@ -524,13 +524,13 @@
 		affected_atom.add_mood_event("maintenance_fun", /datum/mood_event/maintenance_high)
 		metabolization_rate *= 0.8
 
-/datum/reagent/consumable/grey_bull/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/grey_bull/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.set_jitter_if_lower(40 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_dizzy(2 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(20 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_dizzy(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	affected_mob.remove_status_effect(/datum/status_effect/drowsiness)
-	affected_mob.AdjustSleeping(-4 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/spacemountainwind
 	name = "SM Wind"
@@ -540,12 +540,12 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/spacemountainwind/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/spacemountainwind/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_drowsiness(-14 SECONDS * REM * seconds_per_tick)
-	affected_mob.AdjustSleeping(-2 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
-	affected_mob.set_jitter_if_lower(10 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-7 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.AdjustSleeping(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/dr_gibb
 	name = "Dr. Gibb"
@@ -554,10 +554,10 @@
 	taste_description = "cherry soda" // FALSE ADVERTISING
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/dr_gibb/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/dr_gibb/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_drowsiness(-12 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_drowsiness(-6 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/space_up
 	name = "Space-Up"
@@ -566,9 +566,9 @@
 	taste_description = "cherry soda"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/space_up/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/space_up/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-8 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-4 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/lemon_lime
 	name = "Lemon Lime"
@@ -577,9 +577,9 @@
 	taste_description = "tangy lime and lemon soda"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/lemon_lime/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/lemon_lime/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-8 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-4 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/pwr_game
 	name = "Pwr Game"
@@ -595,9 +595,9 @@
 		to_chat(exposed_mob, span_nicegreen("As you imbibe the Pwr Game, your gamer third eye opens... \
 		You feel as though a great secret of the universe has been made known to you..."))
 
-/datum/reagent/consumable/pwr_game/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/pwr_game/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-8 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-4 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 	if(SPT_PROB(5, seconds_per_tick))
 		affected_mob.mind?.adjust_experience(/datum/skill/gaming, 5)
 
@@ -608,9 +608,9 @@
 	taste_description = "carbonated metallic soda"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/shamblers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/shamblers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-8 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-4 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/sodawater
 	name = "Soda Water"
@@ -625,11 +625,11 @@
 	mytray.adjust_waterlevel(round(volume))
 	mytray.adjust_plant_health(round(volume * 0.1))
 
-/datum/reagent/consumable/sodawater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/sodawater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_dizzy(-10 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-6 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/tonic
 	name = "Tonic Water"
@@ -638,12 +638,12 @@
 	taste_description = "tart and fresh"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/tonic/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/tonic/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_dizzy(-10 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-6 SECONDS * REM * seconds_per_tick)
-	affected_mob.AdjustSleeping(-4 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/wellcheers
 	name = "Wellcheers"
@@ -652,17 +652,17 @@
 	taste_description = "grapes and the fresh open sea"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/wellcheers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/wellcheers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_drowsiness(3 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_drowsiness(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	var/need_mob_update
 	switch(affected_mob.mob_mood.sanity_level)
 		if (SANITY_LEVEL_GREAT to SANITY_LEVEL_NEUTRAL)
-			need_mob_update = affected_mob.adjust_brute_loss(-1.5 * REM * seconds_per_tick, updating_health = FALSE)
+			need_mob_update = affected_mob.adjust_brute_loss(-0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
 		if (SANITY_LEVEL_DISTURBED to SANITY_LEVEL_UNSTABLE)
 			affected_mob.add_mood_event("wellcheers", /datum/mood_event/wellcheers)
 		if (SANITY_LEVEL_CRAZY to SANITY_LEVEL_INSANE)
-			need_mob_update = affected_mob.adjust_stamina_loss(3 * REM * seconds_per_tick, updating_stamina = FALSE)
+			need_mob_update = affected_mob.adjust_stamina_loss(1.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -675,13 +675,13 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/monkey_energy/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/monkey_energy/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.set_jitter_if_lower(80 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_dizzy(2 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(40 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_dizzy(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	affected_mob.remove_status_effect(/datum/status_effect/drowsiness)
-	affected_mob.AdjustSleeping(-4 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/monkey_energy/on_mob_metabolize(mob/living/affected_mob)
 	. = ..()
@@ -692,7 +692,7 @@
 	. = ..()
 	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/monkey_energy)
 
-/datum/reagent/consumable/monkey_energy/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/monkey_energy/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(7.5, seconds_per_tick))
 		affected_mob.say(pick_list_replacements(BOOMER_FILE, "boomer"), forced = /datum/reagent/consumable/monkey_energy)
@@ -705,9 +705,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/cup/glass/ice
 
-/datum/reagent/consumable/ice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/ice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, FALSE, affected_mob.get_body_temp_normal()))
+	if(affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, FALSE, affected_mob.get_body_temp_normal()))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/soy_latte
@@ -721,19 +721,19 @@
 	glass_price = DRINK_PRICE_EASY
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/soy_latte/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/soy_latte/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.set_jitter_if_lower(10 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
-/datum/reagent/consumable/soy_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/soy_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_dizzy(-10 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-6 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	var/need_mob_update
 	need_mob_update = affected_mob.SetSleeping(0)
-	affected_mob.adjust_bodytemperature(5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 	if(affected_mob.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
-		need_mob_update += affected_mob.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 0, updating_health = FALSE)
+		need_mob_update += affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -748,19 +748,19 @@
 	glass_price = DRINK_PRICE_EASY
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/cafe_latte/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/cafe_latte/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.set_jitter_if_lower(10 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
-/datum/reagent/consumable/cafe_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/cafe_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_dizzy(-10 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-12 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-6 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	var/need_mob_update
 	need_mob_update = affected_mob.SetSleeping(0)
-	affected_mob.adjust_bodytemperature(5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 	if(affected_mob.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
-		need_mob_update += affected_mob.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 0, updating_health = FALSE)
+		need_mob_update += affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -772,18 +772,18 @@
 	taste_description = "homely fruit"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/doctor_delight/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/doctor_delight/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_tox_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update = affected_mob.adjust_brute_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_tox_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(affected_mob.nutrition && (affected_mob.nutrition - 2 > 0))
 		var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 		if(!(HAS_TRAIT(liver, TRAIT_MEDICAL_METABOLISM)))
 			// Drains the nutrition of the holder. Not medical doctors though, since it's the Doctor's Delight!
-			affected_mob.adjust_nutrition(-2 * REM * seconds_per_tick)
+			affected_mob.adjust_nutrition(-1 * REM * metabolized_volume * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -795,9 +795,9 @@
 	taste_description = "sweet tangy fruit"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/cinderella/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/cinderella/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_disgust(-5 * REM * seconds_per_tick)
+	affected_mob.adjust_disgust(-2.5 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/cherryshake
 	name = "Cherry Shake"
@@ -879,19 +879,19 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/pumpkin_latte/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/pumpkin_latte/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.set_jitter_if_lower(10 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
-/datum/reagent/consumable/pumpkin_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/pumpkin_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_dizzy(-10 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_drowsiness(-6 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_dizzy(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	var/need_mob_update
 	need_mob_update = affected_mob.SetSleeping(0)
-	affected_mob.adjust_bodytemperature(5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 	if(affected_mob.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
-		need_mob_update += affected_mob.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 0, updating_health = FALSE)
+		need_mob_update += affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -933,9 +933,9 @@
 	taste_description = "grape soda"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/grape_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/grape_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/milk/chocolate_milk
 	name = "Chocolate Milk"
@@ -953,13 +953,13 @@
 	taste_description = "creamy chocolate"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/hot_coco/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
-	affected_mob.adjust_bodytemperature(5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+/datum/reagent/consumable/hot_coco/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+	affected_mob.adjust_bodytemperature(2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 	if(affected_mob.get_brute_loss() && SPT_PROB(10, seconds_per_tick))
-		if(affected_mob.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 0, updating_health = FALSE))
+		if(affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0, updating_health = FALSE))
 			. = UPDATE_MOB_HEALTH
 	if(holder.has_reagent(/datum/reagent/consumable/capsaicin))
-		holder.remove_reagent(/datum/reagent/consumable/capsaicin, 2 * REM * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/consumable/capsaicin, 1 * REM * metabolized_volume * seconds_per_tick)
 	return ..() || .
 
 /datum/reagent/consumable/italian_coco
@@ -971,9 +971,9 @@
 	taste_description = "thick creamy chocolate"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/italian_coco/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/italian_coco/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_bodytemperature(5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/menthol
 	name = "Menthol"
@@ -983,7 +983,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/juice/menthol
 
-/datum/reagent/consumable/menthol/on_mob_life(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/menthol/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	affected_mob.apply_status_effect(/datum/status_effect/throat_soothed)
 
@@ -999,10 +999,10 @@
 	if(IS_REVOLUTIONARY(drinker))
 		to_chat(drinker, span_warning("Antioxidants are weakening your radical spirit!"))
 
-/datum/reagent/consumable/grenadine/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/grenadine/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(IS_REVOLUTIONARY(drinker))
-		drinker.set_dizzy_if_lower(10 SECONDS * REM * seconds_per_tick)
+		drinker.set_dizzy_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 		if(drinker.get_stamina_loss() < 80)
 			drinker.adjust_stamina_loss(12, required_biotype = affected_biotype) //The pomegranate stops free radicals! Har har.
 
@@ -1036,9 +1036,9 @@
 	taste_description = "fizzy vanilla"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/cream_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/cream_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-2.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/sol_dry
 	name = "Sol Dry"
@@ -1048,9 +1048,9 @@
 	taste_description = "sweet ginger spice"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/sol_dry/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/sol_dry/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_disgust(-5 * REM * seconds_per_tick)
+	affected_mob.adjust_disgust(-2.5 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/shirley_temple
 	name = "Shirley Temple"
@@ -1060,8 +1060,8 @@
 	taste_description = "sweet cherry syrup and ginger spice"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/shirley_temple/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
-	affected_mob.adjust_disgust(-3 * REM * seconds_per_tick)
+/datum/reagent/consumable/shirley_temple/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+	affected_mob.adjust_disgust(-1.5 * REM * metabolized_volume * seconds_per_tick)
 	return ..()
 
 /datum/reagent/consumable/red_queen
@@ -1073,7 +1073,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	var/current_size = RESIZE_DEFAULT_SIZE
 
-/datum/reagent/consumable/red_queen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/red_queen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(50, seconds_per_tick))
 		return
@@ -1111,10 +1111,10 @@
 	taste_description = "vegetable"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/aloejuice/on_mob_life(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/aloejuice/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.get_tox_loss() && SPT_PROB(16, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/agua_fresca
@@ -1125,9 +1125,9 @@
 	taste_description = "cool refreshing watermelon"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/agua_fresca/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/agua_fresca/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_bodytemperature(-8 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(-4 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 	if(affected_mob.get_tox_loss() && SPT_PROB(10, seconds_per_tick))
 		if(affected_mob.adjust_tox_loss(-0.5, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
@@ -1140,10 +1140,10 @@
 	taste_description = "mushrooms"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/mushroom_tea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/mushroom_tea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(islizard(affected_mob))
-		if(affected_mob.adjust_oxy_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
+		if(affected_mob.adjust_oxy_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
 			return UPDATE_MOB_HEALTH
 
 //Moth Stuff
@@ -1227,9 +1227,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	glass_price = DRINK_PRICE_HIGH
 
-/datum/reagent/consumable/cucumberlemonade/on_mob_life(mob/living/carbon/doll, seconds_per_tick)
+/datum/reagent/consumable/cucumberlemonade/on_mob_life(mob/living/carbon/doll, seconds_per_tick, metabolized_volume)
 	. = ..()
-	doll.adjust_bodytemperature(-8 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, doll.get_body_temp_normal())
+	doll.adjust_bodytemperature(-4 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, doll.get_body_temp_normal())
 	if(doll.get_tox_loss() && SPT_PROB(10, seconds_per_tick))
 		if(doll.adjust_tox_loss(-0.5, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
@@ -1241,16 +1241,16 @@
 	taste_description = "sludge seeping down your throat"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/mississippi_queen/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/consumable/mississippi_queen/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	switch(current_cycle)
 		if(11 to 21)
-			drinker.adjust_dizzy(4 SECONDS * REM * seconds_per_tick)
+			drinker.adjust_dizzy(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
 		if(21 to 31)
 			if(SPT_PROB(15, seconds_per_tick))
-				drinker.adjust_confusion(4 SECONDS * REM * seconds_per_tick)
+				drinker.adjust_confusion(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
 		if(31 to 201)
-			drinker.adjust_hallucinations(60 SECONDS * REM * seconds_per_tick)
+			drinker.adjust_hallucinations(30 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/t_letter
 	name = "T"
@@ -1260,15 +1260,15 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/consumable/t_letter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/t_letter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!HAS_MIND_TRAIT(affected_mob, TRAIT_MIMING))
 		return
 	affected_mob.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
-	affected_mob.adjust_drowsiness(-6 SECONDS * REM * seconds_per_tick)
-	affected_mob.AdjustSleeping(-4 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.AdjustSleeping(-2 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(affected_mob.get_tox_loss() && SPT_PROB(25, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/hakka_mate
@@ -1319,7 +1319,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	quality = DRINK_VERYGOOD
 
-/datum/reagent/consumable/fruit_punch/on_mob_life(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/fruit_punch/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	var/found_valid_cooler = FALSE
@@ -1333,14 +1333,14 @@
 	if(found_valid_cooler)
 		affected_mob.clear_alert("punch_bad")
 		affected_mob.throw_alert("punch_good", /atom/movable/screen/alert/fruit_punch_good)
-		need_mob_update = affected_mob.adjust_tox_loss(-0.6 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update = affected_mob.adjust_brute_loss(-0.6 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update = affected_mob.adjust_fire_loss(-0.6 * REM * seconds_per_tick, updating_health = FALSE)
+		need_mob_update = affected_mob.adjust_tox_loss(-0.3 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update = affected_mob.adjust_brute_loss(-0.3 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update = affected_mob.adjust_fire_loss(-0.3 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
 		affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/punch_punishment)
 	else
 		affected_mob.clear_alert("punch_good")
 		affected_mob.throw_alert("punch_bad", /atom/movable/screen/alert/fruit_punch_bad)
-		need_mob_update = affected_mob.apply_damage(1.5 * REM * seconds_per_tick, TOX)
+		need_mob_update = affected_mob.apply_damage(0.75 * REM * metabolized_volume * seconds_per_tick, TOX)
 		affected_mob.add_movespeed_modifier(/datum/movespeed_modifier/punch_punishment)
 		if(SPT_PROB(10, seconds_per_tick))
 			affected_mob.Knockdown(3 SECONDS, 6 SECONDS) //Gives daze effect. Using the cooler is a commitment and if you get jumped during it or have to run away to fight something, you should be vulnerable.
@@ -1378,9 +1378,9 @@
 	taste_description = "mild aromatics"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/ethanol/bitters_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/ethanol/bitters_soda/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_disgust(-5 * REM * seconds_per_tick)
+	affected_mob.adjust_disgust(-2.5 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/lean
 	name = "Lean"
@@ -1390,16 +1390,16 @@
 	taste_description = "purple and a hint of opioid."
 	addiction_types = list(/datum/addiction/opioids = 6)
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	metabolization_rate = 0.2 * REM
+	metabolization_rate = 0.1
 
-/datum/reagent/consumable/lean/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/lean/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_jitter(2.5 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_stutter(2.25 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_drugginess(2 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_jitter(1.25 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_stutter(1.125 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drugginess(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(SPT_PROB(15, seconds_per_tick))
 		affected_mob.emote(pick("taunt","twitch","shiver","laugh","moan","blush","stare"))
 	if(current_cycle > 16 && SPT_PROB(3.5, seconds_per_tick))
-		affected_mob.adjust_dizzy(15 SECONDS * REM * seconds_per_tick)
-		affected_mob.adjust_drowsiness(7.5 SECONDS * REM * seconds_per_tick)
+		affected_mob.adjust_dizzy(7.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_drowsiness(3.25 SECONDS * REM * metabolized_volume * seconds_per_tick)
 		affected_mob.emote("drool")

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -93,8 +93,8 @@
 /datum/reagent/drug/nicotine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(0.05 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(0.55 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update = affected_mob.adjust_tox_loss(0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(4.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -435,9 +435,9 @@
 	var/mob/living/carbon/carbie = affected_mob
 	//You will be vomiting so the damage is really for a few ticks before you flush it out of your system
 	var/need_mob_update
-	need_mob_update = carbie.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = carbie.adjust_tox_loss(0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(SPT_PROB(5, seconds_per_tick))
-		need_mob_update += carbie.adjust_tox_loss(5 * metabolization_ratio, required_biotype = affected_biotype, updating_health = FALSE)
+		need_mob_update += carbie.adjust_tox_loss(2.5 * metabolization_ratio, required_biotype = affected_biotype, updating_health = FALSE)
 		carbie.vomit(VOMIT_CATEGORY_DEFAULT)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
@@ -760,7 +760,7 @@
 		invisible_man.emote("giggle")
 	if(SPT_PROB(5, seconds_per_tick))
 		invisible_man.emote("laugh")
-	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, ((0.2 * REAGENTS_METABOLISM) / metabolization_rate) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, METABOLIZE_FREE_CONSTANT(0.2) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/saturnx/stable

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -2,7 +2,7 @@
 	name = "Drug"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "bitterness"
-	var/trippy = TRUE //Does this drug make you trip?
+	var/trippy = TRUE
 
 /datum/reagent/drug/on_mob_end_metabolize(mob/living/affected_mob)
 	. = ..()
@@ -20,7 +20,7 @@
 
 /datum/reagent/drug/space_drugs/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_drugginess(15 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.set_drugginess(30 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(isturf(affected_mob.loc) && !isspaceturf(affected_mob.loc) && !HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && SPT_PROB(5, seconds_per_tick))
 		step(affected_mob, pick(GLOB.cardinals))
 	if(SPT_PROB(3.5, seconds_per_tick))
@@ -54,7 +54,7 @@
 		to_chat(affected_mob, span_notice("[smoke_message]"))
 	if(SPT_PROB(2, seconds_per_tick))
 		affected_mob.emote(pick("smile","laugh","giggle"))
-	affected_mob.adjust_nutrition(-0.075 * metabolization_ratio * seconds_per_tick) //munchies
+	affected_mob.adjust_nutrition(-0.6 * metabolization_ratio * seconds_per_tick) //munchies
 	if(SPT_PROB(4, seconds_per_tick) && affected_mob.body_position == LYING_DOWN && !affected_mob.IsSleeping()) //chance to fall asleep if lying down
 		to_chat(affected_mob, span_warning("You doze off..."))
 		affected_mob.Sleeping(10 SECONDS)
@@ -86,7 +86,7 @@
 		to_chat(affected_mob, span_notice("[smoke_message]"))
 	affected_mob.add_mood_event("smoked", /datum/mood_event/smoked)
 	affected_mob.remove_status_effect(/datum/status_effect/jitter)
-	affected_mob.AdjustAllImmobility(-25 * metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustAllImmobility(-200 * metabolization_ratio * seconds_per_tick)
 
 	return UPDATE_MOB_HEALTH
 
@@ -128,8 +128,8 @@
 /datum/reagent/drug/krokodil/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.125 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update = affected_mob.adjust_tox_loss(0.125 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_tox_loss(0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -174,11 +174,11 @@
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[high_message]"))
 	affected_mob.add_mood_event("tweaking", /datum/mood_event/stimulant_medium)
-	affected_mob.AdjustAllImmobility(-20 * metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustAllImmobility(-26.67 * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	affected_mob.set_jitter_if_lower(2 SECONDS * metabolization_ratio * seconds_per_tick)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * rand(1, 4) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_stamina_loss(-3.34 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	affected_mob.set_jitter_if_lower(2.67 SECONDS * metabolization_ratio * seconds_per_tick)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.67 * rand(1, 4) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH
 	if(SPT_PROB(2.5, seconds_per_tick))
@@ -187,7 +187,7 @@
 /datum/reagent/drug/methamphetamine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && !ismovable(affected_mob.loc))
-		for(var/i in 1 to round(2 * metabolization_ratio * seconds_per_tick, 1))
+		for(var/i in 1 to round(2.67 * metabolization_ratio * seconds_per_tick, 1))
 			step(affected_mob, pick(GLOB.cardinals))
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.emote("laugh")
@@ -195,8 +195,8 @@
 		affected_mob.visible_message(span_danger("[affected_mob]'s hands flip out and flail everywhere!"))
 		affected_mob.drop_all_held_items()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * (rand(5, 10) / 10) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_tox_loss(0.67 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.67 * (rand(5, 10) / 10) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -233,9 +233,9 @@
 		to_chat(affected_mob, span_notice("[high_message]"))
 	affected_mob.add_mood_event("salted", /datum/mood_event/stimulant_heavy)
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(-3 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	affected_mob.adjust_hallucinations(5 SECONDS * metabolization_ratio * seconds_per_tick)
+	need_mob_update = affected_mob.adjust_stamina_loss(-6 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 4 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	affected_mob.adjust_hallucinations(10 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH
 	if(!HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && !ismovable(affected_mob.loc))
@@ -244,9 +244,9 @@
 
 /datum/reagent/drug/bath_salts/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_hallucinations(5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_hallucinations(10 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(!HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && !ismovable(affected_mob.loc))
-		for(var/i in 1 to round(4 * metabolization_ratio * seconds_per_tick, 1))
+		for(var/i in 1 to round(8 * metabolization_ratio * seconds_per_tick, 1))
 			step(affected_mob, pick(GLOB.cardinals))
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.emote(pick("twitch","drool","moan"))
@@ -269,8 +269,8 @@
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[high_message]"))
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(-9 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_tox_loss(0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_stamina_loss(-18 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(SPT_PROB(30, seconds_per_tick))
 		affected_mob.losebreath++
 		need_mob_update += affected_mob.adjust_oxy_loss(1, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
@@ -302,7 +302,7 @@
 	affected_mob.remove_status_effect(/datum/status_effect/jitter)
 	affected_mob.remove_status_effect(/datum/status_effect/confusion)
 	affected_mob.disgust = 0
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.1 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.2 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/happiness/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
@@ -319,7 +319,7 @@
 			if(3)
 				affected_mob.emote("frown")
 				affected_mob.add_mood_event("happiness_drug", /datum/mood_event/happiness_drug_bad_od)
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/pumpup
@@ -341,7 +341,7 @@
 
 /datum/reagent/drug/pumpup/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_jitter_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(2.5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[pick("Go! Go! GO!", "You feel ready...", "You feel invincible...")]"))
@@ -356,7 +356,7 @@
 
 /datum/reagent/drug/pumpup/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_jitter_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(2.5 SECONDS * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
 	if(SPT_PROB(2.5, seconds_per_tick))
 		affected_mob.drop_all_held_items()
@@ -397,11 +397,11 @@
 
 /datum/reagent/drug/maint/powder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.05 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.1 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	// 5x if you want to OD, you can potentially go higher, but good luck managing the brain damage.
 	var/amt = max(round(volume/3, 0.1), 1)
 	affected_mob?.mind?.experience_multiplier_reasons |= type
-	affected_mob?.mind?.experience_multiplier_reasons[type] = 0.5 * amt * metabolization_ratio * seconds_per_tick
+	affected_mob?.mind?.experience_multiplier_reasons[type] = 1 * amt * metabolization_ratio * seconds_per_tick
 
 /datum/reagent/drug/maint/powder/on_mob_end_metabolize(mob/living/affected_mob)
 	. = ..()
@@ -410,7 +410,7 @@
 
 /datum/reagent/drug/maint/powder/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 3 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 6 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/maint/sludge
@@ -425,7 +425,7 @@
 
 /datum/reagent/drug/maint/sludge/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(0.25 * metabolization_ratio * seconds_per_tick, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.125 * metabolization_ratio * seconds_per_tick, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/maint/sludge/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
@@ -437,7 +437,7 @@
 	var/need_mob_update
 	need_mob_update = carbie.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(SPT_PROB(5, seconds_per_tick))
-		need_mob_update += carbie.adjust_tox_loss(5, required_biotype = affected_biotype, updating_health = FALSE)
+		need_mob_update += carbie.adjust_tox_loss(5 * metabolization_ratio, required_biotype = affected_biotype, updating_health = FALSE)
 		carbie.vomit(VOMIT_CATEGORY_DEFAULT)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
@@ -452,15 +452,15 @@
 
 /datum/reagent/drug/maint/tar/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.AdjustAllImmobility(-5 * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.75 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	affected_mob.AdjustAllImmobility(-10 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 1.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/maint/tar/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_update
-	need_update = affected_mob.adjust_tox_loss(2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 1.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_update = affected_mob.adjust_tox_loss(5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 3 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_update)
 		return UPDATE_MOB_HEALTH
 
@@ -477,18 +477,18 @@
 
 /datum/reagent/drug/mushroomhallucinogen/on_mob_life(mob/living/carbon/psychonaut, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	psychonaut.set_slurring_if_lower(0.5 SECONDS * metabolization_ratio * seconds_per_tick)
+	psychonaut.set_slurring_if_lower(2.5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	switch(current_cycle)
 		if(2 to 6)
 			if(SPT_PROB(5, seconds_per_tick))
 				psychonaut.emote(pick("twitch","giggle"))
 		if(6 to 11)
-			psychonaut.set_jitter_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
+			psychonaut.set_jitter_if_lower(50 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(10, seconds_per_tick))
 				psychonaut.emote(pick("twitch","giggle"))
 		if (11 to INFINITY)
-			psychonaut.set_jitter_if_lower(20 SECONDS * metabolization_ratio * seconds_per_tick)
+			psychonaut.set_jitter_if_lower(100 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(16, seconds_per_tick))
 				psychonaut.emote(pick("twitch","giggle"))
 
@@ -613,7 +613,7 @@
 
 /datum/reagent/drug/blastoff/on_mob_life(mob/living/carbon/dancer, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(dancer.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.15 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(dancer.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.3 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
 	dancer.AdjustKnockdown(-20)
 
@@ -622,7 +622,7 @@
 
 /datum/reagent/drug/blastoff/overdose_process(mob/living/dancer, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(dancer.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.15 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(dancer.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.3 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
 
 	if(SPT_PROB(BLASTOFF_DANCE_MOVE_CHANCE_PER_UNIT * volume, seconds_per_tick))
@@ -678,14 +678,13 @@
 	taste_description = "metallic bitterness"
 	color = "#638b9b"
 	overdose_threshold = 25
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	ph = 10
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/maintenance_drugs = 20)
 
 /datum/reagent/drug/saturnx/on_mob_life(mob/living/carbon/invisible_man, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.15 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.3 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/saturnx/on_mob_metabolize(mob/living/invisible_man)
@@ -761,7 +760,7 @@
 		invisible_man.emote("giggle")
 	if(SPT_PROB(5, seconds_per_tick))
 		invisible_man.emote("laugh")
-	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.2 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, ((0.2 * REAGENTS_METABOLISM) / metabolization_rate) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/saturnx/stable
@@ -840,14 +839,14 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 	. = ..()
 	var/need_mob_update
 	kronkaine_fiend.add_mood_event("tweaking", /datum/mood_event/stimulant_medium)
-	if(kronkaine_fiend.adjust_organ_loss(ORGAN_SLOT_HEART, 0.5 * (0.1 + 0.04 * volume) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(kronkaine_fiend.adjust_organ_loss(ORGAN_SLOT_HEART, 0.67 * (0.1 + 0.04 * volume) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		need_mob_update = UPDATE_MOB_HEALTH
 		if(kronkaine_fiend.get_organ_loss(ORGAN_SLOT_HEART) >= 75 && prob(15))
 			to_chat(kronkaine_fiend, span_userdanger("You feel like your heart is about to explode!"))
 			playsound(kronkaine_fiend, 'sound/effects/singlebeat.ogg', 200, TRUE)
-	kronkaine_fiend.set_jitter_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
-	kronkaine_fiend.AdjustSleeping(-1 SECONDS * metabolization_ratio * seconds_per_tick)
-	kronkaine_fiend.adjust_drowsiness(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+	kronkaine_fiend.set_jitter_if_lower(13.34 SECONDS * metabolization_ratio * seconds_per_tick)
+	kronkaine_fiend.AdjustSleeping(-1.34 SECONDS * metabolization_ratio * seconds_per_tick)
+	kronkaine_fiend.adjust_drowsiness(-6.67 SECONDS * metabolization_ratio * seconds_per_tick)
 	/* Do not try to cheese the overdose threshhold with purging chems to become stamina immune, if you purge and take stamina damage you will be punished!
 
 	The reason why I choose to add the adrenal crisis anti-cheese mechanic is because the main combat benefit is so front loaded, you could easily negate all the risk and downsides by mixing it with a small amount of a purger like haloperidol.
@@ -860,15 +859,15 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 				kronkaine_fiend.visible_message(span_bolddanger("[kronkaine_fiend.name] suddenly tenses up, it looks like the shock is causing their body to shut down!"), span_userdanger("The sudden shock in combination with the cocktail of drugs and purgatives in your body makes your adrenal system go haywire. Uh oh!"))
 				kronkaine_fiend.ForceContractDisease(new /datum/disease/adrenal_crisis(), FALSE, TRUE) //We punish players for purging, since unchecked purging would allow players to reap the stamina healing benefits without any drawbacks. This also has the benefit of making haloperidol a counter, like it is supposed to be.
 				break
-	need_mob_update = kronkaine_fiend.adjust_stamina_loss(-0.4 * volume * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update = kronkaine_fiend.adjust_stamina_loss(-0.54 * volume * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/kronkaine/overdose_process(mob/living/kronkaine_fiend, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(kronkaine_fiend.adjust_organ_loss(ORGAN_SLOT_HEART, 0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(kronkaine_fiend.adjust_organ_loss(ORGAN_SLOT_HEART, 0.34 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
-	kronkaine_fiend.set_jitter_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
+	kronkaine_fiend.set_jitter_if_lower(13.34 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(SPT_PROB(10, seconds_per_tick))
 		to_chat(kronkaine_fiend, span_danger(pick("Your heart is racing!", "Your ears are ringing!", "You sweat like a pig!", "You clench your jaw and grind your teeth.", "You feel prickles of pain in your chest.")))
 
@@ -913,7 +912,7 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 	if(isnull(liver) || !(liver.organ_flags & affected_organ_flags))
 		return
 	// non-trivial but not immediately dangerous liver damage
-	liver.apply_organ_damage(0.25 * metabolization_ratio * seconds_per_tick)
+	liver.apply_organ_damage(0.5 * metabolization_ratio * seconds_per_tick)
 	// anti-hallucinogens can counteract the effects
 	if(HAS_TRAIT(affected_mob, TRAIT_HALLUCINATION_IMMUNE) || affected_mob.reagents.has_reagent(/datum/reagent/medicine/haloperidol, amount = 3, needs_metabolizing = TRUE))
 		QDEL_NULL(active_hallucination_weakref)
@@ -933,7 +932,7 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 		active_hallucination_weakref = WEAKREF(affected_mob.cause_hallucination(greatest_fear, name, duration = 5 MINUTES, skip_nearby = !overdosed))
 	else
 		// if they're just some random schmuck, give them random hallucinations
-		affected_mob.adjust_hallucinations_up_to(2 SECONDS * metabolization_ratio * seconds_per_tick, 30 SECONDS)
+		affected_mob.adjust_hallucinations_up_to(4 SECONDS * metabolization_ratio * seconds_per_tick, 30 SECONDS)
 
 /datum/reagent/drug/syndol/on_mob_end_metabolize(mob/living/affected_mob)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -18,20 +18,20 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/hallucinogens = 10) //4 per 2 seconds
 
-/datum/reagent/drug/space_drugs/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/drug/space_drugs/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.set_drugginess(30 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_drugginess(15 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(isturf(affected_mob.loc) && !isspaceturf(affected_mob.loc) && !HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && SPT_PROB(5, seconds_per_tick))
 		step(affected_mob, pick(GLOB.cardinals))
 	if(SPT_PROB(3.5, seconds_per_tick))
 		affected_mob.emote(pick("twitch","drool","moan","giggle"))
 
-/datum/reagent/drug/space_drugs/overdose_start(mob/living/affected_mob)
+/datum/reagent/drug/space_drugs/overdose_start(mob/living/affected_mob, metabolized_volume)
 	. = ..()
 	to_chat(affected_mob, span_userdanger("You start tripping hard!"))
 	affected_mob.add_mood_event("[type]_overdose", /datum/mood_event/overdose, name)
 
-/datum/reagent/drug/space_drugs/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/drug/space_drugs/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/hallucination_duration_in_seconds = (affected_mob.get_timed_status_effect_duration(/datum/status_effect/hallucination) / 10)
 	if(hallucination_duration_in_seconds < volume && SPT_PROB(10, seconds_per_tick))
@@ -46,7 +46,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 
-/datum/reagent/drug/cannabis/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/drug/cannabis/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	affected_mob.apply_status_effect(/datum/status_effect/stoned)
 	if(SPT_PROB(1, seconds_per_tick))
@@ -54,7 +54,7 @@
 		to_chat(affected_mob, span_notice("[smoke_message]"))
 	if(SPT_PROB(2, seconds_per_tick))
 		affected_mob.emote(pick("smile","laugh","giggle"))
-	affected_mob.adjust_nutrition(-0.15 * REM * seconds_per_tick) //munchies
+	affected_mob.adjust_nutrition(-0.075 * REM * metabolized_volume * seconds_per_tick) //munchies
 	if(SPT_PROB(4, seconds_per_tick) && affected_mob.body_position == LYING_DOWN && !affected_mob.IsSleeping()) //chance to fall asleep if lying down
 		to_chat(affected_mob, span_warning("You doze off..."))
 		affected_mob.Sleeping(10 SECONDS)
@@ -79,22 +79,22 @@
 	mytray.adjust_toxic(round(volume))
 	mytray.adjust_pestlevel(-rand(1, 2))
 
-/datum/reagent/drug/nicotine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/drug/nicotine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(0.5, seconds_per_tick))
 		var/smoke_message = pick("You feel relaxed.", "You feel calmed.","You feel alert.","You feel rugged.")
 		to_chat(affected_mob, span_notice("[smoke_message]"))
 	affected_mob.add_mood_event("smoked", /datum/mood_event/smoked)
 	affected_mob.remove_status_effect(/datum/status_effect/jitter)
-	affected_mob.AdjustAllImmobility(-50 * REM * seconds_per_tick)
+	affected_mob.AdjustAllImmobility(-25 * REM * metabolized_volume * seconds_per_tick)
 
 	return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/nicotine/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/drug/nicotine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(0.1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(1.1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update = affected_mob.adjust_tox_loss(0.05 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(0.55 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -109,7 +109,7 @@
 	inverse_chem = /datum/reagent/inverse/krokodil
 	addiction_types = list(/datum/addiction/opioids = 18) //7.2 per 2 seconds
 
-/datum/reagent/drug/krokodil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/drug/krokodil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/high_message = pick("You feel calm.", "You feel collected.", "You feel like you need to relax.")
 	if(SPT_PROB(2.5, seconds_per_tick))
@@ -125,11 +125,11 @@
 			if(affected_mob.adjust_brute_loss(50 * REM, updating_health = FALSE, required_bodytype = affected_bodytype)) // holy shit your skin just FELL THE FUCK OFF
 				return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/krokodil/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/drug/krokodil/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.25 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update = affected_mob.adjust_tox_loss(0.25 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.125 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_tox_loss(0.125 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -168,26 +168,26 @@
 	. = ..()
 	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/methamphetamine)
 
-/datum/reagent/drug/methamphetamine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/drug/methamphetamine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/high_message = pick("You feel hyper.", "You feel like you need to go faster.", "You feel like you can run the world.", "You understand now.")
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[high_message]"))
 	affected_mob.add_mood_event("tweaking", /datum/mood_event/stimulant_medium)
-	affected_mob.AdjustAllImmobility(-40 * REM * seconds_per_tick)
+	affected_mob.AdjustAllImmobility(-20 * REM * metabolized_volume * seconds_per_tick)
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(-5 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	affected_mob.set_jitter_if_lower(4 SECONDS * REM * seconds_per_tick)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, rand(1, 4) * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_stamina_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	affected_mob.set_jitter_if_lower(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * rand(1, 4) * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH
 	if(SPT_PROB(2.5, seconds_per_tick))
 		affected_mob.emote(pick("twitch", "shiver"))
 
-/datum/reagent/drug/methamphetamine/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/drug/methamphetamine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && !ismovable(affected_mob.loc))
-		for(var/i in 1 to round(4 * REM * seconds_per_tick, 1))
+		for(var/i in 1 to round(2 * REM * metabolized_volume * seconds_per_tick, 1))
 			step(affected_mob, pick(GLOB.cardinals))
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.emote("laugh")
@@ -195,8 +195,8 @@
 		affected_mob.visible_message(span_danger("[affected_mob]'s hands flip out and flail everywhere!"))
 		affected_mob.drop_all_held_items()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, (rand(5, 10) / 10) * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * (rand(5, 10) / 10) * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -226,27 +226,27 @@
 	if(rage)
 		QDEL_NULL(rage)
 
-/datum/reagent/drug/bath_salts/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/drug/bath_salts/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[high_message]"))
 	affected_mob.add_mood_event("salted", /datum/mood_event/stimulant_heavy)
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(-6 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 4 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	affected_mob.adjust_hallucinations(10 SECONDS * REM * seconds_per_tick)
+	need_mob_update = affected_mob.adjust_stamina_loss(-3 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	affected_mob.adjust_hallucinations(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH
 	if(!HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && !ismovable(affected_mob.loc))
 		step(affected_mob, pick(GLOB.cardinals))
 		step(affected_mob, pick(GLOB.cardinals))
 
-/datum/reagent/drug/bath_salts/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/drug/bath_salts/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_hallucinations(10 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_hallucinations(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(!HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && !ismovable(affected_mob.loc))
-		for(var/i in 1 to round(8 * REM * seconds_per_tick, 1))
+		for(var/i in 1 to round(4 * REM * metabolized_volume * seconds_per_tick, 1))
 			step(affected_mob, pick(GLOB.cardinals))
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.emote(pick("twitch","drool","moan"))
@@ -263,14 +263,14 @@
 	addiction_types = list(/datum/addiction/stimulants = 8)
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/drug/aranesp/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/drug/aranesp/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[high_message]"))
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(-18 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_tox_loss(0.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_stamina_loss(-9 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_tox_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(SPT_PROB(30, seconds_per_tick))
 		affected_mob.losebreath++
 		need_mob_update += affected_mob.adjust_oxy_loss(1, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
@@ -297,15 +297,15 @@
 	. = ..()
 	affected_mob.clear_mood_event("happiness_drug")
 
-/datum/reagent/drug/happiness/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/drug/happiness/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	affected_mob.remove_status_effect(/datum/status_effect/jitter)
 	affected_mob.remove_status_effect(/datum/status_effect/confusion)
 	affected_mob.disgust = 0
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.2 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.1 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/happiness/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/drug/happiness/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(16, seconds_per_tick))
 		var/reaction = rand(1,3)
@@ -319,7 +319,7 @@
 			if(3)
 				affected_mob.emote("frown")
 				affected_mob.add_mood_event("happiness_drug", /datum/mood_event/happiness_drug_bad_od)
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.25 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/pumpup
@@ -339,9 +339,9 @@
 		affected_mob.add_mood_event("maintenance_fun", /datum/mood_event/maintenance_high)
 		metabolization_rate *= 0.8
 
-/datum/reagent/drug/pumpup/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/drug/pumpup/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.set_jitter_if_lower(10 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[pick("Go! Go! GO!", "You feel ready...", "You feel invincible...")]"))
@@ -350,13 +350,13 @@
 		affected_mob.adjust_tox_loss(2, updating_health = FALSE, required_biotype = affected_biotype)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/pumpup/overdose_start(mob/living/affected_mob)
+/datum/reagent/drug/pumpup/overdose_start(mob/living/affected_mob, metabolized_volume)
 	. = ..()
 	to_chat(affected_mob, span_userdanger("You can't stop shaking, your heart beats faster and faster..."))
 
-/datum/reagent/drug/pumpup/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/drug/pumpup/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.set_jitter_if_lower(10 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	var/need_mob_update
 	if(SPT_PROB(2.5, seconds_per_tick))
 		affected_mob.drop_all_held_items()
@@ -395,22 +395,22 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/maintenance_drugs = 14)
 
-/datum/reagent/drug/maint/powder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/drug/maint/powder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.1 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.05 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	// 5x if you want to OD, you can potentially go higher, but good luck managing the brain damage.
 	var/amt = max(round(volume/3, 0.1), 1)
 	affected_mob?.mind?.experience_multiplier_reasons |= type
-	affected_mob?.mind?.experience_multiplier_reasons[type] = amt * REM * seconds_per_tick
+	affected_mob?.mind?.experience_multiplier_reasons[type] = 0.5 * amt * REM * metabolized_volume * seconds_per_tick
 
 /datum/reagent/drug/maint/powder/on_mob_end_metabolize(mob/living/affected_mob)
 	. = ..()
 	affected_mob?.mind?.experience_multiplier_reasons[type] = null
 	affected_mob?.mind?.experience_multiplier_reasons -= type
 
-/datum/reagent/drug/maint/powder/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/drug/maint/powder/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 6 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 3 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/maint/sludge
@@ -423,19 +423,19 @@
 	addiction_types = list(/datum/addiction/maintenance_drugs = 8)
 	metabolized_traits = list(TRAIT_HARDLY_WOUNDED, TRAIT_ANALGESIA)
 
-/datum/reagent/drug/maint/sludge/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/drug/maint/sludge/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(0.5 * REM * seconds_per_tick, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.25 * REM * metabolized_volume * seconds_per_tick, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/maint/sludge/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/drug/maint/sludge/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!iscarbon(affected_mob))
 		return
 	var/mob/living/carbon/carbie = affected_mob
 	//You will be vomiting so the damage is really for a few ticks before you flush it out of your system
 	var/need_mob_update
-	need_mob_update = carbie.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = carbie.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(SPT_PROB(5, seconds_per_tick))
 		need_mob_update += carbie.adjust_tox_loss(5, required_biotype = affected_biotype, updating_health = FALSE)
 		carbie.vomit(VOMIT_CATEGORY_DEFAULT)
@@ -450,17 +450,17 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/maintenance_drugs = 5)
 
-/datum/reagent/drug/maint/tar/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/drug/maint/tar/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.AdjustAllImmobility(-10 * REM * seconds_per_tick)
-	affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 1.5 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	affected_mob.AdjustAllImmobility(-5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.75 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/maint/tar/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/drug/maint/tar/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_update
-	need_update = affected_mob.adjust_tox_loss(5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 3 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_update = affected_mob.adjust_tox_loss(2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 1.5 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_update)
 		return UPDATE_MOB_HEALTH
 
@@ -475,20 +475,20 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/hallucinogens = 12)
 
-/datum/reagent/drug/mushroomhallucinogen/on_mob_life(mob/living/carbon/psychonaut, seconds_per_tick)
+/datum/reagent/drug/mushroomhallucinogen/on_mob_life(mob/living/carbon/psychonaut, seconds_per_tick, metabolized_volume)
 	. = ..()
-	psychonaut.set_slurring_if_lower(1 SECONDS * REM * seconds_per_tick)
+	psychonaut.set_slurring_if_lower(0.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 	switch(current_cycle)
 		if(2 to 6)
 			if(SPT_PROB(5, seconds_per_tick))
 				psychonaut.emote(pick("twitch","giggle"))
 		if(6 to 11)
-			psychonaut.set_jitter_if_lower(20 SECONDS * REM * seconds_per_tick)
+			psychonaut.set_jitter_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
 			if(SPT_PROB(10, seconds_per_tick))
 				psychonaut.emote(pick("twitch","giggle"))
 		if (11 to INFINITY)
-			psychonaut.set_jitter_if_lower(40 SECONDS * REM * seconds_per_tick)
+			psychonaut.set_jitter_if_lower(20 SECONDS * REM * metabolized_volume * seconds_per_tick)
 			if(SPT_PROB(16, seconds_per_tick))
 				psychonaut.emote(pick("twitch","giggle"))
 
@@ -539,7 +539,7 @@
 	game_plane_master_controller.remove_filter("rainbow")
 	game_plane_master_controller.remove_filter("psilocybin_wave")
 
-/datum/reagent/drug/mushroomhallucinogen/overdose_process(mob/living/psychonaut, seconds_per_tick)
+/datum/reagent/drug/mushroomhallucinogen/overdose_process(mob/living/psychonaut, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(10, seconds_per_tick))
 		psychonaut.emote(pick("twitch","drool","moan"))
@@ -611,18 +611,18 @@
 	game_plane_master_controller.remove_filter("blastoff_wave")
 	dancer.sound_environment_override = NONE
 
-/datum/reagent/drug/blastoff/on_mob_life(mob/living/carbon/dancer, seconds_per_tick)
+/datum/reagent/drug/blastoff/on_mob_life(mob/living/carbon/dancer, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(dancer.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.3 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(dancer.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.15 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
 	dancer.AdjustKnockdown(-20)
 
 	if(SPT_PROB(BLASTOFF_DANCE_MOVE_CHANCE_PER_UNIT * volume, seconds_per_tick))
 		dancer.emote("flip")
 
-/datum/reagent/drug/blastoff/overdose_process(mob/living/dancer, seconds_per_tick)
+/datum/reagent/drug/blastoff/overdose_process(mob/living/dancer, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(dancer.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.3 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(dancer.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.15 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
 
 	if(SPT_PROB(BLASTOFF_DANCE_MOVE_CHANCE_PER_UNIT * volume, seconds_per_tick))
@@ -683,9 +683,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/maintenance_drugs = 20)
 
-/datum/reagent/drug/saturnx/on_mob_life(mob/living/carbon/invisible_man, seconds_per_tick)
+/datum/reagent/drug/saturnx/on_mob_life(mob/living/carbon/invisible_man, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.3 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.15 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/saturnx/on_mob_metabolize(mob/living/invisible_man)
@@ -755,13 +755,13 @@
 	game_plane_master_controller.remove_filter("saturnx_filter")
 	game_plane_master_controller.remove_filter("saturnx_blur")
 
-/datum/reagent/drug/saturnx/overdose_process(mob/living/invisible_man, seconds_per_tick)
+/datum/reagent/drug/saturnx/overdose_process(mob/living/invisible_man, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(7.5, seconds_per_tick))
 		invisible_man.emote("giggle")
 	if(SPT_PROB(5, seconds_per_tick))
 		invisible_man.emote("laugh")
-	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.4 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.2 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/saturnx/stable
@@ -836,18 +836,18 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 		stamina_heal_per_unit = 6
 	druggo.adjust_stamina_loss(-stamina_heal_per_unit * trans_volume)
 
-/datum/reagent/drug/kronkaine/on_mob_life(mob/living/carbon/kronkaine_fiend, seconds_per_tick)
+/datum/reagent/drug/kronkaine/on_mob_life(mob/living/carbon/kronkaine_fiend, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	kronkaine_fiend.add_mood_event("tweaking", /datum/mood_event/stimulant_medium)
-	if(kronkaine_fiend.adjust_organ_loss(ORGAN_SLOT_HEART, (0.1 + 0.04 * volume) * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(kronkaine_fiend.adjust_organ_loss(ORGAN_SLOT_HEART, 0.5 * (0.1 + 0.04 * volume) * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		need_mob_update = UPDATE_MOB_HEALTH
 		if(kronkaine_fiend.get_organ_loss(ORGAN_SLOT_HEART) >= 75 && prob(15))
 			to_chat(kronkaine_fiend, span_userdanger("You feel like your heart is about to explode!"))
 			playsound(kronkaine_fiend, 'sound/effects/singlebeat.ogg', 200, TRUE)
-	kronkaine_fiend.set_jitter_if_lower(20 SECONDS * REM * seconds_per_tick)
-	kronkaine_fiend.AdjustSleeping(-2 SECONDS * REM * seconds_per_tick)
-	kronkaine_fiend.adjust_drowsiness(-10 SECONDS * REM * seconds_per_tick)
+	kronkaine_fiend.set_jitter_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	kronkaine_fiend.AdjustSleeping(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	kronkaine_fiend.adjust_drowsiness(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	/* Do not try to cheese the overdose threshhold with purging chems to become stamina immune, if you purge and take stamina damage you will be punished!
 
 	The reason why I choose to add the adrenal crisis anti-cheese mechanic is because the main combat benefit is so front loaded, you could easily negate all the risk and downsides by mixing it with a small amount of a purger like haloperidol.
@@ -860,19 +860,19 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 				kronkaine_fiend.visible_message(span_bolddanger("[kronkaine_fiend.name] suddenly tenses up, it looks like the shock is causing their body to shut down!"), span_userdanger("The sudden shock in combination with the cocktail of drugs and purgatives in your body makes your adrenal system go haywire. Uh oh!"))
 				kronkaine_fiend.ForceContractDisease(new /datum/disease/adrenal_crisis(), FALSE, TRUE) //We punish players for purging, since unchecked purging would allow players to reap the stamina healing benefits without any drawbacks. This also has the benefit of making haloperidol a counter, like it is supposed to be.
 				break
-	need_mob_update = kronkaine_fiend.adjust_stamina_loss(-0.8 * volume * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update = kronkaine_fiend.adjust_stamina_loss(-0.4 * volume * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/kronkaine/overdose_process(mob/living/kronkaine_fiend, seconds_per_tick)
+/datum/reagent/drug/kronkaine/overdose_process(mob/living/kronkaine_fiend, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(kronkaine_fiend.adjust_organ_loss(ORGAN_SLOT_HEART, 0.5 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(kronkaine_fiend.adjust_organ_loss(ORGAN_SLOT_HEART, 0.25 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
-	kronkaine_fiend.set_jitter_if_lower(20 SECONDS * REM * seconds_per_tick)
+	kronkaine_fiend.set_jitter_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(SPT_PROB(10, seconds_per_tick))
 		to_chat(kronkaine_fiend, span_danger(pick("Your heart is racing!", "Your ears are ringing!", "You sweat like a pig!", "You clench your jaw and grind your teeth.", "You feel prickles of pain in your chest.")))
 
-/datum/reagent/drug/kronkaine/overdose_start(mob/living/affected_mob)
+/datum/reagent/drug/kronkaine/overdose_start(mob/living/affected_mob, metabolized_volume)
 	. = ..()
 	SEND_SOUND(affected_mob, sound('sound/effects/health/fastbeat.ogg', repeat = TRUE, channel = CHANNEL_HEARTBEAT, volume = 90))
 
@@ -884,7 +884,7 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 	ph = 4
 	chemical_flags = NONE
 
-/datum/reagent/drug/kronkaine/gore/overdose_start(mob/living/gored)
+/datum/reagent/drug/kronkaine/gore/overdose_start(mob/living/gored, metabolized_volume)
 	. = ..()
 	gored.visible_message(
 		span_danger("[gored] explodes in a shower of gore!"),
@@ -907,13 +907,13 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 	/// Track the active hallucination we're giving out so we don't replace it by accident
 	VAR_PRIVATE/datum/weakref/active_hallucination_weakref
 
-/datum/reagent/drug/syndol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/drug/syndol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(isnull(liver) || !(liver.organ_flags & affected_organ_flags))
 		return
 	// non-trivial but not immediately dangerous liver damage
-	liver.apply_organ_damage(0.5 * REM * seconds_per_tick)
+	liver.apply_organ_damage(0.25 * REM * metabolized_volume * seconds_per_tick)
 	// anti-hallucinogens can counteract the effects
 	if(HAS_TRAIT(affected_mob, TRAIT_HALLUCINATION_IMMUNE) || affected_mob.reagents.has_reagent(/datum/reagent/medicine/haloperidol, amount = 3, needs_metabolizing = TRUE))
 		QDEL_NULL(active_hallucination_weakref)
@@ -933,13 +933,13 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 		active_hallucination_weakref = WEAKREF(affected_mob.cause_hallucination(greatest_fear, name, duration = 5 MINUTES, skip_nearby = !overdosed))
 	else
 		// if they're just some random schmuck, give them random hallucinations
-		affected_mob.adjust_hallucinations_up_to(4 SECONDS * REM * seconds_per_tick, 30 SECONDS)
+		affected_mob.adjust_hallucinations_up_to(2 SECONDS * REM * metabolized_volume * seconds_per_tick, 30 SECONDS)
 
 /datum/reagent/drug/syndol/on_mob_end_metabolize(mob/living/affected_mob)
 	. = ..()
 	affected_mob.adjust_hallucinations(-16 SECONDS)
 	QDEL_NULL(active_hallucination_weakref)
 
-/datum/reagent/drug/syndol/overdose_start(mob/living/affected_mob)
+/datum/reagent/drug/syndol/overdose_start(mob/living/affected_mob, metabolized_volume)
 	// no message, just refresh the hallucination
 	QDEL_NULL(active_hallucination_weakref)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -18,20 +18,20 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/hallucinogens = 10) //4 per 2 seconds
 
-/datum/reagent/drug/space_drugs/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/space_drugs/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_drugginess(15 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_drugginess(15 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(isturf(affected_mob.loc) && !isspaceturf(affected_mob.loc) && !HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && SPT_PROB(5, seconds_per_tick))
 		step(affected_mob, pick(GLOB.cardinals))
 	if(SPT_PROB(3.5, seconds_per_tick))
 		affected_mob.emote(pick("twitch","drool","moan","giggle"))
 
-/datum/reagent/drug/space_drugs/overdose_start(mob/living/affected_mob, metabolized_volume)
+/datum/reagent/drug/space_drugs/overdose_start(mob/living/affected_mob, metabolization_ratio)
 	. = ..()
 	to_chat(affected_mob, span_userdanger("You start tripping hard!"))
 	affected_mob.add_mood_event("[type]_overdose", /datum/mood_event/overdose, name)
 
-/datum/reagent/drug/space_drugs/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/space_drugs/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/hallucination_duration_in_seconds = (affected_mob.get_timed_status_effect_duration(/datum/status_effect/hallucination) / 10)
 	if(hallucination_duration_in_seconds < volume && SPT_PROB(10, seconds_per_tick))
@@ -46,7 +46,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 
-/datum/reagent/drug/cannabis/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/cannabis/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	affected_mob.apply_status_effect(/datum/status_effect/stoned)
 	if(SPT_PROB(1, seconds_per_tick))
@@ -54,7 +54,7 @@
 		to_chat(affected_mob, span_notice("[smoke_message]"))
 	if(SPT_PROB(2, seconds_per_tick))
 		affected_mob.emote(pick("smile","laugh","giggle"))
-	affected_mob.adjust_nutrition(-0.075 * REM * metabolized_volume * seconds_per_tick) //munchies
+	affected_mob.adjust_nutrition(-0.075 * metabolization_ratio * seconds_per_tick) //munchies
 	if(SPT_PROB(4, seconds_per_tick) && affected_mob.body_position == LYING_DOWN && !affected_mob.IsSleeping()) //chance to fall asleep if lying down
 		to_chat(affected_mob, span_warning("You doze off..."))
 		affected_mob.Sleeping(10 SECONDS)
@@ -79,22 +79,22 @@
 	mytray.adjust_toxic(round(volume))
 	mytray.adjust_pestlevel(-rand(1, 2))
 
-/datum/reagent/drug/nicotine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/nicotine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(0.5, seconds_per_tick))
 		var/smoke_message = pick("You feel relaxed.", "You feel calmed.","You feel alert.","You feel rugged.")
 		to_chat(affected_mob, span_notice("[smoke_message]"))
 	affected_mob.add_mood_event("smoked", /datum/mood_event/smoked)
 	affected_mob.remove_status_effect(/datum/status_effect/jitter)
-	affected_mob.AdjustAllImmobility(-25 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.AdjustAllImmobility(-25 * metabolization_ratio * seconds_per_tick)
 
 	return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/nicotine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/nicotine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(0.05 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(0.55 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update = affected_mob.adjust_tox_loss(0.05 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(0.55 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -109,7 +109,7 @@
 	inverse_chem = /datum/reagent/inverse/krokodil
 	addiction_types = list(/datum/addiction/opioids = 18) //7.2 per 2 seconds
 
-/datum/reagent/drug/krokodil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/krokodil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/high_message = pick("You feel calm.", "You feel collected.", "You feel like you need to relax.")
 	if(SPT_PROB(2.5, seconds_per_tick))
@@ -125,11 +125,11 @@
 			if(affected_mob.adjust_brute_loss(50 * REM, updating_health = FALSE, required_bodytype = affected_bodytype)) // holy shit your skin just FELL THE FUCK OFF
 				return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/krokodil/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/krokodil/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.125 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update = affected_mob.adjust_tox_loss(0.125 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.125 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_tox_loss(0.125 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -168,26 +168,26 @@
 	. = ..()
 	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/methamphetamine)
 
-/datum/reagent/drug/methamphetamine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/methamphetamine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/high_message = pick("You feel hyper.", "You feel like you need to go faster.", "You feel like you can run the world.", "You understand now.")
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[high_message]"))
 	affected_mob.add_mood_event("tweaking", /datum/mood_event/stimulant_medium)
-	affected_mob.AdjustAllImmobility(-20 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.AdjustAllImmobility(-20 * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	affected_mob.set_jitter_if_lower(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * rand(1, 4) * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_stamina_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	affected_mob.set_jitter_if_lower(2 SECONDS * metabolization_ratio * seconds_per_tick)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * rand(1, 4) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH
 	if(SPT_PROB(2.5, seconds_per_tick))
 		affected_mob.emote(pick("twitch", "shiver"))
 
-/datum/reagent/drug/methamphetamine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/methamphetamine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && !ismovable(affected_mob.loc))
-		for(var/i in 1 to round(2 * REM * metabolized_volume * seconds_per_tick, 1))
+		for(var/i in 1 to round(2 * metabolization_ratio * seconds_per_tick, 1))
 			step(affected_mob, pick(GLOB.cardinals))
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.emote("laugh")
@@ -195,8 +195,8 @@
 		affected_mob.visible_message(span_danger("[affected_mob]'s hands flip out and flail everywhere!"))
 		affected_mob.drop_all_held_items()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * (rand(5, 10) / 10) * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * (rand(5, 10) / 10) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -226,27 +226,27 @@
 	if(rage)
 		QDEL_NULL(rage)
 
-/datum/reagent/drug/bath_salts/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/bath_salts/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[high_message]"))
 	affected_mob.add_mood_event("salted", /datum/mood_event/stimulant_heavy)
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(-3 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	affected_mob.adjust_hallucinations(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	need_mob_update = affected_mob.adjust_stamina_loss(-3 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	affected_mob.adjust_hallucinations(5 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH
 	if(!HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && !ismovable(affected_mob.loc))
 		step(affected_mob, pick(GLOB.cardinals))
 		step(affected_mob, pick(GLOB.cardinals))
 
-/datum/reagent/drug/bath_salts/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/bath_salts/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_hallucinations(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_hallucinations(5 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(!HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && !ismovable(affected_mob.loc))
-		for(var/i in 1 to round(4 * REM * metabolized_volume * seconds_per_tick, 1))
+		for(var/i in 1 to round(4 * metabolization_ratio * seconds_per_tick, 1))
 			step(affected_mob, pick(GLOB.cardinals))
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.emote(pick("twitch","drool","moan"))
@@ -263,14 +263,14 @@
 	addiction_types = list(/datum/addiction/stimulants = 8)
 	metabolized_traits = list(TRAIT_STIMULATED)
 
-/datum/reagent/drug/aranesp/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/aranesp/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[high_message]"))
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_stamina_loss(-9 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_tox_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_stamina_loss(-9 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_tox_loss(0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(SPT_PROB(30, seconds_per_tick))
 		affected_mob.losebreath++
 		need_mob_update += affected_mob.adjust_oxy_loss(1, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
@@ -297,15 +297,15 @@
 	. = ..()
 	affected_mob.clear_mood_event("happiness_drug")
 
-/datum/reagent/drug/happiness/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/happiness/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	affected_mob.remove_status_effect(/datum/status_effect/jitter)
 	affected_mob.remove_status_effect(/datum/status_effect/confusion)
 	affected_mob.disgust = 0
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.1 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.1 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/happiness/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/happiness/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(16, seconds_per_tick))
 		var/reaction = rand(1,3)
@@ -319,7 +319,7 @@
 			if(3)
 				affected_mob.emote("frown")
 				affected_mob.add_mood_event("happiness_drug", /datum/mood_event/happiness_drug_bad_od)
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.25 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/pumpup
@@ -339,9 +339,9 @@
 		affected_mob.add_mood_event("maintenance_fun", /datum/mood_event/maintenance_high)
 		metabolization_rate *= 0.8
 
-/datum/reagent/drug/pumpup/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/pumpup/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[pick("Go! Go! GO!", "You feel ready...", "You feel invincible...")]"))
@@ -350,13 +350,13 @@
 		affected_mob.adjust_tox_loss(2, updating_health = FALSE, required_biotype = affected_biotype)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/pumpup/overdose_start(mob/living/affected_mob, metabolized_volume)
+/datum/reagent/drug/pumpup/overdose_start(mob/living/affected_mob, metabolization_ratio)
 	. = ..()
 	to_chat(affected_mob, span_userdanger("You can't stop shaking, your heart beats faster and faster..."))
 
-/datum/reagent/drug/pumpup/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/pumpup/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
 	if(SPT_PROB(2.5, seconds_per_tick))
 		affected_mob.drop_all_held_items()
@@ -395,22 +395,22 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/maintenance_drugs = 14)
 
-/datum/reagent/drug/maint/powder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/maint/powder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.05 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.05 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	// 5x if you want to OD, you can potentially go higher, but good luck managing the brain damage.
 	var/amt = max(round(volume/3, 0.1), 1)
 	affected_mob?.mind?.experience_multiplier_reasons |= type
-	affected_mob?.mind?.experience_multiplier_reasons[type] = 0.5 * amt * REM * metabolized_volume * seconds_per_tick
+	affected_mob?.mind?.experience_multiplier_reasons[type] = 0.5 * amt * metabolization_ratio * seconds_per_tick
 
 /datum/reagent/drug/maint/powder/on_mob_end_metabolize(mob/living/affected_mob)
 	. = ..()
 	affected_mob?.mind?.experience_multiplier_reasons[type] = null
 	affected_mob?.mind?.experience_multiplier_reasons -= type
 
-/datum/reagent/drug/maint/powder/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/maint/powder/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 3 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 3 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/maint/sludge
@@ -423,19 +423,19 @@
 	addiction_types = list(/datum/addiction/maintenance_drugs = 8)
 	metabolized_traits = list(TRAIT_HARDLY_WOUNDED, TRAIT_ANALGESIA)
 
-/datum/reagent/drug/maint/sludge/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/maint/sludge/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(0.25 * REM * metabolized_volume * seconds_per_tick, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.25 * metabolization_ratio * seconds_per_tick, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/maint/sludge/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/maint/sludge/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!iscarbon(affected_mob))
 		return
 	var/mob/living/carbon/carbie = affected_mob
 	//You will be vomiting so the damage is really for a few ticks before you flush it out of your system
 	var/need_mob_update
-	need_mob_update = carbie.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = carbie.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(SPT_PROB(5, seconds_per_tick))
 		need_mob_update += carbie.adjust_tox_loss(5, required_biotype = affected_biotype, updating_health = FALSE)
 		carbie.vomit(VOMIT_CATEGORY_DEFAULT)
@@ -450,17 +450,17 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/maintenance_drugs = 5)
 
-/datum/reagent/drug/maint/tar/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/maint/tar/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.AdjustAllImmobility(-5 * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.75 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	affected_mob.AdjustAllImmobility(-5 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.75 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/maint/tar/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/maint/tar/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_update
-	need_update = affected_mob.adjust_tox_loss(2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 1.5 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_update = affected_mob.adjust_tox_loss(2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 1.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	if(need_update)
 		return UPDATE_MOB_HEALTH
 
@@ -475,20 +475,20 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/hallucinogens = 12)
 
-/datum/reagent/drug/mushroomhallucinogen/on_mob_life(mob/living/carbon/psychonaut, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/mushroomhallucinogen/on_mob_life(mob/living/carbon/psychonaut, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	psychonaut.set_slurring_if_lower(0.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	psychonaut.set_slurring_if_lower(0.5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	switch(current_cycle)
 		if(2 to 6)
 			if(SPT_PROB(5, seconds_per_tick))
 				psychonaut.emote(pick("twitch","giggle"))
 		if(6 to 11)
-			psychonaut.set_jitter_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			psychonaut.set_jitter_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(10, seconds_per_tick))
 				psychonaut.emote(pick("twitch","giggle"))
 		if (11 to INFINITY)
-			psychonaut.set_jitter_if_lower(20 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			psychonaut.set_jitter_if_lower(20 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(16, seconds_per_tick))
 				psychonaut.emote(pick("twitch","giggle"))
 
@@ -539,7 +539,7 @@
 	game_plane_master_controller.remove_filter("rainbow")
 	game_plane_master_controller.remove_filter("psilocybin_wave")
 
-/datum/reagent/drug/mushroomhallucinogen/overdose_process(mob/living/psychonaut, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/mushroomhallucinogen/overdose_process(mob/living/psychonaut, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(10, seconds_per_tick))
 		psychonaut.emote(pick("twitch","drool","moan"))
@@ -611,18 +611,18 @@
 	game_plane_master_controller.remove_filter("blastoff_wave")
 	dancer.sound_environment_override = NONE
 
-/datum/reagent/drug/blastoff/on_mob_life(mob/living/carbon/dancer, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/blastoff/on_mob_life(mob/living/carbon/dancer, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(dancer.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.15 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(dancer.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.15 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
 	dancer.AdjustKnockdown(-20)
 
 	if(SPT_PROB(BLASTOFF_DANCE_MOVE_CHANCE_PER_UNIT * volume, seconds_per_tick))
 		dancer.emote("flip")
 
-/datum/reagent/drug/blastoff/overdose_process(mob/living/dancer, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/blastoff/overdose_process(mob/living/dancer, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(dancer.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.15 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(dancer.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.15 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
 
 	if(SPT_PROB(BLASTOFF_DANCE_MOVE_CHANCE_PER_UNIT * volume, seconds_per_tick))
@@ -683,9 +683,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/maintenance_drugs = 20)
 
-/datum/reagent/drug/saturnx/on_mob_life(mob/living/carbon/invisible_man, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/saturnx/on_mob_life(mob/living/carbon/invisible_man, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.15 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.15 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/saturnx/on_mob_metabolize(mob/living/invisible_man)
@@ -755,13 +755,13 @@
 	game_plane_master_controller.remove_filter("saturnx_filter")
 	game_plane_master_controller.remove_filter("saturnx_blur")
 
-/datum/reagent/drug/saturnx/overdose_process(mob/living/invisible_man, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/saturnx/overdose_process(mob/living/invisible_man, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(7.5, seconds_per_tick))
 		invisible_man.emote("giggle")
 	if(SPT_PROB(5, seconds_per_tick))
 		invisible_man.emote("laugh")
-	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.2 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(invisible_man.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.2 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/drug/saturnx/stable
@@ -836,18 +836,18 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 		stamina_heal_per_unit = 6
 	druggo.adjust_stamina_loss(-stamina_heal_per_unit * trans_volume)
 
-/datum/reagent/drug/kronkaine/on_mob_life(mob/living/carbon/kronkaine_fiend, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/kronkaine/on_mob_life(mob/living/carbon/kronkaine_fiend, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	kronkaine_fiend.add_mood_event("tweaking", /datum/mood_event/stimulant_medium)
-	if(kronkaine_fiend.adjust_organ_loss(ORGAN_SLOT_HEART, 0.5 * (0.1 + 0.04 * volume) * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(kronkaine_fiend.adjust_organ_loss(ORGAN_SLOT_HEART, 0.5 * (0.1 + 0.04 * volume) * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		need_mob_update = UPDATE_MOB_HEALTH
 		if(kronkaine_fiend.get_organ_loss(ORGAN_SLOT_HEART) >= 75 && prob(15))
 			to_chat(kronkaine_fiend, span_userdanger("You feel like your heart is about to explode!"))
 			playsound(kronkaine_fiend, 'sound/effects/singlebeat.ogg', 200, TRUE)
-	kronkaine_fiend.set_jitter_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	kronkaine_fiend.AdjustSleeping(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	kronkaine_fiend.adjust_drowsiness(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	kronkaine_fiend.set_jitter_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
+	kronkaine_fiend.AdjustSleeping(-1 SECONDS * metabolization_ratio * seconds_per_tick)
+	kronkaine_fiend.adjust_drowsiness(-5 SECONDS * metabolization_ratio * seconds_per_tick)
 	/* Do not try to cheese the overdose threshhold with purging chems to become stamina immune, if you purge and take stamina damage you will be punished!
 
 	The reason why I choose to add the adrenal crisis anti-cheese mechanic is because the main combat benefit is so front loaded, you could easily negate all the risk and downsides by mixing it with a small amount of a purger like haloperidol.
@@ -860,19 +860,19 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 				kronkaine_fiend.visible_message(span_bolddanger("[kronkaine_fiend.name] suddenly tenses up, it looks like the shock is causing their body to shut down!"), span_userdanger("The sudden shock in combination with the cocktail of drugs and purgatives in your body makes your adrenal system go haywire. Uh oh!"))
 				kronkaine_fiend.ForceContractDisease(new /datum/disease/adrenal_crisis(), FALSE, TRUE) //We punish players for purging, since unchecked purging would allow players to reap the stamina healing benefits without any drawbacks. This also has the benefit of making haloperidol a counter, like it is supposed to be.
 				break
-	need_mob_update = kronkaine_fiend.adjust_stamina_loss(-0.4 * volume * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update = kronkaine_fiend.adjust_stamina_loss(-0.4 * volume * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/drug/kronkaine/overdose_process(mob/living/kronkaine_fiend, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/kronkaine/overdose_process(mob/living/kronkaine_fiend, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(kronkaine_fiend.adjust_organ_loss(ORGAN_SLOT_HEART, 0.25 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(kronkaine_fiend.adjust_organ_loss(ORGAN_SLOT_HEART, 0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
-	kronkaine_fiend.set_jitter_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	kronkaine_fiend.set_jitter_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(SPT_PROB(10, seconds_per_tick))
 		to_chat(kronkaine_fiend, span_danger(pick("Your heart is racing!", "Your ears are ringing!", "You sweat like a pig!", "You clench your jaw and grind your teeth.", "You feel prickles of pain in your chest.")))
 
-/datum/reagent/drug/kronkaine/overdose_start(mob/living/affected_mob, metabolized_volume)
+/datum/reagent/drug/kronkaine/overdose_start(mob/living/affected_mob, metabolization_ratio)
 	. = ..()
 	SEND_SOUND(affected_mob, sound('sound/effects/health/fastbeat.ogg', repeat = TRUE, channel = CHANNEL_HEARTBEAT, volume = 90))
 
@@ -884,7 +884,7 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 	ph = 4
 	chemical_flags = NONE
 
-/datum/reagent/drug/kronkaine/gore/overdose_start(mob/living/gored, metabolized_volume)
+/datum/reagent/drug/kronkaine/gore/overdose_start(mob/living/gored, metabolization_ratio)
 	. = ..()
 	gored.visible_message(
 		span_danger("[gored] explodes in a shower of gore!"),
@@ -907,13 +907,13 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 	/// Track the active hallucination we're giving out so we don't replace it by accident
 	VAR_PRIVATE/datum/weakref/active_hallucination_weakref
 
-/datum/reagent/drug/syndol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/drug/syndol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(isnull(liver) || !(liver.organ_flags & affected_organ_flags))
 		return
 	// non-trivial but not immediately dangerous liver damage
-	liver.apply_organ_damage(0.25 * REM * metabolized_volume * seconds_per_tick)
+	liver.apply_organ_damage(0.25 * metabolization_ratio * seconds_per_tick)
 	// anti-hallucinogens can counteract the effects
 	if(HAS_TRAIT(affected_mob, TRAIT_HALLUCINATION_IMMUNE) || affected_mob.reagents.has_reagent(/datum/reagent/medicine/haloperidol, amount = 3, needs_metabolizing = TRUE))
 		QDEL_NULL(active_hallucination_weakref)
@@ -933,13 +933,13 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 		active_hallucination_weakref = WEAKREF(affected_mob.cause_hallucination(greatest_fear, name, duration = 5 MINUTES, skip_nearby = !overdosed))
 	else
 		// if they're just some random schmuck, give them random hallucinations
-		affected_mob.adjust_hallucinations_up_to(2 SECONDS * REM * metabolized_volume * seconds_per_tick, 30 SECONDS)
+		affected_mob.adjust_hallucinations_up_to(2 SECONDS * metabolization_ratio * seconds_per_tick, 30 SECONDS)
 
 /datum/reagent/drug/syndol/on_mob_end_metabolize(mob/living/affected_mob)
 	. = ..()
 	affected_mob.adjust_hallucinations(-16 SECONDS)
 	QDEL_NULL(active_hallucination_weakref)
 
-/datum/reagent/drug/syndol/overdose_start(mob/living/affected_mob, metabolized_volume)
+/datum/reagent/drug/syndol/overdose_start(mob/living/affected_mob, metabolization_ratio)
 	// no message, just refresh the hallucination
 	QDEL_NULL(active_hallucination_weakref)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -372,7 +372,7 @@
 			heating = 15
 		if(35 to INFINITY)
 			heating = 20
-	affected_mob.adjust_bodytemperature(0.5 * heating * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(0.5 * TEMPERATURE_DAMAGE_COEFFICIENT * heating * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/frostoil
 	name = "Frost Oil"
@@ -403,7 +403,7 @@
 			cooling = -40
 			if(prob(5))
 				affected_mob.emote("shiver")
-	affected_mob.adjust_bodytemperature(0.5 * cooling * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50)
+	affected_mob.adjust_bodytemperature(0.5 * TEMPERATURE_DAMAGE_COEFFICIENT * cooling * metabolization_ratio * seconds_per_tick, 50)
 
 /datum/reagent/consumable/frostoil/expose_turf(turf/exposed_turf, reac_volume)
 	. = ..()
@@ -556,7 +556,7 @@
 		var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 		if(liver && HAS_TRAIT(liver, TRAIT_CULINARY_METABOLISM))
 			if(SPT_PROB(10, seconds_per_tick)) //stays in the system much longer than sprinkles/banana juice, so heals slower to partially compensate
-				if(affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, burn = 1 * metabolization_ratio, updating_health = FALSE))
+				if(affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, burn = 0.5 * metabolization_ratio, updating_health = FALSE))
 					return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/tearjuice
@@ -821,10 +821,10 @@
 	holder.add_reagent(/datum/reagent/consumable/sugar, 1.5 * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
 	if(SPT_PROB(33, seconds_per_tick))
-		need_mob_update = affected_mob.adjust_brute_loss(-1 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-1 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-1 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_tox_loss(-1 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = affected_mob.adjust_brute_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -908,9 +908,9 @@
 		affected_mob.Unconscious(20 * metabolization_ratio * seconds_per_tick, FALSE)
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.losebreath += 4
-		affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2 * metabolization_ratio, 150, affected_biotype)
-		affected_mob.adjust_tox_loss(3 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
-		affected_mob.adjust_stamina_loss(10 * metabolization_ratio, updating_stamina = FALSE, required_biotype = affected_biotype)
+		affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1 * metabolization_ratio, 150, affected_biotype)
+		affected_mob.adjust_tox_loss(1.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
+		affected_mob.adjust_stamina_loss(5 * metabolization_ratio, updating_stamina = FALSE, required_biotype = affected_biotype)
 		affected_mob.set_eye_blur_if_lower(10 SECONDS)
 		need_mob_update = TRUE
 	if(need_mob_update)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -23,13 +23,13 @@
 	// All food reagents function at a fixed rate
 	chemical_flags |= REAGENT_UNAFFECTED_BY_METABOLISM
 
-/datum/reagent/consumable/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!ishuman(affected_mob) || HAS_TRAIT(affected_mob, TRAIT_NOHUNGER))
 		return
 
 	var/mob/living/carbon/human/affected_human = affected_mob
-	affected_human.adjust_nutrition(0.5 * get_nutriment_factor(affected_mob) * REM * metabolized_volume * seconds_per_tick)
+	affected_human.adjust_nutrition(0.5 * get_nutriment_factor(affected_mob) * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
@@ -74,10 +74,10 @@
 /datum/reagent/consumable/nutriment/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)
 	mytray.adjust_plant_health(round(volume * 0.2))
 
-/datum/reagent/consumable/nutriment/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/nutriment/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(30, seconds_per_tick))
-		if(affected_mob.heal_bodypart_damage(brute = 0.5 * brute_heal * REM * metabolized_volume * seconds_per_tick, burn = 0.5 * burn_heal * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC))
+		if(affected_mob.heal_bodypart_damage(brute = 0.5 * brute_heal * metabolization_ratio, burn = 0.5 * burn_heal * metabolization_ratio, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/nutriment/on_new(list/supplied_data)
@@ -131,10 +131,10 @@
 	brute_heal = 1
 	burn_heal = 1
 
-/datum/reagent/consumable/nutriment/vitamin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/nutriment/vitamin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.satiety < MAX_SATIETY)
-		affected_mob.satiety += 15 * REM * metabolized_volume * seconds_per_tick
+		affected_mob.satiety += 15 * metabolization_ratio * seconds_per_tick
 
 /// The basic resource of vat growing.
 /datum/reagent/consumable/nutriment/protein
@@ -258,7 +258,7 @@
 	///Amount of satiety that will be drained when the cloth_fibers is fully metabolized
 	var/delayed_satiety_drain = 2 * CLOTHING_NUTRITION_GAIN
 
-/datum/reagent/consumable/nutriment/cloth_fibers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/nutriment/cloth_fibers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.satiety < MAX_SATIETY)
 		affected_mob.adjust_nutrition(CLOTHING_NUTRITION_GAIN)
@@ -306,14 +306,14 @@
 	mytray.adjust_weedlevel(rand(1, 2))
 	mytray.adjust_pestlevel(rand(1, 2))
 
-/datum/reagent/consumable/sugar/overdose_start(mob/living/affected_mob, metabolized_volume)
+/datum/reagent/consumable/sugar/overdose_start(mob/living/affected_mob, metabolization_ratio)
 	. = ..()
 	to_chat(affected_mob, span_userdanger("You go into hyperglycemic shock! Lay off the twinkies!"))
 	affected_mob.AdjustSleeping(20 SECONDS)
 
-/datum/reagent/consumable/sugar/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/sugar/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_drowsiness_up_to((2.5 SECONDS * REM * metabolized_volume * seconds_per_tick), 60 SECONDS)
+	affected_mob.adjust_drowsiness_up_to((2.5 SECONDS * metabolization_ratio * seconds_per_tick), 60 SECONDS)
 
 /datum/reagent/consumable/sugar/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
@@ -358,21 +358,21 @@
 	taste_mult = 1.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/capsaicin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/capsaicin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/heating = 0
 	switch(current_cycle)
 		if(1 to 15)
 			heating = 5
 			if(holder.has_reagent(/datum/reagent/cryostylane))
-				holder.remove_reagent(/datum/reagent/cryostylane, 2.5 * REM * metabolized_volume * seconds_per_tick)
+				holder.remove_reagent(/datum/reagent/cryostylane, 2.5 * metabolization_ratio * seconds_per_tick)
 		if(15 to 25)
 			heating = 10
 		if(25 to 35)
 			heating = 15
 		if(35 to INFINITY)
 			heating = 20
-	affected_mob.adjust_bodytemperature(0.5 * heating * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(0.5 * heating * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/frostoil
 	name = "Frost Oil"
@@ -385,14 +385,14 @@
 	specific_heat = 40
 	default_container = /obj/item/reagent_containers/cup/bottle/frostoil
 
-/datum/reagent/consumable/frostoil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/frostoil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/cooling = 0
 	switch(current_cycle)
 		if(1 to 15)
 			cooling = -10
 			if(holder.has_reagent(/datum/reagent/consumable/capsaicin))
-				holder.remove_reagent(/datum/reagent/consumable/capsaicin, 2.5 * REM * metabolized_volume * seconds_per_tick)
+				holder.remove_reagent(/datum/reagent/consumable/capsaicin, 2.5 * metabolization_ratio * seconds_per_tick)
 		if(15 to 25)
 			cooling = -20
 		if(25 to 35)
@@ -403,7 +403,7 @@
 			cooling = -40
 			if(prob(5))
 				affected_mob.emote("shiver")
-	affected_mob.adjust_bodytemperature(0.5 * cooling * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 50)
+	affected_mob.adjust_bodytemperature(0.5 * cooling * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 50)
 
 /datum/reagent/consumable/frostoil/expose_turf(turf/exposed_turf, reac_volume)
 	. = ..()
@@ -461,7 +461,7 @@
 				victim.vomit(VOMIT_CATEGORY_DEFAULT)
 	return ..()
 
-/datum/reagent/consumable/condensedcapsaicin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/condensedcapsaicin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!holder.has_reagent(/datum/reagent/consumable/milk))
 		if(SPT_PROB(5, seconds_per_tick))
@@ -542,7 +542,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	added_traits = list(TRAIT_GARLIC_BREATH)
 
-/datum/reagent/consumable/garlic/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/garlic/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(isvampire(affected_mob)) //incapacitating but not lethal. Unfortunately, vampires cannot vomit.
 		if(SPT_PROB(min((current_cycle-1)/2, 12.5), seconds_per_tick))
@@ -556,7 +556,7 @@
 		var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 		if(liver && HAS_TRAIT(liver, TRAIT_CULINARY_METABOLISM))
 			if(SPT_PROB(10, seconds_per_tick)) //stays in the system much longer than sprinkles/banana juice, so heals slower to partially compensate
-				if(affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+				if(affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, burn = 1 * metabolization_ratio, updating_health = FALSE))
 					return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/tearjuice
@@ -586,11 +586,11 @@
 	taste_description = "childhood whimsy"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/sprinkles/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/sprinkles/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		if(affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+		if(affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio * seconds_per_tick, burn = 0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/enzyme
@@ -626,9 +626,9 @@
 	taste_description = "your imprisonment"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/hot_ramen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/hot_ramen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(5 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/hell_ramen
 	name = "Hell Ramen"
@@ -638,9 +638,9 @@
 	taste_description = "wet and cheap noodles on fire"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/hell_ramen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/hell_ramen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_bodytemperature(5 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/flour
 	name = "Flour"
@@ -793,9 +793,9 @@
 	taste_description = "sweet slime"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/corn_syrup/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/corn_syrup/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	holder.add_reagent(/datum/reagent/consumable/sugar, 1.5 * REM * metabolized_volume * seconds_per_tick)
+	holder.add_reagent(/datum/reagent/consumable/sugar, 1.5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/honey
 	name = "Honey"
@@ -816,15 +816,15 @@
 	mytray.adjust_weedlevel(rand(1, 2))
 	mytray.adjust_pestlevel(rand(1, 2))
 
-/datum/reagent/consumable/honey/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/honey/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	holder.add_reagent(/datum/reagent/consumable/sugar, 1.5 * REM * metabolized_volume * seconds_per_tick)
+	holder.add_reagent(/datum/reagent/consumable/sugar, 1.5 * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
 	if(SPT_PROB(33, seconds_per_tick))
-		need_mob_update = affected_mob.adjust_brute_loss(-1, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-1, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-1, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_tox_loss(-1, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = affected_mob.adjust_brute_loss(-1 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-1 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-1 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_tox_loss(-1 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -861,7 +861,7 @@
 	metabolized_traits = list(TRAIT_GLUTTON)
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/moltobeso/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/moltobeso/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	for(var/datum/reagent/consumable/food in affected_mob.reagents.reagent_list)
 		if(food == src)
@@ -869,7 +869,7 @@
 		var/food_factor = food.get_nutriment_factor(affected_mob)
 		if(food_factor <= 0)
 			continue
-		affected_mob.adjust_nutrition(0.5 * food_factor * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_nutrition(0.5 * food_factor * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/eggrot
 	name = "Rotten Eggyolk"
@@ -885,10 +885,10 @@
 	color = "#664330" // rgb: 102, 67, 48
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/nutriment/stabilized/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/nutriment/stabilized/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.nutrition > NUTRITION_LEVEL_FULL - 25)
-		affected_mob.adjust_nutrition(-1.5 * REM * metabolized_volume * get_nutriment_factor(affected_mob) * seconds_per_tick)
+		affected_mob.adjust_nutrition(-1.5 * metabolization_ratio * get_nutriment_factor(affected_mob) * seconds_per_tick)
 
 ////Lavaland Flora Reagents////
 
@@ -901,16 +901,16 @@
 	ph = 12
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/entpoly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/entpoly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	if(current_cycle > 10)
-		affected_mob.Unconscious(20 * REM * metabolized_volume * seconds_per_tick, FALSE)
+		affected_mob.Unconscious(20 * metabolization_ratio * seconds_per_tick, FALSE)
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.losebreath += 4
-		affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2*REM, 150, affected_biotype)
-		affected_mob.adjust_tox_loss(3*REM, updating_health = FALSE, required_biotype = affected_biotype)
-		affected_mob.adjust_stamina_loss(10*REM, updating_stamina = FALSE, required_biotype = affected_biotype)
+		affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2 * metabolization_ratio, 150, affected_biotype)
+		affected_mob.adjust_tox_loss(3 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
+		affected_mob.adjust_stamina_loss(10 * metabolization_ratio, updating_stamina = FALSE, required_biotype = affected_biotype)
 		affected_mob.set_eye_blur_if_lower(10 SECONDS)
 		need_mob_update = TRUE
 	if(need_mob_update)
@@ -950,12 +950,12 @@
 	ph = 10.4
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/vitfro/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/vitfro/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	if(SPT_PROB(55, seconds_per_tick))
-		need_mob_update = affected_mob.adjust_brute_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_brute_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -980,7 +980,7 @@
 	if(istype(stomach))
 		stomach.adjust_charge(reac_volume * 30 * ETHEREAL_DISCHARGE_RATE)
 
-/datum/reagent/consumable/liquidelectricity/enriched/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/liquidelectricity/enriched/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(isethereal(affected_mob))
 		affected_mob.adjust_blood_volume(1 * seconds_per_tick)
@@ -999,10 +999,10 @@
 	overdose_threshold = 17
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/astrotame/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/astrotame/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.disgust < 80)
-		affected_mob.adjust_disgust(5 * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_disgust(5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/secretsauce
 	name = "Secret Sauce"
@@ -1050,7 +1050,7 @@
 	overdose_threshold = 15
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/char/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/char/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(13, seconds_per_tick))
 		affected_mob.say(pick_list_replacements(BOOMER_FILE, "boomer"), forced = /datum/reagent/consumable/char)
@@ -1162,11 +1162,11 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/condiment/peanut_butter
 
-/datum/reagent/consumable/peanut_butter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume) //ET loves peanut butter
+/datum/reagent/consumable/peanut_butter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio) //ET loves peanut butter
 	. = ..()
 	if(isabductor(affected_mob))
 		affected_mob.add_mood_event("ET_pieces", /datum/mood_event/et_pieces, name)
-		affected_mob.set_drugginess(15 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.set_drugginess(15 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/vinegar
 	name = "Vinegar"
@@ -1223,7 +1223,7 @@
 	taste_description = "mint"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/mintextract/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/consumable/mintextract/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(HAS_TRAIT(affected_mob, TRAIT_FAT))
 		affected_mob.investigate_log("has been gibbed by consuming [src] while fat.", INVESTIGATE_DEATHS)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -23,13 +23,13 @@
 	// All food reagents function at a fixed rate
 	chemical_flags |= REAGENT_UNAFFECTED_BY_METABOLISM
 
-/datum/reagent/consumable/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!ishuman(affected_mob) || HAS_TRAIT(affected_mob, TRAIT_NOHUNGER))
 		return
 
 	var/mob/living/carbon/human/affected_human = affected_mob
-	affected_human.adjust_nutrition(get_nutriment_factor(affected_mob) * REM * seconds_per_tick)
+	affected_human.adjust_nutrition(0.5 * get_nutriment_factor(affected_mob) * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
@@ -74,10 +74,10 @@
 /datum/reagent/consumable/nutriment/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)
 	mytray.adjust_plant_health(round(volume * 0.2))
 
-/datum/reagent/consumable/nutriment/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/nutriment/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(30, seconds_per_tick))
-		if(affected_mob.heal_bodypart_damage(brute = brute_heal * REM * seconds_per_tick, burn = burn_heal * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC))
+		if(affected_mob.heal_bodypart_damage(brute = 0.5 * brute_heal * REM * metabolized_volume * seconds_per_tick, burn = 0.5 * burn_heal * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/nutriment/on_new(list/supplied_data)
@@ -131,10 +131,10 @@
 	brute_heal = 1
 	burn_heal = 1
 
-/datum/reagent/consumable/nutriment/vitamin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/nutriment/vitamin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.satiety < MAX_SATIETY)
-		affected_mob.satiety += 30 * REM * seconds_per_tick
+		affected_mob.satiety += 15 * REM * metabolized_volume * seconds_per_tick
 
 /// The basic resource of vat growing.
 /datum/reagent/consumable/nutriment/protein
@@ -258,7 +258,7 @@
 	///Amount of satiety that will be drained when the cloth_fibers is fully metabolized
 	var/delayed_satiety_drain = 2 * CLOTHING_NUTRITION_GAIN
 
-/datum/reagent/consumable/nutriment/cloth_fibers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/nutriment/cloth_fibers/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.satiety < MAX_SATIETY)
 		affected_mob.adjust_nutrition(CLOTHING_NUTRITION_GAIN)
@@ -306,14 +306,14 @@
 	mytray.adjust_weedlevel(rand(1, 2))
 	mytray.adjust_pestlevel(rand(1, 2))
 
-/datum/reagent/consumable/sugar/overdose_start(mob/living/affected_mob)
+/datum/reagent/consumable/sugar/overdose_start(mob/living/affected_mob, metabolized_volume)
 	. = ..()
 	to_chat(affected_mob, span_userdanger("You go into hyperglycemic shock! Lay off the twinkies!"))
 	affected_mob.AdjustSleeping(20 SECONDS)
 
-/datum/reagent/consumable/sugar/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/sugar/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_drowsiness_up_to((5 SECONDS * REM * seconds_per_tick), 60 SECONDS)
+	affected_mob.adjust_drowsiness_up_to((2.5 SECONDS * REM * metabolized_volume * seconds_per_tick), 60 SECONDS)
 
 /datum/reagent/consumable/sugar/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
@@ -358,21 +358,21 @@
 	taste_mult = 1.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/capsaicin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/capsaicin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/heating = 0
 	switch(current_cycle)
 		if(1 to 15)
 			heating = 5
 			if(holder.has_reagent(/datum/reagent/cryostylane))
-				holder.remove_reagent(/datum/reagent/cryostylane, 5 * REM * seconds_per_tick)
+				holder.remove_reagent(/datum/reagent/cryostylane, 2.5 * REM * metabolized_volume * seconds_per_tick)
 		if(15 to 25)
 			heating = 10
 		if(25 to 35)
 			heating = 15
 		if(35 to INFINITY)
 			heating = 20
-	affected_mob.adjust_bodytemperature(heating * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(0.5 * heating * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/frostoil
 	name = "Frost Oil"
@@ -385,14 +385,14 @@
 	specific_heat = 40
 	default_container = /obj/item/reagent_containers/cup/bottle/frostoil
 
-/datum/reagent/consumable/frostoil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/frostoil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/cooling = 0
 	switch(current_cycle)
 		if(1 to 15)
 			cooling = -10
 			if(holder.has_reagent(/datum/reagent/consumable/capsaicin))
-				holder.remove_reagent(/datum/reagent/consumable/capsaicin, 5 * REM * seconds_per_tick)
+				holder.remove_reagent(/datum/reagent/consumable/capsaicin, 2.5 * REM * metabolized_volume * seconds_per_tick)
 		if(15 to 25)
 			cooling = -20
 		if(25 to 35)
@@ -403,7 +403,7 @@
 			cooling = -40
 			if(prob(5))
 				affected_mob.emote("shiver")
-	affected_mob.adjust_bodytemperature(cooling * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick, 50)
+	affected_mob.adjust_bodytemperature(0.5 * cooling * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 50)
 
 /datum/reagent/consumable/frostoil/expose_turf(turf/exposed_turf, reac_volume)
 	. = ..()
@@ -461,7 +461,7 @@
 				victim.vomit(VOMIT_CATEGORY_DEFAULT)
 	return ..()
 
-/datum/reagent/consumable/condensedcapsaicin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/condensedcapsaicin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!holder.has_reagent(/datum/reagent/consumable/milk))
 		if(SPT_PROB(5, seconds_per_tick))
@@ -542,7 +542,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	added_traits = list(TRAIT_GARLIC_BREATH)
 
-/datum/reagent/consumable/garlic/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/garlic/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(isvampire(affected_mob)) //incapacitating but not lethal. Unfortunately, vampires cannot vomit.
 		if(SPT_PROB(min((current_cycle-1)/2, 12.5), seconds_per_tick))
@@ -556,7 +556,7 @@
 		var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 		if(liver && HAS_TRAIT(liver, TRAIT_CULINARY_METABOLISM))
 			if(SPT_PROB(10, seconds_per_tick)) //stays in the system much longer than sprinkles/banana juice, so heals slower to partially compensate
-				if(affected_mob.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 1 * REM * seconds_per_tick, updating_health = FALSE))
+				if(affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 					return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/tearjuice
@@ -586,11 +586,11 @@
 	taste_description = "childhood whimsy"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/sprinkles/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/sprinkles/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		if(affected_mob.heal_bodypart_damage(brute = 1 * REM * seconds_per_tick, burn = 1 * REM * seconds_per_tick, updating_health = FALSE))
+		if(affected_mob.heal_bodypart_damage(brute = 0.5 * REM * metabolized_volume * seconds_per_tick, burn = 0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/enzyme
@@ -626,9 +626,9 @@
 	taste_description = "your imprisonment"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/hot_ramen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/hot_ramen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_bodytemperature(10 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
+	affected_mob.adjust_bodytemperature(5 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 0, affected_mob.get_body_temp_normal())
 
 /datum/reagent/consumable/hell_ramen
 	name = "Hell Ramen"
@@ -638,9 +638,9 @@
 	taste_description = "wet and cheap noodles on fire"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/hell_ramen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/hell_ramen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_bodytemperature(10 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(5 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/flour
 	name = "Flour"
@@ -793,9 +793,9 @@
 	taste_description = "sweet slime"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/corn_syrup/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/corn_syrup/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	holder.add_reagent(/datum/reagent/consumable/sugar, 3 * REM * seconds_per_tick)
+	holder.add_reagent(/datum/reagent/consumable/sugar, 1.5 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/honey
 	name = "Honey"
@@ -816,9 +816,9 @@
 	mytray.adjust_weedlevel(rand(1, 2))
 	mytray.adjust_pestlevel(rand(1, 2))
 
-/datum/reagent/consumable/honey/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/honey/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	holder.add_reagent(/datum/reagent/consumable/sugar, 3 * REM * seconds_per_tick)
+	holder.add_reagent(/datum/reagent/consumable/sugar, 1.5 * REM * metabolized_volume * seconds_per_tick)
 	var/need_mob_update
 	if(SPT_PROB(33, seconds_per_tick))
 		need_mob_update = affected_mob.adjust_brute_loss(-1, updating_health = FALSE, required_bodytype = affected_bodytype)
@@ -861,7 +861,7 @@
 	metabolized_traits = list(TRAIT_GLUTTON)
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/moltobeso/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/moltobeso/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	for(var/datum/reagent/consumable/food in affected_mob.reagents.reagent_list)
 		if(food == src)
@@ -869,7 +869,7 @@
 		var/food_factor = food.get_nutriment_factor(affected_mob)
 		if(food_factor <= 0)
 			continue
-		affected_mob.adjust_nutrition(food_factor * REM * seconds_per_tick)
+		affected_mob.adjust_nutrition(0.5 * food_factor * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/eggrot
 	name = "Rotten Eggyolk"
@@ -885,10 +885,10 @@
 	color = "#664330" // rgb: 102, 67, 48
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/nutriment/stabilized/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/nutriment/stabilized/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.nutrition > NUTRITION_LEVEL_FULL - 25)
-		affected_mob.adjust_nutrition(-3 * REM * get_nutriment_factor(affected_mob) * seconds_per_tick)
+		affected_mob.adjust_nutrition(-1.5 * REM * metabolized_volume * get_nutriment_factor(affected_mob) * seconds_per_tick)
 
 ////Lavaland Flora Reagents////
 
@@ -901,11 +901,11 @@
 	ph = 12
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/entpoly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/entpoly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	if(current_cycle > 10)
-		affected_mob.Unconscious(40 * REM * seconds_per_tick, FALSE)
+		affected_mob.Unconscious(20 * REM * metabolized_volume * seconds_per_tick, FALSE)
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.losebreath += 4
 		affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2*REM, 150, affected_biotype)
@@ -950,12 +950,12 @@
 	ph = 10.4
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/vitfro/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/vitfro/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	if(SPT_PROB(55, seconds_per_tick))
-		need_mob_update = affected_mob.adjust_brute_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_brute_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -980,7 +980,7 @@
 	if(istype(stomach))
 		stomach.adjust_charge(reac_volume * 30 * ETHEREAL_DISCHARGE_RATE)
 
-/datum/reagent/consumable/liquidelectricity/enriched/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/liquidelectricity/enriched/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(isethereal(affected_mob))
 		affected_mob.adjust_blood_volume(1 * seconds_per_tick)
@@ -999,10 +999,10 @@
 	overdose_threshold = 17
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/astrotame/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/astrotame/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.disgust < 80)
-		affected_mob.adjust_disgust(10 * REM * seconds_per_tick)
+		affected_mob.adjust_disgust(5 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/secretsauce
 	name = "Secret Sauce"
@@ -1050,7 +1050,7 @@
 	overdose_threshold = 15
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/char/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/char/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(13, seconds_per_tick))
 		affected_mob.say(pick_list_replacements(BOOMER_FILE, "boomer"), forced = /datum/reagent/consumable/char)
@@ -1162,11 +1162,11 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/condiment/peanut_butter
 
-/datum/reagent/consumable/peanut_butter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick) //ET loves peanut butter
+/datum/reagent/consumable/peanut_butter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume) //ET loves peanut butter
 	. = ..()
 	if(isabductor(affected_mob))
 		affected_mob.add_mood_event("ET_pieces", /datum/mood_event/et_pieces, name)
-		affected_mob.set_drugginess(30 SECONDS * REM * seconds_per_tick)
+		affected_mob.set_drugginess(15 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/consumable/vinegar
 	name = "Vinegar"
@@ -1223,7 +1223,7 @@
 	taste_description = "mint"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/mintextract/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/consumable/mintextract/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(HAS_TRAIT(affected_mob, TRAIT_FAT))
 		affected_mob.investigate_log("has been gibbed by consuming [src] while fat.", INVESTIGATE_DEATHS)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -802,7 +802,7 @@
 	description = "Sweet sweet honey that decays into sugar. Has antibacterial and natural healing properties."
 	color = "#d3a308"
 	nutriment_factor = 15
-	metabolization_rate = 1 * REAGENTS_METABOLISM
+	metabolization_rate = REAGENTS_METABOLISM
 	taste_description = "sweetness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/condiment/honey
@@ -1141,7 +1141,7 @@
 	description = "A sweet, sugary syrup made from crushed sweet korta nuts."
 	color = "#d3a308"
 	nutriment_factor = 5
-	metabolization_rate = 1 * REAGENTS_METABOLISM
+	metabolization_rate = REAGENTS_METABOLISM
 	taste_description = "peppery sweetness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -77,7 +77,8 @@
 /datum/reagent/consumable/nutriment/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(30, seconds_per_tick))
-		if(affected_mob.heal_bodypart_damage(brute = 0.5 * brute_heal * metabolization_ratio, burn = 0.5 * burn_heal * metabolization_ratio, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC))
+		var/heal = 0.5 * brute_heal * metabolization_ratio
+		if(affected_mob.heal_bodypart_damage(brute = heal, burn = heal, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/nutriment/on_new(list/supplied_data)
@@ -820,10 +821,11 @@
 	holder.add_reagent(/datum/reagent/consumable/sugar, 1.5 * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
 	if(SPT_PROB(33, seconds_per_tick))
-		need_mob_update = affected_mob.adjust_brute_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
+		var/health = -0.5 * metabolization_ratio
+		need_mob_update = affected_mob.adjust_brute_loss(health, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(health, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(health, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_tox_loss(health, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -313,7 +313,7 @@
 
 /datum/reagent/consumable/sugar/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_drowsiness_up_to((2.5 SECONDS * metabolization_ratio * seconds_per_tick), 60 SECONDS)
+	affected_mob.adjust_drowsiness_up_to((0.5 SECONDS * metabolization_ratio * seconds_per_tick), 60 SECONDS)
 
 /datum/reagent/consumable/sugar/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
@@ -556,7 +556,7 @@
 		var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 		if(liver && HAS_TRAIT(liver, TRAIT_CULINARY_METABOLISM))
 			if(SPT_PROB(10, seconds_per_tick)) //stays in the system much longer than sprinkles/banana juice, so heals slower to partially compensate
-				if(affected_mob.heal_bodypart_damage(brute = 0.5 * metabolization_ratio, burn = 0.5 * metabolization_ratio, updating_health = FALSE))
+				if(affected_mob.heal_bodypart_damage(brute = 3.34 * metabolization_ratio, burn = 3.34 * metabolization_ratio, updating_health = FALSE))
 					return UPDATE_MOB_HEALTH
 
 /datum/reagent/consumable/tearjuice
@@ -795,14 +795,13 @@
 
 /datum/reagent/consumable/corn_syrup/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	holder.add_reagent(/datum/reagent/consumable/sugar, 1.5 * metabolization_ratio * seconds_per_tick)
+	holder.add_reagent(/datum/reagent/consumable/sugar, 0.5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/honey
 	name = "Honey"
 	description = "Sweet sweet honey that decays into sugar. Has antibacterial and natural healing properties."
 	color = "#d3a308"
 	nutriment_factor = 15
-	metabolization_rate = REAGENTS_METABOLISM
 	taste_description = "sweetness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/condiment/honey
@@ -869,7 +868,7 @@
 		var/food_factor = food.get_nutriment_factor(affected_mob)
 		if(food_factor <= 0)
 			continue
-		affected_mob.adjust_nutrition(0.5 * food_factor * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_nutrition(20 * food_factor * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/eggrot
 	name = "Rotten Eggyolk"
@@ -1002,7 +1001,7 @@
 /datum/reagent/consumable/astrotame/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.disgust < 80)
-		affected_mob.adjust_disgust(5 * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_disgust(2.5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/consumable/secretsauce
 	name = "Secret Sauce"
@@ -1141,7 +1140,6 @@
 	description = "A sweet, sugary syrup made from crushed sweet korta nuts."
 	color = "#d3a308"
 	nutriment_factor = 5
-	metabolization_rate = REAGENTS_METABOLISM
 	taste_description = "peppery sweetness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -112,9 +112,10 @@
 	. = ..()
 	metabolization_rate += 0.01 //speed up our metabolism over time. Chop chop.
 
-/datum/reagent/inverse/cryostylane/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+/datum/reagent/inverse/cryostylane/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(current_cycle >= 60)
-		holder.remove_reagent(type, volume) // remove it all if we're past 60 cycles
+		volume = 0 // remove it all if we're past 60 cycles
+		holder.update_total()
 		return
 
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -11,7 +11,7 @@
 	ph = 3
 	inverse_chem = null
 	inverse_chem_val = 0
-	metabolization_rate = 0.05//default impurity is 0.75, so we get 25% converted. Default metabolisation rate is 0.4, so we're 4 times slower.
+	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	var/liver_damage = 0.5
 
 /datum/reagent/impurity/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
@@ -95,7 +95,7 @@
 	taste_description = "your tongue freezing, shortly followed by your thoughts. Brr!"
 	ph = 14
 	chemical_flags = REAGENT_DEAD_PROCESS | REAGENT_IGNORE_STASIS | REAGENT_UNAFFECTED_BY_METABOLISM
-	metabolization_rate = 0.5
+	metabolization_rate = 2.5 * REAGENTS_METABOLISM
 
 /datum/reagent/inverse/cryostylane/expose_mob(mob/living/carbon/human/human_thing, methods, reac_volume, show_message, touch_protection)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -22,7 +22,7 @@
 	if(liver)//Though, lets be safe
 		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.5 * liver_damage * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	else
-		need_mob_update = affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)//Incase of no liver!
+		need_mob_update = affected_mob.adjust_tox_loss(1 * liver_damage * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)//Incase of no liver!
 
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
@@ -38,10 +38,10 @@
 	///how much this reagent does for tox damage too
 	var/tox_damage = 1
 
-
 /datum/reagent/inverse/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(0.5 * tox_damage * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+
+	if(affected_mob.adjust_tox_loss(METABOLIZE_FREE_CONSTANT(0.5) * tox_damage * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 //Failed chems - generally use inverse if you want to use a impure subtype for it
@@ -110,7 +110,7 @@
 
 /datum/reagent/inverse/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	metabolization_rate += 0.01 //speed up our metabolism over time. Chop chop.
+	metabolization_rate += 0.05 * REAGENTS_METABOLISM //speed up our metabolism over time. Chop chop.
 
 /datum/reagent/inverse/cryostylane/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(current_cycle >= 60)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -41,7 +41,7 @@
 /datum/reagent/inverse/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 
-	if(affected_mob.adjust_tox_loss(METABOLIZE_FREE_CONSTANT(0.5) * tox_damage * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss((0.5 / metabolization_rate) * tox_damage * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 //Failed chems - generally use inverse if you want to use a impure subtype for it

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -11,18 +11,18 @@
 	ph = 3
 	inverse_chem = null
 	inverse_chem_val = 0
-	metabolization_rate = 0.1 * REM //default impurity is 0.75, so we get 25% converted. Default metabolisation rate is 0.4, so we're 4 times slower.
+	metabolization_rate = 0.05//default impurity is 0.75, so we get 25% converted. Default metabolisation rate is 0.4, so we're 4 times slower.
 	var/liver_damage = 0.5
 
-/datum/reagent/impurity/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/impurity/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	var/need_mob_update
 
 	if(liver)//Though, lets be safe
-		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, liver_damage * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.5 * liver_damage * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	else
-		need_mob_update = affected_mob.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)//Incase of no liver!
+		need_mob_update = affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)//Incase of no liver!
 
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
@@ -39,9 +39,9 @@
 	var/tox_damage = 1
 
 
-/datum/reagent/inverse/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(tox_damage * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.5 * tox_damage * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 //Failed chems - generally use inverse if you want to use a impure subtype for it
@@ -67,7 +67,7 @@
 	chemical_flags = NONE
 	tox_damage = 0
 
-/datum/reagent/inverse/eigenswap/on_mob_life(mob/living/carbon/affected_mob)
+/datum/reagent/inverse/eigenswap/on_mob_life(mob/living/carbon/affected_mob, metabolized_volume)
 	. = ..()
 	if(!prob(creation_purity * 100))
 		return
@@ -95,7 +95,7 @@
 	taste_description = "your tongue freezing, shortly followed by your thoughts. Brr!"
 	ph = 14
 	chemical_flags = REAGENT_DEAD_PROCESS | REAGENT_IGNORE_STASIS | REAGENT_UNAFFECTED_BY_METABOLISM
-	metabolization_rate = 1 * REM
+	metabolization_rate = 0.5
 
 /datum/reagent/inverse/cryostylane/expose_mob(mob/living/carbon/human/human_thing, methods, reac_volume, show_message, touch_protection)
 	. = ..()
@@ -108,11 +108,11 @@
 
 	human_thing.apply_status_effect(/datum/status_effect/reagent_effect/freeze, type)
 
-/datum/reagent/inverse/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	metabolization_rate += 0.01 //speed up our metabolism over time. Chop chop.
 
-/datum/reagent/inverse/cryostylane/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/cryostylane/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(current_cycle >= 60)
 		holder.remove_reagent(type, volume) // remove it all if we're past 60 cycles
 		return

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -20,7 +20,7 @@
 	var/need_mob_update
 
 	if(liver)//Though, lets be safe
-		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.5 * liver_damage * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, METABOLIZE_FREE_CONSTANT(0.5) * liver_damage * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	else
 		need_mob_update = affected_mob.adjust_tox_loss(1 * liver_damage * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)//Incase of no liver!
 

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -41,7 +41,7 @@
 /datum/reagent/inverse/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 
-	if(affected_mob.adjust_tox_loss((0.5 / metabolization_rate) * tox_damage * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(METABOLIZE_FREE_CONSTANT(0.5) * tox_damage * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 //Failed chems - generally use inverse if you want to use a impure subtype for it

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -14,15 +14,15 @@
 	metabolization_rate = 0.05//default impurity is 0.75, so we get 25% converted. Default metabolisation rate is 0.4, so we're 4 times slower.
 	var/liver_damage = 0.5
 
-/datum/reagent/impurity/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/impurity/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	var/need_mob_update
 
 	if(liver)//Though, lets be safe
-		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.5 * liver_damage * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.5 * liver_damage * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	else
-		need_mob_update = affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)//Incase of no liver!
+		need_mob_update = affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)//Incase of no liver!
 
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
@@ -39,9 +39,9 @@
 	var/tox_damage = 1
 
 
-/datum/reagent/inverse/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(0.5 * tox_damage * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.5 * tox_damage * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 //Failed chems - generally use inverse if you want to use a impure subtype for it
@@ -67,7 +67,7 @@
 	chemical_flags = NONE
 	tox_damage = 0
 
-/datum/reagent/inverse/eigenswap/on_mob_life(mob/living/carbon/affected_mob, metabolized_volume)
+/datum/reagent/inverse/eigenswap/on_mob_life(mob/living/carbon/affected_mob, metabolization_ratio)
 	. = ..()
 	if(!prob(creation_purity * 100))
 		return
@@ -108,11 +108,11 @@
 
 	human_thing.apply_status_effect(/datum/status_effect/reagent_effect/freeze, type)
 
-/datum/reagent/inverse/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	metabolization_rate += 0.01 //speed up our metabolism over time. Chop chop.
 
-/datum/reagent/inverse/cryostylane/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/cryostylane/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	if(current_cycle >= 60)
 		holder.remove_reagent(type, volume) // remove it all if we're past 60 cycles
 		return

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -43,11 +43,11 @@
 		if("brute")
 			need_mob_update = affected_mob.adjust_brute_loss(-0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		if("burn")
-			need_mob_update += affected_mob.adjust_fire_loss(-0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+			need_mob_update = affected_mob.adjust_fire_loss(-0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		if("tox")
-			need_mob_update += affected_mob.adjust_tox_loss(-0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+			need_mob_update = affected_mob.adjust_tox_loss(-0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 		if("oxy")
-			need_mob_update += affected_mob.adjust_oxy_loss(-0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update = affected_mob.adjust_oxy_loss(-0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -192,9 +192,9 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 /datum/reagent/peptides_failed/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 4 * metabolization_ratio * seconds_per_tick, 170))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.125 * metabolization_ratio * seconds_per_tick, 170))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_nutrition(-80 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_nutrition(-2.5 * metabolization_ratio * seconds_per_tick)
 
 //Lenturi
 //inverse
@@ -809,7 +809,6 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Anabolic steroid that promotes the growth of muscle during and after exercise."
 	color = "#520c23"
 	taste_description = "sweat"
-	metabolization_rate = REAGENTS_METABOLISM
 	overdose_threshold = 25
 	ph = 12.2
 	tox_damage = 0
@@ -857,7 +856,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	. = ..()
 	if(HAS_TRAIT(affected_mob, TRAIT_IRRADIATED))
 		affected_mob.set_jitter_if_lower(10 SECONDS)
-		affected_mob.adjust_disgust(24 * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_disgust(2.4 * metabolization_ratio * seconds_per_tick)
 		if(SPT_PROB(2.5, seconds_per_tick))
 			to_chat(affected_mob, span_warning("A horrible ache spreads in your insides!"))
 			affected_mob.adjust_confusion_up_to(10 SECONDS, 15 SECONDS)
@@ -877,7 +876,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, -1 * metabolization_ratio * seconds_per_tick)
 	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, -1 * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.get_tox_loss() <= 25)
-		need_mob_update = affected_mob.adjust_tox_loss(-1, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = affected_mob.adjust_tox_loss(-0.5, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -902,7 +901,6 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "A ghastly looking mess of mercury by-product. Causes bursts of manic hysteria."
 	color = "#353535"
 	ph = 10.2
-	metabolization_rate = REAGENTS_METABOLISM
 	tox_damage = 0
 
 /datum/reagent/inverse/ammoniated_mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
@@ -1033,7 +1031,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		return
 
 	affected_mob.coagulant_effect(0.08 * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_blood_volume(1.6 * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
+	affected_mob.adjust_blood_volume(1.6 * metabolization_ratio * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
 	affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.16 * metabolization_ratio * seconds_per_tick)
 
 	switch(current_cycle)
@@ -1147,7 +1145,6 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Potent psychotropic that causes intense anger within users."
 	color = "#ff0000"
 	ph = 1
-	metabolization_rate = REAGENTS_METABOLISM
 	tox_damage = 0
 	var/delayed_burn_damage = 0
 
@@ -1211,14 +1208,6 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	/// Used when applying colors on valid things
 	var/list/random_color_list = list("#1a1a1a","#2e2e2e","#424242","#565656","#6a6a6a","#7e7e7e","#929292","#a6a6a6","#bababa","#cecece")
 
-/datum/reagent/inverse/colorful_reagent/on_mob_metabolize(mob/living/carbon/affected_mob)
-	. = ..()
-	affected_mob.gain_trauma(/datum/brain_trauma/mild/color_blindness, TRAUMA_RESILIENCE_ABSOLUTE)
-
-/datum/reagent/inverse/colorful_reagent/on_mob_end_metabolize(mob/living/carbon/affected_mob)
-	. = ..()
-	affected_mob.cure_trauma_type(/datum/brain_trauma/mild/color_blindness, resilience = TRAUMA_RESILIENCE_ABSOLUTE)
-
 /datum/reagent/inverse/colorful_reagent/New()
 	color_callback = CALLBACK(src, PROC_REF(UpdateColor))
 	SSticker.OnRoundstart(color_callback)
@@ -1228,6 +1217,18 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	LAZYREMOVE(SSticker.round_end_events, color_callback)
 	color_callback = null
 	return ..()
+
+/datum/reagent/inverse/colorful_reagent/overdose_start(mob/living/affected_mob)
+	. = ..()
+	metabolization_rate = 0.04 * REM
+
+/datum/reagent/inverse/colorful_reagent/on_mob_metabolize(mob/living/carbon/affected_mob)
+	. = ..()
+	affected_mob.gain_trauma(/datum/brain_trauma/mild/color_blindness, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/reagent/inverse/colorful_reagent/on_mob_end_metabolize(mob/living/carbon/affected_mob)
+	. = ..()
+	affected_mob.cure_trauma_type(/datum/brain_trauma/mild/color_blindness, resilience = TRAUMA_RESILIENCE_ABSOLUTE)
 
 /datum/reagent/inverse/colorful_reagent/proc/UpdateColor()
 	color_callback = null

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -35,7 +35,7 @@
 	affected_respiration_type = ALL
 
 //Random healing of the 4 main groups
-/datum/reagent/impurity/healing/medicine_failure/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/impurity/healing/medicine_failure/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	var/pick = pick("brute", "burn", "tox", "oxy")
@@ -83,7 +83,7 @@ Then I attempt to calculate the how many hands to created based off the current 
 I take the 2s interval period and divide it by the number of hands I want to make (i.e. the current seconds_per_tick) and I keep track of how many hands I'm creating (since I always create one on a tick, then I start at 1 hand). For each hand I then use this time value multiplied by the number of hands. Since we're spawning one now, and it checks to see if hands is less than, but not less than or equal to, seconds_per_tick, no hands will be created on the next expected tick.
 Basically, we fill the time between now and 2s from now with hands based off the current lag.
 */
-/datum/reagent/inverse/helgrasp/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/helgrasp/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	spawn_hands(affected_mob)
 	lag_remainder += seconds_per_tick - FLOOR(seconds_per_tick, 1)
@@ -130,9 +130,9 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	addiction_types = list(/datum/addiction/medicine = 4)
 	tox_damage = 0
 
-/datum/reagent/inverse/libitoil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/libitoil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.05 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.05 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/inverse/libitoil/on_mob_add(mob/living/affected_mob, amount)
 	. = ..()
@@ -180,7 +180,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	addiction_types = list(/datum/addiction/medicine = 5)
 	liver_damage = 0
 
-/datum/reagent/impurity/probital_failed/overdose_start(mob/living/carbon/M, metabolized_volume)
+/datum/reagent/impurity/probital_failed/overdose_start(mob/living/carbon/M, metabolization_ratio)
 	. = ..()
 	metabolization_rate = 4  * REAGENTS_METABOLISM
 
@@ -190,7 +190,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "These inhibitory peptides drains nutrition and causes brain damage in the patient!"
 	ph = 2.1
 
-/datum/reagent/peptides_failed/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/peptides_failed/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.25 * seconds_per_tick, 170))
 		. = UPDATE_MOB_HEALTH
@@ -223,8 +223,8 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	var/amount_of_blur_applied = 1.25 SECONDS
 	tox_damage = 0
 
-/datum/reagent/inverse/aiuri/on_mob_life(mob/living/carbon/owner, seconds_per_tick, metabolized_volume)
-	owner.adjust_organ_loss(ORGAN_SLOT_EYES, 0.05 * REM * metabolized_volume * seconds_per_tick)
+/datum/reagent/inverse/aiuri/on_mob_life(mob/living/carbon/owner, seconds_per_tick, metabolization_ratio)
+	owner.adjust_organ_loss(ORGAN_SLOT_EYES, 0.05 * metabolization_ratio * seconds_per_tick)
 	owner.adjust_eye_blur(amount_of_blur_applied * seconds_per_tick)
 	. = ..()
 	return TRUE
@@ -242,9 +242,9 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	taste_description = "heat! Ouch!"
 	addiction_types = list(/datum/addiction/medicine = 2.5)
 
-/datum/reagent/inverse/hercuri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/hercuri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	var/heating = 0.5 * rand(5, 25) * creation_purity * REM * metabolized_volume * seconds_per_tick
+	var/heating = 0.5 * rand(5, 25) * creation_purity * metabolization_ratio * seconds_per_tick
 	var/datum/reagents/mob_reagents = affected_mob.reagents
 	if(mob_reagents)
 		mob_reagents.expose_temperature(mob_reagents.chem_temp + heating, 1)
@@ -262,11 +262,11 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	exposed_mob.adjust_bodytemperature(reac_volume * TEMPERATURE_DAMAGE_COEFFICIENT)
 	exposed_mob.adjust_fire_stacks(reac_volume / 2)
 
-/datum/reagent/inverse/hercuri/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/hercuri/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 1 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)) //Makes it so you can't abuse it with pyroxadone very easily (liver dies from 25u unless it's fully upgraded)
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 1 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)) //Makes it so you can't abuse it with pyroxadone very easily (liver dies from 25u unless it's fully upgraded)
 		. = UPDATE_MOB_HEALTH
-	var/heating = 5 * creation_purity * REM * metabolized_volume * seconds_per_tick * TEMPERATURE_DAMAGE_COEFFICIENT
+	var/heating = 5 * creation_purity * metabolization_ratio * seconds_per_tick * TEMPERATURE_DAMAGE_COEFFICIENT
 	affected_mob.adjust_bodytemperature(heating) //hot hot
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/human = affected_mob
@@ -282,7 +282,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	addiction_types = list(/datum/addiction/medicine = 5)
 
 //Makes patients fall asleep, then boosts the purirty of their medicine reagents if they're asleep
-/datum/reagent/inverse/healing/tirimol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/healing/tirimol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	switch(current_cycle)
 		if(2 to 11)//same delay as chloral hydrate
@@ -404,7 +404,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 	var/poison_interval = (9 SECONDS)
 
-/datum/reagent/inverse/technetium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/technetium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	time_until_next_poison -= seconds_per_tick * (1 SECONDS)
 	if (time_until_next_poison <= 0)
@@ -457,13 +457,13 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	addiction_types = list(/datum/addiction/medicine = 3.5)
 
 //Heals toxins if it's the only thing present - kinda the oposite of multiver! Maybe that's why it's inverse!
-/datum/reagent/inverse/healing/monover/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/healing/monover/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	if(length(affected_mob.reagents.reagent_list) > 1)
 		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.5 * seconds_per_tick, required_organ_flag = affected_organ_flags) //Hey! It's everyone's favourite drawback from multiver!
 	else
-		need_mob_update = affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * creation_purity * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = affected_mob.adjust_tox_loss(-1 * metabolization_ratio * creation_purity * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -495,7 +495,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		TRAIT_NO_OXYLOSS_PASSOUT,
 	)
 
-/datum/reagent/inverse/penthrite/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/penthrite/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if (HAS_TRAIT(affected_mob, TRAIT_SUICIDED))
 		return
@@ -517,7 +517,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	affected_mob.emote("gasp")
 	affected_mob.playsound_local(affected_mob, 'sound/effects/health/fastbeat.ogg', 65)
 
-/datum/reagent/inverse/penthrite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/penthrite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!back_from_the_dead)
 		return
@@ -526,10 +526,10 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	REMOVE_TRAIT(affected_mob, TRAIT_KNOCKEDOUT, CRIT_HEALTH_TRAIT)
 	REMOVE_TRAIT(affected_mob, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT)
 	for(var/datum/wound/iter_wound as anything in affected_mob.all_wounds)
-		iter_wound.adjust_blood_flow(0.5 * creation_impurity * REM * metabolized_volume * seconds_per_tick)
+		iter_wound.adjust_blood_flow(0.5 * creation_impurity * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(2.5 * creation_impurity * REM * metabolized_volume * seconds_per_tick, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.5 * ((1 + creation_impurity) * REM * metabolized_volume * seconds_per_tick), required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_brute_loss(2.5 * creation_impurity * metabolization_ratio * seconds_per_tick, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.5 * ((1 + creation_impurity) * metabolization_ratio * seconds_per_tick), required_organ_flag = affected_organ_flags)
 	if(affected_mob.health < HEALTH_THRESHOLD_CRIT)
 		affected_mob.add_movespeed_modifier(/datum/movespeed_modifier/reagent/nooartrium)
 	if(affected_mob.health < HEALTH_THRESHOLD_FULLCRIT)
@@ -549,7 +549,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		qdel(heart)
 		affected_mob.visible_message(span_boldwarning("[affected_mob]'s heart explodes!"))
 
-/datum/reagent/inverse/penthrite/overdose_start(mob/living/carbon/affected_mob, metabolized_volume)
+/datum/reagent/inverse/penthrite/overdose_start(mob/living/carbon/affected_mob, metabolization_ratio)
 	. = ..()
 	if(!back_from_the_dead)
 		return ..()
@@ -624,11 +624,11 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	//The temporary trauma passed to the affected mob
 	var/datum/brain_trauma/temp_trauma
 
-/datum/reagent/inverse/neurine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/neurine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(temp_trauma)
 		return
-	if(!(SPT_PROB(creation_purity*10, seconds_per_tick)))
+	if(!(SPT_PROB(creation_purity * 10, seconds_per_tick)))
 		return
 	var/static/list/traumalist
 	if (!traumalist)
@@ -721,7 +721,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	color = "#4C8000"
 	tox_damage = 0
 
-/datum/reagent/inverse/antihol/on_mob_life(mob/living/carbon/C, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/antihol/on_mob_life(mob/living/carbon/C, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	for(var/datum/reagent/consumable/ethanol/alcohol in C.reagents.reagent_list)
 		alcohol.boozepwr += seconds_per_tick
@@ -739,7 +739,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	///Did we get a headache?
 	var/headache = FALSE
 
-/datum/reagent/inverse/oculine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/oculine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(headache)
 		return ..()
@@ -817,18 +817,18 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	ph = 12.2
 	tox_damage = 0
 
-/datum/reagent/inverse/oxandrolone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/oxandrolone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/high_message = pick("You feel unstoppable.", "Giving it EVERYTHING!!", "You feel ready for anything.", "You feel like doing a thousand jumping jacks!")
 	if(SPT_PROB(2, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[high_message]"))
 
-/datum/reagent/inverse/oxandrolone/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/oxandrolone/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(25, seconds_per_tick))
-		affected_mob.adjust_bodytemperature(15 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_bodytemperature(15 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio)
 		affected_mob.set_jitter_if_lower(3 SECONDS)
-		affected_mob.adjust_stamina_loss(2.5 * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_stamina_loss(2.5 * metabolization_ratio)
 	else if(SPT_PROB(5, seconds_per_tick))
 		affected_mob.vomit(VOMIT_CATEGORY_BLOOD, lost_nutrition = 0, distance = 3)
 		affected_mob.Paralyze(3 SECONDS)
@@ -852,15 +852,15 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	metabolization_rate = 0.125
 	tox_damage = 0
 
-/datum/reagent/inverse/pen_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
-	holder.remove_reagent(/datum/reagent/medicine/c2/seiver, 2.5 * REM * metabolized_volume * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/medicine/potass_iodide, 2.5 * REM * metabolized_volume * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/medicine/c2/multiver, 2.5 * REM * metabolized_volume * seconds_per_tick)
+/datum/reagent/inverse/pen_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+	holder.remove_reagent(/datum/reagent/medicine/c2/seiver, 2.5 * metabolization_ratio * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/medicine/potass_iodide, 2.5 * metabolization_ratio * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/medicine/c2/multiver, 2.5 * metabolization_ratio * seconds_per_tick)
 
 	. = ..()
 	if(HAS_TRAIT(affected_mob, TRAIT_IRRADIATED))
 		affected_mob.set_jitter_if_lower(10 SECONDS)
-		affected_mob.adjust_disgust(1.5 * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_disgust(1.5 * metabolization_ratio * seconds_per_tick)
 		if(SPT_PROB(2.5, seconds_per_tick))
 			to_chat(affected_mob, span_warning("A horrible ache spreads in your insides!"))
 			affected_mob.adjust_confusion_up_to(10 SECONDS, 15 SECONDS)
@@ -874,17 +874,17 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	tox_damage = 0
 	overdose_threshold = 40
 
-/datum/reagent/inverse/atropine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/atropine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, -0.5 * REM * metabolized_volume * seconds_per_tick)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, -0.5 * REM * metabolized_volume * seconds_per_tick)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, -0.5 * metabolization_ratio * seconds_per_tick)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, -0.5 * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.get_tox_loss() <= 25)
 		need_mob_update = affected_mob.adjust_tox_loss(-0.5, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/inverse/atropine/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/atropine/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/static/list/possible_organs = list(
 		ORGAN_SLOT_HEART,
@@ -898,7 +898,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		ORGAN_SLOT_TONGUE,
 	)
 	affected_mob.adjust_organ_loss(pick(possible_organs) ,2 * seconds_per_tick)
-	affected_mob.reagents.remove_reagent(type, 0.5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.reagents.remove_reagent(type, 0.5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/inverse/ammoniated_mercury
 	name = "Ammoniated Sludge"
@@ -908,7 +908,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	metabolization_rate = 0.2
 	tox_damage = 0
 
-/datum/reagent/inverse/ammoniated_mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/ammoniated_mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(7.5, seconds_per_tick))
 		affected_mob.emote("scream")
@@ -957,11 +957,11 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 	exposed_mob.add_surgery_speed_mod(type, 0.7, min(reac_volume * 1 MINUTES, 5 MINUTES))
 
-/datum/reagent/inverse/krokodil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/krokodil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	affected_mob.add_mood_event("smacked out", /datum/mood_event/narcotic_heavy)
 
-/datum/reagent/inverse/krokodil/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/krokodil/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	affected_mob.set_jitter_if_lower(10 SECONDS)
 	affected_mob.set_dizzy_if_lower(5 SECONDS)
@@ -1001,7 +1001,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		affected_mob.remove_traits(list(TRAIT_STUNIMMUNE, TRAIT_SLEEPIMMUNE, TRAIT_ANALGESIA, TRAIT_STIMULATED), type)
 		affected_mob.Sleeping(30 SECONDS)
 
-/datum/reagent/inverse/bath_salts/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/bath_salts/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(holder.has_reagent(/datum/reagent/drug/bath_salts))
 		holder.remove_reagent(type, volume)
@@ -1009,10 +1009,10 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 	if(is_simian(affected_mob))
 		var/need_mob_update
-		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2.5 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 
 		if(holder.has_reagent(/datum/reagent/consumable/monkey_energy))
-			need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2.5 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+			need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
@@ -1030,24 +1030,24 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	ph = 6.1
 	tox_damage = 0
 
-/datum/reagent/inverse/aranesp/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/aranesp/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(overdosed)
 		return
 
-	affected_mob.coagulant_effect(0.05 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.coagulant_effect(0.05 * metabolization_ratio * seconds_per_tick)
 	affected_mob.adjust_blood_volume(1 * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
-	affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.1 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.1 * metabolization_ratio * seconds_per_tick)
 
 	switch(current_cycle)
 		if(10)
 			to_chat(affected_mob, span_warning("You feel a migraine coming on..."))
-			affected_mob.adjust_eye_blur(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.adjust_eye_blur(1 SECONDS * metabolization_ratio * seconds_per_tick)
 
 		if(15 to 30)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Your head aches as your vision blurs."))
-				affected_mob.adjust_eye_blur(2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+				affected_mob.adjust_eye_blur(2.5 SECONDS * metabolization_ratio)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Your face contorts as a sudden pain forms in your head."))
 				affected_mob.Stun(1 SECONDS)
@@ -1055,7 +1055,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		if(31 to 45)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Intense pressure forms in your head, you can barely see!"))
-				affected_mob.adjust_eye_blur(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+				affected_mob.adjust_eye_blur(5 SECONDS * metabolization_ratio)
 				affected_mob.adjust_confusion_up_to(5 SECONDS, 20 SECONDS)
 				affected_mob.adjust_hallucinations(10 SECONDS)
 			if(SPT_PROB(5, seconds_per_tick))
@@ -1064,12 +1064,12 @@ Basically, we fill the time between now and 2s from now with hands based off the
 				affected_mob.emote(pick("stare","drool","moan","look"))
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Your inhaling becomes more stressed, it's getting harder to breathe!"))
-				holder.add_reagent(/datum/reagent/toxin/histamine, 2 * REM * metabolized_volume * seconds_per_tick)
+				holder.add_reagent(/datum/reagent/toxin/histamine, 2 * metabolization_ratio)
 
 		if(46 to INFINITY)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("It feels like your head is going to implode!"))
-				affected_mob.adjust_eye_blur(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+				affected_mob.adjust_eye_blur(5 SECONDS * metabolization_ratio)
 				affected_mob.adjust_confusion_up_to(10 SECONDS, 20 SECONDS)
 				affected_mob.adjust_hallucinations(30 SECONDS)
 			if(SPT_PROB(5, seconds_per_tick))
@@ -1078,15 +1078,15 @@ Basically, we fill the time between now and 2s from now with hands based off the
 				affected_mob.emote(pick("stare","drool","tremble","shake"))
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Your breathing becomes weak and raspy, you can barely stay conscious!"))
-				holder.add_reagent(/datum/reagent/toxin/histamine, 3 * REM * metabolized_volume * seconds_per_tick)
+				holder.add_reagent(/datum/reagent/toxin/histamine, 3 * metabolization_ratio)
 				affected_mob.losebreath += 3
 
-/datum/reagent/inverse/aranesp/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/aranesp/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	if(SPT_PROB(10, seconds_per_tick))
 		to_chat(affected_mob, span_warning("It feels like your head is going to implode!"))
-		affected_mob.adjust_eye_blur(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_eye_blur(5 SECONDS * metabolization_ratio)
 		affected_mob.adjust_confusion_up_to(10 SECONDS, 20 SECONDS)
 		affected_mob.adjust_hallucinations(30 SECONDS)
 	if(SPT_PROB(10, seconds_per_tick))
@@ -1095,7 +1095,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		affected_mob.emote(pick("stare","drool","tremble","shake"))
 	if(SPT_PROB(10, seconds_per_tick))
 		to_chat(affected_mob, span_warning("Your breathing becomes weak and raspy, you can barely stay conscious!"))
-		holder.add_reagent(/datum/reagent/toxin/histamine, 3 * REM * metabolized_volume * seconds_per_tick)
+		holder.add_reagent(/datum/reagent/toxin/histamine, 3 * metabolization_ratio)
 		affected_mob.losebreath += 3
 		need_mob_update = TRUE
 
@@ -1128,16 +1128,16 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		exposed_mob.emote("cry")
 		return
 
-/datum/reagent/inverse/happiness/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/happiness/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.mob_mood?.has_mood_of_category("friendly_hug") && !HAS_TRAIT(affected_mob, TRAIT_BADTOUCH))
 		holder.remove_reagent(type, volume)
 		return
 
-	holder.remove_reagent(/datum/reagent/drug/happiness, 2.5 * REM * metabolized_volume * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/medicine/psicodine, 2.5 * REM * metabolized_volume * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/drug/happiness, 2.5 * metabolization_ratio * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/medicine/psicodine, 2.5 * metabolization_ratio * seconds_per_tick)
 
-	affected_mob.mob_mood.adjust_sanity(-3.25 * REM * metabolized_volume * seconds_per_tick, minimum = SANITY_INSANE)
+	affected_mob.mob_mood.adjust_sanity(-3.25 * metabolization_ratio * seconds_per_tick, minimum = SANITY_INSANE)
 	if(affected_mob.mob_mood != null && affected_mob.mob_mood.sanity < (SANITY_CRAZY))
 		affected_mob.adjust_drowsiness_up_to(5 SECONDS, 30 SECONDS)
 		if(SPT_PROB(25, seconds_per_tick))
@@ -1167,12 +1167,12 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	affected_mob.manual_emote("exhales sharply.")
 	to_chat(affected_mob, span_warning("You feel an intense burning sensation as your anger subsides!"))
 
-/datum/reagent/inverse/baldium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/baldium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	delayed_burn_damage += (seconds_per_tick * 1)
 	if(holder.has_reagent(/datum/reagent/consumable/salt))
-		holder.remove_reagent(/datum/reagent/inverse/baldium, 1.5 * REM * metabolized_volume * seconds_per_tick)
-		holder.remove_reagent(/datum/reagent/consumable/salt, 0.5 * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/inverse/baldium, 1.5 * metabolization_ratio * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/consumable/salt, 0.5 * metabolization_ratio * seconds_per_tick)
 
 	switch(current_cycle)
 		if(5)
@@ -1222,7 +1222,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	. = ..()
 	affected_mob.cure_trauma_type(/datum/brain_trauma/mild/color_blindness, resilience = TRAUMA_RESILIENCE_ABSOLUTE)
 
-/datum/reagent/inverse/colorful_reagent/overdose_start(mob/living/affected_mob, metabolized_volume)
+/datum/reagent/inverse/colorful_reagent/overdose_start(mob/living/affected_mob, metabolization_ratio)
 	. = ..()
 	metabolization_rate = 0.02
 
@@ -1271,7 +1271,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	for (var/obj/item/bodypart/part as anything in exposed_carbon.bodyparts)
 		part.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
 
-/datum/reagent/inverse/colorful_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/colorful_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 
 	if (!iscarbon(affected_mob))
@@ -1312,7 +1312,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	. = ..()
 	affected_mob.RemoveElement(/datum/element/forced_gravity, gravity = 5, ignore_turf_gravity = TRUE, can_override = FALSE)
 
-/datum/reagent/inverse/gravitum/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/inverse/gravitum/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 
 	switch(current_cycle)
@@ -1331,7 +1331,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 				affected_mob.cause_wound_of_type_and_severity(WOUND_BLUNT, leg, WOUND_SEVERITY_CRITICAL)
 			to_chat(affected_mob, span_warning("The gravity of this situation makes your bones snap like popsicle sticks!"))
 
-/datum/reagent/inverse/gravitum/overdose_start(mob/living/carbon/affected_mob, metabolized_volume)
+/datum/reagent/inverse/gravitum/overdose_start(mob/living/carbon/affected_mob, metabolization_ratio)
 	. = ..()
 	affected_mob.AddElement(/datum/element/squish, 120 SECONDS)
 	for(var/obj/item/bodypart/leg/leg in affected_mob.bodyparts)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -28,7 +28,7 @@
 /datum/reagent/impurity/healing/medicine_failure
 	name = "Insolvent Medicinal Precipitate"
 	description = "A viscous mess of various medicines. Will heal a damage type at random"
-	metabolization_rate = 0.5//This is fast
+	metabolization_rate = 2.5 * REAGENTS_METABOLISM
 	addiction_types = list(/datum/addiction/medicine = 7.5)
 	ph = 11
 	affected_biotype = MOB_ORGANIC | MOB_MINERAL | MOB_PLANT // no healing ghosts
@@ -57,7 +57,7 @@
 /datum/reagent/inverse/helgrasp
 	name = "Helgrasp"
 	description = "This rare and forbidden concoction is thought to bring you closer to the grasp of the Norse goddess Hel."
-	metabolization_rate = 0.5 //This is fast
+	metabolization_rate = 2.5 * REAGENTS_METABOLISM
 	tox_damage = 0.25
 	ph = 14
 	//Compensates for seconds_per_tick lag by spawning multiple hands at the end
@@ -116,7 +116,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 /datum/reagent/inverse/helgrasp/heretic
 	name = "Grasp of the Mansus"
 	description = "The Hand of the Mansus is at your neck."
-	metabolization_rate = 0.5
+	metabolization_rate = 2.5 * REAGENTS_METABOLISM
 	tox_damage = 0
 
 //libital
@@ -396,7 +396,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 /datum/reagent/inverse/technetium
 	name = "Technetium 99"
 	description = "A radioactive tracer agent that can improve a scanner's ability to detect internal organ damage. Will poison the patient when present very slowly, purging or using a low dose is recommended after use."
-	metabolization_rate = 0.15
+	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 	chemical_flags = NONE //Do show this on scanner
 	tox_damage = 0
 
@@ -476,7 +476,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	name = "Nooartrium"
 	description = "A reagent that is known to stimulate the heart in a dead patient, temporarily bringing back recently dead patients at great cost to their heart."
 	ph = 14
-	metabolization_rate = 0.025
+	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	addiction_types = list(/datum/addiction/medicine = 12)
 	overdose_threshold = 20
 	self_consuming = TRUE //No pesky liver shenanigans
@@ -502,7 +502,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	var/obj/item/organ/heart/heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
 	if(!heart || heart.organ_flags & ORGAN_FAILING)
 		return
-	metabolization_rate = 0.2 * REM
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	affected_mob.add_traits(trait_buffs, type)
 	affected_mob.set_stat(CONSCIOUS) //This doesn't touch knocked out
 	affected_mob.updatehealth()
@@ -619,7 +619,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	color = "#DCDCAA"
 	ph = 13.4
 	addiction_types = list(/datum/addiction/medicine = 8)
-	metabolization_rate = 0.0125
+	metabolization_rate = 0.0625 * REAGENTS_METABOLISM
 	tox_damage = 0
 	//The temporary trauma passed to the affected mob
 	var/datum/brain_trauma/temp_trauma
@@ -690,7 +690,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	self_consuming = TRUE
 	ph = 13.5
 	addiction_types = list(/datum/addiction/medicine = 2.5)
-	metabolization_rate = 0.5
+	metabolization_rate = 2.5 * REAGENTS_METABOLISM
 	chemical_flags = REAGENT_DEAD_PROCESS
 	tox_damage = 0
 
@@ -716,7 +716,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Promotes alcoholic substances within the patients body, making their effects more potent."
 	taste_description = "alcohol" //mostly for sneaky slips
 	chemical_flags = REAGENT_INVISIBLE
-	metabolization_rate = 0.025//This is fast
+	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	addiction_types = list(/datum/addiction/medicine = 4.5)
 	color = "#4C8000"
 	tox_damage = 0
@@ -730,12 +730,11 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	name = "Oculater"
 	description = "Temporarily blinds the patient."
 	color = "#DDDDDD"
-	metabolization_rate = 0.05
 	addiction_types = list(/datum/addiction/medicine = 3)
 	taste_description = "funky toxin"
 	ph = 13
 	tox_damage = 0
-	metabolization_rate = 0.1
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	///Did we get a headache?
 	var/headache = FALSE
 
@@ -762,7 +761,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	taste_description = "the heat evaporating from your mouth."
 	ph = 1
 	liver_damage = 0.1
-	metabolization_rate = 0.02
+	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 	///The random span we start hearing in
 	var/random_span
 
@@ -812,7 +811,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Anabolic steroid that promotes the growth of muscle during and after exercise."
 	color = "#520c23"
 	taste_description = "sweat"
-	metabolization_rate = 0.2
+	metabolization_rate = REAGENTS_METABOLISM
 	overdose_threshold = 25
 	ph = 12.2
 	tox_damage = 0
@@ -839,7 +838,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	color = "#ecd4d6"
 	taste_description = "paint thinner"
 	ph = 4.5
-	metabolization_rate = 0.04
+	metabolization_rate = 0.2 * REAGENTS_METABOLISM
 	tox_damage = 0
 	metabolized_traits = list(TRAIT_EASYBLEED)
 
@@ -849,7 +848,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	color = "#09ff00"
 	ph = 3.7
 	taste_description = "venom"
-	metabolization_rate = 0.125
+	metabolization_rate = 0.0625 * REAGENTS_METABOLISM
 	tox_damage = 0
 
 /datum/reagent/inverse/pen_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
@@ -870,7 +869,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Slowly regenerates all damaged organs, but cannot restore non-functional organs."
 	color = "#273333"
 	ph = 13.6
-	metabolization_rate = 0.1
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	tox_damage = 0
 	overdose_threshold = 40
 
@@ -905,7 +904,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "A ghastly looking mess of mercury by-product. Causes bursts of manic hysteria."
 	color = "#353535"
 	ph = 10.2
-	metabolization_rate = 0.2
+	metabolization_rate = REAGENTS_METABOLISM
 	tox_damage = 0
 
 /datum/reagent/inverse/ammoniated_mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
@@ -919,7 +918,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Makes the user horribly afraid of all things related to fish."
 	color = "#c92eb4"
 	ph = 13.9
-	metabolization_rate = 0.025
+	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	tox_damage = 0
 
 /datum/reagent/inverse/rezadone/on_mob_metabolize(mob/living/carbon/affected_mob)
@@ -935,7 +934,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Weakens the immune system, acclerating the effects of bacteria, viruses, and parasites while negating the effects of immunity boosters." //it's like spacacillin but evil muahaha
 	color = "#002f06" //Gross green-black. Seemed fitting.
 	ph = 8.1
-	metabolization_rate = 0.05
+	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	tox_damage = 0
 	metabolized_traits = list(TRAIT_IMMUNODEFICIENCY)
 
@@ -943,7 +942,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	name = "Permonid"
 	description = "Highly potent sedative that provides the best benefits for pain management and surgery. Extremely addictive."
 	color = "#15b5dd55"
-	metabolization_rate = 0.05
+	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	overdose_threshold = 20
 	ph = 2.5
 	addiction_types = list(/datum/addiction/opioids = 30)
@@ -979,7 +978,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Oop aak chee aak eek chee. Eek aak oop chee oop aak aak!!"
 	color = "#7e3900"
 	ph = 14
-	metabolization_rate = 0.1
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	tox_damage = 0
 	/// The martial art we teach (to monkies)
 	var/datum/martial_art/jungle_arts/jungle_arts
@@ -1025,7 +1024,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Synthetic medication that induces blood regeneration and wound clotting in patients. \
 		Causes adverse side effects, including arterial damage and migraines when excessively used over time."
 	color = "#dee4ff"
-	metabolization_rate = 0.125
+	metabolization_rate = 0.625 * REAGENTS_METABOLISM
 	overdose_threshold = 20
 	ph = 6.1
 	tox_damage = 0
@@ -1107,7 +1106,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Causes severe depressive behavior in users, and actively purges other antidepressants."
 	color = "#0004ff"
 	ph = 12
-	metabolization_rate = 0.05
+	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	tox_damage = 0
 	penetrates_skin = TOUCH|VAPOR
 
@@ -1150,7 +1149,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Potent psychotropic that causes intense anger within users."
 	color = "#ff0000"
 	ph = 1
-	metabolization_rate = 0.2
+	metabolization_rate = REAGENTS_METABOLISM
 	tox_damage = 0
 	var/delayed_burn_damage = 0
 
@@ -1201,7 +1200,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Extremely drab coloring pigment that is favored by corporations who wish to maximize suffering."
 	color = COLOR_GRAY
 	ph = 10
-	metabolization_rate = 0.2
+	metabolization_rate = REAGENTS_METABOLISM
 	tox_damage = 0
 	/// Whenever this reagent can color mob limbs and organs upon exposure
 	var/can_color_mobs = TRUE
@@ -1224,7 +1223,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 /datum/reagent/inverse/colorful_reagent/overdose_start(mob/living/affected_mob, metabolization_ratio)
 	. = ..()
-	metabolization_rate = 0.02
+	metabolization_rate = REAGENTS_METABOLISM
 
 /datum/reagent/inverse/colorful_reagent/New()
 	color_callback = CALLBACK(src, PROC_REF(UpdateColor))
@@ -1300,7 +1299,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Experimental reagent that induces heavy gravokinetic effects on users."
 	color = "#4b0082"
 	ph = 2.3
-	metabolization_rate = 0.5
+	metabolization_rate = 2.5 * REAGENTS_METABOLISM
 	overdose_threshold = 30
 	tox_damage = 0
 

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -41,13 +41,13 @@
 	var/pick = pick("brute", "burn", "tox", "oxy")
 	switch(pick)
 		if("brute")
-			need_mob_update = affected_mob.adjust_brute_loss(-0.5, updating_health = FALSE, required_bodytype = affected_bodytype)
+			need_mob_update = affected_mob.adjust_brute_loss(-0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		if("burn")
-			need_mob_update += affected_mob.adjust_fire_loss(-0.5, updating_health = FALSE, required_bodytype = affected_bodytype)
+			need_mob_update += affected_mob.adjust_fire_loss(-0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		if("tox")
-			need_mob_update += affected_mob.adjust_tox_loss(-0.5, updating_health = FALSE, required_biotype = affected_biotype)
+			need_mob_update += affected_mob.adjust_tox_loss(-0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 		if("oxy")
-			need_mob_update += affected_mob.adjust_oxy_loss(-0.5, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_oxy_loss(-0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -192,9 +192,9 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 /datum/reagent/peptides_failed/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.25 * seconds_per_tick, 170))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 4 * metabolization_ratio * seconds_per_tick, 170))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_nutrition(-5 * REAGENTS_METABOLISM * seconds_per_tick)
+	affected_mob.adjust_nutrition(-80 * metabolization_ratio * seconds_per_tick)
 
 //Lenturi
 //inverse
@@ -399,9 +399,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 	chemical_flags = NONE //Do show this on scanner
 	tox_damage = 0
-
 	var/time_until_next_poison = 0
-
 	var/poison_interval = (9 SECONDS)
 
 /datum/reagent/inverse/technetium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
@@ -409,7 +407,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	time_until_next_poison -= seconds_per_tick * (1 SECONDS)
 	if (time_until_next_poison <= 0)
 		time_until_next_poison = poison_interval
-		if(affected_mob.adjust_tox_loss(creation_purity * 1, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(1.34 * creation_purity * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 //Kind of a healing effect, Presumably you're using syrinver to purge so this helps that
@@ -526,10 +524,10 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	REMOVE_TRAIT(affected_mob, TRAIT_KNOCKEDOUT, CRIT_HEALTH_TRAIT)
 	REMOVE_TRAIT(affected_mob, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT)
 	for(var/datum/wound/iter_wound as anything in affected_mob.all_wounds)
-		iter_wound.adjust_blood_flow(0.5 * creation_impurity * metabolization_ratio * seconds_per_tick)
+		iter_wound.adjust_blood_flow(4 * creation_impurity * metabolization_ratio * seconds_per_tick)
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(2.5 * creation_impurity * metabolization_ratio * seconds_per_tick, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.5 * ((1 + creation_impurity) * metabolization_ratio * seconds_per_tick), required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_brute_loss(20 * creation_impurity * metabolization_ratio * seconds_per_tick, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 4 * ((1 + creation_impurity) * metabolization_ratio * seconds_per_tick), required_organ_flag = affected_organ_flags)
 	if(affected_mob.health < HEALTH_THRESHOLD_CRIT)
 		affected_mob.add_movespeed_modifier(/datum/movespeed_modifier/reagent/nooartrium)
 	if(affected_mob.health < HEALTH_THRESHOLD_FULLCRIT)
@@ -724,7 +722,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 /datum/reagent/inverse/antihol/on_mob_life(mob/living/carbon/C, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	for(var/datum/reagent/consumable/ethanol/alcohol in C.reagents.reagent_list)
-		alcohol.boozepwr += seconds_per_tick
+		alcohol.boozepwr += 8 * metabolization_ratio * seconds_per_tick
 
 /datum/reagent/inverse/oculine
 	name = "Oculater"
@@ -852,14 +850,14 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	tox_damage = 0
 
 /datum/reagent/inverse/pen_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
-	holder.remove_reagent(/datum/reagent/medicine/c2/seiver, 2.5 * metabolization_ratio * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/medicine/potass_iodide, 2.5 * metabolization_ratio * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/medicine/c2/multiver, 2.5 * metabolization_ratio * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/medicine/c2/seiver, 40 * metabolization_ratio * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/medicine/potass_iodide, 40 * metabolization_ratio * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/medicine/c2/multiver, 40 * metabolization_ratio * seconds_per_tick)
 
 	. = ..()
 	if(HAS_TRAIT(affected_mob, TRAIT_IRRADIATED))
 		affected_mob.set_jitter_if_lower(10 SECONDS)
-		affected_mob.adjust_disgust(1.5 * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_disgust(24 * metabolization_ratio * seconds_per_tick)
 		if(SPT_PROB(2.5, seconds_per_tick))
 			to_chat(affected_mob, span_warning("A horrible ache spreads in your insides!"))
 			affected_mob.adjust_confusion_up_to(10 SECONDS, 15 SECONDS)
@@ -876,10 +874,10 @@ Basically, we fill the time between now and 2s from now with hands based off the
 /datum/reagent/inverse/atropine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, -0.5 * metabolization_ratio * seconds_per_tick)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, -0.5 * metabolization_ratio * seconds_per_tick)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, -1 * metabolization_ratio * seconds_per_tick)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, -1 * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.get_tox_loss() <= 25)
-		need_mob_update = affected_mob.adjust_tox_loss(-0.5, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = affected_mob.adjust_tox_loss(-1, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -897,7 +895,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		ORGAN_SLOT_TONGUE,
 	)
 	affected_mob.adjust_organ_loss(pick(possible_organs) ,2 * seconds_per_tick)
-	affected_mob.reagents.remove_reagent(type, 0.5 * metabolization_ratio * seconds_per_tick)
+	affected_mob.reagents.remove_reagent(type, 1 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/inverse/ammoniated_mercury
 	name = "Ammoniated Sludge"
@@ -1008,10 +1006,10 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 	if(is_simian(affected_mob))
 		var/need_mob_update
-		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 
 		if(holder.has_reagent(/datum/reagent/consumable/monkey_energy))
-			need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+			need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
@@ -1034,19 +1032,19 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	if(overdosed)
 		return
 
-	affected_mob.coagulant_effect(0.05 * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_blood_volume(1 * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
-	affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.1 * metabolization_ratio * seconds_per_tick)
+	affected_mob.coagulant_effect(0.08 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_blood_volume(1.6 * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
+	affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.16 * metabolization_ratio * seconds_per_tick)
 
 	switch(current_cycle)
 		if(10)
 			to_chat(affected_mob, span_warning("You feel a migraine coming on..."))
-			affected_mob.adjust_eye_blur(1 SECONDS * metabolization_ratio * seconds_per_tick)
+			affected_mob.adjust_eye_blur(0.16 SECONDS * metabolization_ratio * seconds_per_tick)
 
 		if(15 to 30)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Your head aches as your vision blurs."))
-				affected_mob.adjust_eye_blur(2.5 SECONDS * metabolization_ratio)
+				affected_mob.adjust_eye_blur(4 SECONDS * metabolization_ratio)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Your face contorts as a sudden pain forms in your head."))
 				affected_mob.Stun(1 SECONDS)
@@ -1054,7 +1052,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		if(31 to 45)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Intense pressure forms in your head, you can barely see!"))
-				affected_mob.adjust_eye_blur(5 SECONDS * metabolization_ratio)
+				affected_mob.adjust_eye_blur(8 SECONDS * metabolization_ratio)
 				affected_mob.adjust_confusion_up_to(5 SECONDS, 20 SECONDS)
 				affected_mob.adjust_hallucinations(10 SECONDS)
 			if(SPT_PROB(5, seconds_per_tick))
@@ -1063,12 +1061,12 @@ Basically, we fill the time between now and 2s from now with hands based off the
 				affected_mob.emote(pick("stare","drool","moan","look"))
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Your inhaling becomes more stressed, it's getting harder to breathe!"))
-				holder.add_reagent(/datum/reagent/toxin/histamine, 2 * metabolization_ratio)
+				holder.add_reagent(/datum/reagent/toxin/histamine, 3.2 * metabolization_ratio)
 
 		if(46 to INFINITY)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("It feels like your head is going to implode!"))
-				affected_mob.adjust_eye_blur(5 SECONDS * metabolization_ratio)
+				affected_mob.adjust_eye_blur(8 SECONDS * metabolization_ratio)
 				affected_mob.adjust_confusion_up_to(10 SECONDS, 20 SECONDS)
 				affected_mob.adjust_hallucinations(30 SECONDS)
 			if(SPT_PROB(5, seconds_per_tick))
@@ -1077,7 +1075,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 				affected_mob.emote(pick("stare","drool","tremble","shake"))
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Your breathing becomes weak and raspy, you can barely stay conscious!"))
-				holder.add_reagent(/datum/reagent/toxin/histamine, 3 * metabolization_ratio)
+				holder.add_reagent(/datum/reagent/toxin/histamine, 4.8 * metabolization_ratio)
 				affected_mob.losebreath += 3
 
 /datum/reagent/inverse/aranesp/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
@@ -1085,7 +1083,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	var/need_mob_update
 	if(SPT_PROB(10, seconds_per_tick))
 		to_chat(affected_mob, span_warning("It feels like your head is going to implode!"))
-		affected_mob.adjust_eye_blur(5 SECONDS * metabolization_ratio)
+		affected_mob.adjust_eye_blur(8 SECONDS * metabolization_ratio)
 		affected_mob.adjust_confusion_up_to(10 SECONDS, 20 SECONDS)
 		affected_mob.adjust_hallucinations(30 SECONDS)
 	if(SPT_PROB(10, seconds_per_tick))
@@ -1094,7 +1092,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		affected_mob.emote(pick("stare","drool","tremble","shake"))
 	if(SPT_PROB(10, seconds_per_tick))
 		to_chat(affected_mob, span_warning("Your breathing becomes weak and raspy, you can barely stay conscious!"))
-		holder.add_reagent(/datum/reagent/toxin/histamine, 3 * metabolization_ratio)
+		holder.add_reagent(/datum/reagent/toxin/histamine, 4.8 * metabolization_ratio)
 		affected_mob.losebreath += 3
 		need_mob_update = TRUE
 
@@ -1133,10 +1131,10 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		holder.remove_reagent(type, volume)
 		return
 
-	holder.remove_reagent(/datum/reagent/drug/happiness, 2.5 * metabolization_ratio * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/medicine/psicodine, 2.5 * metabolization_ratio * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/drug/happiness, 10 * metabolization_ratio * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/medicine/psicodine, 10 * metabolization_ratio * seconds_per_tick)
 
-	affected_mob.mob_mood.adjust_sanity(-3.25 * metabolization_ratio * seconds_per_tick, minimum = SANITY_INSANE)
+	affected_mob.mob_mood.adjust_sanity(-13 * metabolization_ratio * seconds_per_tick, minimum = SANITY_INSANE)
 	if(affected_mob.mob_mood != null && affected_mob.mob_mood.sanity < (SANITY_CRAZY))
 		affected_mob.adjust_drowsiness_up_to(5 SECONDS, 30 SECONDS)
 		if(SPT_PROB(25, seconds_per_tick))
@@ -1220,10 +1218,6 @@ Basically, we fill the time between now and 2s from now with hands based off the
 /datum/reagent/inverse/colorful_reagent/on_mob_end_metabolize(mob/living/carbon/affected_mob)
 	. = ..()
 	affected_mob.cure_trauma_type(/datum/brain_trauma/mild/color_blindness, resilience = TRAUMA_RESILIENCE_ABSOLUTE)
-
-/datum/reagent/inverse/colorful_reagent/overdose_start(mob/living/affected_mob, metabolization_ratio)
-	. = ..()
-	metabolization_rate = REAGENTS_METABOLISM
 
 /datum/reagent/inverse/colorful_reagent/New()
 	color_callback = CALLBACK(src, PROC_REF(UpdateColor))

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -28,14 +28,14 @@
 /datum/reagent/impurity/healing/medicine_failure
 	name = "Insolvent Medicinal Precipitate"
 	description = "A viscous mess of various medicines. Will heal a damage type at random"
-	metabolization_rate = 1 * REM//This is fast
+	metabolization_rate = 0.5//This is fast
 	addiction_types = list(/datum/addiction/medicine = 7.5)
 	ph = 11
 	affected_biotype = MOB_ORGANIC | MOB_MINERAL | MOB_PLANT // no healing ghosts
 	affected_respiration_type = ALL
 
 //Random healing of the 4 main groups
-/datum/reagent/impurity/healing/medicine_failure/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/impurity/healing/medicine_failure/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	var/pick = pick("brute", "burn", "tox", "oxy")
@@ -57,7 +57,7 @@
 /datum/reagent/inverse/helgrasp
 	name = "Helgrasp"
 	description = "This rare and forbidden concoction is thought to bring you closer to the grasp of the Norse goddess Hel."
-	metabolization_rate = 1*REM //This is fast
+	metabolization_rate = 0.5 //This is fast
 	tox_damage = 0.25
 	ph = 14
 	//Compensates for seconds_per_tick lag by spawning multiple hands at the end
@@ -83,7 +83,7 @@ Then I attempt to calculate the how many hands to created based off the current 
 I take the 2s interval period and divide it by the number of hands I want to make (i.e. the current seconds_per_tick) and I keep track of how many hands I'm creating (since I always create one on a tick, then I start at 1 hand). For each hand I then use this time value multiplied by the number of hands. Since we're spawning one now, and it checks to see if hands is less than, but not less than or equal to, seconds_per_tick, no hands will be created on the next expected tick.
 Basically, we fill the time between now and 2s from now with hands based off the current lag.
 */
-/datum/reagent/inverse/helgrasp/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/helgrasp/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	spawn_hands(affected_mob)
 	lag_remainder += seconds_per_tick - FLOOR(seconds_per_tick, 1)
@@ -116,7 +116,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 /datum/reagent/inverse/helgrasp/heretic
 	name = "Grasp of the Mansus"
 	description = "The Hand of the Mansus is at your neck."
-	metabolization_rate = 1 * REM
+	metabolization_rate = 0.5
 	tox_damage = 0
 
 //libital
@@ -130,9 +130,9 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	addiction_types = list(/datum/addiction/medicine = 4)
 	tox_damage = 0
 
-/datum/reagent/inverse/libitoil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/libitoil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.1 * REM * seconds_per_tick)
+	affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.05 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/inverse/libitoil/on_mob_add(mob/living/affected_mob, amount)
 	. = ..()
@@ -180,7 +180,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	addiction_types = list(/datum/addiction/medicine = 5)
 	liver_damage = 0
 
-/datum/reagent/impurity/probital_failed/overdose_start(mob/living/carbon/M)
+/datum/reagent/impurity/probital_failed/overdose_start(mob/living/carbon/M, metabolized_volume)
 	. = ..()
 	metabolization_rate = 4  * REAGENTS_METABOLISM
 
@@ -190,7 +190,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "These inhibitory peptides drains nutrition and causes brain damage in the patient!"
 	ph = 2.1
 
-/datum/reagent/peptides_failed/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/peptides_failed/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.25 * seconds_per_tick, 170))
 		. = UPDATE_MOB_HEALTH
@@ -223,8 +223,8 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	var/amount_of_blur_applied = 1.25 SECONDS
 	tox_damage = 0
 
-/datum/reagent/inverse/aiuri/on_mob_life(mob/living/carbon/owner, seconds_per_tick)
-	owner.adjust_organ_loss(ORGAN_SLOT_EYES, 0.1 * REM * seconds_per_tick)
+/datum/reagent/inverse/aiuri/on_mob_life(mob/living/carbon/owner, seconds_per_tick, metabolized_volume)
+	owner.adjust_organ_loss(ORGAN_SLOT_EYES, 0.05 * REM * metabolized_volume * seconds_per_tick)
 	owner.adjust_eye_blur(amount_of_blur_applied * seconds_per_tick)
 	. = ..()
 	return TRUE
@@ -242,9 +242,9 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	taste_description = "heat! Ouch!"
 	addiction_types = list(/datum/addiction/medicine = 2.5)
 
-/datum/reagent/inverse/hercuri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/hercuri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	var/heating = rand(5, 25) * creation_purity * REM * seconds_per_tick
+	var/heating = 0.5 * rand(5, 25) * creation_purity * REM * metabolized_volume * seconds_per_tick
 	var/datum/reagents/mob_reagents = affected_mob.reagents
 	if(mob_reagents)
 		mob_reagents.expose_temperature(mob_reagents.chem_temp + heating, 1)
@@ -262,11 +262,11 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	exposed_mob.adjust_bodytemperature(reac_volume * TEMPERATURE_DAMAGE_COEFFICIENT)
 	exposed_mob.adjust_fire_stacks(reac_volume / 2)
 
-/datum/reagent/inverse/hercuri/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/hercuri/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 2 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)) //Makes it so you can't abuse it with pyroxadone very easily (liver dies from 25u unless it's fully upgraded)
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 1 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)) //Makes it so you can't abuse it with pyroxadone very easily (liver dies from 25u unless it's fully upgraded)
 		. = UPDATE_MOB_HEALTH
-	var/heating = 10 * creation_purity * REM * seconds_per_tick * TEMPERATURE_DAMAGE_COEFFICIENT
+	var/heating = 5 * creation_purity * REM * metabolized_volume * seconds_per_tick * TEMPERATURE_DAMAGE_COEFFICIENT
 	affected_mob.adjust_bodytemperature(heating) //hot hot
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/human = affected_mob
@@ -282,7 +282,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	addiction_types = list(/datum/addiction/medicine = 5)
 
 //Makes patients fall asleep, then boosts the purirty of their medicine reagents if they're asleep
-/datum/reagent/inverse/healing/tirimol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/healing/tirimol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	switch(current_cycle)
 		if(2 to 11)//same delay as chloral hydrate
@@ -396,7 +396,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 /datum/reagent/inverse/technetium
 	name = "Technetium 99"
 	description = "A radioactive tracer agent that can improve a scanner's ability to detect internal organ damage. Will poison the patient when present very slowly, purging or using a low dose is recommended after use."
-	metabolization_rate = 0.3 * REM
+	metabolization_rate = 0.15
 	chemical_flags = NONE //Do show this on scanner
 	tox_damage = 0
 
@@ -404,7 +404,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 	var/poison_interval = (9 SECONDS)
 
-/datum/reagent/inverse/technetium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/technetium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	time_until_next_poison -= seconds_per_tick * (1 SECONDS)
 	if (time_until_next_poison <= 0)
@@ -457,13 +457,13 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	addiction_types = list(/datum/addiction/medicine = 3.5)
 
 //Heals toxins if it's the only thing present - kinda the oposite of multiver! Maybe that's why it's inverse!
-/datum/reagent/inverse/healing/monover/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/healing/monover/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	if(length(affected_mob.reagents.reagent_list) > 1)
 		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.5 * seconds_per_tick, required_organ_flag = affected_organ_flags) //Hey! It's everyone's favourite drawback from multiver!
 	else
-		need_mob_update = affected_mob.adjust_tox_loss(-2 * REM * creation_purity * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * creation_purity * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -476,7 +476,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	name = "Nooartrium"
 	description = "A reagent that is known to stimulate the heart in a dead patient, temporarily bringing back recently dead patients at great cost to their heart."
 	ph = 14
-	metabolization_rate = 0.05 * REM
+	metabolization_rate = 0.025
 	addiction_types = list(/datum/addiction/medicine = 12)
 	overdose_threshold = 20
 	self_consuming = TRUE //No pesky liver shenanigans
@@ -495,7 +495,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		TRAIT_NO_OXYLOSS_PASSOUT,
 	)
 
-/datum/reagent/inverse/penthrite/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/penthrite/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if (HAS_TRAIT(affected_mob, TRAIT_SUICIDED))
 		return
@@ -517,7 +517,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	affected_mob.emote("gasp")
 	affected_mob.playsound_local(affected_mob, 'sound/effects/health/fastbeat.ogg', 65)
 
-/datum/reagent/inverse/penthrite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/penthrite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!back_from_the_dead)
 		return
@@ -526,10 +526,10 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	REMOVE_TRAIT(affected_mob, TRAIT_KNOCKEDOUT, CRIT_HEALTH_TRAIT)
 	REMOVE_TRAIT(affected_mob, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT)
 	for(var/datum/wound/iter_wound as anything in affected_mob.all_wounds)
-		iter_wound.adjust_blood_flow(creation_impurity * REM * seconds_per_tick)
+		iter_wound.adjust_blood_flow(0.5 * creation_impurity * REM * metabolized_volume * seconds_per_tick)
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(5 * creation_impurity * REM * seconds_per_tick, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, ((1 + creation_impurity) * REM * seconds_per_tick), required_organ_flag = affected_organ_flags)
+	need_mob_update = affected_mob.adjust_brute_loss(2.5 * creation_impurity * REM * metabolized_volume * seconds_per_tick, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.5 * ((1 + creation_impurity) * REM * metabolized_volume * seconds_per_tick), required_organ_flag = affected_organ_flags)
 	if(affected_mob.health < HEALTH_THRESHOLD_CRIT)
 		affected_mob.add_movespeed_modifier(/datum/movespeed_modifier/reagent/nooartrium)
 	if(affected_mob.health < HEALTH_THRESHOLD_FULLCRIT)
@@ -549,7 +549,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		qdel(heart)
 		affected_mob.visible_message(span_boldwarning("[affected_mob]'s heart explodes!"))
 
-/datum/reagent/inverse/penthrite/overdose_start(mob/living/carbon/affected_mob)
+/datum/reagent/inverse/penthrite/overdose_start(mob/living/carbon/affected_mob, metabolized_volume)
 	. = ..()
 	if(!back_from_the_dead)
 		return ..()
@@ -619,12 +619,12 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	color = "#DCDCAA"
 	ph = 13.4
 	addiction_types = list(/datum/addiction/medicine = 8)
-	metabolization_rate = 0.025 * REM
+	metabolization_rate = 0.0125
 	tox_damage = 0
 	//The temporary trauma passed to the affected mob
 	var/datum/brain_trauma/temp_trauma
 
-/datum/reagent/inverse/neurine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/neurine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(temp_trauma)
 		return
@@ -690,7 +690,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	self_consuming = TRUE
 	ph = 13.5
 	addiction_types = list(/datum/addiction/medicine = 2.5)
-	metabolization_rate = REM
+	metabolization_rate = 0.5
 	chemical_flags = REAGENT_DEAD_PROCESS
 	tox_damage = 0
 
@@ -716,12 +716,12 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Promotes alcoholic substances within the patients body, making their effects more potent."
 	taste_description = "alcohol" //mostly for sneaky slips
 	chemical_flags = REAGENT_INVISIBLE
-	metabolization_rate = 0.05 * REM//This is fast
+	metabolization_rate = 0.025//This is fast
 	addiction_types = list(/datum/addiction/medicine = 4.5)
 	color = "#4C8000"
 	tox_damage = 0
 
-/datum/reagent/inverse/antihol/on_mob_life(mob/living/carbon/C, seconds_per_tick)
+/datum/reagent/inverse/antihol/on_mob_life(mob/living/carbon/C, seconds_per_tick, metabolized_volume)
 	. = ..()
 	for(var/datum/reagent/consumable/ethanol/alcohol in C.reagents.reagent_list)
 		alcohol.boozepwr += seconds_per_tick
@@ -730,16 +730,16 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	name = "Oculater"
 	description = "Temporarily blinds the patient."
 	color = "#DDDDDD"
-	metabolization_rate = 0.1 * REM
+	metabolization_rate = 0.05
 	addiction_types = list(/datum/addiction/medicine = 3)
 	taste_description = "funky toxin"
 	ph = 13
 	tox_damage = 0
-	metabolization_rate = 0.2 * REM
+	metabolization_rate = 0.1
 	///Did we get a headache?
 	var/headache = FALSE
 
-/datum/reagent/inverse/oculine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/oculine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(headache)
 		return ..()
@@ -762,7 +762,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	taste_description = "the heat evaporating from your mouth."
 	ph = 1
 	liver_damage = 0.1
-	metabolization_rate = 0.04 * REM
+	metabolization_rate = 0.02
 	///The random span we start hearing in
 	var/random_span
 
@@ -812,23 +812,23 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Anabolic steroid that promotes the growth of muscle during and after exercise."
 	color = "#520c23"
 	taste_description = "sweat"
-	metabolization_rate = 0.4 * REM
+	metabolization_rate = 0.2
 	overdose_threshold = 25
 	ph = 12.2
 	tox_damage = 0
 
-/datum/reagent/inverse/oxandrolone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/oxandrolone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/high_message = pick("You feel unstoppable.", "Giving it EVERYTHING!!", "You feel ready for anything.", "You feel like doing a thousand jumping jacks!")
 	if(SPT_PROB(2, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[high_message]"))
 
-/datum/reagent/inverse/oxandrolone/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/oxandrolone/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(25, seconds_per_tick))
-		affected_mob.adjust_bodytemperature(30 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick)
+		affected_mob.adjust_bodytemperature(15 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick)
 		affected_mob.set_jitter_if_lower(3 SECONDS)
-		affected_mob.adjust_stamina_loss(5 * REM * seconds_per_tick)
+		affected_mob.adjust_stamina_loss(2.5 * REM * metabolized_volume * seconds_per_tick)
 	else if(SPT_PROB(5, seconds_per_tick))
 		affected_mob.vomit(VOMIT_CATEGORY_BLOOD, lost_nutrition = 0, distance = 3)
 		affected_mob.Paralyze(3 SECONDS)
@@ -839,7 +839,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	color = "#ecd4d6"
 	taste_description = "paint thinner"
 	ph = 4.5
-	metabolization_rate = 0.08 * REM
+	metabolization_rate = 0.04
 	tox_damage = 0
 	metabolized_traits = list(TRAIT_EASYBLEED)
 
@@ -849,18 +849,18 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	color = "#09ff00"
 	ph = 3.7
 	taste_description = "venom"
-	metabolization_rate = 0.25 * REM
+	metabolization_rate = 0.125
 	tox_damage = 0
 
-/datum/reagent/inverse/pen_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/medicine/c2/seiver, 5 * REM * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/medicine/potass_iodide, 5 * REM * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/medicine/c2/multiver, 5 * REM * seconds_per_tick)
+/datum/reagent/inverse/pen_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+	holder.remove_reagent(/datum/reagent/medicine/c2/seiver, 2.5 * REM * metabolized_volume * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/medicine/potass_iodide, 2.5 * REM * metabolized_volume * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/medicine/c2/multiver, 2.5 * REM * metabolized_volume * seconds_per_tick)
 
 	. = ..()
 	if(HAS_TRAIT(affected_mob, TRAIT_IRRADIATED))
 		affected_mob.set_jitter_if_lower(10 SECONDS)
-		affected_mob.adjust_disgust(3 * REM * seconds_per_tick)
+		affected_mob.adjust_disgust(1.5 * REM * metabolized_volume * seconds_per_tick)
 		if(SPT_PROB(2.5, seconds_per_tick))
 			to_chat(affected_mob, span_warning("A horrible ache spreads in your insides!"))
 			affected_mob.adjust_confusion_up_to(10 SECONDS, 15 SECONDS)
@@ -870,21 +870,21 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Slowly regenerates all damaged organs, but cannot restore non-functional organs."
 	color = "#273333"
 	ph = 13.6
-	metabolization_rate = 0.2 * REM
+	metabolization_rate = 0.1
 	tox_damage = 0
 	overdose_threshold = 40
 
-/datum/reagent/inverse/atropine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/atropine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, -1 * REM * seconds_per_tick)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, -1 * REM * seconds_per_tick)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_STOMACH, -0.5 * REM * metabolized_volume * seconds_per_tick)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, -0.5 * REM * metabolized_volume * seconds_per_tick)
 	if(affected_mob.get_tox_loss() <= 25)
 		need_mob_update = affected_mob.adjust_tox_loss(-0.5, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/inverse/atropine/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/atropine/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/static/list/possible_organs = list(
 		ORGAN_SLOT_HEART,
@@ -898,17 +898,17 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		ORGAN_SLOT_TONGUE,
 	)
 	affected_mob.adjust_organ_loss(pick(possible_organs) ,2 * seconds_per_tick)
-	affected_mob.reagents.remove_reagent(type, 1 * REM * seconds_per_tick)
+	affected_mob.reagents.remove_reagent(type, 0.5 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/inverse/ammoniated_mercury
 	name = "Ammoniated Sludge"
 	description = "A ghastly looking mess of mercury by-product. Causes bursts of manic hysteria."
 	color = "#353535"
 	ph = 10.2
-	metabolization_rate = 0.4 * REM
+	metabolization_rate = 0.2
 	tox_damage = 0
 
-/datum/reagent/inverse/ammoniated_mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/ammoniated_mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(7.5, seconds_per_tick))
 		affected_mob.emote("scream")
@@ -919,7 +919,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Makes the user horribly afraid of all things related to fish."
 	color = "#c92eb4"
 	ph = 13.9
-	metabolization_rate = 0.05 * REM
+	metabolization_rate = 0.025
 	tox_damage = 0
 
 /datum/reagent/inverse/rezadone/on_mob_metabolize(mob/living/carbon/affected_mob)
@@ -935,7 +935,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Weakens the immune system, acclerating the effects of bacteria, viruses, and parasites while negating the effects of immunity boosters." //it's like spacacillin but evil muahaha
 	color = "#002f06" //Gross green-black. Seemed fitting.
 	ph = 8.1
-	metabolization_rate = 0.1 * REM
+	metabolization_rate = 0.05
 	tox_damage = 0
 	metabolized_traits = list(TRAIT_IMMUNODEFICIENCY)
 
@@ -943,7 +943,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	name = "Permonid"
 	description = "Highly potent sedative that provides the best benefits for pain management and surgery. Extremely addictive."
 	color = "#15b5dd55"
-	metabolization_rate = 0.1 * REM
+	metabolization_rate = 0.05
 	overdose_threshold = 20
 	ph = 2.5
 	addiction_types = list(/datum/addiction/opioids = 30)
@@ -957,11 +957,11 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 	exposed_mob.add_surgery_speed_mod(type, 0.7, min(reac_volume * 1 MINUTES, 5 MINUTES))
 
-/datum/reagent/inverse/krokodil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/krokodil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	affected_mob.add_mood_event("smacked out", /datum/mood_event/narcotic_heavy)
 
-/datum/reagent/inverse/krokodil/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/krokodil/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	affected_mob.set_jitter_if_lower(10 SECONDS)
 	affected_mob.set_dizzy_if_lower(5 SECONDS)
@@ -979,7 +979,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Oop aak chee aak eek chee. Eek aak oop chee oop aak aak!!"
 	color = "#7e3900"
 	ph = 14
-	metabolization_rate = 0.2 * REM
+	metabolization_rate = 0.1
 	tox_damage = 0
 	/// The martial art we teach (to monkies)
 	var/datum/martial_art/jungle_arts/jungle_arts
@@ -1001,7 +1001,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		affected_mob.remove_traits(list(TRAIT_STUNIMMUNE, TRAIT_SLEEPIMMUNE, TRAIT_ANALGESIA, TRAIT_STIMULATED), type)
 		affected_mob.Sleeping(30 SECONDS)
 
-/datum/reagent/inverse/bath_salts/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/bath_salts/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(holder.has_reagent(/datum/reagent/drug/bath_salts))
 		holder.remove_reagent(type, volume)
@@ -1009,10 +1009,10 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 	if(is_simian(affected_mob))
 		var/need_mob_update
-		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 5 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+		need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2.5 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 
 		if(holder.has_reagent(/datum/reagent/consumable/monkey_energy))
-			need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 5 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+			need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2.5 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
@@ -1025,29 +1025,29 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Synthetic medication that induces blood regeneration and wound clotting in patients. \
 		Causes adverse side effects, including arterial damage and migraines when excessively used over time."
 	color = "#dee4ff"
-	metabolization_rate = 0.25 * REM
+	metabolization_rate = 0.125
 	overdose_threshold = 20
 	ph = 6.1
 	tox_damage = 0
 
-/datum/reagent/inverse/aranesp/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/aranesp/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(overdosed)
 		return
 
-	affected_mob.coagulant_effect(0.1 * REM * seconds_per_tick)
+	affected_mob.coagulant_effect(0.05 * REM * metabolized_volume * seconds_per_tick)
 	affected_mob.adjust_blood_volume(1 * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
-	affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.2 * REM * seconds_per_tick)
+	affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 0.1 * REM * metabolized_volume * seconds_per_tick)
 
 	switch(current_cycle)
 		if(10)
 			to_chat(affected_mob, span_warning("You feel a migraine coming on..."))
-			affected_mob.adjust_eye_blur(2 SECONDS * REM * seconds_per_tick)
+			affected_mob.adjust_eye_blur(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 		if(15 to 30)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Your head aches as your vision blurs."))
-				affected_mob.adjust_eye_blur(5 SECONDS * REM * seconds_per_tick)
+				affected_mob.adjust_eye_blur(2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Your face contorts as a sudden pain forms in your head."))
 				affected_mob.Stun(1 SECONDS)
@@ -1055,7 +1055,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		if(31 to 45)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Intense pressure forms in your head, you can barely see!"))
-				affected_mob.adjust_eye_blur(10 SECONDS * REM * seconds_per_tick)
+				affected_mob.adjust_eye_blur(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 				affected_mob.adjust_confusion_up_to(5 SECONDS, 20 SECONDS)
 				affected_mob.adjust_hallucinations(10 SECONDS)
 			if(SPT_PROB(5, seconds_per_tick))
@@ -1064,12 +1064,12 @@ Basically, we fill the time between now and 2s from now with hands based off the
 				affected_mob.emote(pick("stare","drool","moan","look"))
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Your inhaling becomes more stressed, it's getting harder to breathe!"))
-				holder.add_reagent(/datum/reagent/toxin/histamine, 4 * REM * seconds_per_tick)
+				holder.add_reagent(/datum/reagent/toxin/histamine, 2 * REM * metabolized_volume * seconds_per_tick)
 
 		if(46 to INFINITY)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("It feels like your head is going to implode!"))
-				affected_mob.adjust_eye_blur(10 SECONDS * REM * seconds_per_tick)
+				affected_mob.adjust_eye_blur(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 				affected_mob.adjust_confusion_up_to(10 SECONDS, 20 SECONDS)
 				affected_mob.adjust_hallucinations(30 SECONDS)
 			if(SPT_PROB(5, seconds_per_tick))
@@ -1078,15 +1078,15 @@ Basically, we fill the time between now and 2s from now with hands based off the
 				affected_mob.emote(pick("stare","drool","tremble","shake"))
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_warning("Your breathing becomes weak and raspy, you can barely stay conscious!"))
-				holder.add_reagent(/datum/reagent/toxin/histamine, 6 * REM * seconds_per_tick)
+				holder.add_reagent(/datum/reagent/toxin/histamine, 3 * REM * metabolized_volume * seconds_per_tick)
 				affected_mob.losebreath += 3
 
-/datum/reagent/inverse/aranesp/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/aranesp/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	if(SPT_PROB(10, seconds_per_tick))
 		to_chat(affected_mob, span_warning("It feels like your head is going to implode!"))
-		affected_mob.adjust_eye_blur(10 SECONDS * REM * seconds_per_tick)
+		affected_mob.adjust_eye_blur(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 		affected_mob.adjust_confusion_up_to(10 SECONDS, 20 SECONDS)
 		affected_mob.adjust_hallucinations(30 SECONDS)
 	if(SPT_PROB(10, seconds_per_tick))
@@ -1095,7 +1095,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		affected_mob.emote(pick("stare","drool","tremble","shake"))
 	if(SPT_PROB(10, seconds_per_tick))
 		to_chat(affected_mob, span_warning("Your breathing becomes weak and raspy, you can barely stay conscious!"))
-		holder.add_reagent(/datum/reagent/toxin/histamine, 6 * REM * seconds_per_tick)
+		holder.add_reagent(/datum/reagent/toxin/histamine, 3 * REM * metabolized_volume * seconds_per_tick)
 		affected_mob.losebreath += 3
 		need_mob_update = TRUE
 
@@ -1107,7 +1107,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Causes severe depressive behavior in users, and actively purges other antidepressants."
 	color = "#0004ff"
 	ph = 12
-	metabolization_rate = 0.1 * REM
+	metabolization_rate = 0.05
 	tox_damage = 0
 	penetrates_skin = TOUCH|VAPOR
 
@@ -1128,16 +1128,16 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		exposed_mob.emote("cry")
 		return
 
-/datum/reagent/inverse/happiness/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/happiness/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.mob_mood?.has_mood_of_category("friendly_hug") && !HAS_TRAIT(affected_mob, TRAIT_BADTOUCH))
 		holder.remove_reagent(type, volume)
 		return
 
-	holder.remove_reagent(/datum/reagent/drug/happiness, 5 * REM * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/medicine/psicodine, 5 * REM * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/drug/happiness, 2.5 * REM * metabolized_volume * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/medicine/psicodine, 2.5 * REM * metabolized_volume * seconds_per_tick)
 
-	affected_mob.mob_mood.adjust_sanity(-7.5 * REM * seconds_per_tick, minimum = SANITY_INSANE)
+	affected_mob.mob_mood.adjust_sanity(-3.25 * REM * metabolized_volume * seconds_per_tick, minimum = SANITY_INSANE)
 	if(affected_mob.mob_mood != null && affected_mob.mob_mood.sanity < (SANITY_CRAZY))
 		affected_mob.adjust_drowsiness_up_to(5 SECONDS, 30 SECONDS)
 		if(SPT_PROB(25, seconds_per_tick))
@@ -1150,7 +1150,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Potent psychotropic that causes intense anger within users."
 	color = "#ff0000"
 	ph = 1
-	metabolization_rate = 0.4 * REM
+	metabolization_rate = 0.2
 	tox_damage = 0
 	var/delayed_burn_damage = 0
 
@@ -1167,12 +1167,12 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	affected_mob.manual_emote("exhales sharply.")
 	to_chat(affected_mob, span_warning("You feel an intense burning sensation as your anger subsides!"))
 
-/datum/reagent/inverse/baldium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/baldium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	delayed_burn_damage += (seconds_per_tick * 1)
 	if(holder.has_reagent(/datum/reagent/consumable/salt))
-		holder.remove_reagent(/datum/reagent/inverse/baldium, 3 * REM * seconds_per_tick)
-		holder.remove_reagent(/datum/reagent/consumable/salt, 1 * REM * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/inverse/baldium, 1.5 * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/consumable/salt, 0.5 * REM * metabolized_volume * seconds_per_tick)
 
 	switch(current_cycle)
 		if(5)
@@ -1201,7 +1201,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Extremely drab coloring pigment that is favored by corporations who wish to maximize suffering."
 	color = COLOR_GRAY
 	ph = 10
-	metabolization_rate = 0.4 * REM
+	metabolization_rate = 0.2
 	tox_damage = 0
 	/// Whenever this reagent can color mob limbs and organs upon exposure
 	var/can_color_mobs = TRUE
@@ -1222,9 +1222,9 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	. = ..()
 	affected_mob.cure_trauma_type(/datum/brain_trauma/mild/color_blindness, resilience = TRAUMA_RESILIENCE_ABSOLUTE)
 
-/datum/reagent/inverse/colorful_reagent/overdose_start(mob/living/affected_mob)
+/datum/reagent/inverse/colorful_reagent/overdose_start(mob/living/affected_mob, metabolized_volume)
 	. = ..()
-	metabolization_rate = 0.04 * REM
+	metabolization_rate = 0.02
 
 /datum/reagent/inverse/colorful_reagent/New()
 	color_callback = CALLBACK(src, PROC_REF(UpdateColor))
@@ -1271,7 +1271,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	for (var/obj/item/bodypart/part as anything in exposed_carbon.bodyparts)
 		part.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
 
-/datum/reagent/inverse/colorful_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/colorful_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 
 	if (!iscarbon(affected_mob))
@@ -1300,7 +1300,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	description = "Experimental reagent that induces heavy gravokinetic effects on users."
 	color = "#4b0082"
 	ph = 2.3
-	metabolization_rate = 1 * REM
+	metabolization_rate = 0.5
 	overdose_threshold = 30
 	tox_damage = 0
 
@@ -1312,7 +1312,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	. = ..()
 	affected_mob.RemoveElement(/datum/element/forced_gravity, gravity = 5, ignore_turf_gravity = TRUE, can_override = FALSE)
 
-/datum/reagent/inverse/gravitum/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/inverse/gravitum/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 
 	switch(current_cycle)
@@ -1331,7 +1331,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 				affected_mob.cause_wound_of_type_and_severity(WOUND_BLUNT, leg, WOUND_SEVERITY_CRITICAL)
 			to_chat(affected_mob, span_warning("The gravity of this situation makes your bones snap like popsicle sticks!"))
 
-/datum/reagent/inverse/gravitum/overdose_start(mob/living/carbon/affected_mob)
+/datum/reagent/inverse/gravitum/overdose_start(mob/living/carbon/affected_mob, metabolized_volume)
 	. = ..()
 	affected_mob.AddElement(/datum/element/squish, 120 SECONDS)
 	for(var/obj/item/bodypart/leg/leg in affected_mob.bodyparts)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_toxin_reagents.dm
@@ -26,10 +26,10 @@
 	ph = 7
 	liver_damage = 0
 
-/datum/reagent/impurity/methanol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/impurity/methanol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/eyes/eyes = affected_mob.get_organ_slot(ORGAN_SLOT_EYES)
-	if(eyes?.apply_organ_damage(0.5 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(eyes?.apply_organ_damage(0.25 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 //Chloral Hydrate - Impure Version
@@ -40,9 +40,9 @@
 	ph = 7
 	liver_damage = 0
 
-/datum/reagent/impurity/chloralax/on_mob_life(mob/living/carbon/owner, seconds_per_tick)
+/datum/reagent/impurity/chloralax/on_mob_life(mob/living/carbon/owner, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(owner.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(owner.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 //Mindbreaker Toxin - Impure Version
@@ -54,7 +54,7 @@
 	liver_damage = 0
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 
-/datum/reagent/impurity/rosenol/on_mob_life(mob/living/carbon/owner, seconds_per_tick)
+/datum/reagent/impurity/rosenol/on_mob_life(mob/living/carbon/owner, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/tongue/tongue = owner.get_organ_slot(ORGAN_SLOT_TONGUE)
 	if(!tongue)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_toxin_reagents.dm
@@ -26,10 +26,10 @@
 	ph = 7
 	liver_damage = 0
 
-/datum/reagent/impurity/methanol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/impurity/methanol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/eyes/eyes = affected_mob.get_organ_slot(ORGAN_SLOT_EYES)
-	if(eyes?.apply_organ_damage(0.25 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(eyes?.apply_organ_damage(0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 //Chloral Hydrate - Impure Version
@@ -40,9 +40,9 @@
 	ph = 7
 	liver_damage = 0
 
-/datum/reagent/impurity/chloralax/on_mob_life(mob/living/carbon/owner, seconds_per_tick, metabolized_volume)
+/datum/reagent/impurity/chloralax/on_mob_life(mob/living/carbon/owner, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(owner.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(owner.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 //Mindbreaker Toxin - Impure Version
@@ -54,7 +54,7 @@
 	liver_damage = 0
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 
-/datum/reagent/impurity/rosenol/on_mob_life(mob/living/carbon/owner, seconds_per_tick, metabolized_volume)
+/datum/reagent/impurity/rosenol/on_mob_life(mob/living/carbon/owner, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/tongue/tongue = owner.get_organ_slot(ORGAN_SLOT_TONGUE)
 	if(!tongue)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -21,19 +21,19 @@
 	color = "#DB90C6"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/leporazine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/leporazine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/target_temp = affected_mob.get_body_temp_normal(apply_change = FALSE)
 	if(affected_mob.bodytemperature > target_temp)
-		affected_mob.adjust_bodytemperature(-40 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick, target_temp)
+		affected_mob.adjust_bodytemperature(-20 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, target_temp)
 	else if(affected_mob.bodytemperature < (target_temp + 1))
-		affected_mob.adjust_bodytemperature(40 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick, 0, target_temp)
+		affected_mob.adjust_bodytemperature(20 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 0, target_temp)
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/affected_human = affected_mob
 		if(affected_human.coretemperature > target_temp)
-			affected_human.adjust_coretemperature(-40 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick, target_temp)
+			affected_human.adjust_coretemperature(-20 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, target_temp)
 		else if(affected_human.coretemperature < (target_temp + 1))
-			affected_human.adjust_coretemperature(40 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick, 0, target_temp)
+			affected_human.adjust_coretemperature(20 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 0, target_temp)
 
 /datum/reagent/medicine/adminordrazine //An OP chemical for admins
 	name = "Adminordrazine"
@@ -65,10 +65,10 @@
 			if(prob(20))
 				mytray.visible_message(span_warning("Nothing happens..."))
 
-/datum/reagent/medicine/adminordrazine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/adminordrazine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.heal_bodypart_damage(brute = 5 * REM * seconds_per_tick, burn = 5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	affected_mob.adjust_tox_loss(-5 * REM * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
+	affected_mob.heal_bodypart_damage(brute = 2.5 * REM * metabolized_volume * seconds_per_tick, burn = 2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	affected_mob.adjust_tox_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
 	// Heal everything! That we want to. But really don't heal reagents. Otherwise we'll lose ... us.
 	affected_mob.fully_heal(full_heal_flags & ~HEAL_ALL_REAGENTS) // there is no need to return UPDATE_MOB_HEALTH because this proc calls updatehealth()
 
@@ -85,14 +85,14 @@
 	ph = 4
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/synaptizine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/synaptizine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_drowsiness(-10 SECONDS * REM * seconds_per_tick)
-	affected_mob.AdjustAllImmobility(-20 * REM * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.AdjustAllImmobility(-10 * REM * metabolized_volume * seconds_per_tick)
 
 	if(holder.has_reagent(/datum/reagent/toxin/mindbreaker))
-		holder.remove_reagent(/datum/reagent/toxin/mindbreaker, 5 * REM * seconds_per_tick)
-	affected_mob.adjust_hallucinations(-20 SECONDS * REM * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/toxin/mindbreaker, 2.5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_hallucinations(-10 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(SPT_PROB(16, seconds_per_tick))
 		if(affected_mob.adjust_tox_loss(1, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
@@ -104,16 +104,16 @@
 	ph = 5.2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/medicine/synaphydramine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/synaphydramine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_drowsiness(-10 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(holder.has_reagent(/datum/reagent/toxin/mindbreaker))
-		holder.remove_reagent(/datum/reagent/toxin/mindbreaker, 5 * REM * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/toxin/mindbreaker, 2.5 * REM * metabolized_volume * seconds_per_tick)
 	if(holder.has_reagent(/datum/reagent/toxin/histamine))
-		holder.remove_reagent(/datum/reagent/toxin/histamine, 5 * REM * seconds_per_tick)
-	affected_mob.adjust_hallucinations(-20 SECONDS * REM * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/toxin/histamine, 2.5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_hallucinations(-10 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(SPT_PROB(16, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/sansufentanyl
@@ -123,11 +123,11 @@
 	ph = 6.2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/sansufentanyl/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/sansufentanyl/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_confusion_up_to(3 SECONDS * REM * seconds_per_tick, 5 SECONDS)
-	affected_mob.adjust_dizzy_up_to(6 SECONDS * REM * seconds_per_tick, 12 SECONDS)
-	if(affected_mob.adjust_stamina_loss(1 * REM * seconds_per_tick, updating_stamina = FALSE))
+	affected_mob.adjust_confusion_up_to(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick, 5 SECONDS)
+	affected_mob.adjust_dizzy_up_to(3 SECONDS * REM * metabolized_volume * seconds_per_tick, 12 SECONDS)
+	if(affected_mob.adjust_stamina_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
 		. = UPDATE_MOB_HEALTH
 
 	if(SPT_PROB(10, seconds_per_tick))
@@ -145,20 +145,20 @@
 	burning_volume = 0.1
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	metabolization_rate = REAGENTS_METABOLISM * (0.00001 * (affected_mob.bodytemperature ** 2) + 0.5)
 	if(affected_mob.bodytemperature >= T0C || !HAS_TRAIT(affected_mob, TRAIT_KNOCKEDOUT))
 		return
 	var/power = -0.00003 * (affected_mob.bodytemperature ** 2) + 3
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_oxy_loss(-3 * power * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(-power * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-power * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_tox_loss(-power * REM * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype) //heals TOXINLOVERs
+	need_mob_update = affected_mob.adjust_oxy_loss(-1.5 * power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(0.5 * -power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(0.5 * -power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_tox_loss(0.5 * -power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype) //heals TOXINLOVERs
 	for(var/i in affected_mob.all_wounds)
 		var/datum/wound/iter_wound = i
-		iter_wound.on_xadone(power * REM * seconds_per_tick)
+		iter_wound.on_xadone(0.5 * power * REM * metabolized_volume * seconds_per_tick)
 	REMOVE_TRAIT(affected_mob, TRAIT_DISFIGURED, TRAIT_GENERIC) //fixes common causes for disfiguration
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
@@ -176,7 +176,7 @@
 	ph = 12
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/pyroxadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/pyroxadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.bodytemperature > BODYTEMP_HEAT_DAMAGE_LIMIT)
 		var/power = 0
@@ -191,15 +191,15 @@
 			power *= 2
 
 		var/need_mob_update
-		need_mob_update = affected_mob.adjust_oxy_loss(-2 * power * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += affected_mob.adjust_brute_loss(-power * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-1.5 * power * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_tox_loss(-power * REM * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
+		need_mob_update = affected_mob.adjust_oxy_loss(-1 * power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += affected_mob.adjust_brute_loss(0.5 * -power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-075 * power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_tox_loss(0.5 * -power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
 		for(var/i in affected_mob.all_wounds)
 			var/datum/wound/iter_wound = i
-			iter_wound.on_xadone(power * REM * seconds_per_tick)
+			iter_wound.on_xadone(0.5 * power * REM * metabolized_volume * seconds_per_tick)
 		REMOVE_TRAIT(affected_mob, TRAIT_DISFIGURED, TRAIT_GENERIC)
 
 /datum/reagent/medicine/rezadone
@@ -214,23 +214,23 @@
 	inverse_chem = /datum/reagent/inverse/rezadone
 
 // Rezadone is almost never used in favor of cryoxadone. Hopefully this will change that. // No such luck so far // with clone damage gone, someone will find a better use for rezadone... right?
-/datum/reagent/medicine/rezadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/rezadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.heal_bodypart_damage(
-		brute = 1 * REM * seconds_per_tick,
-		burn = 1 * REM * seconds_per_tick,
+		brute = 0.5 * REM * metabolized_volume * seconds_per_tick,
+		burn = 0.5 * REM * metabolized_volume * seconds_per_tick,
 		updating_health = FALSE,
 		required_bodytype = affected_biotype
 	))
 		. = UPDATE_MOB_HEALTH
 	REMOVE_TRAIT(affected_mob, TRAIT_DISFIGURED, TRAIT_GENERIC)
 
-/datum/reagent/medicine/rezadone/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/rezadone/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.set_dizzy_if_lower(10 SECONDS * REM * seconds_per_tick)
-	affected_mob.set_jitter_if_lower(10 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_dizzy_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/medicine/rezadone/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message = TRUE, touch_protection = 0)
 	. = ..()
@@ -268,20 +268,20 @@
 	inverse_chem_val = 0.3
 	inverse_chem = /datum/reagent/inverse/oxandrolone
 
-/datum/reagent/medicine/oxandrolone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/oxandrolone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	if(affected_mob.get_fire_loss() > 25)
-		need_mob_update = affected_mob.adjust_fire_loss(-4 * REM * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype) //Twice as effective as AIURI for severe burns
+		need_mob_update = affected_mob.adjust_fire_loss(-2 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype) //Twice as effective as AIURI for severe burns
 	else
-		need_mob_update = affected_mob.adjust_fire_loss(-0.5 * REM * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype) //But only a quarter as effective for more minor ones
+		need_mob_update = affected_mob.adjust_fire_loss(-0.25 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype) //But only a quarter as effective for more minor ones
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/oxandrolone/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/oxandrolone/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.get_fire_loss()) //It only makes existing burns worse
-		if(affected_mob.adjust_fire_loss(4.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)) // it's going to be healing either 4 or 0.5
+		if(affected_mob.adjust_fire_loss(2.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)) // it's going to be healing either 4 or 0.5
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/salglu_solution
@@ -306,23 +306,23 @@
 	/// Only supplements blood types that use this restoration chem.
 	var/required_restoration_chem = /datum/reagent/iron
 
-/datum/reagent/medicine/salglu_solution/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/salglu_solution/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update = FALSE
 
 	if(SPT_PROB(18, seconds_per_tick))
-		need_mob_update = affected_mob.adjust_brute_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)
+		need_mob_update = affected_mob.adjust_brute_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)
 
 	// Regen is handled here, dilution is handled in [living/proc/get_blood_volume]
 	var/datum/blood_type/blood_type = affected_mob.get_bloodtype()
 	if(blood_type?.restoration_chem == required_restoration_chem)
-		affected_mob.adjust_blood_volume(extra_regen * REM * seconds_per_tick)
+		affected_mob.adjust_blood_volume(0.5 * extra_regen * REM * metabolized_volume * seconds_per_tick)
 
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/salglu_solution/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/salglu_solution/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	if(SPT_PROB(1.5, seconds_per_tick))
@@ -336,8 +336,8 @@
 			holder.add_reagent(/datum/reagent/consumable/sugar, 1)
 			holder.remove_reagent(/datum/reagent/medicine/salglu_solution, 0.5)
 	if(SPT_PROB(18, seconds_per_tick))
-		need_mob_update = affected_mob.adjust_brute_loss(0.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)
-		need_mob_update += affected_mob.adjust_fire_loss(0.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)
+		need_mob_update = affected_mob.adjust_brute_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)
+		need_mob_update += affected_mob.adjust_fire_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -350,11 +350,11 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_AFFECTS_WOUNDS
 	metabolized_traits = list(TRAIT_ANALGESIA)
 
-/datum/reagent/medicine/mine_salve/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/mine_salve/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-0.25 * REM * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-0.25 * REM * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_brute_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -397,23 +397,23 @@
 	ph = 2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/omnizine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/omnizine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(-healing * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(-healing * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(-healing * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-healing * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_tox_loss(0.5 * -healing * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(0.5 * -healing * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(0.5 * -healing * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(0.5 * -healing * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/omnizine/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/omnizine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(1.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(1.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(1.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(1.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_tox_loss(0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -435,20 +435,20 @@
 	ph = 1.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/calomel/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/calomel/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	for(var/datum/reagent/target_reagent as anything in affected_mob.reagents.reagent_list)
 		if(istype(target_reagent, /datum/reagent/medicine/calomel))
 			continue
-		affected_mob.reagents.remove_reagent(target_reagent.type, 3 * target_reagent.purge_multiplier * REM * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(target_reagent.type, 1.5 * target_reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
 	var/toxin_amount = round(affected_mob.health / 40, 0.1)
-	if(affected_mob.adjust_tox_loss(toxin_amount * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.5 * toxin_amount * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/calomel/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/calomel/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.reagents.remove_reagent(type, 2 * REM * seconds_per_tick)
-	if(affected_mob.adjust_tox_loss(2.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	affected_mob.reagents.remove_reagent(type, 1 * REM * metabolized_volume * seconds_per_tick)
+	if(affected_mob.adjust_tox_loss(1.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/ammoniated_mercury
@@ -465,22 +465,22 @@
 	inverse_chem_val = 0.50
 	inverse_chem = /datum/reagent/inverse/ammoniated_mercury
 
-/datum/reagent/medicine/ammoniated_mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/ammoniated_mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/toxin_chem_amount = 0
 	for(var/datum/reagent/toxin/target_reagent in affected_mob.reagents.reagent_list)
 		toxin_chem_amount += 1
-		affected_mob.reagents.remove_reagent(target_reagent.type, 5 * target_reagent.purge_multiplier * REM * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(target_reagent.type, 2.5 * target_reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
 	var/toxin_amount = round(affected_mob.get_brute_loss() / 15, 0.1) + round(affected_mob.get_fire_loss() / 30, 0.1) - 3
-	if(affected_mob.adjust_tox_loss(toxin_amount * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.5 * toxin_amount * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
 	if(toxin_chem_amount == 0)
 		for(var/datum/reagent/medicine/ammoniated_mercury/target_reagent in affected_mob.reagents.reagent_list)
-			affected_mob.reagents.remove_reagent(target_reagent.type, 1 * REM * seconds_per_tick)
+			affected_mob.reagents.remove_reagent(target_reagent.type, 0.5 * REM * metabolized_volume * seconds_per_tick)
 
-/datum/reagent/medicine/ammoniated_mercury/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/ammoniated_mercury/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(3 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/potass_iodide
@@ -492,10 +492,10 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_HALT_RADIATION_EFFECTS)
 
-/datum/reagent/medicine/potass_iodide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/potass_iodide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(HAS_TRAIT(affected_mob, TRAIT_IRRADIATED))
-		if(affected_mob.adjust_tox_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/pen_acid
@@ -509,13 +509,13 @@
 	inverse_chem = /datum/reagent/inverse/pen_acid
 	metabolized_traits = list(TRAIT_HALT_RADIATION_EFFECTS)
 
-/datum/reagent/medicine/pen_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/pen_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
 	for(var/datum/reagent/reagent as anything in affected_mob.reagents.reagent_list)
 		if(reagent != src)
-			affected_mob.reagents.remove_reagent(reagent.type, 2 * reagent.purge_multiplier * REM * seconds_per_tick)
+			affected_mob.reagents.remove_reagent(reagent.type, 1 * reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/medicine/sal_acid
 	name = "Salicylic Acid"
@@ -528,20 +528,20 @@
 	inverse_chem_val = 0.3
 	inverse_chem = /datum/reagent/inverse/sal_acid
 
-/datum/reagent/medicine/sal_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/sal_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	if(affected_mob.get_brute_loss() > 25)
-		need_mob_update = affected_mob.adjust_brute_loss(-4 * REM * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_brute_loss(-2 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
 	else
-		need_mob_update = affected_mob.adjust_brute_loss(-0.5 * REM * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_brute_loss(-0.25 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/sal_acid/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/sal_acid/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.get_brute_loss()) //It only makes existing bruises worse
-		if(affected_mob.adjust_brute_loss(4.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC)) // it's going to be healing either 4 or 0.5
+		if(affected_mob.adjust_brute_loss(2.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC)) // it's going to be healing either 4 or 0.5
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/salbutamol
@@ -554,15 +554,15 @@
 	inverse_chem_val = 0.25
 	inverse_chem = /datum/reagent/inverse/salbutamol
 
-/datum/reagent/medicine/salbutamol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/salbutamol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_oxy_loss(-3 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update = affected_mob.adjust_oxy_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(affected_mob.losebreath >= 4)
 		var/obj/item/organ/lungs/affected_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
 		var/our_respiration_type = affected_lungs ? affected_lungs.respiration_type : affected_mob.mob_respiration_type // use lungs' respiration type or mob_respiration_type if no lungs
 		if(our_respiration_type & affected_respiration_type)
-			affected_mob.losebreath -= 2 * REM * seconds_per_tick
+			affected_mob.losebreath -= 1 * REM * metabolized_volume * seconds_per_tick
 			need_mob_update = TRUE
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
@@ -611,7 +611,7 @@
 	var/obj/item/organ/lungs/holder_lungs = carbon_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
 	holder_lungs?.adjust_received_pressure_mult(-pressure_mult_increment)
 
-/datum/reagent/medicine/albuterol/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/albuterol/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 
 	if (!iscarbon(affected_mob))
@@ -672,7 +672,7 @@
 	. = ..()
 	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ephedrine)
 
-/datum/reagent/medicine/ephedrine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/ephedrine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/active_held_item = affected_mob.get_active_held_item()
 	if(SPT_PROB(10 * (1.5-creation_purity), seconds_per_tick) && iscarbon(affected_mob) && active_held_item?.w_class > WEIGHT_CLASS_SMALL)
@@ -680,12 +680,12 @@
 			to_chat(affected_mob, span_notice("Your hands spaz out and you drop what you were holding!"))
 			affected_mob.set_jitter_if_lower(20 SECONDS)
 
-	affected_mob.AdjustAllImmobility(-20 * REM * seconds_per_tick * normalise_creation_purity())
-	affected_mob.adjust_stamina_loss(-4 * REM * seconds_per_tick * normalise_creation_purity(), updating_stamina = FALSE)
+	affected_mob.AdjustAllImmobility(-10 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity())
+	affected_mob.adjust_stamina_loss(-2 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_stamina = FALSE)
 
 	return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/ephedrine/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/ephedrine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(1 * (1 + (1-normalise_creation_purity())), seconds_per_tick) && iscarbon(affected_mob))
 		affected_mob.apply_status_effect(/datum/status_effect/heart_attack)
@@ -696,7 +696,7 @@
 		to_chat(affected_mob, span_notice("[pick("Your head pounds.", "You feel a tight pain in your chest.", "You find it hard to stay still.", "You feel your heart practically beating out of your chest.")]"))
 
 	if(SPT_PROB(18 * (1 + (1-normalise_creation_purity())), seconds_per_tick))
-		affected_mob.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 		affected_mob.losebreath++
 		return UPDATE_MOB_HEALTH
 
@@ -708,12 +708,12 @@
 	ph = 11.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/diphenhydramine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/diphenhydramine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
 		affected_mob.adjust_drowsiness(2 SECONDS)
-	affected_mob.adjust_jitter(-2 SECONDS * REM * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/toxin/histamine, 3 * REM * seconds_per_tick)
+	affected_mob.adjust_jitter(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/toxin/histamine, 1 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/medicine/morphine
 	name = "Morphine"
@@ -735,34 +735,34 @@
 	. = ..()
 	affected_mob.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 
-/datum/reagent/medicine/morphine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/morphine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(current_cycle > 5)
 		affected_mob.add_mood_event("numb", /datum/mood_event/narcotic_medium, name)
 	if(affected_mob.disgust < DISGUST_LEVEL_VERYGROSS && SPT_PROB(50 * (2 - creation_purity), seconds_per_tick))
-		affected_mob.adjust_disgust(1.5 * REM * seconds_per_tick)
+		affected_mob.adjust_disgust(0.75 * REM * metabolized_volume * seconds_per_tick)
 
 	switch(current_cycle)
 		if(16) //~3u
 			to_chat(affected_mob, span_warning("You start to feel tired..."))
-			affected_mob.adjust_eye_blur(2 SECONDS * REM * seconds_per_tick)
+			affected_mob.adjust_eye_blur(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
 			if(SPT_PROB(66, seconds_per_tick))
 				affected_mob.emote("yawn")
 
 		if(24 to 36) // 5u to 7.5u
 			if(SPT_PROB(66 * (2 - creation_purity), seconds_per_tick))
-				affected_mob.adjust_drowsiness_up_to(2 SECONDS * REM * seconds_per_tick, 12 SECONDS)
+				affected_mob.adjust_drowsiness_up_to(1 SECONDS * REM * metabolized_volume * seconds_per_tick, 12 SECONDS)
 
 		if(36 to 48) // 7.5u to 10u
-			affected_mob.adjust_drowsiness_up_to(2 SECONDS * REM * seconds_per_tick, 12 SECONDS)
+			affected_mob.adjust_drowsiness_up_to(1 SECONDS * REM * metabolized_volume * seconds_per_tick, 12 SECONDS)
 
 		if(48 to INFINITY) //10u onward
-			affected_mob.adjust_drowsiness_up_to(3 SECONDS * REM * seconds_per_tick, 20 SECONDS)
+			affected_mob.adjust_drowsiness_up_to(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick, 20 SECONDS)
 			// doesn't scale from purity - at this point it tries to guarantee sleep
 			if(SPT_PROB(30 * (48 - current_cycle), seconds_per_tick))
-				affected_mob.Sleeping(4 SECONDS * REM * seconds_per_tick)
+				affected_mob.Sleeping(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
-/datum/reagent/medicine/morphine/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/morphine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(18, seconds_per_tick))
 		affected_mob.drop_all_held_items()
@@ -819,15 +819,15 @@
 	var/obj/item/organ/eyes/eyes = organ
 	restore_eyesight(prev_affected_mob, eyes)
 
-/datum/reagent/medicine/oculine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/oculine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/normalized_purity = normalise_creation_purity()
-	affected_mob.adjust_temp_blindness(-4 SECONDS * REM * seconds_per_tick * normalized_purity)
-	affected_mob.adjust_eye_blur(-4 SECONDS * REM * seconds_per_tick * normalized_purity)
+	affected_mob.adjust_temp_blindness(-2 SECONDS * REM * metabolized_volume * seconds_per_tick * normalized_purity)
+	affected_mob.adjust_eye_blur(-2 SECONDS * REM * metabolized_volume * seconds_per_tick * normalized_purity)
 	var/obj/item/organ/eyes/eyes = affected_mob.get_organ_slot(ORGAN_SLOT_EYES)
 	if(eyes)
 		// Healing eye damage will cure nearsightedness and blindness from ... eye damage
-		if(eyes.apply_organ_damage(-2 * REM * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
+		if(eyes.apply_organ_damage(-1 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
 			. = UPDATE_MOB_HEALTH
 		// If our eyes are seriously damaged, we have a probability of causing eye blur while healing depending on purity
 		if(eyes.damage >= eyes.low_threshold && IS_ORGANIC_ORGAN(eyes) && SPT_PROB(16 - min(normalized_purity * 6, 12), seconds_per_tick))
@@ -846,9 +846,9 @@
 		return
 	restore_eyesight(affected_mob, eyes)
 
-/datum/reagent/medicine/oculine/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/oculine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, 1.5 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, 0.75 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/oculine/flumpuline
@@ -874,7 +874,7 @@
 	eyes.lighting_cutoff -= delta_light
 	affected_mob.update_sight()
 
-/datum/reagent/medicine/oculine/flumpuline/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/oculine/flumpuline/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/eyes/eyes = affected_mob.get_organ_slot(ORGAN_SLOT_EYES)
 	// if no eyes or inorganic do nothing. we let already changed eyes go because funny
@@ -887,7 +887,7 @@
 	flump_eyes(affected_mob, eyes)
 
 // Overdose causes constant eye popping
-/datum/reagent/medicine/oculine/flumpuline/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/oculine/flumpuline/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!prob(25))
 		return
@@ -925,12 +925,12 @@
 		if(affected_mob.can_hear())
 			to_chat(affected_mob, span_nicegreen("You can feel your hearing drastically improve!"))
 
-/datum/reagent/medicine/inacusiate/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/inacusiate/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/ears/ears = affected_mob.get_organ_slot(ORGAN_SLOT_EARS)
 	if(!ears)
 		return
-	var/multiplier = REM * seconds_per_tick * normalise_creation_purity()
+	var/multiplier = 0.75 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity()
 	ears.apply_organ_damage(-4 * multiplier)
 	ears.adjust_temporary_deafness(-8 * multiplier)
 	return UPDATE_MOB_HEALTH
@@ -953,14 +953,14 @@
 	inverse_chem = /datum/reagent/inverse/atropine
 	added_traits = list(TRAIT_PREVENT_IMPLANT_AUTO_EXPLOSION)
 
-/datum/reagent/medicine/atropine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/atropine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.health <= affected_mob.crit_threshold)
 		var/need_mob_update
-		need_mob_update = affected_mob.adjust_tox_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-2* REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update = affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
 	var/obj/item/organ/lungs/affected_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
@@ -971,12 +971,12 @@
 		affected_mob.set_dizzy_if_lower(10 SECONDS)
 		affected_mob.set_jitter_if_lower(10 SECONDS)
 
-/datum/reagent/medicine/atropine/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/atropine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(0.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.set_dizzy_if_lower(2 SECONDS * REM * seconds_per_tick)
-	affected_mob.set_jitter_if_lower(2 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_dizzy_if_lower(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/medicine/epinephrine
 	name = "Epinephrine"
@@ -989,7 +989,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_NOCRITDAMAGE)
 
-/datum/reagent/medicine/epinephrine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/epinephrine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(holder.has_reagent(/datum/reagent/toxin/lexorin))
 		if(SPT_PROB(10, seconds_per_tick))
@@ -998,38 +998,38 @@
 
 	var/need_mob_update
 	if(affected_mob.health <= affected_mob.crit_threshold)
-		need_mob_update = affected_mob.adjust_tox_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update = affected_mob.adjust_tox_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(affected_mob.losebreath >= 4)
 		var/obj/item/organ/lungs/affected_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
 		var/our_respiration_type = affected_lungs ? affected_lungs.respiration_type : affected_mob.mob_respiration_type
 		if(our_respiration_type & affected_respiration_type)
-			affected_mob.losebreath -= 2 * REM * seconds_per_tick
+			affected_mob.losebreath -= 1 * REM * metabolized_volume * seconds_per_tick
 			need_mob_update = TRUE
 	if(affected_mob.losebreath < 0)
 		affected_mob.losebreath = 0
 		need_mob_update = TRUE
-	need_mob_update += affected_mob.adjust_stamina_loss(-2 * REM * seconds_per_tick, updating_stamina = FALSE)
+	need_mob_update += affected_mob.adjust_stamina_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.AdjustAllImmobility(-20)
 		need_mob_update = TRUE
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/epinephrine/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/epinephrine/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(holder.has_reagent(/datum/reagent/toxin/lexorin))
-		holder.remove_reagent(/datum/reagent/toxin/lexorin, 2 * REM * seconds_per_tick)
-		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 1 * REM * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/toxin/lexorin, 1 * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 0.5 * REM * metabolized_volume * seconds_per_tick)
 	return ..()
 
-/datum/reagent/medicine/epinephrine/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/epinephrine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(SPT_PROB(18, REM * seconds_per_tick))
+	if(SPT_PROB(18, 0.5 * REM * metabolized_volume * seconds_per_tick))
 		var/need_mob_update
-		need_mob_update = affected_mob.adjust_stamina_loss(2.5 * REM * seconds_per_tick, updating_stamina = FALSE)
-		need_mob_update += affected_mob.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = affected_mob.adjust_stamina_loss(1.25 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
+		need_mob_update += affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 		var/obj/item/organ/lungs/affected_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
 		var/our_respiration_type = affected_lungs ? affected_lungs.respiration_type : affected_mob.mob_respiration_type
 		if(our_respiration_type & affected_respiration_type)
@@ -1144,12 +1144,12 @@
 
 	return ..()
 
-/datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/damage_at_random = rand(0, 250)/100 //0 to 2.5
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(damage_at_random * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(damage_at_random * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_brute_loss(0.5 * damage_at_random * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(0.5 * damage_at_random * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1186,16 +1186,16 @@
 	inverse_chem_val = 0.45
 	metabolized_traits = list(TRAIT_TUMOR_SUPPRESSED) //Having mannitol in you will pause the brain damage from brain tumor (so it heals an even 2 brain damage instead of 1.8)
 
-/datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -2 * REM * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -1 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/mannitol/overdose_start(mob/living/affected_mob)
+/datum/reagent/medicine/mannitol/overdose_start(mob/living/affected_mob, metabolized_volume)
 	. = ..()
 	to_chat(affected_mob, span_notice("You suddenly feel <span class='purple'>E N L I G H T E N E D!</span>"))
 
-/datum/reagent/medicine/mannitol/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/mannitol/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(65, seconds_per_tick))
 		return
@@ -1237,16 +1237,16 @@
 	if(initial_bdamage < affected_carbon.get_organ_loss(ORGAN_SLOT_BRAIN))
 		affected_carbon.set_organ_loss(ORGAN_SLOT_BRAIN, initial_bdamage)
 
-/datum/reagent/medicine/neurine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/neurine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(holder.has_reagent(/datum/reagent/consumable/ethanol/neurotoxin))
-		holder.remove_reagent(/datum/reagent/consumable/ethanol/neurotoxin, 5 * REM * seconds_per_tick * normalise_creation_purity())
+		holder.remove_reagent(/datum/reagent/consumable/ethanol/neurotoxin, 2.5 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity())
 	if(SPT_PROB(8 * normalise_creation_purity(), seconds_per_tick))
 		affected_mob.cure_trauma_type(resilience = TRAUMA_RESILIENCE_BASIC)
 
-/datum/reagent/medicine/neurine/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/neurine/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -1 * REM * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -0.5 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/mutadone
@@ -1270,7 +1270,7 @@
 		human_mob.monkeyize()
 
 
-/datum/reagent/medicine/mutadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/mutadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	affected_mob.remove_status_effect(/datum/status_effect/jitter)
 	if(affected_mob.has_dna())
@@ -1296,14 +1296,14 @@
 		/datum/status_effect/speech/slurring/drunk,
 	)
 
-/datum/reagent/medicine/antihol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/antihol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	for(var/effect in status_effects_to_clear)
 		affected_mob.remove_status_effect(effect)
-	affected_mob.reagents.remove_reagent(/datum/reagent/consumable/ethanol, 8 * REM * seconds_per_tick * normalise_creation_purity(), include_subtypes = TRUE)
-	if(affected_mob.adjust_tox_loss(-0.2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	affected_mob.reagents.remove_reagent(/datum/reagent/consumable/ethanol, 4 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), include_subtypes = TRUE)
+	if(affected_mob.adjust_tox_loss(-0.1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_drunk_effect(-10 * REM * seconds_per_tick * normalise_creation_purity())
+	affected_mob.adjust_drunk_effect(-5 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity())
 
 /datum/reagent/medicine/antihol/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
@@ -1331,20 +1331,20 @@
 	. = ..()
 	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/stimulants)
 
-/datum/reagent/medicine/stimulants/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/stimulants/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.health < 50 && affected_mob.health > 0)
 		var/need_mob_update
-		need_mob_update += affected_mob.adjust_oxy_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += affected_mob.adjust_tox_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
-	affected_mob.AdjustAllImmobility(-60  * REM * seconds_per_tick)
-	affected_mob.adjust_stamina_loss(-12 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	affected_mob.AdjustAllImmobility(-30  * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_stamina_loss(-6 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 
-/datum/reagent/medicine/stimulants/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/stimulants/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(18, seconds_per_tick))
 		affected_mob.adjust_stamina_loss(2.5, updating_stamina = FALSE, required_biotype = affected_biotype)
@@ -1360,10 +1360,10 @@
 	ph = 6.7
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/insulin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/insulin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.AdjustSleeping(-2 SECONDS * REM * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/consumable/sugar, 3 * REM * seconds_per_tick)
+	affected_mob.AdjustSleeping(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/consumable/sugar, 1.5 * REM * metabolized_volume * seconds_per_tick)
 
 //Trek Chems, used primarily by medibots. Only heals a specific damage type, but is very efficient.
 
@@ -1374,10 +1374,10 @@
 	ph = 8.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/medicine/inaprovaline/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/inaprovaline/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.losebreath >= 5)
-		affected_mob.losebreath -= 5 * REM * seconds_per_tick
+		affected_mob.losebreath -= 2.5 * REM * metabolized_volume * seconds_per_tick
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/regen_jelly
@@ -1398,13 +1398,13 @@
 	exposed_human.set_facial_haircolor(color, update = FALSE)
 	exposed_human.set_haircolor(color, update = TRUE)
 
-/datum/reagent/medicine/regen_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/regen_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-1.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-1.5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_oxy_loss(-1.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_tox_loss(-1.5 * REM * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype) //heals TOXINLOVERs
+	need_mob_update = affected_mob.adjust_brute_loss(-0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(-0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_oxy_loss(-0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_tox_loss(-0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype) //heals TOXINLOVERs
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1416,18 +1416,18 @@
 	ph = 11
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-5 * REM * seconds_per_tick, updating_health = FALSE) //A ton of healing - this is a 50 telecrystal investment.
-	need_mob_update += affected_mob.adjust_fire_loss(-5 * REM * seconds_per_tick, updating_health = FALSE)
-	need_mob_update += affected_mob.adjust_oxy_loss(-15 * REM * seconds_per_tick, updating_health = FALSE)
-	need_mob_update += affected_mob.adjust_tox_loss(-5 * REM * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -15 * REM * seconds_per_tick)
+	need_mob_update = affected_mob.adjust_brute_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE) //A ton of healing - this is a 50 telecrystal investment.
+	need_mob_update += affected_mob.adjust_fire_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+	need_mob_update += affected_mob.adjust_oxy_loss(-7.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+	need_mob_update += affected_mob.adjust_tox_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -7.5 * REM * metabolized_volume * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/syndicate_nanites/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick) //wtb flavortext messages that hint that you're vomitting up robots
+/datum/reagent/medicine/syndicate_nanites/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume) //wtb flavortext messages that hint that you're vomitting up robots
 	. = ..()
 	if(SPT_PROB(13, seconds_per_tick))
 		affected_mob.reagents.remove_reagent(type, metabolization_rate * 15) // ~5 units at a rate of 0.4 but i wanted a nice number in code
@@ -1444,38 +1444,38 @@
 	addiction_types = list(/datum/addiction/hallucinogens = 14)
 	metabolized_traits = list(TRAIT_PACIFISM)
 
-/datum/reagent/medicine/earthsblood/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/earthsblood/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	if(current_cycle < 25) //10u has to be processed before u get into THE FUN ZONE
-		need_mob_update = affected_mob.adjust_brute_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += affected_mob.adjust_tox_loss(-0.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_stamina_loss(-2 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1 * REM * seconds_per_tick, 150, affected_organ_flags) //This does, after all, come from ambrosia, and the most powerful ambrosia in existence, at that!
+		need_mob_update = affected_mob.adjust_brute_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += affected_mob.adjust_tox_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_stamina_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * REM * metabolized_volume * seconds_per_tick, 150, affected_organ_flags) //This does, after all, come from ambrosia, and the most powerful ambrosia in existence, at that!
 	else
-		need_mob_update = affected_mob.adjust_brute_loss(-5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype) //slow to start, but very quick healing once it gets going
-		need_mob_update += affected_mob.adjust_fire_loss(-5 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-3 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += affected_mob.adjust_tox_loss(-3 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_stamina_loss(-8 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 2 * REM * seconds_per_tick, 150, affected_organ_flags)
-		affected_mob.adjust_jitter_up_to(6 SECONDS * REM * seconds_per_tick, 1 MINUTES)
+		need_mob_update = affected_mob.adjust_brute_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype) //slow to start, but very quick healing once it gets going
+		need_mob_update += affected_mob.adjust_fire_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += affected_mob.adjust_tox_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_stamina_loss(-4 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1 * REM * metabolized_volume * seconds_per_tick, 150, affected_organ_flags)
+		affected_mob.adjust_jitter_up_to(3 SECONDS * REM * metabolized_volume * seconds_per_tick, 1 MINUTES)
 		if(SPT_PROB(5, seconds_per_tick))
 			affected_mob.say(return_hippie_line(), forced = /datum/reagent/medicine/earthsblood)
-	affected_mob.adjust_drugginess_up_to(20 SECONDS * REM * seconds_per_tick, 30 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_drugginess_up_to(10 SECONDS * REM * metabolized_volume * seconds_per_tick, 15 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/earthsblood/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/earthsblood/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_hallucinations_up_to(10 SECONDS * REM * seconds_per_tick, 120 SECONDS)
+	affected_mob.adjust_hallucinations_up_to(5 SECONDS * REM * metabolized_volume * seconds_per_tick, 120 SECONDS)
 	var/need_mob_update
 	if(current_cycle > 26)
-		need_mob_update = affected_mob.adjust_tox_loss(4 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = affected_mob.adjust_tox_loss(2 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 		if(current_cycle > 101) //podpeople get out reeeeeeeeeeeeeeeeeeeee
-			need_mob_update += affected_mob.adjust_tox_loss(6 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+			need_mob_update += affected_mob.adjust_tox_loss(3 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(iscarbon(affected_mob))
 		var/mob/living/carbon/hippie = affected_mob
 		hippie.gain_trauma(/datum/brain_trauma/severe/pacifism)
@@ -1504,25 +1504,25 @@
 	ph = 4.3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/haloperidol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/haloperidol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	for(var/datum/reagent/drug/reagent in affected_mob.reagents.reagent_list)
-		affected_mob.reagents.remove_reagent(reagent.type, 5 * reagent.purge_multiplier * REM * seconds_per_tick)
-	affected_mob.adjust_drowsiness(4 SECONDS * REM * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(reagent.type, 2.5 * reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 	if(affected_mob.get_timed_status_effect_duration(/datum/status_effect/jitter) >= 6 SECONDS)
-		affected_mob.adjust_jitter(-6 SECONDS * REM * seconds_per_tick)
+		affected_mob.adjust_jitter(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 	if (affected_mob.get_timed_status_effect_duration(/datum/status_effect/hallucination) >= 10 SECONDS)
-		affected_mob.adjust_hallucinations(-10 SECONDS * REM * seconds_per_tick)
+		affected_mob.adjust_hallucinations(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 	if(affected_mob.get_stamina_loss() >= 100)
-		affected_mob.reagents.remove_reagent(type, metabolization_rate * REM * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(type, 0.5 * metabolization_rate * REM * metabolized_volume * seconds_per_tick)
 
 	var/need_mob_update = FALSE
 	if(SPT_PROB(10, seconds_per_tick))
 		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1, 50, affected_organ_flags)
-	need_mob_update += affected_mob.adjust_stamina_loss(2.5 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_stamina_loss(1.25 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1534,13 +1534,13 @@
 	overdose_threshold = 30
 	chemical_flags = REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/medicine/changelingadrenaline/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick)
+/datum/reagent/medicine/changelingadrenaline/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolized_volume)
 	. = ..()
-	metabolizer.AdjustAllImmobility(-20 * REM * seconds_per_tick)
-	if(metabolizer.adjust_stamina_loss(-30 * REM * seconds_per_tick, updating_stamina = FALSE))
+	metabolizer.AdjustAllImmobility(-10 * REM * metabolized_volume * seconds_per_tick)
+	if(metabolizer.adjust_stamina_loss(-15 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
 		. = UPDATE_MOB_HEALTH
-	metabolizer.set_jitter_if_lower(20 SECONDS * REM * seconds_per_tick)
-	metabolizer.set_dizzy_if_lower(20 SECONDS * REM * seconds_per_tick)
+	metabolizer.set_jitter_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	metabolizer.set_dizzy_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/medicine/changelingadrenaline/on_mob_metabolize(mob/living/affected_mob)
 	. = ..()
@@ -1563,9 +1563,9 @@
 	volume -= (min(volume, 1))
 	return STAMCRIT_CANCELLED
 
-/datum/reagent/medicine/changelingadrenaline/overdose_process(mob/living/metabolizer, seconds_per_tick)
+/datum/reagent/medicine/changelingadrenaline/overdose_process(mob/living/metabolizer, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(metabolizer.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE))
+	if(metabolizer.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/changelinghaste
@@ -1583,9 +1583,9 @@
 	. = ..()
 	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/changelinghaste)
 
-/datum/reagent/medicine/changelinghaste/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick)
+/datum/reagent/medicine/changelinghaste/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(metabolizer.adjust_tox_loss(2 * REM * seconds_per_tick, updating_health = FALSE))
+	if(metabolizer.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/higadrite
@@ -1637,40 +1637,40 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_SLEEPIMMUNE)
 
-/datum/reagent/medicine/modafinil/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick)
+/datum/reagent/medicine/modafinil/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(overdosed) // We do not want any effects on OD
 		return
-	overdose_threshold = overdose_threshold + ((rand(-10, 10) / 10) * REM * seconds_per_tick) // for extra fun
-	metabolizer.AdjustAllImmobility(-5 * REM * seconds_per_tick)
-	metabolizer.adjust_stamina_loss(-3 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	metabolizer.set_jitter_if_lower(1 SECONDS * REM * seconds_per_tick)
+	overdose_threshold = 0.5 * overdose_threshold + ((rand(-10, 10) / 10) * REM * metabolized_volume * seconds_per_tick) // for extra fun
+	metabolizer.AdjustAllImmobility(-2.5 * REM * metabolized_volume * seconds_per_tick)
+	metabolizer.adjust_stamina_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	metabolizer.set_jitter_if_lower(0.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	metabolization_rate = 0.005 * REAGENTS_METABOLISM * rand(5, 20) // randomizes metabolism between 0.02 and 0.08 per second
 	return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/modafinil/overdose_start(mob/living/affected_mob)
+/datum/reagent/medicine/modafinil/overdose_start(mob/living/affected_mob, metabolized_volume)
 	. = ..()
 	to_chat(affected_mob, span_userdanger("You feel awfully out of breath and jittery!"))
 	metabolization_rate = 0.025 * REAGENTS_METABOLISM // sets metabolism to 0.005 per second on overdose
 
-/datum/reagent/medicine/modafinil/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/modafinil/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	overdose_progress++
 	var/need_mob_update
 	switch(overdose_progress)
 		if(1 to 40)
-			affected_mob.adjust_jitter_up_to(2 SECONDS * REM * seconds_per_tick, 20 SECONDS)
-			affected_mob.adjust_stutter_up_to(2 SECONDS * REM * seconds_per_tick, 20 SECONDS)
-			affected_mob.set_dizzy_if_lower(10 SECONDS * REM * seconds_per_tick)
+			affected_mob.adjust_jitter_up_to(1 SECONDS * REM * metabolized_volume * seconds_per_tick, 20 SECONDS)
+			affected_mob.adjust_stutter_up_to(1 SECONDS * REM * metabolized_volume * seconds_per_tick, 20 SECONDS)
+			affected_mob.set_dizzy_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 			if(SPT_PROB(30, seconds_per_tick))
 				affected_mob.losebreath++
 				need_mob_update = TRUE
 		if(41 to 80)
-			need_mob_update = affected_mob.adjust_oxy_loss(0.1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-			need_mob_update += affected_mob.adjust_stamina_loss(0.1 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-			affected_mob.adjust_jitter_up_to(2 SECONDS * REM * seconds_per_tick, 40 SECONDS)
-			affected_mob.adjust_stutter_up_to(2 SECONDS * REM * seconds_per_tick, 40 SECONDS)
-			affected_mob.set_dizzy_if_lower(20 SECONDS * REM * seconds_per_tick)
+			need_mob_update = affected_mob.adjust_oxy_loss(0.1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_stamina_loss(0.1 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+			affected_mob.adjust_jitter_up_to(1 SECONDS * REM * metabolized_volume * seconds_per_tick, 40 SECONDS)
+			affected_mob.adjust_stutter_up_to(1 SECONDS * REM * metabolized_volume * seconds_per_tick, 40 SECONDS)
+			affected_mob.set_dizzy_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
 			if(SPT_PROB(30, seconds_per_tick))
 				affected_mob.losebreath++
 				need_mob_update = TRUE
@@ -1680,13 +1680,13 @@
 				affected_mob.Paralyze(20) // you should be in a bad spot at this point unless epipen has been used
 		if(81)
 			to_chat(affected_mob, span_userdanger("You feel too exhausted to continue!")) // at this point you will eventually die unless you get charcoal
-			need_mob_update = affected_mob.adjust_oxy_loss(0.1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-			need_mob_update += affected_mob.adjust_stamina_loss(0.1 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+			need_mob_update = affected_mob.adjust_oxy_loss(0.05 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_stamina_loss(0.05 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(82 to INFINITY)
 			REMOVE_TRAIT(affected_mob, TRAIT_SLEEPIMMUNE, type)
-			affected_mob.Sleeping(100 * REM * seconds_per_tick)
-			need_mob_update += affected_mob.adjust_oxy_loss(1.5 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-			need_mob_update += affected_mob.adjust_stamina_loss(1.5 * REM * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+			affected_mob.Sleeping(50 * REM * metabolized_volume * seconds_per_tick)
+			need_mob_update += affected_mob.adjust_oxy_loss(0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_stamina_loss(0.75 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1700,19 +1700,19 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_FEARLESS)
 
-/datum/reagent/medicine/psicodine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/psicodine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_jitter(-12 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_dizzy(-12 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjust_confusion(-6 SECONDS * REM * seconds_per_tick)
-	affected_mob.disgust = max(affected_mob.disgust - (6 * REM * seconds_per_tick), 0)
+	affected_mob.adjust_jitter(-6 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_dizzy(-6 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_confusion(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.disgust = max(affected_mob.disgust - (3 * REM * metabolized_volume * seconds_per_tick), 0)
 	if(affected_mob.mob_mood != null && affected_mob.mob_mood.sanity <= SANITY_NEUTRAL) // only take effect if in negative sanity and then...
-		affected_mob.mob_mood.adjust_sanity(5 * REM * seconds_per_tick, maximum = SANITY_NEUTRAL) // set minimum to prevent unwanted spiking over neutral
+		affected_mob.mob_mood.adjust_sanity(2.5 * REM * metabolized_volume * seconds_per_tick, maximum = SANITY_NEUTRAL) // set minimum to prevent unwanted spiking over neutral
 
-/datum/reagent/medicine/psicodine/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/psicodine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_hallucinations_up_to(10 SECONDS * REM * seconds_per_tick, 120 SECONDS)
-	if(affected_mob.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	affected_mob.adjust_hallucinations_up_to(5 SECONDS * REM * metabolized_volume * seconds_per_tick, 120 SECONDS)
+	if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/metafactor
@@ -1725,11 +1725,11 @@
 	inverse_chem = /datum/reagent/impurity/probital_failed
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/metafactor/overdose_start(mob/living/carbon/affected_mob)
+/datum/reagent/medicine/metafactor/overdose_start(mob/living/carbon/affected_mob, metabolized_volume)
 	. = ..()
 	metabolization_rate = 2  * REAGENTS_METABOLISM
 
-/datum/reagent/medicine/metafactor/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/metafactor/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(13, seconds_per_tick))
 		affected_mob.vomit(VOMIT_CATEGORY_KNOCKDOWN)
@@ -1741,9 +1741,9 @@
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/silibinin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/silibinin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, -2 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)) // Add a chance to cure liver trauma once implemented.
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, -1 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)) // Add a chance to cure liver trauma once implemented.
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/polypyr  //This is intended to be an ingredient in advanced chems.
@@ -1755,11 +1755,11 @@
 	taste_description = "numbing bitterness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/polypyr/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick) //I wanted a collection of small positive effects, this is as hard to obtain as coniine after all.
+/datum/reagent/medicine/polypyr/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume) //I wanted a collection of small positive effects, this is as hard to obtain as coniine after all.
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, -0.25 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_brute_loss(-0.35 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, -0.125 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_brute_loss(-0.175 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1770,9 +1770,9 @@
 	exposed_human.set_facial_haircolor("#9922ff", update = FALSE)
 	exposed_human.set_haircolor(color) //this will call update_body_parts()
 
-/datum/reagent/medicine/polypyr/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/polypyr/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.5 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.25 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/granibitaluri
@@ -1784,20 +1784,20 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_ANALGESIA)
 
-/datum/reagent/medicine/granibitaluri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/granibitaluri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/healamount = max(0.5 - round(0.01 * (affected_mob.get_brute_loss() + affected_mob.get_fire_loss()), 0.1), 0) //base of 0.5 healing per cycle and loses 0.1 healing for every 10 combined brute/burn damage you have
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-healamount * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-healamount * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_brute_loss(0.5 * -healamount * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(0.5 * -healamount * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/granibitaluri/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/granibitaluri/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.2 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_tox_loss(0.2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //Only really deadly if you eat over 100u
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.1 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_tox_loss(0.1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //Only really deadly if you eat over 100u
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1831,9 +1831,9 @@
 		var/mob/living/carbon/human/blood_boy = affected_mob
 		blood_boy.physiology?.bleed_mod /= passive_bleed_modifier
 
-/datum/reagent/medicine/coagulant/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/coagulant/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.coagulant_effect(clot_rate * REM * seconds_per_tick))
+	if(affected_mob.coagulant_effect(0.5 * clot_rate * REM * metabolized_volume * seconds_per_tick))
 		if(!was_working)
 			to_chat(affected_mob, span_green("You can feel your flowing blood start thickening!"))
 			was_working = TRUE
@@ -1841,7 +1841,7 @@
 	else if(was_working)
 		was_working = FALSE
 
-/datum/reagent/medicine/coagulant/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/coagulant/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!CAN_HAVE_BLOOD(affected_mob))
 		return
@@ -1853,14 +1853,14 @@
 			to_chat(affected_mob, span_danger("You can feel your blood clotting up in your veins!"))
 		else if(prob(10))
 			to_chat(affected_mob, span_userdanger("You feel like your blood has stopped moving!"))
-			affected_mob.adjust_oxy_loss(rand(3, 4) * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			affected_mob.adjust_oxy_loss(0.5 * rand(3, 4) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 
 		if(prob(50))
 			var/obj/item/organ/lungs/our_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
-			our_lungs.apply_organ_damage(1 * REM * seconds_per_tick)
+			our_lungs.apply_organ_damage(0.5 * REM * metabolized_volume * seconds_per_tick)
 		else
 			var/obj/item/organ/heart/our_heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
-			our_heart.apply_organ_damage(1 * REM * seconds_per_tick)
+			our_heart.apply_organ_damage(0.5 * REM * metabolized_volume * seconds_per_tick)
 
 		return UPDATE_MOB_HEALTH
 
@@ -1904,20 +1904,20 @@
 	ph = 10.6
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/ondansetron/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/ondansetron/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(8, seconds_per_tick))
-		affected_mob.adjust_drowsiness(2 SECONDS * REM * seconds_per_tick)
+		affected_mob.adjust_drowsiness(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(SPT_PROB(15, seconds_per_tick) && !affected_mob.get_stamina_loss())
-		if(affected_mob.adjust_stamina_loss(10 * REM * seconds_per_tick, updating_stamina = FALSE))
+		if(affected_mob.adjust_stamina_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
 			. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_disgust(-10 * REM * seconds_per_tick)
+	affected_mob.adjust_disgust(-5 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/medicine/naloxone
 	name = "Naloxone"
 	description = "Opioid antagonist that purges drowsiness and narcotics from the patient, restores breath loss and accelerates addiction recovery."
 	color = "#f5f5dc"
-	metabolization_rate = 0.2 * REM
+	metabolization_rate = 0.1
 	ph = 4
 	penetrates_skin = TOUCH|VAPOR
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
@@ -1930,10 +1930,10 @@
 		/datum/reagent/inverse/krokodil,
 	)
 
-/datum/reagent/medicine/naloxone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/medicine/naloxone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	for(var/opiate in opiates_to_clear)
-		holder.remove_reagent(opiate, 3 * REM * seconds_per_tick)
+		holder.remove_reagent(opiate, 1.5 * REM * metabolized_volume * seconds_per_tick)
 
 	if(affected_mob.mob_mood?.get_mood_event("numb"))
 		affected_mob.clear_mood_event("numb")
@@ -1943,7 +1943,7 @@
 		affected_mob.clear_mood_event("smacked out")
 		affected_mob.add_mood_event("not smacked out", /datum/mood_event/antinarcotic_heavy)
 
-	affected_mob.adjust_drowsiness(-5 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	if(affected_mob.losebreath >= 1)
-		affected_mob.losebreath -= 1 * REM * seconds_per_tick
+		affected_mob.losebreath -= 0.5 * REM * metabolized_volume * seconds_per_tick
 		return UPDATE_MOB_HEALTH

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1831,7 +1831,7 @@
 
 /datum/reagent/medicine/coagulant/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.coagulant_effect((0.5 / metabolization_rate) * clot_rate * metabolization_ratio * seconds_per_tick))
+	if(affected_mob.coagulant_effect(METABOLIZE_FREE_CONSTANT(0.5) * clot_rate * metabolization_ratio * seconds_per_tick))
 		if(!was_working)
 			to_chat(affected_mob, span_green("You can feel your flowing blood start thickening!"))
 			was_working = TRUE
@@ -1846,19 +1846,19 @@
 
 	if(SPT_PROB(7.5, seconds_per_tick))
 		affected_mob.losebreath += rand(2, 4)
-		affected_mob.adjust_oxy_loss((1 / metabolization_rate) * rand(1, 3) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		affected_mob.adjust_oxy_loss(METABOLIZE_FREE_CONSTANT(1) * rand(1, 3) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 		if(prob(30))
 			to_chat(affected_mob, span_danger("You can feel your blood clotting up in your veins!"))
 		else if(prob(10))
 			to_chat(affected_mob, span_userdanger("You feel like your blood has stopped moving!"))
-			affected_mob.adjust_oxy_loss((0.5 / metabolization_rate) * rand(3, 4) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			affected_mob.adjust_oxy_loss(METABOLIZE_FREE_CONSTANT(0.5) * rand(3, 4) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 
 		if(prob(50))
 			var/obj/item/organ/lungs/our_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
-			our_lungs.apply_organ_damage((0.5 / metabolization_rate) * metabolization_ratio)
+			our_lungs.apply_organ_damage(METABOLIZE_FREE_CONSTANT(0.5) * metabolization_ratio)
 		else
 			var/obj/item/organ/heart/our_heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
-			our_heart.apply_organ_damage((0.5 / metabolization_rate) * metabolization_ratio)
+			our_heart.apply_organ_damage(METABOLIZE_FREE_CONSTANT(0.5) * metabolization_ratio)
 
 		return UPDATE_MOB_HEALTH
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -21,19 +21,19 @@
 	color = "#DB90C6"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/leporazine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/leporazine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/target_temp = affected_mob.get_body_temp_normal(apply_change = FALSE)
 	if(affected_mob.bodytemperature > target_temp)
-		affected_mob.adjust_bodytemperature(-20 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, target_temp)
+		affected_mob.adjust_bodytemperature(-20 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, target_temp)
 	else if(affected_mob.bodytemperature < (target_temp + 1))
-		affected_mob.adjust_bodytemperature(20 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 0, target_temp)
+		affected_mob.adjust_bodytemperature(20 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 0, target_temp)
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/affected_human = affected_mob
 		if(affected_human.coretemperature > target_temp)
-			affected_human.adjust_coretemperature(-20 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, target_temp)
+			affected_human.adjust_coretemperature(-20 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, target_temp)
 		else if(affected_human.coretemperature < (target_temp + 1))
-			affected_human.adjust_coretemperature(20 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, 0, target_temp)
+			affected_human.adjust_coretemperature(20 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, 0, target_temp)
 
 /datum/reagent/medicine/adminordrazine //An OP chemical for admins
 	name = "Adminordrazine"
@@ -65,10 +65,10 @@
 			if(prob(20))
 				mytray.visible_message(span_warning("Nothing happens..."))
 
-/datum/reagent/medicine/adminordrazine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/adminordrazine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.heal_bodypart_damage(brute = 2.5 * REM * metabolized_volume * seconds_per_tick, burn = 2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	affected_mob.adjust_tox_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
+	affected_mob.heal_bodypart_damage(brute = 2.5 * metabolization_ratio * seconds_per_tick, burn = 2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	affected_mob.adjust_tox_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
 	// Heal everything! That we want to. But really don't heal reagents. Otherwise we'll lose ... us.
 	affected_mob.fully_heal(full_heal_flags & ~HEAL_ALL_REAGENTS) // there is no need to return UPDATE_MOB_HEALTH because this proc calls updatehealth()
 
@@ -85,16 +85,16 @@
 	ph = 4
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/synaptizine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/synaptizine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_drowsiness(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.AdjustAllImmobility(-10 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustAllImmobility(-10 * metabolization_ratio * seconds_per_tick)
 
 	if(holder.has_reagent(/datum/reagent/toxin/mindbreaker))
-		holder.remove_reagent(/datum/reagent/toxin/mindbreaker, 2.5 * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_hallucinations(-10 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/toxin/mindbreaker, 2.5 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_hallucinations(-10 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(SPT_PROB(16, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(1, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/synaphydramine
@@ -104,16 +104,16 @@
 	ph = 5.2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/medicine/synaphydramine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/synaphydramine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_drowsiness(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-5 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(holder.has_reagent(/datum/reagent/toxin/mindbreaker))
-		holder.remove_reagent(/datum/reagent/toxin/mindbreaker, 2.5 * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/toxin/mindbreaker, 2.5 * metabolization_ratio * seconds_per_tick)
 	if(holder.has_reagent(/datum/reagent/toxin/histamine))
-		holder.remove_reagent(/datum/reagent/toxin/histamine, 2.5 * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_hallucinations(-10 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/toxin/histamine, 2.5 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_hallucinations(-10 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(SPT_PROB(16, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/sansufentanyl
@@ -123,11 +123,11 @@
 	ph = 6.2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/sansufentanyl/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/sansufentanyl/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_confusion_up_to(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick, 5 SECONDS)
-	affected_mob.adjust_dizzy_up_to(3 SECONDS * REM * metabolized_volume * seconds_per_tick, 12 SECONDS)
-	if(affected_mob.adjust_stamina_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
+	affected_mob.adjust_confusion_up_to(1.5 SECONDS * metabolization_ratio * seconds_per_tick, 5 SECONDS)
+	affected_mob.adjust_dizzy_up_to(3 SECONDS * metabolization_ratio * seconds_per_tick, 12 SECONDS)
+	if(affected_mob.adjust_stamina_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE))
 		. = UPDATE_MOB_HEALTH
 
 	if(SPT_PROB(10, seconds_per_tick))
@@ -145,20 +145,20 @@
 	burning_volume = 0.1
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	metabolization_rate = REAGENTS_METABOLISM * (0.00001 * (affected_mob.bodytemperature ** 2) + 0.5)
 	if(affected_mob.bodytemperature >= T0C || !HAS_TRAIT(affected_mob, TRAIT_KNOCKEDOUT))
 		return
 	var/power = -0.00003 * (affected_mob.bodytemperature ** 2) + 3
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_oxy_loss(-1.5 * power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(0.5 * -power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(0.5 * -power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_tox_loss(0.5 * -power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype) //heals TOXINLOVERs
+	need_mob_update = affected_mob.adjust_oxy_loss(-1.5 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(0.5 * -power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(0.5 * -power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_tox_loss(0.5 * -power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype) //heals TOXINLOVERs
 	for(var/i in affected_mob.all_wounds)
 		var/datum/wound/iter_wound = i
-		iter_wound.on_xadone(0.5 * power * REM * metabolized_volume * seconds_per_tick)
+		iter_wound.on_xadone(0.5 * power * metabolization_ratio * seconds_per_tick)
 	REMOVE_TRAIT(affected_mob, TRAIT_DISFIGURED, TRAIT_GENERIC) //fixes common causes for disfiguration
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
@@ -176,7 +176,7 @@
 	ph = 12
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/pyroxadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/pyroxadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.bodytemperature > BODYTEMP_HEAT_DAMAGE_LIMIT)
 		var/power = 0
@@ -191,15 +191,15 @@
 			power *= 2
 
 		var/need_mob_update
-		need_mob_update = affected_mob.adjust_oxy_loss(-1 * power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += affected_mob.adjust_brute_loss(0.5 * -power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-075 * power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_tox_loss(0.5 * -power * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
+		need_mob_update = affected_mob.adjust_oxy_loss(-1 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += affected_mob.adjust_brute_loss(0.5 * -power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-075 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_tox_loss(0.5 * -power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
 		for(var/i in affected_mob.all_wounds)
 			var/datum/wound/iter_wound = i
-			iter_wound.on_xadone(0.5 * power * REM * metabolized_volume * seconds_per_tick)
+			iter_wound.on_xadone(0.5 * power * metabolization_ratio * seconds_per_tick)
 		REMOVE_TRAIT(affected_mob, TRAIT_DISFIGURED, TRAIT_GENERIC)
 
 /datum/reagent/medicine/rezadone
@@ -214,23 +214,23 @@
 	inverse_chem = /datum/reagent/inverse/rezadone
 
 // Rezadone is almost never used in favor of cryoxadone. Hopefully this will change that. // No such luck so far // with clone damage gone, someone will find a better use for rezadone... right?
-/datum/reagent/medicine/rezadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/rezadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.heal_bodypart_damage(
-		brute = 0.5 * REM * metabolized_volume * seconds_per_tick,
-		burn = 0.5 * REM * metabolized_volume * seconds_per_tick,
+		brute = 0.5 * metabolization_ratio * seconds_per_tick,
+		burn = 0.5 * metabolization_ratio * seconds_per_tick,
 		updating_health = FALSE,
 		required_bodytype = affected_biotype
 	))
 		. = UPDATE_MOB_HEALTH
 	REMOVE_TRAIT(affected_mob, TRAIT_DISFIGURED, TRAIT_GENERIC)
 
-/datum/reagent/medicine/rezadone/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/rezadone/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.set_dizzy_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.set_jitter_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_dizzy_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/rezadone/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message = TRUE, touch_protection = 0)
 	. = ..()
@@ -268,20 +268,20 @@
 	inverse_chem_val = 0.3
 	inverse_chem = /datum/reagent/inverse/oxandrolone
 
-/datum/reagent/medicine/oxandrolone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/oxandrolone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	if(affected_mob.get_fire_loss() > 25)
-		need_mob_update = affected_mob.adjust_fire_loss(-2 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype) //Twice as effective as AIURI for severe burns
+		need_mob_update = affected_mob.adjust_fire_loss(-2 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype) //Twice as effective as AIURI for severe burns
 	else
-		need_mob_update = affected_mob.adjust_fire_loss(-0.25 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype) //But only a quarter as effective for more minor ones
+		need_mob_update = affected_mob.adjust_fire_loss(-0.25 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype) //But only a quarter as effective for more minor ones
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/oxandrolone/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/oxandrolone/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.get_fire_loss()) //It only makes existing burns worse
-		if(affected_mob.adjust_fire_loss(2.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)) // it's going to be healing either 4 or 0.5
+		if(affected_mob.adjust_fire_loss(2.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)) // it's going to be healing either 4 or 0.5
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/salglu_solution
@@ -306,23 +306,23 @@
 	/// Only supplements blood types that use this restoration chem.
 	var/required_restoration_chem = /datum/reagent/iron
 
-/datum/reagent/medicine/salglu_solution/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/salglu_solution/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update = FALSE
 
 	if(SPT_PROB(18, seconds_per_tick))
-		need_mob_update = affected_mob.adjust_brute_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)
+		need_mob_update = affected_mob.adjust_brute_loss(-0.25 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_biotype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.25 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_biotype)
 
 	// Regen is handled here, dilution is handled in [living/proc/get_blood_volume]
 	var/datum/blood_type/blood_type = affected_mob.get_bloodtype()
 	if(blood_type?.restoration_chem == required_restoration_chem)
-		affected_mob.adjust_blood_volume(0.5 * extra_regen * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_blood_volume(0.5 * extra_regen * metabolization_ratio * seconds_per_tick)
 
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/salglu_solution/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/salglu_solution/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	if(SPT_PROB(1.5, seconds_per_tick))
@@ -336,8 +336,8 @@
 			holder.add_reagent(/datum/reagent/consumable/sugar, 1)
 			holder.remove_reagent(/datum/reagent/medicine/salglu_solution, 0.5)
 	if(SPT_PROB(18, seconds_per_tick))
-		need_mob_update = affected_mob.adjust_brute_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)
-		need_mob_update += affected_mob.adjust_fire_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)
+		need_mob_update = affected_mob.adjust_brute_loss(0.25 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_biotype)
+		need_mob_update += affected_mob.adjust_fire_loss(0.25 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -350,11 +350,11 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_AFFECTS_WOUNDS
 	metabolized_traits = list(TRAIT_ANALGESIA)
 
-/datum/reagent/medicine/mine_salve/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/mine_salve/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_brute_loss(-0.125 * metabolization_ratio * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(-0.125 * metabolization_ratio * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -397,23 +397,23 @@
 	ph = 2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/omnizine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/omnizine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(0.5 * -healing * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(0.5 * -healing * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(0.5 * -healing * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(0.5 * -healing * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_tox_loss(0.5 * -healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(0.5 * -healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(0.5 * -healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(0.5 * -healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/omnizine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/omnizine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_tox_loss(0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -435,20 +435,20 @@
 	ph = 1.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/calomel/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/calomel/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	for(var/datum/reagent/target_reagent as anything in affected_mob.reagents.reagent_list)
 		if(istype(target_reagent, /datum/reagent/medicine/calomel))
 			continue
-		affected_mob.reagents.remove_reagent(target_reagent.type, 1.5 * target_reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(target_reagent.type, 1.5 * target_reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 	var/toxin_amount = round(affected_mob.health / 40, 0.1)
-	if(affected_mob.adjust_tox_loss(0.5 * toxin_amount * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.5 * toxin_amount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/calomel/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/calomel/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.reagents.remove_reagent(type, 1 * REM * metabolized_volume * seconds_per_tick)
-	if(affected_mob.adjust_tox_loss(1.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	affected_mob.reagents.remove_reagent(type, 1 * metabolization_ratio * seconds_per_tick)
+	if(affected_mob.adjust_tox_loss(1.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/ammoniated_mercury
@@ -465,22 +465,22 @@
 	inverse_chem_val = 0.50
 	inverse_chem = /datum/reagent/inverse/ammoniated_mercury
 
-/datum/reagent/medicine/ammoniated_mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/ammoniated_mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/toxin_chem_amount = 0
 	for(var/datum/reagent/toxin/target_reagent in affected_mob.reagents.reagent_list)
 		toxin_chem_amount += 1
-		affected_mob.reagents.remove_reagent(target_reagent.type, 2.5 * target_reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(target_reagent.type, 2.5 * target_reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 	var/toxin_amount = round(affected_mob.get_brute_loss() / 15, 0.1) + round(affected_mob.get_fire_loss() / 30, 0.1) - 3
-	if(affected_mob.adjust_tox_loss(0.5 * toxin_amount * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.5 * toxin_amount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
 	if(toxin_chem_amount == 0)
 		for(var/datum/reagent/medicine/ammoniated_mercury/target_reagent in affected_mob.reagents.reagent_list)
-			affected_mob.reagents.remove_reagent(target_reagent.type, 0.5 * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.reagents.remove_reagent(target_reagent.type, 0.5 * metabolization_ratio * seconds_per_tick)
 
-/datum/reagent/medicine/ammoniated_mercury/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/ammoniated_mercury/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/potass_iodide
@@ -492,10 +492,10 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_HALT_RADIATION_EFFECTS)
 
-/datum/reagent/medicine/potass_iodide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/potass_iodide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(HAS_TRAIT(affected_mob, TRAIT_IRRADIATED))
-		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/pen_acid
@@ -509,13 +509,13 @@
 	inverse_chem = /datum/reagent/inverse/pen_acid
 	metabolized_traits = list(TRAIT_HALT_RADIATION_EFFECTS)
 
-/datum/reagent/medicine/pen_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/pen_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
 	for(var/datum/reagent/reagent as anything in affected_mob.reagents.reagent_list)
 		if(reagent != src)
-			affected_mob.reagents.remove_reagent(reagent.type, 1 * reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.reagents.remove_reagent(reagent.type, 1 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/sal_acid
 	name = "Salicylic Acid"
@@ -528,20 +528,20 @@
 	inverse_chem_val = 0.3
 	inverse_chem = /datum/reagent/inverse/sal_acid
 
-/datum/reagent/medicine/sal_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/sal_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	if(affected_mob.get_brute_loss() > 25)
-		need_mob_update = affected_mob.adjust_brute_loss(-2 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_brute_loss(-2 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
 	else
-		need_mob_update = affected_mob.adjust_brute_loss(-0.25 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_brute_loss(-0.25 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/sal_acid/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/sal_acid/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.get_brute_loss()) //It only makes existing bruises worse
-		if(affected_mob.adjust_brute_loss(2.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC)) // it's going to be healing either 4 or 0.5
+		if(affected_mob.adjust_brute_loss(2.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC)) // it's going to be healing either 4 or 0.5
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/salbutamol
@@ -554,15 +554,15 @@
 	inverse_chem_val = 0.25
 	inverse_chem = /datum/reagent/inverse/salbutamol
 
-/datum/reagent/medicine/salbutamol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/salbutamol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_oxy_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update = affected_mob.adjust_oxy_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(affected_mob.losebreath >= 4)
 		var/obj/item/organ/lungs/affected_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
 		var/our_respiration_type = affected_lungs ? affected_lungs.respiration_type : affected_mob.mob_respiration_type // use lungs' respiration type or mob_respiration_type if no lungs
 		if(our_respiration_type & affected_respiration_type)
-			affected_mob.losebreath -= 1 * REM * metabolized_volume * seconds_per_tick
+			affected_mob.losebreath -= 1 * metabolization_ratio * seconds_per_tick
 			need_mob_update = TRUE
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
@@ -611,7 +611,7 @@
 	var/obj/item/organ/lungs/holder_lungs = carbon_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
 	holder_lungs?.adjust_received_pressure_mult(-pressure_mult_increment)
 
-/datum/reagent/medicine/albuterol/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/albuterol/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 
 	if (!iscarbon(affected_mob))
@@ -672,7 +672,7 @@
 	. = ..()
 	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/ephedrine)
 
-/datum/reagent/medicine/ephedrine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/ephedrine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/active_held_item = affected_mob.get_active_held_item()
 	if(SPT_PROB(10 * (1.5-creation_purity), seconds_per_tick) && iscarbon(affected_mob) && active_held_item?.w_class > WEIGHT_CLASS_SMALL)
@@ -680,12 +680,12 @@
 			to_chat(affected_mob, span_notice("Your hands spaz out and you drop what you were holding!"))
 			affected_mob.set_jitter_if_lower(20 SECONDS)
 
-	affected_mob.AdjustAllImmobility(-10 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity())
-	affected_mob.adjust_stamina_loss(-2 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), updating_stamina = FALSE)
+	affected_mob.AdjustAllImmobility(-10 * metabolization_ratio * seconds_per_tick * normalise_creation_purity())
+	affected_mob.adjust_stamina_loss(-2 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_stamina = FALSE)
 
 	return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/ephedrine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/ephedrine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(1 * (1 + (1-normalise_creation_purity())), seconds_per_tick) && iscarbon(affected_mob))
 		affected_mob.apply_status_effect(/datum/status_effect/heart_attack)
@@ -696,7 +696,7 @@
 		to_chat(affected_mob, span_notice("[pick("Your head pounds.", "You feel a tight pain in your chest.", "You find it hard to stay still.", "You feel your heart practically beating out of your chest.")]"))
 
 	if(SPT_PROB(18 * (1 + (1-normalise_creation_purity())), seconds_per_tick))
-		affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		affected_mob.adjust_tox_loss(0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
 		affected_mob.losebreath++
 		return UPDATE_MOB_HEALTH
 
@@ -708,12 +708,12 @@
 	ph = 11.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/diphenhydramine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/diphenhydramine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
 		affected_mob.adjust_drowsiness(2 SECONDS)
-	affected_mob.adjust_jitter(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/toxin/histamine, 1 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_jitter(-1 SECONDS * metabolization_ratio)
+	holder.remove_reagent(/datum/reagent/toxin/histamine, 1 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/morphine
 	name = "Morphine"
@@ -735,34 +735,34 @@
 	. = ..()
 	affected_mob.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 
-/datum/reagent/medicine/morphine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/morphine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 5)
 		affected_mob.add_mood_event("numb", /datum/mood_event/narcotic_medium, name)
 	if(affected_mob.disgust < DISGUST_LEVEL_VERYGROSS && SPT_PROB(50 * (2 - creation_purity), seconds_per_tick))
-		affected_mob.adjust_disgust(0.75 * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_disgust(0.75 * metabolization_ratio)
 
 	switch(current_cycle)
 		if(16) //~3u
 			to_chat(affected_mob, span_warning("You start to feel tired..."))
-			affected_mob.adjust_eye_blur(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.adjust_eye_blur(1 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(66, seconds_per_tick))
 				affected_mob.emote("yawn")
 
 		if(24 to 36) // 5u to 7.5u
 			if(SPT_PROB(66 * (2 - creation_purity), seconds_per_tick))
-				affected_mob.adjust_drowsiness_up_to(1 SECONDS * REM * metabolized_volume * seconds_per_tick, 12 SECONDS)
+				affected_mob.adjust_drowsiness_up_to(1 SECONDS * metabolization_ratio, 12 SECONDS)
 
 		if(36 to 48) // 7.5u to 10u
-			affected_mob.adjust_drowsiness_up_to(1 SECONDS * REM * metabolized_volume * seconds_per_tick, 12 SECONDS)
+			affected_mob.adjust_drowsiness_up_to(1 SECONDS * metabolization_ratio * seconds_per_tick, 12 SECONDS)
 
 		if(48 to INFINITY) //10u onward
-			affected_mob.adjust_drowsiness_up_to(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick, 20 SECONDS)
+			affected_mob.adjust_drowsiness_up_to(1.5 SECONDS * metabolization_ratio * seconds_per_tick, 20 SECONDS)
 			// doesn't scale from purity - at this point it tries to guarantee sleep
 			if(SPT_PROB(30 * (48 - current_cycle), seconds_per_tick))
-				affected_mob.Sleeping(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+				affected_mob.Sleeping(2 SECONDS * metabolization_ratio)
 
-/datum/reagent/medicine/morphine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/morphine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(18, seconds_per_tick))
 		affected_mob.drop_all_held_items()
@@ -819,15 +819,15 @@
 	var/obj/item/organ/eyes/eyes = organ
 	restore_eyesight(prev_affected_mob, eyes)
 
-/datum/reagent/medicine/oculine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/oculine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/normalized_purity = normalise_creation_purity()
-	affected_mob.adjust_temp_blindness(-2 SECONDS * REM * metabolized_volume * seconds_per_tick * normalized_purity)
-	affected_mob.adjust_eye_blur(-2 SECONDS * REM * metabolized_volume * seconds_per_tick * normalized_purity)
+	affected_mob.adjust_temp_blindness(-2 SECONDS * metabolization_ratio * seconds_per_tick * normalized_purity)
+	affected_mob.adjust_eye_blur(-2 SECONDS * metabolization_ratio * seconds_per_tick * normalized_purity)
 	var/obj/item/organ/eyes/eyes = affected_mob.get_organ_slot(ORGAN_SLOT_EYES)
 	if(eyes)
 		// Healing eye damage will cure nearsightedness and blindness from ... eye damage
-		if(eyes.apply_organ_damage(-1 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
+		if(eyes.apply_organ_damage(-1 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
 			. = UPDATE_MOB_HEALTH
 		// If our eyes are seriously damaged, we have a probability of causing eye blur while healing depending on purity
 		if(eyes.damage >= eyes.low_threshold && IS_ORGANIC_ORGAN(eyes) && SPT_PROB(16 - min(normalized_purity * 6, 12), seconds_per_tick))
@@ -846,9 +846,9 @@
 		return
 	restore_eyesight(affected_mob, eyes)
 
-/datum/reagent/medicine/oculine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/oculine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, 0.75 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_EYES, 0.75 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		. = UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/oculine/flumpuline
@@ -874,7 +874,7 @@
 	eyes.lighting_cutoff -= delta_light
 	affected_mob.update_sight()
 
-/datum/reagent/medicine/oculine/flumpuline/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/oculine/flumpuline/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/eyes/eyes = affected_mob.get_organ_slot(ORGAN_SLOT_EYES)
 	// if no eyes or inorganic do nothing. we let already changed eyes go because funny
@@ -887,7 +887,7 @@
 	flump_eyes(affected_mob, eyes)
 
 // Overdose causes constant eye popping
-/datum/reagent/medicine/oculine/flumpuline/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/oculine/flumpuline/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!prob(25))
 		return
@@ -925,12 +925,12 @@
 		if(affected_mob.can_hear())
 			to_chat(affected_mob, span_nicegreen("You can feel your hearing drastically improve!"))
 
-/datum/reagent/medicine/inacusiate/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/inacusiate/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/ears/ears = affected_mob.get_organ_slot(ORGAN_SLOT_EARS)
 	if(!ears)
 		return
-	var/multiplier = 0.75 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity()
+	var/multiplier = 0.75 * metabolization_ratio * seconds_per_tick * normalise_creation_purity()
 	ears.apply_organ_damage(-4 * multiplier)
 	ears.adjust_temporary_deafness(-8 * multiplier)
 	return UPDATE_MOB_HEALTH
@@ -953,14 +953,14 @@
 	inverse_chem = /datum/reagent/inverse/atropine
 	added_traits = list(TRAIT_PREVENT_IMPLANT_AUTO_EXPLOSION)
 
-/datum/reagent/medicine/atropine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/atropine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.health <= affected_mob.crit_threshold)
 		var/need_mob_update
-		need_mob_update = affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update = affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
 	var/obj/item/organ/lungs/affected_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
@@ -971,12 +971,12 @@
 		affected_mob.set_dizzy_if_lower(10 SECONDS)
 		affected_mob.set_jitter_if_lower(10 SECONDS)
 
-/datum/reagent/medicine/atropine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/atropine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.set_dizzy_if_lower(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.set_jitter_if_lower(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_dizzy_if_lower(1 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(1 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/epinephrine
 	name = "Epinephrine"
@@ -989,7 +989,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_NOCRITDAMAGE)
 
-/datum/reagent/medicine/epinephrine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/epinephrine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(holder.has_reagent(/datum/reagent/toxin/lexorin))
 		if(SPT_PROB(10, seconds_per_tick))
@@ -998,38 +998,38 @@
 
 	var/need_mob_update
 	if(affected_mob.health <= affected_mob.crit_threshold)
-		need_mob_update = affected_mob.adjust_tox_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update = affected_mob.adjust_tox_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(affected_mob.losebreath >= 4)
 		var/obj/item/organ/lungs/affected_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
 		var/our_respiration_type = affected_lungs ? affected_lungs.respiration_type : affected_mob.mob_respiration_type
 		if(our_respiration_type & affected_respiration_type)
-			affected_mob.losebreath -= 1 * REM * metabolized_volume * seconds_per_tick
+			affected_mob.losebreath -= 1 * metabolization_ratio * seconds_per_tick
 			need_mob_update = TRUE
 	if(affected_mob.losebreath < 0)
 		affected_mob.losebreath = 0
 		need_mob_update = TRUE
-	need_mob_update += affected_mob.adjust_stamina_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
+	need_mob_update += affected_mob.adjust_stamina_loss(-1 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.AdjustAllImmobility(-20)
 		need_mob_update = TRUE
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/epinephrine/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/epinephrine/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	if(holder.has_reagent(/datum/reagent/toxin/lexorin))
-		holder.remove_reagent(/datum/reagent/toxin/lexorin, 1 * REM * metabolized_volume * seconds_per_tick)
-		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 0.5 * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/toxin/lexorin, 1 * metabolization_ratio * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 0.5 * metabolization_ratio * seconds_per_tick)
 	return ..()
 
-/datum/reagent/medicine/epinephrine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/epinephrine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(SPT_PROB(18, 0.5 * REM * metabolized_volume * seconds_per_tick))
+	if(SPT_PROB(18, 0.5 * metabolization_ratio * seconds_per_tick))
 		var/need_mob_update
-		need_mob_update = affected_mob.adjust_stamina_loss(1.25 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
-		need_mob_update += affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = affected_mob.adjust_stamina_loss(1.25 * metabolization_ratio, updating_stamina = FALSE)
+		need_mob_update += affected_mob.adjust_tox_loss(0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
 		var/obj/item/organ/lungs/affected_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
 		var/our_respiration_type = affected_lungs ? affected_lungs.respiration_type : affected_mob.mob_respiration_type
 		if(our_respiration_type & affected_respiration_type)
@@ -1144,12 +1144,12 @@
 
 	return ..()
 
-/datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/damage_at_random = rand(0, 250)/100 //0 to 2.5
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(0.5 * damage_at_random * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(0.5 * damage_at_random * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_brute_loss(0.5 * damage_at_random * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(0.5 * damage_at_random * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1186,16 +1186,16 @@
 	inverse_chem_val = 0.45
 	metabolized_traits = list(TRAIT_TUMOR_SUPPRESSED) //Having mannitol in you will pause the brain damage from brain tumor (so it heals an even 2 brain damage instead of 1.8)
 
-/datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -1 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -1 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/mannitol/overdose_start(mob/living/affected_mob, metabolized_volume)
+/datum/reagent/medicine/mannitol/overdose_start(mob/living/affected_mob, metabolization_ratio)
 	. = ..()
 	to_chat(affected_mob, span_notice("You suddenly feel <span class='purple'>E N L I G H T E N E D!</span>"))
 
-/datum/reagent/medicine/mannitol/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/mannitol/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(65, seconds_per_tick))
 		return
@@ -1237,16 +1237,16 @@
 	if(initial_bdamage < affected_carbon.get_organ_loss(ORGAN_SLOT_BRAIN))
 		affected_carbon.set_organ_loss(ORGAN_SLOT_BRAIN, initial_bdamage)
 
-/datum/reagent/medicine/neurine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/neurine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(holder.has_reagent(/datum/reagent/consumable/ethanol/neurotoxin))
-		holder.remove_reagent(/datum/reagent/consumable/ethanol/neurotoxin, 2.5 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity())
+		holder.remove_reagent(/datum/reagent/consumable/ethanol/neurotoxin, 2.5 * metabolization_ratio * seconds_per_tick * normalise_creation_purity())
 	if(SPT_PROB(8 * normalise_creation_purity(), seconds_per_tick))
 		affected_mob.cure_trauma_type(resilience = TRAUMA_RESILIENCE_BASIC)
 
-/datum/reagent/medicine/neurine/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/neurine/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -0.5 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -0.5 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/mutadone
@@ -1270,7 +1270,7 @@
 		human_mob.monkeyize()
 
 
-/datum/reagent/medicine/mutadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/mutadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	affected_mob.remove_status_effect(/datum/status_effect/jitter)
 	if(affected_mob.has_dna())
@@ -1296,14 +1296,14 @@
 		/datum/status_effect/speech/slurring/drunk,
 	)
 
-/datum/reagent/medicine/antihol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/antihol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	for(var/effect in status_effects_to_clear)
 		affected_mob.remove_status_effect(effect)
-	affected_mob.reagents.remove_reagent(/datum/reagent/consumable/ethanol, 4 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), include_subtypes = TRUE)
-	if(affected_mob.adjust_tox_loss(-0.1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	affected_mob.reagents.remove_reagent(/datum/reagent/consumable/ethanol, 4 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), include_subtypes = TRUE)
+	if(affected_mob.adjust_tox_loss(-0.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_drunk_effect(-5 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity())
+	affected_mob.adjust_drunk_effect(-5 * metabolization_ratio * seconds_per_tick * normalise_creation_purity())
 
 /datum/reagent/medicine/antihol/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
@@ -1331,24 +1331,24 @@
 	. = ..()
 	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/stimulants)
 
-/datum/reagent/medicine/stimulants/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/stimulants/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.health < 50 && affected_mob.health > 0)
 		var/need_mob_update
-		need_mob_update += affected_mob.adjust_oxy_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
-	affected_mob.AdjustAllImmobility(-30  * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_stamina_loss(-6 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	affected_mob.AdjustAllImmobility(-30  * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_stamina_loss(-6 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 
-/datum/reagent/medicine/stimulants/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/stimulants/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(18, seconds_per_tick))
-		affected_mob.adjust_stamina_loss(2.5, updating_stamina = FALSE, required_biotype = affected_biotype)
-		affected_mob.adjust_tox_loss(1, updating_health = FALSE, required_biotype = affected_biotype)
+		affected_mob.adjust_stamina_loss(2.5 * metabolization_ratio, updating_stamina = FALSE, required_biotype = affected_biotype)
+		affected_mob.adjust_tox_loss(1 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
 		affected_mob.losebreath++
 		return UPDATE_MOB_HEALTH
 
@@ -1360,10 +1360,10 @@
 	ph = 6.7
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/insulin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/insulin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.AdjustSleeping(-1 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/consumable/sugar, 1.5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.AdjustSleeping(-1 SECONDS * metabolization_ratio * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/consumable/sugar, 1.5 * metabolization_ratio * seconds_per_tick)
 
 //Trek Chems, used primarily by medibots. Only heals a specific damage type, but is very efficient.
 
@@ -1374,10 +1374,10 @@
 	ph = 8.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/medicine/inaprovaline/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/inaprovaline/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.losebreath >= 5)
-		affected_mob.losebreath -= 2.5 * REM * metabolized_volume * seconds_per_tick
+		affected_mob.losebreath -= 2.5 * metabolization_ratio * seconds_per_tick
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/regen_jelly
@@ -1398,13 +1398,13 @@
 	exposed_human.set_facial_haircolor(color, update = FALSE)
 	exposed_human.set_haircolor(color, update = TRUE)
 
-/datum/reagent/medicine/regen_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/regen_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_oxy_loss(-0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_tox_loss(-0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype) //heals TOXINLOVERs
+	need_mob_update = affected_mob.adjust_brute_loss(-0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(-0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_oxy_loss(-0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_tox_loss(-0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype) //heals TOXINLOVERs
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1416,21 +1416,21 @@
 	ph = 11
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE) //A ton of healing - this is a 50 telecrystal investment.
-	need_mob_update += affected_mob.adjust_fire_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-	need_mob_update += affected_mob.adjust_oxy_loss(-7.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-	need_mob_update += affected_mob.adjust_tox_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -7.5 * REM * metabolized_volume * seconds_per_tick)
+	need_mob_update = affected_mob.adjust_brute_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE) //A ton of healing - this is a 50 telecrystal investment.
+	need_mob_update += affected_mob.adjust_fire_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+	need_mob_update += affected_mob.adjust_oxy_loss(-7.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+	need_mob_update += affected_mob.adjust_tox_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, -7.5 * metabolization_ratio * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/syndicate_nanites/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume) //wtb flavortext messages that hint that you're vomitting up robots
+/datum/reagent/medicine/syndicate_nanites/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio) //wtb flavortext messages that hint that you're vomitting up robots
 	. = ..()
 	if(SPT_PROB(13, seconds_per_tick))
-		affected_mob.reagents.remove_reagent(type, metabolization_rate * 15) // ~5 units at a rate of 0.4 but i wanted a nice number in code
+		affected_mob.reagents.remove_reagent(type, 5 * metabolization_rate) // ~5 units at a rate of 0.4 but i wanted a nice number in code
 		affected_mob.vomit(vomit_flags = VOMIT_CATEGORY_DEFAULT, vomit_type = /obj/effect/decal/cleanable/vomit/nanites, lost_nutrition = 20) // nanite safety protocols make your body expel them to prevent harmies
 
 /datum/reagent/medicine/earthsblood //Created by ambrosia gaia plants
@@ -1444,38 +1444,38 @@
 	addiction_types = list(/datum/addiction/hallucinogens = 14)
 	metabolized_traits = list(TRAIT_PACIFISM)
 
-/datum/reagent/medicine/earthsblood/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/earthsblood/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	if(current_cycle < 25) //10u has to be processed before u get into THE FUN ZONE
-		need_mob_update = affected_mob.adjust_brute_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += affected_mob.adjust_tox_loss(-0.25 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_stamina_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * REM * metabolized_volume * seconds_per_tick, 150, affected_organ_flags) //This does, after all, come from ambrosia, and the most powerful ambrosia in existence, at that!
+		need_mob_update = affected_mob.adjust_brute_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += affected_mob.adjust_tox_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_stamina_loss(-1 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * metabolization_ratio * seconds_per_tick, 150, affected_organ_flags) //This does, after all, come from ambrosia, and the most powerful ambrosia in existence, at that!
 	else
-		need_mob_update = affected_mob.adjust_brute_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype) //slow to start, but very quick healing once it gets going
-		need_mob_update += affected_mob.adjust_fire_loss(-2.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += affected_mob.adjust_tox_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_stamina_loss(-4 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1 * REM * metabolized_volume * seconds_per_tick, 150, affected_organ_flags)
-		affected_mob.adjust_jitter_up_to(3 SECONDS * REM * metabolized_volume * seconds_per_tick, 1 MINUTES)
+		need_mob_update = affected_mob.adjust_brute_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype) //slow to start, but very quick healing once it gets going
+		need_mob_update += affected_mob.adjust_fire_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += affected_mob.adjust_tox_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_stamina_loss(-4 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1 * metabolization_ratio * seconds_per_tick, 150, affected_organ_flags)
+		affected_mob.adjust_jitter_up_to(3 SECONDS * metabolization_ratio * seconds_per_tick, 1 MINUTES)
 		if(SPT_PROB(5, seconds_per_tick))
 			affected_mob.say(return_hippie_line(), forced = /datum/reagent/medicine/earthsblood)
-	affected_mob.adjust_drugginess_up_to(10 SECONDS * REM * metabolized_volume * seconds_per_tick, 15 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drugginess_up_to(10 SECONDS * metabolization_ratio * seconds_per_tick, 15 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/earthsblood/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/earthsblood/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_hallucinations_up_to(5 SECONDS * REM * metabolized_volume * seconds_per_tick, 120 SECONDS)
+	affected_mob.adjust_hallucinations_up_to(5 SECONDS * metabolization_ratio * seconds_per_tick, 120 SECONDS)
 	var/need_mob_update
 	if(current_cycle > 26)
-		need_mob_update = affected_mob.adjust_tox_loss(2 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = affected_mob.adjust_tox_loss(2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 		if(current_cycle > 101) //podpeople get out reeeeeeeeeeeeeeeeeeeee
-			need_mob_update += affected_mob.adjust_tox_loss(3 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+			need_mob_update += affected_mob.adjust_tox_loss(3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(iscarbon(affected_mob))
 		var/mob/living/carbon/hippie = affected_mob
 		hippie.gain_trauma(/datum/brain_trauma/severe/pacifism)
@@ -1504,25 +1504,25 @@
 	ph = 4.3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/haloperidol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/haloperidol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	for(var/datum/reagent/drug/reagent in affected_mob.reagents.reagent_list)
-		affected_mob.reagents.remove_reagent(reagent.type, 2.5 * reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_drowsiness(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(reagent.type, 2.5 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(2 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	if(affected_mob.get_timed_status_effect_duration(/datum/status_effect/jitter) >= 6 SECONDS)
-		affected_mob.adjust_jitter(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_jitter(-3 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	if (affected_mob.get_timed_status_effect_duration(/datum/status_effect/hallucination) >= 10 SECONDS)
-		affected_mob.adjust_hallucinations(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_hallucinations(-5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	if(affected_mob.get_stamina_loss() >= 100)
-		affected_mob.reagents.remove_reagent(type, 0.5 * metabolization_rate * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(type, 0.5 * metabolization_rate * metabolization_ratio * seconds_per_tick)
 
 	var/need_mob_update = FALSE
 	if(SPT_PROB(10, seconds_per_tick))
 		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1, 50, affected_organ_flags)
-	need_mob_update += affected_mob.adjust_stamina_loss(1.25 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_stamina_loss(1.25 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1534,13 +1534,13 @@
 	overdose_threshold = 30
 	chemical_flags = REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/medicine/changelingadrenaline/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/changelingadrenaline/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	metabolizer.AdjustAllImmobility(-10 * REM * metabolized_volume * seconds_per_tick)
-	if(metabolizer.adjust_stamina_loss(-15 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
+	metabolizer.AdjustAllImmobility(-10 * metabolization_ratio * seconds_per_tick)
+	if(metabolizer.adjust_stamina_loss(-15 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE))
 		. = UPDATE_MOB_HEALTH
-	metabolizer.set_jitter_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	metabolizer.set_dizzy_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	metabolizer.set_jitter_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
+	metabolizer.set_dizzy_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/changelingadrenaline/on_mob_metabolize(mob/living/affected_mob)
 	. = ..()
@@ -1563,9 +1563,9 @@
 	volume -= (min(volume, 1))
 	return STAMCRIT_CANCELLED
 
-/datum/reagent/medicine/changelingadrenaline/overdose_process(mob/living/metabolizer, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/changelingadrenaline/overdose_process(mob/living/metabolizer, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(metabolizer.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+	if(metabolizer.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/changelinghaste
@@ -1583,9 +1583,9 @@
 	. = ..()
 	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/changelinghaste)
 
-/datum/reagent/medicine/changelinghaste/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/changelinghaste/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(metabolizer.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+	if(metabolizer.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/higadrite
@@ -1637,40 +1637,40 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_SLEEPIMMUNE)
 
-/datum/reagent/medicine/modafinil/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/modafinil/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(overdosed) // We do not want any effects on OD
 		return
-	overdose_threshold = 0.5 * overdose_threshold + ((rand(-10, 10) / 10) * REM * metabolized_volume * seconds_per_tick) // for extra fun
-	metabolizer.AdjustAllImmobility(-2.5 * REM * metabolized_volume * seconds_per_tick)
-	metabolizer.adjust_stamina_loss(-1.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	metabolizer.set_jitter_if_lower(0.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	overdose_threshold = 0.5 * overdose_threshold + ((rand(-10, 10) / 10) * metabolization_ratio * seconds_per_tick) // for extra fun
+	metabolizer.AdjustAllImmobility(-2.5 * metabolization_ratio * seconds_per_tick)
+	metabolizer.adjust_stamina_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	metabolizer.set_jitter_if_lower(0.5 SECONDS * metabolization_ratio * seconds_per_tick)
 	metabolization_rate = 0.005 * REAGENTS_METABOLISM * rand(5, 20) // randomizes metabolism between 0.02 and 0.08 per second
 	return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/modafinil/overdose_start(mob/living/affected_mob, metabolized_volume)
+/datum/reagent/medicine/modafinil/overdose_start(mob/living/affected_mob, metabolization_ratio)
 	. = ..()
 	to_chat(affected_mob, span_userdanger("You feel awfully out of breath and jittery!"))
 	metabolization_rate = 0.025 * REAGENTS_METABOLISM // sets metabolism to 0.005 per second on overdose
 
-/datum/reagent/medicine/modafinil/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/modafinil/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	overdose_progress++
 	var/need_mob_update
 	switch(overdose_progress)
 		if(1 to 40)
-			affected_mob.adjust_jitter_up_to(1 SECONDS * REM * metabolized_volume * seconds_per_tick, 20 SECONDS)
-			affected_mob.adjust_stutter_up_to(1 SECONDS * REM * metabolized_volume * seconds_per_tick, 20 SECONDS)
-			affected_mob.set_dizzy_if_lower(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.adjust_jitter_up_to(1 SECONDS * metabolization_ratio * seconds_per_tick, 20 SECONDS)
+			affected_mob.adjust_stutter_up_to(1 SECONDS * metabolization_ratio * seconds_per_tick, 20 SECONDS)
+			affected_mob.set_dizzy_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(30, seconds_per_tick))
 				affected_mob.losebreath++
 				need_mob_update = TRUE
 		if(41 to 80)
-			need_mob_update = affected_mob.adjust_oxy_loss(0.1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-			need_mob_update += affected_mob.adjust_stamina_loss(0.1 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-			affected_mob.adjust_jitter_up_to(1 SECONDS * REM * metabolized_volume * seconds_per_tick, 40 SECONDS)
-			affected_mob.adjust_stutter_up_to(1 SECONDS * REM * metabolized_volume * seconds_per_tick, 40 SECONDS)
-			affected_mob.set_dizzy_if_lower(10 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			need_mob_update = affected_mob.adjust_oxy_loss(0.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_stamina_loss(0.1 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+			affected_mob.adjust_jitter_up_to(1 SECONDS * metabolization_ratio * seconds_per_tick, 40 SECONDS)
+			affected_mob.adjust_stutter_up_to(1 SECONDS * metabolization_ratio * seconds_per_tick, 40 SECONDS)
+			affected_mob.set_dizzy_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(30, seconds_per_tick))
 				affected_mob.losebreath++
 				need_mob_update = TRUE
@@ -1680,13 +1680,13 @@
 				affected_mob.Paralyze(20) // you should be in a bad spot at this point unless epipen has been used
 		if(81)
 			to_chat(affected_mob, span_userdanger("You feel too exhausted to continue!")) // at this point you will eventually die unless you get charcoal
-			need_mob_update = affected_mob.adjust_oxy_loss(0.05 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-			need_mob_update += affected_mob.adjust_stamina_loss(0.05 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+			need_mob_update = affected_mob.adjust_oxy_loss(0.05 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_stamina_loss(0.05 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(82 to INFINITY)
 			REMOVE_TRAIT(affected_mob, TRAIT_SLEEPIMMUNE, type)
-			affected_mob.Sleeping(50 * REM * metabolized_volume * seconds_per_tick)
-			need_mob_update += affected_mob.adjust_oxy_loss(0.75 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-			need_mob_update += affected_mob.adjust_stamina_loss(0.75 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+			affected_mob.Sleeping(50 * metabolization_ratio * seconds_per_tick)
+			need_mob_update += affected_mob.adjust_oxy_loss(0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_stamina_loss(0.75 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1700,19 +1700,19 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_FEARLESS)
 
-/datum/reagent/medicine/psicodine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/psicodine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_jitter(-6 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_dizzy(-6 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_confusion(-3 SECONDS * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.disgust = max(affected_mob.disgust - (3 * REM * metabolized_volume * seconds_per_tick), 0)
+	affected_mob.adjust_jitter(-6 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_dizzy(-6 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_confusion(-3 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.disgust = max(affected_mob.disgust - (3 * metabolization_ratio * seconds_per_tick), 0)
 	if(affected_mob.mob_mood != null && affected_mob.mob_mood.sanity <= SANITY_NEUTRAL) // only take effect if in negative sanity and then...
-		affected_mob.mob_mood.adjust_sanity(2.5 * REM * metabolized_volume * seconds_per_tick, maximum = SANITY_NEUTRAL) // set minimum to prevent unwanted spiking over neutral
+		affected_mob.mob_mood.adjust_sanity(2.5 * metabolization_ratio * seconds_per_tick, maximum = SANITY_NEUTRAL) // set minimum to prevent unwanted spiking over neutral
 
-/datum/reagent/medicine/psicodine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/psicodine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_hallucinations_up_to(5 SECONDS * REM * metabolized_volume * seconds_per_tick, 120 SECONDS)
-	if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	affected_mob.adjust_hallucinations_up_to(5 SECONDS * metabolization_ratio * seconds_per_tick, 120 SECONDS)
+	if(affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/metafactor
@@ -1725,11 +1725,11 @@
 	inverse_chem = /datum/reagent/impurity/probital_failed
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/metafactor/overdose_start(mob/living/carbon/affected_mob, metabolized_volume)
+/datum/reagent/medicine/metafactor/overdose_start(mob/living/carbon/affected_mob, metabolization_ratio)
 	. = ..()
 	metabolization_rate = 2  * REAGENTS_METABOLISM
 
-/datum/reagent/medicine/metafactor/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/metafactor/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(13, seconds_per_tick))
 		affected_mob.vomit(VOMIT_CATEGORY_KNOCKDOWN)
@@ -1741,9 +1741,9 @@
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/silibinin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/silibinin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, -1 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)) // Add a chance to cure liver trauma once implemented.
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, -1 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)) // Add a chance to cure liver trauma once implemented.
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/polypyr  //This is intended to be an ingredient in advanced chems.
@@ -1755,11 +1755,11 @@
 	taste_description = "numbing bitterness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/polypyr/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume) //I wanted a collection of small positive effects, this is as hard to obtain as coniine after all.
+/datum/reagent/medicine/polypyr/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio) //I wanted a collection of small positive effects, this is as hard to obtain as coniine after all.
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, -0.125 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_brute_loss(-0.175 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, -0.125 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_brute_loss(-0.175 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1770,9 +1770,9 @@
 	exposed_human.set_facial_haircolor("#9922ff", update = FALSE)
 	exposed_human.set_haircolor(color) //this will call update_body_parts()
 
-/datum/reagent/medicine/polypyr/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/polypyr/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.25 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/granibitaluri
@@ -1784,20 +1784,20 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_ANALGESIA)
 
-/datum/reagent/medicine/granibitaluri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/granibitaluri/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/healamount = max(0.5 - round(0.01 * (affected_mob.get_brute_loss() + affected_mob.get_fire_loss()), 0.1), 0) //base of 0.5 healing per cycle and loses 0.1 healing for every 10 combined brute/burn damage you have
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(0.5 * -healamount * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(0.5 * -healamount * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_brute_loss(0.5 * -healamount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(0.5 * -healamount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/granibitaluri/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/granibitaluri/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.1 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_tox_loss(0.1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //Only really deadly if you eat over 100u
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.1 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_tox_loss(0.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //Only really deadly if you eat over 100u
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1831,9 +1831,9 @@
 		var/mob/living/carbon/human/blood_boy = affected_mob
 		blood_boy.physiology?.bleed_mod /= passive_bleed_modifier
 
-/datum/reagent/medicine/coagulant/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/coagulant/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.coagulant_effect(0.5 * clot_rate * REM * metabolized_volume * seconds_per_tick))
+	if(affected_mob.coagulant_effect(0.5 * clot_rate * metabolization_ratio * seconds_per_tick))
 		if(!was_working)
 			to_chat(affected_mob, span_green("You can feel your flowing blood start thickening!"))
 			was_working = TRUE
@@ -1841,26 +1841,26 @@
 	else if(was_working)
 		was_working = FALSE
 
-/datum/reagent/medicine/coagulant/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/coagulant/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!CAN_HAVE_BLOOD(affected_mob))
 		return
 
 	if(SPT_PROB(7.5, seconds_per_tick))
 		affected_mob.losebreath += rand(2, 4)
-		affected_mob.adjust_oxy_loss(rand(1, 3), updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		affected_mob.adjust_oxy_loss(rand(1, 3) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 		if(prob(30))
 			to_chat(affected_mob, span_danger("You can feel your blood clotting up in your veins!"))
 		else if(prob(10))
 			to_chat(affected_mob, span_userdanger("You feel like your blood has stopped moving!"))
-			affected_mob.adjust_oxy_loss(0.5 * rand(3, 4) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			affected_mob.adjust_oxy_loss(0.5 * rand(3, 4) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 
 		if(prob(50))
 			var/obj/item/organ/lungs/our_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
-			our_lungs.apply_organ_damage(0.5 * REM * metabolized_volume * seconds_per_tick)
+			our_lungs.apply_organ_damage(0.5 * metabolization_ratio)
 		else
 			var/obj/item/organ/heart/our_heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
-			our_heart.apply_organ_damage(0.5 * REM * metabolized_volume * seconds_per_tick)
+			our_heart.apply_organ_damage(0.5 * metabolization_ratio)
 
 		return UPDATE_MOB_HEALTH
 
@@ -1904,14 +1904,14 @@
 	ph = 10.6
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/ondansetron/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/ondansetron/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(8, seconds_per_tick))
-		affected_mob.adjust_drowsiness(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_drowsiness(1 SECONDS * metabolization_ratio)
 	if(SPT_PROB(15, seconds_per_tick) && !affected_mob.get_stamina_loss())
-		if(affected_mob.adjust_stamina_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
+		if(affected_mob.adjust_stamina_loss(5 * metabolization_ratio, updating_stamina = FALSE))
 			. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_disgust(-5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_disgust(-5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/naloxone
 	name = "Naloxone"
@@ -1930,10 +1930,10 @@
 		/datum/reagent/inverse/krokodil,
 	)
 
-/datum/reagent/medicine/naloxone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/medicine/naloxone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	for(var/opiate in opiates_to_clear)
-		holder.remove_reagent(opiate, 1.5 * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(opiate, 1.5 * metabolization_ratio * seconds_per_tick)
 
 	if(affected_mob.mob_mood?.get_mood_event("numb"))
 		affected_mob.clear_mood_event("numb")
@@ -1943,7 +1943,7 @@
 		affected_mob.clear_mood_event("smacked out")
 		affected_mob.add_mood_event("not smacked out", /datum/mood_event/antinarcotic_heavy)
 
-	affected_mob.adjust_drowsiness(-2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-2.5 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.losebreath >= 1)
-		affected_mob.losebreath -= 0.5 * REM * metabolized_volume * seconds_per_tick
+		affected_mob.losebreath -= 0.5 * metabolization_ratio * seconds_per_tick
 		return UPDATE_MOB_HEALTH

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -272,16 +272,16 @@
 	. = ..()
 	var/need_mob_update
 	if(affected_mob.get_fire_loss() > 25)
-		need_mob_update = affected_mob.adjust_fire_loss(-2 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype) //Twice as effective as AIURI for severe burns
+		need_mob_update = affected_mob.adjust_fire_loss(-4 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype) //Twice as effective as AIURI for severe burns
 	else
-		need_mob_update = affected_mob.adjust_fire_loss(-0.25 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype) //But only a quarter as effective for more minor ones
+		need_mob_update = affected_mob.adjust_fire_loss(-0.5 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype) //But only a quarter as effective for more minor ones
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/oxandrolone/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.get_fire_loss()) //It only makes existing burns worse
-		if(affected_mob.adjust_fire_loss(2.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)) // it's going to be healing either 4 or 0.5
+		if(affected_mob.adjust_fire_loss(4.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_biotype)) // it's going to be healing either 4 or 0.5
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/salglu_solution
@@ -311,13 +311,13 @@
 	var/need_mob_update = FALSE
 
 	if(SPT_PROB(18, seconds_per_tick))
-		need_mob_update = affected_mob.adjust_brute_loss(-0.25 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_biotype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.25 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_biotype)
+		need_mob_update = affected_mob.adjust_brute_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_biotype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_biotype)
 
 	// Regen is handled here, dilution is handled in [living/proc/get_blood_volume]
 	var/datum/blood_type/blood_type = affected_mob.get_bloodtype()
 	if(blood_type?.restoration_chem == required_restoration_chem)
-		affected_mob.adjust_blood_volume(0.5 * extra_regen * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_blood_volume(1 * extra_regen * metabolization_ratio * seconds_per_tick)
 
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
@@ -336,8 +336,8 @@
 			holder.add_reagent(/datum/reagent/consumable/sugar, 1)
 			holder.remove_reagent(/datum/reagent/medicine/salglu_solution, 0.5)
 	if(SPT_PROB(18, seconds_per_tick))
-		need_mob_update = affected_mob.adjust_brute_loss(0.25 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_biotype)
-		need_mob_update += affected_mob.adjust_fire_loss(0.25 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_biotype)
+		need_mob_update = affected_mob.adjust_brute_loss(0.5 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_biotype)
+		need_mob_update += affected_mob.adjust_fire_loss(0.5 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -353,8 +353,8 @@
 /datum/reagent/medicine/mine_salve/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-0.125 * metabolization_ratio * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-0.125 * metabolization_ratio * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_brute_loss(-0.3125 * metabolization_ratio * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(-0.3125 * metabolization_ratio * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -393,27 +393,27 @@
 	color = "#DCDCDC"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	overdose_threshold = 30
-	var/healing = 0.5
 	ph = 2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	var/healing = 0.5
 
 /datum/reagent/medicine/omnizine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(-0.5 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(-0.5 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(-0.5 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-0.5 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_tox_loss(-2 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(-2 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(-2 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(-2 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/omnizine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_tox_loss(3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -429,7 +429,6 @@
 	description = "Quickly purges the body of all chemicals except itself. The more health a person has, \
 		the more toxin damage it will deal. It can heal toxin damage when people have low enough health."
 	color = "#c85319"
-	metabolization_rate = 1 * REAGENTS_METABOLISM
 	taste_description = "acid"
 	overdose_threshold = 20
 	ph = 1.5
@@ -470,17 +469,17 @@
 	var/toxin_chem_amount = 0
 	for(var/datum/reagent/toxin/target_reagent in affected_mob.reagents.reagent_list)
 		toxin_chem_amount += 1
-		affected_mob.reagents.remove_reagent(target_reagent.type, 2.5 * target_reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(target_reagent.type, 25 * target_reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 	var/toxin_amount = round(affected_mob.get_brute_loss() / 15, 0.1) + round(affected_mob.get_fire_loss() / 30, 0.1) - 3
-	if(affected_mob.adjust_tox_loss(0.5 * toxin_amount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(5 * toxin_amount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
 	if(toxin_chem_amount == 0)
 		for(var/datum/reagent/medicine/ammoniated_mercury/target_reagent in affected_mob.reagents.reagent_list)
-			affected_mob.reagents.remove_reagent(target_reagent.type, 0.5 * metabolization_ratio * seconds_per_tick)
+			affected_mob.reagents.remove_reagent(target_reagent.type, 5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/ammoniated_mercury/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(15 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/potass_iodide
@@ -495,7 +494,7 @@
 /datum/reagent/medicine/potass_iodide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(HAS_TRAIT(affected_mob, TRAIT_IRRADIATED))
-		if(affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/pen_acid
@@ -511,11 +510,11 @@
 
 /datum/reagent/medicine/pen_acid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(-2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
 	for(var/datum/reagent/reagent as anything in affected_mob.reagents.reagent_list)
 		if(reagent != src)
-			affected_mob.reagents.remove_reagent(reagent.type, 1 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
+			affected_mob.reagents.remove_reagent(reagent.type, 2 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/sal_acid
 	name = "Salicylic Acid"
@@ -532,16 +531,16 @@
 	. = ..()
 	var/need_mob_update
 	if(affected_mob.get_brute_loss() > 25)
-		need_mob_update = affected_mob.adjust_brute_loss(-2 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_brute_loss(-4 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
 	else
-		need_mob_update = affected_mob.adjust_brute_loss(-0.25 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_brute_loss(-0.5 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/sal_acid/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.get_brute_loss()) //It only makes existing bruises worse
-		if(affected_mob.adjust_brute_loss(2.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC)) // it's going to be healing either 4 or 0.5
+		if(affected_mob.adjust_brute_loss(4.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC)) // it's going to be healing either 4 or 0.5
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/salbutamol
@@ -557,12 +556,12 @@
 /datum/reagent/medicine/salbutamol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_oxy_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update = affected_mob.adjust_oxy_loss(-6 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(affected_mob.losebreath >= 4)
 		var/obj/item/organ/lungs/affected_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
 		var/our_respiration_type = affected_lungs ? affected_lungs.respiration_type : affected_mob.mob_respiration_type // use lungs' respiration type or mob_respiration_type if no lungs
 		if(our_respiration_type & affected_respiration_type)
-			affected_mob.losebreath -= 1 * metabolization_ratio * seconds_per_tick
+			affected_mob.losebreath -= 4 * metabolization_ratio * seconds_per_tick
 			need_mob_update = TRUE
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
@@ -680,8 +679,8 @@
 			to_chat(affected_mob, span_notice("Your hands spaz out and you drop what you were holding!"))
 			affected_mob.set_jitter_if_lower(20 SECONDS)
 
-	affected_mob.AdjustAllImmobility(-10 * metabolization_ratio * seconds_per_tick * normalise_creation_purity())
-	affected_mob.adjust_stamina_loss(-2 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_stamina = FALSE)
+	affected_mob.AdjustAllImmobility(-20 * metabolization_ratio * seconds_per_tick * normalise_creation_purity())
+	affected_mob.adjust_stamina_loss(-4 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), updating_stamina = FALSE)
 
 	return UPDATE_MOB_HEALTH
 
@@ -696,7 +695,7 @@
 		to_chat(affected_mob, span_notice("[pick("Your head pounds.", "You feel a tight pain in your chest.", "You find it hard to stay still.", "You feel your heart practically beating out of your chest.")]"))
 
 	if(SPT_PROB(18 * (1 + (1-normalise_creation_purity())), seconds_per_tick))
-		affected_mob.adjust_tox_loss(0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
+		affected_mob.adjust_tox_loss(1 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
 		affected_mob.losebreath++
 		return UPDATE_MOB_HEALTH
 
@@ -712,8 +711,8 @@
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
 		affected_mob.adjust_drowsiness(2 SECONDS)
-	affected_mob.adjust_jitter(-1 SECONDS * metabolization_ratio * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/toxin/histamine, 1 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_jitter(-2 SECONDS * metabolization_ratio * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/toxin/histamine, 2 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/morphine
 	name = "Morphine"
@@ -740,27 +739,27 @@
 	if(current_cycle > 5)
 		affected_mob.add_mood_event("numb", /datum/mood_event/narcotic_medium, name)
 	if(affected_mob.disgust < DISGUST_LEVEL_VERYGROSS && SPT_PROB(50 * (2 - creation_purity), seconds_per_tick))
-		affected_mob.adjust_disgust(0.75 * metabolization_ratio)
+		affected_mob.adjust_disgust(1.5 * metabolization_ratio)
 
 	switch(current_cycle)
 		if(16) //~3u
 			to_chat(affected_mob, span_warning("You start to feel tired..."))
-			affected_mob.adjust_eye_blur(1 SECONDS * metabolization_ratio * seconds_per_tick)
+			affected_mob.adjust_eye_blur(2 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(66, seconds_per_tick))
 				affected_mob.emote("yawn")
 
 		if(24 to 36) // 5u to 7.5u
 			if(SPT_PROB(66 * (2 - creation_purity), seconds_per_tick))
-				affected_mob.adjust_drowsiness_up_to(1 SECONDS * metabolization_ratio, 12 SECONDS)
+				affected_mob.adjust_drowsiness_up_to(2 SECONDS * metabolization_ratio, 12 SECONDS)
 
 		if(36 to 48) // 7.5u to 10u
-			affected_mob.adjust_drowsiness_up_to(1 SECONDS * metabolization_ratio * seconds_per_tick, 12 SECONDS)
+			affected_mob.adjust_drowsiness_up_to(2 SECONDS * metabolization_ratio * seconds_per_tick, 12 SECONDS)
 
 		if(48 to INFINITY) //10u onward
-			affected_mob.adjust_drowsiness_up_to(1.5 SECONDS * metabolization_ratio * seconds_per_tick, 20 SECONDS)
+			affected_mob.adjust_drowsiness_up_to(3 SECONDS * metabolization_ratio * seconds_per_tick, 20 SECONDS)
 			// doesn't scale from purity - at this point it tries to guarantee sleep
 			if(SPT_PROB(30 * (48 - current_cycle), seconds_per_tick))
-				affected_mob.Sleeping(2 SECONDS * metabolization_ratio)
+				affected_mob.Sleeping(4 SECONDS * metabolization_ratio)
 
 /datum/reagent/medicine/morphine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
@@ -774,7 +773,6 @@
 	name = "Oculine"
 	description = "Quickly restores eye damage, cures nearsightedness, and has a chance to restore vision to the blind."
 	color = "#404040" //oculine is dark grey, inacusiate is light grey
-	metabolization_rate = REAGENTS_METABOLISM
 	overdose_threshold = 30
 	taste_description = "earthy bitterness"
 	purity = REAGENT_STANDARD_PURITY
@@ -957,10 +955,10 @@
 	. = ..()
 	if(affected_mob.health <= affected_mob.crit_threshold)
 		var/need_mob_update
-		need_mob_update = affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-2.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update = affected_mob.adjust_tox_loss(-4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-10 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
 	var/obj/item/organ/lungs/affected_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
@@ -973,10 +971,10 @@
 
 /datum/reagent/medicine/atropine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
-	affected_mob.set_dizzy_if_lower(1 SECONDS * metabolization_ratio * seconds_per_tick)
-	affected_mob.set_jitter_if_lower(1 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.set_dizzy_if_lower(4 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.set_jitter_if_lower(4 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/epinephrine
 	name = "Epinephrine"
@@ -998,20 +996,20 @@
 
 	var/need_mob_update
 	if(affected_mob.health <= affected_mob.crit_threshold)
-		need_mob_update = affected_mob.adjust_tox_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-0.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update = affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(affected_mob.losebreath >= 4)
 		var/obj/item/organ/lungs/affected_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
 		var/our_respiration_type = affected_lungs ? affected_lungs.respiration_type : affected_mob.mob_respiration_type
 		if(our_respiration_type & affected_respiration_type)
-			affected_mob.losebreath -= 1 * metabolization_ratio * seconds_per_tick
+			affected_mob.losebreath -= 4 * metabolization_ratio * seconds_per_tick
 			need_mob_update = TRUE
 	if(affected_mob.losebreath < 0)
 		affected_mob.losebreath = 0
 		need_mob_update = TRUE
-	need_mob_update += affected_mob.adjust_stamina_loss(-1 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
+	need_mob_update += affected_mob.adjust_stamina_loss(-4 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.AdjustAllImmobility(-20)
 		need_mob_update = TRUE
@@ -1026,10 +1024,10 @@
 
 /datum/reagent/medicine/epinephrine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(SPT_PROB(18, 0.5 * metabolization_ratio * seconds_per_tick))
+	if(SPT_PROB(18, seconds_per_tick))
 		var/need_mob_update
-		need_mob_update = affected_mob.adjust_stamina_loss(1.25 * metabolization_ratio, updating_stamina = FALSE)
-		need_mob_update += affected_mob.adjust_tox_loss(0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update = affected_mob.adjust_stamina_loss(5 * metabolization_ratio, updating_stamina = FALSE)
+		need_mob_update += affected_mob.adjust_tox_loss(2 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
 		var/obj/item/organ/lungs/affected_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
 		var/our_respiration_type = affected_lungs ? affected_lungs.respiration_type : affected_mob.mob_respiration_type
 		if(our_respiration_type & affected_respiration_type)
@@ -1148,8 +1146,8 @@
 	. = ..()
 	var/damage_at_random = rand(0, 250)/100 //0 to 2.5
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(0.5 * damage_at_random * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(0.5 * damage_at_random * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_brute_loss(0.4 * damage_at_random * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(0.4 * damage_at_random * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1335,20 +1333,20 @@
 	. = ..()
 	if(affected_mob.health < 50 && affected_mob.health > 0)
 		var/need_mob_update
-		need_mob_update += affected_mob.adjust_oxy_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
-	affected_mob.AdjustAllImmobility(-30  * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_stamina_loss(-6 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	affected_mob.AdjustAllImmobility(-60  * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_stamina_loss(-12 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 
 /datum/reagent/medicine/stimulants/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(18, seconds_per_tick))
-		affected_mob.adjust_stamina_loss(1.25 * metabolization_ratio, updating_stamina = FALSE, required_biotype = affected_biotype)
-		affected_mob.adjust_tox_loss(0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
+		affected_mob.adjust_stamina_loss(2.5 * metabolization_ratio, updating_stamina = FALSE, required_biotype = affected_biotype)
+		affected_mob.adjust_tox_loss(1 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
 		affected_mob.losebreath++
 		return UPDATE_MOB_HEALTH
 
@@ -1362,8 +1360,8 @@
 
 /datum/reagent/medicine/insulin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.AdjustSleeping(-1 SECONDS * metabolization_ratio * seconds_per_tick)
-	holder.remove_reagent(/datum/reagent/consumable/sugar, 1.5 * metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustSleeping(-2 SECONDS * metabolization_ratio * seconds_per_tick)
+	holder.remove_reagent(/datum/reagent/consumable/sugar, 3 * metabolization_ratio * seconds_per_tick)
 
 //Trek Chems, used primarily by medibots. Only heals a specific damage type, but is very efficient.
 
@@ -1437,7 +1435,6 @@
 	name = "Earthsblood"
 	description = "Ichor from an extremely powerful plant. Great for restoring wounds, but it's a little heavy on the brain. For some strange reason, it also induces temporary pacifism in those who imbibe it and semi-permanent pacifism in those who overdose on it."
 	color = "#FFAF00"
-	metabolization_rate = REAGENTS_METABOLISM //Math is based on specific metab rate so we want this to be static AKA if define or medicine metab rate changes, we want this to stay until we can rework calculations.
 	overdose_threshold = 25
 	ph = 11
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
@@ -1508,21 +1505,21 @@
 	. = ..()
 	for(var/datum/reagent/drug/reagent in affected_mob.reagents.reagent_list)
 		affected_mob.reagents.remove_reagent(reagent.type, 2.5 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_drowsiness(2 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	if(affected_mob.get_timed_status_effect_duration(/datum/status_effect/jitter) >= 6 SECONDS)
-		affected_mob.adjust_jitter(-3 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_jitter(-7.5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	if (affected_mob.get_timed_status_effect_duration(/datum/status_effect/hallucination) >= 10 SECONDS)
-		affected_mob.adjust_hallucinations(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_hallucinations(-12.5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	if(affected_mob.get_stamina_loss() >= 100)
-		affected_mob.reagents.remove_reagent(type, 0.5 * metabolization_rate * metabolization_ratio * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(type, 3.125 * metabolization_rate * metabolization_ratio * seconds_per_tick)
 
 	var/need_mob_update = FALSE
 	if(SPT_PROB(10, seconds_per_tick))
 		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1, 50, affected_organ_flags)
-	need_mob_update += affected_mob.adjust_stamina_loss(1.25 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_stamina_loss(3.125 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1585,7 +1582,7 @@
 
 /datum/reagent/medicine/changelinghaste/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(metabolizer.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
+	if(metabolizer.adjust_tox_loss(0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/higadrite
@@ -1632,10 +1629,11 @@
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 	overdose_threshold = 20 // with the random effects this might be awesome or might kill you at less than 10u (extensively tested)
 	taste_description = "salt" // it actually does taste salty
-	var/overdose_progress = 0 // to track overdose progress
 	ph = 7.89
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_SLEEPIMMUNE)
+	/// To track overdose progress
+	var/overdose_progress = 0
 
 /datum/reagent/medicine/modafinil/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolization_ratio)
 	. = ..()
@@ -1702,17 +1700,17 @@
 
 /datum/reagent/medicine/psicodine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_jitter(-6 SECONDS * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_dizzy(-6 SECONDS * metabolization_ratio * seconds_per_tick)
-	affected_mob.adjust_confusion(-3 SECONDS * metabolization_ratio * seconds_per_tick)
-	affected_mob.disgust = max(affected_mob.disgust - (3 * metabolization_ratio * seconds_per_tick), 0)
+	affected_mob.adjust_jitter(-24 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_dizzy(-24 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_confusion(-12 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.disgust = max(affected_mob.disgust - (12 * metabolization_ratio * seconds_per_tick), 0)
 	if(affected_mob.mob_mood != null && affected_mob.mob_mood.sanity <= SANITY_NEUTRAL) // only take effect if in negative sanity and then...
-		affected_mob.mob_mood.adjust_sanity(2.5 * metabolization_ratio * seconds_per_tick, maximum = SANITY_NEUTRAL) // set minimum to prevent unwanted spiking over neutral
+		affected_mob.mob_mood.adjust_sanity(10 * metabolization_ratio * seconds_per_tick, maximum = SANITY_NEUTRAL) // set minimum to prevent unwanted spiking over neutral
 
 /datum/reagent/medicine/psicodine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_hallucinations_up_to(5 SECONDS * metabolization_ratio * seconds_per_tick, 120 SECONDS)
-	if(affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	affected_mob.adjust_hallucinations_up_to(20 SECONDS * metabolization_ratio * seconds_per_tick, 120 SECONDS)
+	if(affected_mob.adjust_tox_loss(2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/metafactor
@@ -1727,7 +1725,7 @@
 
 /datum/reagent/medicine/metafactor/overdose_start(mob/living/carbon/affected_mob, metabolization_ratio)
 	. = ..()
-	metabolization_rate = 2  * REAGENTS_METABOLISM
+	metabolization_rate = 2 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/metafactor/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
@@ -1743,7 +1741,7 @@
 
 /datum/reagent/medicine/silibinin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, -1 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)) // Add a chance to cure liver trauma once implemented.
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, -0.67 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)) // Add a chance to cure liver trauma once implemented.
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/polypyr  //This is intended to be an ingredient in advanced chems.
@@ -1758,8 +1756,8 @@
 /datum/reagent/medicine/polypyr/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio) //I wanted a collection of small positive effects, this is as hard to obtain as coniine after all.
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, -0.125 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_brute_loss(-0.175 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, -0.5 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_brute_loss(-0.7 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1772,7 +1770,7 @@
 
 /datum/reagent/medicine/polypyr/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.25 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 1 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/granibitaluri
@@ -1788,16 +1786,16 @@
 	. = ..()
 	var/healamount = max(0.5 - round(0.01 * (affected_mob.get_brute_loss() + affected_mob.get_fire_loss()), 0.1), 0) //base of 0.5 healing per cycle and loses 0.1 healing for every 10 combined brute/burn damage you have
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-0.5 * healamount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-0.5 * healamount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_brute_loss(-1 * healamount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(-1 * healamount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/granibitaluri/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.1 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += affected_mob.adjust_tox_loss(0.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //Only really deadly if you eat over 100u
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LIVER, 0.2 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += affected_mob.adjust_tox_loss(0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype) //Only really deadly if you eat over 100u
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1833,7 +1831,7 @@
 
 /datum/reagent/medicine/coagulant/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.coagulant_effect(0.5 * clot_rate * metabolization_ratio * seconds_per_tick))
+	if(affected_mob.coagulant_effect(METABOLIZE_FREE_CONSTANT(0.5) * clot_rate * metabolization_ratio * seconds_per_tick))
 		if(!was_working)
 			to_chat(affected_mob, span_green("You can feel your flowing blood start thickening!"))
 			was_working = TRUE
@@ -1848,19 +1846,19 @@
 
 	if(SPT_PROB(7.5, seconds_per_tick))
 		affected_mob.losebreath += rand(2, 4)
-		affected_mob.adjust_oxy_loss(rand(1, 3) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		affected_mob.adjust_oxy_loss(METABOLIZE_FREE_CONSTANT(1) * rand(1, 3) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 		if(prob(30))
 			to_chat(affected_mob, span_danger("You can feel your blood clotting up in your veins!"))
 		else if(prob(10))
 			to_chat(affected_mob, span_userdanger("You feel like your blood has stopped moving!"))
-			affected_mob.adjust_oxy_loss(0.5 * rand(3, 4) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			affected_mob.adjust_oxy_loss(METABOLIZE_FREE_CONSTANT(0.5) * rand(3, 4) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 
 		if(prob(50))
 			var/obj/item/organ/lungs/our_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
-			our_lungs.apply_organ_damage(0.5 * metabolization_ratio)
+			our_lungs.apply_organ_damage(METABOLIZE_FREE_CONSTANT(0.5) * metabolization_ratio)
 		else
 			var/obj/item/organ/heart/our_heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
-			our_heart.apply_organ_damage(0.5 * metabolization_ratio)
+			our_heart.apply_organ_damage(METABOLIZE_FREE_CONSTANT(0.5) * metabolization_ratio)
 
 		return UPDATE_MOB_HEALTH
 
@@ -1907,11 +1905,11 @@
 /datum/reagent/medicine/ondansetron/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(8, seconds_per_tick))
-		affected_mob.adjust_drowsiness(1 SECONDS * metabolization_ratio)
+		affected_mob.adjust_drowsiness(2 SECONDS * metabolization_ratio)
 	if(SPT_PROB(15, seconds_per_tick) && !affected_mob.get_stamina_loss())
-		if(affected_mob.adjust_stamina_loss(5 * metabolization_ratio, updating_stamina = FALSE))
+		if(affected_mob.adjust_stamina_loss(10 * metabolization_ratio, updating_stamina = FALSE))
 			. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_disgust(-5 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_disgust(-10 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/naloxone
 	name = "Naloxone"
@@ -1933,7 +1931,7 @@
 /datum/reagent/medicine/naloxone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	for(var/opiate in opiates_to_clear)
-		holder.remove_reagent(opiate, 1.5 * metabolization_ratio * seconds_per_tick)
+		holder.remove_reagent(opiate, 3 * metabolization_ratio * seconds_per_tick)
 
 	if(affected_mob.mob_mood?.get_mood_event("numb"))
 		affected_mob.clear_mood_event("numb")
@@ -1943,7 +1941,7 @@
 		affected_mob.clear_mood_event("smacked out")
 		affected_mob.add_mood_event("not smacked out", /datum/mood_event/antinarcotic_heavy)
 
-	affected_mob.adjust_drowsiness(-2.5 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(-5 SECONDS * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.losebreath >= 1)
-		affected_mob.losebreath -= 0.5 * metabolization_ratio * seconds_per_tick
+		affected_mob.losebreath -= 1 * metabolization_ratio * seconds_per_tick
 		return UPDATE_MOB_HEALTH

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -399,21 +399,23 @@
 
 /datum/reagent/medicine/omnizine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
+	var/heal = -2 * healing * metabolization_ratio * seconds_per_tick
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(-2 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(-2 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(-2 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-2 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_tox_loss(heal, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(heal, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(heal, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(heal, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/omnizine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
+	var/hurt = 3 * metabolization_ratio * seconds_per_tick
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(3 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_tox_loss(hurt, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(hurt, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(hurt, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(hurt, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -928,9 +930,9 @@
 	var/obj/item/organ/ears/ears = affected_mob.get_organ_slot(ORGAN_SLOT_EARS)
 	if(!ears)
 		return
-	var/multiplier = 0.75 * metabolization_ratio * seconds_per_tick * normalise_creation_purity()
-	ears.apply_organ_damage(-4 * multiplier)
-	ears.adjust_temporary_deafness(-8 * multiplier)
+	var/multiplier = normalise_creation_purity() * metabolization_ratio * seconds_per_tick
+	ears.apply_organ_damage(-2 * multiplier)
+	ears.adjust_temporary_deafness(-4 * multiplier)
 	return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/inacusiate/on_mob_delete(mob/living/affected_mob)
@@ -996,10 +998,11 @@
 
 	var/need_mob_update
 	if(affected_mob.health <= affected_mob.crit_threshold)
-		need_mob_update = affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_oxy_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		var/heal = -1 * metabolization_ratio * seconds_per_tick
+		need_mob_update = affected_mob.adjust_tox_loss(heal, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(heal, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(heal, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(heal, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	if(affected_mob.losebreath >= 4)
 		var/obj/item/organ/lungs/affected_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
 		var/our_respiration_type = affected_lungs ? affected_lungs.respiration_type : affected_mob.mob_respiration_type
@@ -1332,11 +1335,12 @@
 /datum/reagent/medicine/stimulants/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.health < 50 && affected_mob.health > 0)
+		var/heal = -1 * metabolization_ratio * seconds_per_tick
 		var/need_mob_update
-		need_mob_update += affected_mob.adjust_oxy_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(heal, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update += affected_mob.adjust_tox_loss(heal, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(heal, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(heal, updating_health = FALSE, required_bodytype = affected_bodytype)
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
 	affected_mob.AdjustAllImmobility(-60  * metabolization_ratio * seconds_per_tick)
@@ -1398,11 +1402,12 @@
 
 /datum/reagent/medicine/regen_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
+	var/heal = -0.75 * metabolization_ratio * seconds_per_tick
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(-0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(-0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_oxy_loss(-0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_tox_loss(-0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype) //heals TOXINLOVERs
+	need_mob_update = affected_mob.adjust_brute_loss(heal, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(heal, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_oxy_loss(heal, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_tox_loss(heal, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype) //heals TOXINLOVERs
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1514,7 +1519,7 @@
 		affected_mob.adjust_hallucinations(-12.5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	if(affected_mob.get_stamina_loss() >= 100)
-		affected_mob.reagents.remove_reagent(type, 3.125 * metabolization_rate * metabolization_ratio * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(type, 1.25 * metabolization_rate * metabolization_ratio * seconds_per_tick)
 
 	var/need_mob_update = FALSE
 	if(SPT_PROB(10, seconds_per_tick))
@@ -1582,7 +1587,7 @@
 
 /datum/reagent/medicine/changelinghaste/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(metabolizer.adjust_tox_loss(0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
+	if(metabolizer.adjust_tox_loss(4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/medicine/higadrite
@@ -1639,10 +1644,10 @@
 	. = ..()
 	if(overdosed) // We do not want any effects on OD
 		return
-	overdose_threshold = overdose_threshold + 0.5 * ((rand(-10, 10) / 10) * metabolization_ratio * seconds_per_tick) // for extra fun
-	metabolizer.AdjustAllImmobility(-2.5 * metabolization_ratio * seconds_per_tick)
-	metabolizer.adjust_stamina_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-	metabolizer.set_jitter_if_lower(0.5 SECONDS * metabolization_ratio * seconds_per_tick)
+	overdose_threshold = overdose_threshold + 5 * ((rand(-10, 10) / 10) * metabolization_ratio * seconds_per_tick) // for extra fun
+	metabolizer.AdjustAllImmobility(-25 * metabolization_ratio * seconds_per_tick)
+	metabolizer.adjust_stamina_loss(-15 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+	metabolizer.set_jitter_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
 	metabolization_rate = 0.005 * REAGENTS_METABOLISM * rand(5, 20) // randomizes metabolism between 0.02 and 0.08 per second
 	return UPDATE_MOB_HEALTH
 
@@ -1657,18 +1662,18 @@
 	var/need_mob_update
 	switch(overdose_progress)
 		if(1 to 40)
-			affected_mob.adjust_jitter_up_to(1 SECONDS * metabolization_ratio * seconds_per_tick, 20 SECONDS)
-			affected_mob.adjust_stutter_up_to(1 SECONDS * metabolization_ratio * seconds_per_tick, 20 SECONDS)
-			affected_mob.set_dizzy_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
+			affected_mob.adjust_jitter_up_to(40 SECONDS * metabolization_ratio * seconds_per_tick, 20 SECONDS)
+			affected_mob.adjust_stutter_up_to(40 SECONDS * metabolization_ratio * seconds_per_tick, 20 SECONDS)
+			affected_mob.set_dizzy_if_lower(200 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(30, seconds_per_tick))
 				affected_mob.losebreath++
 				need_mob_update = TRUE
 		if(41 to 80)
-			need_mob_update = affected_mob.adjust_oxy_loss(0.05 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-			need_mob_update += affected_mob.adjust_stamina_loss(0.05 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
-			affected_mob.adjust_jitter_up_to(1 SECONDS * metabolization_ratio * seconds_per_tick, 40 SECONDS)
-			affected_mob.adjust_stutter_up_to(1 SECONDS * metabolization_ratio * seconds_per_tick, 40 SECONDS)
-			affected_mob.set_dizzy_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
+			need_mob_update = affected_mob.adjust_oxy_loss(2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_stamina_loss(2 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+			affected_mob.adjust_jitter_up_to(40 SECONDS * metabolization_ratio * seconds_per_tick, 40 SECONDS)
+			affected_mob.adjust_stutter_up_to(40 SECONDS * metabolization_ratio * seconds_per_tick, 40 SECONDS)
+			affected_mob.set_dizzy_if_lower(400 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(30, seconds_per_tick))
 				affected_mob.losebreath++
 				need_mob_update = TRUE
@@ -1678,13 +1683,13 @@
 				affected_mob.Paralyze(20) // you should be in a bad spot at this point unless epipen has been used
 		if(81)
 			to_chat(affected_mob, span_userdanger("You feel too exhausted to continue!")) // at this point you will eventually die unless you get charcoal
-			need_mob_update = affected_mob.adjust_oxy_loss(0.05 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-			need_mob_update += affected_mob.adjust_stamina_loss(0.05 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+			need_mob_update = affected_mob.adjust_oxy_loss(2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_stamina_loss(2 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 		if(82 to INFINITY)
 			REMOVE_TRAIT(affected_mob, TRAIT_SLEEPIMMUNE, type)
-			affected_mob.Sleeping(50 * metabolization_ratio * seconds_per_tick)
-			need_mob_update += affected_mob.adjust_oxy_loss(0.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-			need_mob_update += affected_mob.adjust_stamina_loss(0.75 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+			affected_mob.Sleeping(200 SECONDS * metabolization_ratio * seconds_per_tick)
+			need_mob_update += affected_mob.adjust_oxy_loss(30 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_stamina_loss(30 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -153,9 +153,9 @@
 	var/power = -0.00003 * (affected_mob.bodytemperature ** 2) + 3
 	var/need_mob_update
 	need_mob_update = affected_mob.adjust_oxy_loss(-1.5 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(0.5 * -power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(0.5 * -power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_tox_loss(0.5 * -power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype) //heals TOXINLOVERs
+	need_mob_update += affected_mob.adjust_brute_loss(-0.5 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(-0.5 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_tox_loss(-0.5 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype) //heals TOXINLOVERs
 	for(var/i in affected_mob.all_wounds)
 		var/datum/wound/iter_wound = i
 		iter_wound.on_xadone(0.5 * power * metabolization_ratio * seconds_per_tick)
@@ -192,9 +192,9 @@
 
 		var/need_mob_update
 		need_mob_update = affected_mob.adjust_oxy_loss(-1 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update += affected_mob.adjust_brute_loss(0.5 * -power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-075 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_tox_loss(0.5 * -power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-0.5 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.75 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_tox_loss(-0.5 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
 		for(var/i in affected_mob.all_wounds)
@@ -400,10 +400,10 @@
 /datum/reagent/medicine/omnizine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_tox_loss(0.5 * -healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-	need_mob_update += affected_mob.adjust_oxy_loss(0.5 * -healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(0.5 * -healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(0.5 * -healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_tox_loss(-0.5 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update += affected_mob.adjust_oxy_loss(-0.5 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(-0.5 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(-0.5 * healing * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -712,7 +712,7 @@
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
 		affected_mob.adjust_drowsiness(2 SECONDS)
-	affected_mob.adjust_jitter(-1 SECONDS * metabolization_ratio)
+	affected_mob.adjust_jitter(-1 SECONDS * metabolization_ratio * seconds_per_tick)
 	holder.remove_reagent(/datum/reagent/toxin/histamine, 1 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/medicine/morphine
@@ -1347,8 +1347,8 @@
 /datum/reagent/medicine/stimulants/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(18, seconds_per_tick))
-		affected_mob.adjust_stamina_loss(2.5 * metabolization_ratio, updating_stamina = FALSE, required_biotype = affected_biotype)
-		affected_mob.adjust_tox_loss(1 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
+		affected_mob.adjust_stamina_loss(1.25 * metabolization_ratio, updating_stamina = FALSE, required_biotype = affected_biotype)
+		affected_mob.adjust_tox_loss(0.5 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
 		affected_mob.losebreath++
 		return UPDATE_MOB_HEALTH
 
@@ -1641,7 +1641,7 @@
 	. = ..()
 	if(overdosed) // We do not want any effects on OD
 		return
-	overdose_threshold = 0.5 * overdose_threshold + ((rand(-10, 10) / 10) * metabolization_ratio * seconds_per_tick) // for extra fun
+	overdose_threshold = overdose_threshold + 0.5 * ((rand(-10, 10) / 10) * metabolization_ratio * seconds_per_tick) // for extra fun
 	metabolizer.AdjustAllImmobility(-2.5 * metabolization_ratio * seconds_per_tick)
 	metabolizer.adjust_stamina_loss(-1.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 	metabolizer.set_jitter_if_lower(0.5 SECONDS * metabolization_ratio * seconds_per_tick)
@@ -1666,8 +1666,8 @@
 				affected_mob.losebreath++
 				need_mob_update = TRUE
 		if(41 to 80)
-			need_mob_update = affected_mob.adjust_oxy_loss(0.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-			need_mob_update += affected_mob.adjust_stamina_loss(0.1 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
+			need_mob_update = affected_mob.adjust_oxy_loss(0.05 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			need_mob_update += affected_mob.adjust_stamina_loss(0.05 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE, required_biotype = affected_biotype)
 			affected_mob.adjust_jitter_up_to(1 SECONDS * metabolization_ratio * seconds_per_tick, 40 SECONDS)
 			affected_mob.adjust_stutter_up_to(1 SECONDS * metabolization_ratio * seconds_per_tick, 40 SECONDS)
 			affected_mob.set_dizzy_if_lower(10 SECONDS * metabolization_ratio * seconds_per_tick)
@@ -1788,8 +1788,8 @@
 	. = ..()
 	var/healamount = max(0.5 - round(0.01 * (affected_mob.get_brute_loss() + affected_mob.get_fire_loss()), 0.1), 0) //base of 0.5 healing per cycle and loses 0.1 healing for every 10 combined brute/burn damage you have
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(0.5 * -healamount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_fire_loss(0.5 * -healamount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update = affected_mob.adjust_brute_loss(-0.5 * healamount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_fire_loss(-0.5 * healamount * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1018,10 +1018,10 @@
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
-/datum/reagent/medicine/epinephrine/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+/datum/reagent/medicine/epinephrine/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(holder.has_reagent(/datum/reagent/toxin/lexorin))
-		holder.remove_reagent(/datum/reagent/toxin/lexorin, 1 * metabolization_ratio * seconds_per_tick)
-		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 0.5 * metabolization_ratio * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/toxin/lexorin, 1 * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 0.5 * REM * metabolized_volume * seconds_per_tick)
 	return ..()
 
 /datum/reagent/medicine/epinephrine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -774,7 +774,7 @@
 	name = "Oculine"
 	description = "Quickly restores eye damage, cures nearsightedness, and has a chance to restore vision to the blind."
 	color = "#404040" //oculine is dark grey, inacusiate is light grey
-	metabolization_rate = 1 * REAGENTS_METABOLISM
+	metabolization_rate = REAGENTS_METABOLISM
 	overdose_threshold = 30
 	taste_description = "earthy bitterness"
 	purity = REAGENT_STANDARD_PURITY
@@ -1917,7 +1917,7 @@
 	name = "Naloxone"
 	description = "Opioid antagonist that purges drowsiness and narcotics from the patient, restores breath loss and accelerates addiction recovery."
 	color = "#f5f5dc"
-	metabolization_rate = 0.1
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	ph = 4
 	penetrates_skin = TOUCH|VAPOR
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1831,7 +1831,7 @@
 
 /datum/reagent/medicine/coagulant/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.coagulant_effect(METABOLIZE_FREE_CONSTANT(0.5) * clot_rate * metabolization_ratio * seconds_per_tick))
+	if(affected_mob.coagulant_effect((0.5 / metabolization_rate) * clot_rate * metabolization_ratio * seconds_per_tick))
 		if(!was_working)
 			to_chat(affected_mob, span_green("You can feel your flowing blood start thickening!"))
 			was_working = TRUE
@@ -1846,19 +1846,19 @@
 
 	if(SPT_PROB(7.5, seconds_per_tick))
 		affected_mob.losebreath += rand(2, 4)
-		affected_mob.adjust_oxy_loss(METABOLIZE_FREE_CONSTANT(1) * rand(1, 3) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		affected_mob.adjust_oxy_loss((1 / metabolization_rate) * rand(1, 3) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 		if(prob(30))
 			to_chat(affected_mob, span_danger("You can feel your blood clotting up in your veins!"))
 		else if(prob(10))
 			to_chat(affected_mob, span_userdanger("You feel like your blood has stopped moving!"))
-			affected_mob.adjust_oxy_loss(METABOLIZE_FREE_CONSTANT(0.5) * rand(3, 4) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			affected_mob.adjust_oxy_loss((0.5 / metabolization_rate) * rand(3, 4) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 
 		if(prob(50))
 			var/obj/item/organ/lungs/our_lungs = affected_mob.get_organ_slot(ORGAN_SLOT_LUNGS)
-			our_lungs.apply_organ_damage(METABOLIZE_FREE_CONSTANT(0.5) * metabolization_ratio)
+			our_lungs.apply_organ_damage((0.5 / metabolization_rate) * metabolization_ratio)
 		else
 			var/obj/item/organ/heart/our_heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
-			our_heart.apply_organ_damage(METABOLIZE_FREE_CONSTANT(0.5) * metabolization_ratio)
+			our_heart.apply_organ_damage((0.5 / metabolization_rate) * metabolization_ratio)
 
 		return UPDATE_MOB_HEALTH
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -223,7 +223,7 @@
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver?.damage && !IS_ROBOTIC_ORGAN(liver) && !(liver.organ_flags & ORGAN_FAILING))
 		var/healing_bonus = liver.healing_factor * liver.maxHealth
-		liver.apply_organ_damage(0.5 * -healing_bonus * metabolization_ratio * seconds_per_tick)
+		liver.apply_organ_damage(-0.5 * healing_bonus * metabolization_ratio * seconds_per_tick)
 
 	var/water_adaptation = HAS_TRAIT(affected_mob, TRAIT_WATER_ADAPTATION)
 	var/blood_restored = water_adaptation ? 0.3 : 0.1
@@ -2890,7 +2890,7 @@
 		var/obj/item/bodypart/wounded_part = W.limb
 		if(wounded_part)
 			wounded_part.heal_damage(0.125 * metabolization_ratio * seconds_per_tick, 0.25 * metabolization_ratio * seconds_per_tick)
-		if(affected_mob.adjust_stamina_loss(-2 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)) // the more wounds, the more stamina regen
+		if(affected_mob.adjust_stamina_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)) // the more wounds, the more stamina regen
 			return UPDATE_MOB_HEALTH
 
 // unholy water, but for heretics.

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -217,24 +217,24 @@
 #undef WATER_TO_WET_STACKS_FACTOR_VAPOR
 
 
-/datum/reagent/water/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/water/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver?.damage && !IS_ROBOTIC_ORGAN(liver) && !(liver.organ_flags & ORGAN_FAILING))
 		var/healing_bonus = liver.healing_factor * liver.maxHealth
-		liver.apply_organ_damage(0.5 * -healing_bonus * REM * metabolized_volume * seconds_per_tick)
+		liver.apply_organ_damage(0.5 * -healing_bonus * metabolization_ratio * seconds_per_tick)
 
 	var/water_adaptation = HAS_TRAIT(affected_mob, TRAIT_WATER_ADAPTATION)
 	var/blood_restored = water_adaptation ? 0.3 : 0.1
-	affected_mob.adjust_blood_volume(0.5 * blood_restored * REM * metabolized_volume * seconds_per_tick) // water is good for you!
+	affected_mob.adjust_blood_volume(0.5 * blood_restored * metabolization_ratio * seconds_per_tick) // water is good for you!
 	var/drunkness_restored = water_adaptation ? -0.5 : -0.25
-	affected_mob.adjust_drunk_effect(0.5 * drunkness_restored * REM * metabolized_volume * seconds_per_tick) // and even sobers you up slowly!!
+	affected_mob.adjust_drunk_effect(0.5 * drunkness_restored * metabolization_ratio * seconds_per_tick) // and even sobers you up slowly!!
 	if(water_adaptation)
 		var/need_mob_update = FALSE
-		need_mob_update = affected_mob.adjust_tox_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_brute_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_tox_loss(-0.125 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.125 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_brute_loss(-0.125 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		return need_mob_update ? UPDATE_MOB_HEALTH : .
 
 // For weird backwards situations where water manages to get added to trays nutrients, as opposed to being snowflaked away like usual.
@@ -247,9 +247,9 @@
 	name = "Mineral Water"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE|REAGENT_CLEANS
 
-/datum/reagent/water/mineral/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/water/mineral/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_tox_loss(-0.05 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+	affected_mob.adjust_tox_loss(-0.05 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
 	return UPDATE_MOB_HEALTH
 
 /datum/reagent/water/salt
@@ -337,12 +337,12 @@
 	if(IS_CULTIST(affected_mob))
 		to_chat(affected_mob, span_userdanger("A vile holiness begins to spread its shining tendrils through your mind, purging the Geometer of Blood's influence!"))
 
-/datum/reagent/water/holywater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/water/holywater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 
 	data["deciseconds_metabolized"] += (seconds_per_tick * 1 SECONDS * REM)
 
-	affected_mob.adjust_jitter_up_to(2 SECONDS * REM * metabolized_volume * seconds_per_tick, 20 SECONDS)
+	affected_mob.adjust_jitter_up_to(2 SECONDS * metabolization_ratio * seconds_per_tick, 20 SECONDS)
 	var/need_mob_update = FALSE
 
 	if(IS_CULTIST(affected_mob))
@@ -355,7 +355,7 @@
 				to_chat(affected_mob, span_cult_large("Your blood rites falter as holy water scours your body!"))
 
 	if(data["deciseconds_metabolized"] >= (25 SECONDS)) // 10 units
-		affected_mob.adjust_stutter_up_to(2 SECONDS * REM * metabolized_volume * seconds_per_tick, 20 SECONDS)
+		affected_mob.adjust_stutter_up_to(2 SECONDS * metabolization_ratio * seconds_per_tick, 20 SECONDS)
 		affected_mob.set_dizzy_if_lower(10 SECONDS)
 		if(IS_CULTIST(affected_mob) && SPT_PROB(10, seconds_per_tick))
 			affected_mob.say(pick("Av'te Nar'Sie","Pa'lid Mors","INO INO ORA ANA","SAT ANA!","Daim'niodeis Arc'iai Le'eones","R'ge Na'sie","Diabo us Vo'iscum","Eld' Mon Nobis"), forced = "holy water")
@@ -367,7 +367,7 @@
 		else if(HAS_TRAIT(affected_mob, TRAIT_EVIL) && SPT_PROB(25, seconds_per_tick)) //Congratulations, your committment to evil has now made holy water a deadly poison to you!
 			if(!IS_CULTIST(affected_mob) || affected_mob.mind?.holy_role != HOLY_ROLE_PRIEST)
 				affected_mob.emote("scream")
-				need_mob_update += affected_mob.adjust_fire_loss(1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+				need_mob_update += affected_mob.adjust_fire_loss(1.5 * metabolization_ratio, updating_health = FALSE)
 
 	if(data["deciseconds_metabolized"] >= (1 MINUTES)) // 24 units
 		if(IS_CULTIST(affected_mob))
@@ -375,7 +375,7 @@
 			affected_mob.Unconscious(10 SECONDS)
 		else if(HAS_TRAIT(affected_mob, TRAIT_EVIL)) //At this much holy water, you're probably going to fucking melt. good luck
 			if(!IS_CULTIST(affected_mob) || affected_mob.mind?.holy_role != HOLY_ROLE_PRIEST)
-				need_mob_update += affected_mob.adjust_fire_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+				need_mob_update += affected_mob.adjust_fire_loss(5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
 		affected_mob.remove_status_effect(/datum/status_effect/jitter)
 		affected_mob.remove_status_effect(/datum/status_effect/speech/stutter)
 		for(var/datum/status_effect/eldritch_painting/eldritch_curses in affected_mob.status_effects)
@@ -460,28 +460,28 @@
 	if(IS_CULTIST(affected_mob))
 		ADD_TRAIT(affected_mob, TRAIT_COAGULATING, type)
 
-/datum/reagent/fuel/unholywater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/fuel/unholywater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 
 	var/need_mob_update = FALSE
 	if(IS_CULTIST(affected_mob))
-		affected_mob.adjust_drowsiness(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-		affected_mob.AdjustAllImmobility(-20 * REM * metabolized_volume * seconds_per_tick)
-		need_mob_update += affected_mob.adjust_stamina_loss(-5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
-		need_mob_update += affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_oxy_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_brute_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_fire_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		affected_mob.adjust_drowsiness(-5 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.AdjustAllImmobility(-20 * metabolization_ratio * seconds_per_tick)
+		need_mob_update += affected_mob.adjust_stamina_loss(-5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
+		need_mob_update += affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_oxy_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
 		need_mob_update = TRUE
-		affected_mob.adjust_blood_volume(1.5 * REM * metabolized_volume * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
-		affected_mob.coagulant_effect(1 * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_blood_volume(1.5 * metabolization_ratio * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
+		affected_mob.coagulant_effect(1 * metabolization_ratio * seconds_per_tick)
 
 	else  // Will deal about 90 damage when 50 units are thrown
-		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1.5 * REM * metabolized_volume * seconds_per_tick, 150)
-		need_mob_update += affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_fire_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_oxy_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_brute_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1.5 * metabolization_ratio * seconds_per_tick, 150)
+		need_mob_update += affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_fire_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_oxy_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_brute_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -496,7 +496,7 @@
 	ph = 0.1
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/hellwater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/hellwater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	affected_mob.set_fire_stacks(min(affected_mob.fire_stacks + (1.5 * seconds_per_tick), 5))
 	affected_mob.ignite_mob() //Only problem with igniting people is currently the commonly available fire suits make you immune to being on fire
@@ -611,7 +611,7 @@
 		if((methods & INGEST) && show_message)
 			to_chat(exposed_mob, span_notice("That tasted horrible."))
 
-/datum/reagent/spraytan/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/spraytan/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 
@@ -663,7 +663,7 @@
 									"Your appendages begin morphing." = MUT_MSG_EXTENDED,
 									"You feel as though you're about to change at any moment!" = MUT_MSG_ABOUT2TURN)
 
-/datum/reagent/mutationtoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/mutationtoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!ishuman(affected_mob))
 		return
@@ -747,7 +747,7 @@
 	taste_description = "grandma's gelatin"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/mutationtoxin/jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/mutationtoxin/jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	if(!ishuman(affected_mob))
 		return ..()
 	var/mob/living/carbon/affected_human = affected_mob
@@ -848,7 +848,7 @@
 	taste_description = "slime"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/mulligan/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/mulligan/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!ishuman(affected_mob))
 		return
@@ -894,7 +894,7 @@
 	ph = 10
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/serotrotium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/serotrotium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(3.5, seconds_per_tick))
 		affected_mob.emote(pick("twitch","drool","moan","gasp"))
@@ -966,13 +966,13 @@
 	taste_mult = 0 // apparently tasteless.
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!HAS_TRAIT(src, TRAIT_IMMOBILIZED) && isturf(affected_mob.loc) && !isgroundlessturf(affected_mob.loc))
 		step(affected_mob, pick(GLOB.cardinals))
 	if(SPT_PROB(3.5, seconds_per_tick))
 		affected_mob.emote(pick("twitch","drool","moan"))
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5*seconds_per_tick))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * metabolization_ratio * seconds_per_tick))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/sulfur
@@ -1016,7 +1016,7 @@
 	// White Phosphorous + water -> phosphoric acid. That's not a good thing really.
 
 
-/datum/reagent/chlorine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/chlorine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.take_bodypart_damage(0.5*REM*seconds_per_tick, 0))
 		return UPDATE_MOB_HEALTH
@@ -1036,7 +1036,7 @@
 	mytray.adjust_waterlevel(-round(volume * 0.5))
 	mytray.adjust_weedlevel(-rand(1, 4))
 
-/datum/reagent/fluorine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/fluorine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.adjust_tox_loss(0.5*REM*seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
@@ -1071,7 +1071,7 @@
 	ph = 11.3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/lithium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/lithium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && isturf(affected_mob.loc) && !isgroundlessturf(affected_mob.loc))
 		step(affected_mob, pick(GLOB.cardinals))
@@ -1143,7 +1143,7 @@
 	/// How radioactive is this reagent
 	var/rad_power = 1
 
-/datum/reagent/uranium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/uranium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_IRRADIATED) && SSradiation.can_irradiate_basic(affected_mob))
 		var/chance = min(volume / (20 - rad_power * 5), rad_power)
@@ -1238,7 +1238,7 @@
 
 	do_teleport(exposed_mob, get_turf(exposed_mob), (reac_volume / 5), asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE) //4 tiles per crystal
 
-/datum/reagent/bluespace/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/bluespace/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 10 && SPT_PROB(7.5, seconds_per_tick))
 		to_chat(affected_mob, span_warning("You feel unstable..."))
@@ -1290,7 +1290,7 @@
 
 	exposed_mob.adjust_fire_stacks(reac_volume / 10)
 
-/datum/reagent/fuel/on_mob_life(mob/living/carbon/victim, seconds_per_tick, metabolized_volume)
+/datum/reagent/fuel/on_mob_life(mob/living/carbon/victim, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/liver/liver = victim.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_HUMAN_AI_METABOLISM))
@@ -1359,7 +1359,7 @@
 	ph = 2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/space_cleaner/ez_clean/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/space_cleaner/ez_clean/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	need_mob_update = affected_mob.adjust_brute_loss(1.665*seconds_per_tick, updating_health = FALSE)
@@ -1388,7 +1388,7 @@
 	ph = 11.9
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/cryptobiolin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/cryptobiolin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	affected_mob.set_dizzy_if_lower(2 SECONDS)
 
@@ -1410,7 +1410,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/opioids = 10)
 
-/datum/reagent/impedrezene/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/impedrezene/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	affected_mob.adjust_jitter(-5 SECONDS * seconds_per_tick)
 	if(SPT_PROB(55, seconds_per_tick))
@@ -1579,9 +1579,9 @@
 	. = ..()
 	REMOVE_TRAIT(affected_mob, TRAIT_BLOOD_FOUNTAIN, type)
 
-/datum/reagent/nitrous_oxide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/nitrous_oxide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_drowsiness(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_drowsiness(2 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	if(!HAS_TRAIT(affected_mob, TRAIT_BLOOD_FOUNTAIN) && !HAS_TRAIT(affected_mob, TRAIT_COAGULATING)) //So long as they do not have a coagulant, if they did not have the bloody mess trait, they do now
 		ADD_TRAIT(affected_mob, TRAIT_BLOOD_FOUNTAIN, type)
@@ -1734,10 +1734,10 @@
 	taste_description = "plant food"
 	ph = 3
 
-/datum/reagent/plantnutriment/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/plantnutriment/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(tox_prob, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(1, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(1 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/plantnutriment/eznutriment
@@ -1833,9 +1833,9 @@
 	ph = 1.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/stable_plasma/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/stable_plasma/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjustPlasma(5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjustPlasma(5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/iodine
 	name = "Iodine"
@@ -1918,7 +1918,7 @@
 	name = "Royal Carpet?"
 	description = "For those that break the game and need to make an issue report."
 
-/datum/reagent/carpet/royal/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/carpet/royal/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver)
@@ -2196,7 +2196,7 @@
 	for (var/obj/item/bodypart/part as anything in exposed_carbon.bodyparts)
 		part.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
 
-/datum/reagent/colorful_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/colorful_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 
 	if (!iscarbon(affected_mob))
@@ -2300,7 +2300,7 @@
 		exposed_human.set_hairstyle("Very Long Hair", update = TRUE)
 	to_chat(exposed_human, span_notice("Your[HAS_TRAIT(exposed_human, TRAIT_BALD) ? " facial" : ""] hair starts growing at an incredible speed!"))
 
-/datum/reagent/concentrated_barbers_aid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/concentrated_barbers_aid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 21 / creation_purity)
 		if(!ishuman(affected_mob))
@@ -2449,7 +2449,7 @@
 	ph = 3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/royal_bee_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/royal_bee_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(1, seconds_per_tick))
 		affected_mob.say(pick("Bzzz...","BZZ BZZ","Bzzzzzzzzzzz..."), forced = "royal bee jelly")
@@ -2491,7 +2491,7 @@
 	color = "#00f041"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/magillitis/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/magillitis/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if((ishuman(affected_mob)) && current_cycle > 10)
 		var/mob/living/basic/gorilla/new_gorilla = affected_mob.gorillize()
@@ -2505,7 +2505,7 @@
 	taste_description = "bitterness" // apparently what viagra tastes like
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/growthserum/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/growthserum/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/newsize = current_size
 	switch(volume)
@@ -2549,7 +2549,7 @@
 	taste_description = "plastic"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/glitter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/glitter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(25, seconds_per_tick))
 		affected_mob.emote("cough")
@@ -2630,11 +2630,11 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 	metabolized_traits = list(TRAIT_CHANGELING_HIVEMIND_MUTE)
 
-/datum/reagent/bz_metabolites/on_mob_life(mob/living/carbon/target, seconds_per_tick, metabolized_volume)
+/datum/reagent/bz_metabolites/on_mob_life(mob/living/carbon/target, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	target.adjust_hallucinations(2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	target.adjust_hallucinations(2.5 SECONDS * metabolization_ratio * seconds_per_tick)
 	var/datum/antagonist/changeling/changeling = IS_CHANGELING(target)
-	changeling?.adjust_chemicals(-1 * REM * metabolized_volume * seconds_per_tick)
+	changeling?.adjust_chemicals(-1 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/pax/peaceborg
 	name = "Synthpax"
@@ -2649,10 +2649,10 @@
 	taste_description = "dizziness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/peaceborg/confuse/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/peaceborg/confuse/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_confusion_up_to(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick, 5 SECONDS)
-	affected_mob.adjust_dizzy_up_to(3 SECONDS * REM * metabolized_volume * seconds_per_tick, 12 SECONDS)
+	affected_mob.adjust_confusion_up_to(1.5 SECONDS * metabolization_ratio * seconds_per_tick, 5 SECONDS)
+	affected_mob.adjust_dizzy_up_to(3 SECONDS * metabolization_ratio * seconds_per_tick, 12 SECONDS)
 
 	if(SPT_PROB(10, seconds_per_tick))
 		to_chat(affected_mob, "You feel confused and disoriented.")
@@ -2664,12 +2664,12 @@
 	taste_description = "tiredness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/peaceborg/tire/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/peaceborg/tire/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/healthcomp = (100 - affected_mob.health) //DOES NOT ACCOUNT FOR ADMINBUS THINGS THAT MAKE YOU HAVE MORE THAN 200/210 HEALTH, OR SOMETHING OTHER THAN A HUMAN PROCESSING THIS.
 	. = FALSE
 	if(affected_mob.get_stamina_loss() < (45 - healthcomp)) //At 50 health you would have 200 - 150 health meaning 50 compensation. 60 - 50 = 10, so would only do 10-19 stamina.)
-		if(affected_mob.adjust_stamina_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
+		if(affected_mob.adjust_stamina_loss(5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE))
 			. = UPDATE_MOB_HEALTH
 	if(SPT_PROB(16, seconds_per_tick))
 		to_chat(affected_mob, "You should sit down and take a rest...")
@@ -2716,7 +2716,7 @@
 
 #define YUCK_PUKE_CYCLES 3 // every X cycle is a puke
 #define YUCK_PUKES_TO_STUN 3 // hit this amount of pukes in a row to start stunning
-/datum/reagent/yuck/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/yuck/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!yuck_cycle)
 		if(SPT_PROB(4, seconds_per_tick))
@@ -2877,7 +2877,7 @@
 		affected_mob.adjust_stamina_loss(stam_crash)
 	affected_mob.remove_status_effect(/datum/status_effect/determined)
 
-/datum/reagent/determination/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/determination/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!significant && volume >= WOUND_DETERMINATION_SEVERE)
 		significant = TRUE
@@ -2889,8 +2889,8 @@
 		var/datum/wound/W = thing
 		var/obj/item/bodypart/wounded_part = W.limb
 		if(wounded_part)
-			wounded_part.heal_damage(0.125 * REM * metabolized_volume * seconds_per_tick, 0.25 * REM * metabolized_volume * seconds_per_tick)
-		if(affected_mob.adjust_stamina_loss(-2 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)) // the more wounds, the more stamina regen
+			wounded_part.heal_damage(0.125 * metabolization_ratio * seconds_per_tick, 0.25 * metabolization_ratio * seconds_per_tick)
+		if(affected_mob.adjust_stamina_loss(-2 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)) // the more wounds, the more stamina regen
 			return UPDATE_MOB_HEALTH
 
 // unholy water, but for heretics.
@@ -2908,29 +2908,29 @@
 	metabolization_rate = 2.5 * REAGENTS_METABOLISM  //0.5u/second
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/eldritch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
+/datum/reagent/eldritch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update = FALSE
 	if(IS_HERETIC_OR_MONSTER(drinker))
-		drinker.adjust_drowsiness(-5 * REM * metabolized_volume * seconds_per_tick)
-		drinker.AdjustAllImmobility(-20 * REM * metabolized_volume * seconds_per_tick)
-		need_mob_update += drinker.adjust_stamina_loss(-5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
-		need_mob_update += drinker.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, forced = TRUE)
-		need_mob_update += drinker.adjust_oxy_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_brute_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_fire_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		drinker.adjust_blood_volume(1.5 * REM * metabolized_volume * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
+		drinker.adjust_drowsiness(-5 * metabolization_ratio * seconds_per_tick)
+		drinker.AdjustAllImmobility(-20 * metabolization_ratio * seconds_per_tick)
+		need_mob_update += drinker.adjust_stamina_loss(-5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
+		need_mob_update += drinker.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE)
+		need_mob_update += drinker.adjust_oxy_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		drinker.adjust_blood_volume(1.5 * metabolization_ratio * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
 		// Slowly regulates your body temp
 		drinker.adjust_bodytemperature((drinker.get_body_temp_normal() - drinker.bodytemperature) / 5)
 		for(var/datum/reagent/reagent as anything in drinker.reagents.reagent_list)
 			if(reagent != src)
-				drinker.reagents.remove_reagent(reagent.type, 2 * reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
+				drinker.reagents.remove_reagent(reagent.type, 2 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 	else
-		need_mob_update = drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1.5 * REM * metabolized_volume * seconds_per_tick, 150)
-		need_mob_update += drinker.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_fire_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_oxy_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_brute_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update = drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1.5 * metabolization_ratio * seconds_per_tick, 150)
+		need_mob_update += drinker.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_fire_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_oxy_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_brute_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -2987,7 +2987,7 @@
 	name = "glass of ants"
 	desc = "Bottoms up...?"
 
-/datum/reagent/ants/on_mob_life(mob/living/carbon/victim, seconds_per_tick, metabolized_volume)
+/datum/reagent/ants/on_mob_life(mob/living/carbon/victim, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	victim.adjust_brute_loss(max(0.1, round((ant_ticks * ant_damage),0.1))) //Scales with time. Roughly 32 brute with 100u.
 	ant_ticks++
@@ -3072,7 +3072,7 @@
 	color = "#80919d"
 	metabolization_rate = 0.4 * REAGENTS_METABOLISM
 
-/datum/reagent/lead/on_mob_life(mob/living/carbon/victim, metabolized_volume)
+/datum/reagent/lead/on_mob_life(mob/living/carbon/victim, metabolization_ratio)
 	. = ..()
 	if(victim.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5))
 		return UPDATE_MOB_HEALTH
@@ -3087,10 +3087,10 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/stimulants = 5)
 
-/datum/reagent/kronkus_extract/on_mob_life(mob/living/carbon/kronkus_enjoyer, seconds_per_tick, metabolized_volume)
+/datum/reagent/kronkus_extract/on_mob_life(mob/living/carbon/kronkus_enjoyer, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = kronkus_enjoyer.adjust_organ_loss(ORGAN_SLOT_HEART, 0.1 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = kronkus_enjoyer.adjust_organ_loss(ORGAN_SLOT_HEART, 0.1 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	need_mob_update += kronkus_enjoyer.adjust_stamina_loss(-6, updating_stamina = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
@@ -3102,7 +3102,7 @@
 	taste_description = "burning"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/brimdust/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/brimdust/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.adjust_fire_loss((ispodperson(affected_mob) ? -1 : 1 * seconds_per_tick), updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
@@ -3140,7 +3140,7 @@
 	affected_mob.clear_mood_event(name)
 	affected_mob.add_mood_event(name, /datum/mood_event/love_reagent, duration_of_moodlet)
 
-/datum/reagent/love/overdose_process(mob/living/metabolizer, seconds_per_tick, metabolized_volume)
+/datum/reagent/love/overdose_process(mob/living/metabolizer, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/mob/living/carbon/carbon_metabolizer = metabolizer
 	if(!istype(carbon_metabolizer) || !carbon_metabolizer.can_heartattack() || carbon_metabolizer.undergoing_cardiac_arrest())
@@ -3179,17 +3179,17 @@
 	else
 		affected_mob.add_mood_event("hauntium_spirits", /datum/mood_event/hauntium_spirits, name) //8 minutes of mood debuff
 
-/datum/reagent/hauntium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/hauntium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.mob_biotypes & MOB_UNDEAD || HAS_MIND_TRAIT(affected_mob, TRAIT_MORBID)) //if morbid or undead,acts like an addiction-less drug
 		affected_mob.remove_status_effect(/datum/status_effect/jitter)
-		affected_mob.AdjustStun(-2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-		affected_mob.AdjustKnockdown(-2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-		affected_mob.AdjustUnconscious(-2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-		affected_mob.AdjustParalyzed(-2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-		affected_mob.AdjustImmobilized(-2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.AdjustStun(-2.5 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.AdjustKnockdown(-2.5 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.AdjustUnconscious(-2.5 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.AdjustParalyzed(-2.5 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.AdjustImmobilized(-2.5 SECONDS * metabolization_ratio * seconds_per_tick)
 	else
-		if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, REM * metabolized_volume * seconds_per_tick)) //1 heart damage per tick
+		if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, metabolization_ratio * seconds_per_tick)) //1 heart damage per tick
 			. = UPDATE_MOB_HEALTH
 		if(SPT_PROB(10, seconds_per_tick))
 			affected_mob.emote(pick("twitch","choke","shiver","gag"))
@@ -3248,7 +3248,7 @@
 	if (eyes && !IS_ROBOTIC_ORGAN(eyes) && !overdosed)
 		REMOVE_TRAIT(affected_human, TRAIT_LUMINESCENT_EYES, REF(src))
 
-/datum/reagent/luminescent_fluid/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/luminescent_fluid/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 
 	if (isnull(glowing) && !added_light && volume > 20)
@@ -3258,7 +3258,7 @@
 		added_light = TRUE
 
 	if (SPT_PROB(8, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(1, updating_health = FALSE))
+		if(affected_mob.adjust_tox_loss(1 * metabolization_ratio, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/luminescent_fluid/proc/on_organ_added(mob/living/source, obj/item/organ/eyes/new_eyes)
@@ -3273,7 +3273,7 @@
 	if (istype(old_eyes) && !IS_ROBOTIC_ORGAN(old_eyes) && !overdosed)
 		REMOVE_TRAIT(source, TRAIT_LUMINESCENT_EYES, REF(src))
 
-/datum/reagent/luminescent_fluid/overdose_start(mob/living/affected_mob, metabolized_volume)
+/datum/reagent/luminescent_fluid/overdose_start(mob/living/affected_mob, metabolization_ratio)
 	. = ..()
 	if (!ishuman(affected_mob))
 		return
@@ -3290,7 +3290,7 @@
 	// The glow *is* unnatural, so...
 	metabolized_traits = list(TRAIT_MINOR_NIGHT_VISION, TRAIT_UNNATURAL_RED_GLOWY_EYES)
 
-/datum/reagent/luminescent_fluid/red/overdose_start(mob/living/affected_mob, metabolized_volume)
+/datum/reagent/luminescent_fluid/red/overdose_start(mob/living/affected_mob, metabolization_ratio)
 	. = ..()
 	if (!ishuman(affected_mob))
 		return

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -108,9 +108,9 @@
 	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen."
 	color = "#AAAAAA77" // rgb: 170, 170, 170, 77 (alpha)
 	taste_description = "water"
-	var/cooling_temperature = 2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_CLEANS
 	default_container = /obj/item/reagent_containers/cup/glass/waterbottle
+	var/cooling_temperature = 2
 
 /datum/glass_style/shot_glass/water
 	required_drink_type = /datum/reagent/water
@@ -405,7 +405,6 @@
 	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen and oxygen." //intended intended
 	color = "#AAAAAA77" // rgb: 170, 170, 170, 77 (alpha)
 	taste_description = "burning water"
-	var/cooling_temperature = 2
 	ph = 6.2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -1317,9 +1316,9 @@
 	taste_description = "sourness"
 	reagent_weight = 0.6 //so it sprays further
 	penetrates_skin = VAPOR
-	var/clean_types = CLEAN_WASH
 	ph = 5.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_CLEANS|REAGENT_AFFECTS_WOUNDS
+	var/clean_types = CLEAN_WASH
 
 /datum/reagent/space_cleaner/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
 	. = ..()
@@ -1360,10 +1359,11 @@
 
 /datum/reagent/space_cleaner/ez_clean/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
+	var/heal = 1.1 * metabolization_ratio * seconds_per_tick
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(1.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-	need_mob_update += affected_mob.adjust_fire_loss(1.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-	need_mob_update += affected_mob.adjust_tox_loss(1.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+	need_mob_update = affected_mob.adjust_brute_loss(heal, updating_health = FALSE)
+	need_mob_update += affected_mob.adjust_fire_loss(heal, updating_health = FALSE)
+	need_mob_update += affected_mob.adjust_tox_loss(heal, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1729,9 +1729,9 @@
 	name = "Generic Nutriment"
 	description = "Some kind of nutriment. You can't really tell what it is. You should probably report it, along with how you obtained it."
 	color = COLOR_BLACK // RBG: 0, 0, 0
-	var/tox_prob = 0
 	taste_description = "plant food"
 	ph = 3
+	var/tox_prob = 0
 
 /datum/reagent/plantnutriment/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
@@ -2909,15 +2909,16 @@
 
 /datum/reagent/eldritch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
 	. = ..()
+	var/common = 0.4 * metabolization_ratio * seconds_per_tick
 	var/need_mob_update = FALSE
 	if(IS_HERETIC_OR_MONSTER(drinker))
 		drinker.adjust_drowsiness(-2 * metabolization_ratio * seconds_per_tick)
 		drinker.AdjustAllImmobility(-8 * metabolization_ratio * seconds_per_tick)
 		need_mob_update += drinker.adjust_stamina_loss(-2 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
-		need_mob_update += drinker.adjust_tox_loss(-0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE)
-		need_mob_update += drinker.adjust_oxy_loss(-0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_brute_loss(-0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_fire_loss(-0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_tox_loss(-common, updating_health = FALSE, forced = TRUE)
+		need_mob_update += drinker.adjust_oxy_loss(-common, updating_health = FALSE)
+		need_mob_update += drinker.adjust_brute_loss(-common, updating_health = FALSE)
+		need_mob_update += drinker.adjust_fire_loss(-common, updating_health = FALSE)
 		drinker.adjust_blood_volume(0.6 * metabolization_ratio * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
 		// Slowly regulates your body temp
 		drinker.adjust_bodytemperature((drinker.get_body_temp_normal() - drinker.bodytemperature) / 5)
@@ -2926,10 +2927,10 @@
 				drinker.reagents.remove_reagent(reagent.type, 0.8 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 	else
 		need_mob_update = drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.6 * metabolization_ratio * seconds_per_tick, 150)
-		need_mob_update += drinker.adjust_tox_loss(0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_fire_loss(0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_oxy_loss(0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_brute_loss(0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_tox_loss(common, updating_health = FALSE)
+		need_mob_update += drinker.adjust_fire_loss(common, updating_health = FALSE)
+		need_mob_update += drinker.adjust_oxy_loss(common, updating_health = FALSE)
+		need_mob_update += drinker.adjust_brute_loss(common, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -3090,7 +3091,7 @@
 	. = ..()
 	var/need_mob_update
 	need_mob_update = kronkus_enjoyer.adjust_organ_loss(ORGAN_SLOT_HEART, 0.2 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += kronkus_enjoyer.adjust_stamina_loss(-12 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
+	need_mob_update += kronkus_enjoyer.adjust_stamina_loss(-6 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -3181,12 +3182,13 @@
 /datum/reagent/hauntium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.mob_biotypes & MOB_UNDEAD || HAS_MIND_TRAIT(affected_mob, TRAIT_MORBID)) //if morbid or undead,acts like an addiction-less drug
+		var/common = -3.34 SECONDS * metabolization_ratio * seconds_per_tick
 		affected_mob.remove_status_effect(/datum/status_effect/jitter)
-		affected_mob.AdjustStun(-3.34 SECONDS * metabolization_ratio * seconds_per_tick)
-		affected_mob.AdjustKnockdown(-3.34 SECONDS * metabolization_ratio * seconds_per_tick)
-		affected_mob.AdjustUnconscious(-3.34 SECONDS * metabolization_ratio * seconds_per_tick)
-		affected_mob.AdjustParalyzed(-3.34 SECONDS * metabolization_ratio * seconds_per_tick)
-		affected_mob.AdjustImmobilized(-3.34 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.AdjustStun(common)
+		affected_mob.AdjustKnockdown(common)
+		affected_mob.AdjustUnconscious(common)
+		affected_mob.AdjustParalyzed(common)
+		affected_mob.AdjustImmobilized(common)
 	else
 		if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 1.34 * metabolization_ratio * seconds_per_tick)) //1 heart damage per tick
 			. = UPDATE_MOB_HEALTH

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -217,24 +217,24 @@
 #undef WATER_TO_WET_STACKS_FACTOR_VAPOR
 
 
-/datum/reagent/water/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/water/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver?.damage && !IS_ROBOTIC_ORGAN(liver) && !(liver.organ_flags & ORGAN_FAILING))
 		var/healing_bonus = liver.healing_factor * liver.maxHealth
-		liver.apply_organ_damage(-healing_bonus * REM * seconds_per_tick)
+		liver.apply_organ_damage(0.5 * -healing_bonus * REM * metabolized_volume * seconds_per_tick)
 
 	var/water_adaptation = HAS_TRAIT(affected_mob, TRAIT_WATER_ADAPTATION)
 	var/blood_restored = water_adaptation ? 0.3 : 0.1
-	affected_mob.adjust_blood_volume(blood_restored * REM * seconds_per_tick) // water is good for you!
+	affected_mob.adjust_blood_volume(0.5 * blood_restored * REM * metabolized_volume * seconds_per_tick) // water is good for you!
 	var/drunkness_restored = water_adaptation ? -0.5 : -0.25
-	affected_mob.adjust_drunk_effect(drunkness_restored * REM * seconds_per_tick) // and even sobers you up slowly!!
+	affected_mob.adjust_drunk_effect(0.5 * drunkness_restored * REM * metabolized_volume * seconds_per_tick) // and even sobers you up slowly!!
 	if(water_adaptation)
 		var/need_mob_update = FALSE
-		need_mob_update = affected_mob.adjust_tox_loss(-0.25 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.25 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_brute_loss(-0.25 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update = affected_mob.adjust_tox_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_brute_loss(-0.125 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		return need_mob_update ? UPDATE_MOB_HEALTH : .
 
 // For weird backwards situations where water manages to get added to trays nutrients, as opposed to being snowflaked away like usual.
@@ -247,9 +247,9 @@
 	name = "Mineral Water"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE|REAGENT_CLEANS
 
-/datum/reagent/water/mineral/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/water/mineral/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_tox_loss(-0.1 * REM * seconds_per_tick, updating_health = FALSE)
+	affected_mob.adjust_tox_loss(-0.05 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
 	return UPDATE_MOB_HEALTH
 
 /datum/reagent/water/salt
@@ -337,12 +337,12 @@
 	if(IS_CULTIST(affected_mob))
 		to_chat(affected_mob, span_userdanger("A vile holiness begins to spread its shining tendrils through your mind, purging the Geometer of Blood's influence!"))
 
-/datum/reagent/water/holywater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/water/holywater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 
 	data["deciseconds_metabolized"] += (seconds_per_tick * 1 SECONDS * REM)
 
-	affected_mob.adjust_jitter_up_to(4 SECONDS * REM * seconds_per_tick, 20 SECONDS)
+	affected_mob.adjust_jitter_up_to(2 SECONDS * REM * metabolized_volume * seconds_per_tick, 20 SECONDS)
 	var/need_mob_update = FALSE
 
 	if(IS_CULTIST(affected_mob))
@@ -355,7 +355,7 @@
 				to_chat(affected_mob, span_cult_large("Your blood rites falter as holy water scours your body!"))
 
 	if(data["deciseconds_metabolized"] >= (25 SECONDS)) // 10 units
-		affected_mob.adjust_stutter_up_to(4 SECONDS * REM * seconds_per_tick, 20 SECONDS)
+		affected_mob.adjust_stutter_up_to(2 SECONDS * REM * metabolized_volume * seconds_per_tick, 20 SECONDS)
 		affected_mob.set_dizzy_if_lower(10 SECONDS)
 		if(IS_CULTIST(affected_mob) && SPT_PROB(10, seconds_per_tick))
 			affected_mob.say(pick("Av'te Nar'Sie","Pa'lid Mors","INO INO ORA ANA","SAT ANA!","Daim'niodeis Arc'iai Le'eones","R'ge Na'sie","Diabo us Vo'iscum","Eld' Mon Nobis"), forced = "holy water")
@@ -367,7 +367,7 @@
 		else if(HAS_TRAIT(affected_mob, TRAIT_EVIL) && SPT_PROB(25, seconds_per_tick)) //Congratulations, your committment to evil has now made holy water a deadly poison to you!
 			if(!IS_CULTIST(affected_mob) || affected_mob.mind?.holy_role != HOLY_ROLE_PRIEST)
 				affected_mob.emote("scream")
-				need_mob_update += affected_mob.adjust_fire_loss(3 * REM * seconds_per_tick, updating_health = FALSE)
+				need_mob_update += affected_mob.adjust_fire_loss(1.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
 
 	if(data["deciseconds_metabolized"] >= (1 MINUTES)) // 24 units
 		if(IS_CULTIST(affected_mob))
@@ -375,7 +375,7 @@
 			affected_mob.Unconscious(10 SECONDS)
 		else if(HAS_TRAIT(affected_mob, TRAIT_EVIL)) //At this much holy water, you're probably going to fucking melt. good luck
 			if(!IS_CULTIST(affected_mob) || affected_mob.mind?.holy_role != HOLY_ROLE_PRIEST)
-				need_mob_update += affected_mob.adjust_fire_loss(10 * REM * seconds_per_tick, updating_health = FALSE)
+				need_mob_update += affected_mob.adjust_fire_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
 		affected_mob.remove_status_effect(/datum/status_effect/jitter)
 		affected_mob.remove_status_effect(/datum/status_effect/speech/stutter)
 		for(var/datum/status_effect/eldritch_painting/eldritch_curses in affected_mob.status_effects)
@@ -460,28 +460,28 @@
 	if(IS_CULTIST(affected_mob))
 		ADD_TRAIT(affected_mob, TRAIT_COAGULATING, type)
 
-/datum/reagent/fuel/unholywater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/fuel/unholywater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 
 	var/need_mob_update = FALSE
 	if(IS_CULTIST(affected_mob))
-		affected_mob.adjust_drowsiness(-10 SECONDS * REM * seconds_per_tick)
-		affected_mob.AdjustAllImmobility(-40 * REM * seconds_per_tick)
-		need_mob_update += affected_mob.adjust_stamina_loss(-10 * REM * seconds_per_tick, updating_stamina = FALSE)
-		need_mob_update += affected_mob.adjust_tox_loss(-2 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_oxy_loss(-2 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_brute_loss(-2 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_fire_loss(-2 * REM * seconds_per_tick, updating_health = FALSE)
+		affected_mob.adjust_drowsiness(-5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.AdjustAllImmobility(-20 * REM * metabolized_volume * seconds_per_tick)
+		need_mob_update += affected_mob.adjust_stamina_loss(-5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
+		need_mob_update += affected_mob.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_oxy_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_brute_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_fire_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
 		need_mob_update = TRUE
-		affected_mob.adjust_blood_volume(3 * REM * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
-		affected_mob.coagulant_effect(2 * REM * seconds_per_tick)
+		affected_mob.adjust_blood_volume(1.5 * REM * metabolized_volume * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
+		affected_mob.coagulant_effect(1 * REM * metabolized_volume * seconds_per_tick)
 
 	else  // Will deal about 90 damage when 50 units are thrown
-		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 3 * REM * seconds_per_tick, 150)
-		need_mob_update += affected_mob.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_fire_loss(1 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_oxy_loss(1 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_brute_loss(1 * REM * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1.5 * REM * metabolized_volume * seconds_per_tick, 150)
+		need_mob_update += affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_fire_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_oxy_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_brute_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -496,7 +496,7 @@
 	ph = 0.1
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/hellwater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/hellwater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	affected_mob.set_fire_stacks(min(affected_mob.fire_stacks + (1.5 * seconds_per_tick), 5))
 	affected_mob.ignite_mob() //Only problem with igniting people is currently the commonly available fire suits make you immune to being on fire
@@ -611,7 +611,7 @@
 		if((methods & INGEST) && show_message)
 			to_chat(exposed_mob, span_notice("That tasted horrible."))
 
-/datum/reagent/spraytan/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/spraytan/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 
@@ -663,7 +663,7 @@
 									"Your appendages begin morphing." = MUT_MSG_EXTENDED,
 									"You feel as though you're about to change at any moment!" = MUT_MSG_ABOUT2TURN)
 
-/datum/reagent/mutationtoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/mutationtoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!ishuman(affected_mob))
 		return
@@ -747,7 +747,7 @@
 	taste_description = "grandma's gelatin"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/mutationtoxin/jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/mutationtoxin/jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(!ishuman(affected_mob))
 		return ..()
 	var/mob/living/carbon/affected_human = affected_mob
@@ -848,7 +848,7 @@
 	taste_description = "slime"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/mulligan/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/mulligan/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!ishuman(affected_mob))
 		return
@@ -894,7 +894,7 @@
 	ph = 10
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/serotrotium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/serotrotium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(3.5, seconds_per_tick))
 		affected_mob.emote(pick("twitch","drool","moan","gasp"))
@@ -966,7 +966,7 @@
 	taste_mult = 0 // apparently tasteless.
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/mercury/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!HAS_TRAIT(src, TRAIT_IMMOBILIZED) && isturf(affected_mob.loc) && !isgroundlessturf(affected_mob.loc))
 		step(affected_mob, pick(GLOB.cardinals))
@@ -1016,7 +1016,7 @@
 	// White Phosphorous + water -> phosphoric acid. That's not a good thing really.
 
 
-/datum/reagent/chlorine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/chlorine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.take_bodypart_damage(0.5*REM*seconds_per_tick, 0))
 		return UPDATE_MOB_HEALTH
@@ -1036,7 +1036,7 @@
 	mytray.adjust_waterlevel(-round(volume * 0.5))
 	mytray.adjust_weedlevel(-rand(1, 4))
 
-/datum/reagent/fluorine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/fluorine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.adjust_tox_loss(0.5*REM*seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
@@ -1071,7 +1071,7 @@
 	ph = 11.3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/lithium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/lithium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_IMMOBILIZED) && isturf(affected_mob.loc) && !isgroundlessturf(affected_mob.loc))
 		step(affected_mob, pick(GLOB.cardinals))
@@ -1143,7 +1143,7 @@
 	/// How radioactive is this reagent
 	var/rad_power = 1
 
-/datum/reagent/uranium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/uranium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_IRRADIATED) && SSradiation.can_irradiate_basic(affected_mob))
 		var/chance = min(volume / (20 - rad_power * 5), rad_power)
@@ -1238,7 +1238,7 @@
 
 	do_teleport(exposed_mob, get_turf(exposed_mob), (reac_volume / 5), asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE) //4 tiles per crystal
 
-/datum/reagent/bluespace/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/bluespace/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(current_cycle > 10 && SPT_PROB(7.5, seconds_per_tick))
 		to_chat(affected_mob, span_warning("You feel unstable..."))
@@ -1290,7 +1290,7 @@
 
 	exposed_mob.adjust_fire_stacks(reac_volume / 10)
 
-/datum/reagent/fuel/on_mob_life(mob/living/carbon/victim, seconds_per_tick)
+/datum/reagent/fuel/on_mob_life(mob/living/carbon/victim, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/liver/liver = victim.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_HUMAN_AI_METABOLISM))
@@ -1359,7 +1359,7 @@
 	ph = 2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/space_cleaner/ez_clean/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/space_cleaner/ez_clean/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	need_mob_update = affected_mob.adjust_brute_loss(1.665*seconds_per_tick, updating_health = FALSE)
@@ -1388,7 +1388,7 @@
 	ph = 11.9
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/cryptobiolin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/cryptobiolin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	affected_mob.set_dizzy_if_lower(2 SECONDS)
 
@@ -1410,7 +1410,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/opioids = 10)
 
-/datum/reagent/impedrezene/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/impedrezene/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	affected_mob.adjust_jitter(-5 SECONDS * seconds_per_tick)
 	if(SPT_PROB(55, seconds_per_tick))
@@ -1579,9 +1579,9 @@
 	. = ..()
 	REMOVE_TRAIT(affected_mob, TRAIT_BLOOD_FOUNTAIN, type)
 
-/datum/reagent/nitrous_oxide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/nitrous_oxide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_drowsiness(4 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_drowsiness(2 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 	if(!HAS_TRAIT(affected_mob, TRAIT_BLOOD_FOUNTAIN) && !HAS_TRAIT(affected_mob, TRAIT_COAGULATING)) //So long as they do not have a coagulant, if they did not have the bloody mess trait, they do now
 		ADD_TRAIT(affected_mob, TRAIT_BLOOD_FOUNTAIN, type)
@@ -1734,7 +1734,7 @@
 	taste_description = "plant food"
 	ph = 3
 
-/datum/reagent/plantnutriment/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/plantnutriment/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(tox_prob, seconds_per_tick))
 		if(affected_mob.adjust_tox_loss(1, updating_health = FALSE, required_biotype = affected_biotype))
@@ -1833,9 +1833,9 @@
 	ph = 1.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/stable_plasma/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/stable_plasma/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjustPlasma(10 * REM * seconds_per_tick)
+	affected_mob.adjustPlasma(5 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/iodine
 	name = "Iodine"
@@ -1918,7 +1918,7 @@
 	name = "Royal Carpet?"
 	description = "For those that break the game and need to make an issue report."
 
-/datum/reagent/carpet/royal/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/carpet/royal/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver)
@@ -2196,7 +2196,7 @@
 	for (var/obj/item/bodypart/part as anything in exposed_carbon.bodyparts)
 		part.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
 
-/datum/reagent/colorful_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/colorful_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 
 	if (!iscarbon(affected_mob))
@@ -2300,7 +2300,7 @@
 		exposed_human.set_hairstyle("Very Long Hair", update = TRUE)
 	to_chat(exposed_human, span_notice("Your[HAS_TRAIT(exposed_human, TRAIT_BALD) ? " facial" : ""] hair starts growing at an incredible speed!"))
 
-/datum/reagent/concentrated_barbers_aid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/concentrated_barbers_aid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(current_cycle > 21 / creation_purity)
 		if(!ishuman(affected_mob))
@@ -2449,7 +2449,7 @@
 	ph = 3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/royal_bee_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/royal_bee_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(1, seconds_per_tick))
 		affected_mob.say(pick("Bzzz...","BZZ BZZ","Bzzzzzzzzzzz..."), forced = "royal bee jelly")
@@ -2491,7 +2491,7 @@
 	color = "#00f041"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/magillitis/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/magillitis/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if((ishuman(affected_mob)) && current_cycle > 10)
 		var/mob/living/basic/gorilla/new_gorilla = affected_mob.gorillize()
@@ -2505,7 +2505,7 @@
 	taste_description = "bitterness" // apparently what viagra tastes like
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/growthserum/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/growthserum/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/newsize = current_size
 	switch(volume)
@@ -2549,7 +2549,7 @@
 	taste_description = "plastic"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/glitter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/glitter/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(25, seconds_per_tick))
 		affected_mob.emote("cough")
@@ -2630,11 +2630,11 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 	metabolized_traits = list(TRAIT_CHANGELING_HIVEMIND_MUTE)
 
-/datum/reagent/bz_metabolites/on_mob_life(mob/living/carbon/target, seconds_per_tick)
+/datum/reagent/bz_metabolites/on_mob_life(mob/living/carbon/target, seconds_per_tick, metabolized_volume)
 	. = ..()
-	target.adjust_hallucinations(5 SECONDS * REM * seconds_per_tick)
+	target.adjust_hallucinations(2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	var/datum/antagonist/changeling/changeling = IS_CHANGELING(target)
-	changeling?.adjust_chemicals(-2 * REM * seconds_per_tick)
+	changeling?.adjust_chemicals(-1 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/pax/peaceborg
 	name = "Synthpax"
@@ -2649,10 +2649,10 @@
 	taste_description = "dizziness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/peaceborg/confuse/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/peaceborg/confuse/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_confusion_up_to(3 SECONDS * REM * seconds_per_tick, 5 SECONDS)
-	affected_mob.adjust_dizzy_up_to(6 SECONDS * REM * seconds_per_tick, 12 SECONDS)
+	affected_mob.adjust_confusion_up_to(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick, 5 SECONDS)
+	affected_mob.adjust_dizzy_up_to(3 SECONDS * REM * metabolized_volume * seconds_per_tick, 12 SECONDS)
 
 	if(SPT_PROB(10, seconds_per_tick))
 		to_chat(affected_mob, "You feel confused and disoriented.")
@@ -2664,12 +2664,12 @@
 	taste_description = "tiredness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/peaceborg/tire/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/peaceborg/tire/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/healthcomp = (100 - affected_mob.health) //DOES NOT ACCOUNT FOR ADMINBUS THINGS THAT MAKE YOU HAVE MORE THAN 200/210 HEALTH, OR SOMETHING OTHER THAN A HUMAN PROCESSING THIS.
 	. = FALSE
 	if(affected_mob.get_stamina_loss() < (45 - healthcomp)) //At 50 health you would have 200 - 150 health meaning 50 compensation. 60 - 50 = 10, so would only do 10-19 stamina.)
-		if(affected_mob.adjust_stamina_loss(10 * REM * seconds_per_tick, updating_stamina = FALSE))
+		if(affected_mob.adjust_stamina_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
 			. = UPDATE_MOB_HEALTH
 	if(SPT_PROB(16, seconds_per_tick))
 		to_chat(affected_mob, "You should sit down and take a rest...")
@@ -2716,7 +2716,7 @@
 
 #define YUCK_PUKE_CYCLES 3 // every X cycle is a puke
 #define YUCK_PUKES_TO_STUN 3 // hit this amount of pukes in a row to start stunning
-/datum/reagent/yuck/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/yuck/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!yuck_cycle)
 		if(SPT_PROB(4, seconds_per_tick))
@@ -2877,7 +2877,7 @@
 		affected_mob.adjust_stamina_loss(stam_crash)
 	affected_mob.remove_status_effect(/datum/status_effect/determined)
 
-/datum/reagent/determination/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/determination/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!significant && volume >= WOUND_DETERMINATION_SEVERE)
 		significant = TRUE
@@ -2889,8 +2889,8 @@
 		var/datum/wound/W = thing
 		var/obj/item/bodypart/wounded_part = W.limb
 		if(wounded_part)
-			wounded_part.heal_damage(0.25 * REM * seconds_per_tick, 0.25 * REM * seconds_per_tick)
-		if(affected_mob.adjust_stamina_loss(-1 * REM * seconds_per_tick, updating_stamina = FALSE)) // the more wounds, the more stamina regen
+			wounded_part.heal_damage(0.125 * REM * metabolized_volume * seconds_per_tick, 0.25 * REM * metabolized_volume * seconds_per_tick)
+		if(affected_mob.adjust_stamina_loss(-2 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)) // the more wounds, the more stamina regen
 			return UPDATE_MOB_HEALTH
 
 // unholy water, but for heretics.
@@ -2908,29 +2908,29 @@
 	metabolization_rate = 2.5 * REAGENTS_METABOLISM  //0.5u/second
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/eldritch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
+/datum/reagent/eldritch/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update = FALSE
 	if(IS_HERETIC_OR_MONSTER(drinker))
-		drinker.adjust_drowsiness(-10 * REM * seconds_per_tick)
-		drinker.AdjustAllImmobility(-40 * REM * seconds_per_tick)
-		need_mob_update += drinker.adjust_stamina_loss(-10 * REM * seconds_per_tick, updating_stamina = FALSE)
-		need_mob_update += drinker.adjust_tox_loss(-2 * REM * seconds_per_tick, updating_health = FALSE, forced = TRUE)
-		need_mob_update += drinker.adjust_oxy_loss(-2 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_brute_loss(-2 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_fire_loss(-2 * REM * seconds_per_tick, updating_health = FALSE)
-		drinker.adjust_blood_volume(3 * REM * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
+		drinker.adjust_drowsiness(-5 * REM * metabolized_volume * seconds_per_tick)
+		drinker.AdjustAllImmobility(-20 * REM * metabolized_volume * seconds_per_tick)
+		need_mob_update += drinker.adjust_stamina_loss(-5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
+		need_mob_update += drinker.adjust_tox_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, forced = TRUE)
+		need_mob_update += drinker.adjust_oxy_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_brute_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_fire_loss(-1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		drinker.adjust_blood_volume(1.5 * REM * metabolized_volume * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
 		// Slowly regulates your body temp
 		drinker.adjust_bodytemperature((drinker.get_body_temp_normal() - drinker.bodytemperature) / 5)
 		for(var/datum/reagent/reagent as anything in drinker.reagents.reagent_list)
 			if(reagent != src)
-				drinker.reagents.remove_reagent(reagent.type, 2 * reagent.purge_multiplier * REM * seconds_per_tick)
+				drinker.reagents.remove_reagent(reagent.type, 2 * reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
 	else
-		need_mob_update = drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 3 * REM * seconds_per_tick, 150)
-		need_mob_update += drinker.adjust_tox_loss(2 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_fire_loss(2 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_oxy_loss(2 * REM * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_brute_loss(2 * REM * seconds_per_tick, updating_health = FALSE)
+		need_mob_update = drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1.5 * REM * metabolized_volume * seconds_per_tick, 150)
+		need_mob_update += drinker.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_fire_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_oxy_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_brute_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -2987,7 +2987,7 @@
 	name = "glass of ants"
 	desc = "Bottoms up...?"
 
-/datum/reagent/ants/on_mob_life(mob/living/carbon/victim, seconds_per_tick)
+/datum/reagent/ants/on_mob_life(mob/living/carbon/victim, seconds_per_tick, metabolized_volume)
 	. = ..()
 	victim.adjust_brute_loss(max(0.1, round((ant_ticks * ant_damage),0.1))) //Scales with time. Roughly 32 brute with 100u.
 	ant_ticks++
@@ -3072,7 +3072,7 @@
 	color = "#80919d"
 	metabolization_rate = 0.4 * REAGENTS_METABOLISM
 
-/datum/reagent/lead/on_mob_life(mob/living/carbon/victim)
+/datum/reagent/lead/on_mob_life(mob/living/carbon/victim, metabolized_volume)
 	. = ..()
 	if(victim.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5))
 		return UPDATE_MOB_HEALTH
@@ -3087,10 +3087,10 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/stimulants = 5)
 
-/datum/reagent/kronkus_extract/on_mob_life(mob/living/carbon/kronkus_enjoyer, seconds_per_tick)
+/datum/reagent/kronkus_extract/on_mob_life(mob/living/carbon/kronkus_enjoyer, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = kronkus_enjoyer.adjust_organ_loss(ORGAN_SLOT_HEART, 0.2 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update = kronkus_enjoyer.adjust_organ_loss(ORGAN_SLOT_HEART, 0.1 * REM * metabolized_volume * seconds_per_tick, required_organ_flag = affected_organ_flags)
 	need_mob_update += kronkus_enjoyer.adjust_stamina_loss(-6, updating_stamina = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
@@ -3102,7 +3102,7 @@
 	taste_description = "burning"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/brimdust/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/brimdust/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.adjust_fire_loss((ispodperson(affected_mob) ? -1 : 1 * seconds_per_tick), updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
@@ -3140,7 +3140,7 @@
 	affected_mob.clear_mood_event(name)
 	affected_mob.add_mood_event(name, /datum/mood_event/love_reagent, duration_of_moodlet)
 
-/datum/reagent/love/overdose_process(mob/living/metabolizer, seconds_per_tick)
+/datum/reagent/love/overdose_process(mob/living/metabolizer, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/mob/living/carbon/carbon_metabolizer = metabolizer
 	if(!istype(carbon_metabolizer) || !carbon_metabolizer.can_heartattack() || carbon_metabolizer.undergoing_cardiac_arrest())
@@ -3179,17 +3179,17 @@
 	else
 		affected_mob.add_mood_event("hauntium_spirits", /datum/mood_event/hauntium_spirits, name) //8 minutes of mood debuff
 
-/datum/reagent/hauntium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/hauntium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.mob_biotypes & MOB_UNDEAD || HAS_MIND_TRAIT(affected_mob, TRAIT_MORBID)) //if morbid or undead,acts like an addiction-less drug
 		affected_mob.remove_status_effect(/datum/status_effect/jitter)
-		affected_mob.AdjustStun(-5 SECONDS * REM * seconds_per_tick)
-		affected_mob.AdjustKnockdown(-5 SECONDS * REM * seconds_per_tick)
-		affected_mob.AdjustUnconscious(-5 SECONDS * REM * seconds_per_tick)
-		affected_mob.AdjustParalyzed(-5 SECONDS * REM * seconds_per_tick)
-		affected_mob.AdjustImmobilized(-5 SECONDS * REM * seconds_per_tick)
+		affected_mob.AdjustStun(-2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.AdjustKnockdown(-2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.AdjustUnconscious(-2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.AdjustParalyzed(-2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.AdjustImmobilized(-2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 	else
-		if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, REM * seconds_per_tick)) //1 heart damage per tick
+		if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, REM * metabolized_volume * seconds_per_tick)) //1 heart damage per tick
 			. = UPDATE_MOB_HEALTH
 		if(SPT_PROB(10, seconds_per_tick))
 			affected_mob.emote(pick("twitch","choke","shiver","gag"))
@@ -3248,7 +3248,7 @@
 	if (eyes && !IS_ROBOTIC_ORGAN(eyes) && !overdosed)
 		REMOVE_TRAIT(affected_human, TRAIT_LUMINESCENT_EYES, REF(src))
 
-/datum/reagent/luminescent_fluid/on_mob_life(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/luminescent_fluid/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 
 	if (isnull(glowing) && !added_light && volume > 20)
@@ -3273,7 +3273,7 @@
 	if (istype(old_eyes) && !IS_ROBOTIC_ORGAN(old_eyes) && !overdosed)
 		REMOVE_TRAIT(source, TRAIT_LUMINESCENT_EYES, REF(src))
 
-/datum/reagent/luminescent_fluid/overdose_start(mob/living/affected_mob)
+/datum/reagent/luminescent_fluid/overdose_start(mob/living/affected_mob, metabolized_volume)
 	. = ..()
 	if (!ishuman(affected_mob))
 		return
@@ -3290,7 +3290,7 @@
 	// The glow *is* unnatural, so...
 	metabolized_traits = list(TRAIT_MINOR_NIGHT_VISION, TRAIT_UNNATURAL_RED_GLOWY_EYES)
 
-/datum/reagent/luminescent_fluid/red/overdose_start(mob/living/affected_mob)
+/datum/reagent/luminescent_fluid/red/overdose_start(mob/living/affected_mob, metabolized_volume)
 	. = ..()
 	if (!ishuman(affected_mob))
 		return

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -613,7 +613,7 @@
 
 /datum/reagent/spraytan/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	metabolization_rate = 1 * REAGENTS_METABOLISM
+	metabolization_rate = REAGENTS_METABOLISM
 
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/affected_human = affected_mob

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -465,23 +465,22 @@
 
 	var/need_mob_update = FALSE
 	if(IS_CULTIST(affected_mob))
-		affected_mob.adjust_drowsiness(-5 SECONDS * metabolization_ratio * seconds_per_tick)
-		affected_mob.AdjustAllImmobility(-20 * metabolization_ratio * seconds_per_tick)
-		need_mob_update += affected_mob.adjust_stamina_loss(-5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
-		need_mob_update += affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_oxy_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update = TRUE
-		affected_mob.adjust_blood_volume(1.5 * metabolization_ratio * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
-		affected_mob.coagulant_effect(1 * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_drowsiness(-2 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.AdjustAllImmobility(-8 * metabolization_ratio * seconds_per_tick)
+		need_mob_update += affected_mob.adjust_stamina_loss(-2 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
+		need_mob_update += affected_mob.adjust_tox_loss(-0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_oxy_loss(-0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_brute_loss(-0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		affected_mob.adjust_blood_volume(0.6 * metabolization_ratio * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
+		affected_mob.coagulant_effect(0.4 * metabolization_ratio * seconds_per_tick)
 
 	else  // Will deal about 90 damage when 50 units are thrown
-		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1.5 * metabolization_ratio * seconds_per_tick, 150)
-		need_mob_update += affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_fire_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_oxy_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += affected_mob.adjust_brute_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.6 * metabolization_ratio * seconds_per_tick, 150)
+		need_mob_update += affected_mob.adjust_tox_loss(0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_fire_loss(0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_oxy_loss(0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += affected_mob.adjust_brute_loss(0.2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1362,9 +1361,9 @@
 /datum/reagent/space_cleaner/ez_clean/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_brute_loss(1.665*seconds_per_tick, updating_health = FALSE)
-	need_mob_update += affected_mob.adjust_fire_loss(1.665*seconds_per_tick, updating_health = FALSE)
-	need_mob_update += affected_mob.adjust_tox_loss(1.665*seconds_per_tick, updating_health = FALSE)
+	need_mob_update = affected_mob.adjust_brute_loss(1.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+	need_mob_update += affected_mob.adjust_fire_loss(1.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+	need_mob_update += affected_mob.adjust_tox_loss(1.1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -1581,7 +1580,7 @@
 
 /datum/reagent/nitrous_oxide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_drowsiness(2 SECONDS * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_drowsiness(1.34 SECONDS * metabolization_ratio * seconds_per_tick)
 
 	if(!HAS_TRAIT(affected_mob, TRAIT_BLOOD_FOUNTAIN) && !HAS_TRAIT(affected_mob, TRAIT_COAGULATING)) //So long as they do not have a coagulant, if they did not have the bloody mess trait, they do now
 		ADD_TRAIT(affected_mob, TRAIT_BLOOD_FOUNTAIN, type)
@@ -2632,9 +2631,9 @@
 
 /datum/reagent/bz_metabolites/on_mob_life(mob/living/carbon/target, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	target.adjust_hallucinations(2.5 SECONDS * metabolization_ratio * seconds_per_tick)
+	target.adjust_hallucinations(12.5 SECONDS * metabolization_ratio * seconds_per_tick)
 	var/datum/antagonist/changeling/changeling = IS_CHANGELING(target)
-	changeling?.adjust_chemicals(-1 * metabolization_ratio * seconds_per_tick)
+	changeling?.adjust_chemicals(-5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/pax/peaceborg
 	name = "Synthpax"
@@ -2651,8 +2650,8 @@
 
 /datum/reagent/peaceborg/confuse/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_confusion_up_to(1.5 SECONDS * metabolization_ratio * seconds_per_tick, 5 SECONDS)
-	affected_mob.adjust_dizzy_up_to(3 SECONDS * metabolization_ratio * seconds_per_tick, 12 SECONDS)
+	affected_mob.adjust_confusion_up_to(1 SECONDS * metabolization_ratio * seconds_per_tick, 5 SECONDS)
+	affected_mob.adjust_dizzy_up_to(2 SECONDS * metabolization_ratio * seconds_per_tick, 12 SECONDS)
 
 	if(SPT_PROB(10, seconds_per_tick))
 		to_chat(affected_mob, "You feel confused and disoriented.")
@@ -2669,7 +2668,7 @@
 	var/healthcomp = (100 - affected_mob.health) //DOES NOT ACCOUNT FOR ADMINBUS THINGS THAT MAKE YOU HAVE MORE THAN 200/210 HEALTH, OR SOMETHING OTHER THAN A HUMAN PROCESSING THIS.
 	. = FALSE
 	if(affected_mob.get_stamina_loss() < (45 - healthcomp)) //At 50 health you would have 200 - 150 health meaning 50 compensation. 60 - 50 = 10, so would only do 10-19 stamina.)
-		if(affected_mob.adjust_stamina_loss(5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE))
+		if(affected_mob.adjust_stamina_loss(3.34 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE))
 			. = UPDATE_MOB_HEALTH
 	if(SPT_PROB(16, seconds_per_tick))
 		to_chat(affected_mob, "You should sit down and take a rest...")
@@ -2889,8 +2888,8 @@
 		var/datum/wound/W = thing
 		var/obj/item/bodypart/wounded_part = W.limb
 		if(wounded_part)
-			wounded_part.heal_damage(0.125 * metabolization_ratio * seconds_per_tick, 0.25 * metabolization_ratio * seconds_per_tick)
-		if(affected_mob.adjust_stamina_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)) // the more wounds, the more stamina regen
+			wounded_part.heal_damage(0.167 * metabolization_ratio * seconds_per_tick, 0.25 * metabolization_ratio * seconds_per_tick)
+		if(affected_mob.adjust_stamina_loss(-0.67 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)) // the more wounds, the more stamina regen
 			return UPDATE_MOB_HEALTH
 
 // unholy water, but for heretics.
@@ -2912,25 +2911,25 @@
 	. = ..()
 	var/need_mob_update = FALSE
 	if(IS_HERETIC_OR_MONSTER(drinker))
-		drinker.adjust_drowsiness(-5 * metabolization_ratio * seconds_per_tick)
-		drinker.AdjustAllImmobility(-20 * metabolization_ratio * seconds_per_tick)
-		need_mob_update += drinker.adjust_stamina_loss(-5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
-		need_mob_update += drinker.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE)
-		need_mob_update += drinker.adjust_oxy_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_brute_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_fire_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		drinker.adjust_blood_volume(1.5 * metabolization_ratio * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
+		drinker.adjust_drowsiness(-2 * metabolization_ratio * seconds_per_tick)
+		drinker.AdjustAllImmobility(-8 * metabolization_ratio * seconds_per_tick)
+		need_mob_update += drinker.adjust_stamina_loss(-2 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
+		need_mob_update += drinker.adjust_tox_loss(-0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, forced = TRUE)
+		need_mob_update += drinker.adjust_oxy_loss(-0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_brute_loss(-0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_fire_loss(-0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		drinker.adjust_blood_volume(0.6 * metabolization_ratio * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
 		// Slowly regulates your body temp
 		drinker.adjust_bodytemperature((drinker.get_body_temp_normal() - drinker.bodytemperature) / 5)
 		for(var/datum/reagent/reagent as anything in drinker.reagents.reagent_list)
 			if(reagent != src)
-				drinker.reagents.remove_reagent(reagent.type, 2 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
+				drinker.reagents.remove_reagent(reagent.type, 0.8 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 	else
-		need_mob_update = drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1.5 * metabolization_ratio * seconds_per_tick, 150)
-		need_mob_update += drinker.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_fire_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_oxy_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
-		need_mob_update += drinker.adjust_brute_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update = drinker.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.6 * metabolization_ratio * seconds_per_tick, 150)
+		need_mob_update += drinker.adjust_tox_loss(0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_fire_loss(0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_oxy_loss(0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
+		need_mob_update += drinker.adjust_brute_loss(0.4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -2989,7 +2988,7 @@
 
 /datum/reagent/ants/on_mob_life(mob/living/carbon/victim, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	victim.adjust_brute_loss(max(0.1, round((ant_ticks * ant_damage),0.1))) //Scales with time. Roughly 32 brute with 100u.
+	victim.adjust_brute_loss(0.2 * max(0.1, round((ant_ticks * ant_damage),0.1)) * metabolization_ratio * seconds_per_tick) //Scales with time. Roughly 32 brute with 100u.
 	ant_ticks++
 	if(ant_ticks < 5) // Makes ant food a little more appetizing, since you won't be screaming as much.
 		return
@@ -3090,8 +3089,8 @@
 /datum/reagent/kronkus_extract/on_mob_life(mob/living/carbon/kronkus_enjoyer, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = kronkus_enjoyer.adjust_organ_loss(ORGAN_SLOT_HEART, 0.1 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	need_mob_update += kronkus_enjoyer.adjust_stamina_loss(-6, updating_stamina = FALSE)
+	need_mob_update = kronkus_enjoyer.adjust_organ_loss(ORGAN_SLOT_HEART, 0.2 * metabolization_ratio * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	need_mob_update += kronkus_enjoyer.adjust_stamina_loss(-12 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -3183,13 +3182,13 @@
 	. = ..()
 	if(affected_mob.mob_biotypes & MOB_UNDEAD || HAS_MIND_TRAIT(affected_mob, TRAIT_MORBID)) //if morbid or undead,acts like an addiction-less drug
 		affected_mob.remove_status_effect(/datum/status_effect/jitter)
-		affected_mob.AdjustStun(-2.5 SECONDS * metabolization_ratio * seconds_per_tick)
-		affected_mob.AdjustKnockdown(-2.5 SECONDS * metabolization_ratio * seconds_per_tick)
-		affected_mob.AdjustUnconscious(-2.5 SECONDS * metabolization_ratio * seconds_per_tick)
-		affected_mob.AdjustParalyzed(-2.5 SECONDS * metabolization_ratio * seconds_per_tick)
-		affected_mob.AdjustImmobilized(-2.5 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.AdjustStun(-3.34 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.AdjustKnockdown(-3.34 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.AdjustUnconscious(-3.34 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.AdjustParalyzed(-3.34 SECONDS * metabolization_ratio * seconds_per_tick)
+		affected_mob.AdjustImmobilized(-3.34 SECONDS * metabolization_ratio * seconds_per_tick)
 	else
-		if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, metabolization_ratio * seconds_per_tick)) //1 heart damage per tick
+		if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 1.34 * metabolization_ratio * seconds_per_tick)) //1 heart damage per tick
 			. = UPDATE_MOB_HEALTH
 		if(SPT_PROB(10, seconds_per_tick))
 			affected_mob.emote(pick("twitch","choke","shiver","gag"))
@@ -3258,7 +3257,7 @@
 		added_light = TRUE
 
 	if (SPT_PROB(8, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(1 * metabolization_ratio, updating_health = FALSE))
+		if(affected_mob.adjust_tox_loss(3.34 * metabolization_ratio, updating_health = FALSE))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/luminescent_fluid/proc/on_organ_added(mob/living/source, obj/item/organ/eyes/new_eyes)

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -11,9 +11,9 @@
 	if(reac_volume >= 1)
 		exposed_turf.AddComponent(/datum/component/thermite, reac_volume)
 
-/datum/reagent/thermite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/thermite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_fire_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+	if(affected_mob.adjust_fire_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/nitroglycerin
@@ -24,9 +24,9 @@
 	taste_description = "oil"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/nitroglycerin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/nitroglycerin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, -0.5 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, -0.5 * metabolization_ratio * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/stabilizing_agent
@@ -49,10 +49,10 @@
 	penetrates_skin = NONE
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/clf3/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/clf3/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_fire_stacks(1 * REM * metabolized_volume * seconds_per_tick)
-	if(affected_mob.adjust_fire_loss(0.15 * max(affected_mob.fire_stacks, 1) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+	affected_mob.adjust_fire_stacks(1 * metabolization_ratio * seconds_per_tick)
+	if(affected_mob.adjust_fire_loss(0.15 * max(affected_mob.fire_stacks, 1) * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/clf3/expose_turf(turf/exposed_turf, reac_volume)
@@ -171,10 +171,10 @@
 		exposed_mob.adjust_fire_loss(burndmg, 0)
 	exposed_mob.ignite_mob()
 
-/datum/reagent/phlogiston/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolized_volume)
+/datum/reagent/phlogiston/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	metabolizer.adjust_fire_stacks(0.5 * REM * metabolized_volume * seconds_per_tick)
-	if(metabolizer.adjust_fire_loss(0.15 * max(metabolizer.fire_stacks, 0.15) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
+	metabolizer.adjust_fire_stacks(0.5 * metabolization_ratio * seconds_per_tick)
+	if(metabolizer.adjust_fire_loss(0.15 * max(metabolizer.fire_stacks, 0.15) * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/napalm
@@ -194,9 +194,9 @@
 
 	mytray.adjust_weedlevel(-rand(5,9)) //At least give them a small reward if they bother.
 
-/datum/reagent/napalm/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/napalm/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_fire_stacks(0.5 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_fire_stacks(0.5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/napalm/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
@@ -238,19 +238,19 @@
 	affected_mob.color = COLOR_WHITE
 
 //Pauses decay! Does do something, I promise.
-/datum/reagent/cryostylane/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/cryostylane/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	metabolization_rate = 0.05 * REM //slower consumption when dead
 
-/datum/reagent/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	metabolization_rate = 0.25 * REM//faster consumption when alive
 	if(affected_mob.reagents.has_reagent(/datum/reagent/oxygen))
-		affected_mob.reagents.remove_reagent(/datum/reagent/oxygen, 0.25 * REM * metabolized_volume * seconds_per_tick)
-		affected_mob.adjust_bodytemperature(-7.5 * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(/datum/reagent/oxygen, 0.25 * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_bodytemperature(-7.5 * metabolization_ratio * seconds_per_tick)
 		if(ishuman(affected_mob))
 			var/mob/living/carbon/human/humi = affected_mob
-			humi.adjust_coretemperature(-7.5 * REM * metabolized_volume * seconds_per_tick)
+			humi.adjust_coretemperature(-7.5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/cryostylane/expose_turf(turf/exposed_turf, reac_volume)
 	. = ..()
@@ -273,14 +273,14 @@
 	burning_volume = 0.05
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/pyrosium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/pyrosium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(holder.has_reagent(/datum/reagent/oxygen))
-		holder.remove_reagent(/datum/reagent/oxygen, 0.25 * REM * metabolized_volume * seconds_per_tick)
-		affected_mob.adjust_bodytemperature(7.5 * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/oxygen, 0.25 * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_bodytemperature(7.5 * metabolization_ratio * seconds_per_tick)
 		if(ishuman(affected_mob))
 			var/mob/living/carbon/human/affected_human = affected_mob
-			affected_human.adjust_coretemperature(7.5 * REM * metabolized_volume * seconds_per_tick)
+			affected_human.adjust_coretemperature(7.5 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/pyrosium/burn(datum/reagents/holder)
 	if(holder.has_reagent(/datum/reagent/oxygen))
@@ -298,7 +298,7 @@
 	var/shock_timer = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/teslium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/teslium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	shock_timer++
 	if(shock_timer >= rand(5, 30)) //Random shocks are wildly unpredictable
@@ -335,16 +335,16 @@
 	taste_description = "jelly"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/teslium/energized_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/teslium/energized_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	if(!isjellyperson(affected_mob)) //everyone but jellypeople get shocked as normal.
 		return ..()
-	affected_mob.AdjustAllImmobility(-20  *REM * metabolized_volume * seconds_per_tick)
-	if(affected_mob.adjust_stamina_loss(-5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
+	affected_mob.AdjustAllImmobility(-20  *metabolization_ratio * seconds_per_tick)
+	if(affected_mob.adjust_stamina_loss(-5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE))
 		. = UPDATE_MOB_HEALTH
 	if(is_species(affected_mob, /datum/species/jelly/luminescent))
 		var/mob/living/carbon/human/affected_human = affected_mob
 		var/datum/species/jelly/luminescent/slime_species = affected_human.dna.species
-		slime_species.extract_cooldown = max(slime_species.extract_cooldown - (1 SECONDS * REM * metabolized_volume * seconds_per_tick), 0)
+		slime_species.extract_cooldown = max(slime_species.extract_cooldown - (1 SECONDS * metabolization_ratio * seconds_per_tick), 0)
 
 /datum/reagent/firefighting_foam
 	name = "Firefighting Foam"

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -11,9 +11,9 @@
 	if(reac_volume >= 1)
 		exposed_turf.AddComponent(/datum/component/thermite, reac_volume)
 
-/datum/reagent/thermite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/thermite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_fire_loss(1 * REM * seconds_per_tick, updating_health = FALSE))
+	if(affected_mob.adjust_fire_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/nitroglycerin
@@ -24,9 +24,9 @@
 	taste_description = "oil"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/nitroglycerin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/nitroglycerin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, -1 * REM * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, -0.5 * REM * metabolized_volume * seconds_per_tick * normalise_creation_purity(), required_organ_flag = affected_organ_flags))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/stabilizing_agent
@@ -49,10 +49,10 @@
 	penetrates_skin = NONE
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/clf3/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/clf3/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_fire_stacks(2 * REM * seconds_per_tick)
-	if(affected_mob.adjust_fire_loss(0.3 * max(affected_mob.fire_stacks, 1) * REM * seconds_per_tick, updating_health = FALSE))
+	affected_mob.adjust_fire_stacks(1 * REM * metabolized_volume * seconds_per_tick)
+	if(affected_mob.adjust_fire_loss(0.15 * max(affected_mob.fire_stacks, 1) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/clf3/expose_turf(turf/exposed_turf, reac_volume)
@@ -171,10 +171,10 @@
 		exposed_mob.adjust_fire_loss(burndmg, 0)
 	exposed_mob.ignite_mob()
 
-/datum/reagent/phlogiston/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick)
+/datum/reagent/phlogiston/on_mob_life(mob/living/carbon/metabolizer, seconds_per_tick, metabolized_volume)
 	. = ..()
-	metabolizer.adjust_fire_stacks(1 * REM * seconds_per_tick)
-	if(metabolizer.adjust_fire_loss(0.3 * max(metabolizer.fire_stacks, 0.15) * REM * seconds_per_tick, updating_health = FALSE))
+	metabolizer.adjust_fire_stacks(0.5 * REM * metabolized_volume * seconds_per_tick)
+	if(metabolizer.adjust_fire_loss(0.15 * max(metabolizer.fire_stacks, 0.15) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/napalm
@@ -194,9 +194,9 @@
 
 	mytray.adjust_weedlevel(-rand(5,9)) //At least give them a small reward if they bother.
 
-/datum/reagent/napalm/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/napalm/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_fire_stacks(1 * REM * seconds_per_tick)
+	affected_mob.adjust_fire_stacks(0.5 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/napalm/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
@@ -238,19 +238,19 @@
 	affected_mob.color = COLOR_WHITE
 
 //Pauses decay! Does do something, I promise.
-/datum/reagent/cryostylane/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/cryostylane/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	metabolization_rate = 0.05 * REM //slower consumption when dead
 
-/datum/reagent/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	metabolization_rate = 0.25 * REM//faster consumption when alive
 	if(affected_mob.reagents.has_reagent(/datum/reagent/oxygen))
-		affected_mob.reagents.remove_reagent(/datum/reagent/oxygen, 0.5 * REM * seconds_per_tick)
-		affected_mob.adjust_bodytemperature(-15 * REM * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(/datum/reagent/oxygen, 0.25 * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_bodytemperature(-7.5 * REM * metabolized_volume * seconds_per_tick)
 		if(ishuman(affected_mob))
 			var/mob/living/carbon/human/humi = affected_mob
-			humi.adjust_coretemperature(-15 * REM * seconds_per_tick)
+			humi.adjust_coretemperature(-7.5 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/cryostylane/expose_turf(turf/exposed_turf, reac_volume)
 	. = ..()
@@ -273,14 +273,14 @@
 	burning_volume = 0.05
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/pyrosium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/pyrosium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(holder.has_reagent(/datum/reagent/oxygen))
-		holder.remove_reagent(/datum/reagent/oxygen, 0.5 * REM * seconds_per_tick)
-		affected_mob.adjust_bodytemperature(15 * REM * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/oxygen, 0.25 * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_bodytemperature(7.5 * REM * metabolized_volume * seconds_per_tick)
 		if(ishuman(affected_mob))
 			var/mob/living/carbon/human/affected_human = affected_mob
-			affected_human.adjust_coretemperature(15 * REM * seconds_per_tick)
+			affected_human.adjust_coretemperature(7.5 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/pyrosium/burn(datum/reagents/holder)
 	if(holder.has_reagent(/datum/reagent/oxygen))
@@ -298,7 +298,7 @@
 	var/shock_timer = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/teslium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/teslium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	shock_timer++
 	if(shock_timer >= rand(5, 30)) //Random shocks are wildly unpredictable
@@ -335,16 +335,16 @@
 	taste_description = "jelly"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/teslium/energized_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/teslium/energized_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(!isjellyperson(affected_mob)) //everyone but jellypeople get shocked as normal.
 		return ..()
-	affected_mob.AdjustAllImmobility(-40  *REM * seconds_per_tick)
-	if(affected_mob.adjust_stamina_loss(-10 * REM * seconds_per_tick, updating_stamina = FALSE))
+	affected_mob.AdjustAllImmobility(-20  *REM * metabolized_volume * seconds_per_tick)
+	if(affected_mob.adjust_stamina_loss(-5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
 		. = UPDATE_MOB_HEALTH
 	if(is_species(affected_mob, /datum/species/jelly/luminescent))
 		var/mob/living/carbon/human/affected_human = affected_mob
 		var/datum/species/jelly/luminescent/slime_species = affected_human.dna.species
-		slime_species.extract_cooldown = max(slime_species.extract_cooldown - (2 SECONDS * REM * seconds_per_tick), 0)
+		slime_species.extract_cooldown = max(slime_species.extract_cooldown - (1 SECONDS * REM * metabolized_volume * seconds_per_tick), 0)
 
 /datum/reagent/firefighting_foam
 	name = "Firefighting Foam"

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -51,8 +51,8 @@
 
 /datum/reagent/clf3/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_fire_stacks(1 * metabolization_ratio * seconds_per_tick)
-	if(affected_mob.adjust_fire_loss(0.15 * max(affected_mob.fire_stacks, 1) * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
+	affected_mob.adjust_fire_stacks(0.1 * metabolization_ratio * seconds_per_tick)
+	if(affected_mob.adjust_fire_loss(0.015 * max(affected_mob.fire_stacks, 1) * metabolization_ratio * seconds_per_tick, updating_health = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/clf3/expose_turf(turf/exposed_turf, reac_volume)
@@ -240,17 +240,17 @@
 //Pauses decay! Does do something, I promise.
 /datum/reagent/cryostylane/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	metabolization_rate = 0.05 * REM //slower consumption when dead
+	metabolization_rate = 0.125 * REAGENTS_METABOLISM //slower consumption when dead
 
 /datum/reagent/cryostylane/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	metabolization_rate = 0.25 * REM//faster consumption when alive
 	if(affected_mob.reagents.has_reagent(/datum/reagent/oxygen))
-		affected_mob.reagents.remove_reagent(/datum/reagent/oxygen, 0.25 * metabolization_ratio * seconds_per_tick)
-		affected_mob.adjust_bodytemperature(-7.5 * metabolization_ratio * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(/datum/reagent/oxygen, 1 * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_bodytemperature(-30 * metabolization_ratio * seconds_per_tick)
 		if(ishuman(affected_mob))
 			var/mob/living/carbon/human/humi = affected_mob
-			humi.adjust_coretemperature(-7.5 * metabolization_ratio * seconds_per_tick)
+			humi.adjust_coretemperature(-30 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/cryostylane/expose_turf(turf/exposed_turf, reac_volume)
 	. = ..()
@@ -276,11 +276,11 @@
 /datum/reagent/pyrosium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(holder.has_reagent(/datum/reagent/oxygen))
-		holder.remove_reagent(/datum/reagent/oxygen, 0.25 * metabolization_ratio * seconds_per_tick)
-		affected_mob.adjust_bodytemperature(7.5 * metabolization_ratio * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/oxygen, 0.5 * metabolization_ratio * seconds_per_tick)
+		affected_mob.adjust_bodytemperature(15 * metabolization_ratio * seconds_per_tick)
 		if(ishuman(affected_mob))
 			var/mob/living/carbon/human/affected_human = affected_mob
-			affected_human.adjust_coretemperature(7.5 * metabolization_ratio * seconds_per_tick)
+			affected_human.adjust_coretemperature(15 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/pyrosium/burn(datum/reagents/holder)
 	if(holder.has_reagent(/datum/reagent/oxygen))

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -338,7 +338,7 @@
 /datum/reagent/teslium/energized_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	if(!isjellyperson(affected_mob)) //everyone but jellypeople get shocked as normal.
 		return ..()
-	affected_mob.AdjustAllImmobility(-20  *metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustAllImmobility(-20  * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.adjust_stamina_loss(-5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE))
 		. = UPDATE_MOB_HEALTH
 	if(is_species(affected_mob, /datum/species/jelly/luminescent))

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -728,7 +728,7 @@
 		holder.remove_reagent(/datum/reagent/toxin/formaldehyde, 1.2)
 	return ..()
 
-/datum/reagent/toxin/formaldehyde/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+/datum/reagent/toxin/formaldehyde/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(HAS_TRAIT(affected_mob, TRAIT_BLOCK_FORMALDEHYDE_METABOLISM))
 		return
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1207,19 +1207,18 @@
 	name = "Toxin Microcapsules"
 	description = "Causes heavy toxin damage after a brief time of inactivity."
 	metabolization_rate = 0 //stays in the system until active.
-	var/actual_metaboliztion_rate = REAGENTS_METABOLISM
 	toxpwr = 0
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 	var/actual_toxpwr = 5
 	var/delay = 31
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
 /datum/reagent/toxin/delayed/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle <= delay)
 		return
 	if(holder)
-		holder.remove_reagent(type, actual_metaboliztion_rate * affected_mob.metabolism_efficiency * seconds_per_tick)
-	if(affected_mob.adjust_tox_loss(0.5 * actual_toxpwr * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		holder.remove_reagent(type, REAGENTS_METABOLISM * affected_mob.metabolism_efficiency * seconds_per_tick)
+	if(affected_mob.adjust_tox_loss(0.5 * actual_toxpwr * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
 	if(SPT_PROB(5, seconds_per_tick))
 		affected_mob.Paralyze(20)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -23,10 +23,10 @@
 /datum/reagent/toxin/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)
 	mytray.adjust_toxic(round(volume * 2))
 
-/datum/reagent/toxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(toxpwr && affected_mob.health > health_required)
-		if(affected_mob.adjust_tox_loss(0.5 * toxpwr * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(0.5 * toxpwr * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/amatoxin
@@ -65,7 +65,7 @@
 		exposed_mob.updateappearance()
 		exposed_mob.domutcheck()
 
-/datum/reagent/toxin/mutagen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/mutagen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.adjust_tox_loss(0.5 * seconds_per_tick * REM, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
@@ -105,11 +105,11 @@
 	UnregisterSignal(holder, COMSIG_REAGENTS_TEMP_CHANGE)
 	return ..()
 
-/datum/reagent/toxin/plasma/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/plasma/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(holder.has_reagent(/datum/reagent/medicine/epinephrine))
-		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 1 * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjustPlasma(10 * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 1 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjustPlasma(10 * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/toxin/plasma/on_mob_metabolize(mob/living/carbon/affected_mob)
 	. = ..()
@@ -160,15 +160,15 @@
 	material = /datum/material/hot_ice
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/hot_ice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/hot_ice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(holder.has_reagent(/datum/reagent/medicine/epinephrine))
-		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 1 * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjustPlasma(10 * REM * metabolized_volume * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-3.5 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, affected_mob.get_body_temp_normal())
+		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 1 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjustPlasma(10 * metabolization_ratio * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-3.5 * TEMPERATURE_DAMAGE_COEFFICIENT * metabolization_ratio * seconds_per_tick, affected_mob.get_body_temp_normal())
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/humi = affected_mob
-		humi.adjust_coretemperature(-3.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+		humi.adjust_coretemperature(-3.5 * metabolization_ratio * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/toxin/hot_ice/on_mob_metabolize(mob/living/carbon/affected_mob)
 	. = ..()
@@ -190,11 +190,11 @@
 	ph = 1.2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/lexorin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/lexorin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_NOBREATH))
-		affected_mob.adjust_oxy_loss(2.5 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		affected_mob.losebreath += 1 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick
+		affected_mob.adjust_oxy_loss(2.5 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		affected_mob.losebreath += 1 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick
 		. = UPDATE_MOB_HEALTH
 		if(SPT_PROB(10, seconds_per_tick))
 			affected_mob.emote("gasp")
@@ -221,11 +221,11 @@
 	ph = 10
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/slimejelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/slimejelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
 		to_chat(affected_mob, span_danger("Your insides are burning!"))
-		if(affected_mob.adjust_tox_loss(rand(20, 60), updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(rand(20, 60) * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 	else if(SPT_PROB(23, seconds_per_tick))
 		if(affected_mob.heal_bodypart_damage(5))
@@ -292,18 +292,18 @@
 	. = ..()
 	affected_mob.remove_status_effect(/datum/status_effect/reagent_effect/fakedeath)
 
-/datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(HAS_TRAIT(affected_mob, TRAIT_FAKEDEATH) && HAS_TRAIT(affected_mob, TRAIT_DEATHCOMA))
 		return
 	var/need_mob_update
 	switch(current_cycle)
 		if(2 to 6)
-			affected_mob.adjust_confusion(0.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-			affected_mob.adjust_drowsiness(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
-			affected_mob.adjust_slurring(3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.adjust_confusion(0.5 SECONDS * metabolization_ratio * seconds_per_tick)
+			affected_mob.adjust_drowsiness(1 SECONDS * metabolization_ratio * seconds_per_tick)
+			affected_mob.adjust_slurring(3 SECONDS * metabolization_ratio * seconds_per_tick)
 		if(6 to 9)
-			need_mob_update = affected_mob.adjust_stamina_loss(20 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
+			need_mob_update = affected_mob.adjust_stamina_loss(20 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 		if(10 to INFINITY)
 			if(affected_mob.stat != DEAD)
 				affected_mob.fakedeath(type)
@@ -322,9 +322,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_FAKEDEATH)
 
-/datum/reagent/toxin/ghoulpowder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/ghoulpowder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_oxy_loss(0.5 * REM * metabolized_volume * seconds_per_tick, FALSE, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
+	if(affected_mob.adjust_oxy_loss(0.5 * metabolization_ratio * seconds_per_tick, FALSE, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/mindbreaker
@@ -341,7 +341,7 @@
 	addiction_types = list(/datum/addiction/hallucinogens = 18)  //7.2 per 2 seconds
 	metabolized_traits = list(TRAIT_RDS_SUPPRESSED)
 
-/datum/reagent/toxin/mindbreaker/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/mindbreaker/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	// mindbreaker toxin assuages hallucinations in those plagued with it, mentally
 	if(affected_mob.has_trauma_type(/datum/brain_trauma/mild/hallucinations))
@@ -349,7 +349,7 @@
 
 	// otherwise it creates hallucinations. truly a miracle medicine.
 	else
-		affected_mob.adjust_hallucinations(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.adjust_hallucinations(5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/toxin/mindbreaker/fish
 	name = "Jellyfish Hallucinogen"
@@ -433,9 +433,9 @@
 	. = ..()
 	AddElement(/datum/element/bugkiller_reagent)
 
-/datum/reagent/toxin/pestkiller/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/pestkiller/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(1 * toxpwr * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = MOB_BUG))
+	if(affected_mob.adjust_tox_loss(1 * toxpwr * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = MOB_BUG))
 		return UPDATE_MOB_HEALTH
 
 //Pest Spray
@@ -478,11 +478,11 @@
 		spore_lung_victim.Stun(1 SECONDS)
 		spore_lung_victim.emote("cough")
 
-/datum/reagent/toxin/spore/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/spore/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	affected_mob.damageoverlaytemp = 60
 	affected_mob.update_damage_hud()
-	affected_mob.set_eye_blur_if_lower(3 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.set_eye_blur_if_lower(3 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/toxin/spore_burning
 	name = "Burning Spore Toxin"
@@ -493,9 +493,9 @@
 	ph = 13
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/spore_burning/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/spore_burning/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_fire_stacks(1 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_fire_stacks(1 * metabolization_ratio * seconds_per_tick)
 	affected_mob.ignite_mob()
 
 /datum/reagent/toxin/chloralhydrate
@@ -511,17 +511,17 @@
 	inverse_chem = /datum/reagent/impurity/chloralax
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/chloralhydrate/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/chloralhydrate/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	switch(current_cycle)
 		if(2 to 11)
-			affected_mob.adjust_confusion(1 SECONDS * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
-			affected_mob.adjust_drowsiness(2 SECONDS * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
+			affected_mob.adjust_confusion(1 SECONDS * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
+			affected_mob.adjust_drowsiness(2 SECONDS * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
 		if(11 to 51)
-			affected_mob.Sleeping(20 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
+			affected_mob.Sleeping(20 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
 		if(52 to INFINITY)
-			affected_mob.Sleeping(20 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
-			if(affected_mob.adjust_tox_loss(0.5 * (current_cycle - 51) * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			affected_mob.Sleeping(20 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
+			if(affected_mob.adjust_tox_loss(0.5 * (current_cycle - 51) * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/fakebeer //disguised as normal beer for use by emagged brobots
@@ -545,14 +545,14 @@
 	icon = initial(copy_from.icon)
 	icon_state = initial(copy_from.icon_state)
 
-/datum/reagent/toxin/fakebeer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/fakebeer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	switch(current_cycle)
 		if(2 to 51)
-			affected_mob.Sleeping(20 * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.Sleeping(20 * metabolization_ratio * seconds_per_tick)
 		if(52 to INFINITY)
-			affected_mob.Sleeping(20 * REM * metabolized_volume * seconds_per_tick)
-			if(affected_mob.adjust_tox_loss(0.5 * (current_cycle - 50) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			affected_mob.Sleeping(20 * metabolization_ratio * seconds_per_tick)
+			if(affected_mob.adjust_tox_loss(0.5 * (current_cycle - 50) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/coffeepowder
@@ -595,10 +595,10 @@
 	ph = 12.2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/mutetoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/mutetoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	// Gain approximately 12 seconds * creation purity seconds of silence every metabolism tick.
-	affected_mob.set_silence_if_lower(3 SECONDS * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
+	affected_mob.set_silence_if_lower(3 SECONDS * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
 
 /datum/reagent/toxin/staminatoxin
 	name = "Tirizene"
@@ -609,9 +609,9 @@
 	toxpwr = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/staminatoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/staminatoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_stamina_loss(0.5 * data * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
+	if(affected_mob.adjust_stamina_loss(0.5 * data * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE))
 		. = UPDATE_MOB_HEALTH
 	data = max(data - 1, 3)
 
@@ -625,14 +625,14 @@
 	/// How radioactive is this reagent
 	var/rad_power = 3
 
-/datum/reagent/toxin/polonium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/polonium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_IRRADIATED) && SSradiation.can_irradiate_basic(affected_mob))
 		var/chance = min(volume / (20 - rad_power * 5), rad_power)
 		if(SPT_PROB(chance, seconds_per_tick)) // ignore rad protection calculations bc it's inside of us
 			affected_mob.AddComponent(/datum/component/irradiated)
 	else
-		if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/polonium/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
@@ -677,7 +677,7 @@
 	toxpwr = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/histamine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/histamine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(30, seconds_per_tick))
 		switch(pick(1, 2, 3, 4))
@@ -691,15 +691,15 @@
 			if(4)
 				if(prob(75))
 					to_chat(affected_mob, span_danger("You scratch at an itch."))
-					if(affected_mob.adjust_brute_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+					if(affected_mob.adjust_brute_loss(1 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype))
 						return UPDATE_MOB_HEALTH
 
-/datum/reagent/toxin/histamine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/histamine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_oxy_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_oxy_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -717,10 +717,10 @@
 	inverse_chem = /datum/reagent/impurity/methanol
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/formaldehyde/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/formaldehyde/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_CORONER_METABOLISM)) //mmmm, the forbidden pickle juice
-		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)) //it counteracts its own toxin damage.
+		if(affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)) //it counteracts its own toxin damage.
 			return UPDATE_MOB_HEALTH
 		return
 	else if(SPT_PROB(2.5, seconds_per_tick) && !HAS_TRAIT(affected_mob, TRAIT_BLOCK_FORMALDEHYDE_METABOLISM))
@@ -728,7 +728,7 @@
 		holder.remove_reagent(/datum/reagent/toxin/formaldehyde, 1.2)
 	return ..()
 
-/datum/reagent/toxin/formaldehyde/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/formaldehyde/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	if(HAS_TRAIT(affected_mob, TRAIT_BLOCK_FORMALDEHYDE_METABOLISM))
 		return
 
@@ -744,13 +744,13 @@
 	///Mob Size of the current mob sprite.
 	var/current_size = RESIZE_DEFAULT_SIZE
 
-/datum/reagent/toxin/venom/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/venom/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	var/newsize = 1.1 * RESIZE_DEFAULT_SIZE
 	affected_mob.update_transform(newsize/current_size)
 	current_size = newsize
 	toxpwr = 0.1 * volume
 
-	if(affected_mob.adjust_brute_loss((0.15 * volume) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+	if(affected_mob.adjust_brute_loss((0.15 * volume) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 		. = UPDATE_MOB_HEALTH
 
 	// chance to either decay into histamine or go the normal route of toxin metabolization
@@ -777,16 +777,16 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/opioids = 25)
 
-/datum/reagent/toxin/fentanyl/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/fentanyl/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1.5 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, 150)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1.5 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, 150)
 	if(affected_mob.toxloss <= 60)
-		need_mob_update += affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(current_cycle > 4)
 		affected_mob.add_mood_event("smacked out", /datum/mood_event/narcotic_heavy, name)
 	if(current_cycle > 18)
-		affected_mob.Sleeping(20 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
+		affected_mob.Sleeping(20 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -801,7 +801,7 @@
 	ph = 9.3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/cyanide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/cyanide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update = FALSE
 	if(SPT_PROB(2.5, seconds_per_tick))
@@ -810,7 +810,7 @@
 	if(SPT_PROB(4, seconds_per_tick))
 		to_chat(affected_mob, span_danger("You feel horrendously weak!"))
 		affected_mob.Stun(40)
-		need_mob_update += affected_mob.adjust_tox_loss(1 * REM * metabolized_volume * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_tox_loss(1 * metabolization_ratio * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -836,7 +836,7 @@
 	penetrates_skin = TOUCH|VAPOR
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/itching_powder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/itching_powder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	var/scratched = FALSE
 	var/scratch_damage = 0.2 * REM
 
@@ -868,7 +868,7 @@
 	toxpwr = 2.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/initropidril/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/initropidril/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!SPT_PROB(13, seconds_per_tick))
 		return
@@ -902,10 +902,10 @@
 	taste_mult = 0 // undetectable, I guess?
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/pancuronium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/pancuronium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 10)
-		affected_mob.Stun(20 * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.Stun(20 * metabolization_ratio * seconds_per_tick)
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.losebreath += 4
 		return UPDATE_MOB_HEALTH
@@ -920,11 +920,11 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 	added_traits = list(TRAIT_ANTICONVULSANT)
 
-/datum/reagent/toxin/sodium_thiopental/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/sodium_thiopental/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 10)
-		affected_mob.Sleeping(20 * REM * metabolized_volume * seconds_per_tick)
-	if(affected_mob.adjust_stamina_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
+		affected_mob.Sleeping(20 * metabolization_ratio * seconds_per_tick)
+	if(affected_mob.adjust_stamina_loss(5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/sulfonal
@@ -939,10 +939,10 @@
 	ph = 6
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/sulfonal/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/sulfonal/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 22)
-		affected_mob.Sleeping(20 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
+		affected_mob.Sleeping(20 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
 
 /datum/reagent/toxin/amanitin
 	name = "Amanitin"
@@ -954,7 +954,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	var/delayed_toxin_damage = 0
 
-/datum/reagent/toxin/amanitin/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/amanitin/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	delayed_toxin_damage += (seconds_per_tick * 3)
 
@@ -977,12 +977,12 @@
 	inverse_chem = /datum/reagent/impurity/ipecacide
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/lipolicide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/lipolicide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.nutrition <= NUTRITION_LEVEL_STARVING)
-		if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_nutrition(-1.5 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick) // making the chef more valuable, one meme trap at a time
+	affected_mob.adjust_nutrition(-1.5 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick) // making the chef more valuable, one meme trap at a time
 	affected_mob.overeatduration = 0
 
 /datum/reagent/toxin/coniine
@@ -993,10 +993,10 @@
 	toxpwr = 1.75
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/coniine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/coniine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.losebreath < 5)
-		affected_mob.losebreath = min(affected_mob.losebreath + 2.5 * REM * metabolized_volume * seconds_per_tick, 5)
+		affected_mob.losebreath = min(affected_mob.losebreath + 2.5 * metabolization_ratio * seconds_per_tick, 5)
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/spewium
@@ -1009,7 +1009,7 @@
 	taste_description = "vomit"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/spewium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/spewium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 11 && SPT_PROB(min(31, current_cycle), seconds_per_tick))
 		affected_mob.vomit(10, prob(10), prob(50), rand(0,4), TRUE)
@@ -1021,9 +1021,9 @@
 		affected_mob.vomit(vomit_flags = constructed_flags, distance = rand(0,4))
 		for(var/datum/reagent/toxin/reagent in affected_mob.reagents.reagent_list)
 			if(reagent != src)
-				affected_mob.reagents.remove_reagent(reagent.type, 1 * reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
+				affected_mob.reagents.remove_reagent(reagent.type, 1 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 
-/datum/reagent/toxin/spewium/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/spewium/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 33 && SPT_PROB(7.5, seconds_per_tick))
 		affected_mob.spew_organ()
@@ -1038,10 +1038,10 @@
 	toxpwr = 1
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/curare/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/curare/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 11)
-		affected_mob.Paralyze(30 * REM * metabolized_volume * seconds_per_tick)
+		affected_mob.Paralyze(30 * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.adjust_oxy_loss(0.5*REM*seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
 		return UPDATE_MOB_HEALTH
 
@@ -1059,9 +1059,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_BLOOD_FOUNTAIN)
 
-/datum/reagent/toxin/heparin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/heparin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	if(holder.has_reagent(/datum/reagent/medicine/coagulant)) //Directly purges coagulants from the system. Get rid of the heparin BEFORE attempting to use coagulants.
-		holder.remove_reagent(/datum/reagent/medicine/coagulant, 1 * REM * metabolized_volume * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/medicine/coagulant, 1 * metabolization_ratio * seconds_per_tick)
 	return ..()
 
 /datum/reagent/toxin/rotatium //Rotatium. Fucks up your rotation and is hilarious
@@ -1077,7 +1077,7 @@
 	taste_description = "spinning"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/rotatium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/rotatium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!affected_mob.hud_used || (current_cycle < 20 || (current_cycle % 20) == 0))
 		return
@@ -1106,13 +1106,13 @@
 	ph = 8
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/anacea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/anacea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	var/remove_amt = 5
 	if(holder.has_reagent(/datum/reagent/medicine/calomel) || holder.has_reagent(/datum/reagent/medicine/pen_acid))
 		remove_amt = 0.5
 	. = ..()
 	for(var/datum/reagent/medicine/reagent in affected_mob.reagents.reagent_list)
-		affected_mob.reagents.remove_reagent(reagent.type, 0.5 * remove_amt * reagent.purge_multiplier * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(reagent.type, 0.5 * remove_amt * reagent.purge_multiplier * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
 
 //ACID
 
@@ -1181,9 +1181,9 @@
 	mytray.adjust_toxic(round(volume * 3))
 	mytray.adjust_weedlevel(-rand(1,4))
 
-/datum/reagent/toxin/acid/fluacid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/acid/fluacid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_fire_loss(0.5 * ((current_cycle-1)/15) * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+	if(affected_mob.adjust_fire_loss(0.5 * ((current_cycle-1)/15) * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/acid/nitracid
@@ -1197,9 +1197,9 @@
 	ph = 1.3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/acid/nitracid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/acid/nitracid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_fire_loss(0.5 * (volume/10) * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)) //here you go nervar
+	if(affected_mob.adjust_fire_loss(0.5 * (volume/10) * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)) //here you go nervar
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/delayed
@@ -1212,13 +1212,13 @@
 	var/delay = 31
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/delayed/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/delayed/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle <= delay)
 		return
 	if(holder)
 		holder.remove_reagent(type, actual_metaboliztion_rate * affected_mob.metabolism_efficiency * seconds_per_tick)
-	if(affected_mob.adjust_tox_loss(0.5 * actual_toxpwr * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.5 * actual_toxpwr * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
 	if(SPT_PROB(5, seconds_per_tick))
 		affected_mob.Paralyze(20)
@@ -1253,9 +1253,9 @@
 	. = ..()
 	affected_mob.say("oof ouch my bones", forced = /datum/reagent/toxin/bonehurtingjuice)
 
-/datum/reagent/toxin/bonehurtingjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/bonehurtingjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_stamina_loss(3.25 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
+	if(affected_mob.adjust_stamina_loss(3.25 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE))
 		. = UPDATE_MOB_HEALTH
 	if(!SPT_PROB(10, seconds_per_tick))
 		return
@@ -1267,7 +1267,7 @@
 		if(3)
 			to_chat(affected_mob, span_warning("Your bones hurt!"))
 
-/datum/reagent/toxin/bonehurtingjuice/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/bonehurtingjuice/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(SPT_PROB(2, seconds_per_tick) && iscarbon(affected_mob)) //big oof
 		var/selected_part = pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG) //God help you if the same limb gets picked twice quickly.
@@ -1297,9 +1297,9 @@
 	taste_description = "tannin"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/bungotoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/bungotoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 1.5 * REM * metabolized_volume * seconds_per_tick))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 1.5 * metabolization_ratio * seconds_per_tick))
 		. = UPDATE_MOB_HEALTH
 
 	// If our mob's currently dizzy from anything else, we will also gain confusion
@@ -1321,11 +1321,11 @@
 	taste_description = "sugary sweetness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/leadacetate/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/leadacetate/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_EARS, 0.5 * REM * metabolized_volume * seconds_per_tick)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * REM * metabolized_volume * seconds_per_tick)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_EARS, 0.5 * metabolization_ratio * seconds_per_tick)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * metabolization_ratio * seconds_per_tick)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH
 	if(SPT_PROB(0.5, seconds_per_tick))
@@ -1345,9 +1345,9 @@
 	health_required = 10
 	liver_damage_multiplier = 0
 
-/datum/reagent/toxin/viperspider/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/viperspider/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	affected_mob.adjust_hallucinations(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_hallucinations(5 SECONDS * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/toxin/tetrodotoxin
 	name = "Tetrodotoxin"
@@ -1368,7 +1368,7 @@
 		TRAIT_PARALYSIS_R_LEG = BODY_ZONE_R_LEG,
 	)
 
-/datum/reagent/toxin/tetrodotoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
+/datum/reagent/toxin/tetrodotoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
 	if(HAS_TRAIT(affected_mob, TRAIT_TETRODOTOXIN_HEALING))
@@ -1376,10 +1376,10 @@
 		liver_tolerance_multiplier = 0
 		silent_toxin = TRUE
 		remove_paralysis()
-		need_mob_update += affected_mob.adjust_oxy_loss(-0.35 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update = affected_mob.adjust_tox_loss(-0.325 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-0.6 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.675 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-0.35 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update = affected_mob.adjust_tox_loss(-0.325 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-0.6 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.675 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		return need_mob_update ? UPDATE_MOB_HEALTH : .
 
 	liver_tolerance_multiplier = initial(liver_tolerance_multiplier)
@@ -1389,25 +1389,25 @@
 	switch(current_cycle)
 		if(7 to 13)
 			if(SPT_PROB(20, seconds_per_tick))
-				affected_mob.set_jitter_if_lower(0.5 * rand(2 SECONDS, 3 SECONDS) * REM * metabolized_volume * seconds_per_tick)
+				affected_mob.set_jitter_if_lower(0.5 * rand(2 SECONDS, 3 SECONDS) * metabolization_ratio)
 			if(SPT_PROB(5, seconds_per_tick))
 				var/obj/item/organ/tongue/tongue = affected_mob.get_organ_slot(ORGAN_SLOT_TONGUE)
 				if(tongue)
 					to_chat(affected_mob, span_warning("Your [tongue.name] feels numb..."))
-				affected_mob.set_slurring_if_lower(2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-			affected_mob.adjust_disgust(1.25 * REM * metabolized_volume * seconds_per_tick)
+				affected_mob.set_slurring_if_lower(2.5 SECONDS * metabolization_ratio)
+			affected_mob.adjust_disgust(1.25 * metabolization_ratio * seconds_per_tick)
 		if(13 to 21)
 			silent_toxin = FALSE
 			toxpwr = 0.5
-			need_mob_update = affected_mob.adjust_stamina_loss(1.25 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
+			need_mob_update = affected_mob.adjust_stamina_loss(1.25 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 			if(SPT_PROB(20, seconds_per_tick))
-				affected_mob.losebreath += 0.5 * REM * metabolized_volume * seconds_per_tick
+				affected_mob.losebreath += 0.5 * metabolization_ratio
 				need_mob_update = TRUE
 			if(SPT_PROB(40, seconds_per_tick))
-				affected_mob.set_jitter_if_lower(0.5 * rand(2 SECONDS, 3 SECONDS) * REM * metabolized_volume * seconds_per_tick)
-			affected_mob.adjust_disgust(1.5 * REM * metabolized_volume * seconds_per_tick)
-			affected_mob.set_slurring_if_lower(0.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-			affected_mob.adjust_stamina_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
+				affected_mob.set_jitter_if_lower(0.5 * rand(2 SECONDS, 3 SECONDS) * metabolization_ratio)
+			affected_mob.adjust_disgust(1.5 * metabolization_ratio * seconds_per_tick)
+			affected_mob.set_slurring_if_lower(0.5 SECONDS * metabolization_ratio * seconds_per_tick)
+			affected_mob.adjust_stamina_loss(1 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 			if(SPT_PROB(4, seconds_per_tick))
 				paralyze_limb(affected_mob)
 				need_mob_update = TRUE
@@ -1418,13 +1418,13 @@
 			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5)
 			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.7)
 			if(SPT_PROB(40, seconds_per_tick))
-				affected_mob.losebreath += 1 * REM * metabolized_volume * seconds_per_tick
+				affected_mob.losebreath += 1 * metabolization_ratio
 				need_mob_update = TRUE
-			affected_mob.adjust_disgust(1.5 * REM * metabolized_volume * seconds_per_tick)
-			affected_mob.set_slurring_if_lower(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.adjust_disgust(1.5 * metabolization_ratio * seconds_per_tick)
+			affected_mob.set_slurring_if_lower(1.5 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_danger("You feel horribly weak."))
-			need_mob_update += affected_mob.adjust_stamina_loss(2.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
+			need_mob_update += affected_mob.adjust_stamina_loss(2.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 			if(SPT_PROB(8, seconds_per_tick))
 				paralyze_limb(affected_mob)
 				need_mob_update = TRUE
@@ -1434,9 +1434,9 @@
 			toxpwr = 1.5
 			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1, BRAIN_DAMAGE_DEATH)
 			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 1.4)
-			affected_mob.set_silence_if_lower(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
-			need_mob_update += affected_mob.adjust_stamina_loss(2.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
-			affected_mob.adjust_disgust(1 * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.set_silence_if_lower(1.5 SECONDS * metabolization_ratio * seconds_per_tick)
+			need_mob_update += affected_mob.adjust_stamina_loss(2.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
+			affected_mob.adjust_disgust(1 * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(15, seconds_per_tick))
 				paralyze_limb(affected_mob)
 				need_mob_update = TRUE

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -26,7 +26,7 @@
 /datum/reagent/toxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(toxpwr && affected_mob.health > health_required)
-		if(affected_mob.adjust_tox_loss(METABOLIZE_FREE_CONSTANT(0.5) * toxpwr * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(METABOLIZE_FREE_CONSTANT(0.5) * toxpwr * normalise_creation_purity() * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/amatoxin

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -515,13 +515,13 @@
 	. = ..()
 	switch(current_cycle)
 		if(2 to 11)
-			affected_mob.adjust_confusion(1 SECONDS * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
-			affected_mob.adjust_drowsiness(2 SECONDS * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
+			affected_mob.adjust_confusion(0.67 SECONDS * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
+			affected_mob.adjust_drowsiness(1.34 SECONDS * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
 		if(11 to 51)
-			affected_mob.Sleeping(20 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
+			affected_mob.Sleeping(13.34 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
 		if(52 to INFINITY)
-			affected_mob.Sleeping(20 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
-			if(affected_mob.adjust_tox_loss(0.5 * (current_cycle - 51) * normalise_creation_purity() * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			affected_mob.Sleeping(13.34 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
+			if(affected_mob.adjust_tox_loss(0.34 * (current_cycle - 51) * normalise_creation_purity() * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/fakebeer //disguised as normal beer for use by emagged brobots
@@ -549,10 +549,10 @@
 	. = ..()
 	switch(current_cycle)
 		if(2 to 51)
-			affected_mob.Sleeping(20 * metabolization_ratio * seconds_per_tick)
+			affected_mob.Sleeping(13.34 * metabolization_ratio * seconds_per_tick)
 		if(52 to INFINITY)
-			affected_mob.Sleeping(20 * metabolization_ratio * seconds_per_tick)
-			if(affected_mob.adjust_tox_loss(0.5 * (current_cycle - 50) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			affected_mob.Sleeping(13.34 * metabolization_ratio * seconds_per_tick)
+			if(affected_mob.adjust_tox_loss(0.34 * (current_cycle - 50) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/coffeepowder
@@ -632,7 +632,7 @@
 		if(SPT_PROB(chance, seconds_per_tick)) // ignore rad protection calculations bc it's inside of us
 			affected_mob.AddComponent(/datum/component/irradiated)
 	else
-		if(affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/polonium/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
@@ -691,15 +691,15 @@
 			if(4)
 				if(prob(75))
 					to_chat(affected_mob, span_danger("You scratch at an itch."))
-					if(affected_mob.adjust_brute_loss(1 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype))
+					if(affected_mob.adjust_brute_loss(4 * metabolization_ratio, updating_health = FALSE, required_bodytype = affected_bodytype))
 						return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/histamine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_oxy_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_oxy_loss(4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_tox_loss(4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -720,12 +720,12 @@
 /datum/reagent/toxin/formaldehyde/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_CORONER_METABOLISM)) //mmmm, the forbidden pickle juice
-		if(affected_mob.adjust_tox_loss(-0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)) //it counteracts its own toxin damage.
+		if(affected_mob.adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)) //it counteracts its own toxin damage.
 			return UPDATE_MOB_HEALTH
 		return
 	else if(SPT_PROB(2.5, seconds_per_tick) && !HAS_TRAIT(affected_mob, TRAIT_BLOCK_FORMALDEHYDE_METABOLISM))
 		holder.add_reagent(/datum/reagent/toxin/histamine, pick(5,15))
-		holder.remove_reagent(/datum/reagent/toxin/formaldehyde, 1.2)
+		holder.remove_reagent(/datum/reagent/toxin/formaldehyde, 2.4 * metabolization_ratio * seconds_per_tick)
 	return ..()
 
 /datum/reagent/toxin/formaldehyde/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
@@ -750,7 +750,7 @@
 	current_size = newsize
 	toxpwr = 0.1 * volume
 
-	if(affected_mob.adjust_brute_loss(0.5 * (0.3 * volume) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+	if(affected_mob.adjust_brute_loss(2 * (0.3 * volume) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 		. = UPDATE_MOB_HEALTH
 
 	// chance to either decay into histamine or go the normal route of toxin metabolization
@@ -780,13 +780,13 @@
 /datum/reagent/toxin/fentanyl/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1.5 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, 150)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 3 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, 150)
 	if(affected_mob.toxloss <= 60)
-		need_mob_update += affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_tox_loss(1 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(current_cycle > 4)
 		affected_mob.add_mood_event("smacked out", /datum/mood_event/narcotic_heavy, name)
 	if(current_cycle > 18)
-		affected_mob.Sleeping(20 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
+		affected_mob.Sleeping(40 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -810,7 +810,7 @@
 	if(SPT_PROB(4, seconds_per_tick))
 		to_chat(affected_mob, span_danger("You feel horrendously weak!"))
 		affected_mob.Stun(40)
-		need_mob_update += affected_mob.adjust_tox_loss(1 * normalise_creation_purity() * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_tox_loss(8 * normalise_creation_purity() * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -879,7 +879,7 @@
 			affected_mob.Paralyze(60)
 		if(2)
 			affected_mob.losebreath += 10
-			affected_mob.adjust_oxy_loss(rand(5,25), updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+			affected_mob.adjust_oxy_loss(2 * rand(5,25) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 			need_mob_update = TRUE
 		if(3)
 			if(!affected_mob.undergoing_cardiac_arrest() && affected_mob.can_heartattack())
@@ -905,7 +905,7 @@
 /datum/reagent/toxin/pancuronium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 10)
-		affected_mob.Stun(20 * metabolization_ratio * seconds_per_tick)
+		affected_mob.Stun(80 * metabolization_ratio * seconds_per_tick)
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.losebreath += 4
 		return UPDATE_MOB_HEALTH
@@ -923,8 +923,8 @@
 /datum/reagent/toxin/sodium_thiopental/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 10)
-		affected_mob.Sleeping(20 * metabolization_ratio * seconds_per_tick)
-	if(affected_mob.adjust_stamina_loss(5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE))
+		affected_mob.Sleeping(80 * metabolization_ratio * seconds_per_tick)
+	if(affected_mob.adjust_stamina_loss(0.67 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/sulfonal
@@ -942,7 +942,7 @@
 /datum/reagent/toxin/sulfonal/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 22)
-		affected_mob.Sleeping(20 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
+		affected_mob.Sleeping(160 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/toxin/amanitin
 	name = "Amanitin"
@@ -956,7 +956,7 @@
 
 /datum/reagent/toxin/amanitin/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	delayed_toxin_damage += (seconds_per_tick * 3)
+	delayed_toxin_damage += 6 * metabolization_ratio * seconds_per_tick
 
 /datum/reagent/toxin/amanitin/on_mob_delete(mob/living/affected_mob)
 	. = ..()
@@ -980,9 +980,9 @@
 /datum/reagent/toxin/lipolicide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.nutrition <= NUTRITION_LEVEL_STARVING)
-		if(affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_nutrition(-1.5 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick) // making the chef more valuable, one meme trap at a time
+	affected_mob.adjust_nutrition(-3 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick) // making the chef more valuable, one meme trap at a time
 	affected_mob.overeatduration = 0
 
 /datum/reagent/toxin/coniine
@@ -996,14 +996,13 @@
 /datum/reagent/toxin/coniine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.losebreath < 5)
-		affected_mob.losebreath = min(affected_mob.losebreath + 2.5 * metabolization_ratio * seconds_per_tick, 5)
+		affected_mob.losebreath = min(affected_mob.losebreath + 41.67 * metabolization_ratio * seconds_per_tick, 5)
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/spewium
 	name = "Spewium"
 	description = "A powerful emetic, causes uncontrollable vomiting.  May result in vomiting organs at high doses."
 	color = "#2f6617" //A sickly green color
-	metabolization_rate = REAGENTS_METABOLISM
 	overdose_threshold = 29
 	toxpwr = 0
 	taste_description = "vomit"
@@ -1041,7 +1040,7 @@
 /datum/reagent/toxin/curare/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 11)
-		affected_mob.Paralyze(30 * metabolization_ratio * seconds_per_tick)
+		affected_mob.Paralyze(240 * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.adjust_oxy_loss(0.5*REM*seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
 		return UPDATE_MOB_HEALTH
 
@@ -1061,7 +1060,7 @@
 
 /datum/reagent/toxin/heparin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	if(holder.has_reagent(/datum/reagent/medicine/coagulant)) //Directly purges coagulants from the system. Get rid of the heparin BEFORE attempting to use coagulants.
-		holder.remove_reagent(/datum/reagent/medicine/coagulant, 1 * metabolization_ratio * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/medicine/coagulant, 5 * metabolization_ratio * seconds_per_tick)
 	return ..()
 
 /datum/reagent/toxin/rotatium //Rotatium. Fucks up your rotation and is hilarious
@@ -1112,7 +1111,7 @@
 		remove_amt = 0.5
 	. = ..()
 	for(var/datum/reagent/medicine/reagent in affected_mob.reagents.reagent_list)
-		reagent.volume -= remove_amt * reagent.purge_multiplier * normalise_creation_purity() * metabolization_ratio * seconds_per_tick
+		reagent.volume -= 12.5 * remove_amt * reagent.purge_multiplier * normalise_creation_purity() * metabolization_ratio * seconds_per_tick
 	affected_mob.reagents.update_total()
 
 //ACID
@@ -1299,7 +1298,7 @@
 
 /datum/reagent/toxin/bungotoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 1.5 * metabolization_ratio * seconds_per_tick))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 3 * metabolization_ratio * seconds_per_tick))
 		. = UPDATE_MOB_HEALTH
 
 	// If our mob's currently dizzy from anything else, we will also gain confusion
@@ -1376,10 +1375,10 @@
 		liver_tolerance_multiplier = 0
 		silent_toxin = TRUE
 		remove_paralysis()
-		need_mob_update += affected_mob.adjust_oxy_loss(-0.35 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update = affected_mob.adjust_tox_loss(-0.325 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-0.6 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-0.675 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-3.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update = affected_mob.adjust_tox_loss(-3.25 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-6 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-6.75 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		return need_mob_update ? UPDATE_MOB_HEALTH : .
 
 	liver_tolerance_multiplier = initial(liver_tolerance_multiplier)
@@ -1389,25 +1388,25 @@
 	switch(current_cycle)
 		if(7 to 13)
 			if(SPT_PROB(20, seconds_per_tick))
-				affected_mob.set_jitter_if_lower(0.5 * rand(2 SECONDS, 3 SECONDS) * metabolization_ratio)
+				affected_mob.set_jitter_if_lower(5 * rand(2 SECONDS, 3 SECONDS) * metabolization_ratio)
 			if(SPT_PROB(5, seconds_per_tick))
 				var/obj/item/organ/tongue/tongue = affected_mob.get_organ_slot(ORGAN_SLOT_TONGUE)
 				if(tongue)
 					to_chat(affected_mob, span_warning("Your [tongue.name] feels numb..."))
-				affected_mob.set_slurring_if_lower(2.5 SECONDS * metabolization_ratio)
-			affected_mob.adjust_disgust(1.75 * metabolization_ratio * seconds_per_tick)
+				affected_mob.set_slurring_if_lower(25 SECONDS * metabolization_ratio)
+			affected_mob.adjust_disgust(17.5 * metabolization_ratio * seconds_per_tick)
 		if(13 to 21)
 			silent_toxin = FALSE
 			toxpwr = 0.5
-			need_mob_update = affected_mob.adjust_stamina_loss(1.25 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
+			need_mob_update = affected_mob.adjust_stamina_loss(12.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 			if(SPT_PROB(20, seconds_per_tick))
-				affected_mob.losebreath += 0.5 * metabolization_ratio
+				affected_mob.losebreath += 5 * metabolization_ratio
 				need_mob_update = TRUE
 			if(SPT_PROB(40, seconds_per_tick))
-				affected_mob.set_jitter_if_lower(0.5 * rand(2 SECONDS, 3 SECONDS) * metabolization_ratio)
-			affected_mob.adjust_disgust(1.5 * metabolization_ratio * seconds_per_tick)
-			affected_mob.set_slurring_if_lower(0.5 SECONDS * metabolization_ratio * seconds_per_tick)
-			affected_mob.adjust_stamina_loss(1 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
+				affected_mob.set_jitter_if_lower(5 * rand(2 SECONDS, 3 SECONDS) * metabolization_ratio)
+			affected_mob.adjust_disgust(15 * metabolization_ratio * seconds_per_tick)
+			affected_mob.set_slurring_if_lower(5 SECONDS * metabolization_ratio * seconds_per_tick)
+			affected_mob.adjust_stamina_loss(10 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 			if(SPT_PROB(4, seconds_per_tick))
 				paralyze_limb(affected_mob)
 				need_mob_update = TRUE
@@ -1418,13 +1417,13 @@
 			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5)
 			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.7)
 			if(SPT_PROB(40, seconds_per_tick))
-				affected_mob.losebreath += 1 * metabolization_ratio
+				affected_mob.losebreath += 10 * metabolization_ratio
 				need_mob_update = TRUE
-			affected_mob.adjust_disgust(1.5 * metabolization_ratio * seconds_per_tick)
-			affected_mob.set_slurring_if_lower(1.5 SECONDS * metabolization_ratio * seconds_per_tick)
+			affected_mob.adjust_disgust(15 * metabolization_ratio * seconds_per_tick)
+			affected_mob.set_slurring_if_lower(15 SECONDS * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_danger("You feel horribly weak."))
-			need_mob_update += affected_mob.adjust_stamina_loss(2.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
+			need_mob_update += affected_mob.adjust_stamina_loss(25 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 			if(SPT_PROB(8, seconds_per_tick))
 				paralyze_limb(affected_mob)
 				need_mob_update = TRUE
@@ -1434,9 +1433,9 @@
 			toxpwr = 1.5
 			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1, BRAIN_DAMAGE_DEATH)
 			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 1.4)
-			affected_mob.set_silence_if_lower(1.5 SECONDS * metabolization_ratio * seconds_per_tick)
-			need_mob_update += affected_mob.adjust_stamina_loss(2.5 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
-			affected_mob.adjust_disgust(1 * metabolization_ratio * seconds_per_tick)
+			affected_mob.set_silence_if_lower(15 SECONDS * metabolization_ratio * seconds_per_tick)
+			need_mob_update += affected_mob.adjust_stamina_loss(25 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
+			affected_mob.adjust_disgust(10 * metabolization_ratio * seconds_per_tick)
 			if(SPT_PROB(15, seconds_per_tick))
 				paralyze_limb(affected_mob)
 				need_mob_update = TRUE

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -26,7 +26,7 @@
 /datum/reagent/toxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(toxpwr && affected_mob.health > health_required)
-		if(affected_mob.adjust_tox_loss(0.5 * toxpwr * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(METABOLIZE_FREE_CONSTANT(0.5) * toxpwr * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/amatoxin

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1111,7 +1111,9 @@
 	if(holder.has_reagent(/datum/reagent/medicine/calomel) || holder.has_reagent(/datum/reagent/medicine/pen_acid))
 		remove_amt = 0.5
 	. = ..()
-	affected_mob.reagents.remove_all(0.5 * remove_amt * reagent.purge_multiplier * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
+	for(var/datum/reagent/medicine/reagent in affected_mob.reagents.reagent_list)
+		reagent.volume -= remove_amt * reagent.purge_multiplier * normalise_creation_purity() * metabolization_ratio * seconds_per_tick
+	affected_mob.reagents.update_total()
 
 //ACID
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -193,8 +193,8 @@
 /datum/reagent/toxin/lexorin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_NOBREATH))
-		affected_mob.adjust_oxy_loss(2.5 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		affected_mob.losebreath += 1 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick
+		affected_mob.adjust_oxy_loss(2.5 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		affected_mob.losebreath += 1 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick
 		. = UPDATE_MOB_HEALTH
 		if(SPT_PROB(10, seconds_per_tick))
 			affected_mob.emote("gasp")
@@ -515,13 +515,13 @@
 	. = ..()
 	switch(current_cycle)
 		if(2 to 11)
-			affected_mob.adjust_confusion(1 SECONDS * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
-			affected_mob.adjust_drowsiness(2 SECONDS * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
+			affected_mob.adjust_confusion(1 SECONDS * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
+			affected_mob.adjust_drowsiness(2 SECONDS * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
 		if(11 to 51)
-			affected_mob.Sleeping(20 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
+			affected_mob.Sleeping(20 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
 		if(52 to INFINITY)
-			affected_mob.Sleeping(20 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
-			if(affected_mob.adjust_tox_loss(0.5 * (current_cycle - 51) * metabolization_ratio * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			affected_mob.Sleeping(20 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
+			if(affected_mob.adjust_tox_loss(0.5 * (current_cycle - 51) * normalise_creation_purity() * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/fakebeer //disguised as normal beer for use by emagged brobots
@@ -750,7 +750,7 @@
 	current_size = newsize
 	toxpwr = 0.1 * volume
 
-	if(affected_mob.adjust_brute_loss((0.15 * volume) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+	if(affected_mob.adjust_brute_loss(0.5 * (0.3 * volume) * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 		. = UPDATE_MOB_HEALTH
 
 	// chance to either decay into histamine or go the normal route of toxin metabolization
@@ -810,7 +810,7 @@
 	if(SPT_PROB(4, seconds_per_tick))
 		to_chat(affected_mob, span_danger("You feel horrendously weak!"))
 		affected_mob.Stun(40)
-		need_mob_update += affected_mob.adjust_tox_loss(1 * metabolization_ratio * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_tox_loss(1 * normalise_creation_purity() * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -942,7 +942,7 @@
 /datum/reagent/toxin/sulfonal/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 22)
-		affected_mob.Sleeping(20 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
+		affected_mob.Sleeping(20 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/toxin/amanitin
 	name = "Amanitin"
@@ -982,7 +982,7 @@
 	if(affected_mob.nutrition <= NUTRITION_LEVEL_STARVING)
 		if(affected_mob.adjust_tox_loss(0.5 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_nutrition(-1.5 * metabolization_ratio * normalise_creation_purity() * seconds_per_tick) // making the chef more valuable, one meme trap at a time
+	affected_mob.adjust_nutrition(-1.5 * normalise_creation_purity() * metabolization_ratio * seconds_per_tick) // making the chef more valuable, one meme trap at a time
 	affected_mob.overeatduration = 0
 
 /datum/reagent/toxin/coniine
@@ -1021,7 +1021,7 @@
 		affected_mob.vomit(vomit_flags = constructed_flags, distance = rand(0,4))
 		for(var/datum/reagent/toxin/reagent in affected_mob.reagents.reagent_list)
 			if(reagent != src)
-				affected_mob.reagents.remove_reagent(reagent.type, 1 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
+				affected_mob.reagents.remove_reagent(reagent.type, 0.5 * reagent.purge_multiplier * metabolization_ratio * seconds_per_tick)
 
 /datum/reagent/toxin/spewium/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
@@ -1111,8 +1111,7 @@
 	if(holder.has_reagent(/datum/reagent/medicine/calomel) || holder.has_reagent(/datum/reagent/medicine/pen_acid))
 		remove_amt = 0.5
 	. = ..()
-	for(var/datum/reagent/medicine/reagent in affected_mob.reagents.reagent_list)
-		affected_mob.reagents.remove_reagent(reagent.type, 0.5 * remove_amt * reagent.purge_multiplier * metabolization_ratio * normalise_creation_purity() * seconds_per_tick)
+	affected_mob.reagents.remove_all(0.5 * remove_amt * reagent.purge_multiplier * normalise_creation_purity() * metabolization_ratio * seconds_per_tick)
 
 //ACID
 
@@ -1395,7 +1394,7 @@
 				if(tongue)
 					to_chat(affected_mob, span_warning("Your [tongue.name] feels numb..."))
 				affected_mob.set_slurring_if_lower(2.5 SECONDS * metabolization_ratio)
-			affected_mob.adjust_disgust(1.25 * metabolization_ratio * seconds_per_tick)
+			affected_mob.adjust_disgust(1.75 * metabolization_ratio * seconds_per_tick)
 		if(13 to 21)
 			silent_toxin = FALSE
 			toxpwr = 0.5

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -696,10 +696,11 @@
 
 /datum/reagent/toxin/histamine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
+	var/heal = 4 * metabolization_ratio * seconds_per_tick
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_oxy_loss(4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_tox_loss(4 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_oxy_loss(heal, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(heal, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_tox_loss(heal, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -923,7 +924,7 @@
 /datum/reagent/toxin/sodium_thiopental/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(current_cycle > 10)
-		affected_mob.Sleeping(80 * metabolization_ratio * seconds_per_tick)
+		affected_mob.Sleeping(26.67 * metabolization_ratio * seconds_per_tick)
 	if(affected_mob.adjust_stamina_loss(0.67 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE))
 		return UPDATE_MOB_HEALTH
 
@@ -1041,7 +1042,7 @@
 	. = ..()
 	if(current_cycle > 11)
 		affected_mob.Paralyze(240 * metabolization_ratio * seconds_per_tick)
-	if(affected_mob.adjust_oxy_loss(0.5*REM*seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
+	if(affected_mob.adjust_oxy_loss(2 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/heparin //Based on a real-life anticoagulant. I'm not a doctor, so this won't be realistic.
@@ -1111,7 +1112,7 @@
 		remove_amt = 0.5
 	. = ..()
 	for(var/datum/reagent/medicine/reagent in affected_mob.reagents.reagent_list)
-		reagent.volume -= 12.5 * remove_amt * reagent.purge_multiplier * normalise_creation_purity() * metabolization_ratio * seconds_per_tick
+		reagent.volume -= 6.25 * remove_amt * reagent.purge_multiplier * normalise_creation_purity() * metabolization_ratio * seconds_per_tick
 	affected_mob.reagents.update_total()
 
 //ACID
@@ -1208,16 +1209,14 @@
 	metabolization_rate = 0 //stays in the system until active.
 	toxpwr = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
-	var/actual_toxpwr = 5
-	var/delay = 31
 
 /datum/reagent/toxin/delayed/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	if(current_cycle <= delay)
+	if(current_cycle <= 31)
 		return
 	if(holder)
 		holder.remove_reagent(type, REAGENTS_METABOLISM * affected_mob.metabolism_efficiency * seconds_per_tick)
-	if(affected_mob.adjust_tox_loss(0.5 * actual_toxpwr * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.5 * 5 * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
 	if(SPT_PROB(5, seconds_per_tick))
 		affected_mob.Paralyze(20)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -23,10 +23,10 @@
 /datum/reagent/toxin/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)
 	mytray.adjust_toxic(round(volume * 2))
 
-/datum/reagent/toxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(toxpwr && affected_mob.health > health_required)
-		if(affected_mob.adjust_tox_loss(toxpwr * REM * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(0.5 * toxpwr * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/amatoxin
@@ -65,7 +65,7 @@
 		exposed_mob.updateappearance()
 		exposed_mob.domutcheck()
 
-/datum/reagent/toxin/mutagen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/mutagen/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.adjust_tox_loss(0.5 * seconds_per_tick * REM, required_biotype = affected_biotype))
 		return UPDATE_MOB_HEALTH
@@ -105,11 +105,11 @@
 	UnregisterSignal(holder, COMSIG_REAGENTS_TEMP_CHANGE)
 	return ..()
 
-/datum/reagent/toxin/plasma/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/plasma/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(holder.has_reagent(/datum/reagent/medicine/epinephrine))
-		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 2 * REM * seconds_per_tick)
-	affected_mob.adjustPlasma(20 * REM * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 1 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjustPlasma(10 * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/toxin/plasma/on_mob_metabolize(mob/living/carbon/affected_mob)
 	. = ..()
@@ -160,15 +160,15 @@
 	material = /datum/material/hot_ice
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/hot_ice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/hot_ice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(holder.has_reagent(/datum/reagent/medicine/epinephrine))
-		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 2 * REM * seconds_per_tick)
-	affected_mob.adjustPlasma(20 * REM * seconds_per_tick)
-	affected_mob.adjust_bodytemperature(-7 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * seconds_per_tick, affected_mob.get_body_temp_normal())
+		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 1 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjustPlasma(10 * REM * metabolized_volume * seconds_per_tick)
+	affected_mob.adjust_bodytemperature(-3.5 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * metabolized_volume * seconds_per_tick, affected_mob.get_body_temp_normal())
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/humi = affected_mob
-		humi.adjust_coretemperature(-7 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
+		humi.adjust_coretemperature(-3.5 * REM * metabolized_volume * TEMPERATURE_DAMAGE_COEFFICIENT * seconds_per_tick, affected_mob.get_body_temp_normal())
 
 /datum/reagent/toxin/hot_ice/on_mob_metabolize(mob/living/carbon/affected_mob)
 	. = ..()
@@ -190,11 +190,11 @@
 	ph = 1.2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/lexorin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/lexorin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_NOBREATH))
-		affected_mob.adjust_oxy_loss(5 * REM * normalise_creation_purity() * seconds_per_tick, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		affected_mob.losebreath += 2 * REM * normalise_creation_purity() * seconds_per_tick
+		affected_mob.adjust_oxy_loss(2.5 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		affected_mob.losebreath += 1 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick
 		. = UPDATE_MOB_HEALTH
 		if(SPT_PROB(10, seconds_per_tick))
 			affected_mob.emote("gasp")
@@ -221,7 +221,7 @@
 	ph = 10
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/slimejelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/slimejelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
 		to_chat(affected_mob, span_danger("Your insides are burning!"))
@@ -292,18 +292,18 @@
 	. = ..()
 	affected_mob.remove_status_effect(/datum/status_effect/reagent_effect/fakedeath)
 
-/datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(HAS_TRAIT(affected_mob, TRAIT_FAKEDEATH) && HAS_TRAIT(affected_mob, TRAIT_DEATHCOMA))
 		return
 	var/need_mob_update
 	switch(current_cycle)
 		if(2 to 6)
-			affected_mob.adjust_confusion(1 SECONDS * REM * seconds_per_tick)
-			affected_mob.adjust_drowsiness(2 SECONDS * REM * seconds_per_tick)
-			affected_mob.adjust_slurring(6 SECONDS * REM * seconds_per_tick)
+			affected_mob.adjust_confusion(0.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.adjust_drowsiness(1 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.adjust_slurring(3 SECONDS * REM * metabolized_volume * seconds_per_tick)
 		if(6 to 9)
-			need_mob_update = affected_mob.adjust_stamina_loss(40 * REM * seconds_per_tick, updating_stamina = FALSE)
+			need_mob_update = affected_mob.adjust_stamina_loss(20 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
 		if(10 to INFINITY)
 			if(affected_mob.stat != DEAD)
 				affected_mob.fakedeath(type)
@@ -322,9 +322,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_FAKEDEATH)
 
-/datum/reagent/toxin/ghoulpowder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/ghoulpowder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_oxy_loss(1 * REM * seconds_per_tick, FALSE, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
+	if(affected_mob.adjust_oxy_loss(0.5 * REM * metabolized_volume * seconds_per_tick, FALSE, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/mindbreaker
@@ -341,7 +341,7 @@
 	addiction_types = list(/datum/addiction/hallucinogens = 18)  //7.2 per 2 seconds
 	metabolized_traits = list(TRAIT_RDS_SUPPRESSED)
 
-/datum/reagent/toxin/mindbreaker/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/mindbreaker/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	// mindbreaker toxin assuages hallucinations in those plagued with it, mentally
 	if(affected_mob.has_trauma_type(/datum/brain_trauma/mild/hallucinations))
@@ -349,7 +349,7 @@
 
 	// otherwise it creates hallucinations. truly a miracle medicine.
 	else
-		affected_mob.adjust_hallucinations(10 SECONDS * REM * seconds_per_tick)
+		affected_mob.adjust_hallucinations(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/toxin/mindbreaker/fish
 	name = "Jellyfish Hallucinogen"
@@ -433,9 +433,9 @@
 	. = ..()
 	AddElement(/datum/element/bugkiller_reagent)
 
-/datum/reagent/toxin/pestkiller/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/pestkiller/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_tox_loss(2 * toxpwr * REM * seconds_per_tick, updating_health = FALSE, required_biotype = MOB_BUG))
+	if(affected_mob.adjust_tox_loss(1 * toxpwr * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = MOB_BUG))
 		return UPDATE_MOB_HEALTH
 
 //Pest Spray
@@ -478,11 +478,11 @@
 		spore_lung_victim.Stun(1 SECONDS)
 		spore_lung_victim.emote("cough")
 
-/datum/reagent/toxin/spore/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/spore/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	affected_mob.damageoverlaytemp = 60
 	affected_mob.update_damage_hud()
-	affected_mob.set_eye_blur_if_lower(6 SECONDS * REM * seconds_per_tick)
+	affected_mob.set_eye_blur_if_lower(3 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/toxin/spore_burning
 	name = "Burning Spore Toxin"
@@ -493,9 +493,9 @@
 	ph = 13
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/spore_burning/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/spore_burning/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_fire_stacks(2 * REM * seconds_per_tick)
+	affected_mob.adjust_fire_stacks(1 * REM * metabolized_volume * seconds_per_tick)
 	affected_mob.ignite_mob()
 
 /datum/reagent/toxin/chloralhydrate
@@ -511,17 +511,17 @@
 	inverse_chem = /datum/reagent/impurity/chloralax
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/chloralhydrate/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/chloralhydrate/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	switch(current_cycle)
 		if(2 to 11)
-			affected_mob.adjust_confusion(2 SECONDS * REM * normalise_creation_purity() * seconds_per_tick)
-			affected_mob.adjust_drowsiness(4 SECONDS * REM * normalise_creation_purity() * seconds_per_tick)
+			affected_mob.adjust_confusion(1 SECONDS * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
+			affected_mob.adjust_drowsiness(2 SECONDS * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
 		if(11 to 51)
-			affected_mob.Sleeping(40 * REM * normalise_creation_purity() * seconds_per_tick)
+			affected_mob.Sleeping(20 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
 		if(52 to INFINITY)
-			affected_mob.Sleeping(40 * REM * normalise_creation_purity() * seconds_per_tick)
-			if(affected_mob.adjust_tox_loss(1 * (current_cycle - 51) * REM * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			affected_mob.Sleeping(20 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
+			if(affected_mob.adjust_tox_loss(0.5 * (current_cycle - 51) * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/fakebeer //disguised as normal beer for use by emagged brobots
@@ -545,14 +545,14 @@
 	icon = initial(copy_from.icon)
 	icon_state = initial(copy_from.icon_state)
 
-/datum/reagent/toxin/fakebeer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/fakebeer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	switch(current_cycle)
 		if(2 to 51)
-			affected_mob.Sleeping(40 * REM * seconds_per_tick)
+			affected_mob.Sleeping(20 * REM * metabolized_volume * seconds_per_tick)
 		if(52 to INFINITY)
-			affected_mob.Sleeping(40 * REM * seconds_per_tick)
-			if(affected_mob.adjust_tox_loss(1 * (current_cycle - 50) * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+			affected_mob.Sleeping(20 * REM * metabolized_volume * seconds_per_tick)
+			if(affected_mob.adjust_tox_loss(0.5 * (current_cycle - 50) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 				return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/coffeepowder
@@ -595,10 +595,10 @@
 	ph = 12.2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/mutetoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/mutetoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	// Gain approximately 12 seconds * creation purity seconds of silence every metabolism tick.
-	affected_mob.set_silence_if_lower(6 SECONDS * REM * normalise_creation_purity() * seconds_per_tick)
+	affected_mob.set_silence_if_lower(3 SECONDS * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
 
 /datum/reagent/toxin/staminatoxin
 	name = "Tirizene"
@@ -609,9 +609,9 @@
 	toxpwr = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/staminatoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/staminatoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_stamina_loss(data * REM * seconds_per_tick, updating_stamina = FALSE))
+	if(affected_mob.adjust_stamina_loss(0.5 * data * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
 		. = UPDATE_MOB_HEALTH
 	data = max(data - 1, 3)
 
@@ -625,14 +625,14 @@
 	/// How radioactive is this reagent
 	var/rad_power = 3
 
-/datum/reagent/toxin/polonium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/polonium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!HAS_TRAIT(affected_mob, TRAIT_IRRADIATED) && SSradiation.can_irradiate_basic(affected_mob))
 		var/chance = min(volume / (20 - rad_power * 5), rad_power)
 		if(SPT_PROB(chance, seconds_per_tick)) // ignore rad protection calculations bc it's inside of us
 			affected_mob.AddComponent(/datum/component/irradiated)
 	else
-		if(affected_mob.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/polonium/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
@@ -677,7 +677,7 @@
 	toxpwr = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/histamine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/histamine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(30, seconds_per_tick))
 		switch(pick(1, 2, 3, 4))
@@ -691,15 +691,15 @@
 			if(4)
 				if(prob(75))
 					to_chat(affected_mob, span_danger("You scratch at an itch."))
-					if(affected_mob.adjust_brute_loss(2* REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+					if(affected_mob.adjust_brute_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 						return UPDATE_MOB_HEALTH
 
-/datum/reagent/toxin/histamine/overdose_process(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/histamine/overdose_process(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_oxy_loss(2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	need_mob_update += affected_mob.adjust_brute_loss(2 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-	need_mob_update += affected_mob.adjust_tox_loss(2 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+	need_mob_update = affected_mob.adjust_oxy_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	need_mob_update += affected_mob.adjust_brute_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+	need_mob_update += affected_mob.adjust_tox_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -717,10 +717,10 @@
 	inverse_chem = /datum/reagent/impurity/methanol
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/formaldehyde/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/formaldehyde/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_CORONER_METABOLISM)) //mmmm, the forbidden pickle juice
-		if(affected_mob.adjust_tox_loss(-1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)) //it counteracts its own toxin damage.
+		if(affected_mob.adjust_tox_loss(-0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)) //it counteracts its own toxin damage.
 			return UPDATE_MOB_HEALTH
 		return
 	else if(SPT_PROB(2.5, seconds_per_tick) && !HAS_TRAIT(affected_mob, TRAIT_BLOCK_FORMALDEHYDE_METABOLISM))
@@ -728,7 +728,7 @@
 		holder.remove_reagent(/datum/reagent/toxin/formaldehyde, 1.2)
 	return ..()
 
-/datum/reagent/toxin/formaldehyde/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/formaldehyde/metabolize_reagent(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(HAS_TRAIT(affected_mob, TRAIT_BLOCK_FORMALDEHYDE_METABOLISM))
 		return
 
@@ -744,13 +744,13 @@
 	///Mob Size of the current mob sprite.
 	var/current_size = RESIZE_DEFAULT_SIZE
 
-/datum/reagent/toxin/venom/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/venom/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	var/newsize = 1.1 * RESIZE_DEFAULT_SIZE
 	affected_mob.update_transform(newsize/current_size)
 	current_size = newsize
 	toxpwr = 0.1 * volume
 
-	if(affected_mob.adjust_brute_loss((0.3 * volume) * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+	if(affected_mob.adjust_brute_loss((0.15 * volume) * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 		. = UPDATE_MOB_HEALTH
 
 	// chance to either decay into histamine or go the normal route of toxin metabolization
@@ -777,16 +777,16 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/opioids = 25)
 
-/datum/reagent/toxin/fentanyl/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/fentanyl/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 3 * REM * normalise_creation_purity() * seconds_per_tick, 150)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1.5 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, 150)
 	if(affected_mob.toxloss <= 60)
-		need_mob_update += affected_mob.adjust_tox_loss(1 * REM * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
 	if(current_cycle > 4)
 		affected_mob.add_mood_event("smacked out", /datum/mood_event/narcotic_heavy, name)
 	if(current_cycle > 18)
-		affected_mob.Sleeping(40 * REM * normalise_creation_purity() * seconds_per_tick)
+		affected_mob.Sleeping(20 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -801,7 +801,7 @@
 	ph = 9.3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/cyanide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/cyanide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update = FALSE
 	if(SPT_PROB(2.5, seconds_per_tick))
@@ -810,7 +810,7 @@
 	if(SPT_PROB(4, seconds_per_tick))
 		to_chat(affected_mob, span_danger("You feel horrendously weak!"))
 		affected_mob.Stun(40)
-		need_mob_update += affected_mob.adjust_tox_loss(2*REM * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_tox_loss(1 * REM * metabolized_volume * normalise_creation_purity(), updating_health = FALSE, required_biotype = affected_biotype)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 
@@ -836,7 +836,7 @@
 	penetrates_skin = TOUCH|VAPOR
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/itching_powder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/itching_powder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	var/scratched = FALSE
 	var/scratch_damage = 0.2 * REM
 
@@ -868,7 +868,7 @@
 	toxpwr = 2.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/initropidril/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/initropidril/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!SPT_PROB(13, seconds_per_tick))
 		return
@@ -902,10 +902,10 @@
 	taste_mult = 0 // undetectable, I guess?
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/pancuronium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/pancuronium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(current_cycle > 10)
-		affected_mob.Stun(40 * REM * seconds_per_tick)
+		affected_mob.Stun(20 * REM * metabolized_volume * seconds_per_tick)
 	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.losebreath += 4
 		return UPDATE_MOB_HEALTH
@@ -920,11 +920,11 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 	added_traits = list(TRAIT_ANTICONVULSANT)
 
-/datum/reagent/toxin/sodium_thiopental/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/sodium_thiopental/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(current_cycle > 10)
-		affected_mob.Sleeping(40 * REM * seconds_per_tick)
-	if(affected_mob.adjust_stamina_loss(10 * REM * seconds_per_tick, updating_stamina = FALSE))
+		affected_mob.Sleeping(20 * REM * metabolized_volume * seconds_per_tick)
+	if(affected_mob.adjust_stamina_loss(5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/sulfonal
@@ -939,10 +939,10 @@
 	ph = 6
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/sulfonal/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/sulfonal/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(current_cycle > 22)
-		affected_mob.Sleeping(40 * REM * normalise_creation_purity() * seconds_per_tick)
+		affected_mob.Sleeping(20 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
 
 /datum/reagent/toxin/amanitin
 	name = "Amanitin"
@@ -954,7 +954,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	var/delayed_toxin_damage = 0
 
-/datum/reagent/toxin/amanitin/on_mob_life(mob/living/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/amanitin/on_mob_life(mob/living/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	delayed_toxin_damage += (seconds_per_tick * 3)
 
@@ -977,12 +977,12 @@
 	inverse_chem = /datum/reagent/impurity/ipecacide
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/lipolicide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/lipolicide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.nutrition <= NUTRITION_LEVEL_STARVING)
-		if(affected_mob.adjust_tox_loss(1 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjust_tox_loss(0.5 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 			. = UPDATE_MOB_HEALTH
-	affected_mob.adjust_nutrition(-3 * REM * normalise_creation_purity() * seconds_per_tick) // making the chef more valuable, one meme trap at a time
+	affected_mob.adjust_nutrition(-1.5 * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick) // making the chef more valuable, one meme trap at a time
 	affected_mob.overeatduration = 0
 
 /datum/reagent/toxin/coniine
@@ -993,10 +993,10 @@
 	toxpwr = 1.75
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/coniine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/coniine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(affected_mob.losebreath < 5)
-		affected_mob.losebreath = min(affected_mob.losebreath + 5 * REM * seconds_per_tick, 5)
+		affected_mob.losebreath = min(affected_mob.losebreath + 2.5 * REM * metabolized_volume * seconds_per_tick, 5)
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/spewium
@@ -1009,7 +1009,7 @@
 	taste_description = "vomit"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/spewium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/spewium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(current_cycle > 11 && SPT_PROB(min(31, current_cycle), seconds_per_tick))
 		affected_mob.vomit(10, prob(10), prob(50), rand(0,4), TRUE)
@@ -1021,9 +1021,9 @@
 		affected_mob.vomit(vomit_flags = constructed_flags, distance = rand(0,4))
 		for(var/datum/reagent/toxin/reagent in affected_mob.reagents.reagent_list)
 			if(reagent != src)
-				affected_mob.reagents.remove_reagent(reagent.type, 1 * reagent.purge_multiplier * REM * seconds_per_tick)
+				affected_mob.reagents.remove_reagent(reagent.type, 1 * reagent.purge_multiplier * REM * metabolized_volume * seconds_per_tick)
 
-/datum/reagent/toxin/spewium/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/spewium/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(current_cycle > 33 && SPT_PROB(7.5, seconds_per_tick))
 		affected_mob.spew_organ()
@@ -1038,10 +1038,10 @@
 	toxpwr = 1
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/curare/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/curare/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(current_cycle > 11)
-		affected_mob.Paralyze(60 * REM * seconds_per_tick)
+		affected_mob.Paralyze(30 * REM * metabolized_volume * seconds_per_tick)
 	if(affected_mob.adjust_oxy_loss(0.5*REM*seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type))
 		return UPDATE_MOB_HEALTH
 
@@ -1059,9 +1059,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolized_traits = list(TRAIT_BLOOD_FOUNTAIN)
 
-/datum/reagent/toxin/heparin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/heparin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	if(holder.has_reagent(/datum/reagent/medicine/coagulant)) //Directly purges coagulants from the system. Get rid of the heparin BEFORE attempting to use coagulants.
-		holder.remove_reagent(/datum/reagent/medicine/coagulant, 2 * REM * seconds_per_tick)
+		holder.remove_reagent(/datum/reagent/medicine/coagulant, 1 * REM * metabolized_volume * seconds_per_tick)
 	return ..()
 
 /datum/reagent/toxin/rotatium //Rotatium. Fucks up your rotation and is hilarious
@@ -1077,7 +1077,7 @@
 	taste_description = "spinning"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/rotatium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/rotatium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(!affected_mob.hud_used || (current_cycle < 20 || (current_cycle % 20) == 0))
 		return
@@ -1106,13 +1106,13 @@
 	ph = 8
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/anacea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/anacea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	var/remove_amt = 5
 	if(holder.has_reagent(/datum/reagent/medicine/calomel) || holder.has_reagent(/datum/reagent/medicine/pen_acid))
 		remove_amt = 0.5
 	. = ..()
 	for(var/datum/reagent/medicine/reagent in affected_mob.reagents.reagent_list)
-		affected_mob.reagents.remove_reagent(reagent.type, remove_amt * reagent.purge_multiplier * REM * normalise_creation_purity() * seconds_per_tick)
+		affected_mob.reagents.remove_reagent(reagent.type, 0.5 * remove_amt * reagent.purge_multiplier * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick)
 
 //ACID
 
@@ -1181,9 +1181,9 @@
 	mytray.adjust_toxic(round(volume * 3))
 	mytray.adjust_weedlevel(-rand(1,4))
 
-/datum/reagent/toxin/acid/fluacid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/acid/fluacid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_fire_loss(((current_cycle-1)/15) * REM * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
+	if(affected_mob.adjust_fire_loss(0.5 * ((current_cycle-1)/15) * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype))
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/acid/nitracid
@@ -1197,9 +1197,9 @@
 	ph = 1.3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/acid/nitracid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/acid/nitracid/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_fire_loss((volume/10) * REM * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)) //here you go nervar
+	if(affected_mob.adjust_fire_loss(0.5 * (volume/10) * REM * metabolized_volume * normalise_creation_purity() * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)) //here you go nervar
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/toxin/delayed
@@ -1212,13 +1212,13 @@
 	var/delay = 31
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/toxin/delayed/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/delayed/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(current_cycle <= delay)
 		return
 	if(holder)
 		holder.remove_reagent(type, actual_metaboliztion_rate * affected_mob.metabolism_efficiency * seconds_per_tick)
-	if(affected_mob.adjust_tox_loss(actual_toxpwr * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
+	if(affected_mob.adjust_tox_loss(0.5 * actual_toxpwr * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype))
 		. = UPDATE_MOB_HEALTH
 	if(SPT_PROB(5, seconds_per_tick))
 		affected_mob.Paralyze(20)
@@ -1253,9 +1253,9 @@
 	. = ..()
 	affected_mob.say("oof ouch my bones", forced = /datum/reagent/toxin/bonehurtingjuice)
 
-/datum/reagent/toxin/bonehurtingjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/bonehurtingjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_stamina_loss(7.5 * REM * seconds_per_tick, updating_stamina = FALSE))
+	if(affected_mob.adjust_stamina_loss(3.25 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE))
 		. = UPDATE_MOB_HEALTH
 	if(!SPT_PROB(10, seconds_per_tick))
 		return
@@ -1267,7 +1267,7 @@
 		if(3)
 			to_chat(affected_mob, span_warning("Your bones hurt!"))
 
-/datum/reagent/toxin/bonehurtingjuice/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/bonehurtingjuice/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	if(SPT_PROB(2, seconds_per_tick) && iscarbon(affected_mob)) //big oof
 		var/selected_part = pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG) //God help you if the same limb gets picked twice quickly.
@@ -1297,9 +1297,9 @@
 	taste_description = "tannin"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/bungotoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/bungotoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 3 * REM * seconds_per_tick))
+	if(affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 1.5 * REM * metabolized_volume * seconds_per_tick))
 		. = UPDATE_MOB_HEALTH
 
 	// If our mob's currently dizzy from anything else, we will also gain confusion
@@ -1321,11 +1321,11 @@
 	taste_description = "sugary sweetness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/leadacetate/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/leadacetate/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
-	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_EARS, 1 * REM * seconds_per_tick)
-	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1 * REM * seconds_per_tick)
+	need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_EARS, 0.5 * REM * metabolized_volume * seconds_per_tick)
+	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5 * REM * metabolized_volume * seconds_per_tick)
 	if(need_mob_update)
 		. = UPDATE_MOB_HEALTH
 	if(SPT_PROB(0.5, seconds_per_tick))
@@ -1345,9 +1345,9 @@
 	health_required = 10
 	liver_damage_multiplier = 0
 
-/datum/reagent/toxin/viperspider/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/viperspider/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
-	affected_mob.adjust_hallucinations(10 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_hallucinations(5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 
 /datum/reagent/toxin/tetrodotoxin
 	name = "Tetrodotoxin"
@@ -1368,7 +1368,7 @@
 		TRAIT_PARALYSIS_R_LEG = BODY_ZONE_R_LEG,
 	)
 
-/datum/reagent/toxin/tetrodotoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/toxin/tetrodotoxin/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolized_volume)
 	. = ..()
 	var/need_mob_update
 	if(HAS_TRAIT(affected_mob, TRAIT_TETRODOTOXIN_HEALING))
@@ -1376,10 +1376,10 @@
 		liver_tolerance_multiplier = 0
 		silent_toxin = TRUE
 		remove_paralysis()
-		need_mob_update += affected_mob.adjust_oxy_loss(-0.7 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-		need_mob_update = affected_mob.adjust_tox_loss(-0.75 * REM * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
-		need_mob_update += affected_mob.adjust_brute_loss(-1.2 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
-		need_mob_update += affected_mob.adjust_fire_loss(-1.35 * REM * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_oxy_loss(-0.35 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+		need_mob_update = affected_mob.adjust_tox_loss(-0.325 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
+		need_mob_update += affected_mob.adjust_brute_loss(-0.6 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
+		need_mob_update += affected_mob.adjust_fire_loss(-0.675 * REM * metabolized_volume * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)
 		return need_mob_update ? UPDATE_MOB_HEALTH : .
 
 	liver_tolerance_multiplier = initial(liver_tolerance_multiplier)
@@ -1389,25 +1389,25 @@
 	switch(current_cycle)
 		if(7 to 13)
 			if(SPT_PROB(20, seconds_per_tick))
-				affected_mob.set_jitter_if_lower(rand(2 SECONDS, 3 SECONDS) * REM * seconds_per_tick)
+				affected_mob.set_jitter_if_lower(0.5 * rand(2 SECONDS, 3 SECONDS) * REM * metabolized_volume * seconds_per_tick)
 			if(SPT_PROB(5, seconds_per_tick))
 				var/obj/item/organ/tongue/tongue = affected_mob.get_organ_slot(ORGAN_SLOT_TONGUE)
 				if(tongue)
 					to_chat(affected_mob, span_warning("Your [tongue.name] feels numb..."))
-				affected_mob.set_slurring_if_lower(5 SECONDS * REM * seconds_per_tick)
-			affected_mob.adjust_disgust(3.5 * REM * seconds_per_tick)
+				affected_mob.set_slurring_if_lower(2.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.adjust_disgust(1.25 * REM * metabolized_volume * seconds_per_tick)
 		if(13 to 21)
 			silent_toxin = FALSE
 			toxpwr = 0.5
-			need_mob_update = affected_mob.adjust_stamina_loss(2.5 * REM * seconds_per_tick, updating_stamina = FALSE)
+			need_mob_update = affected_mob.adjust_stamina_loss(1.25 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
 			if(SPT_PROB(20, seconds_per_tick))
-				affected_mob.losebreath += 1 * REM * seconds_per_tick
+				affected_mob.losebreath += 0.5 * REM * metabolized_volume * seconds_per_tick
 				need_mob_update = TRUE
 			if(SPT_PROB(40, seconds_per_tick))
-				affected_mob.set_jitter_if_lower(rand(2 SECONDS, 3 SECONDS) * REM * seconds_per_tick)
-			affected_mob.adjust_disgust(3 * REM * seconds_per_tick)
-			affected_mob.set_slurring_if_lower(1 SECONDS * REM * seconds_per_tick)
-			affected_mob.adjust_stamina_loss(2 * REM * seconds_per_tick, updating_stamina = FALSE)
+				affected_mob.set_jitter_if_lower(0.5 * rand(2 SECONDS, 3 SECONDS) * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.adjust_disgust(1.5 * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.set_slurring_if_lower(0.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.adjust_stamina_loss(1 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
 			if(SPT_PROB(4, seconds_per_tick))
 				paralyze_limb(affected_mob)
 				need_mob_update = TRUE
@@ -1418,13 +1418,13 @@
 			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 0.5)
 			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 0.7)
 			if(SPT_PROB(40, seconds_per_tick))
-				affected_mob.losebreath += 2 * REM * seconds_per_tick
+				affected_mob.losebreath += 1 * REM * metabolized_volume * seconds_per_tick
 				need_mob_update = TRUE
-			affected_mob.adjust_disgust(3 * REM * seconds_per_tick)
-			affected_mob.set_slurring_if_lower(3 SECONDS * REM * seconds_per_tick)
+			affected_mob.adjust_disgust(1.5 * REM * metabolized_volume * seconds_per_tick)
+			affected_mob.set_slurring_if_lower(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
 			if(SPT_PROB(5, seconds_per_tick))
 				to_chat(affected_mob, span_danger("You feel horribly weak."))
-			need_mob_update += affected_mob.adjust_stamina_loss(5 * REM * seconds_per_tick, updating_stamina = FALSE)
+			need_mob_update += affected_mob.adjust_stamina_loss(2.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
 			if(SPT_PROB(8, seconds_per_tick))
 				paralyze_limb(affected_mob)
 				need_mob_update = TRUE
@@ -1434,9 +1434,9 @@
 			toxpwr = 1.5
 			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_BRAIN, 1, BRAIN_DAMAGE_DEATH)
 			need_mob_update = affected_mob.adjust_organ_loss(ORGAN_SLOT_LUNGS, 1.4)
-			affected_mob.set_silence_if_lower(3 SECONDS * REM * seconds_per_tick)
-			need_mob_update += affected_mob.adjust_stamina_loss(5 * REM * seconds_per_tick, updating_stamina = FALSE)
-			affected_mob.adjust_disgust(2 * REM * seconds_per_tick)
+			affected_mob.set_silence_if_lower(1.5 SECONDS * REM * metabolized_volume * seconds_per_tick)
+			need_mob_update += affected_mob.adjust_stamina_loss(2.5 * REM * metabolized_volume * seconds_per_tick, updating_stamina = FALSE)
+			affected_mob.adjust_disgust(1 * REM * metabolized_volume * seconds_per_tick)
 			if(SPT_PROB(15, seconds_per_tick))
 				paralyze_limb(affected_mob)
 				need_mob_update = TRUE

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -76,7 +76,7 @@
 
 	return ..()
 
-/datum/reagent/eigenstate/on_mob_life(mob/living/carbon/living_mob, metabolized_volume)
+/datum/reagent/eigenstate/on_mob_life(mob/living/carbon/living_mob, metabolization_ratio)
 	. = ..()
 	if(prob(20))
 		do_sparks(5,FALSE,living_mob)
@@ -90,7 +90,7 @@
 		do_sparks(5,FALSE,living_mob)
 	qdel(eigenstate)
 
-/datum/reagent/eigenstate/overdose_start(mob/living/living_mob, metabolized_volume) //Overdose, makes you teleport randomly
+/datum/reagent/eigenstate/overdose_start(mob/living/living_mob, metabolization_ratio) //Overdose, makes you teleport randomly
 	. = ..()
 	to_chat(living_mob, span_userdanger("You feel like your perspective is being ripped apart as you begin flitting in and out of reality!"))
 	living_mob.set_jitter_if_lower(40 SECONDS)
@@ -100,7 +100,7 @@
 		carbon_mob.apply_status_effect(/datum/status_effect/eigenstasium)
 	return ..()
 
-/datum/reagent/eigenstate/overdose_process(mob/living/living_mob, metabolized_volume) //Overdose, makes you teleport randomly
+/datum/reagent/eigenstate/overdose_process(mob/living/living_mob, metabolization_ratio) //Overdose, makes you teleport randomly
 	. = ..()
 	do_sparks(5, FALSE, living_mob)
 	do_teleport(living_mob, get_turf(living_mob), 10, asoundin = 'sound/effects/phasein.ogg')

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -15,7 +15,6 @@
 	taste_description = "wiggly cosmic dust."
 	color = "#5020F4"
 	overdose_threshold = 15
-	metabolization_rate = REAGENTS_METABOLISM
 	ph = 3.7
 	purity = 0.5
 	creation_purity = 0.5

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -76,7 +76,7 @@
 
 	return ..()
 
-/datum/reagent/eigenstate/on_mob_life(mob/living/carbon/living_mob)
+/datum/reagent/eigenstate/on_mob_life(mob/living/carbon/living_mob, metabolized_volume)
 	. = ..()
 	if(prob(20))
 		do_sparks(5,FALSE,living_mob)
@@ -90,7 +90,7 @@
 		do_sparks(5,FALSE,living_mob)
 	qdel(eigenstate)
 
-/datum/reagent/eigenstate/overdose_start(mob/living/living_mob) //Overdose, makes you teleport randomly
+/datum/reagent/eigenstate/overdose_start(mob/living/living_mob, metabolized_volume) //Overdose, makes you teleport randomly
 	. = ..()
 	to_chat(living_mob, span_userdanger("You feel like your perspective is being ripped apart as you begin flitting in and out of reality!"))
 	living_mob.set_jitter_if_lower(40 SECONDS)
@@ -100,7 +100,7 @@
 		carbon_mob.apply_status_effect(/datum/status_effect/eigenstasium)
 	return ..()
 
-/datum/reagent/eigenstate/overdose_process(mob/living/living_mob) //Overdose, makes you teleport randomly
+/datum/reagent/eigenstate/overdose_process(mob/living/living_mob, metabolized_volume) //Overdose, makes you teleport randomly
 	. = ..()
 	do_sparks(5, FALSE, living_mob)
 	do_teleport(living_mob, get_turf(living_mob), 10, asoundin = 'sound/effects/phasein.ogg')

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -15,7 +15,7 @@
 	taste_description = "wiggly cosmic dust."
 	color = "#5020F4"
 	overdose_threshold = 15
-	metabolization_rate = 1 * REAGENTS_METABOLISM
+	metabolization_rate = REAGENTS_METABOLISM
 	ph = 3.7
 	purity = 0.5
 	creation_purity = 0.5

--- a/code/modules/surgery/organs/internal/liver/_liver.dm
+++ b/code/modules/surgery/organs/internal/liver/_liver.dm
@@ -304,7 +304,7 @@
 	if(!(organ_owner.mob_biotypes & MOB_PLANT))
 		return
 	if(chem.type == /datum/reagent/toxin/plantbgone)
-		organ_owner.adjust_tox_loss(3 * REM * seconds_per_tick)
+		organ_owner.adjust_tox_loss(1.5 * seconds_per_tick)
 
 /obj/item/organ/liver/snail
 	name = "snail liver"
@@ -330,7 +330,7 @@
 		return
 	if(istype(chem, /datum/reagent/consumable/salt))
 		playsound(organ_owner, SFX_SEAR, 30, TRUE)
-		organ_owner.adjust_fire_loss(2 * REM * seconds_per_tick)
+		organ_owner.adjust_fire_loss(1 * seconds_per_tick)
 		organ_owner.reagents.remove_reagent(chem.type, REAGENTS_METABOLISM * seconds_per_tick)
 		return COMSIG_MOB_STOP_REAGENT_TICK
 

--- a/code/modules/surgery/organs/internal/liver/liver_plasmaman.dm
+++ b/code/modules/surgery/organs/internal/liver/liver_plasmaman.dm
@@ -18,7 +18,7 @@
 	// plasmamen use plasma to reform their bones or whatever
 	if(istype(chem, /datum/reagent/toxin/plasma) || istype(chem, /datum/reagent/toxin/hot_ice))
 		for(var/datum/wound/iter_wound as anything in organ_owner.all_wounds)
-			iter_wound.on_xadone(4 * REM * seconds_per_tick)
+			iter_wound.on_xadone(2 * seconds_per_tick)
 		return // Do normal metabolism
 	// plasmamen get high on gunpowder lol
 	if(istype(chem, /datum/reagent/gunpowder))

--- a/code/modules/surgery/organs/internal/liver/liver_skeleton.dm
+++ b/code/modules/surgery/organs/internal/liver/liver_skeleton.dm
@@ -19,8 +19,8 @@
 	if((. & COMSIG_MOB_STOP_REAGENT_TICK) || (organ_flags & ORGAN_FAILING))
 		return
 	if(istype(chem, /datum/reagent/toxin/bonehurtingjuice))
-		organ_owner.adjust_stamina_loss(7.5 * REM * seconds_per_tick, updating_stamina = FALSE)
-		organ_owner.adjust_brute_loss(0.5 * REM * seconds_per_tick, updating_health = FALSE)
+		organ_owner.adjust_stamina_loss(3.25  * seconds_per_tick, updating_stamina = FALSE)
+		organ_owner.adjust_brute_loss(0.25 * seconds_per_tick, updating_health = FALSE)
 		if(SPT_PROB(10, seconds_per_tick))
 			switch(rand(1, 3))
 				if(1)
@@ -47,7 +47,7 @@
 		if(chem.volume > 50)
 			organ_owner.reagents.remove_reagent(chem.type, (chem.volume - 50))
 			to_chat(organ_owner, span_warning("The excess milk is dripping off your bones!"))
-		organ_owner.heal_bodypart_damage(milk_brute_healing * REM * seconds_per_tick, milk_burn_healing * REM * seconds_per_tick)
+		organ_owner.heal_bodypart_damage(0.5 * milk_brute_healing * seconds_per_tick, 0.5 * milk_burn_healing * seconds_per_tick)
 		for(var/datum/wound/iter_wound as anything in organ_owner.all_wounds)
-			iter_wound.on_xadone(1 * REM * seconds_per_tick)
+			iter_wound.on_xadone(0.5 * seconds_per_tick)
 		return // Do normal metabolism

--- a/code/modules/unit_tests/liver.dm
+++ b/code/modules/unit_tests/liver.dm
@@ -20,8 +20,8 @@
 
 	mrbones.reagents.add_reagent(bonehurting, 40)
 	mrbones.Life(SSMOBS_DT)
-	var/expected_stamina_damage = (7.5 * REM * SECONDS_PER_TICK)
-	var/expected_brute_damage = (0.5 * REM * SECONDS_PER_TICK)
+	var/expected_stamina_damage = (3.25 * SECONDS_PER_TICK)
+	var/expected_brute_damage = (0.25 * SECONDS_PER_TICK)
 
 	TEST_ASSERT_EQUAL(mrbones.get_stamina_loss(), expected_stamina_damage,
 		"Skeleton took [mrbones.get_stamina_loss() > expected_stamina_damage ? "more" : "less"] stamina damage than expected")
@@ -47,7 +47,7 @@
 
 	mrbones.reagents.add_reagent(calcium, 50)
 	mrbones.Life(SSMOBS_DT)
-	var/expected_remaining_damage = DAMAGE_AMOUNT - (2.5 * REM * SECONDS_PER_TICK)
+	var/expected_remaining_damage = DAMAGE_AMOUNT - (1.25 * SECONDS_PER_TICK)
 	// Milk also heals brute on its own, so we may be more healed than expected
 	TEST_ASSERT(damaged_parts[1].brute_dam <= expected_remaining_damage,
 		"Milk did not heal the expected amount of damage (expected at least [expected_remaining_damage], got [damaged_parts[1].brute_dam])")
@@ -73,7 +73,7 @@
 
 	var/obj/item/bodypart/r_arm = mrbones.get_bodypart(BODY_ZONE_R_ARM)
 	var/obj/item/bodypart/l_arm = mrbones.get_bodypart(BODY_ZONE_L_ARM)
-	var/expected_wound_healing = 4 * REM * SECONDS_PER_TICK
+	var/expected_wound_healing = 2 * SECONDS_PER_TICK
 
 	// Test plasma
 


### PR DESCRIPTION
## About The Pull Request
To understand the PR we should first define what is micro dosing & volumetric dosing

- **Micro dosing:** The reagent effects are **independent** of the volume of reagent metabolized and are constant every tick, so the effect you get from metabolizing 0.01u of a reagent is the same as metabolizing 1u of a reagent
- **Volumetric dosing:** The reagent effects are **dependent** on the volume of reagent metabolized per tick, so the effect you get from metabolizing 0.01u is much lower compared to metabolizing 1u of a reagent which is much higher

This PR replaces **micro dosing** with **volumetric dosing** so if you increase metabolization rates and absorb more reagents you get higher effects from that reagent & vice versa for lower metabolization rates. 

With that lets ask the core questions

**How does this affect present reagent values?**

_This PR scales all reagent effects such that even if it has a lower/higher metabolization rate the value is the same as before but will still scale with reagent volumes & mob metabolization levels_

Under normal circumstances most reagents metabolize at 0.4u of reagent per tick so as long as this value isn't changed by cybernetic body parts or other reagents you will get the same values as before and won't notice anything different in normal gameplay.

However, if you do get enhanced body parts like a cybernetic liver/stomach or use reagents with metabolization rates different from 0.4u you will now get more/less affects depending on how much reagent is consumed. Here is an example 

Consider Syriniver this is how the formulae look like.

```dm
adjust_tox_loss(-1 * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype)
``` 

as long as 0.4u of it is metabolized every tick you get 2 tox loss healing which is the same as before. However, this time if you metabolize 0.01u of the reagent you get only 0.1 tox loss healing. If you metabolize 1u reagent per tick, then you get 5 tox loss healing

**What about cigarettes?**
Unaffected. The amount of reagents injected into a mob per tick **does not** affect the rate at which it is metabolized. Even if you have like 10u of cigarette reagents within you, if you are metabolizing just 0.4u of it every tick then nothing changes

## Why It's Good For The Game
- Volumetric dosing is realistic. If you metabolize   more reagent you should be getting more benefits and lesser volumes should yield lesser affects
- Microdosing is an exploit that should have been patched a long of time ago because it encourages people to put in minimal effort to produce just 0.01u of reagent to get maximum affects. This coupled with slower metabolization rates leads to unbalanced higher reagent effects for longer periods of time. 
- This PR address the core issue in #93991 which is heal all patches. Plumbing was gutted in an unnatural way by making the plumbing iv drip/output gate/pill press behave essentially as mini reaction chambers by filtering just 5 reagents. With this heal all patches are nerfed based on the number & now volume of reagents you can put in a patch, so its concern is addressed. If this does get merged, we can hopefully revert it and make plumbing great and behave like large factories again
<img width="914" height="230" alt="Screenshot (532)" src="https://github.com/user-attachments/assets/96467fad-b32f-409a-a1e8-2a92b8ff6565" />


## Changelog
:cl:
fix: probability reagent affects scale correctly
balance: reagent affects now scale with the volume of reagent metabolized meaning lower metabolization rates (from like cybernetic organs) yield lower effects & higher rates yield higher effects
/:cl:

