### PR TITLE
Enhance bitrunner domain creation blackbox logging

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -15,6 +15,7 @@ SUBSYSTEM_DEF(blackbox)
 							"round_end_stats" = 2,
 							"testmerged_prs" = 2,
 							"dynamic_threat" = 2,
+							"bitrunning_domain_loaded" = 2,
 						) //associative list of any feedback variables that have had their format changed since creation and their current version, remember to update this
 
 /datum/controller/subsystem/blackbox/Initialize()

--- a/code/controllers/subsystem/networks/bitrunning.dm
+++ b/code/controllers/subsystem/networks/bitrunning.dm
@@ -21,8 +21,8 @@ SUBSYSTEM_DEF(bitrunning)
 	for(var/datum/lazy_template/virtual_domain/domain as anything in all_domains)
 		if(domain.domain_flags & DOMAIN_TEST_ONLY)
 			continue
-		var/can_view = domain.difficulty < scanner_tier && domain.cost <= points + 5
-		var/can_view_reward = domain.difficulty < (scanner_tier + 1) && domain.cost <= points + 3
+		var/can_view = domain.can_view_name(scanner_tier, points)
+		var/can_view_reward = domain.can_view_reward(scanner_tier, points)
 
 		UNTYPED_LIST_ADD(levels, list(
 			"announce_ghosts" = domain.announce_to_ghosts,

--- a/code/modules/bitrunning/objects/quantum_console.dm
+++ b/code/modules/bitrunning/objects/quantum_console.dm
@@ -76,13 +76,13 @@
 
 	switch(action)
 		if("random_domain")
-			server.cold_boot_map(server.get_random_domain_id())
+			server.cold_boot_map(server.get_random_domain_id(), was_random_selection = TRUE)
 			return TRUE
 		if("refresh")
 			ui.send_full_update()
 			return TRUE
 		if("set_domain")
-			server.cold_boot_map(params["id"])
+			server.cold_boot_map(params["id"], was_random_selection = FALSE)
 			return TRUE
 		if("stop_domain")
 			server.begin_shutdown(usr)

--- a/code/modules/bitrunning/server/map_handling.dm
+++ b/code/modules/bitrunning/server/map_handling.dm
@@ -28,7 +28,7 @@
 
 
 /// Links all the loading processes together - does validation for booting a map
-/obj/machinery/quantum_server/proc/cold_boot_map(map_key)
+/obj/machinery/quantum_server/proc/cold_boot_map(map_key, was_random_selection)
 	if(!is_ready)
 		return FALSE
 
@@ -53,8 +53,20 @@
 		scrub_vdom()
 		is_ready = TRUE
 		return FALSE
-
-	SSblackbox.record_feedback("tally", "bitrunning_domain_loaded", 1, map_key)
+		
+		
+	//We will want to record how the domain was selected. Either entirely randomly, with the name redacted, or with full information.
+	//Without this, it is difficult to determine what domains are selected more often intentionallly, vs unintentionally.
+	var/selection_type
+	
+	if(was_random_selection)
+		selection_type = "random selection"
+	else
+		if(generated_domain.can_view_name(scanner_tier, points))
+			selection_type = "full information"
+		else
+			selection_type = "redacted information"
+	SSblackbox.record_feedback("nested tally", "bitrunning_domain_loaded", 1, list(selection_type, map_key))
 
 	is_ready = TRUE
 

--- a/code/modules/bitrunning/virtual_domain/virtual_domain.dm
+++ b/code/modules/bitrunning/virtual_domain/virtual_domain.dm
@@ -85,6 +85,13 @@
 	/// The role that ghosts will get. Only used for poll text.
 	var/spawner_role = "Antagonist"
 
+
+/datum/lazy_template/virtual_domain/proc/can_view_name(scanner_tier, server_points)
+	return difficulty < scanner_tier && cost <= server_points + 5
+
+/datum/lazy_template/virtual_domain/proc/can_view_reward(scanner_tier, server_points)
+	return difficulty < (scanner_tier + 1) && cost <= server_points + 3
+
 /datum/lazy_template/virtual_domain/Destroy(force)
 	QDEL_NULL(ghost_spawners)
 	QDEL_NULL(ghost_mobs)


### PR DESCRIPTION
## About The Pull Request

Improves some blackbox logging for bitrunner domain creation, by also logging how much information they had when they chose it.

Also some minor code improvements, by making methods for whether the name/reward of a domain is visible.

## Why It's Good For The Game

Right now, if we just look at blackbox logs, we cannot easily tell if a domain is being deliberately avoided when possible, as we cannot tell if it's run unintentionally or intentionally.  Now we will record that information, so we can act on it, and hopefully perform actions to improve the domains that people attempt to avoid.

## Changelog
No changelog needed, no playerfacing changes.
