### PR TITLE
Making surgery beds on top of stasis beds no longer possible

### DIFF
--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -62,14 +62,24 @@
 	if(our_stack.get_amount() < 1)
 		balloon_alert(user, "need more material!")
 		return ITEM_INTERACT_BLOCKING
-	if(locate(/obj/structure/table) in loc)
-		balloon_alert(user, "can't stack tables!")
-		return ITEM_INTERACT_BLOCKING
+
+	// Check if the turf is blocked by dense objects or objects that block construction
+	for(var/obj/object in loc)
+		if(object.density && !(object.obj_flags & IGNORE_DENSITY) || object.obj_flags & BLOCKS_CONSTRUCTION)
+			balloon_alert(user, "something is in the way!")
+			return ITEM_INTERACT_BLOCKING
 
 	balloon_alert(user, "constructing table...")
 	if(!do_after(user, 2 SECONDS, target = src))
 		return ITEM_INTERACT_BLOCKING
-	if((locate(/obj/structure/table) in loc) || !our_stack.use(1))
+
+	// Check again after the delay in case something was placed during construction
+	for(var/obj/object in loc)
+		if(object.density && !(object.obj_flags & IGNORE_DENSITY) || object.obj_flags & BLOCKS_CONSTRUCTION)
+			balloon_alert(user, "something is in the way!")
+			return ITEM_INTERACT_BLOCKING
+
+	if(!our_stack.use(1))
 		return ITEM_INTERACT_BLOCKING
 
 	new table_type(loc, src, our_stack)


### PR DESCRIPTION

## About The Pull Request

Fixes #94801 by making table construction closer to other construction objects and has the same error message as other construction bits, Checked the logic in crafting for comparison as well and tested the fix in game.
<img width="371" height="205" alt="Screenshot 2026-01-09 153357" src="https://github.com/user-attachments/assets/bb17031f-320b-4234-97d7-193762ced721" />
<img width="267" height="260" alt="Screenshot 2026-01-09 153424" src="https://github.com/user-attachments/assets/9f38ece7-328b-4f43-b6d8-9c175f7d5687" />
## Why It's Good For The Game

- Fixes unintended exploit method of having all the benefits of surgery with stasis beds
## Changelog
:cl:
fix: Making surgery beds on top of stasis beds no longer possible
/:cl:
