### PR TITLE
Fixed chat tab imports [no gbp]

### DIFF
--- a/tgui/packages/tgui-panel/chat/atom.ts
+++ b/tgui/packages/tgui-panel/chat/atom.ts
@@ -3,7 +3,7 @@ import { createMainPage } from './model';
 
 export const mainPage = createMainPage();
 
-export const versionAtom = atom(5);
+export const versionAtom = atom(4);
 export const scrollTrackingAtom = atom(true);
 export const chatPagesAtom = atom([mainPage.id]);
 export const currentPageIdAtom = atom(mainPage.id);

--- a/tgui/packages/tgui-panel/chat/atom.ts
+++ b/tgui/packages/tgui-panel/chat/atom.ts
@@ -3,7 +3,7 @@ import { createMainPage } from './model';
 
 export const mainPage = createMainPage();
 
-export const versionAtom = atom(4);
+export const versionAtom = atom(5);
 export const scrollTrackingAtom = atom(true);
 export const chatPagesAtom = atom([mainPage.id]);
 export const currentPageIdAtom = atom(mainPage.id);

--- a/tgui/packages/tgui-panel/chat/migration.ts
+++ b/tgui/packages/tgui-panel/chat/migration.ts
@@ -1,4 +1,3 @@
-import { storage } from 'common/storage';
 import { store } from '../events/store';
 import {
   chatPagesAtom,
@@ -7,6 +6,7 @@ import {
   mainPage,
   versionAtom,
 } from './atom';
+import { saveChatState } from './helpers';
 import { chatRenderer } from './renderer';
 import {
   type Page,
@@ -193,7 +193,6 @@ export function startChatStateMigration(state: StoredChatSettings): void {
   if (wasInconsistent) {
     console.error('Chat settings were inconsistent, rewriting to storage');
     console.log('Comparison, stored vs update:', state, loaded);
-    storage.set('chat-state', loaded);
   }
 
   store.set(versionAtom, loaded.version);
@@ -203,5 +202,6 @@ export function startChatStateMigration(state: StoredChatSettings): void {
 
   chatRenderer.changePage(loaded.pageById[loaded.currentPageId]);
 
+  saveChatState(loaded);
   console.log('Restored chat settings:', loaded);
 }

--- a/tgui/packages/tgui-panel/chat/use-chat-persistence.ts
+++ b/tgui/packages/tgui-panel/chat/use-chat-persistence.ts
@@ -3,7 +3,7 @@ import DOMPurify from 'dompurify';
 import { useAtom, useAtomValue } from 'jotai';
 import { useEffect } from 'react';
 import { settingsLoadedAtom } from '../settings/atoms';
-import { allChatAtom, chatLoadedAtom, versionAtom } from './atom';
+import { chatLoadedAtom, versionAtom } from './atom';
 import { MESSAGE_SAVE_INTERVAL } from './constants';
 import { saveChatToStorage } from './helpers';
 import { startChatStateMigration } from './migration';
@@ -19,7 +19,6 @@ const FORBID_TAGS = ['a', 'iframe', 'link', 'video'];
  */
 export function useChatPersistence() {
   const version = useAtomValue(versionAtom);
-  const allChat = useAtomValue(allChatAtom);
 
   const [loaded, setLoaded] = useAtom(chatLoadedAtom);
   const settingsLoaded = useAtomValue(settingsLoadedAtom);
@@ -50,33 +49,6 @@ export function useChatPersistence() {
     return () => clearInterval(saveInterval);
   }, [loaded]);
 
-  /** Saves chat settings shortly after any settings change */
-  useEffect(() => {
-    let timeout: NodeJS.Timeout;
-
-    if (loaded) {
-      timeout = setTimeout(() => {
-        // Avoid persisting frequently-changing unread counts.
-        const pageById = Object.fromEntries(
-          Object.entries(allChat.pageById).map(([id, page]) => [
-            id,
-            {
-              ...page,
-              unreadCount: 0,
-            },
-          ]),
-        );
-
-        storage.set('chat-state', {
-          ...allChat,
-          pageById,
-        });
-      }, 750);
-    }
-
-    return () => clearTimeout(timeout);
-  }, [loaded, allChat]);
-
   async function loadChatFromStorage(): Promise<void> {
     const [state, messages] = await Promise.all([
       storage.get('chat-state'),
@@ -90,7 +62,7 @@ export function useChatPersistence() {
     // Empty settings, set defaults
     if (!state) {
       console.log('Initialized chat with default settings');
-    } else if (state && 'version' in state && state.version === version) {
+    } else if (state && 'version' in state && state.version >= version) {
       console.log('Loaded chat state from storage:', state);
       startChatStateMigration(state);
     } else {

--- a/tgui/packages/tgui-panel/chat/use-chat-persistence.ts
+++ b/tgui/packages/tgui-panel/chat/use-chat-persistence.ts
@@ -62,7 +62,7 @@ export function useChatPersistence() {
     // Empty settings, set defaults
     if (!state) {
       console.log('Initialized chat with default settings');
-    } else if (state && 'version' in state && state.version >= version) {
+    } else if (state && 'version' in state && state.version === version) {
       console.log('Loaded chat state from storage:', state);
       startChatStateMigration(state);
     } else {

--- a/tgui/packages/tgui-panel/settings/settingsImExport.ts
+++ b/tgui/packages/tgui-panel/settings/settingsImExport.ts
@@ -81,7 +81,7 @@ function rebuildChatState(
   }
 
   const rebuiltState: StoredChatSettings = {
-    version: 1,
+    version: 4,
     scrollTracking: true,
     currentPageId: newPageIds[0],
     pages: newPageIds,

--- a/tgui/packages/tgui-panel/settings/settingsImExport.ts
+++ b/tgui/packages/tgui-panel/settings/settingsImExport.ts
@@ -81,7 +81,7 @@ function rebuildChatState(
   }
 
   const rebuiltState: StoredChatSettings = {
-    version: 4,
+    version: 5,
     scrollTracking: true,
     currentPageId: newPageIds[0],
     pages: newPageIds,


### PR DESCRIPTION

## About The Pull Request
Importing chat state erroneously set its version to 1 instead of 5. This would break on the next load, which checks if the version is ok.

I also removed a useeffect which was probably firing too often anyways
## Why It's Good For The Game
Fixes importing chat tabs from a file
## Changelog
:cl:
fix: Fixed importing chat tabs from a file. They should still exist on reload
/:cl:
