### PR TITLE
Gives Ninja Plasmamen plasma tanks

### DIFF
--- a/code/modules/antagonists/ninja/ninja_clothing.dm
+++ b/code/modules/antagonists/ninja/ninja_clothing.dm
@@ -17,6 +17,8 @@
 	flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
 	pepper_tint = FALSE
 
+/obj/item/clothing/mask/gas/ninja/plasmaman
+	starting_filter_type = /obj/item/gas_filter/plasmaman
 
 /obj/item/clothing/under/syndicate/ninja
 	name = "ninja suit"

--- a/code/modules/antagonists/ninja/outfit.dm
+++ b/code/modules/antagonists/ninja/outfit.dm
@@ -33,3 +33,8 @@
 	uniform = /obj/item/clothing/under/syndicate/ninja
 	back = /obj/item/mod/control/pre_equipped/empty/ninja
 	belt = /obj/item/energy_katana
+
+/datum/outfit/ninja/plasmaman
+	name = "Space Ninja (Plasmaman)"
+	mask = /obj/item/clothing/mask/gas/ninja/plasmaman
+	r_pocket = /obj/item/tank/internals/plasmaman/belt/full

--- a/code/modules/antagonists/nukeop/outfits.dm
+++ b/code/modules/antagonists/nukeop/outfits.dm
@@ -27,6 +27,7 @@
 	head = /obj/item/clothing/head/helmet/space/plasmaman/syndie
 	uniform = /obj/item/clothing/under/plasmaman/syndicate
 	r_hand = /obj/item/tank/internals/plasmaman/belt/full
+	internals_slot = ITEM_SLOT_HANDS
 
 /datum/outfit/syndicate/leader
 	name = "Syndicate Leader - Basic"
@@ -39,6 +40,7 @@
 	head = /obj/item/clothing/head/helmet/space/plasmaman/syndie
 	uniform = /obj/item/clothing/under/plasmaman/syndicate
 	r_hand = /obj/item/tank/internals/plasmaman/belt/full
+	internals_slot = ITEM_SLOT_HANDS
 
 /datum/outfit/syndicate/post_equip(mob/living/carbon/human/nukie, visuals_only = FALSE)
 	if(visuals_only)
@@ -88,7 +90,8 @@
 	back = /obj/item/mod/control/pre_equipped/nuclear/plasmaman
 	uniform = /obj/item/clothing/under/plasmaman/syndicate
 	r_pocket = /obj/item/tank/internals/plasmaman/belt/full
-	mask = null
+	internals_slot = ITEM_SLOT_RPOCKET
+	mask = /obj/item/clothing/mask/gas/syndicate/plasmaman
 
 /datum/outfit/syndicate/full/plasmaman/New()
 	backpack_contents += /obj/item/clothing/head/helmet/space/plasmaman/syndie
@@ -119,6 +122,7 @@
 	head = /obj/item/clothing/head/helmet/space/plasmaman/syndie
 	uniform = /obj/item/clothing/under/plasmaman/syndicate
 	r_hand = /obj/item/tank/internals/plasmaman/belt/full
+	internals_slot = ITEM_SLOT_HANDS
 	tc = 0
 
 /datum/outfit/syndicate/support/plasmaman
@@ -128,6 +132,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/syndicate
 	glasses = /obj/item/clothing/glasses/overwatch
 	r_hand = /obj/item/tank/internals/plasmaman/belt/full
+	internals_slot = ITEM_SLOT_HANDS
 
 /datum/outfit/syndicate/reinforcement/gorlex
 	name = "Syndicate Operative - Gorlex Reinforcement"

--- a/code/modules/antagonists/space_ninja/space_ninja.dm
+++ b/code/modules/antagonists/space_ninja/space_ninja.dm
@@ -32,7 +32,7 @@
  * * Returns a proc call on the given human which will equip them with all the gear.
  */
 /datum/antagonist/ninja/proc/equip_space_ninja(mob/living/carbon/human/ninja = owner.current)
-	return ninja.equipOutfit(/datum/outfit/ninja)
+	return ninja.equip_species_outfit(/datum/outfit/ninja)
 
 /**
  * Proc that adds the proper memories to the antag datum

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -284,6 +284,9 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	fishing_modifier = 0
 	pepper_tint = FALSE
 
+/obj/item/clothing/mask/gas/syndicate/plasmaman
+	starting_filter_type = /obj/item/gas_filter/plasmaman
+
 /obj/item/clothing/mask/gas/clown_hat
 	name = "clown wig and mask"
 	desc = "A true prankster's facial attire. A clown is incomplete without his wig and mask."

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -868,6 +868,7 @@
 	gloves = /obj/item/clothing/gloves/color/plasmaman/atmos
 	shoes = /obj/item/clothing/shoes/workboots
 	r_pocket = /obj/item/tank/internals/plasmaman/belt/full
+	internals_slot = ITEM_SLOT_RPOCKET
 
 	back = /obj/item/storage/backpack/industrial
 

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -52,6 +52,7 @@
 	bodytemp_cold_damage_limit = (BODYTEMP_COLD_DAMAGE_LIMIT - 50) // about -50c
 
 	outfit_override_registry = list(
+		/datum/outfit/ninja = /datum/outfit/ninja/plasmaman,
 		/datum/outfit/syndicate = /datum/outfit/syndicate/plasmaman,
 		/datum/outfit/syndicate/full = /datum/outfit/syndicate/full/plasmaman,
 		/datum/outfit/syndicate/leader = /datum/outfit/syndicate/leader/plasmaman,


### PR DESCRIPTION
## About The Pull Request

This PR adds a plasmaman version of the ninja outfit so that if you spawn as a ninja plasmaman you won't suffocate to death in space due to lack of internals.

Also while I was there I went through all the other plasmaman outfits and made sure they had their internals set on so that you don't need to manually toggle them on yourself when you spawn, and added a mask to the "full nuke ops" outfit because there isn't any reason they shouldn't be wearing the mask.

## Changelog

:cl:
fix: When you spawn as a plasmaman ninja, you will also have some breathable air in your pocket
qol: When you spawn as a ghost role plasmaman your internals should be enabled
/:cl: