### PR TITLE
Fix escape sequence warnings in linter

### DIFF
--- a/tools/define_sanity/check.py
+++ b/tools/define_sanity/check.py
@@ -71,7 +71,7 @@ for applicable_file in files_to_scan:
         for define in define_regex.finditer(file_contents):
             number_of_defines += 1
             define_name = define.group(2)
-            if not re.search("#undef\s" + define_name, file_contents):
+            if not re.search(r"#undef\s" + define_name, file_contents):
                 located_error_tuples.append((define_name, applicable_file))
 
 if number_of_defines == 0:

--- a/tools/icon_cutter/check.py
+++ b/tools/icon_cutter/check.py
@@ -75,7 +75,7 @@ fail_count = 0
 output_hash = {}
 files = []
 if platform.system() == "Windows":
-    files = glob.glob(f"{path_to_us}\..\\..\\icons\\**\*.toml", recursive = True)
+    files = glob.glob(f"{path_to_us}\\..\\..\\icons\\**\\*.toml", recursive = True)
 else:
     files = glob.glob(f"{path_to_us}/../../icons/**/*.toml", recursive = True)
 for cutter_template in files:
@@ -100,7 +100,7 @@ if len(output_hash) == 0:
 
 # Execute cutter
 if platform.system() == "Windows":
-    subprocess.run(f"{path_to_us}\..\\build\\build.bat --force-recut --ci icon-cutter")
+    subprocess.run(f"{path_to_us}\\..\\build\\build.bat --force-recut --ci icon-cutter")
 else:
     subprocess.run(f"{path_to_us}/../build/build.sh --force-recut --ci icon-cutter", shell = True)
 


### PR DESCRIPTION

## About The Pull Request

Three warnings are being thrown up in the linter CI because of improper escape sequences, changes one to a raw string and adds extra backslashes to the others

## Why It's Good For The Game

```
/home/runner/work/tgstation/tgstation/tools/define_sanity/check.py:74: SyntaxWarning: invalid escape sequence '\s'
  if not re.search("#undef\s" + define_name, file_contents):
/home/runner/work/tgstation/tgstation/tools/icon_cutter/check.py:78: SyntaxWarning: invalid escape sequence '\.'
  files = glob.glob(f"{path_to_us}\..\\..\\icons\\**\*.toml", recursive = True)
/home/runner/work/tgstation/tgstation/tools/icon_cutter/check.py:103: SyntaxWarning: invalid escape sequence '\.'
  subprocess.run(f"{path_to_us}\..\\build\\build.bat --force-recut --ci icon-cutter")
```

## Changelog

N/A
