### PR TITLE
Deletes the warden's evidence bag

### DIFF
--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -50,9 +50,6 @@
 	uniform = /obj/item/clothing/under/rank/security/warden
 	suit = /obj/item/clothing/suit/armor/vest/warden/alt
 	suit_store = /obj/item/gun/energy/disabler
-	backpack_contents = list(
-		/obj/item/evidencebag = 1,
-		)
 	belt = /obj/item/modular_computer/pda/warden
 	ears = /obj/item/radio/headset/headset_sec/alt
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses


### PR DESCRIPTION
## About The Pull Request

Warden's bag spawns with nothin' but their box. 

## Why It's Good For The Game

I understand the thought process behind giving sec-offs evidence bags
...but the warden doesn't leave the brig - you know, the place where you readily have a supply of bags?
Idk why *they* need to spawn with one. 

## Changelog

:cl: Melbert
del: Wardens no longer spawn with an evidence bag
/:cl:

