### PR TITLE
Messenger no longer force opens its UI

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -625,7 +625,7 @@
 	physical.loc.visible_message(span_notice("[icon2html(physical, viewers(physical.loc))] \The [src] displays a [call_source.filedesc] notification: [alerttext]"))
 
 /obj/item/modular_computer/proc/ring(ringtone, list/balloon_alertees) // bring bring
-	if(!use_energy())
+	if(!use_energy(check_programs = FALSE))
 		return
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_PDA_GLITCHED))
 		playsound(src, pick(


### PR DESCRIPTION
## About The Pull Request

By default, ``use_energy`` will take 0 as the amount of energy to use, turning it into a basic "check if we have power" check, however if we don't exclude ``check_programs`` arg, and because it doesn't use any power, it will loop through every PDA app to see if they are able to be opened while unpowered, and opening those that can operate while powered (aka the PDA messenger).

This is the case for PDA Messenger, so if you're using any app and get a PDA message, or you reply to one, it will call ``ring()``, which will call ``use_energy``, which will swap the PDA app to messenger as if the PDA has no power. This fixes that.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/76965

## Changelog

:cl:
fix: PDA messenger will no longer force itself as your active program when sending/receiving PDA messages.
/:cl: