### PR TITLE
Adds an engi pocket oxygen tank to kinetic crusher kit

### DIFF
--- a/code/modules/mining/voucher_sets.dm
+++ b/code/modules/mining/voucher_sets.dm
@@ -40,12 +40,13 @@
 
 /datum/voucher_set/mining/crusher_kit
 	name = "Crusher Kit"
-	description = "Contains a kinetic crusher and a pocket fire extinguisher. Kinetic crusher is a versatile melee mining tool capable both of mining and fighting local fauna, however it is difficult to use effectively for anyone but most skilled and/or suicidal miners."
+	description = "Contains a kinetic crusher, double pocket oxygen tank and a pocket fire extinguisher. Kinetic crusher is a versatile melee mining tool capable both of mining and fighting local fauna, however it is difficult to use effectively for anyone but most skilled and/or suicidal miners."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "crusher"
 	set_items = list(
 		/obj/item/kinetic_crusher,
 		/obj/item/extinguisher/mini,
+		/obj/item/tank/internals/emergency_oxygen/double,
 	)
 
 /datum/voucher_set/mining/extraction_kit

--- a/code/modules/mining/voucher_sets.dm
+++ b/code/modules/mining/voucher_sets.dm
@@ -40,13 +40,13 @@
 
 /datum/voucher_set/mining/crusher_kit
 	name = "Crusher Kit"
-	description = "Contains a kinetic crusher, double pocket oxygen tank and a pocket fire extinguisher. Kinetic crusher is a versatile melee mining tool capable both of mining and fighting local fauna, however it is difficult to use effectively for anyone but most skilled and/or suicidal miners."
+	description = "Contains a kinetic crusher, expanded pocket oxygen tank and a pocket fire extinguisher. Kinetic crusher is a versatile melee mining tool capable both of mining and fighting local fauna, however it is difficult to use effectively for anyone but most skilled and/or suicidal miners."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "crusher"
 	set_items = list(
 		/obj/item/kinetic_crusher,
 		/obj/item/extinguisher/mini,
-		/obj/item/tank/internals/emergency_oxygen/double,
+		/obj/item/tank/internals/emergency_oxygen/engi,
 	)
 
 /datum/voucher_set/mining/extraction_kit


### PR DESCRIPTION
## About The Pull Request
adds a yellow tank (NOT DOUBLE) to crusher voucher kit so miners can put crushers in their suit storage slot
## Why It's Good For The Game
1) you can now store your axe somewhere like kinetic accelerator
2) miner modsuit has magnetic harness, but your suit storage slot holds your oxygen tank 24/7 so its a bit useless
## Changelog
:cl:
balance: Added yellow pocket oxygen tank to kinetic crusher kit
/:cl:
