### PR TITLE
Stops gateway CI from generating lavaland and space ruins

### DIFF
--- a/_maps/gateway_test.json
+++ b/_maps/gateway_test.json
@@ -3,7 +3,8 @@
 	"map_name": "Gateway Test",
 	"map_path": "map_files/debug",
 	"map_file": "gateway_test.dmm",
-	"space_ruin_levels": 1,
+	"space_ruin_levels": 0,
+	"minetype": "none",
 	"load_all_away_missions": true,
 	"ignored_unit_tests": [
 		"/datum/unit_test/antag_moodlets",

--- a/code/modules/unit_tests/lungs.dm
+++ b/code/modules/unit_tests/lungs.dm
@@ -191,6 +191,11 @@
 
 /// Set up an Lavaland gas mix which is "ideal" for Ashwalker life.
 /datum/unit_test/lungs/proc/create_lavaland_mix()
+	if(!SSair.planetary[LAVALAND_DEFAULT_ATMOS])
+		var/datum/gas_mixture/immutable/planetary/mix = new
+		mix.parse_string_immutable(LAVALAND_DEFAULT_ATMOS)
+		SSair.planetary[LAVALAND_DEFAULT_ATMOS] = mix
+
 	var/datum/gas_mixture/immutable/planetary/lavaland_mix = SSair.planetary[LAVALAND_DEFAULT_ATMOS]
 	var/datum/gas_mixture/test_mix = allocate(/datum/gas_mixture, 2500)
 	test_mix.copy_from(lavaland_mix)


### PR DESCRIPTION

## About The Pull Request
Lightens up the Gateway CI, as it's a very memory-intensive test that creeps ever closer to the 4gb limit. 
## Why It's Good For The Game
Functional and consistent CI is good 
## Changelog
N/A
