### PR TITLE
[NO GBP] Fixes inability to place flipped trinary atmospheric implements with RPD

### DIFF
--- a/code/_globalvars/pipe_info.dm
+++ b/code/_globalvars/pipe_info.dm
@@ -57,7 +57,7 @@
 	var/list/rows = list()
 	for(var/dir in dirs)
 		var/numdir = text2num(dir)
-		var/flipped = ((dirtype == PIPE_UNARY_FLIPPABLE) || (dirtype == PIPE_ONEDIR_FLIPPABLE)) && (ISDIAGONALDIR(numdir))
+		var/flipped = ((dirtype == PIPE_TRIN_M && !ispath(id, /obj/structure/disposalpipe)) || (dirtype == PIPE_UNARY_FLIPPABLE) || (dirtype == PIPE_ONEDIR_FLIPPABLE)) && (ISDIAGONALDIR(numdir))
 		var/is_variant_selected = selected && (!selected_dir ? FALSE : (dirtype == PIPE_ONEDIR ? TRUE : (numdir == selected_dir)))
 		rows += list(list(
 			"selected" = is_variant_selected,


### PR DESCRIPTION

## About The Pull Request

I forgot to check the devices. Disposal pipes are just gonna have to be a direct exception. I could make it a proc overriden by subtype but that seems like it'd be even more unreadable.

## Why It's Good For The Game

fixes #94815

## Changelog
:cl:

fix: Flipped RPD-placed trinary atmospheric implements now place properly.

/:cl:
