### PR TITLE
Fixes light deconstruction working wrong

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -429,7 +429,7 @@
 		if("floor bulb")
 			frame = new /obj/structure/light_construct/floor(loc)
 	frame.stage = LIGHT_CONSTRUCT_WIRED
-	frame.icon_state = "[fitting == "floor bulb" ? "floor" : fitting]-construct-stage2"
+	frame.icon_state = "[frame.fixture_type]-construct-stage2"
 	frame.setDir(dir)
 	frame.find_and_mount_on_atom()
 	if(!disassembled)

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -406,7 +406,7 @@
 		tool.play_tool_sound(src, 75)
 		user.visible_message(span_notice("[user.name] opens [src]'s casing."), \
 			span_notice("You open [src]'s casing."), span_hear("You hear a noise."))
-		deconstruct()
+		deconstruct(disassembled = TRUE)
 		return
 
 	if(tool.item_flags & ABSTRACT)
@@ -419,16 +419,19 @@
 			electrocute_mob(user, get_area(src), src, (rand(7,10) * 0.1), TRUE)
 
 /obj/machinery/light/on_deconstruction(disassembled)
-	var/atom/drop_point = drop_location()
 
-	var/obj/item/wallframe/light_fixture/frame = null
+	var/obj/structure/light_construct/frame = null
 	switch(fitting)
 		if("tube")
-			frame = new /obj/item/wallframe/light_fixture(drop_point)
+			frame = new /obj/structure/light_construct(loc)
 		if("bulb")
-			frame = new /obj/item/wallframe/light_fixture/small(drop_point)
+			frame = new /obj/structure/light_construct/small(loc)
 		if("floor bulb")
-			frame = new /obj/item/wallframe/light_fixture/small(drop_point)
+			frame = new /obj/structure/light_construct/floor(loc)
+	frame.stage = LIGHT_CONSTRUCT_WIRED
+	frame.icon_state = "[fitting == "floor bulb" ? "floor" : fitting]-construct-stage2"
+	frame.setDir(dir)
+	frame.find_and_mount_on_atom()
 	if(!disassembled)
 		frame.take_damage(frame.max_integrity * 0.5, sound_effect = FALSE)
 		if(status != LIGHT_BROKEN)
@@ -440,7 +443,8 @@
 
 	var/obj/item/stock_parts/power_store/real_cell = get_cell()
 	if(!QDELETED(real_cell))
-		real_cell.forceMove(drop_point)
+		real_cell.forceMove(frame)
+		frame.cell = real_cell
 
 /obj/machinery/light/attacked_by(obj/item/attacking_object, mob/living/user, list/modifiers, list/attack_modifiers)
 	. = ..()

--- a/code/modules/power/lighting/light_construct.dm
+++ b/code/modules/power/lighting/light_construct.dm
@@ -115,6 +115,7 @@
 					user.visible_message(span_notice("[user.name] deconstructs [src]."), \
 						span_notice("You deconstruct [src]."), span_hear("You hear a ratchet."))
 					playsound(src, 'sound/items/deconstruct.ogg', 75, TRUE)
+					deconstruct()
 				return
 
 			if(istype(tool, /obj/item/stack/cable_coil))


### PR DESCRIPTION

## About The Pull Request

fixes that deconstructing an empty light frame doesn't work because the call to actually deconstruct it was removed, & that screwdrivering a full light frame would deconstruct it because the whole process of going back to the structure type was skipped. 

## Why It's Good For The Game

fixes #94872 unless there's actually other wallmounts that aren't working but I couldn't find any others in testing
Light deconstruction is fun again

## Changelog
:cl:

fix: Fixes light deconstruction succeeding when they're fully constructed, and failing when they're not.

/:cl:
