### PR TITLE
Fix lights backup power processing

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -271,7 +271,7 @@
 					l_power = power_set,
 					l_color = color_set
 					)
-	else if(has_emergency_power(LIGHT_EMERGENCY_POWER_USE) && !turned_off())
+	else if(has_emergency_power(LIGHT_EMERGENCY_POWER_USE * SSMACHINES_DT) && !turned_off())
 		use_power = IDLE_POWER_USE
 		low_power_mode = TRUE
 		START_PROCESSING(SSmachines, src)
@@ -326,6 +326,7 @@
 		reagents.handle_reactions()
 	if(low_power_mode && !use_emergency_power(LIGHT_EMERGENCY_POWER_USE * seconds_per_tick))
 		update(FALSE) //Disables emergency mode and sets the color to normal
+		return PROCESS_KILL
 
 /obj/machinery/light/proc/burn_out()
 	if(status == LIGHT_OK)

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -290,9 +290,9 @@
 		var/static_power_used_new = 0
 		var/area/local_area = get_room_area()
 		if (nightshift_enabled && !local_area?.fire)
-			static_power_used_new = nightshift_brightness * nightshift_light_power * power_consumption_rate
+			static_power_used_new = ceil(nightshift_brightness * nightshift_light_power * power_consumption_rate)
 		else
-			static_power_used_new = brightness * bulb_power * power_consumption_rate
+			static_power_used_new = ceil(brightness * bulb_power * power_consumption_rate)
 		if(static_power_used != static_power_used_new) //Consumption changed - update
 			removeStaticPower(static_power_used, AREA_USAGE_STATIC_LIGHT)
 			static_power_used = static_power_used_new

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -237,7 +237,7 @@
 		var/color_set = bulb_colour
 		if(color)
 			color_set = color
-		if(reagents)
+		if(reagents || !is_full_charge())
 			START_PROCESSING(SSmachines, src)
 		var/area/local_area = get_room_area()
 		if (flickering)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/94909 so that lights don't stay processing when the cell is empty.

## Why It's Good For The Game

Fixes bug, broken lights are removed from the machines processing queue.

## Changelog

:cl: LT3
fix: Fixed lights being able to run on emergency power forever
/:cl: