### PR TITLE
Clarity in crate sanity unit test if generate fails to return

### DIFF
--- a/code/modules/unit_tests/cargo_crate_sanity.dm
+++ b/code/modules/unit_tests/cargo_crate_sanity.dm
@@ -19,6 +19,8 @@
 		var/crate_value = counterlist_sum(minimum_cost.total_value)
 
 		var/obj/results = new_crate.generate(testing_floor)
+		if(!results)
+			TEST_FAIL("Cargo crate [new_crate.type] failed to generate an object to export.")
 		var/datum/export_report/export_log = export_item_and_contents(results, apply_elastic = TRUE, delete_unsold = TRUE, export_markets = list(EXPORT_MARKET_STATION))
 
 		// The value of the crate and all of it's contents.


### PR DESCRIPTION

## About The Pull Request
If a crate fails to generate, fail but actually give you the type path so you can fix it
## Why It's Good For The Game
Ran up with an issue trying to debug the return of generate being null while having no clue what type path it was. Prevents that headache in future
## Changelog
N/A
