### PR TITLE
Fixes ebows sprites not resetting on recharge

### DIFF
--- a/code/modules/projectiles/guns/energy/recharge.dm
+++ b/code/modules/projectiles/guns/energy/recharge.dm
@@ -94,8 +94,11 @@
 
 /obj/item/gun/energy/recharge/update_icon_state()
 	. = ..()
-	if(no_charge_state && !can_shoot())
-		icon_state = no_charge_state
+	if(no_charge_state)
+		if(can_shoot())
+			icon_state = base_icon_state
+		else
+			icon_state = no_charge_state
 
 /obj/item/gun/energy/recharge/ebow
 	name = "mini energy crossbow"


### PR DESCRIPTION

## About The Pull Request

Resets icon-based `energy/recharge` gun's sprites when they're ready to fire again. This only applies to ebows.

## Why It's Good For The Game

fixes #93988

## Changelog
:cl:

fix: Ebow sprites appear loaded after reloading

/:cl:
