### PR TITLE
Removes double definitions from sheaths

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -589,7 +589,7 @@
 	interaction_flags_click = parent_type::interaction_flags_click | NEED_DEXTERITY | NEED_HANDS
 	var/stored_blade
 	actions_types = list(/datum/action/innate/blade_counter)
-	action_slots = ITEM_SLOT_BELT
+	action_slots = ITEM_SLOT_BELT | ITEM_SLOT_SUITSTORE
 	COOLDOWN_DECLARE(resheath_cooldown)
 	COOLDOWN_DECLARE(full_ability_cooldown)
 
@@ -736,7 +736,6 @@
 	icon_state = "sheath"
 	inhand_icon_state = "sheath"
 	worn_icon_state = "sheath"
-	action_slots = ITEM_SLOT_BELT | ITEM_SLOT_SUITSTORE
 	storage_type = /datum/storage/sabre_belt
 	stored_blade = /obj/item/melee/sabre
 
@@ -746,7 +745,6 @@
 	icon_state = "grass_sheath"
 	inhand_icon_state = "grass_sheath"
 	worn_icon_state = "grass_sheath"
-	action_slots = ITEM_SLOT_BELT | ITEM_SLOT_SUITSTORE
 	storage_type = /datum/storage/green_sabre_belt
 
 /obj/item/storage/belt/sheath/gladius
@@ -755,7 +753,6 @@
 	icon_state = "gladius_sheath"
 	inhand_icon_state = "gladius_sheath"
 	worn_icon_state = "gladius_sheath"
-	action_slots = ITEM_SLOT_BELT | ITEM_SLOT_SUITSTORE
 	storage_type = /datum/storage/gladius_belt
 	stored_blade = /obj/item/claymore/gladius
 


### PR DESCRIPTION
## About The Pull Request

Removes defined action slots on every subtype of sheath, and puts the definitions on the base sheath

## Why It's Good For The Game

The thing they were talking about where the icon states don't update doesn't happen on my local. I don't know why it would have happened at all. I assume something else was happening.

## Changelog
No player facing changes
