### PR TITLE
Polymorph belt plays nicely with mob evolution

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_spell.dm
+++ b/code/__DEFINES/dcs/signals/signals_spell.dm
@@ -124,6 +124,3 @@
 	#define COMPONENT_ITEM_CHARGED (1 << 0)
 	/// Return if the item had a negative side effect occur while recharging
 	#define COMPONENT_ITEM_BURNT_OUT (1 << 1)
-
-/// Sent from /datum/action/cooldown/spell/shapeshift/polymorph_belt/proc/update_type with the new typepath the belt turns you into
-#define COMSIG_BELT_MOB_TYPE_CHANGED "belt_mob_type_changed"

--- a/code/__DEFINES/dcs/signals/signals_spell.dm
+++ b/code/__DEFINES/dcs/signals/signals_spell.dm
@@ -125,6 +125,5 @@
 	/// Return if the item had a negative side effect occur while recharging
 	#define COMPONENT_ITEM_BURNT_OUT (1 << 1)
 
-
 /// Sent from /datum/action/cooldown/spell/shapeshift/polymorph_belt/proc/update_type with the new typepath the belt turns you into
 #define COMSIG_BELT_MOB_TYPE_CHANGED "belt_mob_type_changed"

--- a/code/__DEFINES/dcs/signals/signals_spell.dm
+++ b/code/__DEFINES/dcs/signals/signals_spell.dm
@@ -124,3 +124,7 @@
 	#define COMPONENT_ITEM_CHARGED (1 << 0)
 	/// Return if the item had a negative side effect occur while recharging
 	#define COMPONENT_ITEM_BURNT_OUT (1 << 1)
+
+
+/// Sent from /datum/action/cooldown/spell/shapeshift/polymorph_belt/proc/update_type with the new typepath the belt turns you into
+#define COMSIG_BELT_MOB_TYPE_CHANGED "belt_mob_type_changed"

--- a/code/datums/components/evolutionary_leap.dm
+++ b/code/datums/components/evolutionary_leap.dm
@@ -23,9 +23,9 @@
 		RegisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING, PROC_REF(comp_on_round_start))
 		return
 
-	//if the round has already taken long enough, just leap right away.
+	//if the round has already taken long enough, evolve in five seconds.
 	if((world.time - SSticker.round_start_time) > evolve_mark)
-		leap(silent = TRUE)
+		addtimer(CALLBACK(src, PROC_REF(leap)), 3 SECONDS, TIMER_DELETE_ME)
 		return
 
 	setup_timer()
@@ -49,12 +49,11 @@
 	var/mark = evolve_mark - sum
 	timer_id = addtimer(CALLBACK(src, PROC_REF(leap), FALSE), mark, TIMER_STOPPABLE)
 
-/datum/component/evolutionary_leap/proc/leap(silent)
+/datum/component/evolutionary_leap/proc/leap()
 	var/mob/living/old_mob = parent
 	if (old_mob.stat == DEAD)
 		return
 	var/mob/living/new_mob = evolve_path
 	var/new_mob_name = initial(new_mob.name)
-	if(!silent)
-		old_mob.visible_message(span_warning("[old_mob] evolves into \a [new_mob_name]!"))
+	old_mob.visible_message(span_warning("[old_mob] evolves into \a [new_mob_name]!"))
 	old_mob.change_mob_type(evolve_path, old_mob.loc, new_name = new_mob_name, delete_old_mob = TRUE)

--- a/code/datums/components/evolutionary_leap.dm
+++ b/code/datums/components/evolutionary_leap.dm
@@ -23,7 +23,7 @@
 		RegisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING, PROC_REF(comp_on_round_start))
 		return
 
-	//if the round has already taken long enough, evolve in five seconds.
+	//if the round has already taken long enough, evolve in three seconds.
 	if((world.time - SSticker.round_start_time) > evolve_mark)
 		addtimer(CALLBACK(src, PROC_REF(leap)), 3 SECONDS, TIMER_DELETE_ME)
 		return

--- a/code/modules/clothing/belts/polymorph_belt.dm
+++ b/code/modules/clothing/belts/polymorph_belt.dm
@@ -98,13 +98,7 @@
 		return
 	if (isnull(transform_action))
 		transform_action = add_item_action(/datum/action/cooldown/spell/shapeshift/polymorph_belt)
-		RegisterSignal(transform_action, COMSIG_BELT_MOB_TYPE_CHANGED, PROC_REF(on_belt_mob_changed))
 	transform_action.update_type(stored_mob_type)
-
-/// If anything else changes our belt transform type we should track it
-/obj/item/polymorph_belt/proc/on_belt_mob_changed(typepath)
-	SIGNAL_HANDLER
-	stored_mob_type = typepath
 
 /// Pre-activated polymorph belt
 /obj/item/polymorph_belt/functioning
@@ -179,7 +173,6 @@
 	var/mob/living/will_become = transform_type
 	desc = "Assume your [initial(will_become.name)] form!"
 	build_all_button_icons(update_flags = UPDATE_BUTTON_NAME)
-	SEND_SIGNAL(src, COMSIG_BELT_MOB_TYPE_CHANGED, shapeshift_type)
 
 /// Subtype of the polymorph status effect which tracks arbitrary mob transformation
 /datum/status_effect/shapechange_mob/from_spell/polymorph_belt
@@ -195,11 +188,7 @@
 /datum/status_effect/shapechange_mob/from_spell/polymorph_belt/proc/on_type_change(mob/living/source, mob/living/new_mob)
 	SIGNAL_HANDLER
 	var/caster = caster_mob // Will be unset when the mob is unshifted
-	var/datum/action/cooldown/spell/shapeshift/polymorph_belt/transform_action = source_weakref?.resolve()
-
-	if (istype(transform_action))
-		transform_action.update_type(new_mob.type)
-	else
-		restore_caster()
-
+	var/datum/action/cooldown/spell/shapeshift/transform_action = source_weakref?.resolve()
+	transform_action.possible_shapes |= new_mob.type
+	restore_caster()
 	new_mob.apply_status_effect(type, caster, transform_action)

--- a/code/modules/clothing/belts/polymorph_belt.dm
+++ b/code/modules/clothing/belts/polymorph_belt.dm
@@ -98,7 +98,13 @@
 		return
 	if (isnull(transform_action))
 		transform_action = add_item_action(/datum/action/cooldown/spell/shapeshift/polymorph_belt)
+		RegisterSignal(transform_action, COMSIG_BELT_MOB_TYPE_CHANGED, PROC_REF(on_belt_mob_changed))
 	transform_action.update_type(stored_mob_type)
+
+/// If anything else changes our belt transform type we should track it
+/obj/item/polymorph_belt/proc/on_belt_mob_changed(typepath)
+	SIGNAL_HANDLER
+	stored_mob_type = typepath
 
 /// Pre-activated polymorph belt
 /obj/item/polymorph_belt/functioning
@@ -115,6 +121,7 @@
 	spell_requirements = NONE
 	possible_shapes = list(/mob/living/basic/cockroach)
 	can_be_shared = FALSE
+	shapechange_type = /datum/status_effect/shapechange_mob/from_spell/polymorph_belt
 	/// Amount of time it takes us to transform back or forth
 	var/channel_time = 3 SECONDS
 
@@ -172,3 +179,27 @@
 	var/mob/living/will_become = transform_type
 	desc = "Assume your [initial(will_become.name)] form!"
 	build_all_button_icons(update_flags = UPDATE_BUTTON_NAME)
+	SEND_SIGNAL(src, COMSIG_BELT_MOB_TYPE_CHANGED, shapeshift_type)
+
+/// Subtype of the polymorph status effect which tracks arbitrary mob transformation
+/datum/status_effect/shapechange_mob/from_spell/polymorph_belt
+
+/datum/status_effect/shapechange_mob/from_spell/polymorph_belt/on_apply()
+	. = ..()
+	RegisterSignal(owner, COMSIG_MOB_CHANGED_TYPE, PROC_REF(on_type_change))
+
+/datum/status_effect/shapechange_mob/from_spell/polymorph_belt/on_pre_type_change(mob/living/source)
+	return // Stub out base effect because we don't want to cancel if they transform
+
+/// If our mob transforms (via aging usually) then move the status effect across to the new mob
+/datum/status_effect/shapechange_mob/from_spell/polymorph_belt/proc/on_type_change(mob/living/source, mob/living/new_mob)
+	SIGNAL_HANDLER
+	var/caster = caster_mob // Will be unset when the mob is unshifted
+	var/datum/action/cooldown/spell/shapeshift/polymorph_belt/transform_action = source_weakref?.resolve()
+
+	if (istype(transform_action))
+		transform_action.update_type(new_mob.type)
+	else
+		restore_caster()
+
+	new_mob.apply_status_effect(type, caster, transform_action)

--- a/code/modules/spells/spell_types/shapeshift/_shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shapeshift.dm
@@ -29,6 +29,9 @@
 	/// This should be implemented even if there is only one choice.
 	var/list/atom/possible_shapes
 
+	/// The shapechange status effect to apply to our mob, it should be a subtype of this if you change it
+	var/shapechange_type = /datum/status_effect/shapechange_mob/from_spell
+
 /datum/action/cooldown/spell/shapeshift/Remove(mob/remove_from)
 	unshift_owner()
 	return ..()
@@ -146,7 +149,7 @@
 /// Actually does the shapeshift, for the caster.
 /datum/action/cooldown/spell/shapeshift/proc/do_shapeshift(mob/living/caster)
 	var/mob/living/new_shape = create_shapeshift_mob(caster.loc)
-	var/datum/status_effect/shapechange_mob/shapechange = new_shape.apply_status_effect(/datum/status_effect/shapechange_mob/from_spell, caster, src)
+	var/datum/status_effect/shapechange_mob/shapechange = new_shape.apply_status_effect(shapechange_type, caster, src)
 	if(!shapechange)
 		// We failed to shift, maybe because we were already shapeshifted?
 		// Whatver the case, this shouldn't happen, so throw a stack trace.
@@ -169,7 +172,7 @@
 
 /// Actually does the un-shapeshift, from the caster. (Caster is a shapeshifted mob.)
 /datum/action/cooldown/spell/shapeshift/proc/do_unshapeshift(mob/living/caster)
-	var/datum/status_effect/shapechange_mob/shapechange = caster.has_status_effect(/datum/status_effect/shapechange_mob/from_spell)
+	var/datum/status_effect/shapechange_mob/shapechange = caster.has_status_effect(shapechange_type)
 	if(!shapechange)
 		// We made it to do_unshapeshift without having a shapeshift status effect, this shouldn't happen.
 		to_chat(caster, span_warning("You can't un-shapeshift from this form!"))
@@ -181,7 +184,7 @@
 	pre_shift_requirements = null
 
 	var/mob/living/unshapeshifted_mob = shapechange.caster_mob
-	caster.remove_status_effect(/datum/status_effect/shapechange_mob/from_spell)
+	caster.remove_status_effect(shapechange_type)
 	return unshapeshifted_mob
 
 /// Helper proc that instantiates the mob we shapeshift into.


### PR DESCRIPTION
## About The Pull Request

Fixes #82319
Fixes #94129

If your mob type changes while you are transformed via the polymorph belt, it will transfer the polymorph status to the new mob.
This means that turning into a Bileworm after Bileworms have evolved will no longer ghost you, and instead you will just keep playing as a vileworm. 
Additionally it means if you copy a chick, spiderling, juvenile lobster, and walk around as one of those for long enough to grow up, it will seamlessly move you over.
Or if you turn into a mouse and a nearby regal rat uses their riot ability it will transform you into a rat, etc.

If you change back into a human and then change back into your mob you will return to the original state though. 

I decided to put this on a new subtype of the status effect rather than the base type because I think it's more of a programming issue if this happens for an ability with a fixed transform type (and we wouldn't want to mutate the possible shapes list in that case), so in those cases we should keep the existing behaviour of just untransforming you.

Additionally, I made the evolutionary leap component always wait a minimum of three seconds instead of being instant before transforming a mob. This means that other things have time to register signals and react to the transformation, so you should never be deleted by bileworm evolution any more.

## Why It's Good For The Game

This fixes a few long-standing bugs and seems more fun than untransforming you.

## Changelog

:cl:
fix: If you use the polymorph belt to turn into a mob which transforms into another mob, it won't ghost you or kick you out upon transformation. 
/:cl:
