### PR TITLE
Gets rid of ignored_factions

### DIFF
--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -112,7 +112,8 @@
 	var/original_speed = shell.loaded_projectile.speed
 	var/original_wounds_bonus = shell.loaded_projectile.wound_bonus
 	var/original_bare_wounds_bonus = shell.loaded_projectile.exposed_wound_bonus
-	var/original_ignored_faction = shell.loaded_projectile.ignored_factions
+	var/original_ignored_faction = shell.loaded_projectile.get_faction()
+	var/original_ignored_allies = shell.loaded_projectile.allies
 
 	for(var/i in 1 to num_pellets)
 		shell.ready_proj(target, user, SUPPRESSED_VERY, zone_override, fired_from)
@@ -129,7 +130,8 @@
 		shell.loaded_projectile.speed = original_speed
 		shell.loaded_projectile.wound_bonus = original_wounds_bonus
 		shell.loaded_projectile.exposed_wound_bonus = original_bare_wounds_bonus
-		shell.loaded_projectile.ignored_factions = original_ignored_faction
+		shell.loaded_projectile.set_faction(original_ignored_faction)
+		shell.loaded_projectile.set_allies(original_ignored_allies)
 		pellets += shell.loaded_projectile
 		var/turf/current_loc = get_turf(fired_from)
 		if (!istype(target_loc) || !istype(current_loc) || !(shell.loaded_projectile))

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -678,7 +678,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	A.firer = src
 	A.fired_from = src
 	if(ignore_faction)
-		A.ignored_factions = faction
+		APPLY_FACTION_AND_ALLIES_FROM(A, src)
 	A.fire()
 	return A
 

--- a/code/modules/antagonists/heretic/magic/rust_wave.dm
+++ b/code/modules/antagonists/heretic/magic/rust_wave.dm
@@ -93,7 +93,7 @@
 	damage_type = TOX
 	hitsound = 'sound/items/weapons/punch3.ogg'
 	trigger_range = 0
-	ignored_factions = list(FACTION_HERETIC)
+	faction = list(FACTION_HERETIC)
 	range = 15
 	speed = 1
 

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -231,6 +231,8 @@
 	return ..()
 
 /obj/effect/mob_spawn/ghost_role/human/ash_walker/allow_spawn(mob/user, silent = FALSE)
+	if(isnull(team))
+		return FALSE
 	if(!(user.ckey in team.players_spawned))//one per person unless you get a bonus spawn
 		return TRUE
 	if(!silent)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -644,7 +644,7 @@
 				return FALSE
 	if(LAZYLEN(faction) && ismob(target) && !direct_target)
 		var/mob/target_mob = target
-		if(FAST_FACTION_CHECK(faction, target_mob.get_faction(), allies, target_mob.allies))
+		if(FAST_FACTION_CHECK(faction, target_mob.get_faction(), allies, target_mob.allies, FALSE))
 			return FALSE
 	if(target.density || cross_failed) //This thing blocks projectiles, hit it regardless of layer/mob stuns/etc.
 		return TRUE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -234,8 +234,6 @@
 	var/log_override = FALSE
 	/// If true, the projectile won't cause any logging whatsoever. Used for hallucinations and shit.
 	var/do_not_log = FALSE
-	/// We ignore mobs with these factions.
-	var/list/ignored_factions
 	/// Turf that we have registered connect_loc signal - this is done for performance, as we're moving ~a dozen turfs per tick
 	/// and registering and unregistering signal for every single one of them is stupid. Unregistering the signal from the correct turf in case we get moved by smth else is important
 	var/turf/last_tick_turf
@@ -644,9 +642,9 @@
 			var/mob/firer_mob = firer
 			if (firer_mob.buckled == target)
 				return FALSE
-	if(ignored_factions?.len && ismob(target) && !direct_target)
+	if(LAZYLEN(faction) && ismob(target) && !direct_target)
 		var/mob/target_mob = target
-		if(target_mob.has_faction(ignored_factions))
+		if(FAST_FACTION_CHECK(faction, target_mob.get_faction(), allies, target_mob.allies))
 			return FALSE
 	if(target.density || cross_failed) //This thing blocks projectiles, hit it regardless of layer/mob stuns/etc.
 		return TRUE

--- a/code/modules/spells/spell_types/projectile/juggernaut.dm
+++ b/code/modules/spells/spell_types/projectile/juggernaut.dm
@@ -15,5 +15,5 @@
 
 /datum/action/cooldown/spell/basic_projectile/juggernaut/fire_projectile(atom/target, mob/caster)
 	var/obj/projectile/magic/aoe/juggernaut/to_fire = ..()
-	to_fire.ignored_factions = caster.get_faction()
+	SET_FACTION_AND_ALLIES_FROM(to_fire, caster)
 	return to_fire


### PR DESCRIPTION
## About The Pull Request

Tin, this is redundant now that faction has been moved to the atom. Also fixes a misc runtime that can occur if someone clicks an ashwalker egg before team datums are created

## Why It's Good For The Game

Updates code

## Changelog

Not player-facing
