### PR TITLE
Catwalk: Fix tcomms windoor

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -14897,7 +14897,7 @@
 /obj/structure/ladder,
 /obj/machinery/door/window/brigdoor/right/directional/east{
 	name = "Telecomms Access";
-	req_access = list("tcoms")
+	req_access = list("tcomms")
 	},
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,


### PR DESCRIPTION
## About The Pull Request

The windoor on the upper floor of the tcomms server room on Catwalk is bugged, as it has "tcoms" in its access field instead of "tcomms". This PR adds literally one letter to the map file to fix this.

## Why It's Good For The Game

Despite the inconsistency of naming things in the code, tcoms doesn't exist and is a bad access requirement

## Changelog

:cl:
map: Fixed the access requirements of the telecomms door in Catwalk.
/:cl:
