### PR TITLE
Adds a shaker upgrade to the service cyborg.

### DIFF
--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -175,6 +175,24 @@
 					cyborg.cell.use(charge_cost)
 					stored_reagents.add_reagent(reagent_to_regen, 5, reagtemp = dispensed_temperature, no_react = TRUE)
 
+/// Upgrade our hypospray to hold even more new reagents!
+/obj/item/reagent_containers/borghypo/proc/upgrade_hypo()
+	upgraded = TRUE
+	// Expand the holder's capacity to allow for our new suite of reagents
+	stored_reagents.maximum_volume += (length(expanded_reagent_types) * (max_volume_per_reagent + 1))
+	for(var/reagent in expanded_reagent_types)
+		var/datum/reagent/reagent_to_add = reagent
+		add_new_reagent(reagent_to_add)
+
+/// Remove the reagents we got from the expansion, back to our base reagents
+/obj/item/reagent_containers/borghypo/proc/remove_hypo_upgrade()
+	upgraded = FALSE
+	for(var/reagent in expanded_reagent_types)
+		var/datum/reagent/reagent_to_remove = reagent
+		stored_reagents.del_reagent(reagent_to_remove)
+	// Reduce the holder's capacity because we no longer need the room for those reagents
+	stored_reagents.maximum_volume -= (length(expanded_reagent_types) * (max_volume_per_reagent + 1))
+
 /obj/item/reagent_containers/borghypo/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!iscarbon(interacting_with))
 		return NONE
@@ -259,24 +277,6 @@
 /obj/item/reagent_containers/borghypo/medical
 	default_reagent_types = BASE_MEDICAL_REAGENTS
 	expanded_reagent_types = EXPANDED_MEDICAL_REAGENTS
-
-/// Upgrade our hypospray to hold even more new reagents!
-/obj/item/reagent_containers/borghypo/medical/proc/upgrade_hypo()
-	upgraded = TRUE
-	// Expand the holder's capacity to allow for our new suite of reagents
-	stored_reagents.maximum_volume += (length(expanded_reagent_types) * (max_volume_per_reagent + 1))
-	for(var/reagent in expanded_reagent_types)
-		var/datum/reagent/reagent_to_add = reagent
-		add_new_reagent(reagent_to_add)
-
-/// Remove the reagents we got from the expansion, back to our base reagents
-/obj/item/reagent_containers/borghypo/medical/proc/remove_hypo_upgrade()
-	upgraded = FALSE
-	for(var/reagent in expanded_reagent_types)
-		var/datum/reagent/reagent_to_remove = reagent
-		stored_reagents.del_reagent(reagent_to_remove)
-	// Reduce the holder's capacity because we no longer need the room for those reagents
-	stored_reagents.maximum_volume -= (length(expanded_reagent_types) * (max_volume_per_reagent + 1))
 
 /obj/item/reagent_containers/borghypo/medical/hacked
 	icon_state = "borghypo_s"

--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -107,6 +107,7 @@
 	icon_state = "borghypo"
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = list(2,5)
+	abstract_type = /obj/item/reagent_containers/borghypo
 
 	/** The maximum volume for each reagent stored in this hypospray
 	 * In most places we add + 1 because we're secretly keeping [max_volume_per_reagent + 1]

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -379,14 +379,8 @@
 		deactivate_sr()
 
 /obj/item/borg/upgrade/hypospray
-	name = "medical cyborg hypospray advanced synthesiser"
-	desc = "An upgrade to the Medical model cyborg's hypospray, allowing it \
-		to produce more advanced and complex medical reagents."
-	icon_state = "module_medical"
+	abstract_type = /obj/item/borg/upgrade/hypospray
 	require_model = TRUE
-	model_type = list(/obj/item/robot_model/medical)
-	model_flags = BORG_MODEL_MEDICAL
-	var/list/additional_reagents = list()
 
 /obj/item/borg/upgrade/hypospray/action(mob/living/silicon/robot/borg, mob/living/user = usr)
 	. = ..()
@@ -399,13 +393,28 @@
 	. = ..()
 	if(!.)
 		return .
-	for(var/obj/item/reagent_containers/borghypo/medical/hypo in borg.model.modules)
-		hypo.remove_hypo_upgrade()
+	for(var/obj/item/reagent_containers/borghypo/hypo in borg.model.modules)
+		if(hypo.upgraded)
+			hypo.remove_hypo_upgrade()
+	for(var/obj/item/reagent_containers/borghypo/hypo in borg.model.emag_modules)
+		if(hypo.upgraded)
+			hypo.remove_hypo_upgrade()
 
-/obj/item/borg/upgrade/hypospray/expanded
+/obj/item/borg/upgrade/hypospray/medical
 	name = "medical cyborg expanded hypospray"
 	desc = "An upgrade to the Medical model's hypospray, allowing it \
 		to treat a wider range of conditions and problems."
+	icon_state = "module_medical"
+	model_type = list(/obj/item/robot_model/medical)
+	model_flags = BORG_MODEL_MEDICAL
+
+/obj/item/borg/upgrade/hypospray/service
+	name = "service cyborg expanded shaker"
+	desc = "An upgrade to the Service model's shaker, allowing it \
+		to prepare a wider variety of food and drink recipes."
+	icon_state = "module_service"
+	model_type = list(/obj/item/robot_model/service)
+	model_flags = BORG_MODEL_SERVICE
 
 /obj/item/borg/upgrade/piercing_hypospray
 	name = "cyborg piercing hypospray"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1349,11 +1349,11 @@
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
 	)
 
-/datum/design/borg_upgrade_expandedsynthesiser
+/datum/design/borg_upgrade_expandedsynthesiser_medical
 	name = "Expanded Hypospray Synthesiser"
-	id = "borg_upgrade_expandedsynthesiser"
+	id = "borg_upgrade_expandedsynthesiser_medical"
 	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/hypospray/expanded
+	build_path = /obj/item/borg/upgrade/hypospray/medical
 	materials = list(
 		/datum/material/iron =SHEET_MATERIAL_AMOUNT*7.5,
 		/datum/material/glass =SHEET_MATERIAL_AMOUNT*7.5,
@@ -1607,6 +1607,22 @@
 		/datum/material/diamond = HALF_SHEET_MATERIAL_AMOUNT,
 	)
 	construction_time = 4 SECONDS
+	category = list(
+		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_SERVICE
+	)
+
+/datum/design/borg_upgrade_expandedsynthesiser_service
+	name = "Expanded Shaker Synthesiser"
+	id = "borg_upgrade_expandedsynthesiser_service"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/hypospray/service
+	materials = list(
+		/datum/material/iron =SHEET_MATERIAL_AMOUNT*7.5,
+		/datum/material/glass =SHEET_MATERIAL_AMOUNT*7.5,
+		/datum/material/plasma =SHEET_MATERIAL_AMOUNT*4,
+		/datum/material/uranium =SHEET_MATERIAL_AMOUNT*4,
+	)
+	construction_time = 8 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_SERVICE
 	)

--- a/code/modules/research/techweb/nodes/cyborg_nodes.dm
+++ b/code/modules/research/techweb/nodes/cyborg_nodes.dm
@@ -55,6 +55,7 @@
 	design_ids = list(
 		"borg_upgrade_rolling_table",
 		"borg_upgrade_condiment_synthesizer",
+		"borg_upgrade_expandedsynthesiser_service",
 		"borg_upgrade_silicon_knife",
 		"borg_upgrade_service_apparatus",
 		"borg_upgrade_drink_apparatus",
@@ -86,7 +87,7 @@
 		"borg_upgrade_pinpointer",
 		"borg_upgrade_beakerapp",
 		"borg_upgrade_defibrillator",
-		"borg_upgrade_expandedsynthesiser",
+		"borg_upgrade_expandedsynthesiser_medical",
 		"borg_upgrade_piercinghypospray",
 		"borg_upgrade_surgicalprocessor",
 		"borg_upgrade_surgicalomnitool",


### PR DESCRIPTION
## About The Pull Request

Turns out there was a set of reagents for upgraded service cyborgs that was never usable for the simple reason that there wasn't an upgrade to enable it. This PR adds such an upgrade, and moves the hypospray upgrading code up from the medborg hypo to the abstract borg hypo. The base hypospray upgrade and the base borg hypospray have been marked as abstract types. Additionally removes an unused var definition in the base borg hypo upgrade.

## Why It's Good For The Game

Provides access to something that was probably meant to be a thing for a very long time, but simply wasn't.

## Changelog

:cl:
add: Adds the Service cyborg expanded shaker upgrade.
/:cl:
