### PR TITLE
Fix runtime when killing yourself via starfish

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -752,19 +752,25 @@
 /datum/status_effect/go_away/deletes_mob
 	id = "go_away_deletes_mob"
 	duration = 30 SECONDS
+	/// Timer that tracks when we should vanish
+	var/deletion_timer
 
 /datum/status_effect/go_away/deletes_mob/on_creation(mob/living/new_owner, set_duration)
 	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(wipe_bozo)), duration, TIMER_DELETE_ME)
-	RegisterSignal(new_owner, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(wipe_bozo))
+	deletion_timer = addtimer(CALLBACK(src, PROC_REF(wipe_bozo)), duration - 5 SECONDS, TIMER_STOPPABLE | TIMER_DELETE_ME)
+	ADD_TRAIT(owner, TRAIT_IMMOBILIZED, REF(src))
+	RegisterSignals(new_owner, list(COMSIG_MOVABLE_Z_CHANGED, COMSIG_LIVING_DEATH), PROC_REF(wipe_bozo))
 
 /datum/status_effect/go_away/deletes_mob/proc/wipe_bozo()
+	deltimer(deletion_timer)
 	owner.fade_into_nothing()
-	qdel(src)
+	UnregisterSignal(owner, list(COMSIG_MOVABLE_Z_CHANGED, COMSIG_LIVING_DEATH))
 
 /datum/status_effect/go_away/deletes_mob/on_remove()
 	. = ..()
-	UnregisterSignal(owner, COMSIG_MOVABLE_Z_CHANGED)
+	deltimer(deletion_timer)
+	REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, REF(src))
+	UnregisterSignal(owner, list(COMSIG_MOVABLE_Z_CHANGED, COMSIG_LIVING_DEATH))
 
 /atom/movable/screen/alert/status_effect/go_away
 	name = "TO THE STARS AND BEYOND!"

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -755,15 +755,16 @@
 
 /datum/status_effect/go_away/deletes_mob/on_creation(mob/living/new_owner, set_duration)
 	. = ..()
+	addtimer(CALLBACK(src, PROC_REF(wipe_bozo)), duration, TIMER_DELETE_ME)
 	RegisterSignal(new_owner, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(wipe_bozo))
 
 /datum/status_effect/go_away/deletes_mob/proc/wipe_bozo()
+	owner.fade_into_nothing()
 	qdel(src)
 
 /datum/status_effect/go_away/deletes_mob/on_remove()
 	. = ..()
-	if(!QDELETED(owner))
-		qdel(owner)
+	UnregisterSignal(owner, COMSIG_MOVABLE_Z_CHANGED)
 
 /atom/movable/screen/alert/status_effect/go_away
 	name = "TO THE STARS AND BEYOND!"

--- a/code/modules/fishing/fish/types/air_space.dm
+++ b/code/modules/fishing/fish/types/air_space.dm
@@ -113,11 +113,15 @@
 
 /obj/item/fish/starfish/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] swallows [src], and looks upwards..."))
-	user.say("I must go. My people need me.", forced = "starfish suicide")
+	if (prob(20))
+		user.say("I must go. My people need me.", forced = "starfish suicide")
 	addtimer(CALLBACK(src, PROC_REF(ascension), user), 1 SECONDS)
 	return MANUAL_SUICIDE
 
 /obj/item/fish/starfish/proc/ascension(mob/living/user)
+	user.visible_message(span_suicide("[user] abandons [user.p_their()] corporeal form!"))
+	user.drop_everything()
+	user.add_filter("space", 1, layering_filter(icon = icon('icons/mob/human/textures.dmi', "spacey"), blend_mode = BLEND_INSET_OVERLAY))
 	user.apply_status_effect(/datum/status_effect/go_away/deletes_mob)
 	qdel(src)
 


### PR DESCRIPTION
## About The Pull Request

When you use a starfish (fished from Hyperspace) to commit suicide your character will walk off screen until they exit the Z level or 30 seconds have elapsed, at which point they are deleted.
Deleting a mob as it attempts to change Z level causes some runtime errors. Happily, we can fix this by delaying and animating the deletion which not only fixes the bug but makes it look a little nicer (although in most cases, nobody but the suicidee will see it).

This _also_ currently causes the obliteration of all of your items which we prefer to avoid in suicides in case something important is destroyed. I have _also_ solved this in an appearance-based way.
Now you drop your entire inventory before beginning your final journey, but because it would look stupid to do this in the nude it applies a starry voidwalker texture to the mob as it starts to leave.

Finally I made it only say the meme line 20% of the time, because it's funny but I hate fun.

## Changelog

:cl:
fix: Killing yourself via starfish no longer causes a runtime error when you float onto another Z level
fix: Killing yourself via starfish now unequips your pants before turning you into an astral being
/:cl:
