### PR TITLE
Dimensional anomaly transformed airlocks save their cycling id

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
+++ b/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
@@ -155,7 +155,8 @@
 	if(istype(object, /obj/machinery/door/airlock))
 		if(istype(new_object, /obj/machinery/door/airlock)) //carry over access-related and adjacent variables. The rest is not as important
 			var/obj/machinery/door/airlock/airlock = object
-			var/obj/machinery/door/new_airlock = new_object
+			var/obj/machinery/door/airlock/new_airlock = new_object
+			new_airlock.closeOtherId = airlock.closeOtherId
 			new_airlock.unres_sides = airlock.unres_sides
 			new_airlock.req_access = airlock.req_access?.Copy()
 			new_airlock.req_one_access = airlock.req_one_access?.Copy()


### PR DESCRIPTION
## About The Pull Request
- Fixes #94061

## Changelog
:cl:
fix: dimensional anomaly transformed airlocks save their cycling id
/:cl:

