### PR TITLE
General maintenance for plumbing disposer

### DIFF
--- a/code/datums/components/plumbing/simple_components.dm
+++ b/code/datums/components/plumbing/simple_components.dm
@@ -20,6 +20,19 @@
 		edge_overlay.pixel_z = -parent_movable.pixel_y - parent_movable.pixel_z
 		overlays += edge_overlay
 
+///For disposing reagents
+/datum/component/plumbing/simple_demand/disposer
+
+/datum/component/plumbing/simple_demand/disposer/Initialize(ducting_layer, distinct_reagent_cap)
+	if(!istype(parent, /obj/machinery/plumbing/disposer))
+		return COMPONENT_INCOMPATIBLE
+	return ..()
+
+/datum/component/plumbing/simple_demand/disposer/send_request(dir)
+	var/obj/machinery/plumbing/disposer/target = parent
+	if(target.on)
+		process_request(target.disposal_rate * SSFLUIDS_DT, dir = dir)
+
 ///has one pipe output that only supplies. example is liquid pump and manual input pipe
 /datum/component/plumbing/simple_supply
 	supply_connects = SOUTH

--- a/code/modules/plumbing/plumbers/destroyer.dm
+++ b/code/modules/plumbing/plumbers/destroyer.dm
@@ -82,7 +82,7 @@
 			if(!isnum(num))
 				return FALSE
 
-			disposal_rate = round(clamp(num, 1, MAX_DISPOSAL_RATE), CHEMICAL_VOLUME_ROUNDING)
+			disposal_rate = round(clamp(num, 0.1, MAX_DISPOSAL_RATE), CHEMICAL_VOLUME_ROUNDING)
 			return TRUE
 
 /obj/machinery/plumbing/disposer/process(seconds_per_tick)

--- a/code/modules/plumbing/plumbers/destroyer.dm
+++ b/code/modules/plumbing/plumbers/destroyer.dm
@@ -1,25 +1,62 @@
+//Maximum disposal rate
+#define MAX_DISPOSAL_RATE 15
+
 /obj/machinery/plumbing/disposer
 	name = "chemical disposer"
 	desc = "Breaks down chemicals and annihilates them."
 	icon_state = "disposal"
+	base_icon_state = "disposal"
 	pass_flags_self = PASSMACHINE | LETPASSTHROW // Small
 
-	///we remove 5 reagents per second
+	///Reagents to remove per second
 	var/disposal_rate = 5
 
 /obj/machinery/plumbing/disposer/Initialize(mapload, layer)
 	. = ..()
 	AddComponent(/datum/component/plumbing/simple_demand, layer)
+	RegisterSignal(reagents, COMSIG_REAGENTS_HOLDER_UPDATED, PROC_REF(update))
+
+/obj/machinery/plumbing/disposer/examine(mob/user)
+	. = ..()
+	. += span_notice("It is disposing [disposal_rate]u reagents per second.")
+	. += span_notice("Use hand to change disposal rate.")
+
+/obj/machinery/plumbing/disposer/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	if(isnull(held_item))
+		context[SCREENTIP_CONTEXT_LMB] = "Set transfer rate"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	return ..()
+
+/obj/machinery/plumbing/disposer/proc/update()
+	SIGNAL_HANDLER
+
+	update_appearance(UPDATE_ICON_STATE)
+
+/obj/machinery/plumbing/disposer/update_icon_state()
+	icon_state = "[base_icon_state][is_operational && anchored && reagents.total_volume ? "_working" : ""]"
+	return ..()
+
+/obj/machinery/plumbing/disposer/on_set_is_operational(old_value)
+	. = ..()
+	update_appearance(UPDATE_ICON_STATE)
+
+/obj/machinery/plumbing/disposer/wrench_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if(. == ITEM_INTERACT_SUCCESS)
+		update_appearance(UPDATE_ICON_STATE)
+
+/obj/machinery/plumbing/disposer/attack_hand(mob/living/user, list/modifiers)
+	. = ..()
+	var/new_volume = tgui_input_number(user, "Enter new disposal rate", "Disposal rate", disposal_rate, MAX_DISPOSAL_RATE, initial(disposal_rate))
+	if(!new_volume || QDELETED(user) || QDELETED(src) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
+		return
+	disposal_rate = new_volume
 
 /obj/machinery/plumbing/disposer/process(seconds_per_tick)
-	if(!is_operational)
+	if(!is_operational || !reagents.total_volume)
 		return
-	if(reagents.total_volume)
-		if(icon_state != initial(icon_state) + "_working") //threw it here instead of update icon since it only has two states
-			icon_state = initial(icon_state) + "_working"
-		reagents.remove_all(disposal_rate * seconds_per_tick)
-		use_energy(active_power_usage * seconds_per_tick)
-	else
-		if(icon_state != initial(icon_state))
-			icon_state = initial(icon_state)
+	reagents.remove_all(disposal_rate * seconds_per_tick)
+	use_energy((disposal_rate / MAX_DISPOSAL_RATE) * active_power_usage * seconds_per_tick)
 
+#undef MAX_DISPOSAL_RATE

--- a/code/modules/plumbing/plumbers/destroyer.dm
+++ b/code/modules/plumbing/plumbers/destroyer.dm
@@ -82,7 +82,7 @@
 			if(!isnum(num))
 				return FALSE
 
-			disposal_rate = clamp(num, 1, MAX_DISPOSAL_RATE)
+			disposal_rate = round(clamp(num, 1, MAX_DISPOSAL_RATE), CHEMICAL_VOLUME_ROUNDING)
 			return TRUE
 
 /obj/machinery/plumbing/disposer/process(seconds_per_tick)

--- a/code/modules/plumbing/plumbers/destroyer.dm
+++ b/code/modules/plumbing/plumbers/destroyer.dm
@@ -57,7 +57,6 @@
 
 /obj/machinery/plumbing/disposer/ui_static_data(mob/user)
 	return list(
-		min_volume = initial(disposal_rate),
 		max_volume = MAX_DISPOSAL_RATE
 	)
 
@@ -83,7 +82,7 @@
 			if(!isnum(num))
 				return FALSE
 
-			disposal_rate = clamp(num, initial(disposal_rate), MAX_DISPOSAL_RATE)
+			disposal_rate = clamp(num, 1, MAX_DISPOSAL_RATE)
 			return TRUE
 
 /obj/machinery/plumbing/disposer/process(seconds_per_tick)

--- a/tgui/packages/tgui/interfaces/ChemDisposer.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDisposer.tsx
@@ -39,7 +39,7 @@ export function ChemDisposer() {
                 value={disposal_rate}
                 unit="u"
                 width="50px"
-                minValue={1}
+                minValue={0.1}
                 maxValue={max_volume}
                 step={1}
                 stepPixelSize={2}

--- a/tgui/packages/tgui/interfaces/ChemDisposer.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDisposer.tsx
@@ -10,14 +10,13 @@ import { Window } from '../layouts';
 
 type Data = {
   enabled: BooleanLike;
-  min_volume: number;
   max_volume: number;
   disposal_rate: number;
 };
 
 export function ChemDisposer() {
   const { act, data } = useBackend<Data>();
-  const { enabled, min_volume, max_volume, disposal_rate } = data;
+  const { enabled, max_volume, disposal_rate } = data;
 
   return (
     <Window width={320} height={105}>
@@ -40,9 +39,9 @@ export function ChemDisposer() {
                 value={disposal_rate}
                 unit="u"
                 width="50px"
-                minValue={min_volume}
+                minValue={1}
                 maxValue={max_volume}
-                step={2}
+                step={1}
                 stepPixelSize={2}
                 onChange={(value) =>
                   act('change_volume', {

--- a/tgui/packages/tgui/interfaces/ChemDisposer.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDisposer.tsx
@@ -1,0 +1,59 @@
+import { useBackend } from 'tgui/backend';
+import {
+  Button,
+  LabeledList,
+  NumberInput,
+  Section,
+} from 'tgui-core/components';
+import type { BooleanLike } from 'tgui-core/react';
+import { Window } from '../layouts';
+
+type Data = {
+  enabled: BooleanLike;
+  min_volume: number;
+  max_volume: number;
+  disposal_rate: number;
+};
+
+export function ChemDisposer() {
+  const { act, data } = useBackend<Data>();
+  const { enabled, min_volume, max_volume, disposal_rate } = data;
+
+  return (
+    <Window width={320} height={105}>
+      <Window.Content>
+        <Section
+          title="Control Panel"
+          buttons={
+            <Button
+              icon="power-off"
+              selected={enabled}
+              onClick={() => act('toggle_power')}
+            >
+              {enabled ? 'On' : 'Off'}
+            </Button>
+          }
+        >
+          <LabeledList>
+            <LabeledList.Item label="Volume">
+              <NumberInput
+                value={disposal_rate}
+                unit="u"
+                width="50px"
+                minValue={min_volume}
+                maxValue={max_volume}
+                step={2}
+                stepPixelSize={2}
+                onChange={(value) =>
+                  act('change_volume', {
+                    volume: value,
+                  })
+                }
+              />
+            </LabeledList.Item>
+          </LabeledList>
+        </Section>
+      </Window.Content>
+    </Window>
+  );
+}


### PR DESCRIPTION
## About The Pull Request
- Plumbing disposer disposal rate can now be changed with hand nad has TGUI interface. It accepts a value between 5->15 meaning it can dispose anywhere from 10u to 50u reagents per tick. Added examines & screen tips for the same
- Fixes plumbing disposer icon state not correctly switching between working and off under certain circumstances

## Changelog
:cl:
qol: plumbing disposer now has TGUI interface for operations
fix: plumbing disposer icon state correctly switches between on & off under circumstances
/:cl:

