### PR TITLE
Fixes population lock text in uplinks

### DIFF
--- a/tgui/packages/tgui/interfaces/Uplink/GenericUplink.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/GenericUplink.tsx
@@ -229,14 +229,21 @@ const ItemList = (props: ItemListProps) => {
                     >
                       {item.insufficient_population ? (
                         <Box
-                          mt="-12px"
-                          mb="-6px"
                           style={{
                             opacity: '0.5',
                           }}
+                          mt="-12px"
+                          mb="-8px"
                         >
-                          <Icon name="lock" lineHeight="36px" />{' '}
-                          {item.population_tooltip}
+                          <Icon
+                            name="lock"
+                            lineHeight="36px"
+                            position="absolute"
+                            top="-2px"
+                          />
+                          <p style={{ textIndent: '1.5em' }}>
+                            {item.population_tooltip}
+                          </p>
                         </Box>
                       ) : (
                         ''


### PR DESCRIPTION

## About The Pull Request

Before:

<img width="530" height="177" alt="dreamseeker_FlzPesJnIz" src="https://github.com/user-attachments/assets/80c7548b-873a-4d25-8d00-e7f78fa63090" />

After:

<img width="541" height="110" alt="dreamseeker_slppdfXtaW" src="https://github.com/user-attachments/assets/39a243c7-7df5-4300-8a6c-0db345029e82" />

## Changelog
:cl:
fix: Fixed population lock text in uplinks
/:cl:
