### PR TITLE
Fixes regex key in spawn panel

### DIFF
--- a/tgui/packages/tgui/interfaces/SpawnSearch.tsx
+++ b/tgui/packages/tgui/interfaces/SpawnSearch.tsx
@@ -21,8 +21,8 @@ import {
 } from 'tgui-core/keycodes';
 import type { BooleanLike } from 'tgui-core/react';
 import { resolveAsset } from '../assets';
-import { useBackend } from './../backend';
-import { Window } from './../layouts';
+import { useBackend } from '../backend';
+import { Window } from '../layouts';
 import { logger } from '../logging';
 
 type SpawnSearchData = {


### PR DESCRIPTION

## About The Pull Request
The original issue was that using <kbd>alt</kbd><kbd>R</kbd> wouldn't change the input's text as expected. This is correct behavior in tgui-core, inputs cannot be altered while focused (ux concern). A hacky way to fix this would be to just blur and refocus, but I think the intent here is just to display `re:` next to the text. 

![dreamseeker_OceEFtFcMI](https://github.com/user-attachments/assets/aece09b0-b9b3-4ce0-93f2-782892c8561e)

Outside of this, I tried to optimize the component as much as I could. Removing the input control logic (just to add re:) simplifies it quite a bit. I also removed the filter's useEffect instead to derive the filter/validity states from `query`. It should run smoothly!
## Why It's Good For The Game
The UI should work. I don't think there's an issue up for this yet
## Changelog
:cl:
fix: Fixed the regex mode toggle in the spawn (verb) panel.
/:cl:
