### PR TITLE
Replaces instances of mapped in normal wooden barricades on top of objects with crude wooden barricades

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_smoking_room.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_smoking_room.dmm
@@ -72,7 +72,7 @@
 /turf/open/floor/wood,
 /area/ruin/smoking_room/house)
 "m" = (
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/wood,
 /obj/structure/curtain/cloth/fancy{
 	open = 0

--- a/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_2.dmm
@@ -47,7 +47,7 @@
 	name = "Kitchen"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/template_noop,
 /area/space/nearstation)
 "L" = (
@@ -58,7 +58,7 @@
 	name = "Kitchen"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/template_noop,
 /area/space/nearstation)
 "S" = (

--- a/_maps/RandomRuins/SpaceRuins/DJstation/quarters_4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/quarters_4.dmm
@@ -27,7 +27,7 @@
 	name = "Rest Room"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/template_noop,
 /area/space/nearstation)
 "q" = (
@@ -70,7 +70,7 @@
 	},
 /obj/modular_map_connector,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/template_noop,
 /area/space/nearstation)
 "W" = (

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -540,7 +540,7 @@
 	name = "Power Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)

--- a/_maps/RandomRuins/SpaceRuins/derelict5.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict5.dmm
@@ -64,7 +64,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav)
 "r" = (
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/external/ruin,
 /turf/open/misc/asteroid/airless,
 /area/ruin/space/has_grav)

--- a/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
@@ -1331,7 +1331,6 @@
 /obj/machinery/door/airlock/cult/unruned/friendly{
 	name = "Processing"
 	},
-/obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
@@ -2088,7 +2087,6 @@
 /obj/machinery/door/airlock/science{
 	name = "Xenobiology"
 	},
-/obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/mineral/titanium/tiled/purple,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)

--- a/_maps/RandomRuins/SpaceRuins/meatderelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/meatderelict.dmm
@@ -355,7 +355,7 @@
 /turf/open/indestructible/white,
 /area/ruin/space/has_grav/powered/biooutpost)
 "hY" = (
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/science/glass{
 	name = "Janitorial Closet"
 	},

--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -1582,7 +1582,7 @@
 "ip" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/hatch,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/mineral/plastitanium/red{
 	name = "soviet floor"
 	},

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -762,7 +762,7 @@
 /obj/machinery/door/airlock/medical{
 	name = "Medical"
 	},
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron,
 /area/awaymission/caves/bmp_asteroid)
 "fH" = (

--- a/_maps/RandomZLevels/heretic.dmm
+++ b/_maps/RandomZLevels/heretic.dmm
@@ -4859,7 +4859,6 @@
 /area/awaymission/caves/heretic_laboratory)
 "yZ" = (
 /obj/machinery/door/airlock/hatch,
-/obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory)
@@ -5052,7 +5051,6 @@
 /area/awaymission/caves/heretic_laboratory)
 "Av" = (
 /obj/machinery/door/airlock/hatch,
-/obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/crude,
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4

--- a/_maps/RandomZLevels/museum.dmm
+++ b/_maps/RandomZLevels/museum.dmm
@@ -6029,7 +6029,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/broken_flooring/side/directional/east,
 /obj/machinery/door/airlock/atmos/glass,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/all/away/generic3,
 /turf/open/indestructible/plating,

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -693,7 +693,7 @@
 /obj/machinery/door/airlock{
 	name = "Freezer"
 	},
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/iron/freezer,
 /area/awaymission/snowdin/post/kitchen)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5065,7 +5065,7 @@
 /obj/machinery/door/airlock/command{
 	name = "Auxiliary E.V.A. Storage"
 	},
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14347,7 +14347,7 @@
 /area/station/commons/locker)
 "dBs" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "dBv" = (
@@ -15762,7 +15762,7 @@
 	name = "E.V.A. Storage Shutters"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16273,7 +16273,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
 	},
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -18664,7 +18664,7 @@
 /area/station/service/library/abandoned)
 "eGp" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "eGq" = (
@@ -23394,7 +23394,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "fPt" = (
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -24742,7 +24742,7 @@
 /obj/machinery/door/airlock/command{
 	name = "Auxiliary E.V.A. Storage"
 	},
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -24807,7 +24807,7 @@
 /area/station/medical/virology)
 "gfg" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/science/research/abandoned)
 "gfj" = (
@@ -28562,7 +28562,7 @@
 	name = "Maintenance Hatch"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40261,7 +40261,7 @@
 	id = "evashutters2";
 	name = "E.V.A. Storage Shutters"
 	},
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -46867,7 +46867,7 @@
 	name = "Maintenance Hatch"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -63573,7 +63573,7 @@
 /area/station/science/breakroom)
 "pOn" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "pOz" = (
@@ -68685,7 +68685,7 @@
 /area/station/hallway/primary/central/aft)
 "rbj" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "rbC" = (
@@ -72352,7 +72352,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -74559,7 +74559,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "sxk" = (
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -76076,7 +76076,7 @@
 /area/station/science/xenobiology)
 "sPo" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "sPF" = (
@@ -82354,7 +82354,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "urO" = (
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -84594,7 +84594,7 @@
 /area/station/engineering/supermatter/room)
 "uRy" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -86858,7 +86858,7 @@
 /turf/closed/wall/r_wall,
 /area/station/security/prison/visit)
 "vxL" = (
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -88996,7 +88996,7 @@
 /area/station/solars/port/fore)
 "waI" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "waK" = (
@@ -93459,7 +93459,7 @@
 	name = "Maintenance Hatch"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -96587,7 +96587,7 @@
 /area/station/maintenance/department/medical/morgue)
 "xVr" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "xVE" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -3510,7 +3510,7 @@
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp)
 "aWu" = (
-/obj/structure/barricade/wooden/snowed,
+/obj/structure/barricade/wooden/crude/snow,
 /obj/machinery/light/small/red/directional/north,
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
@@ -66531,7 +66531,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
-/obj/structure/barricade/wooden/snowed,
+/obj/structure/barricade/wooden/crude/snow,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "sGH" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10730,7 +10730,7 @@
 /area/station/security/prison/rec)
 "cTz" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/mapping_helpers/airlock/unres/delayed{
 	dir = 4
@@ -36897,7 +36897,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "kuR" = (
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
@@ -41144,9 +41144,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/barricade/wooden{
-	name = "wooden barricade (CLOSED)"
-	},
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "lCY" = (
@@ -74503,7 +74501,7 @@
 /area/station/commons/dorms/laundry)
 "vah" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/mapping_helpers/airlock/unres/delayed{

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -5544,7 +5544,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "bWn" = (
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -20564,7 +20564,7 @@
 "hgB" = (
 /obj/machinery/door/airlock/maintenance/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/mapping_helpers/airlock/unres/delayed{
 	dir = 8
 	},
@@ -51019,7 +51019,7 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/landmark/navigate_destination,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "rBZ" = (

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -38,7 +38,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "aj" = (
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/cult,
 /area/shuttle/escape)

--- a/_maps/virtual_domains/heretic_hunt.dmm
+++ b/_maps/virtual_domains/heretic_hunt.dmm
@@ -1046,7 +1046,7 @@
 /area/virtual_domain)
 "LB" = (
 /obj/machinery/door/airlock/maintenance_hatch,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/virtual_domain)

--- a/tools/maplint/lints/barricade_stacking.yml
+++ b/tools/maplint/lints/barricade_stacking.yml
@@ -3,5 +3,13 @@ help: "Please use crude barricades on top of dense objects."
   banned_neighbors:
     /obj/machinery/door/airlock:
     /obj/effect/spawner/structure/window:
+    /obj/machinery/door/poddoor/shutters:
+    FULLTILE_WINDOW:
+      pattern: ^/obj/structure/window[/\w]*?fulltile$
+=/obj/structure/barricade/wooden/snowed:
+  banned_neighbors:
+    /obj/machinery/door/airlock:
+    /obj/effect/spawner/structure/window:
+    /obj/machinery/door/poddoor/shutters:
     FULLTILE_WINDOW:
       pattern: ^/obj/structure/window[/\w]*?fulltile$

--- a/tools/maplint/lints/barricade_stacking.yml
+++ b/tools/maplint/lints/barricade_stacking.yml
@@ -1,0 +1,7 @@
+help: "Please use crude barricades on top of dense objects."
+=/obj/structure/barricade/wooden:
+  banned_neighbors:
+    /obj/machinery/door/airlock:
+    /obj/effect/spawner/structure/window:
+    FULLTILE_WINDOW:
+      pattern: ^/obj/structure/window[/\w]*?fulltile$


### PR DESCRIPTION
## About The Pull Request

We've all seen that thing that happens where you open a door in maintenance, and a large barricade of wood materializes where the door just was. That's not right. The obvious solution would be to make the barricade appear on top of the door beforehand, and while that works in terms of behaviour, it looks really weird:
<img width="82" height="82" alt="image" src="https://github.com/user-attachments/assets/e2c170d8-8a3d-4f09-80a4-976c525bed9f" />
and even weirder on objects such as windows & shutters. I suppose that's why you're not able to build them on top of these things in actual gameplay.

Instead, this replaces every instance of a mapped-in wooden standard barricade that appears on top of an object (save for one on top of a girder in icebox) with a crude barricade, causing it to both appear on top of the object and look right doing so.

Additionally, comes with a linter for big barricades on top of airlocks & windows.

## Why It's Good For The Game

It doesn't look weird nor act weird. Even aside from the airlocks, these things are weird with windows, acting like they're inside the glass.

Additionally, while this does technically reduce their integrity, increase projectile passing rate & reduce plank drop amount, so I'm labeling it balance out of good faith, the only actual balance implication this has is that the barricade being on top of the door prevents it from being opened via a simple bump, which could and does effect atmos situations, but I'd sooner call that a bugfix than a balance change.

## Changelog
:cl:

balance: wooden barricades mapped on top of objects are now crude barricades, preventing them from materializing when you open a door.

/:cl:
