### PR TITLE
Fixes the quirk menu not updating

### DIFF
--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -106,7 +106,7 @@
 		// If the client is sending an invalid give_quirk, that means that
 		// something went wrong with the client prediction, so we should
 		// catch it back up to speed.
-		preferences.update_static_data(user)
+		preferences.update_static_data(user, always_instant = TRUE)
 		return TRUE
 
 	preferences.all_quirks = new_quirks
@@ -126,7 +126,7 @@
 		// If the client is sending an invalid remove_quirk, that means that
 		// something went wrong with the client prediction, so we should
 		// catch it back up to speed.
-		preferences.update_static_data(user)
+		preferences.update_static_data(user, always_instant = TRUE)
 		return TRUE
 
 	preferences.all_quirks = new_quirks

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -27,7 +27,6 @@
 	if(response != "Yes")
 		return TRUE
 
-
 /datum/preference_middleware/quirks/post_set_preference(mob/user, preference, value)
 	if(preference != "species")
 		return
@@ -112,7 +111,7 @@
 
 	preferences.all_quirks = new_quirks
 	preferences.character_preview_view?.update_body()
-	preferences.update_static_data(user)
+	preferences.update_static_data(user, always_instant = TRUE)
 
 	return TRUE
 
@@ -132,6 +131,7 @@
 
 	preferences.all_quirks = new_quirks
 	preferences.character_preview_view?.update_body()
+	preferences.update_static_data(user, always_instant = TRUE)
 
 	return TRUE
 

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -112,6 +112,7 @@
 
 	preferences.all_quirks = new_quirks
 	preferences.character_preview_view?.update_body()
+	preferences.update_static_data(user)
 
 	return TRUE
 

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -27,7 +27,6 @@
 	if(response != "Yes")
 		return TRUE
 
-
 /datum/preference_middleware/quirks/post_set_preference(mob/user, preference, value)
 	if(preference != "species")
 		return
@@ -132,6 +131,7 @@
 
 	preferences.all_quirks = new_quirks
 	preferences.character_preview_view?.update_body()
+	preferences.update_static_data(user, always_instant = TRUE)
 
 	return TRUE
 

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -55,12 +55,13 @@
  *
  * required user the mob currently interacting with the ui
  * optional ui ui to be updated
+ * always_instant when set to true stops the ui update cooldown from happening
  */
-/datum/proc/update_static_data(mob/user, datum/tgui/ui)
+/datum/proc/update_static_data(mob/user, datum/tgui/ui, always_instant)
 	if(!ui)
 		ui = SStgui.get_open_ui(user, src)
 	if(ui)
-		ui.send_full_update()
+		ui.send_full_update(always_instant)
 
 /**
  * public

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -61,7 +61,7 @@
 	if(!ui)
 		ui = SStgui.get_open_ui(user, src)
 	if(ui)
-		ui.send_full_update(always_instant)
+		ui.send_full_update(always_instant = always_instant)
 
 /**
  * public

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -219,11 +219,12 @@
  *
  * optional custom_data list Custom data to send instead of ui_data.
  * optional force bool Send an update even if UI is not interactive.
+ * optional always_instant bool Send and update regardless of the cooldown.
  */
-/datum/tgui/proc/send_full_update(custom_data, force)
+/datum/tgui/proc/send_full_update(custom_data, force, always_instant)
 	if(!user.client || !initialized || closing)
 		return
-	if(!COOLDOWN_FINISHED(src, refresh_cooldown))
+	if(!always_instant && !COOLDOWN_FINISHED(src, refresh_cooldown))
 		refreshing = TRUE
 		addtimer(CALLBACK(src, PROC_REF(send_full_update), custom_data, force), COOLDOWN_TIMELEFT(src, refresh_cooldown), TIMER_UNIQUE)
 		return
@@ -233,7 +234,8 @@
 		custom_data,
 		with_data = should_update_data,
 		with_static_data = TRUE))
-	COOLDOWN_START(src, refresh_cooldown, TGUI_REFRESH_FULL_UPDATE_COOLDOWN)
+	if(!always_instant)
+		COOLDOWN_START(src, refresh_cooldown, TGUI_REFRESH_FULL_UPDATE_COOLDOWN)
 
 /**
  * public

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -234,7 +234,8 @@
 		custom_data,
 		with_data = should_update_data,
 		with_static_data = TRUE))
-	COOLDOWN_START(src, refresh_cooldown, TGUI_REFRESH_FULL_UPDATE_COOLDOWN)
+	if(!always_instant)
+		COOLDOWN_START(src, refresh_cooldown, TGUI_REFRESH_FULL_UPDATE_COOLDOWN)
 
 /**
  * public

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -219,11 +219,12 @@
  *
  * optional custom_data list Custom data to send instead of ui_data.
  * optional force bool Send an update even if UI is not interactive.
+ * optional always_instant bool Send and update regardless of the cooldown.
  */
-/datum/tgui/proc/send_full_update(custom_data, force)
+/datum/tgui/proc/send_full_update(custom_data, force, always_instant)
 	if(!user.client || !initialized || closing)
 		return
-	if(!COOLDOWN_FINISHED(src, refresh_cooldown))
+	if(!always_instant && !COOLDOWN_FINISHED(src, refresh_cooldown))
 		refreshing = TRUE
 		addtimer(CALLBACK(src, PROC_REF(send_full_update), custom_data, force), COOLDOWN_TIMELEFT(src, refresh_cooldown), TIMER_UNIQUE)
 		return

--- a/tgui/packages/tgfont/static/tgfont.css
+++ b/tgui/packages/tgfont/static/tgfont.css
@@ -7,25 +7,25 @@
 [class*=" tg-"] {
 	/* biome-ignore lint/complexity/noImportantStyles: Just leave it */
 	font-family: "tgfont" !important;
-	font-size: undefined;
+	font-size: inherit;
 	font-style: normal;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
 
 :root {
-	--tg-air-tank-slash: "ea01";
-	--tg-air-tank: "ea02";
-	--tg-bad-touch: "ea03";
-	--tg-image-minus: "ea04";
-	--tg-image-plus: "ea05";
-	--tg-nanotrasen-logo: "ea06";
-	--tg-non-binary: "ea07";
-	--tg-prosthetic-full: "ea08";
-	--tg-prosthetic-leg: "ea09";
-	--tg-sound-minus: "ea0a";
-	--tg-sound-plus: "ea0b";
-	--tg-syndicate-logo: "ea0c";
+	--tg-air-tank-slash: "\ea01";
+	--tg-air-tank: "\ea02";
+	--tg-bad-touch: "\ea03";
+	--tg-image-minus: "\ea04";
+	--tg-image-plus: "\ea05";
+	--tg-nanotrasen-logo: "\ea06";
+	--tg-non-binary: "\ea07";
+	--tg-prosthetic-full: "\ea08";
+	--tg-prosthetic-leg: "\ea09";
+	--tg-sound-minus: "\ea0a";
+	--tg-sound-plus: "\ea0b";
+	--tg-syndicate-logo: "\ea0c";
 }
 .tg-air-tank-slash::before {
 	content: var(--tg-air-tank-slash);

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
@@ -314,7 +314,7 @@ function QuirkPage() {
 
   const [quirkActionLocked, setQuirkActionLocked] = useState(false);
 
-  function withQuirkDebounce(debounce: () => void, delay = 250) {
+  function withQuirkDebounce(debounce: () => void, delay = 200) {
     if (quirkActionLocked) return;
 
     setQuirkActionLocked(true);

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
@@ -35,7 +35,7 @@ function getColorValueClass(quirk: Quirk) {
 
 function getCorrespondingPreferences(
   customization_options: string[],
-  relevant_preferences: Record<string, string>,
+  relevant_preferences: Record<string, string> = {},
 ) {
   return Object.fromEntries(
     filter(Object.entries(relevant_preferences), ([key, value]) =>
@@ -51,7 +51,7 @@ type QuirkListProps = {
 };
 
 type QuirkProps = {
-  onClick: (quirkName: string, quirk: Quirk) => void;
+  handleClick: (quirkName: string, quirk: Quirk) => void;
   randomBodyEnabled: boolean;
   selected: boolean;
   serverData: ServerData;
@@ -61,7 +61,7 @@ function QuirkList(props: QuirkProps & QuirkListProps) {
   const {
     quirks = [],
     selected,
-    onClick,
+    handleClick,
     serverData,
     randomBodyEnabled,
   } = props;
@@ -71,7 +71,7 @@ function QuirkList(props: QuirkProps & QuirkListProps) {
       {quirks.map(([quirkKey, quirk]) => (
         <Stack.Item key={quirkKey} m={0}>
           <QuirkDisplay
-            onClick={onClick}
+            handleClick={handleClick}
             quirk={quirk}
             quirkKey={quirkKey}
             randomBodyEnabled={randomBodyEnabled}
@@ -91,7 +91,7 @@ type QuirkDisplayProps = {
 } & QuirkProps;
 
 function QuirkDisplay(props: QuirkDisplayProps) {
-  const { quirk, quirkKey, onClick, selected } = props;
+  const { quirk, quirkKey, handleClick, selected } = props;
   const { icon, value, name, description, customizable, failTooltip } = quirk;
 
   const [customizationExpanded, setCustomizationExpanded] = useState(false);
@@ -107,7 +107,7 @@ function QuirkDisplay(props: QuirkDisplayProps) {
           setCustomizationExpanded(false);
         }
 
-        onClick(quirkKey, quirk);
+        handleClick(quirkKey, quirk);
       }}
     >
       <Stack fill g={0}>
@@ -422,7 +422,7 @@ function QuirkPage() {
           <Stack.Item grow className="PreferencesMenu__Quirks__QuirkList">
             <QuirkList
               selected={false}
-              onClick={(quirkName, quirk) => {
+              handleClick={(quirkName, quirk) => {
                 if (getReasonToNotAdd(quirkName) !== undefined) {
                   return;
                 }
@@ -483,7 +483,7 @@ function QuirkPage() {
           <Stack.Item grow className="PreferencesMenu__Quirks__QuirkList">
             <QuirkList
               selected
-              onClick={(quirkName, quirk) => {
+              handleClick={(quirkName, quirk) => {
                 if (getReasonToNotRemove(quirkName) !== undefined) {
                   return;
                 }

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
@@ -108,16 +108,15 @@ function QuirkDisplay(props: QuirkDisplayProps) {
         opacity: props.quirkActionLocked ? 0.6 : 1,
         pointerEvents: props.quirkActionLocked ? 'none' : 'auto',
       }}
-        onClick={(event) => {
-          if (quirkActionLocked) return;
+      onClick={() => {
+        if (quirkActionLocked)
+          return;
+        if (selected) {
+          setCustomizationExpanded(false);
+        }
 
-          event.stopPropagation();
-          if (selected) {
-            setCustomizationExpanded(false);
-          }
-
-          handleClick(quirkKey, quirk);
-        }}
+        handleClick(quirkKey, quirk);
+      }}
     >
       <Stack fill g={0}>
         <Stack.Item

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dropdowns.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/dropdowns.tsx
@@ -136,6 +136,7 @@ export function FeatureIconnedDropdownInput(props: IconnedDropdownInputProps) {
       options={dropdownOptions}
       selected={value}
       width="100%"
+      menuWidth="max-content"
     />
   );
 }


### PR DESCRIPTION
## About The Pull Request

This adds a debounce to the TSX end as well as fixes some issues with the static ui not updated after the recent backend updates. Also fixes the tg local fontawesome icons displaying as unicode literals, as well as an issue with the dropdown being cut off for the nearsightedness quirk preferences. (Fixes https://github.com/tgstation/tgstation/issues/93598)

## Why It's Good For The Game

Bugfix.

## Changelog

:cl:
fix: fixes a bug where the quirk menu does not update when adding/removing quirks
fix: fixes some fontawesome ui icons displaying as unicode literals instead of the actual icons
fix: nearsightedness and other quirk prefs that use iconned dropdowns will no longer be cut off
/:cl: