### PR TITLE
Fixes search in crafting menu

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -673,8 +673,8 @@
 			data["structures"] += atoms.Find(req_atom)
 
 	// Ingredients / Materials
+	data["reqs"] = list()
 	if(recipe.reqs.len)
-		data["reqs"] = list()
 		for(var/req_atom in recipe.reqs)
 			var/id = atoms.Find(req_atom)
 			data["reqs"]["[id]"] = recipe.reqs[req_atom]


### PR DESCRIPTION
## About The Pull Request
The frontend is expecting a recipe's requirements `reqs` to be an object, but it doesn't send it when there are none

<img width="415" height="102" alt="image" src="https://github.com/user-attachments/assets/b4c453e6-6d17-4733-bfe2-3e44153d7962" />

This kills the tgui
## Why It's Good For The Game
Fixes #94604
## Changelog
:cl:
fix: Fixed a bluescreen in the personal crafting menu
/:cl:
