### PR TITLE
The white ship emits a distinct space signal.

### DIFF
--- a/code/__DEFINES/space.dm
+++ b/code/__DEFINES/space.dm
@@ -1,4 +1,5 @@
 #define SPACE_SIGNAL_GPSTAG "Distant Signal"
+#define SPACE_SIGNAL_GPSTAG_WHITE_SHIP "Distress Signal"
 
 /// Every mob in the game will have a screen object sitting inside them with a reference matching this
 /// So you can render_source against it and never need to update it again

--- a/code/modules/shuttle/shuttle_consoles/white_ship.dm
+++ b/code/modules/shuttle/shuttle_consoles/white_ship.dm
@@ -9,12 +9,12 @@
 /// Console used on the whiteship bridge. Comes with GPS pre-baked.
 /obj/machinery/computer/shuttle/white_ship/bridge
 	name = "White Ship Bridge Console"
-	desc = "Used to control the White Ship from the bridge. Emits a faint GPS signal."
+	desc = "Used to control the White Ship from the bridge. It appears to be emitting an emergency signal, and has been for some time..."
 	circuit = /obj/item/circuitboard/computer/white_ship/bridge
 
 /obj/machinery/computer/shuttle/white_ship/bridge/Initialize(mapload, obj/item/circuitboard/C)
 	. = ..()
-	AddComponent(/datum/component/gps, SPACE_SIGNAL_GPSTAG)
+	AddComponent(/datum/component/gps, SPACE_SIGNAL_GPSTAG_WHITE_SHIP)
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/whiteship
 	name = "White Ship Navigation Computer"


### PR DESCRIPTION

## About The Pull Request

Rather than 'Distant Signal', the white ship GPS signal is now 'Distress Signal'.

## Why It's Good For The Game

The white ship is an excellent playground for player innovation and construction projects. What often hampers players is that finding it is usually attempting to sift through dozens of meaningless or unhelpful signals for what could be the majority of a round. Most people aim for the white ship to do projects. But the time sink in even getting to it is often more than enough to put people off finding it. IF it even spawned in the first place.

Most white ships are not _that_ extreme in terms of a power boost to warrant blocking players off if they were already willing to go to the lengths needed to go acquire a white ship. Concerns about players being incentivized to go out into space and off station are a bit moot when the only times they will actually be interacting with the white ship in the first place is that they've come to the conclusion that they're going to go do that.

Obnoxious overuse of the white ship is what I feel like something better handled by admin oversight and not squashed by the code base. 

And yes, while you can make custom shuttles at the moment, not everyone starts as the roles able to construct one. Also, they're a bit chunky, so the white ship is not usually ideal if you have a specific design shape in mind.

## Changelog
:cl:
qol: The white ship has a unique GPS signal. Just look for the 'Distress Signal' co-ordinate.
/:cl:
