### PR TITLE
Corrects incorrect RPD preview menu & allows you to place clockwise rotator pieces

### DIFF
--- a/code/_globalvars/pipe_info.dm
+++ b/code/_globalvars/pipe_info.dm
@@ -57,7 +57,7 @@
 	var/list/rows = list()
 	for(var/dir in dirs)
 		var/numdir = text2num(dir)
-		var/flipped = ((dirtype == PIPE_TRIN_M) || (dirtype == PIPE_UNARY_FLIPPABLE) || (dirtype == PIPE_ONEDIR_FLIPPABLE)) && (ISDIAGONALDIR(numdir))
+		var/flipped = ((dirtype == PIPE_UNARY_FLIPPABLE) || (dirtype == PIPE_ONEDIR_FLIPPABLE)) && (ISDIAGONALDIR(numdir))
 		var/is_variant_selected = selected && (!selected_dir ? FALSE : (dirtype == PIPE_ONEDIR ? TRUE : (numdir == selected_dir)))
 		rows += list(list(
 			"selected" = is_variant_selected,

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -38,9 +38,9 @@
 
 	// this only gets used by pipes created by RPDs or pipe dispensers
 	if(flip)
-		// Simulate two right clicks to flip this thing upside down
-		usr.base_click_alt_secondary(src)
-		usr.base_click_alt_secondary(src)
+		// Rotate, bypassing simple_rotation for 180 degrees at once
+		setDir(turn(dir, ROTATION_FLIP))
+		post_rotation(usr, ROTATION_FLIP)
 
 	update_appearance(UPDATE_ICON)
 


### PR DESCRIPTION

## About The Pull Request

RPD preview menus for diagonal three-way disposal pipes, such as sorters, were incorrect, due to `flipped` being erroneously set true. 
Additionally, the 4-way "rotator" pipe piece would always come out of the RPD going counterclockwise, as the only way to get a piece's `flip_type` variant is to hit `post_rotation()` with 180 degrees at once, and the "flipping" that it does is currently two separate 90-degree rotations as that is all `simple_rotation` is capable of. These two simulated clicks have been replaced by direct calls to `setDir()` & `post_rotation()`, to give it the full 180 degrees at once. None of the safety checks within `simple_rotation` will ever fail coming out of an RPD, so it's just as safe.

## Why It's Good For The Game

When you press a button with a picture on it that picture should represent the object that appears when you press the button

## Changelog
:cl:

fix: Disposal pipe previews within the RPD ui will now be correct

/:cl:
