### PR TITLE
Makes fish price calculation use exponentiation instead of bitwise XORing

### DIFF
--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -1518,10 +1518,10 @@ GLOBAL_LIST_INIT(fish_compatible_fluid_types, list(
 
 ///Returns the price of this fish, for the fish export.
 /obj/item/fish/proc/get_export_price(price)
-	var/size_weight_exponentation = (size * weight * FISH_PRICE_MULTIPLIER)^FISH_PRICE_CURVE_EXPONENT
+	var/size_weight_exponentation = (size * weight * FISH_PRICE_MULTIPLIER)**FISH_PRICE_CURVE_EXPONENT
 	var/raw_price = price + size_weight_exponentation
 	if(raw_price >= FISH_PRICE_SOFT_CAP_THRESHOLD + 1)
-		var/soft_cap = (raw_price - FISH_PRICE_SOFT_CAP_THRESHOLD)^FISH_PRICE_SOFT_CAP_EXPONENT
+		var/soft_cap = (raw_price - FISH_PRICE_SOFT_CAP_THRESHOLD)**FISH_PRICE_SOFT_CAP_EXPONENT
 		raw_price = FISH_PRICE_SOFT_CAP_THRESHOLD + soft_cap
 	if(HAS_TRAIT(src, TRAIT_FISH_LOW_PRICE)) //Avoid printing money by simply ordering fish and sending it back.
 		raw_price *= 0.05


### PR DESCRIPTION
## About The Pull Request

Silly goose, `^` is bitwise XOR. `**` is exponentiation.

## Why It's Good For The Game

Makes fish export pricing work as intended.

## Changelog

:cl:
fix: The Spinward Sector Fishery Association would like to apologize for using a bitwise XOR instead of exponentiation in the source code of their automated fish price evaluation system.
/:cl:
