### PR TITLE
Broodmother spider team antag update

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spiders.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spiders.dm
@@ -57,6 +57,7 @@
 	ADD_TRAIT(src, TRAIT_STRONG_GRABBER, INNATE_TRAIT)
 
 	AddElement(/datum/element/web_walker, /datum/movespeed_modifier/slow_web)
+	AddElement(/datum/element/door_pryer, pry_time = 5 SECONDS)
 
 /**
  * ### Guard Spider
@@ -108,6 +109,8 @@
 
 /mob/living/basic/spider/giant/hunter/Initialize(mapload)
 	. = ..()
+	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
+
 	AddElement(/datum/element/web_walker, /datum/movespeed_modifier/fast_web)
 
 ///Used in the caves away mission.
@@ -180,8 +183,8 @@
 	ADD_TRAIT(src, TRAIT_MEDICAL_HUD, INNATE_TRAIT)
 
 	AddComponent(/datum/component/healing_touch,\
-		heal_brute = 10,\
-		heal_burn = 10,\
+		heal_brute = 25,\
+		heal_burn = 25,\
 		heal_time = 2.5 SECONDS,\
 		interaction_key = DOAFTER_SOURCE_SPIDER,\
 		valid_targets_typecache = typecacheof(list(/mob/living/basic/spider/giant)),\
@@ -293,6 +296,21 @@
 		complete_text = "%SOURCE%'s wounds mend together.",\
 	)
 
+/mob/living/basic/spider/giant/tank/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit, blocked)
+	if(!istype(hitting_projectile, /obj/projectile/energy) && !istype(hitting_projectile, /obj/projectile/beam))
+		return ..()
+	if(!prob(40 - round(hitting_projectile.damage / 3))) // reflect chance
+		return ..()
+
+	apply_damage(hitting_projectile.damage * 0.2, hitting_projectile.damage_type)
+	visible_message(
+		span_danger("\The [hitting_projectile] is reflected by [src]'s armored exoskeleton!"),
+		span_userdanger("\The [hitting_projectile] is reflected by your armored exoskeleton!"),
+	)
+
+	hitting_projectile.reflect(src)
+	return BULLET_ACT_FORCE_PIERCE
+
 /// Prevent you from healing when on fire
 /mob/living/basic/spider/giant/tank/proc/can_mend(mob/living/source, mob/living/target)
 	if (on_fire)
@@ -340,6 +358,7 @@
 
 	AddElement(/datum/element/wall_tearer)
 	AddElement(/datum/element/web_walker, /datum/movespeed_modifier/below_average_web)
+	AddElement(/datum/element/door_pryer, pry_time = 3 SECONDS)
 
 /**
  * ### Tarantula
@@ -381,6 +400,7 @@
 	charge.Grant(src)
 
 	AddElement(/datum/element/web_walker, /datum/movespeed_modifier/slow_web)
+	AddElement(/datum/element/door_pryer, pry_time = 7 SECONDS)
 
 /mob/living/basic/spider/giant/tarantula/Destroy()
 	QDEL_NULL(charge)
@@ -419,6 +439,7 @@
 
 /mob/living/basic/spider/giant/viper/Initialize(mapload)
 	. = ..()
+	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 	AddElement(/datum/element/bonus_damage)
 
 /**
@@ -462,9 +483,19 @@
 
 /mob/living/basic/spider/giant/midwife/Initialize(mapload)
 	. = ..()
-
+	ADD_TRAIT(src, TRAIT_MEDICAL_HUD, INNATE_TRAIT)
 	AddElement(/datum/element/web_walker, /datum/movespeed_modifier/average_web)
+	AddElement(/datum/element/door_pryer, pry_time = 7 SECONDS)
 
+	AddComponent(/datum/component/healing_touch,\
+		heal_brute = 10,\
+		heal_burn = 10,\
+		heal_time = 3 SECONDS,\
+		interaction_key = DOAFTER_SOURCE_SPIDER,\
+		valid_targets_typecache = typecacheof(list(/mob/living/basic/spider/giant)),\
+		action_text = "%SOURCE% begins wrapping the wounds of %TARGET%.",\
+		complete_text = "%SOURCE% wraps the wounds of %TARGET%.",\
+	)
 /**
  * ### Giant Ice Spider
  *

--- a/code/modules/mob/living/basic/space_fauna/spider/spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider.dm
@@ -71,7 +71,6 @@
 	add_traits(list(TRAIT_WEB_SURFER, TRAIT_FENCE_CLIMBER), INNATE_TRAIT)
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_CLAW)
 	AddElement(/datum/element/nerfed_pulling, GLOB.typecache_general_bad_things_to_easily_move)
-	AddElement(/datum/element/prevent_attacking_of_types, GLOB.typecache_general_bad_hostile_attack_targets, "this tastes awful!")
 	AddElement(/datum/element/cliff_walking)
 	AddComponent(/datum/component/health_scaling_effects, min_health_slowdown = 1.5)
 	AddElement(/datum/element/basic_allergenic_attack, allergen = BUGS, allergen_chance = 20, histamine_add = 5)


### PR DESCRIPTION
## About The Pull Request

Im gonna be honest spiders feel 80% of the time a absolute joke so im gonna throw them a stick,

First of all giant spiders no longer care about structures if they want to break it they can break it this includes apcs scrubbers and etc, letting them push for apc points or have a backline unit break it so they can gain a adventage with their night vision or stop vents from emitting plasma and such

Broodmother spider. (Make them a more all round caste so they can get their start going on by nesting somewhere that isnt always maints and allows them to heal spiders early game, time healing is time spent not webbing/laying eggs)
Can force pry powered doors takes 7 seconds to do so.
Can heal other spiders now. 10/10 and can see other spiders health

Nurse spider. (for a deticated caste that can heal 10/10 feels like a joke when half of the other spiders can just self heal)
Healing buffed to 25/25

Tank spider. (for a tank spider this is also a absolute joke with reflecting shots this lets them take more a lead on the front instead of being glorious damage sacks)
These spiders can now reflect laser shots and take reduced damage from them when they do.
Heres a example of me using laser scattergun into it (unarmoured)
https://github.com/user-attachments/assets/0e052f69-6fea-4959-8763-c5c2b2279da7

Tarantula Spider
Can pry open doors which takes 7 seconds to do so

Breacher spider
Can pry open doors at a faster rate then other spiders takes 3 seconds to do so.

Viper Spider
Can now ventcrawl so they can come from the flanks and such to assault giving crew a good reason to weld the vents

Hunter spider
Can now ventcrawl so they can come from flanks and such to assault giving crew a good reason to weld the vents

## Why It's Good For The Game

Spiders feel a absolute joke so im gonna throw them a bone by enabling them to use more tactics as a team.
alot of things are in crew favour and its extremely easy to wipe out spiders or hear them existing since they just perma attack doors to get their way around

## Changelog
:cl: Ezel
balance: spiders don't care about taste any longer and can break structures like apc's atmos piping
balance: Tank spiders can now reflect lasers and take reduced damage
balance: Broodmother spider can now heal other spiders and see their health and pry open airlocks
balance: breacher spider can now pry open airlocks quickly takes 3 seconds to do so
balance: Tarantula spider can now pry open airlocks takes 7 seconds to do so
balance: nurse spiders have increased healing
balance: Hunter/viper spider can now ventcrawl
/:cl:
