### PR TITLE
Fixes Freddy's bugged pizza

### DIFF
--- a/_maps/virtual_domains/fredingtonfastingbear.dmm
+++ b/_maps/virtual_domains/fredingtonfastingbear.dmm
@@ -28,7 +28,9 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/table,
-/obj/item/food/pizza/margheritapixel_y = 6},
+/obj/item/food/pizza/margherita{
+	    pixel_y = 6    
+	},
 /turf/open/floor/iron/kitchen,
 /area/virtual_domain)
 "cn" = (
@@ -224,7 +226,8 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/table,
-/obj/item/food/pizza/margherita/turf/open/floor/iron/kitchen,
+/obj/item/food/pizza/margherita,
+/turf/open/floor/iron/kitchen,
 /area/virtual_domain)
 "mX" = (
 /obj/machinery/computer/arcade/amputation{

--- a/_maps/virtual_domains/fredingtonfastingbear.dmm
+++ b/_maps/virtual_domains/fredingtonfastingbear.dmm
@@ -28,9 +28,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/table,
-/obj/item/food/pizza{
-	pixel_y = 6
-	},
+/obj/item/food/pizza/margheritapixel_y = 6},
 /turf/open/floor/iron/kitchen,
 /area/virtual_domain)
 "cn" = (
@@ -226,8 +224,7 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/table,
-/obj/item/food/pizza,
-/turf/open/floor/iron/kitchen,
+/obj/item/food/pizza/margherita/turf/open/floor/iron/kitchen,
 /area/virtual_domain)
 "mX" = (
 /obj/machinery/computer/arcade/amputation{

--- a/_maps/virtual_domains/fredingtonfastingbear.dmm
+++ b/_maps/virtual_domains/fredingtonfastingbear.dmm
@@ -29,7 +29,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/table,
 /obj/item/food/pizza/margherita{
-	    pixel_y = 6    
+	pixel_y = 6
 	},
 /turf/open/floor/iron/kitchen,
 /area/virtual_domain)

--- a/code/game/objects/items/food/pizza.dm
+++ b/code/game/objects/items/food/pizza.dm
@@ -1,11 +1,11 @@
 // Pizza (Whole)
 /obj/item/food/pizza
-	name = "pizza"
+	name = "bugged pizza"
+	desc = "This pizza should not be."
 	icon = 'icons/obj/food/pizza.dmi'
 	abstract_type = /obj/item/food/pizza
 	w_class = WEIGHT_CLASS_NORMAL
 	max_volume = 80
-	icon_state = "pizzamargherita"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 28,
 		/datum/reagent/consumable/nutriment/protein = 3,
@@ -103,6 +103,10 @@
 	slice.pixel_x += rand(-6, 6)
 	slice.pixel_y += rand(-6, 6)
 	user?.put_in_active_hand(slice)
+
+	slice.reagents.remove_all()
+	reagents.trans_to(slice, amount = reagents.total_volume / slices_left, no_react = TRUE)
+
 	slices_left--
 	if(slices_left <= 0)
 		qdel(src)
@@ -123,11 +127,11 @@
 
 // Pizza Slice
 /obj/item/food/pizzaslice
-	name = "pizza slice"
+	name = "bugged pizza slice"
+	desc = "This slice of pizza should not be"
 	icon = 'icons/obj/food/pizza.dmi'
 	abstract_type = /obj/item/food/pizzaslice
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5)
-	icon_state = "pizzamargheritaslice"
 	foodtypes = GRAIN
 	w_class = WEIGHT_CLASS_SMALL
 	decomp_type = /obj/item/food/pizzaslice/moldy


### PR DESCRIPTION
## About The Pull Request

Fixes #93688 ?
There were a number of bugs collated into the above issue:

- An unidentified kind of pizza produced abstract slices when cut
- An abstract pizza was mapped into a ruin
- Robo pizza slices do not turn you into a robot

I could not replicate any of the existing pizza types spawning the wrong slice type when cut, so I assume that bug A was caused by bug B and have simply removed the abstract pizza from the ruin.
In addition I've removed the icon state from abstract pizza so it's more obvious to mappers not to put it there, and to players that it's broken (if you slice an abstract pizza it will use the mask to make them into pizza slice shaped source errors which is kind of funny).

Finally the titular and more important change is that when you sliced a pizza it was just creating a new pizzaslice object with 5 nutriment in it, rather than a pizzaslice that inherited the reagents of the pizza it was sliced from. 
This meant that while margherita pizza has tomato juice in it, margherita pizza slices did not and so on.
So now when we slice a pizza we distribute our pizza reagents into that slice.
The upshot of this is that now when you slice a robo pizza, all the slices will turn people into robots instead of none of them.

Melbert suggested making a unit test to ensure that all pizzas spawned non-abstract slice types but that didn't actually seem to be a problem so I didn't bother to do that yet.

## Why It's Good For The Game

Fixes bug.
Makes it harder to introduce bug by accident.

## Changelog

:cl:
fix: Pizza slices now contain a proportional amount of whatever the pizza contained, so sliced poisoned pizza will still be poisonous and sliced robo pizza will still turn people into robots.
fix: Removed a bugged pizza from the pizza ruin and replaced it with a margherita pizza.
fix: Bugged pizza no longer looks identical to functional margherita pizza; it's a big error graphic.
/:cl: