### PR TITLE
lavaland battle site hitsplash fix

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_battle_site.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_battle_site.dmm
@@ -106,9 +106,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "L" = (
-/obj/effect/decal/cleanable/blood/hitsplatter{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/blood/drip,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "M" = (


### PR DESCRIPTION

## About The Pull Request

fixes https://github.com/tgstation/tgstation/issues/91059

## Why It's Good For The Game

muh immersion

## Changelog
:cl:

fix: fixed permanently animated bloodsplash in lavaland battle site ruin

/:cl:
