### PR TITLE
Hotfix crafting menu 'Material' tab bug

### DIFF
--- a/tgui/packages/tgui/interfaces/PersonalCrafting/index.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting/index.tsx
@@ -97,7 +97,7 @@ export function PersonalCrafting(props: any) {
             recipe.foodtypes?.includes(activeType))) ||
         // Is material mode and the active material or catalysts match
         (tabMode === TABS.material &&
-          Object.keys(recipe.reqs).includes(activeMaterial)) ||
+          activeMaterial in (recipe.reqs ?? {})) ||
         // Is category mode and the active categroy matches
         (tabMode === TABS.category &&
           ((activeCategory === 'Can Make' &&


### PR DESCRIPTION
## About The Pull Request

Fixes a bluescreen that occurs when switching to crafting menu

![evJIvXVxIx](https://github.com/user-attachments/assets/4a0e69c1-f719-421a-912c-4a486789d83c)


Caused by the recipe for

`/obj/item/gun/energy/laser/musket/repeater`

not having any `reqs` so it is undefined for that key. So we need to take into account recipes like this.

## Why It's Good For The Game

Bugfix

## Changelog

:cl:
fix: fixes a bluescreen when going to the 'Material' tab of the crafting menu
/:cl: