### PR TITLE
Converts AI controller processing subsystems to use `currentrun`

### DIFF
--- a/code/controllers/subsystem/ai_controllers.dm
+++ b/code/controllers/subsystem/ai_controllers.dm
@@ -8,6 +8,7 @@ SUBSYSTEM_DEF(ai_controllers)
 	)
 	wait = 0.5 SECONDS //Plan every half second if required, not great not terrible.
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	var/list/currentrun = list()
 	///type of status we are interested in running
 	var/planning_status = AI_STATUS_ON
 	/// The average tick cost of all active AI, calculated on fire.
@@ -26,9 +27,16 @@ SUBSYSTEM_DEF(ai_controllers)
 
 /datum/controller/subsystem/ai_controllers/fire(resumed)
 	if(!resumed)
+		var/list/planning_list = GLOB.ai_controllers_by_status[planning_status]
+		currentrun = planning_list.Copy()
 		summing_cost = 0
+
+	//cache for sanic speed (lists are references anyways)
+	var/list/current_run = src.currentrun
 	var/timer = TICK_USAGE_REAL
-	for(var/datum/ai_controller/ai_controller as anything in GLOB.ai_controllers_by_status[planning_status])
+	while(length(current_run))
+		var/datum/ai_controller/ai_controller = current_run[length(current_run)]
+		current_run.len--
 		if(!ai_controller.able_to_plan)
 			continue
 		ai_controller.SelectBehaviors(wait * 0.1)

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -87,6 +87,7 @@ multiple modular subtrees with behaviors
 		for(var/datum/controller/subsystem/ai_controllers/controller_subsystem in Master.subsystems)
 			if(controller_subsystem.planning_status == ai_status)
 				controller_subsystem.currentrun -= src
+				break
 	our_cells = null
 	set_movement_target(type, null)
 	if(ai_movement.moving_controllers[src])
@@ -437,6 +438,7 @@ multiple modular subtrees with behaviors
 		for(var/datum/controller/subsystem/ai_controllers/controller_subsystem in Master.subsystems)
 			if(controller_subsystem.planning_status == ai_status)
 				controller_subsystem.currentrun -= src
+				break
 	remove_from_unplanned_controllers()
 	stop_previous_processing()
 	ai_status = new_ai_status

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -84,6 +84,9 @@ multiple modular subtrees with behaviors
 	UnpossessPawn(FALSE)
 	if(ai_status)
 		GLOB.ai_controllers_by_status[ai_status] -= src
+		for(var/datum/controller/subsystem/ai_controllers/controller_subsystem in Master.subsystems)
+			if(controller_subsystem.planning_status == ai_status)
+				controller_subsystem.currentrun -= src
 	our_cells = null
 	set_movement_target(type, null)
 	if(ai_movement.moving_controllers[src])
@@ -431,6 +434,9 @@ multiple modular subtrees with behaviors
 	//remove old status, if we've got one
 	if(ai_status)
 		GLOB.ai_controllers_by_status[ai_status] -= src
+		for(var/datum/controller/subsystem/ai_controllers/controller_subsystem in Master.subsystems)
+			if(controller_subsystem.planning_status == ai_status)
+				controller_subsystem.currentrun -= src
 	remove_from_unplanned_controllers()
 	stop_previous_processing()
 	ai_status = new_ai_status


### PR DESCRIPTION

## About The Pull Request

this makes it so `SSai_controllers` and its subtypes use a `currentrun` loop, instead of directly looping thru `GLOB.ai_controllers_by_status[planning_status]`

## Why It's Good For The Game

most other processing subsystems do this, why shouldn't we?
it should ensure all ai controllers get to process, even if the server's under load.

## Changelog

no player-facing changes, prolly