### PR TITLE
Fixes Gateway offset when viewed through a camera console

### DIFF
--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -154,7 +154,7 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 	pixel_y = -32
 	bound_height = 64
 	bound_width = 96
-	bound_x = -32
+	bound_x = 0
 	bound_y = 0
 	density = TRUE
 


### PR DESCRIPTION

## About The Pull Request

closes #94793 

after checking things it would seem that 5 years ago when the Gateway was refactored the bound X was set to -32, this may have had a purpose but that purpose seems to no longer exist, bound Y isnt changed despite both pixel X and Y being set to -32, so my guess is maybe the bound was accidentally set to -32? im not sure, either way the bound was offsetting the gateway one tile to the right when viewed through camera consoles, setting the bound back to 0 solves this issue, and yes, I did extensive testing with the gateway, the bound being set to 0 does not change the gateways hitbox or anything, the gateway turns on, you can walk into it etc.. its completely unchanged except that now the camera consoles dont offset it

it is a bit confusing that its been 5 years and the issue just recently showed up but there has been some changes to camera code lately so one of them might have caused issues with things that have both their bound and pixel offset



all that being said, I am not an expert on bounding, or gateway code, if it turns out there is an actual purpose/need for the bound to be offset then i guess we will have to find a different fix, but atleast smartkar in discord seemed to think the bound being set to 0 shouldnt cause any issues in this case
## Why It's Good For The Game

no wonky offsets when viewing cameras through a console
## Changelog
:cl: Nari Harimoto
fix: Camera Consoles no longer hallucinate the Gateway in a different position
/:cl:
