### PR TITLE
Fixes Flakey Ashwalker Lung Unit Test Failures on `gateway_test`

### DIFF
--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -998,7 +998,7 @@
 #define GAS_TOLERANCE 5
 
 /obj/item/organ/lungs/lavaland/Initialize(mapload)
-	var/datum/gas_mixture/immutable/planetary/mix = SSair.planetary[LAVALAND_DEFAULT_ATMOS]
+	var/datum/gas_mixture/immutable/planetary/mix = SSair.parse_gas_string(LAVALAND_DEFAULT_ATMOS, /datum/gas_mixture/immutable/planetary)
 
 	if(!mix?.total_moles()) // this typically means we didn't load lavaland, like if we're using the LOWMEMORYMODE define
 		return ..()

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -1000,9 +1000,6 @@
 /obj/item/organ/lungs/lavaland/Initialize(mapload)
 	var/datum/gas_mixture/immutable/planetary/mix = SSair.parse_gas_string(LAVALAND_DEFAULT_ATMOS, /datum/gas_mixture/immutable/planetary)
 
-	if(!mix?.total_moles()) // this typically means we didn't load lavaland, like if we're using the LOWMEMORYMODE define
-		return ..()
-
 	// Take a "breath" of the air
 	var/datum/gas_mixture/breath = mix.remove(mix.total_moles() * BREATH_PERCENTAGE)
 

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -998,10 +998,13 @@
 #define GAS_TOLERANCE 5
 
 /obj/item/organ/lungs/lavaland/Initialize(mapload)
+	var/datum/gas_mixture/volumed_mix = new(BREATH_VOLUME * 1000) // to be safe
 	var/datum/gas_mixture/immutable/planetary/mix = SSair.parse_gas_string(LAVALAND_DEFAULT_ATMOS, /datum/gas_mixture/immutable/planetary)
 
+	volumed_mix.copy_from(mix)
+
 	// Take a "breath" of the air
-	var/datum/gas_mixture/breath = mix.remove(mix.total_moles() * BREATH_PERCENTAGE)
+	var/datum/gas_mixture/breath = volumed_mix.remove(volumed_mix.total_moles() * BREATH_PERCENTAGE)
 
 	var/list/breath_gases = breath.gases
 

--- a/code/modules/unit_tests/breath.dm
+++ b/code/modules/unit_tests/breath.dm
@@ -96,10 +96,13 @@
 /datum/unit_test/breath/breath_sanity_ashwalker/proc/turn_room_into_lavaland()
 	var/area/unit_test_area = get_area(run_loc_floor_bottom_left)
 	var/list/turf/lavalandable_turfs = unit_test_area.get_turfs_from_all_zlevels()
+
+	var/datum/gas_mixture/lavaland_mix = SSair.parse_gas_string(LAVALAND_DEFAULT_ATMOS, /datum/gas_mixture/turf)
+	var/datum/gas_mixture/volumetric_mix = allocate(/datum/gas_mixture, 2500)
+
+	test_mix.copy_from(lavaland_mix)
+
 	for(var/turf/open/tile in lavalandable_turfs)
-		var/datum/gas_mixture/lavaland_mix = SSair.parse_gas_string(LAVALAND_DEFAULT_ATMOS, /datum/gas_mixture/turf)
-
-		tile.copy_air(lavaland_mix)
+		tile.copy_air(test_mix)
 		tile.air_update_turf(update = FALSE, remove = FALSE)
-
 

--- a/code/modules/unit_tests/breath.dm
+++ b/code/modules/unit_tests/breath.dm
@@ -97,7 +97,7 @@
 	var/area/unit_test_area = get_area(run_loc_floor_bottom_left)
 	var/list/turf/lavalandable_turfs = unit_test_area.get_turfs_from_all_zlevels()
 
-	var/datum/gas_mixture/lavaland_mix = SSair.parse_gas_string(LAVALAND_DEFAULT_ATMOS, /datum/gas_mixture/turf)
+	var/datum/gas_mixture/lavaland_mix = SSair.parse_gas_string(LAVALAND_DEFAULT_ATMOS, /datum/gas_mixture/immutable/planetary)
 	var/datum/gas_mixture/volumetric_mix = allocate(/datum/gas_mixture, 2500)
 
 	volumetric_mix.copy_from(lavaland_mix)
@@ -105,4 +105,3 @@
 	for(var/turf/open/tile in lavalandable_turfs)
 		tile.copy_air(volumetric_mix)
 		tile.air_update_turf(update = FALSE, remove = FALSE)
-

--- a/code/modules/unit_tests/breath.dm
+++ b/code/modules/unit_tests/breath.dm
@@ -100,9 +100,9 @@
 	var/datum/gas_mixture/lavaland_mix = SSair.parse_gas_string(LAVALAND_DEFAULT_ATMOS, /datum/gas_mixture/turf)
 	var/datum/gas_mixture/volumetric_mix = allocate(/datum/gas_mixture, 2500)
 
-	test_mix.copy_from(lavaland_mix)
+	volumetric_mix.copy_from(lavaland_mix)
 
 	for(var/turf/open/tile in lavalandable_turfs)
-		tile.copy_air(test_mix)
+		tile.copy_air(volumetric_mix)
 		tile.air_update_turf(update = FALSE, remove = FALSE)
 

--- a/code/modules/unit_tests/breath.dm
+++ b/code/modules/unit_tests/breath.dm
@@ -87,15 +87,19 @@
 
 /datum/unit_test/breath/breath_sanity_ashwalker/Run()
 	var/mob/living/carbon/human/species/lizard/ashwalker/lab_rat = allocate(/mob/living/carbon/human/species/lizard/ashwalker)
-	lab_rat.forceMove(run_loc_floor_bottom_left)
-	var/turf/open/to_fill = run_loc_floor_bottom_left
-	to_fill.initial_gas_mix = LAVALAND_DEFAULT_ATMOS
-	to_fill.air = to_fill.create_gas_mixture()
+
+	turn_room_into_lavaland()
 	lab_rat.breathe()
 	TEST_ASSERT(!lab_rat.has_alert(ALERT_NOT_ENOUGH_OXYGEN), "Ashwalkers can't get a full breath from the Lavaland's initial_gas_mix on a turf")
 
-/datum/unit_test/breath/breath_sanity_ashwalker/Destroy()
-	//Reset initial_gas_mix to avoid future issues on other tests
-	var/turf/open/to_fill = run_loc_floor_bottom_left
-	to_fill.initial_gas_mix = OPENTURF_DEFAULT_ATMOS
-	return ..()
+/// Replaces the air mix in the entire room with lavaland air mix
+/datum/unit_test/breath/breath_sanity_ashwalker/proc/turn_room_into_lavaland()
+	var/area/unit_test_area = get_area(run_loc_floor_bottom_left)
+	var/list/turf/lavalandable_turfs = unit_test_area.get_turfs_from_all_zlevels()
+	for(var/turf/open/tile in lavalandable_turfs)
+		var/datum/gas_mixture/lavaland_mix = SSair.parse_gas_string(LAVALAND_DEFAULT_ATMOS, /datum/gas_mixture/turf)
+
+		tile.copy_air(lavaland_mix)
+		tile.air_update_turf(update = FALSE, remove = FALSE)
+
+

--- a/code/modules/unit_tests/lungs.dm
+++ b/code/modules/unit_tests/lungs.dm
@@ -191,7 +191,7 @@
 
 /// Set up an Lavaland gas mix which is "ideal" for Ashwalker life.
 /datum/unit_test/lungs/proc/create_lavaland_mix()
-	var/datum/gas_mixture/immutable/planetary/lavaland_mix = SSair.parse_gas_string(LAVALAND_DEFAULT_ATMOS, /datum/gas_mixture/turf)
+	var/datum/gas_mixture/immutable/planetary/lavaland_mix = SSair.parse_gas_string(LAVALAND_DEFAULT_ATMOS, /datum/gas_mixture/immutable/planetary)
 	var/datum/gas_mixture/test_mix = allocate(/datum/gas_mixture, 2500)
 	test_mix.copy_from(lavaland_mix)
 	return test_mix

--- a/code/modules/unit_tests/lungs.dm
+++ b/code/modules/unit_tests/lungs.dm
@@ -191,12 +191,7 @@
 
 /// Set up an Lavaland gas mix which is "ideal" for Ashwalker life.
 /datum/unit_test/lungs/proc/create_lavaland_mix()
-	if(!SSair.planetary[LAVALAND_DEFAULT_ATMOS])
-		var/datum/gas_mixture/immutable/planetary/mix = new
-		mix.parse_string_immutable(LAVALAND_DEFAULT_ATMOS)
-		SSair.planetary[LAVALAND_DEFAULT_ATMOS] = mix
-
-	var/datum/gas_mixture/immutable/planetary/lavaland_mix = SSair.planetary[LAVALAND_DEFAULT_ATMOS]
+	var/datum/gas_mixture/immutable/planetary/lavaland_mix = SSair.parse_gas_string(LAVALAND_DEFAULT_ATMOS, /datum/gas_mixture/turf)
 	var/datum/gas_mixture/test_mix = allocate(/datum/gas_mixture, 2500)
 	test_mix.copy_from(lavaland_mix)
 	return test_mix


### PR DESCRIPTION
## About The Pull Request

Closes #94794

Both of these unit tests were using the outdated way of changing the gas mix on a turf, probably because they were more than a few years old apiece. The modern way is using the `/datum/gas_mixture` and `parse_gas_string()` to either retrieve the gas mix from cache or generate it on-demand. Neither of these tests were doing that, and they worked well enough until they got mutated in #94771 (01c7ef7de16e895a485ea6b829e1b2fe2a732dc4).

I am uncertain of the specifics that are behind either one spontaneously/always failing but I do know that they weren't doing it the "right way". I suspect the flakiness in the Breath Ashwalker Sanity (that loads a full ashwalker carbon instead of just the lungs) is because it was initiating a gas mix with no volume within it, and that volume would get filled up as the other turfs in the loc would update it somewhere in the atmos chain? We only checked for the "low oxygen" status effect on the mob and that could easily have been filled up to normal depending on how much happened. Regardless the best way to fix this is to just have all the turfs in the unit test room get changed to prevent any schenanigans with that.

Another explanation for the flakiness is that the ashwalker lungs themselves use the same "old" way of getting the gas mix instead of the modern way (such that the lung breath values can adapt to changes)... I think...
## Why It's Good For The Game

Less developer frustration at spontaneously failing unit tests through no fault of their own.
## Changelog
Irrelevant
