### PR TITLE
Swaps the values on the syndicate blood-red modsuit and syndicate infiltrator modsuit

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -1287,11 +1287,11 @@
 	)
 
 /datum/armor/mod_theme_syndicate
-	melee = 40
+	melee = 50
 	bullet = 50
-	laser = 30
-	energy = 30
-	bomb = 35
+	laser = 40
+	energy = 50
+	bomb = 40
 	bio = 100
 	fire = 50
 	acid = 90
@@ -1433,11 +1433,11 @@
 	)
 
 /datum/armor/mod_theme_infiltrator
-	melee = 50
+	melee = 40
 	bullet = 50
-	laser = 40
-	energy = 50
-	bomb = 40
+	laser = 30
+	energy = 30
+	bomb = 35
 	fire = 100
 	acid = 100
 	wound = 25


### PR DESCRIPTION
## About The Pull Request

What it says on the tin.

Here are the new values for all the Syndicate modsuits.

| Modsuit | Melee | Bullet | Laser | Energy | Bommb |
| --- | --- |--- |--- |--- |--- |
| Infiltrator | 40 | 50 | 30 | 30 | 35 |
| Blood-Red | 50 | 50 | 40 | 50 | 40 |
| Elite | 60 | 60 | 50 | 50 | 55 |

## Why It's Good For The Game

The infiltrator is, despite marketed as a lesser armor, paradoxically a stronger armor than the blood-red modsuit. This is likely due to some value changes with time, since both suits have had many iterations over the years.

To make sure the infiltrator is not too extreme a value purchase (particularly on Icebox, where the lack of pressure protection doesn't matter whatsoever), and ensure that the blood-red is actually the superior of the two for the cost, their values for melee, bullet, laser, energy and bomb armor have been swapped.

The knock on effect of this is that nukies get a stronger baseline armor. Going to be honest here, I think most people will still buy the elite. More armor is always better. And the elite comes with additional benefits on top.

## Changelog
:cl:
balance: The infiltrator and blood-red modsuit have had their armor values swapped.
/:cl:
