### PR TITLE
Removes two ways into science with just maintenance access on Icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -41267,7 +41267,7 @@
 	name = "Ordnance Launch Room"
 	},
 /obj/effect/mapping_helpers/airlock/unres/delayed,
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "lEz" = (
@@ -56382,7 +56382,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Cytology Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "pQo" = (
@@ -79116,7 +79116,7 @@
 /obj/effect/mapping_helpers/airlock/unres/delayed{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "wvw" = (


### PR DESCRIPTION

## About The Pull Request

Changes the access into the penguin pen(and by extension science general) to science general access, and the access into the ordnance firing room to ordnance access, on icebox.

## Why It's Good For The Game

Door into science should require science access

## Changelog
:cl:

map: Icebox science now requires science access to enter

/:cl:
