### PR TITLE
Fixes Deltastation's Sever Room typo

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -62274,7 +62274,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/north{
-	c_tag = "Science - Sever Room Entrance";
+	c_tag = "Science - Server Room Entrance";
 	name = "science camera";
 	network = list("ss13","rd")
 	},


### PR DESCRIPTION

## About The Pull Request
Fixes a little typo in which Deltastation's Server Room was called "Sever Room" in the cameras.

## Why It's Good For The Game
The server room unfortunately isn't for severing.

## Changelog
:cl: Hardly
spellcheck: Fixed a typo with Deltastation's Server Room Entrance's camera.
/:cl:
