### PR TITLE
Gives deconstructing modular computers with a wrench a doafter

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -872,6 +872,8 @@
 /obj/item/modular_computer/wrench_act_secondary(mob/living/user, obj/item/tool)
 	. = ..()
 	tool.play_tool_sound(src, user, 20, volume=20)
+	if(!do_after(user, 2 SECONDS, target = physical))
+		return ITEM_INTERACT_BLOCKING
 	deconstruct(TRUE)
 	user.balloon_alert(user, "disassembled")
 	return ITEM_INTERACT_SUCCESS


### PR DESCRIPTION

## About The Pull Request
Title. They didn't have a doafter. You could instantly delete shit like any modular computer and PDAs.

## Why It's Good For The Game
I'd rather not accidentally deconstruct my PDA again. Or any other modular computer really.

## Changelog

:cl:
fix: Modular computers now have a 2 second delay before being deconstructed.
/:cl:

