### PR TITLE
Puts the correct date on the latest entry of the sql database changelog

### DIFF
--- a/SQL/database_changelog.md
+++ b/SQL/database_changelog.md
@@ -18,7 +18,7 @@ In any query remember to add a prefix to the table names if you use one.
 
 ---
 
-Version 5.34, godsnoknowswhen 2025, by Ghommie
+Version 5.34, 16 January 2026, by Ghommie
 Added `pda_themes_progress` as the second 'progress' subtype of 'datum/award/scores'
 
 ```sql


### PR DESCRIPTION
## About The Pull Request
So, hopefully everything in that PR works smoothly. I had a small issue with the local server db that I couldn't bother resolving and I got a bit busy with other things as well, but I did test it a few times the other week. However, I never updated the date on the sql db changelog so I'll do it now that the PR is in.

## Why It's Good For The Game
Marks the correct date of the db version change for correctness. It's neither "godsnoknowswhen" nor 2025 anymore.

## Changelog
N/A