### PR TITLE
You can't smell who shot out a monkey unless you can smell, and are next to them, unless you've got a good nose

### DIFF
--- a/code/datums/status_effects/debuffs/slime/slime_food.dm
+++ b/code/datums/status_effects/debuffs/slime/slime_food.dm
@@ -37,6 +37,10 @@
 ///Gaze upon the target
 /datum/status_effect/slime_food/proc/on_examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
+	if(HAS_TRAIT(user, TRAIT_ANOSMIA))
+		return
+	if(get_dist(user, owner) > 1 && !astype(user, /mob/living/carbon)?.dna.get_mutation(/datum/mutation/olfaction))
+		return
 	if(user == feeder)
 		examine_list += span_boldnotice("Their smell reminds you of serenity and yourself.")
 	else


### PR DESCRIPTION

## About The Pull Request

You can't smell monkeys for who output them unless you are adjacent to them, unless you have the olfaction mutation. You also cannot smell monkeys if you have anosmia.

## Why It's Good For The Game

Smelling exactly who hit the button to shoot out a monkey from twenty meters away through space is odd behaviour, and I think these are fairly reasonable interactions with smell-based modifiers.

## Changelog
:cl:

balance: You can't smell monkeys unless you're next to them, or have a good nose.

/:cl:
