### PR TITLE
Tweaks some hallucinations to not trigger while unconscious or deaf

### DIFF
--- a/code/datums/status_effects/debuffs/hallucination.dm
+++ b/code/datums/status_effects/debuffs/hallucination.dm
@@ -86,7 +86,7 @@
 	return STOP_BUMP
 
 /datum/status_effect/hallucination/tick(seconds_between_ticks)
-	if(owner.stat >= UNCONSCIOUS)
+	if(owner.stat == DEAD)
 		return
 	if(!COOLDOWN_FINISHED(src, hallucination_cooldown))
 		return

--- a/code/datums/status_effects/debuffs/hallucination.dm
+++ b/code/datums/status_effects/debuffs/hallucination.dm
@@ -86,7 +86,7 @@
 	return STOP_BUMP
 
 /datum/status_effect/hallucination/tick(seconds_between_ticks)
-	if(owner.stat == DEAD)
+	if(owner.stat >= UNCONSCIOUS)
 		return
 	if(!COOLDOWN_FINISHED(src, hallucination_cooldown))
 		return

--- a/code/modules/hallucination/battle.dm
+++ b/code/modules/hallucination/battle.dm
@@ -4,6 +4,13 @@
 	random_hallucination_weight = 3
 	hallucination_tier = HALLUCINATION_TIER_COMMON
 
+/datum/hallucination/battle/start()
+	if(!hallucinator.can_hear())
+		return FALSE
+
+	// for subtypes
+	return TRUE
+
 /// Subtype of battle hallucination for gun based battles, where it sounds like someone is being shot.
 /datum/hallucination/battle/gun
 	abstract_hallucination_parent = /datum/hallucination/battle/gun
@@ -23,8 +30,11 @@
 	var/chance_to_fall = 80
 
 /datum/hallucination/battle/gun/start()
+	. = ..()
+	if(!.)
+		return
+
 	fire_loop(random_far_turf(), rand(shots_to_fire_lower_range, shots_to_fire_upper_range))
-	return TRUE
 
 /// The main loop for gun based hallucinations.
 /datum/hallucination/battle/gun/proc/fire_loop(turf/source, shots_left = 3, hits = 0)
@@ -81,12 +91,15 @@
 /datum/hallucination/battle/stun_prod
 
 /datum/hallucination/battle/stun_prod/start()
+	. = ..()
+	if(!.)
+		return
+
 	var/turf/source = random_far_turf()
 
 	hallucinator.playsound_local(source, 'sound/items/weapons/egloves.ogg', 40, TRUE)
 	hallucinator.playsound_local(source, SFX_BODYFALL, 25, TRUE)
 	addtimer(CALLBACK(src, PROC_REF(fake_cuff), source), 2 SECONDS)
-	return TRUE
 
 /// Plays a fake cable-cuff sound and deletes the hallucination.
 /datum/hallucination/battle/stun_prod/proc/fake_cuff(turf/source)
@@ -100,13 +113,16 @@
 /datum/hallucination/battle/harm_baton
 
 /datum/hallucination/battle/harm_baton/start()
+	. = ..()
+	if(!.)
+		return
+
 	var/turf/source = random_far_turf()
 
 	hallucinator.playsound_local(source, 'sound/items/weapons/egloves.ogg', 40, TRUE)
 	hallucinator.playsound_local(source, SFX_BODYFALL, 25, TRUE)
 
 	addtimer(CALLBACK(src, PROC_REF(harmbaton_loop), source, rand(5, 12)), 2 SECONDS)
-	return TRUE
 
 /// The main sound loop for harmbatonning.
 /datum/hallucination/battle/harm_baton/proc/harmbaton_loop(turf/source, hits_remaing = 5)
@@ -125,11 +141,14 @@
 /datum/hallucination/battle/e_sword
 
 /datum/hallucination/battle/e_sword/start()
+	. = ..()
+	if(!.)
+		return
+
 	var/turf/source = random_far_turf()
 
 	hallucinator.playsound_local(source, 'sound/items/weapons/saberon.ogg', 15, 1)
 	addtimer(CALLBACK(src, PROC_REF(stab_loop), source, rand(4, 8)), CLICK_CD_MELEE)
-	return TRUE
 
 /// The main sound loop of someone being esworded.
 /datum/hallucination/battle/e_sword/proc/stab_loop(turf/source, stabs_remaining = 4)
@@ -153,8 +172,11 @@
 /datum/hallucination/battle/bomb
 
 /datum/hallucination/battle/bomb/start()
+	. = ..()
+	if(!.)
+		return
+
 	addtimer(CALLBACK(src, PROC_REF(fake_tick), random_far_turf(), rand(3, 11)), 1.5 SECONDS)
-	return TRUE
 
 /// The loop of the (fake) bomb ticking down.
 /datum/hallucination/battle/bomb/proc/fake_tick(turf/source, ticks_remaining = 3)

--- a/code/modules/hallucination/body.dm
+++ b/code/modules/hallucination/body.dm
@@ -17,7 +17,7 @@
 
 /datum/hallucination/body/start()
 	// This hallucination is purely visual, so we don't need to bother for clientless mobs
-	if(!hallucinator.client)
+	if(!hallucinator.client || hallucinator.stat >= UNCONSCIOUS)
 		return FALSE
 
 	var/list/possible_points = list()

--- a/code/modules/hallucination/delusions.dm
+++ b/code/modules/hallucination/delusions.dm
@@ -62,7 +62,7 @@
 	return ..()
 
 /datum/hallucination/delusion/start()
-	if(!hallucinator.client)
+	if(!hallucinator.client || hallucinator.stat >= UNCONSCIOUS)
 		return FALSE
 
 	feedback_details += "Delusion: [delusion_name]"

--- a/code/modules/hallucination/eyes_in_dark.dm
+++ b/code/modules/hallucination/eyes_in_dark.dm
@@ -12,7 +12,7 @@
 	return ..()
 
 /datum/hallucination/eyes_in_dark/start()
-	if(!hallucinator.client)
+	if(!hallucinator.client || hallucinator.stat >= UNCONSCIOUS)
 		return FALSE
 
 	if(hallucinator.lighting_cutoff >= 2.5)

--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -24,6 +24,9 @@
 	return what_they_speak?.spoken_languages?.Copy() || list()
 
 /datum/hallucination/chat/start()
+	if(hallucinator.stat >= UNCONSCIOUS)
+		return FALSE
+
 	var/mob/living/carbon/human/speaker
 	var/list/datum/language/understood_languages = hallucinator.get_language_holder().understood_languages
 	var/understood_language

--- a/code/modules/hallucination/fake_death.dm
+++ b/code/modules/hallucination/fake_death.dm
@@ -15,6 +15,9 @@
 	return ..()
 
 /datum/hallucination/death/start()
+	if(hallucinator.stat >= UNCONSCIOUS) // on your way there already
+		return FALSE
+
 	if(floor_them)
 		hallucinator.Paralyze(30 SECONDS)
 	else

--- a/code/modules/hallucination/fake_message.dm
+++ b/code/modules/hallucination/fake_message.dm
@@ -3,6 +3,9 @@
 	hallucination_tier = HALLUCINATION_TIER_COMMON
 
 /datum/hallucination/message/start()
+	if(hallucinator.stat >= UNCONSCIOUS)
+		return FALSE
+
 	var/list/nearby_humans = list()
 	var/adjacent_to_us = FALSE
 	var/mob/living/carbon/human/suspicious_personnel

--- a/code/modules/hallucination/hazard.dm
+++ b/code/modules/hallucination/hazard.dm
@@ -8,6 +8,9 @@
 	var/hazard_type = /obj/effect/client_image_holder/hallucination/danger
 
 /datum/hallucination/hazard/start()
+	if(hallucinator.stat >= UNCONSCIOUS)
+		return FALSE
+
 	var/list/possible_points = list()
 	for(var/turf/open/floor/floor_in_view in view(hallucinator))
 		possible_points += floor_in_view

--- a/code/modules/hallucination/inhand_fake_item.dm
+++ b/code/modules/hallucination/inhand_fake_item.dm
@@ -10,6 +10,9 @@
 	var/obj/item/template_item_type
 
 /datum/hallucination/fake_item/start()
+	if(hallucinator.stat >= UNCONSCIOUS)
+		return FALSE
+
 	var/list/slots_free = list()
 	if(valid_slots & ITEM_SLOT_HANDS)
 		for(var/hand in hallucinator.get_empty_held_indexes())

--- a/code/modules/hallucination/malf_apc.dm
+++ b/code/modules/hallucination/malf_apc.dm
@@ -11,7 +11,7 @@
 	VAR_PRIVATE/image/hacked_image
 
 /datum/hallucination/malf_apc/start()
-	if(!hallucinator.client)
+	if(!hallucinator.client || hallucinator.stat >= UNCONSCIOUS)
 		return FALSE
 
 	var/num_ais = 0

--- a/code/modules/hallucination/mother.dm
+++ b/code/modules/hallucination/mother.dm
@@ -6,6 +6,9 @@
 	var/obj/effect/client_image_holder/hallucination/your_mother/mother
 
 /datum/hallucination/your_mother/start()
+	if(!hallucinator.client || hallucinator.stat >= UNCONSCIOUS)
+		return FALSE
+
 	var/list/spawn_locs = list()
 	for(var/turf/open/floor in view(hallucinator, 4))
 		if(floor.is_blocked_turf(exclude_mobs = TRUE))

--- a/code/modules/hallucination/nearby_fake_item.dm
+++ b/code/modules/hallucination/nearby_fake_item.dm
@@ -21,7 +21,7 @@
 
 /datum/hallucination/nearby_fake_item/start()
 	// This hallucination is purely visual, so we don't need to bother for clientless mobs
-	if(!hallucinator.client)
+	if(!hallucinator.client || hallucinator.stat >= UNCONSCIOUS)
 		return FALSE
 
 	var/list/mob_pool = list()

--- a/code/modules/hallucination/station_message.dm
+++ b/code/modules/hallucination/station_message.dm
@@ -1,43 +1,55 @@
+#define CANCEL_FAKE_ALERT -1
+
 /datum/hallucination/station_message
 	abstract_hallucination_parent = /datum/hallucination/station_message
 	random_hallucination_weight = 1
 	hallucination_tier = HALLUCINATION_TIER_RARE
+	/// if TRUE, skip on deaf hallucinators
+	var/require_hearing = TRUE
 
 /datum/hallucination/station_message/start()
+	if(require_hearing && !hallucinator.can_hear())
+		return FALSE
+	if(do_fake_alert() == CANCEL_FAKE_ALERT)
+		return FALSE
+
 	qdel(src) // To be implemented by subtypes, call parent for easy cleanup
 	return TRUE
 
-/datum/hallucination/station_message/blob_alert
+/datum/hallucination/station_message/proc/do_fake_alert()
+	return CANCEL_FAKE_ALERT
 
-/datum/hallucination/station_message/blob_alert/start()
+/datum/hallucination/station_message/blob_alert
+	require_hearing = TRUE
+
+/datum/hallucination/station_message/blob_alert/do_fake_alert()
 	priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", \
 		"Biohazard Alert", ANNOUNCER_OUTBREAK5, players = list(hallucinator))
-	return ..()
 
 /datum/hallucination/station_message/shuttle_dock
 
-/datum/hallucination/station_message/shuttle_dock/start()
+/datum/hallucination/station_message/shuttle_dock/do_fake_alert()
 	priority_announce(
-					text = "[SSshuttle.emergency] has docked with the station. You have [DisplayTimeText(SSshuttle.emergency_dock_time)] to board the emergency shuttle.",
-					title = "Emergency Shuttle Arrival",
-					sound = ANNOUNCER_SHUTTLEDOCK,
-					sender_override = "Emergency Shuttle Uplink Alert",
-					players = list(hallucinator),
-					color_override = "orange",
-				)
-	return ..()
+		text = "[SSshuttle.emergency] has docked with the station. You have [DisplayTimeText(SSshuttle.emergency_dock_time)] to board the emergency shuttle.",
+		title = "Emergency Shuttle Arrival",
+		sound = ANNOUNCER_SHUTTLEDOCK,
+		sender_override = "Emergency Shuttle Uplink Alert",
+		players = list(hallucinator),
+		color_override = "orange",
+	)
 
 /datum/hallucination/station_message/malf_ai
+	require_hearing = TRUE
 
-/datum/hallucination/station_message/malf_ai/start()
+/datum/hallucination/station_message/malf_ai/do_fake_alert()
 	if(!(locate(/mob/living/silicon/ai) in GLOB.silicon_mobs))
-		return FALSE
+		return CANCEL_FAKE_ALERT
 
 	priority_announce("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.", \
 		"Anomaly Alert", ANNOUNCER_AIMALF, players = list(hallucinator))
-	return ..()
 
 /datum/hallucination/station_message/heretic
+	require_hearing = TRUE
 	/// This is gross and will probably easily be outdated in some time but c'est la vie.
 	/// Maybe if someone datumizes heretic paths or something this can be improved
 	var/static/list/ascension_bodies = list(
@@ -63,11 +75,11 @@
 		)
 	)
 
-/datum/hallucination/station_message/heretic/start()
+/datum/hallucination/station_message/heretic/do_fake_alert()
 	// Unfortunately, this will not be synced if mass hallucinated
 	var/mob/living/carbon/human/totally_real_heretic = random_non_sec_crewmember()
 	if(!totally_real_heretic)
-		return FALSE
+		return CANCEL_FAKE_ALERT
 
 	var/list/fake_ascension = pick(ascension_bodies)
 	var/announcement_text = replacetext(fake_ascension["text"], "%FAKENAME%", totally_real_heretic.real_name)
@@ -78,15 +90,15 @@
 		players = list(hallucinator),
 		color_override = "pink",
 	)
-	return ..()
 
 /datum/hallucination/station_message/cult_summon
+	require_hearing = TRUE
 
-/datum/hallucination/station_message/cult_summon/start()
+/datum/hallucination/station_message/cult_summon/do_fake_alert()
 	// Same, will not be synced if mass hallucinated
 	var/mob/living/carbon/human/totally_real_cult_leader = random_non_sec_crewmember()
 	if(!totally_real_cult_leader)
-		return FALSE
+		return CANCEL_FAKE_ALERT
 
 	// Get a fake area that the summoning is happening in
 	var/area/hallucinator_area = get_area(hallucinator)
@@ -100,21 +112,19 @@
 		has_important_message = TRUE,
 		players = list(hallucinator),
 	)
-	return ..()
 
 /datum/hallucination/station_message/meteors
 	random_hallucination_weight = 2
+	require_hearing = TRUE
 
-/datum/hallucination/station_message/meteors/start()
+/datum/hallucination/station_message/meteors/do_fake_alert()
 	priority_announce("Meteors have been detected on collision course with the station.", "Meteor Alert", ANNOUNCER_METEORS, players = list(hallucinator))
-	return ..()
 
 /datum/hallucination/station_message/supermatter_delam
 
-/datum/hallucination/station_message/supermatter_delam/start()
+/datum/hallucination/station_message/supermatter_delam/do_fake_alert()
 	SEND_SOUND(hallucinator, 'sound/effects/magic/charge.ogg')
 	to_chat(hallucinator, span_bolddanger("You feel reality distort for a moment..."))
-	return ..()
 
 /datum/hallucination/station_message/clock_cult_ark
 	// Clock cult's long gone, but this stays for posterity.
@@ -132,3 +142,5 @@
 
 	hallucinator.playsound_local(get_turf(hallucinator), 'sound/effects/explosion/explosion_distant.ogg', 50, FALSE, pressure_affected = FALSE)
 	qdel(src)
+
+#undef CANCEL_FAKE_ALERT

--- a/code/modules/hallucination/xeno_attack.dm
+++ b/code/modules/hallucination/xeno_attack.dm
@@ -4,6 +4,9 @@
 	hallucination_tier = HALLUCINATION_TIER_RARE
 
 /datum/hallucination/xeno_attack/start()
+	if(hallucinator.stat >= UNCONSCIOUS)
+		return FALSE
+
 	var/turf/xeno_attack_source
 	for(var/obj/machinery/atmospherics/components/unary/vent_pump/nearby_pump in orange(7, hallucinator))
 		if(nearby_pump.welded)


### PR DESCRIPTION
## About The Pull Request

- Fake body
- All delusions
- Eyes in the Dark
- Fake chat messages
- Fake death
- Fake conspicuous messages
- Fake chasms and anomalies
- Mirage items (both self and others)
- Fake malf APCs
- Your Mom
- Xeno attack

Won't trigger while unconscious

- Most fake station messages
- Sound of battle

Won't trigger while deaf

## Why It's Good For The Game

Many of the effects these are mimicking can only trigger while conscious or able to hear, so if you ARE unconscious or deaf, it makes it extremely obvious it's a fake effect. 

We should instead give them a hallucination that will affect them, like appearing to be on fire.

## Changelog

:cl: Melbert
add: Hallucinations that don't make sense to trigger while unconscious or deaf will no longer trigger while unconscious or deaf
/:cl:

