### PR TITLE
Fixes hair dyeing returning a TGUI error

### DIFF
--- a/code/game/objects/items/dyespray.dm
+++ b/code/game/objects/items/dyespray.dm
@@ -57,7 +57,8 @@
 	if(!user.can_perform_action(src, NEED_DEXTERITY))
 		return
 
-	var/new_grad_color = tgui_color_picker(user, "Choose a secondary hair color:", "Character Preference", human_target.get_hair_gradient_color())
+	var/hair_key = what_to_dye == "Hair" ? GRADIENT_HAIR_KEY : GRADIENT_FACIAL_HAIR_KEY
+	var/new_grad_color = tgui_color_picker(user, "Choose a secondary hair color:", "Character Preference", human_target.get_hair_gradient_color(hair_key))
 	if(!new_grad_color || !user.can_perform_action(src, NEED_DEXTERITY) || !target.IsReachableBy(user))
 		return
 


### PR DESCRIPTION

## About The Pull Request
``get_hair_gradient_color()`` returns a list if no arguments are specified, which is no good when we just want a singular hex code of whatever we're dyeing.

## Why It's Good For The Game
Lets people dye in peace

## Changelog
:cl: Hardly
fix: Fixed hair dyes returning a TGUI error when trying to dye a hair.
/:cl:
