### PR TITLE
Fixes Gullion fish suicide

### DIFF
--- a/code/modules/fishing/fish/types/rift.dm
+++ b/code/modules/fishing/fish/types/rift.dm
@@ -396,12 +396,13 @@
 	visible_message(span_suicide("[user] swallows [src] whole! It looks like they're trying to commit suicide!"))
 	forceMove(user)
 	var/datum/gas_mixture/environment = user.loc.return_air()
-	var/oxygen_in_air = check_gases(environment.gases, list(/datum/gas/oxygen))
+	var/oxygen_in_air = check_gases(environment.gases, list(/datum/gas/oxygen = list(10, INFINITY)), extraneous_gas_limit = INFINITY)
 	if(!oxygen_in_air || (status == FISH_DEAD))
 		visible_message(span_suicide("[user] chokes and dies! (Wait, from the fish or from lack of air?)"))
 		return OXYLOSS
 
 	user.petrify(statue_timer = INFINITY)
+	user.death()
 	visible_message(span_suicide("[user]'s skin turns into quartz upon contact with the oxygen in the air!'"))
 	qdel(src)
 	return MANUAL_SUICIDE

--- a/code/modules/fishing/fish/types/rift.dm
+++ b/code/modules/fishing/fish/types/rift.dm
@@ -396,7 +396,7 @@
 	visible_message(span_suicide("[user] swallows [src] whole! It looks like they're trying to commit suicide!"))
 	forceMove(user)
 	var/datum/gas_mixture/environment = user.loc.return_air()
-	var/oxygen_in_air = check_gases(environment.gases, list(/datum/gas/oxygen = list(10, INFINITY)), extraneous_gas_limit = INFINITY)
+	var/oxygen_in_air = locate(/datum/gas/oxygen) in environment.gases
 	if(!oxygen_in_air || (status == FISH_DEAD))
 		visible_message(span_suicide("[user] chokes and dies! (Wait, from the fish or from lack of air?)"))
 		return OXYLOSS


### PR DESCRIPTION
## About The Pull Request

This PR makes the "Gullion" fish suicide work as originally intended, meaning that if used in an environment with Oxygen it will petrify you permanently.

This previously did not work because it was using an overcomplicated check; `check_gases` looks for a list of gases within specified bounds and returns the presence of unlisted gases (like Nitrogen which is basically everywhere you would expect Oxygen to be) as a failure state.
We actually only care if there is a nonzero amount of oxygen present in our tile, which we can check much more simply.

Also previously we never technically kill the mob, only left it permanently alive and petrified. This meant that via some pre-preparation you could teleport yourself out of the statue and then... be walking around with the suicide flag enabled while still alive? This seemed non-ideal and I figure that despite the vibes of "being a living statue that cannot do anything except scream silently in your head" is very cool, probably the desired outcome from players doing this is to die. So now it kills you.

This suicide technically annihilates all of the objects you are wearing, because smashing the statue deletes everything upon your person. I guess I could have added a flag that unpetrifies all of the items you are wearing on death but the whole thing collapsing into dust (as it does now) is more satisfying... I reckon it's probably fine given that this fish is only caught from fishing inside Heretic rifts.

## Changelog

:cl:
fix: Killing yourself with a Gullion fish in an oxygenated environment will correctly turn you into a statue
fix: Killing yourself with a Gullion fish will kill you rather than leaving you as a living statue that can't do anything and forcing you to Ghost manually
/:cl:
