### PR TITLE
Buffs surplus crates

### DIFF
--- a/code/modules/uplink/uplink_items/bundle.dm
+++ b/code/modules/uplink/uplink_items/bundle.dm
@@ -73,7 +73,7 @@
 	purchasable_from = ~(UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY)
 	stock_key = UPLINK_SHARED_STOCK_SURPLUS
 	/// Value of items inside the crate in TC
-	var/crate_tc_value = 30
+	var/crate_tc_value = 40
 	/// crate that will be used for the surplus crate
 	var/crate_type = /obj/structure/closet/crate
 
@@ -136,7 +136,7 @@
 	cost = 20
 	item = /obj/structure/closet/crate/secure/syndicrate
 	stock_key = UPLINK_SHARED_STOCK_SURPLUS
-	crate_tc_value = 80
+	crate_tc_value = 100
 	crate_type = /obj/structure/closet/crate/secure/syndicrate
 
 /// edited version of fill crate for super surplus to ensure it can only be unlocked with the syndicrate key

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -14,7 +14,7 @@
 	cost = 2
 	restricted_roles = list(JOB_CURATOR)
 	limited_stock = 1 //please don't spam deadchat
-	surplus = 0 //currently non-functional
+	surplus = 1 
 
 /datum/uplink_item/role_restricted/mail_counterfeit_kit
 	name = "GLA Brand Mail Counterfeit Kit"

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -14,7 +14,7 @@
 	cost = 2
 	restricted_roles = list(JOB_CURATOR)
 	limited_stock = 1 //please don't spam deadchat
-	surplus = 5
+	surplus = 0 //currently non-functional
 
 /datum/uplink_item/role_restricted/mail_counterfeit_kit
 	name = "GLA Brand Mail Counterfeit Kit"
@@ -237,7 +237,7 @@
 	cost = 12
 	item = /obj/item/storage/box/syndie_kit/mimery
 	restricted_roles = list(JOB_MIME)
-	surplus = 0
+	surplus = 10
 
 /datum/uplink_item/role_restricted/laser_arm
 	name = "Laser Arm Implant"
@@ -361,6 +361,7 @@
 	item = /obj/item/bee_smoker
 	cost = 4
 	restricted_roles = list(JOB_BOTANIST)
+	surplus = 0 //requires too much setup to be worth including in surplus crates
 
 /datum/uplink_item/role_restricted/monkey_agent
 	name = "Simian Agent Reinforcements"


### PR DESCRIPTION
## About The Pull Request

Buffs surplus to 40 TC, united to 100 TC. Reduces haunted eightball spawn rate and removes bee smoker from the surplus pool, and adds advanced mimery tome.
## Why It's Good For The Game

Surplus crates are in a weird state after the progtot changes. They were removed with the progtot implementation, and re-added later on but with a measure for them to respect reputation system. The author that re-added them intended to do so without the rep limitations, but was asked to implement them and did as told (also note that the pr was done when there were still side objectives to gain reputation). That's fine, except for the fact that in the current state of reputation it is only detrimental for the loot the surplus will hold in the first 30 minutes of a round, and in after that it's just as it was before progtot (but you ve had to wait the required time to gain the rep). This pr aims to compensate that fact by simply increasing their contained value. United surplus were buffed as well to not be irrelevant after the basic surplus buff. 

Touched a few items in and out that I thought were logic to have/not have. 

Bee smoker requires botany gameplay, which demands certain knowledge and tools the rest of the traitors item pool doesnt
Haunted eight ball is non functional (in the end i reduced it s spawn rate to minimum)
Advanced mimery was banned from surplus and I couldnt find a coherent reason for this, so I added a 10% spawn rate, similar to the values of pie cannon and clown car (seemed thematically right) 

## Changelog

:cl:

balance: Reduced haunted eightball spawnrate on surplus and removed bee smoker from syndi surplus pools. Added advanced mimery guide.
balance: Increased the amount of TC contained inside surplus crates by 10, and super surplus by 20.

/:cl:
