### PR TITLE
Epinephrine and Inexorable interacts better, also gives `NOCRITDAMAGE` to Atropine

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -699,9 +699,11 @@
 		ADD_TRAIT(owner, TRAIT_SOFTSPOKEN, REF(src))
 
 /datum/mutation/inexorable/on_life(seconds_per_tick)
-	if(owner.health > owner.crit_threshold || owner.stat != CONSCIOUS || HAS_TRAIT(owner, TRAIT_STASIS) || HAS_TRAIT(owner, TRAIT_NOCRITDAMAGE))
+	if(owner.health > owner.crit_threshold || owner.stat != CONSCIOUS || HAS_TRAIT(owner, TRAIT_STASIS))
 		return
-	// Gives you 30 seconds of being in soft crit... give or take
+	if(HAS_TRAIT(owner, TRAIT_NOCRITDAMAGE) && owner.health <= owner.hardcrit_threshold + 10)
+		return
+	// Gives you 30 seconds of being in fake soft crit... give or take
 	if(HAS_TRAIT(owner, TRAIT_TOXIMMUNE) || HAS_TRAIT(owner, TRAIT_TOXINLOVER))
 		owner.adjust_brute_loss(1 * seconds_per_tick * GET_MUTATION_SYNCHRONIZER(src), forced = TRUE)
 	else

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -699,7 +699,7 @@
 		ADD_TRAIT(owner, TRAIT_SOFTSPOKEN, REF(src))
 
 /datum/mutation/inexorable/on_life(seconds_per_tick)
-	if(owner.health > owner.crit_threshold || owner.stat != CONSCIOUS || HAS_TRAIT(owner, TRAIT_STASIS))
+	if(owner.health > owner.crit_threshold || owner.stat != CONSCIOUS || HAS_TRAIT(owner, TRAIT_STASIS) || HAS_TRAIT(owner, TRAIT_NOCRITDAMAGE))
 		return
 	// Gives you 30 seconds of being in soft crit... give or take
 	if(HAS_TRAIT(owner, TRAIT_TOXIMMUNE) || HAS_TRAIT(owner, TRAIT_TOXINLOVER))

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -951,7 +951,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	inverse_chem_val = 0.35
 	inverse_chem = /datum/reagent/inverse/atropine
-	added_traits = list(TRAIT_PREVENT_IMPLANT_AUTO_EXPLOSION)
+	added_traits = list(TRAIT_NOCRITDAMAGE, TRAIT_PREVENT_IMPLANT_AUTO_EXPLOSION)
 
 /datum/reagent/medicine/atropine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

1. Inexorable's extra damage is not applied if in hard crit and you have `NOCRITDAMAGE` (plus a little bit of leeway). This is so epinephrine or atropine can actually pick you up out of hard crit. 

2. Atropine gets `NOCRITDAMAGE`.

## Why It's Good For The Game

1. Inexorable actually makes you die when you otherwise wouldn't, which seems bad. Like pretty bad. (Having experienced it now.)

2. It's an epinephrine analog, so it'd make sense to me.

## Changelog

:cl: Melbert
balance: Inexorable's crit damage is halted in hard crit while you have Epinephrine or similar, so you can actually get healed out of hard crit
balance: Atropine stops crit damage like Epinephrine
/:cl:


