### PR TITLE
Keybinds page tells you how to clear keybind

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/GamePreferences/KeybindingsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/GamePreferences/KeybindingsPage.tsx
@@ -412,7 +412,7 @@ export class KeybindingsPage extends Component<any, KeybindingsPageState> {
     }
 
     if (lastKeyboardEvent === undefined) {
-      return '...';
+      return 'Set New / ESC to Clear';
     }
 
     return formatKeyboardEvent(lastKeyboardEvent);


### PR DESCRIPTION
## About The Pull Request

Closes https://github.com/tgstation/tgstation/issues/92741 and informs the player about ESC to clear the current keybind.

## Why It's Good For The Game

We should probably tell players this instead of passing it down verbally from generation to generation.

## Changelog

:cl: LT3
qol: Keybindings page now tells you how to clear a keybind
/:cl: