### PR TITLE
Changes Full Augmentation check to bitwise & with 'BODYTYPE_ROBOTIC' instead of jsut comparing to it

### DIFF
--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -469,7 +469,7 @@
 		if (!IS_ROBOTIC_ORGAN(organ))
 			return FALSE
 	for (var/obj/item/bodypart/bodypart as anything in check.bodyparts)
-		if (bodypart.bodytype != BODYTYPE_ROBOTIC)
+		if (!(bodypart.bodytype & BODYTYPE_ROBOTIC))
 			return FALSE
 	return TRUE
 

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -469,7 +469,7 @@
 		if (!IS_ROBOTIC_ORGAN(organ))
 			return FALSE
 	for (var/obj/item/bodypart/bodypart as anything in check.bodyparts)
-		if (!(bodypart.bodytype & BODYTYPE_ROBOTIC))
+		if (!IS_ROBOTIC_LIMB(bodypart))
 			return FALSE
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
Changes the check from `not equals` to bitwise & instead
## Why It's Good For The Game
If you are, by chance, have any bodypart with `BODYTYPE_ROBOTIC` and some other flag, check will be failed resulting in you being unable to scan what seemingly is a full robot.
## Changelog
Not player facing.
