### PR TITLE
Regal Rats cannot produce miasma until controlled by a player

### DIFF
--- a/code/__DEFINES/ai/monsters.dm
+++ b/code/__DEFINES/ai/monsters.dm
@@ -103,8 +103,6 @@
 #define BB_TARGET_TREE "BB_target_tree"
 
 // Regal Rats
-/// The rat's ability to corrupt an area.
-#define BB_DOMAIN_ABILITY "BB_domain_ability"
 /// The rat's ability to raise a horde of soldiers.
 #define BB_RAISE_HORDE_ABILITY "BB_raise_horde_ability"
 

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
@@ -74,8 +74,7 @@
 
 /mob/living/basic/regal_rat/Login()
 	. = ..()
-	var/datum/action/cooldown/mob_cooldown/domain/domainaction = new(src)
-	domainaction.Grant(src)
+	GRANT_ACTION(/datum/action/cooldown/mob_cooldown/domain)
 
 /mob/living/basic/regal_rat/death(gibbed)
 	var/datum/component/potential_component = GetComponent(/datum/component/ghost_direct_control)

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
@@ -67,11 +67,15 @@
 	)
 
 	var/static/list/innate_actions = list(
-		/datum/action/cooldown/mob_cooldown/domain = null,
 		/datum/action/cooldown/mob_cooldown/riot = BB_RAISE_HORDE_ABILITY,
 	)
 
 	grant_actions_by_list(innate_actions)
+
+/mob/living/basic/regal_rat/Login()
+	. = ..()
+	var/datum/action/cooldown/mob_cooldown/domain/domainaction = new(src)
+	domainaction.Grant(src)
 
 /mob/living/basic/regal_rat/death(gibbed)
 	var/datum/component/potential_component = GetComponent(/datum/component/ghost_direct_control)

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
@@ -67,7 +67,7 @@
 	)
 
 	var/static/list/innate_actions = list(
-		/datum/action/cooldown/mob_cooldown/domain = BB_DOMAIN_ABILITY,
+		/datum/action/cooldown/mob_cooldown/domain,
 		/datum/action/cooldown/mob_cooldown/riot = BB_RAISE_HORDE_ABILITY,
 	)
 

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
@@ -67,7 +67,7 @@
 	)
 
 	var/static/list/innate_actions = list(
-		/datum/action/cooldown/mob_cooldown/domain,
+		/datum/action/cooldown/mob_cooldown/domain = null,
 		/datum/action/cooldown/mob_cooldown/riot = BB_RAISE_HORDE_ABILITY,
 	)
 

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_ai.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_ai.dm
@@ -16,19 +16,9 @@
 		/datum/ai_planning_subtree/flee_target/from_flee_key,
 		/datum/ai_planning_subtree/attack_obstacle_in_path,
 		/datum/ai_planning_subtree/basic_melee_attack_subtree,
-		/datum/ai_planning_subtree/use_mob_ability/domain,
 	)
 
 /datum/ai_planning_subtree/targeted_mob_ability/riot
 	target_key = BB_BASIC_MOB_FLEE_TARGET // we only want to trigger this when provoked, manpower is low nowadays
 	ability_key = BB_RAISE_HORDE_ABILITY
 	finish_planning = FALSE
-
-/datum/ai_planning_subtree/use_mob_ability/domain
-	ability_key = BB_DOMAIN_ABILITY
-
-/datum/ai_planning_subtree/use_mob_ability/domain/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
-	var/datum/action/cooldown/mob_cooldown/domain/domain = controller.blackboard[ability_key]
-	if (!istype(domain) || domain.is_active)
-		return
-	return ..()


### PR DESCRIPTION
## About The Pull Request

Disables the AI controller's ability to activate the Regal Rat's "Domain" ability, the one that produces miasma, detritus and oil.

## Why It's Good For The Game

Regal Rats, currently, are very repetitive. They produce gas & oil, until they're stumbled upon and killed, leaving five air alarms that will take an hour and a half to go away. There's practically never a controlled regal rat unless there's nobody on station, because it is a wholly negative influence on the station. If the gas attack wasn't happening, there'd be no reason to kill them, and maybe we'd see them conscious more often.

Additionally, what I see as the base for this ability is gone- Regal Rats are no longer capable of reasonably defending themselves without a player controller, as they can no longer summon mice out of thin air. It is unlikely for a maintenance critter to be near the regal rat when it is attacked, much less several, so Regal Rats can't do damage literally to save their life. With this, there's NO reason not to kill them, where they could at least feign resistance before.

## Changelog
:cl:

balance: Regal Rats cannot produce miasma until controlled by a player

/:cl:
