### PR TITLE
Redirect surgical tool clicks on surgical tables that have a surgical patient

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -1033,7 +1033,7 @@
 // surgical tools cannot be placed on the op table while a patient is also on it
 /obj/structure/table/optable/table_place_act(mob/living/user, obj/item/tool, list/modifiers)
 	if(!isnull(patient) && (tool.item_flags & SURGICAL_TOOL))
-		return NONE
+		return tool.melee_attack_chain(user, src, modifiers)
 
 	return ..()
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -1033,7 +1033,8 @@
 // surgical tools cannot be placed on the op table while a patient is also on it
 /obj/structure/table/optable/table_place_act(mob/living/user, obj/item/tool, list/modifiers)
 	if(!isnull(patient) && (tool.item_flags & SURGICAL_TOOL))
-		return tool.melee_attack_chain(user, src, modifiers)
+		tool.melee_attack_chain(user, patient, modifiers)
+		return ITEM_INTERACT_SUCCESS
 
 	return ..()
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -1030,6 +1030,13 @@
 /obj/structure/table/optable/make_climbable()
 	AddElement(/datum/element/elevation, pixel_shift = 12)
 
+// surgical tools cannot be placed on the op table while a patient is also on it
+/obj/structure/table/optable/table_place_act(mob/living/user, obj/item/tool, list/modifiers)
+	if(!isnull(patient) && (tool.item_flags & SURGICAL_TOOL))
+		return NONE
+
+	return ..()
+
 ///Align the mob with the table when buckled.
 /obj/structure/table/optable/post_buckle_mob(mob/living/buckled)
 	buckled.add_offsets(type, z_add = 6)


### PR DESCRIPTION
## About The Pull Request

if a surgery table has a patient on it, and you click it with a surgical tool, it redirects the click to the patient instead of placing the tool on the table

## Why It's Good For The Game

sometimes you misclick on the one pixel of transparency and the tool is lost to the sands of time. this is annoying

## Changelog

:cl: Melbert
qol: If a surgery table has a patient on it, and you click it with a surgical tool, it redirects the click to the patient instead of placing the tool on the table
/:cl:
