### PR TITLE
Fixes monster_core organs keeping their HUD buttons after being removed from the body

### DIFF
--- a/code/modules/mining/equipment/monster_organs/monster_organ.dm
+++ b/code/modules/mining/equipment/monster_organs/monster_organ.dm
@@ -99,7 +99,7 @@
 
 /obj/item/organ/monster_core/on_mob_remove(mob/living/carbon/target_carbon, special, movement_flags)
 	if (!inert && !special)
-		owner.visible_message(span_notice("[src] rapidly decays as it's removed."))
+		target_carbon.visible_message(span_notice("[src] rapidly decays as it's removed."))
 		go_inert()
 	return ..()
 

--- a/code/modules/mining/equipment/monster_organs/monster_organ.dm
+++ b/code/modules/mining/equipment/monster_organs/monster_organ.dm
@@ -99,7 +99,7 @@
 
 /obj/item/organ/monster_core/on_mob_remove(mob/living/carbon/target_carbon, special, movement_flags)
 	if (!inert && !special)
-		target_carbon.visible_message(span_notice("[src] rapidly decays as it's removed."))
+		target_carbon?.visible_message(span_notice("[src] rapidly decays as it's removed."))
 		go_inert()
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
Title.
<img width="682" height="543" alt="afbeelding" src="https://github.com/user-attachments/assets/d2ce739f-1b13-4397-92d6-7fceaef4e70f" />

## Why It's Good For The Game
Bug fix Good

## Changelog

:cl:
fix: The buttons for lavaland organs no longer show up after their removal from your body.
/:cl:

