### PR TITLE
Prevents Crusher Achievement Given For Regular BDM Kills

### DIFF
--- a/code/modules/mob/living/basic/boss/blood_drunk_miner/_blood_drunk_miner.dm
+++ b/code/modules/mob/living/basic/boss/blood_drunk_miner/_blood_drunk_miner.dm
@@ -34,9 +34,10 @@ Difficulty: Medium
 	ai_controller = /datum/ai_controller/blood_drunk_miner
 
 	achievements = list(
-		/datum/award/achievement/boss/boss_killer,
 		/datum/award/achievement/boss/blood_miner_kill,
+		/datum/award/achievement/boss/boss_killer,
 		/datum/award/score/blood_miner_score,
+		/datum/award/score/boss_score,
 	)
 	crusher_achievement_type = /datum/award/achievement/boss/blood_miner_crusher
 	victor_memory_type = /datum/memory/megafauna_slayer

--- a/code/modules/mob/living/basic/boss/blood_drunk_miner/_blood_drunk_miner.dm
+++ b/code/modules/mob/living/basic/boss/blood_drunk_miner/_blood_drunk_miner.dm
@@ -36,7 +36,6 @@ Difficulty: Medium
 	achievements = list(
 		/datum/award/achievement/boss/boss_killer,
 		/datum/award/achievement/boss/blood_miner_kill,
-		/datum/award/achievement/boss/blood_miner_crusher,
 		/datum/award/score/blood_miner_score,
 	)
 	crusher_achievement_type = /datum/award/achievement/boss/blood_miner_crusher


### PR DESCRIPTION
## About The Pull Request

On the tin. Whoops. This was supposed to be boss score but I think I was shuffling stuff around too much and this fell through the cracks.

## Changelog

:cl:
fix: Killing Blood Drunk Miner normally should no longer give you a crusher achievement.
/:cl:
