### PR TITLE
Makes right-clicks on closets with an item open/close them

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -689,6 +689,11 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 	else
 		return ..()
 
+/obj/structure/closet/item_interaction_secondary(mob/living/user, obj/item/tool, list/modifiers)
+	if (attack_hand(user, modifiers))
+		return ITEM_INTERACT_SUCCESS
+	return NONE
+
 /// check if we can install airlock electronics in this closet
 /obj/structure/closet/proc/can_install_airlock_electronics(mob/user)
 	if(secure || !can_install_electronics || opened)
@@ -980,14 +985,15 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 	. = ..()
 	if(.)
 		return
+
 	if(user.body_position == LYING_DOWN && get_dist(src, user) > 0)
 		return
 
 	if(toggle(user))
-		return
+		return TRUE
 
 	if(!opened)
-		togglelock(user)
+		return togglelock(user)
 
 /obj/structure/closet/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)


### PR DESCRIPTION

## About The Pull Request

As title says, right clicking on a closet with an item now opens or closes it. Makes sense you'd be able to do that by using your shoulder or feet.

## Why It's Good For The Game

Makes inventory management a bit easier and lets players offload their backpacks into lockers easier (when they actually do so for once)

## Changelog
:cl:
qol: Right-clicking closets with an item now opens/closes them
/:cl:
