### PR TITLE
AI deploy to shell verb does not take an input

### DIFF
--- a/code/datums/keybinding/artificial_intelligence.dm
+++ b/code/datums/keybinding/artificial_intelligence.dm
@@ -17,5 +17,5 @@
 	if(.)
 		return
 	var/mob/living/silicon/ai/our_ai = user.mob
-	our_ai.deploy_to_shell(our_ai.redeploy_action.last_used_shell)
+	our_ai.select_shell(our_ai.redeploy_action.last_used_shell)
 	return TRUE

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -957,7 +957,7 @@
 	playsound(get_turf(src), 'sound/machines/ding.ogg', 50, TRUE, ignore_walls = FALSE)
 	to_chat(src, "Hack complete. [apc] is now under your exclusive control.")
 
-/mob/living/silicon/ai/verb/deploy()
+/mob/living/silicon/ai/verb/deploy_shell()
 	set category = "AI Commands"
 	set desc = "Transfer to an available remote body."
 	set name = "Deploy to Shell"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -957,10 +957,14 @@
 	playsound(get_turf(src), 'sound/machines/ding.ogg', 50, TRUE, ignore_walls = FALSE)
 	to_chat(src, "Hack complete. [apc] is now under your exclusive control.")
 
-/mob/living/silicon/ai/verb/deploy_to_shell(mob/living/silicon/robot/target)
+/mob/living/silicon/ai/verb/deploy()
 	set category = "AI Commands"
+	set desc = "Transfer to an available remote body."
 	set name = "Deploy to Shell"
 
+	deploy_to_shell()
+
+/mob/living/silicon/ai/proc/deploy_to_shell(mob/living/silicon/robot/target)
 	if(incapacitated)
 		return
 	if(control_disabled)
@@ -976,6 +980,7 @@
 
 	if(!LAZYLEN(possible))
 		to_chat(src, "No usable AI shell beacons detected.")
+		return
 
 	if(!target || !(target in possible)) //If the AI is looking for a new shell, or its pre-selected shell is no longer valid
 		target = tgui_input_list(src, "Which body to control?", "Direct Control", sort_names(possible))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -957,14 +957,14 @@
 	playsound(get_turf(src), 'sound/machines/ding.ogg', 50, TRUE, ignore_walls = FALSE)
 	to_chat(src, "Hack complete. [apc] is now under your exclusive control.")
 
-/mob/living/silicon/ai/verb/deploy_shell()
+/mob/living/silicon/ai/verb/deploy_to_shell()
 	set category = "AI Commands"
 	set desc = "Transfer to an available remote body."
 	set name = "Deploy to Shell"
 
-	deploy_to_shell()
+	select_shell()
 
-/mob/living/silicon/ai/proc/deploy_to_shell(mob/living/silicon/robot/target)
+/mob/living/silicon/ai/proc/select_shell(mob/living/silicon/robot/target)
 	if(incapacitated)
 		return
 	if(control_disabled)
@@ -1008,7 +1008,7 @@
 	var/mob/living/silicon/ai/AI = owner
 	if(!AI)
 		return
-	AI.deploy_to_shell()
+	AI.select_shell()
 
 /datum/action/innate/deploy_last_shell
 	name = "Reconnect to shell"
@@ -1022,7 +1022,7 @@
 		return
 	if(last_used_shell)
 		var/mob/living/silicon/ai/AI = owner
-		AI.deploy_to_shell(last_used_shell)
+		AI.select_shell(last_used_shell)
 	else
 		Remove(owner) //If the last shell is blown, destroy it.
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -955,7 +955,7 @@
 /mob/living/silicon/robot/attack_ai(mob/user)
 	if(shell && (!connected_ai || connected_ai == user))
 		var/mob/living/silicon/ai/AI = user
-		AI.deploy_to_shell(src)
+		AI.select_shell(src)
 
 /mob/living/silicon/robot/mouse_buckle_handling(mob/living/M, mob/living/user)
 	//Don't try buckling on INTENT_HARM so that silicons can search people's inventories without loading them


### PR DESCRIPTION
## About The Pull Request

Fixes #94663 
It seems that using the "Deploy to Shell" verb as an AI will launch a popup asking which mob in view you want to trigger the verb as, which is obviously unintended behaviour.
I've resolved this by moving all of the behaviour to a proc which the verb calls, so existing code which passes in a mob should still function as it did previously.

There might be a different way to do this but I'll be honest I try not to ever add verbs so I don't know what it is.

## Why It's Good For The Game

When you use a verb from the verb panel you implicitly expect to be the mob using the verb, not to have to select yourself from a list first.

## Changelog

:cl:
fix: AI shell deployment verb no longer requires you to select yourself from a list first
/:cl: