### PR TITLE
Adds raptor growth progress bar to RaptorDex

### DIFF
--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_dex.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_dex.dm
@@ -32,6 +32,8 @@
 	scan_data["raptor_speed"] = my_raptor.speed + intent_mod?.multiplicative_slowdown
 	scan_data["raptor_color"] = my_raptor.name
 	scan_data["raptor_gender"] = my_raptor.gender
+	scan_data["raptor_growth"] = my_raptor.growth_progress
+	scan_data["can_grow"] = my_raptor.growth_stage != RAPTOR_ADULT
 	scan_data["raptor_description"] = my_raptor.raptor_color.description
 
 	var/happiness_percentage = my_raptor.ai_controller?.blackboard[BB_BASIC_HAPPINESS]

--- a/code/modules/modular_computers/file_system/programs/raptordex.dm
+++ b/code/modules/modular_computers/file_system/programs/raptordex.dm
@@ -27,6 +27,8 @@
 	scan_data["raptor_speed"] = my_raptor.speed + intent_mod?.multiplicative_slowdown
 	scan_data["raptor_color"] = my_raptor.name
 	scan_data["raptor_gender"] = my_raptor.gender
+	scan_data["raptor_growth"] = my_raptor.growth_progress
+	scan_data["can_grow"] = my_raptor.growth_stage != RAPTOR_ADULT
 	scan_data["raptor_description"] = my_raptor.raptor_color.description
 
 	var/happiness_percentage = my_raptor.ai_controller?.blackboard[BB_BASIC_HAPPINESS]

--- a/tgui/packages/tgui/interfaces/RaptorDex.tsx
+++ b/tgui/packages/tgui/interfaces/RaptorDex.tsx
@@ -16,6 +16,8 @@ type Data = {
   raptor_health: number;
   raptor_max_health: number;
   raptor_speed: number;
+  can_grow: boolean;
+  raptor_growth: number;
   raptor_color: string;
   raptor_image: string;
   raptor_gender: string;
@@ -54,6 +56,8 @@ export const RaptorDexContent = (props) => {
     raptor_speed,
     raptor_image,
     raptor_gender,
+    can_grow,
+    raptor_growth,
     inherited_attack,
     inherited_attack_max,
     inherited_health,
@@ -107,6 +111,11 @@ export const RaptorDexContent = (props) => {
             <LabeledList.Item label="Gender">
               {capitalizeFirst(raptor_gender)}
             </LabeledList.Item>
+            {!!can_grow && (
+              <LabeledList.Item label="Growth">
+                <ProgressBar value={raptor_growth} maxValue={100} />
+              </LabeledList.Item>
+            )}
           </LabeledList>
         </Section>
         <Section title="Inherit Modifiers">


### PR DESCRIPTION

## About The Pull Request
Players can now check their chick's/youngling's growth progress via the RaptorDex item or app

## Why It's Good For The Game

Currently there's no way to know how much food you need to feed to your raptor to advance their growth, which can cause confusion among newer players.

## Changelog
:cl:
qol: Added raptor growth progress bar to RaptorDex
/:cl:
