### PR TITLE
Slightly improve tabular layout of MC statpanel

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -307,7 +307,7 @@
 		if (SS_SLEEPING)
 			. = "S"
 		if (SS_IDLE)
-			. = "  "
+			. = " "
 
 /// Causes the next "cycle" fires to be missed. Effect is accumulative but can reset by calling update_nextfire(reset_time = TRUE)
 /datum/controller/subsystem/proc/postpone(cycles = 1)

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -190,15 +190,15 @@ SUBSYSTEM_DEF(statpanels)
 
 /datum/controller/subsystem/statpanels/proc/generate_mc_data()
 	mc_data = list(
-		list("CPU:", world.cpu),
-		list("Instances:", "[num2text(world.contents.len, 10)]"),
-		list("World Time:", "[world.time]"),
-		list("Globals:", GLOB.stat_entry(), text_ref(GLOB)),
-		list("[config]:", config.stat_entry(), text_ref(config)),
-		list("Byond:", "(FPS:[world.fps]) (TickCount:[world.time/world.tick_lag]) (TickDrift:[round(Master.tickdrift,1)]([round((Master.tickdrift/(world.time/world.tick_lag))*100,0.1)]%))\n  (Internal Tick Usage: [round(MAPTICK_LAST_INTERNAL_TICK_USAGE,0.1)]%)"),
-		list("Master Controller:", Master.stat_entry(), text_ref(Master)),
-		list("Failsafe Controller:", Failsafe.stat_entry(), text_ref(Failsafe)),
-		list("","")
+		list("", "CPU:", world.cpu),
+		list("", "Instances:", "[num2text(world.contents.len, 10)]"),
+		list("", "World Time:", "[world.time]"),
+		list("", "Globals:", GLOB.stat_entry(), text_ref(GLOB)),
+		list("", "[config]:", config.stat_entry(), text_ref(config)),
+		list("", "Byond:", "(FPS:[world.fps]) (TickCount:[world.time/world.tick_lag]) (TickDrift:[round(Master.tickdrift,1)]([round((Master.tickdrift/(world.time/world.tick_lag))*100,0.1)]%))\n  (Internal Tick Usage: [round(MAPTICK_LAST_INTERNAL_TICK_USAGE,0.1)]%)"),
+		list("", "Master Controller:", Master.stat_entry(), text_ref(Master)),
+		list("", "Failsafe Controller:", Failsafe.stat_entry(), text_ref(Failsafe)),
+		list("", "", "")
 	)
 #if defined(MC_TAB_TRACY_INFO) || defined(SPACEMAN_DMM)
 	var/static/tracy_dll
@@ -208,18 +208,18 @@ SUBSYSTEM_DEF(statpanels)
 		tracy_present = fexists(tracy_dll)
 	if(tracy_present)
 		if(Tracy.enabled)
-			mc_data.Insert(2, list(list("byond-tracy:", "Active (reason: [Tracy.init_reason || "N/A"])")))
+			mc_data.Insert(2, list(list("", "byond-tracy:", "Active (reason: [Tracy.init_reason || "N/A"])")))
 		else if(Tracy.error)
-			mc_data.Insert(2, list(list("byond-tracy:", "Errored ([Tracy.error])")))
+			mc_data.Insert(2, list(list("", "byond-tracy:", "Errored ([Tracy.error])")))
 		else if(fexists(TRACY_ENABLE_PATH))
-			mc_data.Insert(2, list(list("byond-tracy:", "Queued for next round")))
+			mc_data.Insert(2, list(list("", "byond-tracy:", "Queued for next round")))
 		else
-			mc_data.Insert(2, list(list("byond-tracy:", "Inactive")))
+			mc_data.Insert(2, list(list("", "byond-tracy:", "Inactive")))
 	else
-		mc_data.Insert(2, list(list("byond-tracy:", "[tracy_dll] not present")))
+		mc_data.Insert(2, list(list("", "byond-tracy:", "[tracy_dll] not present")))
 #endif
 	for(var/datum/controller/subsystem/sub_system as anything in Master.subsystems)
-		mc_data[++mc_data.len] = list("\[[sub_system.state_letter()]][sub_system.name]", sub_system.stat_entry(), text_ref(sub_system))
+		mc_data[++mc_data.len] = list("\[[sub_system.state_letter()]]", sub_system.name, sub_system.stat_entry(), text_ref(sub_system))
 
 ///immediately update the active statpanel tab of the target client
 /datum/controller/subsystem/statpanels/proc/immediate_send_stat_data(client/target)

--- a/html/statbrowser.css
+++ b/html/statbrowser.css
@@ -114,6 +114,14 @@ img {
   white-space: pre;
 }
 
+.mcstatcontent td {
+  vertical-align: top;
+}
+
+.mcstatcontent .monospace {
+  font-family: "Consolas", "Lucida Console", "Courier New", monospace;
+}
+
 #under-menu {
   height: 0.5em;
   background-color: #eeeeee;

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -236,7 +236,7 @@ function tab_change(tab) {
     document.getElementById(tab).className = "button active"; // make current button active
   var spell_tabs_thingy = spell_tabs.includes(tab);
   var verb_tabs_thingy = verb_tabs.includes(tab);
-  statcontentdiv.className = "statcontent"
+  statcontentdiv.className = "statcontent";
   if (tab == "Status") {
     draw_status();
   } else if (tab == "MC") {
@@ -390,23 +390,27 @@ function draw_status() {
 
 function draw_mc() {
   statcontentdiv.textContent = "";
-  statcontentdiv.className = "mcstatcontent"
+  statcontentdiv.className = "mcstatcontent";
   var table = document.createElement("table");
   for (var i = 0; i < mc_tab_parts.length; i++) {
     var part = mc_tab_parts[i];
     var tr = document.createElement("tr");
+    var td0 = document.createElement("td");
+    td0.className = "monospace";
+    td0.textContent = part[0];
     var td1 = document.createElement("td");
-    td1.textContent = part[0];
+    td1.textContent = part[1];
     var td2 = document.createElement("td");
-    if (part[2]) {
+    if (part[3]) {
       var a = document.createElement("a");
       a.href =
-        "byond://?_src_=vars;admin_token=" + href_token + ";Vars=" + part[2];
-      a.textContent = part[1];
+        "byond://?_src_=vars;admin_token=" + href_token + ";Vars=" + part[3];
+      a.textContent = part[2];
       td2.appendChild(a);
     } else {
-      td2.textContent = part[1];
+      td2.textContent = part[2];
     }
+    tr.appendChild(td0);
     tr.appendChild(td1);
     tr.appendChild(td2);
     table.appendChild(tr);
@@ -916,7 +920,7 @@ Byond.subscribeTo("update_stat", function (payload) {
 
 Byond.subscribeTo("update_mc", function (payload) {
   mc_tab_parts = payload.mc_data;
-  mc_tab_parts.splice(0, 0, ["Location:", payload.coord_entry]);
+  mc_tab_parts.splice(0, 0, ["", "Location:", payload.coord_entry]);
 
   if (!verb_tabs.includes("MC")) {
     verb_tabs.push("MC");


### PR DESCRIPTION
## About The Pull Request

* Add a distinct column at the start for the stat letter, and monospace it, to solve "[Q]" and "[R]" being one pixel wider than "[&nbsp;&nbsp;]".
* Vertically align cells to the top, so the name of a subsystem appears next to the first line of its description, not in the middle.

Before:
<img width="558" height="351" alt="image" src="https://github.com/user-attachments/assets/c688d94b-535b-421e-90c6-a3a870cb7a4e" />
<img width="504" height="114" alt="image" src="https://github.com/user-attachments/assets/bcbef34f-f2ff-4987-8643-93bfe6994a8c" />

After:
<img width="558" height="351" alt="image" src="https://github.com/user-attachments/assets/ecc862a6-a7cc-4188-b231-449c22fec1f4" />
<img width="558" height="109" alt="image" src="https://github.com/user-attachments/assets/29a104a2-637e-4026-a386-e1e86397cc8e" />

## Why It's Good For The Game

Looks prettier, easier to navigate by eyeball.