### PR TITLE
Allows hypnoflashes to fit within a security belt.

### DIFF
--- a/code/datums/storage/subtypes/belts.dm
+++ b/code/datums/storage/subtypes/belts.dm
@@ -90,6 +90,7 @@
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing/shotgun,
 		/obj/item/assembly/flash/handheld,
+		/obj/item/assembly/flash/hypnotic,
 		/obj/item/clothing/glasses,
 		/obj/item/clothing/gloves,
 		/obj/item/flashlight/seclite,


### PR DESCRIPTION
## About The Pull Request
Title, right now flash/handheld fits within a security belt, but flash/hypnotic does not.
## Why It's Good For The Game
It's by all means a flash, no reason for it not to fit within a security belt. It not fitting in the belt means it can be meta'd. Searching a roboticist who would reasonably have a flash? Flash doesn't fit in belt? It must be a hypnoflash.

Feels oversighty idk
## Changelog
:cl:
fix: Hypnoflashes now fit on secbelts just like regular flashes.
/:cl:
