### PR TITLE
GIves Nightmares Light Drinker as well as Light Eater

### DIFF
--- a/code/modules/antagonists/nightmare/nightmare_organs.dm
+++ b/code/modules/antagonists/nightmare/nightmare_organs.dm
@@ -88,6 +88,8 @@
 	decay_factor = 0
 	// No love is to be found in a heart so twisted.
 	food_reagents = list(/datum/reagent/consumable/nutriment/organ_tissue = 5)
+	// In case you want to drink light as well as eat it
+	organ_traits = list(TRAIT_LIGHT_DRINKER)
 	/// How many life ticks in the dark the owner has been dead for. Used for nightmare respawns.
 	var/respawn_progress = 0
 	/// The armblade granted to the host of this heart.


### PR DESCRIPTION
## About The Pull Request

Nightmares (and those who eat the heart of a Nightmare) have a Light Eater permanently attached to their hand, but what if they get thirsty?
This PR makes it so that Nightmares also are Light Drinkers.

## Why It's Good For The Game

It just makes sense.

## Changelog

:cl:
balance: Nightmares are Light Drinkers in addition to being Light Eaters.
/:cl:
