### PR TITLE
fixes the HFRs damage from moles over limit

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -457,8 +457,10 @@
 
 	// If we have a preposterous amount of mass in the fusion mix, things get bad extremely fast
 	if(internal_fusion.total_moles() >= HYPERTORUS_HYPERCRITICAL_MOLES)
-		var/hypercritical_damage_taken = max((internal_fusion.total_moles() - HYPERTORUS_HYPERCRITICAL_MOLES) * HYPERTORUS_HYPERCRITICAL_SCALE, 0)
-		critical_threshold_proximity = max(critical_threshold_proximity + min(hypercritical_damage_taken, HYPERTORUS_HYPERCRITICAL_MAX_DAMAGE), 0) * seconds_per_tick
+		var/moles_over_limit = internal_fusion.total_moles() - HYPERTORUS_HYPERCRITICAL_MOLES
+		var/hypercritical_damage_taken = max(moles_over_limit * HYPERTORUS_HYPERCRITICAL_SCALE, 0)
+		hypercritical_damage_taken = min(hypercritical_damage_taken, HYPERTORUS_HYPERCRITICAL_MAX_DAMAGE) * seconds_per_tick
+		critical_threshold_proximity = max(critical_threshold_proximity + hypercritical_damage_taken, 0)
 		warning_damage_flags |= HYPERTORUS_FLAG_HIGH_FUEL_MIX_MOLE
 
 	// High power fusion might create other matter other than helium, iron is dangerous inside the machine, damage can be seen


### PR DESCRIPTION
## About The Pull Request

Fixes the HFRs damage from being over the 10 000 moles of fuel limit. Also makes the code easier to read, by separating the lines of code a little.

Tested on a local repo by launching the HFR and exceeding the 10 000 moles fuel limit. Instead of the HFR exploding almost instantly, it now started taking damage at a reasonable rate and could be saved.

## Why It's Good For The Game

Fixes #94786 

Also makes the code slightly more readable and as such easier to maintain.

## Changelog

:cl: Swan
fix: fixes the HFR health dropping exponentially once it starts taking damage from having too many moles
/:cl:
