### PR TITLE
Fix clipboard interaction bugs

### DIFF
--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -73,6 +73,7 @@
 	to_chat(user, span_notice("You remove [paper] from [src]."))
 
 /obj/item/clipboard/proc/remove_pen(mob/user)
+	var/obj/item/pen/pen = src.pen
 	pen.forceMove(user.loc)
 	user.put_in_hands(pen)
 	to_chat(user, span_notice("You remove [pen] from [src]."))

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -60,8 +60,8 @@
 /obj/item/clipboard/examine()
 	. = ..()
 	if(!integrated_pen && pen)
-		. += span_notice("Alt-click to remove [pen].")
-	if(top_paper)
+		. += span_notice("Right-click to remove [pen].")
+	else if(top_paper)
 		. += span_notice("Right-click to remove [top_paper].")
 
 /// Take out the topmost paper
@@ -91,17 +91,6 @@
 	top_paper = locate(/obj/item/paper) in src
 	update_icon()
 
-/obj/item/clipboard/click_alt(mob/user)
-	if(isnull(pen))
-		return CLICK_ACTION_BLOCKING
-
-	if(integrated_pen)
-		to_chat(user, span_warning("You can't seem to find a way to remove [src]'s [pen]."))
-		return CLICK_ACTION_BLOCKING
-
-	remove_pen(user)
-	return CLICK_ACTION_SUCCESS
-
 /obj/item/clipboard/update_overlays()
 	. = ..()
 	var/paper_to_add = get_paper_overlay()
@@ -122,7 +111,10 @@
 
 /obj/item/clipboard/attack_hand(mob/user, list/modifiers)
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
-		remove_paper(top_paper, user)
+		if(!integrated_pen && pen)
+			remove_pen(user)
+		else
+			remove_paper(top_paper, user)
 		return TRUE
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request

* In `remove_pen`, the `forceMove` calls `Exited` which sets `pen` to null, failing to put it in the user's hands and showing the wrong message. Now fixed.
* The `reskinnable_item` component eats alt-clicks, meaning the "alt-click to remove pen" messaging was incorrect. Instead, right-click now removes first the pen, then the top paper. Possibly caused by #93775?
 
## Changelog

:cl:
fix: Removing the pen from a clipboard is now done by right-clicking, instead of alt-clicking which conflicted with restyling.
fix: Removing the pen from a clipboard now puts it in your hand instead of on the floor.
/:cl:
