### PR TITLE
Fix lights emergency power consumption [No GBP]

### DIFF
--- a/code/__DEFINES/lights.dm
+++ b/code/__DEFINES/lights.dm
@@ -1,5 +1,5 @@
 ///How much power emergency lights will consume per tick
-#define LIGHT_EMERGENCY_POWER_USE (0.0001 * STANDARD_CELL_RATE)
+#define LIGHT_EMERGENCY_POWER_USE (0.0002 * STANDARD_CELL_RATE)
 // status values shared between lighting fixtures and items
 #define LIGHT_OK 0
 #define LIGHT_EMPTY 1


### PR DESCRIPTION
## About The Pull Request

Fixes emergency lighting to use 0.2W per tick as per the code. I missed this in testing https://github.com/tgstation/tgstation/pull/94910

Emergency lights use 0.2 W per tick, meaning ~10 minutes of emergency power from a cell.

## Why It's Good For The Game

Lights consume power for the expected amount of time.

## Changelog

:cl: LT3
fix: Emergency lighting consumes its cell at the expected rate
/:cl: