### PR TITLE
Reset pixel x/y of tactical objects when hiding behind them

### DIFF
--- a/code/datums/components/tactical.dm
+++ b/code/datums/components/tactical.dm
@@ -50,6 +50,8 @@
 	current_slot = slot
 	source.pixel_x = source.base_pixel_x
 	source.pixel_y = source.base_pixel_y
+	source.pixel_w = source.base_pixel_w
+	source.pixel_z = source.base_pixel_z
 
 	on_icon_update(source)
 

--- a/code/datums/components/tactical.dm
+++ b/code/datums/components/tactical.dm
@@ -48,6 +48,8 @@
 	ADD_TRAIT(user, TRAIT_UNKNOWN_APPEARANCE, REF(src))
 
 	current_slot = slot
+	source.pixel_x = source.base_pixel_x
+	source.pixel_y = source.base_pixel_y
 
 	on_icon_update(source)
 


### PR DESCRIPTION
## About The Pull Request

Fixes #94180 
When you pick up an item with the "tactical" component you hide behind it, this is primarily applied to potted plants and cardboard cutouts.
Potted plants are the kind fo item that mappers occasionally like to adjust the position of to make them look like they're on desks or something, however if you hid behind an offset plant then it would maintain the offset until dropped meaning that you could appear to be in the wrong tile.
When you pick up an item you can hide behind it will now first reset its apparent position.

## Changelog

:cl:
fix: When you pick up a plant pot and hide behind it you will now also move it in front of you, in case it is visually far away from your position
/:cl:
