### PR TITLE
Fixes the armor penetration calculation for AP values greater than 100

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -355,7 +355,7 @@ GLOBAL_LIST_INIT(all_precise_body_zones, list(BODY_ZONE_PRECISE_EYES, BODY_ZONE_
 /// Armor can't block more than this as a percentage
 #define ARMOR_MAX_BLOCK 90
 /// Calculates the new armour value after armour penetration. Can return negative values, and those must be caught.
-#define PENETRATE_ARMOUR(armour, penetration) (penetration == 100 ? 0 : 100 * (armour - penetration) / (100 - penetration))
+#define PENETRATE_ARMOUR(armour, penetration) (penetration >= 100 ? 0 : 100 * (armour - penetration) / (100 - penetration))
 
 // Defines for combo attack component
 /// LMB Attack


### PR DESCRIPTION
## About The Pull Request

While testing out some... fuckery... I found out that weapons with more than 100 armor penetration actually *increase* the effectiveness of armor, due to the numerator and denominator of the calculation *both* being negative, resulting in a positive over-unity quotient. This isn't caught by the macro that performs this calculation because it only checks if the penetration *exactly* equals 100. This has been changed to a greater-than-or-equal check.

## Why It's Good For The Game

I'm pretty sure weapons with unimaginably high armor penetration capability shouldn't actually make the armor they are penetrating **stronger** against it.

## Changelog

:cl:
fix: If, for some godforsaken reason, you find yourself with a weapon that has more than 100% armor penetration, it will now properly ignore armor in its entirety instead of ENHANCING it, which it used to do.
/:cl:
