### PR TITLE
Fixes paywall firing pins being unregisterable

### DIFF
--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -282,7 +282,7 @@
 	if(id.registered_account == pin_owner)
 		to_chat(user, span_notice("You unlink the card from the firing pin."))
 		gun_owners -= user.get_bank_account()
-		pin_owner = NUTRITION_LEVEL_START_MIN
+		pin_owner = null
 		return ITEM_INTERACT_SUCCESS
 	var/transaction_amount = tgui_input_number(user, "Insert valid deposit amount for gun purchase", "Money Deposit")
 	if(!transaction_amount || QDELETED(user) || QDELETED(src) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH))

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -276,7 +276,7 @@
 	if(!id.registered_account)
 		to_chat(user, span_warning("ERROR: Identification card lacks registered bank account!"))
 		return ITEM_INTERACT_BLOCKING
-	if(id.registered_account != pin_owner)
+	if(pin_owner && id.registered_account != pin_owner)
 		to_chat(user, span_warning("ERROR: This firing pin has already been authorized!"))
 		return ITEM_INTERACT_BLOCKING
 	if(id.registered_account == pin_owner)


### PR DESCRIPTION

## About The Pull Request

If `pin_owner` is null as it starts off, it fails both if the attemping id has null bank account AND if it doesn't have null bank account.

Also, the `pin_owner` being set to... uh, yeah, that's right... `NUTRITION_LEVEL_START_MIN` on unlink would have made it impossible to relink it later.

## Why It's Good For The Game

It works now and it didn't before. `NUTRITION_LEVEL_START_MIN` is baffling me, though. I hope that that isn't something load bearing.

## Changelog
:cl:

fix: Paywall firing pins are registerable again, & they'll keep being registerable after being unregistered.

/:cl:
