### PR TITLE
Fixes Radioactive Resonance symptom not updating host health

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -601,6 +601,8 @@
 	needs_update += carbon_host.adjust_tox_loss(-2 * heal_amt, updating_health = FALSE)
 	var/brute_burn_heal = carbon_host.heal_overall_damage(heal_amt, heal_amt, required_bodytype = healable_bodytypes, updating_health = FALSE)
 	needs_update += brute_burn_heal
+	if(needs_update)
+		carbon_host.updatehealth()
 	if(brute_burn_heal && prob(4))
 		to_chat(carbon_host, span_notice("Your skin glows faintly, and you feel your wounds mending themselves."))
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Fixes #94975 by making the radheal symptom correctly update the host's health after healing.
There's not really much else to say.

:cl:
fix: Viruses that heal their hosts through radiation no longer cause phantom pain.
/:cl: