### PR TITLE
Patches 10+ year old shitcode

### DIFF
--- a/code/modules/shuttle/misc/special.dm
+++ b/code/modules/shuttle/misc/special.dm
@@ -405,7 +405,7 @@
 	pixel_x = -32
 	pixel_y = -32
 
-/obj/effect/decal/hammerandsickle/shuttleRotate(rotation)
+/obj/effect/decal/hammerandsickle/shuttleRotate(rotation, params)
 	setDir(angle2dir(rotation+dir2angle(dir))) // No parentcall, rest of the rotate code breaks the pixel offset.
 
 #undef LUXURY_MESSAGE_COOLDOWN

--- a/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
+++ b/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
@@ -77,7 +77,7 @@ All ShuttleMove procs go here
 		oldT.ScrapeAway(shuttle_depth)
 
 	if(rotation)
-		shuttleRotate(rotation) //see shuttle_rotate.dm
+		shuttleRotate(rotation, params = ALL) //see shuttle_rotate.dm
 	SEND_SIGNAL(src, COMSIG_TURF_AFTER_SHUTTLE_MOVE, oldT)
 
 	return TRUE
@@ -122,7 +122,7 @@ All ShuttleMove procs go here
 	if(light)
 		update_light()
 	if(rotation)
-		shuttleRotate(rotation)
+		shuttleRotate(rotation, params = ALL)
 
 	update_parallax_contents()
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -74,7 +74,7 @@
 /obj/docking_port/singularity_act()
 	return FALSE
 
-/obj/docking_port/shuttleRotate()
+/obj/docking_port/shuttleRotate(rotation, params)
 	return //we don't rotate with shuttles via this code.
 
 ///returns a list(x0,y0, x1,y1) where points 0 and 1 are bounding corners of the projected rectangle


### PR DESCRIPTION
Most of this code worked purely by accident or was too aggressive as a result of omitting the `params` default values in proc overrides. I checked the history and it was **always like this.**