### PR TITLE
Use evil CSS tricks to fix wiki books looking awful

### DIFF
--- a/code/game/objects/items/wiki_manuals.dm
+++ b/code/game/objects/items/wiki_manuals.dm
@@ -3,28 +3,40 @@
 /// The size of the window that the wiki books open in.
 #define BOOK_WINDOW_BROWSE_SIZE "970x710"
 /// This macro will resolve to code that will open up the associated wiki page in the window.
-#define WIKI_PAGE_IFRAME(wikiurl, link_identifier) {"
-	<html>
+#define WIKI_PAGE_IFRAME(title, wikiurl, link_identifier) {"
+<html>
 	<head>
-	<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
-	<style>
-		iframe {
-			display: none;
-		}
-	</style>
+		<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+		<title>[html_encode(title)]</title>
+		<style>
+			body {
+				margin: 0;
+			}
+			p {
+				margin: 8px;
+			}
+			iframe {
+				border: 0;
+				margin-left: -177px;
+				margin-top: -80px;
+				width: calc(100% + 177px);
+				height: calc(100% + 80px);
+				display: none;
+			}
+			body.loaded p {
+				display: none;
+			}
+			body.loaded iframe {
+				display: inline;
+			}
+		</style>
 	</head>
 	<body>
-	<script type="text/javascript">
-		function pageloaded(myframe) {
-			document.getElementById("loading").style.display = "none";
-			myframe.style.display = "inline";
-	}
-	</script>
-	<p id='loading'>You start skimming through the manual...</p>
-	<iframe width='100%' height='97%' onload="pageloaded(this)" src="[##wikiurl]/[##link_identifier]?printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
+		<p>You start skimming through the manual...</p>
+		<iframe src="[wikiurl]/[link_identifier]?useskin=vector" onload="document.body.classList.add('loaded')"></iframe>
 	</body>
-	</html>
-	"}
+</html>
+"}
 
 // A book that links to the wiki
 /obj/item/book/manual/wiki
@@ -43,7 +55,7 @@
 			return
 		DIRECT_OUTPUT(user, link("[wiki_url]/[page_link]"))
 	else
-		DIRECT_OUTPUT(user, browse(WIKI_PAGE_IFRAME(wiki_url, page_link), "window=manual;size=[BOOK_WINDOW_BROWSE_SIZE]")) // if you change this GUARANTEE that it works.
+		DIRECT_OUTPUT(user, browse(WIKI_PAGE_IFRAME(name, wiki_url, page_link), "window=manual;size=[BOOK_WINDOW_BROWSE_SIZE]")) // if you change this GUARANTEE that it works.
 
 /obj/item/book/manual/wiki/chemistry
 	name = "Chemistry Textbook"

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -86,7 +86,6 @@
 
 /// Proc that handles sending the book information to the user, as well as some housekeeping stuff.
 /obj/item/book/proc/display_content(mob/living/user)
-	credit_book_to_reader(user)
 	ui_interact(user)
 
 /// Proc that checks if the user is capable of reading the book, for UI interactions and otherwise. Returns TRUE if they can, FALSE if they can't.
@@ -125,6 +124,7 @@
 		return
 
 	user.visible_message(span_notice("[user] opens a book titled \"[book_data.title]\" and begins reading intently."))
+	credit_book_to_reader(user)
 	display_content(user)
 
 /obj/item/book/proc/is_carving_tool(obj/item/tool)

--- a/config/config.txt
+++ b/config/config.txt
@@ -196,7 +196,7 @@ IPINTEL_REJECT_BAD
 # FORUMURL http://tgstation13.org/phpBB/index.php
 
 ## Wiki address
-# WIKIURL http://tgstation13.org/wiki
+# WIKIURL https://wiki.tgstation13.org
 
 ## Rules address
 # RULESURL http://tgstation13.org/wiki/Rules


### PR DESCRIPTION
## About The Pull Request

The [MediaWiki "printable" version of pages][p] was at some point deprecated in favor of standard print stylesheets, making wiki books look rather ugly, even uglier than if they weren't using the parameter. However, there seems to be no way to command an iframe to opt in to or simulate the print stylesheet. What we really want is to suppress the sidebar and header. Therefore: position the iframe off of the page to the left and top by the size of the elements we want to hide.

Hiding the left sidebar seems fully clean. However, hiding the top header also hides the first bit of the scrollbar, which is a little odd-looking.

Also, fix wiki books not giving book nerd moodlets.

[p]: https://wiki.tgstation13.org/Guide_to_drinks?printable=yes

Before:
<img width="984" height="790" alt="SS13 wiki book before" src="https://github.com/user-attachments/assets/1eb6e961-bc35-418b-a015-868d7269e2f5" />

After:
<img width="985" height="752" alt="SS13 wiki book after" src="https://github.com/user-attachments/assets/39a63ad3-bc99-4c71-a5e7-ff06ae1b6852" />

## Why It's Good For The Game

Less offensively ugly UI.

## Changelog
:cl:
fix: Wiki books such as "Barman Recipes" and "Space Law" no longer have terrible formatting.
fix: Wiki books now properly give book nerd moodlets.
/:cl: