### PR TITLE
Drops MOB_ROBOTIC from pandora, hierophant, & clockwork defender

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/clockwork_knight.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/clockwork_knight.dm
@@ -23,7 +23,7 @@ I'd rather there be something than the clockwork ruin be entirely empty though s
 	armour_penetration = 40
 	melee_damage_lower = 20
 	melee_damage_upper = 20
-	mob_biotypes = MOB_ROBOTIC|MOB_SPECIAL|MOB_MINING|MOB_MINERAL
+	mob_biotypes = MOB_SPECIAL|MOB_MINING|MOB_MINERAL
 	vision_range = 9
 	aggro_vision_range = 9
 	speed = 5

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -53,7 +53,7 @@ Difficulty: Hard
 	armour_penetration = 50
 	melee_damage_lower = 15
 	melee_damage_upper = 15
-	mob_biotypes = MOB_ROBOTIC|MOB_SPECIAL|MOB_MINING
+	mob_biotypes = MOB_SPECIAL|MOB_MINING
 	speed = 10
 	move_to_delay = 10
 	ranged = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
@@ -36,7 +36,7 @@
 	speed = 3
 	move_to_delay = 10
 	mouse_opacity = MOUSE_OPACITY_ICON
-	mob_biotypes = MOB_ROBOTIC|MOB_MINING|MOB_MINERAL
+	mob_biotypes = MOB_MINING|MOB_MINERAL
 	death_sound = 'sound/effects/magic/repulse.ogg'
 	death_message = "'s lights flicker, before its top part falls down."
 	loot_drop = /obj/item/clothing/accessory/pandora_hope


### PR DESCRIPTION

## About The Pull Request

In #89619 these three mobs were given MOB_ROBOTIC to better represent what they are internally. The downside? You could then oneshot them with an EMP.

## Why It's Good For The Game

You should not be able to oneshot megafauna.

Also, none of these things are electrical, which is really what MOB_ROBOTIC represents, more than just being synthetic.

## Changelog
:cl:

fix: You can no longer oneshot the hierophant with an EMP

/:cl:
