### PR TITLE
Fix cargo PDA app missing currency name

### DIFF
--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -173,6 +173,8 @@
 /datum/computer_file/program/budgetorders/ui_static_data(mob/user)
 	var/list/data = list()
 	data["max_order"] = CARGO_MAX_ORDER
+	data["displayed_currency_full_name"] = " [MONEY_NAME]"
+	data["displayed_currency_name"] = " [MONEY_SYMBOL]"
 	return data
 
 /datum/computer_file/program/budgetorders/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)


### PR DESCRIPTION

## About The Pull Request

All the prices are just numbers theres no cr at the end

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
fix: fixed cargo PDA app missing currency name
/:cl:
