### PR TITLE
Prevents installing piercing hypospray on service cyborgs (because it's technically useless on them)

### DIFF
--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -137,6 +137,8 @@
 	var/datum/reagent/selected_reagent
 	/// The theme for our UI (hacked hypos get syndicate UI)
 	var/tgui_theme = "ntos"
+	/// Whether this hypo should be upgradable to enable piercing
+	var/allow_piercing = TRUE
 
 /obj/item/reagent_containers/borghypo/Initialize(mapload)
 	. = ..()
@@ -332,6 +334,7 @@
 	dispensed_temperature = WATER_MATTERSTATE_CHANGE_TEMP //Water stays wet, ice stays ice
 	default_reagent_types = BASE_SERVICE_REAGENTS
 	expanded_reagent_types = EXPANDED_SERVICE_REAGENTS
+	allow_piercing = FALSE // Can't be used on carbons, so this prevents applying the piercing hypo upgrade to no effect.
 	var/reagent_search_container = REAGENT_CONTAINER_BEVAPPARATUS
 
 /obj/item/reagent_containers/borghypo/borgshaker/ui_interact(mob/user, datum/tgui/ui)
@@ -431,6 +434,7 @@
 	recharge_time = 6 //Double the recharge time too, for the same reason.
 	dispensed_temperature = WATER_MATTERSTATE_CHANGE_TEMP
 	default_reagent_types = EXPANDED_SERVICE_REAGENTS
+	allow_piercing = FALSE // Can't be used on carbons, so this prevents applying the piercing hypo upgrade to no effect.
 
 /obj/item/reagent_containers/borghypo/condiment_synthesizer/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -419,15 +419,18 @@
 		return .
 	var/found_hypo = FALSE
 	for(var/obj/item/reagent_containers/borghypo/hypo in borg.model.modules)
-		hypo.bypass_protection = TRUE
-		found_hypo = TRUE
-	for(var/obj/item/reagent_containers/borghypo/hypo in borg.model.emag_modules)
+		if(!hypo.allow_piercing)
+			continue
 		hypo.bypass_protection = TRUE
 		found_hypo = TRUE
 
 	if(!found_hypo)
 		to_chat(user, span_warning("There are no installed hypospray modules to upgrade with piercing!")) //check to see if any hyposprays were upgraded
 		return FALSE
+
+	// If we are actually going to install the upgrade due to the presence of compatible modules, make sure their emagged counterparts get upgraded too.
+	for(var/obj/item/reagent_containers/borghypo/hypo in borg.model.emag_modules)
+		hypo.bypass_protection = TRUE
 
 /obj/item/borg/upgrade/piercing_hypospray/deactivate(mob/living/silicon/robot/borg, mob/living/user = usr)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Both of the hypospray types that a service cyborg can get are not usable on carbons. This means that there is no point in installing the piercing hypospray module in them. This PR allows certain hypospray types to be incompatible with the piercing hypospray upgrade, and makes the service borg's hyposprays incompatible.

## Why It's Good For The Game

Saves roboticists from wasting time and/or resources on installing an upgrade that provides literally nothing to the borg receiving it.

## Changelog

:cl:
fix: Service cyborgs did not receive any benefit from installing the piercing hypospray upgrade, so it can no longer be installed in them.
/:cl:

<details><summary></summary>I actually wanted to nerf unhacked peacekeeper borgs with this because they really shouldn't fucking be security's antag-neutering attack dogs, but I managed to maintain the restraint to not do that... for now.</details>