### PR TITLE
Revamp handheld gene scanner output (might actually break all of chat)

### DIFF
--- a/code/__DEFINES/tgui.dm
+++ b/code/__DEFINES/tgui.dm
@@ -54,3 +54,13 @@
  * * required_perms: Which admin permission flags to check the user for, such as [R_ADMIN]
  */
 #define ADMIN_STATE(required_perms) (GLOB.admin_states[required_perms] ||= new /datum/ui_state/admin_state(required_perms))
+
+// For winset/winget
+/// Output element id
+#define OUTPUT_ELEMENT_ID "output_selector.legacy_output_selector"
+/// Output element parameter
+#define OUTPUT_ELEMENT_PARAM "left"
+/// Output to legacy / old chat
+#define OUTPUT_ELEMENT_VALUE_LEGACY "output_legacy"
+/// Output to browser / tgui chat
+#define OUTPUT_ELEMENT_VALUE_MODERN "output_browser"

--- a/code/__HELPERS/chat.dm
+++ b/code/__HELPERS/chat.dm
@@ -102,3 +102,23 @@ it will be sent to all connected chats.
 			avoid_highlighting = (creature == source),
 		)
 	send_to_observers(message, source)
+
+/**
+ * Outputs a TGUI component directly to the user's chat'
+ *
+ * * user - The mob to send the component to
+ * * component_name - The name of the TGUI component to send (you MUST have this component registered in tgui-panel/chat/renderer.tsx)
+ * * component_data - A list of key/value pairs to send as data attributes to the component (the data MUST be registered in tgui-panel/chat/renderer.tsx)
+ * * fallback - An optional fallback string to display if TGUI chat is not working
+ */
+/proc/tgui_component_to_chat(mob/user, component_name, list/component_data, fallback)
+	if(winget(user, OUTPUT_ELEMENT_ID, OUTPUT_ELEMENT_PARAM) == OUTPUT_ELEMENT_VALUE_LEGACY)
+		to_chat(user, fallback || span_alert("Unsupported action in legacy chat."))
+		return
+
+	var/list/comps = list("data-component=\"[component_name]\"")
+	for(var/key, value in component_data)
+		comps += "data-[key]=\"[value]\""
+
+	to_chat(user, "<span [jointext(comps, " ")]/>")
+	to_chat(user, "<br>") // the chat won't auto-scroll without this, idk. enjoy your state mandated newline

--- a/code/game/objects/items/devices/scanners/sequence_scanner.dm
+++ b/code/game/objects/items/devices/scanners/sequence_scanner.dm
@@ -103,13 +103,15 @@
 		LAZYSET(buffer, mutation.type, GET_SEQUENCE(mutation.type))
 		active_mutations.Add(mutation.type)
 
-	to_chat(user, span_notice("Subject [target.name]'s DNA sequence has been saved to buffer."))
+	var/output = list("Subject [target.name]'s DNA sequence has been saved to buffer.")
 	for(var/mutation in buffer)
 		//highlight activated mutations
 		if(LAZYFIND(active_mutations, mutation))
-			to_chat(user, span_boldnotice("[get_display_name(mutation)]"))
+			output += "&bull; [span_bold(get_display_name(mutation))]"
 		else
-			to_chat(user, span_notice("[get_display_name(mutation)]"))
+			output += "&bull; [get_display_name(mutation)]"
+
+	to_chat(user, boxed_message(span_notice(jointext(output, "<br>"))))
 
 ///proc for scanning someone's genetic makeup
 /obj/item/sequence_scanner/proc/makeup_scan(mob/living/carbon/target, mob/living/user)
@@ -144,13 +146,18 @@
 			break
 
 	if(sequence)
-		var/display
+		var/fallback
 		for(var/i in 0 to length_char(sequence) / DNA_MUTATION_BLOCKS-1)
 			if(i)
-				display += "-"
-			display += copytext_char(sequence, 1 + i*DNA_MUTATION_BLOCKS, DNA_MUTATION_BLOCKS*(1+i) + 1)
+				fallback += "-"
+			fallback += copytext_char(sequence, 1 + i*DNA_MUTATION_BLOCKS, DNA_MUTATION_BLOCKS*(1+i) + 1)
 
-		to_chat(user, "[span_boldnotice("[display]")]<br>")
+		tgui_component_to_chat(
+			user = user,
+			component_name = "GenomePreview",
+			component_data = list("mutation_sequence" = sequence, "mutation_name" = answer),
+			fallback = span_boldnotice(fallback),
+		)
 
 	ready = FALSE
 	icon_state = "[icon_state]_recharging"

--- a/code/modules/tgui_panel/external.dm
+++ b/code/modules/tgui_panel/external.dm
@@ -19,19 +19,19 @@
 	// Failed to fix, using tg_alert as fallback
 	action = tg_alert(src, "Did that work?", "", "Yes", "No, switch to old ui")
 	if (action == "No, switch to old ui")
-		winset(src, "output_selector.legacy_output_selector", "left=output_legacy")
+		winset(src, OUTPUT_ELEMENT_ID, "[OUTPUT_ELEMENT_PARAM]=[OUTPUT_ELEMENT_VALUE_LEGACY]")
 		log_tgui(src, "Failed to fix.", context = "verb/fix_tgui_panel")
 
 /client/proc/nuke_chat()
 	// Catch all solution (kick the whole thing in the pants)
-	winset(src, "output_selector.legacy_output_selector", "left=output_legacy")
+	winset(src, OUTPUT_ELEMENT_ID, "[OUTPUT_ELEMENT_PARAM]=[OUTPUT_ELEMENT_VALUE_LEGACY]")
 	if(!tgui_panel || !istype(tgui_panel))
 		log_tgui(src, "tgui_panel datum is missing",
 			context = "verb/fix_tgui_panel")
 		tgui_panel = new(src)
 	tgui_panel.initialize(force = TRUE)
 	// Force show the panel to see if there are any errors
-	winset(src, "output_selector.legacy_output_selector", "left=output_browser")
+	winset(src, OUTPUT_ELEMENT_ID, "[OUTPUT_ELEMENT_PARAM]=[OUTPUT_ELEMENT_VALUE_MODERN]")
 
 /client/verb/refresh_tgui()
 	set name = "Refresh TGUI"

--- a/tgui/packages/tgui-panel/chat/renderer.tsx
+++ b/tgui/packages/tgui-panel/chat/renderer.tsx
@@ -9,6 +9,7 @@ import { createLogger } from 'tgui/logging';
 import { Tooltip } from 'tgui-core/components';
 import { EventEmitter } from 'tgui-core/events';
 import { classes } from 'tgui-core/react';
+import { GenomePreview } from '../../tgui/interfaces/DnaConsole/DnaConsoleSequencer';
 import { store } from '../events/store';
 import { scrollTrackingAtom } from './atom';
 import {
@@ -36,6 +37,7 @@ const SCROLL_TRACKING_TOLERANCE = 24;
 // List of injectable component names to the actual type
 export const TGUI_CHAT_COMPONENTS = {
   Tooltip,
+  GenomePreview,
 };
 
 // List of injectable attibute names mapped to their proper prop
@@ -43,6 +45,8 @@ export const TGUI_CHAT_COMPONENTS = {
 export const TGUI_CHAT_ATTRIBUTES_TO_PROPS = {
   position: 'position',
   content: 'content',
+  mutation_sequence: 'mutation_sequence',
+  mutation_name: 'mutation_name',
 };
 
 function createHighlightNode(text, color) {

--- a/tgui/packages/tgui/interfaces/DnaConsole/DnaConsoleSequencer.jsx
+++ b/tgui/packages/tgui/interfaces/DnaConsole/DnaConsoleSequencer.jsx
@@ -1,4 +1,11 @@
-import { Box, Button, Image, Section, Stack } from 'tgui-core/components';
+import {
+  Box,
+  Button,
+  Image,
+  NoticeBox,
+  Section,
+  Stack,
+} from 'tgui-core/components';
 import { classes } from 'tgui-core/react';
 
 import { resolveAsset } from '../../assets';
@@ -77,7 +84,7 @@ const GeneCycler = (props) => {
 };
 
 const GenomeSequencer = (props) => {
-  const { mutation } = props;
+  const { mutation, clickable = true, tip = true } = props;
   if (!mutation) {
     return <Box color="average">No genome selected for sequencing.</Box>;
   }
@@ -94,7 +101,7 @@ const GenomeSequencer = (props) => {
   const buttons = [];
   for (let i = 0; i < sequence.length; i++) {
     const gene = sequence.charAt(i);
-    const button = (
+    const button = clickable ? (
       <GeneCycler
         width="22px"
         textAlign="center"
@@ -108,6 +115,10 @@ const GenomeSequencer = (props) => {
         index={i}
         alias={mutation.Alias}
       />
+    ) : (
+      <Box width="22px" textAlign="center" backgroundColor={GENE_COLORS[gene]}>
+        {gene}
+      </Box>
     );
     buttons.push(button);
   }
@@ -148,11 +159,38 @@ const GenomeSequencer = (props) => {
   return (
     <>
       <Box m={-0.5}>{pairs}</Box>
-      <Box color="label" mt={1}>
-        <b>Tip:</b> Ctrl+Click on the gene to set it to X. Right Click to cycle
-        in reverse.
-      </Box>
+      {tip && (
+        <Box color="label" mt={1}>
+          <b>Tip:</b> Ctrl+Click on the gene to set it to X. Right Click to
+          cycle in reverse.
+        </Box>
+      )}
     </>
+  );
+};
+
+export const GenomePreview = (props) => {
+  const { mutation_sequence, mutation_name } = props;
+  return (
+    <NoticeBox
+      mt={0.5}
+      backgroundColor="label"
+      style={{ borderRadius: '0.25rem' }}
+    >
+      <Box fontSize="125%" mb={1} italic>
+        {mutation_name}
+      </Box>
+      <Box style={{ fontStyle: 'normal' }}>
+        <GenomeSequencer
+          mutation={{
+            Sequence: mutation_sequence,
+            // no other data is needed when clickable is false
+          }}
+          clickable={false}
+          tip={false}
+        />
+      </Box>
+    </NoticeBox>
   );
 };
 
@@ -247,7 +285,7 @@ export const DnaConsoleSequencer = (props) => {
               )
             }
           >
-            <GenomeSequencer mutation={mutation} />
+            <GenomeSequencer mutation={mutation} clickable={true} />
           </Section>
         )}
     </>

--- a/tgui/packages/tgui/interfaces/DnaConsole/DnaConsoleSequencer.jsx
+++ b/tgui/packages/tgui/interfaces/DnaConsole/DnaConsoleSequencer.jsx
@@ -84,7 +84,7 @@ const GeneCycler = (props) => {
 };
 
 const GenomeSequencer = (props) => {
-  const { mutation, clickable = true, tip = true } = props;
+  const { mutation, clickable = true } = props;
   if (!mutation) {
     return <Box color="average">No genome selected for sequencing.</Box>;
   }
@@ -159,7 +159,7 @@ const GenomeSequencer = (props) => {
   return (
     <>
       <Box m={-0.5}>{pairs}</Box>
-      {tip && (
+      {clickable && (
         <Box color="label" mt={1}>
           <b>Tip:</b> Ctrl+Click on the gene to set it to X. Right Click to
           cycle in reverse.
@@ -187,7 +187,6 @@ export const GenomePreview = (props) => {
             // no other data is needed when clickable is false
           }}
           clickable={false}
-          tip={false}
         />
       </Box>
     </NoticeBox>


### PR DESCRIPTION
## About The Pull Request

Genetic hand scanner's mutation list is now bullet pointed and boxed, and displaying a specific mutation outputs the same style output as you'd expect from the dna scanner

<img width="684" height="309" alt="image" src="https://github.com/user-attachments/assets/de706a55-ca0f-4e44-9e6b-36e278d66ab1" />

"Ok, why might it actually break all of chat" this will be the first time a **unique** tgui component is embedded into the chat, and I have no idea what it will do if you load your chat history into a version of the code that does not have the component.

My assumption is it will bluescreen the chat, which is not ideal. IDEK if we can circumvent this. Worth testing, at least? Worst case a few people have their chat blue-screened and have to clear cache. 

## Why It's Good For The Game

My good friend Wallem did something like this and I was a big fan, it makes it a lot clearer what you're getting out of the hand scan. 

## Changelog

:cl: Melbert
qol: Revamps handheld gene scanner output
/:cl:

