### PR TITLE
Turns on skillchip failsafe message when changing species

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -438,7 +438,7 @@
 
 	// If we have some sort of brain type or subtype change and have skillchips, engage the failsafe procedure!
 	if(owner && length(skillchips) && (replacement_brain.type != type))
-		activate_skillchip_failsafe(silent = TRUE)
+		activate_skillchip_failsafe()
 
 	// Check through all our skillchips, remove them from this brain, add them to the replacement brain.
 	for(var/chip in skillchips)

--- a/code/modules/mob/living/brain/skillchip.dm
+++ b/code/modules/mob/living/brain/skillchip.dm
@@ -130,7 +130,7 @@
 /**
  * Deactivates all chips currently in the brain.
  */
-/obj/item/organ/brain/proc/activate_skillchip_failsafe(silent = TRUE)
+/obj/item/organ/brain/proc/activate_skillchip_failsafe()
 	if(QDELETED(owner))
 		return
 
@@ -144,14 +144,14 @@
 			continue
 
 		// Try force-deactivate it.
-		skillchip.try_deactivate_skillchip(silent, TRUE)
+		skillchip.try_deactivate_skillchip(FALSE, TRUE)
 
 		// If it's now no longer active, up the tally.
 		if(!skillchip.active)
 			chip_tally++
 
-	if(chip_tally && !silent)
-		to_chat(owner, span_warning("Unusual brain biology detected during regeneration. Failsafe procedure engaged. [chip_tally] skillchips have been deactivated."))
+	if(chip_tally)
+		to_chat(owner, span_warning("Unusual brain biology detected. Failsafe procedure engaged. [chip_tally] skillchip[chip_tally == 1 ? " has" : "s have"] been deactivated."))
 
 /// Disables or re-enables any extra skillchips after skillchip limit changes.
 /obj/item/organ/brain/proc/update_skillchips()


### PR DESCRIPTION
## About The Pull Request

Shapeshifting such that your brain is changed to another brain calls `activate_skillchip_failsafe()`, turning off your chips. This is a silenced call, so no feedback is provided to the player that their skillchips have been turned off, and it is reasonably assumed that they were simply deleted. This is also the only place `activate_skillchip_failsafe()` is called, so the message cannot ever play. 

This pr removes the `silent` argument, and thus makes the failsafe tell you that it's turned off your chips.

## Why It's Good For The Game

Closes #93796 (gets closed regardless, i suppose)
When this first happened to me, I also thought that it had simply deleted the skillchips. This interaction was initially enabled, with `silent` being false, prior to an undocumented change in #71566. Given that this is the only place that this proc is called, I do not see why a `silent` argument should exist at all.

## Changelog
:cl:

spellcheck: When your skillchips are turned off from shapeshifting, you will now be told.

/:cl:
