### PR TITLE
Singing cauteries

### DIFF
--- a/code/modules/surgery/operations/_operation.dm
+++ b/code/modules/surgery/operations/_operation.dm
@@ -142,7 +142,7 @@
 	visible_message(
 		span_notice("[src] attempts to close [p_their()] own [limb.plaintext_zone] with [tool]..."),
 		span_notice("You attempt to close your own [limb.plaintext_zone] with [tool]..."),
-		span_hear("You hear singing."),
+		span_hear("You hear [tool?.get_temperature() ? "singeing" : "stitching"] sounds."),
 		vision_distance = 5,
 		visible_message_flags = ALWAYS_SHOW_SELF_MESSAGE,
 	)
@@ -158,7 +158,7 @@
 	visible_message(
 		span_notice("[src] closes [p_their()] own [limb.plaintext_zone] with [tool]."),
 		span_notice("You close your own [limb.plaintext_zone] with [tool]."),
-		span_hear("You hear singing."),
+		span_hear("You hear [tool?.get_temperature() ? "singeing" : "stitching"] sounds."),
 		vision_distance = 5,
 		visible_message_flags = ALWAYS_SHOW_SELF_MESSAGE,
 	)


### PR DESCRIPTION
## About The Pull Request

Corrects Singing -> Singeing

Also as this proc can be invoked with a suture, add a message for that too

## Changelog

:cl: Melbert
spellcheck: Corrects the blind message for manual cauterization
/:cl:
