### PR TITLE
voltaic cyberheart: stoppable overlay timer, losing overdrive on heart loss

### DIFF
--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -226,8 +226,6 @@
 /datum/status_effect/voltaic_overdrive/proc/on_organ_lost(mob/living/carbon/source, obj/item/organ/organ, special)
 	SIGNAL_HANDLER
 	if(istype(organ, /obj/item/organ/heart/cybernetic/anomalock))
-		var/obj/item/organ/heart/cybernetic/anomalock/just_fell_out = organ
-		just_fell_out.clear_lightning_overlay()
 		qdel(src)
 
 /atom/movable/screen/alert/status_effect/anomalock_active


### PR DESCRIPTION
## About The Pull Request

Sets the voltaic overdrive from entering crit with the voltaic combat cyberheart to end (by deleting itself) if you lose the cyberheart (e.g. someone pulling it out of you while you're in crit), because why would you still have the overdrive if the thing giving you it just got pulled out? (Also, the self-deleting aspect of the cyberheart causes a runtime when you pull it out via surgery, I think.)

Sets the `clear_lightning_overlay()` timer to be stoppable, and to be stopped when the heart is removed.
Sets `clear_lightning_overlay()` to null-check in case it doesn't have an owner.

## Why It's Good For The Game

Theoretically prevents having a permanent lightning overlay (and maybe stops a runtime) in the event your cyberheart is pulled out while you're lightning-y.

## Changelog

:cl: Hatterhat, vinylspiders
fix: Voltaic combat cyberheart's lightning overlay should be more reliably cleared in the event that it should be lost.
fix: If your voltaic combat cyberheart is lost/removed while you're in voltaic overdrive, you lose the overdrive.
/:cl: