### PR TITLE
If you have immunodeficiency you do not cure diseases on your own

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -209,7 +209,7 @@
 
 		recovery_prob = clamp(recovery_prob / bad_immune, 0, 100)
 
-		if(recovery_prob)
+		if(recovery_prob && (bad_immune == 1))
 			if(SPT_PROB(recovery_prob, seconds_per_tick))
 				if(stage == 1 && prob(cure_chance * DISEASE_FINAL_CURE_CHANCE_MULTIPLIER)) //if we reduce FROM stage == 1, cure the virus - after defeating its cure_chance in a final battle
 					if(!HAS_TRAIT(affected_mob, TRAIT_NOHUNGER) && (affected_mob.satiety < 0 || affected_mob.nutrition < NUTRITION_LEVEL_STARVING))


### PR DESCRIPTION
## About The Pull Request

You no longer have natural recovery if you have immunodeficiency.

## Why It's Good For The Game

Makes you actually need to seek medical assistance when you get sick with immunodeficiency. Right even with a weak immune system you still cure yourself.

## Changelog
:cl:
balance: people with immunodeficiency no longer can cure themselves automatically
/:cl:
