### PR TITLE
Buffs thermal vision mutation

### DIFF
--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -65,8 +65,8 @@
 	if(!istype(to_modify)) // null or invalid
 		return
 
-	to_modify.eye_damage = 10 * GET_MUTATION_SYNCHRONIZER(src)
-	to_modify.thermal_duration = 10 SECONDS * GET_MUTATION_POWER(src)
+	to_modify.eye_damage = /datum/action/cooldown/spell/thermal_vision::eye_damage * GET_MUTATION_SYNCHRONIZER(src) * GET_MUTATION_POWER(src)
+	to_modify.thermal_duration = /datum/action/cooldown/spell/thermal_vision::thermal_duration * GET_MUTATION_POWER(src)
 
 /datum/action/cooldown/spell/thermal_vision
 	name = "Activate Thermal Vision"
@@ -74,13 +74,13 @@
 	button_icon = 'icons/mob/actions/actions_changeling.dmi'
 	button_icon_state = "augmented_eyesight"
 
-	cooldown_time = 25 SECONDS
+	cooldown_time = 60 SECONDS
 	spell_requirements = NONE
 
 	/// How much eye damage is given on cast
-	var/eye_damage = 10
+	var/eye_damage = 8
 	/// The duration of the thermal vision
-	var/thermal_duration = 10 SECONDS
+	var/thermal_duration = 30 SECONDS
 
 /datum/action/cooldown/spell/thermal_vision/Remove(mob/living/remove_from)
 	REMOVE_TRAIT(remove_from, TRAIT_THERMAL_VISION, GENETIC_MUTATION)
@@ -202,4 +202,3 @@
 	if(..())
 		return
 	REMOVE_TRAIT(owner, TRAIT_ILLITERATE, GENETIC_MUTATION)
-

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -78,7 +78,7 @@
 	spell_requirements = NONE
 
 	/// How much eye damage is given on cast
-	var/eye_damage = 8
+	var/eye_damage = 7.5
 	/// The duration of the thermal vision
 	var/thermal_duration = 30 SECONDS
 


### PR DESCRIPTION
## About The Pull Request

Duration 10s -> 30s (with power, 30s->45s)
Cooldown 25s->60s (to accommodate new duration) (with energy, 60s -> 30s)
Damage 10 -> 7.5 (with sync, 7.5 -> 3.75)
Damage is now affected by power chromosome (8->12)

## Why It's Good For The Game

Using thermal vision in any capacity without a stack of carrots is so, so exceedingly painful because by the time you can actually see something... your vision dies!

There's no reason to use these over cybernetic thermals, which are permanent, and have no downside besides EMP.

This should make it a bit more usable in average circumstances, maybe putting it on par with cybernetic thermals?

## Changelog

:cl: Melbert
balance: Thermal vision mutation: Active duration 10s -> 30s  (with power, 30s->45s)
balance: Thermal vision mutation: Cooldown 25s -> 60s (with energy, 60s -> 30s)
balance: Thermal vision mutation: Eye damage 10 -> 7.5 (with sync, 7.5 -> 3.75)
balance: Thermal vision mutation: Eye damage is now affected by power chromosome (with power, 7.5 -> 11.25)
/:cl:

