### PR TITLE
Stops the designs unit test from yelling about abstract organizational surgery design subtypes

### DIFF
--- a/code/modules/unit_tests/designs.dm
+++ b/code/modules/unit_tests/designs.dm
@@ -18,7 +18,7 @@
 		if (length(current_design.reagents_list) && !(current_design.build_type & LIMBGROWER))
 			TEST_FAIL("Design [current_design.type] requires reagents but isn't a limb grower design. Reagent costs are only supported by limb grower designs")
 
-	for(var/datum/design/surgery/path as anything in subtypesof(/datum/design/surgery))
+	for(var/datum/design/surgery/path as anything in valid_subtypesof(/datum/design/surgery))
 		if (path::id == DESIGN_ID_IGNORE)
 			TEST_FAIL("Surgery Design [path] has no ID set")
 		if (isnull(path::surgery))


### PR DESCRIPTION
## About The Pull Request

Tin, these are supported and should be ignored by the unit test.

## Why It's Good For The Game

Fixes an oversight?

## Changelog

Nothing player-facing