### PR TITLE
fixes experimentor not ejecting item after irradiate goo failure (and therefore getting locked until deconstruction)

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -286,6 +286,7 @@
 					if(prob(EFFECT_PROB_VERYHIGH) && !(locate(/obj/effect/decal/cleanable/greenglow) in T))
 						var/obj/effect/decal/cleanable/reagentdecal = new/obj/effect/decal/cleanable/greenglow(T)
 						reagentdecal.reagents.add_reagent(/datum/reagent/uranium/radium, 7)
+			ejectItem(TRUE)
 		else if(prob(EFFECT_PROB_MEDIUM * (100 - malfunction_probability_coeff) * 0.01))
 			var/savedName = "[exp_on]"
 			ejectItem(TRUE)


### PR DESCRIPTION
## About The Pull Request
I assume this was why the experimentor was getting locked, since ejectItem(TRUE) is used in every other fail outcome. Fixes #94892 



## Why It's Good For The Game

fixification

## Changelog


:cl:

fix: fixed experimentor irradiate goo failure locking experimentor

/:cl:


