### PR TITLE
Enforces organs calling `on_life` parent

### DIFF
--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -100,6 +100,8 @@
 	update_gland_hud()
 
 /obj/item/organ/heart/gland/on_life(seconds_per_tick)
+	. = ..()
+
 	if(!active)
 		return
 	if(!ownerCheck())

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -338,6 +338,8 @@
 	return ..()
 
 /obj/item/organ/brain/on_life(seconds_per_tick)
+	. = ..()
+
 	if(HAS_TRAIT(src, TRAIT_BRAIN_DAMAGE_NODEATH))
 		return
 	if(damage >= BRAIN_DAMAGE_DEATH) //rip

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -50,6 +50,8 @@
 	actions_types = list(/datum/action/cooldown/alien/transfer)
 
 /obj/item/organ/alien/plasmavessel/on_life(seconds_per_tick)
+	. = ..()
+
 	var/delta_time = DELTA_WORLD_TIME(SSmobs)
 	//Instantly healing to max health in a single tick would be silly. If it takes 8 seconds to fire, then something's fucked.
 	var/delta_time_capped = min(delta_time, 8)

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -171,6 +171,8 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 			apply_organ_damage(decay_factor * maxHealth * seconds_per_tick * air_temperature_factor)
 
 /obj/item/organ/proc/on_life(seconds_per_tick) //repair organ damage if the organ is not failing
+	SHOULD_CALL_PARENT(TRUE)
+
 	if(organ_flags & ORGAN_FAILING)
 		handle_failing_organs(seconds_per_tick)
 		return

--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -15,6 +15,8 @@
 	slot = ORGAN_SLOT_STOMACH_AID
 
 /obj/item/organ/cyberimp/chest/nutriment/on_life(seconds_per_tick)
+	. = ..()
+
 	if(synthesizing)
 		return
 
@@ -61,6 +63,8 @@
 	try_heal() // Allows implant to work even on dead people
 
 /obj/item/organ/cyberimp/chest/reviver/on_life(seconds_per_tick)
+	. = ..()
+
 	try_heal()
 
 /obj/item/organ/cyberimp/chest/reviver/proc/try_heal()

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -109,7 +109,7 @@
 	return ..() || owner.needs_heart()
 
 /obj/item/organ/heart/on_life(seconds_per_tick)
-	..()
+	. = ..()
 
 	// If the owner doesn't need a heart, we don't need to do anything with it.
 	if(!owner.needs_heart())


### PR DESCRIPTION
## About The Pull Request
on_life handled failing and healing, this makes it so ALL organs call its parent proc for it.
Was originally spurred on by the fact this is not enforced causing stomachs to not call it by mistake.
## Why It's Good For The Game
all organs now heal and fail as intended?
two that MIGHT be intentional are brains and glands. Let me know if so
## Changelog
:cl:
fix: Brains, a few implants, glands, and all other organs now heal and fail as intended
/:cl:
