### PR TITLE
Fix missing emergency shuttle prices

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -637,6 +637,8 @@
 		"callShuttleReasonMinLength" = CALL_SHUTTLE_REASON_LENGTH,
 		"maxStatusLineLength" = MAX_STATUS_LINE_LENGTH,
 		"maxMessageLength" = MAX_MESSAGE_LEN,
+		"displayed_currency_full_name" = " [MONEY_NAME]",
+		"displayed_currency_name" = " [MONEY_SYMBOL]",
 	)
 
 /obj/machinery/computer/communications/Topic(href, href_list)

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole/BuyingShuttle.tsx
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole/BuyingShuttle.tsx
@@ -51,7 +51,7 @@ function ShuttleCard(props: ShuttleCardProps) {
   const { shuttle } = props;
 
   const { act, data } = useBackend<CommsConsoleData>();
-  const { budget } = data;
+  const { budget, displayed_currency_name, displayed_currency_full_name} = data;
 
   return (
     <Section
@@ -76,14 +76,14 @@ function ShuttleCard(props: ShuttleCardProps) {
           }
           tooltip={
             budget < shuttle.creditCost
-              ? `You need ${shuttle.creditCost - budget} more credits.`
+              ? `You need ${shuttle.creditCost - budget} more ${displayed_currency_full_name}.`
               : shuttle.emagOnly
                 ? EMAG_SHUTTLE_NOTICE
                 : undefined
           }
           tooltipPosition="left"
         >
-          {shuttle.emagOnly ? 'Buy' : 'Purchase'}
+          {shuttle.emagOnly ? 'Buy' : `${shuttle.creditCost} ${displayed_currency_name}`}
         </Button>
       }
     >


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/94646 and shows the price of each emergency shuttle option.

<img width="415" height="523" alt="image" src="https://github.com/user-attachments/assets/6c3e830d-03ef-42c3-ba61-7e3f62d27e8c" />

## Why It's Good For The Game

Emergency shuttle price is no longer a mystery

## Changelog

:cl: LT3
fix: Emergency shuttle purchase menu now lists the shuttle prices
/:cl: