### PR TITLE
Small instruments fix

### DIFF
--- a/code/modules/instruments/songs/_song.dm
+++ b/code/modules/instruments/songs/_song.dm
@@ -216,19 +216,19 @@
 	music_player = user
 	START_PROCESSING(SSinstruments, src)
 	if(id)
-		sync_play()
+		sync_play(user)
 
 /**
  * Attempts to find other instruments with the same ID and syncs them to our song.
  */
-/datum/song/proc/sync_play()
+/datum/song/proc/sync_play(atom/user)
 	for(var/datum/song/other_instrument as anything in SSinstruments.songs)
 		if(other_instrument == src || other_instrument.id != id)
 			continue
 		if(other_instrument.playing)
 			continue
 		var/atom/other_player = other_instrument.find_sync_player()
-		if(isnull(other_player) || !(other_player in view(parent)))
+		if(isnull(other_player) || !(other_player in view(user || parent)))
 			continue
 		// copies the main song info to target songs
 		other_instrument.lines = lines.Copy()
@@ -432,7 +432,7 @@
 /datum/song/stationary/should_stop_playing(atom/player)
 	. = ..()
 	if(. == STOP_PLAYING || . == IGNORE_INSTRUMENT_CHECKS)
-		return TRUE
+		return
 	var/obj/structure/musician/M = parent
 	return M.can_play(player) ? NONE : STOP_PLAYING
 


### PR DESCRIPTION
## About The Pull Request

When finding players to sync with, it checked the view of the instrument - if the instrument was held, that would always fail.
So check view of the user instead.

Also tiny error with a return. Dunno if it actually causes issues.

## Changelog

:cl: Melbert
fix: Syncing instruments no longer fails if starting instrument is held
/:cl:

