### PR TITLE
Stops `log_mapping()` writing logs during CI & Map Testing

### DIFF
--- a/code/__HELPERS/logging/debug.dm
+++ b/code/__HELPERS/logging/debug.dm
@@ -27,9 +27,11 @@
 /proc/log_mapping(text, skip_world_log)
 #ifdef UNIT_TESTS
 	GLOB.unit_test_mapping_logs += text
+	return
 #endif
 #ifdef MAP_TEST
 	message_admins("Mapping: [text]")
+	return
 #endif
 	logger.Log(LOG_CATEGORY_DEBUG_MAPPING, text)
 	if(skip_world_log)


### PR DESCRIPTION
## About The Pull Request
I noticed during CI logs are displayed twice. You can check the full issue [here](https://github.com/tgstation/tgstation/actions/runs/20635660297/job/59260223145)
<img width="1147" height="479" alt="Screenshot (535)" src="https://github.com/user-attachments/assets/55ea7bf5-3202-4501-b529-45fc817be7c5" />


Map logs are already displayed under `/datum/unit_test/map_test_logging` during CI and to admin chat during map testing. 

So now under these 2 circumstances no logs will be written to the local log file or to the world. Reduces clutter & work done during logging. 