### PR TITLE
Adds `fire_and_forget` to `/datum/http_request`

### DIFF
--- a/code/datums/http.dm
+++ b/code/datums/http.dm
@@ -27,6 +27,11 @@
 	src.output_file = output_file
 	src.timeout_seconds = timeout_seconds
 
+/datum/http_request/proc/fire_and_forget()
+	var/result = rustg_http_request_fire_and_forget(method, url, body, headers, build_options())
+	if(result != "ok")
+		CRASH("[result]")
+
 /datum/http_request/proc/execute_blocking()
 	_raw_response = rustg_http_request_blocking(method, url, body, headers, build_options())
 
@@ -37,16 +42,17 @@
 	id = rustg_http_request_async(method, url, body, headers, build_options())
 
 	if (isnull(text2num(id)))
-		stack_trace("Proc error: [id]")
 		_raw_response = "Proc error: [id]"
+		CRASH("Proc error: [id]")
 	else
 		in_progress = TRUE
 
 /datum/http_request/proc/build_options()
 	return json_encode(list(
-		"output_filename"=(output_file ? output_file : null),
-		"body_filename"=null,
-		"timeout_seconds"=(timeout_seconds ? timeout_seconds : null)))
+		"output_filename" = output_file ? output_file : null,
+		"body_filename" = null,
+		"timeout_seconds" = timeout_seconds ? timeout_seconds : null,
+	))
 
 /datum/http_request/proc/is_complete()
 	if (isnull(id))
@@ -55,28 +61,28 @@
 	if (!in_progress)
 		return TRUE
 
-	var/r = rustg_http_check_request(id)
+	var/response = rustg_http_check_request(id)
 
-	if (r == RUSTG_JOB_NO_RESULTS_YET)
+	if (response == RUSTG_JOB_NO_RESULTS_YET)
 		return FALSE
 	else
-		_raw_response = r
+		_raw_response = response
 		in_progress = FALSE
 		return TRUE
 
-/datum/http_request/proc/into_response()
-	var/datum/http_response/R = new()
+/datum/http_request/proc/into_response() as /datum/http_response
+	var/datum/http_response/response = new
 
 	try
-		var/list/L = json_decode(_raw_response)
-		R.status_code = L["status_code"]
-		R.headers = L["headers"]
-		R.body = L["body"]
+		var/list/response_data = json_decode(_raw_response)
+		response.status_code = response_data["status_code"]
+		response.headers = response_data["headers"]
+		response.body = response_data["body"]
 	catch
-		R.errored = TRUE
-		R.error = _raw_response
+		response.errored = TRUE
+		response.error = _raw_response
 
-	return R
+	return response
 
 /datum/http_response
 	var/status_code

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -339,9 +339,9 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	// send2chat(new /datum/tgs_message_conent("[initiator_ckey] | [message_content]"), "ahelp", TRUE)
 	var/list/headers = list()
 	headers["Content-Type"] = "application/json"
-	var/datum/http_request/request = new()
+	var/datum/http_request/request = new
 	request.prepare(RUSTG_HTTP_METHOD_POST, webhook, json_encode(webhook_info), headers, "tmp/response.json")
-	request.begin_async()
+	request.fire_and_forget()
 
 /datum/admin_help/Destroy()
 	RemoveActive()


### PR DESCRIPTION

## About The Pull Request

This adds `/datum/http_request/proc/fire_and_forget()`, which wraps `rustg_http_request_fire_and_forget`, used for http requests that you just send and don't care about the response. I've changed `send2adminchat_webhook` to use this, as it didn't care about the response at all.

Also added a return type hint to `into_response()`, and did some minor cleanup on some assorted `/datum/http_request` code.

## Why It's Good For The Game

`fire_and_forget` is very useful because it prevents http request jobs from forever taking up memory if you never call `is_complete()`

## Changelog

No user-facing changes.