### PR TITLE
Moves talking nullrod claymore init proc into talking nullrod claymore subtype

### DIFF
--- a/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
@@ -220,7 +220,7 @@ GLOBAL_LIST_INIT(nullrod_variants, init_nullrod_variants())
 	hitsound = 'sound/items/weapons/rapierhit.ogg'
 	menu_description = "A sharp blade which provides a low chance of blocking incoming melee attacks. Able to awaken a friendly spirit to provide guidance. Can be worn on the back."
 
-/obj/item/nullrod/spellblade/talking/Initialize(mapload)
+/obj/item/nullrod/claymore/talking/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/spirit_holding)
 
@@ -239,7 +239,7 @@ GLOBAL_LIST_INIT(nullrod_variants, init_nullrod_variants())
 	toolspeed = 0.5 //same speed as an active chainsaw
 	chaplain_spawnable = FALSE //prevents being pickable as a chaplain weapon (it has 30 force)
 
-/obj/item/nullrod/spellblade/talking/chainsword/Initialize(mapload)
+/obj/item/nullrod/claymore/talking/chainsword/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/cuffable_item) //Thanks goodness it cannot be selected by chappies
 	AddComponent(


### PR DESCRIPTION
## About The Pull Request

Spellblade/talking isn't a real subtype, it's supposed to be claymore/talking, and these are causing two extra empty nullrod subtypes to be added to GLOB.nullrod_variants. Also, it means that the gimmick of these nullrods don't work at all.

## Why It's Good For The Game

fixes #94491
The talking sword will talk

## Changelog
:cl:

fix: Nullrod possessed swords will talk
fix: Nullrod variant selection menu will no longer have three normal nullrods as options

/:cl:
