### PR TITLE
Ghost chem/health scan displays after examine information

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -60,17 +60,13 @@
 	return FALSE
 
 /mob/living/attack_ghost(mob/dead/observer/user)
+	. = ..()
 	if(user.client)
-		var/scan_done = FALSE
 		if (user.ghost_hud_flags & GHOST_HEALTH)
 			healthscan(user, src, 1, TRUE)
-			scan_done = TRUE
 		if (user.ghost_hud_flags & GHOST_CHEM)
 			chemscan(user, src)
-			scan_done = TRUE
-		if(scan_done)
-			return TRUE
-	return ..()
+	return
 
 // ---------------------------------------
 // And here are some good things for free:

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -61,12 +61,13 @@
 
 /mob/living/attack_ghost(mob/dead/observer/user)
 	. = ..()
-	if(user.client)
-		if (user.ghost_hud_flags & GHOST_HEALTH)
-			healthscan(user, src, 1, TRUE)
-		if (user.ghost_hud_flags & GHOST_CHEM)
-			chemscan(user, src)
-	return
+	if(isnull(user.client))
+		return
+
+	if (user.ghost_hud_flags & GHOST_HEALTH)
+		healthscan(user, src, 1, TRUE)
+	if (user.ghost_hud_flags & GHOST_CHEM)
+		chemscan(user, src)
 
 // ---------------------------------------
 // And here are some good things for free:

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -60,10 +60,16 @@
 	return FALSE
 
 /mob/living/attack_ghost(mob/dead/observer/user)
-	if(user.client && (user.ghost_hud_flags & GHOST_HEALTH))
-		healthscan(user, src, 1, TRUE)
-	if(user.client && (user.ghost_hud_flags & GHOST_CHEM))
-		chemscan(user, src)
+	if(user.client)
+		var/scan_done = FALSE
+		if (user.ghost_hud_flags & GHOST_HEALTH)
+			healthscan(user, src, 1, TRUE)
+			scan_done = TRUE
+		if (user.ghost_hud_flags & GHOST_CHEM)
+			chemscan(user, src)
+			scan_done = TRUE
+		if(scan_done)
+			return TRUE
 	return ..()
 
 // ---------------------------------------


### PR DESCRIPTION
## About The Pull Request

Makes the ghost toggles that make your clicks produce health and chem scans on people show the scan information after standard examine information

## Why It's Good For The Game

This makes these scans less annoying to use, as you don't have to scroll up after using them.

## Changelog
:cl:

qol: Ghost health and chem scanning displays after examine information rather than before

/:cl:
