### PR TITLE
Stops prefs menu from doing an extra update_body() call every time you swap chars

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -428,6 +428,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	return TRUE
 
 /datum/preferences/proc/switch_to_slot(new_slot)
+	if(new_slot == default_slot) // sanity check, nothing to do here.
+		return
 	// SAFETY: `load_character` performs sanitization on the slot number
 	if (!load_character(new_slot))
 		tainted_character_profiles = TRUE

--- a/code/modules/loadout/loadout_menu.dm
+++ b/code/modules/loadout/loadout_menu.dm
@@ -14,9 +14,6 @@
 	QDEL_NULL(menu)
 	return ..()
 
-/datum/preference_middleware/loadout/on_new_character(mob/user)
-	preferences.character_preview_view?.update_body()
-
 /datum/preference_middleware/loadout/proc/action_select_item(list/params, mob/user)
 	PRIVATE_PROC(TRUE)
 	var/path_to_use = text2path(params["path"])


### PR DESCRIPTION
## About The Pull Request

Tin, noticed an extra set of calls when doing some profiling. This is already called from `switch_to_slot()` so it makes no sense to do it a second time in `on_new_character()`.

Also adds a sanity check to the prefs menu for when you switch to the same exact slot.

## Why It's Good For The Game

Snappier prefs menus.

## Changelog

:cl:
fix: switching characters in the prefs menu should be less laggy now
/:cl: