### PR TITLE
Fixes lingering language holders caused by the sleeping carp

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -45,7 +45,8 @@
 	remove_from.remove_traits(scarp_traits, SLEEPING_CARP_TRAIT)
 	UnregisterSignal(remove_from, list(COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_PRE_BULLET_ACT, COMSIG_LIVING_CHECK_BLOCK))
 	remove_from.faction -= FACTION_CARP //:(
-	remove_from.remove_language(/datum/language/carptongue, ALL, type)
+	if (!QDELING(remove_from))
+		remove_from.remove_language(/datum/language/carptongue, ALL, type)
 	return ..()
 
 /datum/martial_art/the_sleeping_carp/proc/check_streak(mob/living/attacker, mob/living/defender)


### PR DESCRIPTION

## About The Pull Request

Sleeping Carp tried to remove the lang holder when the owner was being destroyed, which would cause the holder to be re-instantiated mid-deletion

## Changelog
:cl:
fix: Fixed lingering language holders caused by the sleeping carp
/:cl:
