### PR TITLE
Gives the Chief Engineer workboots rather than sneakers

### DIFF
--- a/code/game/objects/items/storage/garment.dm
+++ b/code/game/objects/items/storage/garment.dm
@@ -146,7 +146,7 @@
 	new /obj/item/clothing/head/utility/hardhat/white(src)
 	new /obj/item/clothing/head/utility/hardhat/welding/white(src)
 	new /obj/item/clothing/neck/cloak/ce(src)
-	new /obj/item/clothing/shoes/sneakers/brown(src)
+	new /obj/item/clothing/shoes/workboots(src)
 
 /obj/item/storage/bag/garment/quartermaster/PopulateContents()
 	new /obj/item/clothing/under/rank/cargo/qm(src)

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -75,7 +75,7 @@
 	ears = /obj/item/radio/headset/heads/ce
 	gloves = /obj/item/clothing/gloves/color/black
 	head = /obj/item/clothing/head/utility/hardhat/welding/white/up
-	shoes = /obj/item/clothing/shoes/sneakers/brown
+	shoes = /obj/item/clothing/shoes/workboots
 	l_pocket = /obj/item/modular_computer/pda/heads/ce
 
 	backpack = /obj/item/storage/backpack/industrial


### PR DESCRIPTION

## About The Pull Request

Changes the Chief Engineer's default shoes to workboots, from brown sneakers. Also in their garment bag.

## Why It's Good For The Game

You're telling me our CHIEF engineer, our FOREMAN, is wearing SNEAKERS to go work with their death machines? I don't think so. This distinction has existed since the invention of work boots a full decade ago, and I don't think it was a intention then. 

They just look better, especially when they're inevitably covered in oil.

## Changelog
:cl:

balance: took away the CE's sneakers and gave them work boots.

/:cl:
