### PR TITLE
Alt Eigenstasium change pr

### DIFF
--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -107,9 +107,7 @@
 
 /datum/reagent/eigenstate/overdose_process(mob/living/living_mob) //Overdose, makes you teleport randomly
 	. = ..()
-	do_sparks(5, FALSE, living_mob)
-	do_teleport(living_mob, get_turf(living_mob), 10, asoundin = 'sound/effects/phasein.ogg')
-	do_sparks(5, FALSE, living_mob)
+	do_teleport(living_mob, get_turf(living_mob), 10, asoundin = 'sound/effects/phasein.ogg', asoundout = 'sound/effects/phaseout.ogg')
 
 //FOR ADDICTION-LIKE EFFECTS, SEE datum/status_effect/eigenstasium
 

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -74,7 +74,7 @@
 
 	//Teleports you home if it's pure enough
 	if(creation_purity > 0.9 && location_created && data["ingested"])
-		do_teleport(living_mob, location_created, 3, asoundin = 'sound/effects/phasein.ogg')
+		do_teleport(living_mob, location_created, 3, asoundin = 'sound/effects/phasein.ogg', asoundout = 'sound/effects/phaseout.ogg')
 
 	return ..()
 
@@ -88,10 +88,10 @@
 	to_chat(living_mob, span_userdanger("You feel strangely whole again."))
 	if(living_mob.reagents.has_reagent(/datum/reagent/stabilizing_agent))
 		var/obj/effect/overlay/holo_pad_hologram/remaining_spirit = make_appearance(living_mob)
-		var/spirit_duration = max(4 MINUTES - (current_cycle * 5 SECOND), 10 SECONDS)
+		var/spirit_duration = max(5 MINUTES - (current_cycle * 5 SECONDS), 10 SECONDS)
 		remaining_spirit.fade_into_nothing(spirit_duration, spirit_duration)
 	else
-		do_teleport(living_mob, location_return, 3, asoundin = 'sound/effects/phasein.ogg') //Teleports home
+		do_teleport(living_mob, location_return, 3, asoundin = 'sound/effects/phasein.ogg', asoundout = 'sound/effects/phaseout.ogg') //Teleports home
 
 	qdel(eigenstate)
 

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -73,7 +73,7 @@
 	to_chat(living_mob, span_userdanger("You feel like part of yourself has split off!"))
 
 	//Teleports you home if it's pure enough
-	if(location_created && data["ingested"])
+	if(creation_purity > 0.75 && location_created && data["ingested"])
 		do_teleport(living_mob, location_created, 3, asoundin = 'sound/effects/phasein.ogg')
 
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -53,26 +53,28 @@
 	eigen.data["ingested"] = TRUE
 
 //Main functions
+/datum/reagent/eigenstate/proc/make_appearance(mob/living/living_mob)
+	var/obj/effect/overlay/holo_pad_hologram/spirit = new (living_mob.loc)
+	spirit.appearance = living_mob.appearance
+	spirit.alpha = 170
+	spirit.add_atom_colour(LIGHT_COLOR_LIGHT_CYAN, FIXED_COLOUR_PRIORITY)
+	spirit.mouse_opacity = MOUSE_OPACITY_TRANSPARENT//So you can't click on it
+	spirit.layer = FLY_LAYER//Above all the other objects/mobs. Or the vast majority of them.
+	spirit.set_anchored(TRUE) //So space wind cannot drag it.
+	spirit.name = "[living_mob.name]'s Eigenstate"//If someone decides to right click.
+	spirit.set_light(2)	//hologram lighting
+	return spirit
+
 /datum/reagent/eigenstate/on_mob_add(mob/living/living_mob, amount)
 	//make hologram at return point to indicate where someone will go back to
-	eigenstate = new (living_mob.loc)
-	eigenstate.appearance = living_mob.appearance
-	eigenstate.alpha = 170
-	eigenstate.add_atom_colour(LIGHT_COLOR_LIGHT_CYAN, FIXED_COLOUR_PRIORITY)
-	eigenstate.mouse_opacity = MOUSE_OPACITY_TRANSPARENT//So you can't click on it.
-	eigenstate.layer = FLY_LAYER//Above all the other objects/mobs. Or the vast majority of them.
-	eigenstate.set_anchored(TRUE) //So space wind cannot drag it.
-	eigenstate.name = "[living_mob.name]'s Eigenstate"//If someone decides to right click.
-	eigenstate.set_light(2)	//hologram lighting
+	eigenstate = make_appearance(living_mob)
 
 	location_return = get_turf(living_mob)	//sets up return point
 	to_chat(living_mob, span_userdanger("You feel like part of yourself has split off!"))
 
 	//Teleports you home if it's pure enough
-	if(creation_purity > 0.9 && location_created && data["ingested"])
-		do_sparks(5,FALSE,living_mob)
-		do_teleport(living_mob, location_created, 0, asoundin = 'sound/effects/phasein.ogg')
-		do_sparks(5,FALSE,living_mob)
+	if(location_created && data["ingested"])
+		do_teleport(living_mob, location_created, 3, asoundin = 'sound/effects/phasein.ogg')
 
 	return ..()
 
@@ -83,11 +85,14 @@
 
 /datum/reagent/eigenstate/on_mob_delete(mob/living/living_mob) //returns back to original location
 	. = ..()
-	do_sparks(5,FALSE,living_mob)
 	to_chat(living_mob, span_userdanger("You feel strangely whole again."))
-	if(!living_mob.reagents.has_reagent(/datum/reagent/stabilizing_agent))
-		do_teleport(living_mob, location_return, 0, asoundin = 'sound/effects/phasein.ogg') //Teleports home
-		do_sparks(5,FALSE,living_mob)
+	if(living_mob.reagents.has_reagent(/datum/reagent/stabilizing_agent))
+		var/obj/effect/overlay/holo_pad_hologram/remaining_spirit = make_appearance(living_mob)
+		var/spirit_duration = max(4 MINUTES - (current_cycle * 5 SECOND), 10 SECONDS)
+		remaining_spirit.fade_into_nothing(spirit_duration, spirit_duration)
+	else
+		do_teleport(living_mob, location_return, 3, asoundin = 'sound/effects/phasein.ogg') //Teleports home
+
 	qdel(eigenstate)
 
 /datum/reagent/eigenstate/overdose_start(mob/living/living_mob) //Overdose, makes you teleport randomly

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -74,7 +74,7 @@
 
 	//Teleports you home if it's pure enough
 	if(creation_purity > 0.9 && location_created && data["ingested"])
-		do_teleport(living_mob, location_created, 3, asoundin = 'sound/effects/phasein.ogg', asoundout = 'sound/effects/phaseout.ogg')
+		do_teleport(living_mob, location_created, 3, asoundin = 'sound/effects/phasein.ogg')
 
 	return ..()
 
@@ -91,7 +91,7 @@
 		var/spirit_duration = max(5 MINUTES - (current_cycle * 5 SECONDS), 10 SECONDS)
 		remaining_spirit.fade_into_nothing(spirit_duration, spirit_duration)
 	else
-		do_teleport(living_mob, location_return, 3, asoundin = 'sound/effects/phasein.ogg', asoundout = 'sound/effects/phaseout.ogg') //Teleports home
+		do_teleport(living_mob, location_return, 3, asoundin = 'sound/effects/phasein.ogg') //Teleports home
 
 	qdel(eigenstate)
 
@@ -107,7 +107,7 @@
 
 /datum/reagent/eigenstate/overdose_process(mob/living/living_mob) //Overdose, makes you teleport randomly
 	. = ..()
-	do_teleport(living_mob, get_turf(living_mob), 10, asoundin = 'sound/effects/phasein.ogg', asoundout = 'sound/effects/phaseout.ogg')
+	do_teleport(living_mob, get_turf(living_mob), 10, asoundin = 'sound/effects/phasein.ogg')
 
 //FOR ADDICTION-LIKE EFFECTS, SEE datum/status_effect/eigenstasium
 

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -53,8 +53,8 @@
 	eigen.data["ingested"] = TRUE
 
 //Main functions
-/datum/reagent/eigenstate/proc/make_appearance(mob/living/living_mob)
-	var/obj/effect/overlay/holo_pad_hologram/spirit = new (living_mob.loc)
+/datum/reagent/eigenstate/proc/make_appearance(mob/living/living_mob, spawn_loc)
+	var/obj/effect/overlay/holo_pad_hologram/spirit = new (spawn_loc)
 	spirit.appearance = living_mob.appearance
 	spirit.alpha = 170
 	spirit.add_atom_colour(LIGHT_COLOR_LIGHT_CYAN, FIXED_COLOUR_PRIORITY)
@@ -67,7 +67,7 @@
 
 /datum/reagent/eigenstate/on_mob_add(mob/living/living_mob, amount)
 	//make hologram at return point to indicate where someone will go back to
-	eigenstate = make_appearance(living_mob)
+	eigenstate = make_appearance(living_mob, living_mob.loc)
 
 	location_return = get_turf(living_mob)	//sets up return point
 	to_chat(living_mob, span_userdanger("You feel like part of yourself has split off!"))
@@ -87,7 +87,7 @@
 	. = ..()
 	to_chat(living_mob, span_userdanger("You feel strangely whole again."))
 	if(living_mob.reagents.has_reagent(/datum/reagent/stabilizing_agent))
-		var/obj/effect/overlay/holo_pad_hologram/remaining_spirit = make_appearance(living_mob)
+		var/obj/effect/overlay/holo_pad_hologram/remaining_spirit = make_appearance(living_mob, eigenstate.loc)
 		var/spirit_duration = max(5 MINUTES - (current_cycle * 5 SECONDS), 10 SECONDS)
 		remaining_spirit.fade_into_nothing(spirit_duration, spirit_duration)
 	else

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -73,7 +73,7 @@
 	to_chat(living_mob, span_userdanger("You feel like part of yourself has split off!"))
 
 	//Teleports you home if it's pure enough
-	if(creation_purity > 0.75 && location_created && data["ingested"])
+	if(creation_purity > 0.9 && location_created && data["ingested"])
 		do_teleport(living_mob, location_created, 3, asoundin = 'sound/effects/phasein.ogg')
 
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Alt to #94421

1. Eigen teleporting now has a precision of 3, rather than 0
2. If you fail to teleport back due to stabilizing agent, your eigenstate remains there for up to 5 minutes, reduced based on how much eigenstate you were exposed to 

## Why It's Good For The Game

1. This seeks to tackle the "teleport onto a recycler, gg, no re" problem of eigenstasium without tackling the "escape" use or the "teleport into a saw room" use. Rather than being able to teleport someone to the exact place with 100% pinpoint accuracy, you're now teleported into an area around the place. 

2. This seeks to tackle the "0.1u teleport + 4.9u stabilizing without a trace, gg, no re" problem of eigenstasium. The echo it leaves behind will stay longer the less reagent you use, but the more reagent you use - the longer the echo stays in the first place. 

## Changelog

:cl: Melbert
balance: Eigenstasium teleportation now has a precision of 3, up from 0 - meaning the teleport now picks a random tile up to 3 tiles away from the creation spot
balance: If Eigenstasium return teleportation fails - due to stabillizing agent - it leaves an echo behind. The echo lasts for 5 minutes, but is reduced the longer the Eigenstasium metabolized in your body.
/:cl:
