### PR TITLE
Add 1676 to unrecommended builds

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -9,6 +9,7 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 	"1670" = "Bug breaking in-world text rendering.",
 	"1671" = "Bug breaking in-world text rendering.",
 	"1675" = "Frequent crashing.",
+	"1676" = "Frequent crashing.",
 ))
 #define LIMITER_SIZE 5
 #define CURRENT_SECOND 1


### PR DESCRIPTION
same thing as #94933, there seems to be no evidence of the crash bug being fixed by reading the logs BUT there seems to be no evidence yet that the crash bug still exists