### PR TITLE
Fix two bugs with Shadow/Nightmares

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -647,7 +647,7 @@
 /// Throw an alert we're in darkness!! Nightvision can make it hard to tell so this is useful
 /datum/status_effect/shadow
 	id = "shadow"
-	duration = 2 SECONDS
+	duration = 2.2 SECONDS // One status effect tick longer than the life tick
 	status_type = STATUS_EFFECT_REFRESH
 	alert_type = /atom/movable/screen/alert/status_effect/shadow_regeneration
 

--- a/code/modules/antagonists/nightmare/nightmare_organs.dm
+++ b/code/modules/antagonists/nightmare/nightmare_organs.dm
@@ -47,8 +47,6 @@
 
 /datum/status_effect/shadow/nightmare
 	id = "nightmare"
-	duration = 2 SECONDS
-	status_type = STATUS_EFFECT_REFRESH
 	alert_type = /atom/movable/screen/alert/status_effect/shadow_regeneration/nightmare
 
 /datum/status_effect/shadow/nightmare/on_apply()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -580,7 +580,7 @@
 		if(40 to INFINITY)
 			combined_msg += span_danger("You feel very unwell!")
 
-	var/cached_blood_volume = get_blood_volume(apply_modifiers = TRUE)
+	var/cached_blood_volume = HAS_TRAIT(src, TRAIT_NOBLOOD) ? BLOOD_VOLUME_NORMAL : get_blood_volume(apply_modifiers = TRUE)
 	var/oxy = get_oxy_loss() + (losebreath * 4) + (cached_blood_volume < BLOOD_VOLUME_NORMAL ? ((BLOOD_VOLUME_NORMAL - cached_blood_volume) * 0.1) : 0) + (HAS_TRAIT(src, TRAIT_SELF_AWARE) ? 0 : (rand(-3, 0) * 5))
 	switch(oxy)
 		if(10 to 20)

--- a/code/modules/surgery/bodyparts/bodypart_effects.dm
+++ b/code/modules/surgery/bodyparts/bodypart_effects.dm
@@ -132,7 +132,9 @@
 
 	// Heal in the dark
 	owner.heal_overall_damage(brute = 0.5 * bodypart_coefficient, burn = 0.5 * bodypart_coefficient, required_bodytype = BODYTYPE_SHADOW)
-	if(!owner.has_status_effect(/datum/status_effect/shadow/nightmare)) // Somewhat awkward, but let's not duplicate the alerts
+
+	var/mob/living/carbon/carbon_owner = owner
+	if(carbon_owner.dna.species.id != SPECIES_NIGHTMARE) // Somewhat awkward, but let's not duplicate the alerts
 		// This only appears when in shadows, don't move to bodypart effect so people with nightvision can still tell if they're in light or not
 		owner.apply_status_effect(/datum/status_effect/shadow)
 

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -364,15 +364,11 @@
 
 /obj/item/bodypart/arm/left/shadow/nightmare
 	bodypart_traits = list(TRAIT_CHUNKYFINGERS)
-
 	bodypart_effects = list(/datum/status_effect/grouped/bodypart_effect/nyxosynthesis)
-	bodytype = BODYTYPE_ORGANIC | BODYTYPE_SHADOW
 
 /obj/item/bodypart/arm/right/shadow/nightmare
 	bodypart_traits = list(TRAIT_CHUNKYFINGERS)
-
 	bodypart_effects = list(/datum/status_effect/grouped/bodypart_effect/nyxosynthesis)
-	bodytype = BODYTYPE_ORGANIC | BODYTYPE_SHADOW
 
 ///SKELETON
 /obj/item/bodypart/head/skeleton


### PR DESCRIPTION
## About The Pull Request

Fixes #94117
The "I'm in shadow" indicator alert was dependent on a status effect being reapplied by `Life()` every 2 seconds. Since we made status effects tick faster, it now quite realiably ends before it is reapplied such that players can see the alert animate out and back in.
I fixed this pretty trivially by just adding one status effect subsystem tick worth of time to the duration so it shouldn't do that any more.

Additionally, there was some code there intended to not display the indicator to Nightmares (they have their own similar one) but it expected the Nightmare status effect to always be present first, which didn't happen. I just made it check specifically for Species instead, as the only item which applies the Nightmare status effect also changes your species anyway.

Finally, while I was testing this I noticed that whenever Shadowpeople or Nightmares examined themselves it would say "You feel like you're about to pass out!"
This is because it was noticing that they had an unusually low amount of blood (none), on account of how they don't have blood.
I changed the code so that bloodless mobs will no longer start getting dizzy at the thought of how they don't have any blood.

## Changelog

:cl:
fix: Species that aren't supposed to have blood will no longer report feeling dizzy from bloodloss on account of how they have no blood.
fix: The "I am stood in the dark" indicator for Shadows and Nightmares will no longer flicker on and off.
/:cl:
