### PR TITLE
Fix for ID cards sometimes not functioning within wallets/PDAs

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -176,9 +176,15 @@
 		if (ismob(old_loc.loc))
 			UnregisterSignal(old_loc.loc, list(COMSIG_MOVABLE_POINTED, COMSIG_MOB_RETRIEVE_ACCESS))
 	. = ..()
-	if (isitem(loc))
-		RegisterSignal(loc, COMSIG_ITEM_EQUIPPED, PROC_REF(on_loc_equipped))
-		RegisterSignal(loc, COMSIG_ITEM_DROPPED, PROC_REF(on_loc_dropped))
+	if (!isitem(loc))
+		return
+	RegisterSignal(loc, COMSIG_ITEM_EQUIPPED, PROC_REF(on_loc_equipped))
+	RegisterSignal(loc, COMSIG_ITEM_DROPPED, PROC_REF(on_loc_dropped))
+	if (ismob(loc.loc))
+		var/mob/wearer = loc.loc
+		// Equip chain shenanigans
+		UnregisterSignal(wearer, list(COMSIG_MOVABLE_POINTED, COMSIG_MOB_RETRIEVE_ACCESS))
+		on_loc_equipped(loc, wearer, wearer.get_slot_by_item(loc))
 
 /obj/item/card/id/equipped(mob/user, slot)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

The signals weren't registered if the PDA/wallet were already equipped in the ID slot.

## Changelog
:cl:
fix: Fixed ID cards sometimes not functioning within wallets/PDAs
/:cl:
