### PR TITLE
Restores emergency access feature

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -337,9 +337,11 @@
 		return
 
 	var/access_check = access_bypass
-	if(unrestricted_side(user) && !delayed_unres_open)
+	if(emergency)
 		access_check = TRUE
-	if(!requiresID())
+	else if(unrestricted_side(user) && !delayed_unres_open)
+		access_check = TRUE
+	else if(!requiresID())
 		access_check = TRUE
 	else if(allowed(user)) // You
 		access_check = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes issue #94835

Emergency Access is currently not functional via comms console, admin verb or AI emergency access. The lights come on but users just get access denied on bumping into the door.

| EA Door | Open Sesame |
|--------|--------|
| <img width="270" height="265" alt="Screenshot 2026-01-11 235032" src="https://github.com/user-attachments/assets/f6c67425-3ff4-4492-b945-ae9729f30583" /> | <img width="275" height="259" alt="Screenshot 2026-01-11 235026" src="https://github.com/user-attachments/assets/c231cc52-1233-4d14-a38a-e52549cca23d" /> | 


#94779 removed it as I suspect an unintended oversight, this restores it while preserving the refactor intention. Tested in game.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Restores emergency access feature
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
