### PR TITLE
removes /human dependancy for blocking

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -622,7 +622,7 @@
 
 // afterattack() and attack() prototypes moved to _onclick/item_attack.dm for consistency
 
-/obj/item/proc/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
+/obj/item/proc/hit_reaction(mob/living/carbon/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_HIT_REACT, owner, hitby, attack_text, final_block_chance, damage, attack_type, damage_type) & COMPONENT_HIT_REACTION_BLOCK)
 		return TRUE
 


### PR DESCRIPTION
## About The Pull Request

fixes #82685 

## Why It's Good For The Game

fixes an oversight and opens up the possibility for the expansion of combat for non humanoids

## Changelog


:cl:

fix: fixed non humanoid mobs not gaining block chance of items with said properties

/:cl:

