### PR TITLE
The Themeify PDA app no longer has an empty checkbox in its options.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/theme_selector.dm
+++ b/code/modules/modular_computers/file_system/programs/theme_selector.dm
@@ -17,7 +17,10 @@
 
 	if(computer.obj_flags & EMAGGED)
 		data["themes"] += list(list("theme_name" = PDA_THEME_SYNDICATE_NAME, "theme_ref" = GLOB.pda_name_to_theme[PDA_THEME_SYNDICATE_NAME]))
-	for(var/theme_key in GLOB.default_pda_themes + imported_themes)
+	var/list/available_themes = GLOB.default_pda_themes.Copy()
+	if(imported_themes)
+		available_themes += imported_themes
+	for(var/theme_key in available_themes)
 		data["themes"] += list(list("theme_name" = theme_key, "theme_ref" = GLOB.pda_name_to_theme[theme_key]))
 
 	return data


### PR DESCRIPTION
## About The Pull Request
The imported themes list was made lazy, but by adding null to a list, you end up having a new key in that list that is null.

## Why It's Good For The Game
Fixing stuff that ArcaneMusic told me about on Discord.

## Changelog

:cl:
fix: The Themeify PDA app no longer has an empty checkbox in its options.
/:cl:
