### PR TITLE
Objects that can pass over tables don't block table construction

### DIFF
--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -65,8 +65,10 @@
 
 	// Check if the turf is blocked by dense objects or objects that block construction
 	for(var/obj/object in loc)
-		if(object.density && !(object.obj_flags & IGNORE_DENSITY) || object.obj_flags & BLOCKS_CONSTRUCTION)
-			balloon_alert(user, "something is in the way!")
+		if(object.pass_flags & PASSTABLE)
+			continue
+		if((object.density && !(object.obj_flags & IGNORE_DENSITY)) || object.obj_flags & BLOCKS_CONSTRUCTION)
+			balloon_alert(user, "[object.name] is in the way!")
 			return ITEM_INTERACT_BLOCKING
 
 	balloon_alert(user, "constructing table...")
@@ -75,8 +77,10 @@
 
 	// Check again after the delay in case something was placed during construction
 	for(var/obj/object in loc)
-		if(object.density && !(object.obj_flags & IGNORE_DENSITY) || object.obj_flags & BLOCKS_CONSTRUCTION)
-			balloon_alert(user, "something is in the way!")
+		if(object.pass_flags & PASSTABLE)
+			continue
+		if((object.density && !(object.obj_flags & IGNORE_DENSITY)) || object.obj_flags & BLOCKS_CONSTRUCTION)
+			balloon_alert(user, "[object.name] is in the way!")
 			return ITEM_INTERACT_BLOCKING
 
 	if(!our_stack.use(1))


### PR DESCRIPTION
## About The Pull Request

#94802 follow up

Dense objects that can pass over tables like microwaves shouldn't block table construction

## Why It's Good For The Game

It's a bit annoying to have to work around tables for machines made to be on tables

## Changelog

:cl: Melbert
qol: Objects that can pass over tables don't block table construction
qol: If table construction fails, it tells you what is blocking, rather than "something is" 
/:cl:
