### PR TITLE
Dna console indicates invalid pairs

### DIFF
--- a/tgui/packages/tgui/interfaces/DnaConsole/DnaConsoleSequencer.jsx
+++ b/tgui/packages/tgui/interfaces/DnaConsole/DnaConsoleSequencer.jsx
@@ -76,6 +76,17 @@ const GeneCycler = (props) => {
   );
 };
 
+function isPairMatched(sequence, index) {
+  const gene1 = sequence.charAt(index);
+  const gene2 = sequence.charAt(index + 1);
+  return (
+    (gene1 === 'A' && gene2 === 'T') ||
+    (gene1 === 'T' && gene2 === 'A') ||
+    (gene1 === 'G' && gene2 === 'C') ||
+    (gene1 === 'C' && gene2 === 'G')
+  );
+}
+
 const GenomeSequencer = (props) => {
   const { mutation } = props;
   if (!mutation) {
@@ -120,9 +131,9 @@ const GenomeSequencer = (props) => {
         <Box
           mt="-2px"
           ml="10px"
-          width="2px"
+          width="3px"
           height="8px"
-          backgroundColor="label"
+          backgroundColor={isPairMatched(sequence, i) ? 'label' : 'red'}
         />
         {buttons[i + 1]}
       </Box>


### PR DESCRIPTION
## About The Pull Request

The bar between dna pairs will change to red if the pair is invalid

<img width="134" height="104" alt="image" src="https://github.com/user-attachments/assets/03f5b800-8abd-4251-9320-9c49218fd6e2" />

It does not indicate that the pair is **incorrect** for the sequence, just that the pair is **invalid** in general

## Why It's Good For The Game

A/T and C/G are the same color so it's very easy to accidentally set up an A-A / C-C / etc pair without realizing it.
This just gives a small visual indicator that a pair is invalid. 

## Changelog

:cl: Melbert
qol: Dna console has a minor visual indicator for invalid pairs (such as A-A or C-T)
/:cl:


