### PR TITLE
Stop logging character dummies not being able to equip accessories

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -231,7 +231,7 @@
 		var/obj/item/clothing/under/U = user.w_uniform
 		if(U)
 			U.attach_accessory(SSwardrobe.provide_type(accessory, user))
-		else
+		else if(!visuals_only)
 			WARNING("Unable to equip accessory [accessory] in outfit [name]. No uniform present!")
 
 	if(l_hand)


### PR DESCRIPTION
## About The Pull Request

Tin, noticed this spam in my log from a character preview that wasn't wearing a uniform, and they had an accessory in their loadout. 

It should not be doing this stuff in the char prefs menu when it's be possible to preview uniformless characters.

## Why It's Good For The Game

Stops senseless world.log spam

## Changelog

Not player-facing