### PR TITLE
Adds some safeties to ensure that hotspots don't cause an infinite infectious runtime and crash clients

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -115,12 +115,15 @@
 		if(!to_check.active_hotspot)
 			continue
 		var/obj/effect/hotspot/enemy_spot = to_check.active_hotspot
+		// Safeguard to prevent infectious init runtimes for hotspots if we somehow end up with a hotspot without a group
+		if(!enemy_spot.our_hot_group)
+			continue
 		if(!our_hot_group)
 			enemy_spot.our_hot_group.add_to_group(src)
-		else if(our_hot_group != enemy_spot.our_hot_group && enemy_spot.our_hot_group) //if we belongs to a hot group from prior loop and we encounter another hot spot with a group then we merge
+		else if(our_hot_group != enemy_spot.our_hot_group) //if we belongs to a hot group from prior loop and we encounter another hot spot with a group then we merge
 			our_hot_group.merge_hot_groups(enemy_spot.our_hot_group)
 
-	if(!our_hot_group)//if after loop through all the adjacents turfs and we havent belong to a group yet, make our own
+	if(QDELETED(our_hot_group))//if after loop through all the adjacents turfs and we havent belong to a group yet, make our own
 		our_hot_group = new
 		our_hot_group.add_to_group(src)
 


### PR DESCRIPTION

## About The Pull Request

Not 100% sure, but somehow we ended up with a missing hot group on Terry which caused newer hotspots to runtime and not get theirs which caused more hotspots- you get it.
Only idea I have is that possibly we could've gotten a hard delete, but there are none in the logs? This should solve the infinite hotspot runtimes at the very least, and possibly? prevent harddels by changing the nullcheck to a qdel check.

## Changelog
:cl:
fix: Added some safeties to ensure that hotspots don't cause an infinite infectious runtime and crash clients
/:cl:
