### PR TITLE
Suiciding shouldn't usually delete your items

### DIFF
--- a/code/modules/fishing/fish/types/air_space.dm
+++ b/code/modules/fishing/fish/types/air_space.dm
@@ -198,7 +198,7 @@
 	if(chest)
 		babby.set_greyscale(chest.species_color) // this isn't working. why isnt this working
 
-	user.gib()
+	user.gib(DROP_ALL_REMAINS)
 	qdel(src)
 
 /obj/item/fish/baby_carp/update_overlays()

--- a/code/modules/fishing/fish/types/freshwater.dm
+++ b/code/modules/fishing/fish/types/freshwater.dm
@@ -253,8 +253,20 @@
 /obj/item/fish/tadpole/proc/gestation(mob/living/user)
 	if(QDELETED(user) || QDELETED(src))
 		return
+	user.visible_message(span_suicide("A live frog bursts out of [user]!"))
 	new /obj/effect/spawner/random/frog(user.drop_location())
-	user.gib()
+
+	var/obj/item/bodypart/chest
+	if (iscarbon(user))
+		var/mob/living/carbon/carbon_user = user
+		chest = carbon_user.get_bodypart(BODY_ZONE_CHEST)
+
+	if (chest)
+		chest.dismember()
+		user.death()
+	else
+		user.gib(DROP_ALL_REMAINS)
+
 	qdel(src)
 
 /obj/item/fish/perch

--- a/code/modules/fishing/fish/types/freshwater.dm
+++ b/code/modules/fishing/fish/types/freshwater.dm
@@ -256,10 +256,7 @@
 	user.visible_message(span_suicide("A live frog bursts out of [user]!"))
 	new /obj/effect/spawner/random/frog(user.drop_location())
 
-	var/obj/item/bodypart/chest
-	if (iscarbon(user))
-		var/mob/living/carbon/carbon_user = user
-		chest = carbon_user.get_bodypart(BODY_ZONE_CHEST)
+	var/obj/item/bodypart/chest = user.get_bodypart(BODY_ZONE_CHEST)
 
 	if (chest)
 		chest.dismember()

--- a/code/modules/fishing/fish/types/holographic.dm
+++ b/code/modules/fishing/fish/types/holographic.dm
@@ -40,7 +40,7 @@
 	visible_message(span_suicide("[user] swallows [src] whole! It looks like [user.p_theyre()] trying to derez [user.p_them()]selves!"))
 	var/area/station/holodeck/holo_area = get_area(src)
 	if(!istype(holo_area))
-		user.dust(just_ash = TRUE, drop_items = FALSE)
+		user.dust(just_ash = TRUE, drop_items = TRUE)
 		return MANUAL_SUICIDE
 	holo_area.linked.add_to_spawned(user) // oh no
 	return MANUAL_SUICIDE_NONLETHAL

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -283,7 +283,7 @@
 	if(discharged_energy < STANDARD_BATTERY_CHARGE)
 		return
 	user.dropItemToGround(src)
-	user.dust(just_ash = TRUE)
+	user.dust(just_ash = TRUE, drop_items = TRUE)
 	playsound(src, 'sound/effects/magic/lightningshock.ogg', 50, TRUE, 10)
 	tesla_zap(source = src, zap_range = 10, power = discharged_energy)
 

--- a/code/modules/spells/spell_types/touch/smite.dm
+++ b/code/modules/spells/spell_types/touch/smite.dm
@@ -64,6 +64,6 @@
 	user.say("SHIA KAZING!!", forced = "smite suicide")
 	do_sparks(4, FALSE, get_turf(user))
 	explosion(user, heavy_impact_range = 2, explosion_cause = src) //Cheap explosion imitation because putting detonate() here causes runtimes
-	user.gib(DROP_BODYPARTS)
+	user.gib(DROP_ALL_REMAINS)
 	qdel(src)
 	return MANUAL_SUICIDE

--- a/code/modules/surgery/surgery_tools.dm
+++ b/code/modules/surgery/surgery_tools.dm
@@ -186,7 +186,7 @@
 
 /obj/item/surgicaldrill/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] rams [src] into [user.p_their()] chest! It looks like [user.p_theyre()] trying to commit suicide!"))
-	addtimer(CALLBACK(user, TYPE_PROC_REF(/mob/living/carbon, gib), null, null, TRUE, TRUE), 2.5 SECONDS)
+	addtimer(CALLBACK(user, TYPE_PROC_REF(/mob/living/carbon, gib), DROP_ALL_REMAINS), 2.5 SECONDS)
 	user.SpinAnimation(3, 10)
 	playsound(user, 'sound/machines/juicer.ogg', 20, TRUE)
 	return MANUAL_SUICIDE


### PR DESCRIPTION
## About The Pull Request

Fixes #94662
Makes the remaining suicides I could find that gib or dust preserve items, as generally suicide should be a personal decision that people aren't using to spitefully deny traitor objectives or whatever.

ALSO I changed tadpole suicide to just make a big hole in your chest instead of gib you because, unlike a space carp, I don't think a tadpole growing into a single regularly sized frog is going to cause your body to burst into pieces.

The thing about "good first issues" is unfortunately we do also still want them to get fixed at some point, and people were mentioning that "suicide drill to delete items" had actually happened in real rounds.

## Changelog

:cl:se
balance: Killing yourself with a tadpole now only bursts your chest open and not your entire body, and frankly even that is pretty impressive work for a single frog to manage.
fix: Killing yourself in various other ways that gib or dust you will no longer delete the items you were wearing, consistent with most of the other ways of killing yourself that gib or dust you.
/:cl:
