### PR TITLE
Makes intercom mic button turn on when it is screwed in, and vice versa

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -69,11 +69,13 @@
 		if(tool.use_tool(src, user, 30, volume=50))
 			user.visible_message(span_notice("[user] tightens [src]'s screws!"), span_notice("You tighten [src]'s screws."))
 			unscrewed = FALSE
+			update_appearance(UPDATE_OVERLAYS)
 	else
 		user.visible_message(span_notice("[user] starts loosening [src]'s screws..."), span_notice("You start unscrewing [src]..."))
 		if(tool.use_tool(src, user, 40, volume=50))
 			user.visible_message(span_notice("[user] loosens [src]'s screws!"), span_notice("You unscrew [src], loosening it from the wall."))
 			unscrewed = TRUE
+			update_appearance(UPDATE_OVERLAYS)
 	return TRUE
 
 /obj/item/radio/intercom/wrench_act(mob/living/user, obj/item/tool)


### PR DESCRIPTION

## About The Pull Request

Updates the intercom's overlays when it is screwed to the wall, and unscrewed, making the mic being on visible. 

## Why It's Good For The Game

I don't like screwing in the frame and then flicking the mic on and off to make it look right

## Changelog
:cl:

fix: intercoms will now visibly have their mic on when constructed manually

/:cl:
