### PR TITLE
Stack items have a number indicating stack size in inventory

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -375,7 +375,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	SET_PLANE_IMPLICIT(thing, initial(thing.plane))
 	thing.mouse_opacity = initial(thing.mouse_opacity)
 	thing.screen_loc = null
-	if(thing.maptext)
+	if(numerical_stacking)
 		thing.maptext = ""
 
 /**

--- a/code/datums/storage/storage_interface.dm
+++ b/code/datums/storage/storage_interface.dm
@@ -113,7 +113,8 @@
 	for(var/obj/item as anything in storage_contents)
 		item.mouse_opacity = MOUSE_OPACITY_OPAQUE
 		item.screen_loc = "[current_x]:[screen_pixel_x],[current_y]:[screen_pixel_y]"
-		item.maptext = storage_contents[item]
+		if(parent_storage.numerical_stacking)
+			item.maptext = storage_contents[item]
 		SET_PLANE(item, ABOVE_HUD_PLANE, our_turf)
 		current_x++
 		if(current_x - screen_start_x < columns)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -125,10 +125,16 @@
 	mats_per_unit = null
 	return ..()
 
+/obj/item/stack/update_name(updates)
+	. = ..()
+	maptext = (ismob(loc) || loc?.atom_storage) ? MAPTEXT("<font color='white'>[amount]</font>") : ""
+
 /obj/item/stack/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
 	. = ..()
 	if((!throwing || throwing.target_turf == loc) && old_loc != loc && (flags_1 & INITIALIZED_1))
 		merge_with_loc(merge_into_ourselves = !isnull(pulledby))
+	if(ismob(loc) || ismob(old_loc) || loc?.atom_storage || old_loc?.atom_storage)
+		update_appearance(UPDATE_NAME)
 
 ///Called to lazily update the materials of the item whenever the used or if more is added
 /obj/item/stack/proc/update_custom_materials()


### PR DESCRIPTION
## About The Pull Request

<img width="528" height="200" alt="image" src="https://github.com/user-attachments/assets/41a30b57-2799-44c8-82cd-ce2f8c8c22c4" />

Number only shows up when it's in the inventory or held - in world it looks as-normal

(I'm pretty sure this idea was subconsciously inspired by another server, but I don't remember...)

## Why It's Good For The Game

Makes it easier to use stacks that don't have a visual sprite change - IE you no longer have to spam examine to see how many you have left

## Changelog

:cl: Melbert
qol: Stack items have a number indicating stack size while held or in inventory.
/:cl:
