### PR TITLE
Adds a preference to adjust emissive bloom size

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -118,6 +118,11 @@ GLOBAL_LIST_INIT(em_block_color, EM_BLOCK_COLOR)
 /// A globally cached version of [EM_MASK_MATRIX] for quick access.
 GLOBAL_LIST_INIT(em_mask_matrix, EM_MASK_MATRIX)
 
+/// Maximum selectable value for emissive bloom, minimum being 0 which just disables it outright
+#define MAXIMUM_EMISSIVE_BLOOM_SIZE 5
+/// Default value for emissive bloom
+#define DEFAULT_EMISSIVE_BLOOM_SIZE 2
+
 /// Parse the hexadecimal color into lumcounts of each perspective.
 #define PARSE_LIGHT_COLOR(source) \
 do { \

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -138,7 +138,12 @@
 /atom/movable/screen/plane_master/rendering_plate/emissive_bloom/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
 	add_filter("emissive_mask", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(EMISSIVE_BLOOM_MASK_RENDER_TARGET, offset)))
-	add_filter("emissive_bloom", 2, bloom_filter(threshold = COLOR_BLACK, size = 2, offset = 1))
+	var/bloom_scale = hud_owner?.mymob?.client?.prefs?.read_preference(/datum/preference/numeric/emissive_bloom)
+	if (isnull(bloom_scale))
+		bloom_scale = DEFAULT_EMISSIVE_BLOOM_SIZE
+	// 0 disables the bloom
+	if (bloom_scale)
+		add_filter("emissive_bloom", 2, bloom_filter(threshold = COLOR_BLACK, size = bloom_scale, offset = ceil(bloom_scale / 2)))
 
 /atom/movable/screen/plane_master/rendering_plate/specular_mask
 	name = "Specular mask plate"

--- a/code/modules/client/preferences/emissive_bloom.dm
+++ b/code/modules/client/preferences/emissive_bloom.dm
@@ -1,0 +1,28 @@
+/// Size of the bloom filter applied to the emissive plane, mostly as a visual preference
+/datum/preference/numeric/emissive_bloom
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "emissive_bloom"
+	savefile_identifier = PREFERENCE_PLAYER
+
+	minimum = 0
+	maximum = MAXIMUM_EMISSIVE_BLOOM_SIZE
+
+/datum/preference/numeric/emissive_bloom/create_default_value()
+	return DEFAULT_EMISSIVE_BLOOM_SIZE
+
+/datum/preference/numeric/emissive_bloom/apply_to_client(client/client, value)
+	// Update the plane master filter
+	var/datum/hud/my_hud = client.mob?.hud_used
+	if(!my_hud)
+		return
+
+	for(var/atom/movable/screen/plane_master/bloom as anything in my_hud.get_true_plane_masters(RENDER_PLANE_EMISSIVE_BLOOM))
+		if (!bloom.get_filter("emissive_bloom"))
+			if (value)
+				bloom.add_filter("emissive_bloom", 2, bloom_filter(threshold = COLOR_BLACK, size = value, offset = ceil(value / 2)))
+			continue
+
+		if (value)
+			bloom.modify_filter("emissive_bloom", list("size" = value, "offset" = ceil(value / 2)))
+		else
+			bloom.remove_filter("emissive_bloom")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3985,6 +3985,7 @@
 #include "code\modules\client\preferences\broadcast_login_logout.dm"
 #include "code\modules\client\preferences\chipped.dm"
 #include "code\modules\client\preferences\clothing.dm"
+#include "code\modules\client\preferences\emissive_bloom.dm"
 #include "code\modules\client\preferences\food_allergy.dm"
 #include "code\modules\client\preferences\fps.dm"
 #include "code\modules\client\preferences\gender.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/emissive_bloom.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/emissive_bloom.tsx
@@ -1,0 +1,8 @@
+import { type Feature, FeatureSliderInput } from '../base';
+
+export const emissive_bloom: Feature<number> = {
+  name: 'Emissive Bloom Strength',
+  category: 'GAMEPLAY',
+  description: `How strong the bloom on emissive objects, such as computer screens, is. This has negligible performance impact.`,
+  component: FeatureSliderInput,
+};


### PR DESCRIPTION

## About The Pull Request

Adds a slider to the gameplay tab which allows users to control the size of the emissive bloom.

## Why It's Good For The Game

This is mostly visual and doesn't have a noticeable performance impact, but some people might find it distracting or might want a stronger bloom for prettier lights.

## Changelog
:cl:
qol: Added a preference to adjust emissive bloom size
/:cl:
