### PR TITLE
Moves stone tile examine text to a examine_lore

### DIFF
--- a/code/game/turfs/open/floor/misc_floor.dm
+++ b/code/game/turfs/open/floor/misc_floor.dm
@@ -284,24 +284,37 @@
 
 /turf/open/floor/stone
 	name = "stone brick floor"
-	desc = "Odd, really, how it looks exactly like the iron walls yet is stone instead of iron. Now, if that's really more of a complaint about\
+	desc = "Rudimentary stone tiles."
+	icon_state = "stone_floor"
+
+/turf/open/floor/stone/Initialize(mapload)
+	. = ..()
+	add_deep_lore()
+
+/turf/open/floor/stone/proc/add_deep_lore()
+	AddElement(/datum/element/examine_lore, \
+		lore_hint = span_notice("You start to ask alot of questions as you [EXAMINE_HINT("look closer")]."), \
+		lore = "Odd, really, how it looks exactly like the iron walls yet is stone instead of iron. Now, if that's really more of a complaint about\
 		the ironness of walls or the stoneness of the floors, that's really up to you. But have you really ever seen iron that dull? I mean, it\
 		makes sense for the station to have dull metal walls but we're talking how a rudimentary iron wall would be. Medieval ages didn't even\
 		use iron walls, iron walls are actually not even something that exists because iron is an expensive and not-so-great thing to build walls\
 		out of. It only makes sense in the context of space because you're trying to keep a freezing vacuum out. Is anyone following me on this? \
-		The idea of a \"rudimentary\" iron wall makes no sense at all! Is anything i'm even saying here true? Someone's gotta fact check this!"
-	icon_state = "stone_floor"
+		The idea of a \"rudimentary\" iron wall makes no sense at all! Is anything i'm even saying here true? Someone's gotta fact check this!" \
+	)
 
 /turf/open/floor/stone/icemoon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
-	name = "stone brick floor"
-	desc = "Odd, really, how it looks exactly like the iron walls yet is stone instead of iron. Now, if that's really more of a complaint about\
+
+/turf/open/floor/stone/icemoon/add_deep_lore()
+	AddElement(/datum/element/examine_lore, \
+		lore_hint = span_notice("You start to ask alot of questions as you [EXAMINE_HINT("look closer")]."), \
+		lore = "Odd, really, how it looks exactly like the iron walls yet is stone instead of iron. Now, if that's really more of a complaint about\
 		the ironness of walls or the stoneness of the floors, that's really up to you. But have you really ever seen iron that dull? I mean, it\
 		makes sense for the station to have dull metal walls but we're talking how a rudimentary iron wall would be. Medieval ages didn't even\
 		use iron walls, iron walls are actually not even something that exists because iron is an expensive and not-so-great thing to build walls\
 		out of. It only makes sense in the context of space because you're trying to keep a freezing vacuum out. Is anyone following me on this? \
-		The idea of a \"rudimentary\" iron wall makes no sense at all! Is anything i'm even saying here true? Someone's gotta fact check this!"
-	icon_state = "stone_floor"
+		The idea of a \"rudimentary\" iron wall makes no sense at all! Is anything i'm even saying here true? Someone's gotta fact check this!" \
+	)
 
 /turf/open/floor/vault
 	name = "strange floor"


### PR DESCRIPTION

## About The Pull Request
The message itself is out of date with it having gone through resprites but I haven't thought of anything funny enough to replace it.
<img width="958" height="211" alt="image" src="https://github.com/user-attachments/assets/d50c83b5-5358-44fb-be5a-1687a85b57af" />
## Why It's Good For The Game
I understand part of the joke is a big fuckoff wall of text in a random desc but it just seems strange to me and mappers have put it in 20 diffrent map files prob unrelated to the original bit. nestles it away in the deep examine so it functions like other "item lores"
## Changelog
:cl:
qol: Stone tile crazed rambling have been hidden in its deep examine
/:cl:
