### PR TITLE
Fixes dreamchecker being upset at MAP_TEST compile flag

### DIFF
--- a/code/__HELPERS/logging/debug.dm
+++ b/code/__HELPERS/logging/debug.dm
@@ -31,13 +31,12 @@
 #endif
 #ifdef MAP_TEST
 	message_admins("Mapping: [text]")
-	return
-#endif
+#else
 	logger.Log(LOG_CATEGORY_DEBUG_MAPPING, text)
 	if(skip_world_log)
 		return
 	SEND_TEXT(world.log, text)
-
+#endif
 /// Logging for game performance
 /proc/log_perf(list/perf_info)
 	. = "[perf_info.Join(",")]\n"


### PR DESCRIPTION

## About The Pull Request

#94688 added a return to stop MAP_TEST from logging info, which made dreamchecker trigger at possibly unreachable code if the flag is enabled. This should've just been an ``#else`` instead.

## Changelog
:cl:
code: Dreamchecker no longer throws an error if you run the game with the MAP_TEST flag
/:cl:
