### PR TITLE
Minor spelling mistake in Slime Management Console

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -254,7 +254,7 @@
 ///Places one monkey, if possible
 /obj/machinery/computer/camera_advanced/xenobio/proc/feed_slime(mob/living/user, turf/open/target_turf)
 	if(stored_monkeys < 1)
-		to_chat(user, span_warning("[src] needs to have at least 1 monkey stored. Currently has [stored_monkeys] stored_monkeys stored."))
+		to_chat(user, span_warning("[src] needs to have at least 1 monkey stored. Currently has [stored_monkeys] monkeys stored."))
 		target_turf.balloon_alert(user, "not enough monkeys")
 		return
 


### PR DESCRIPTION
## About The Pull Request

The Slime Management Console will include a random stored_monkeys in a to_chat if there aren't enough. This removes it so that it reads better.

## Why It's Good For The Game

Reads like proper english in a player facing console.

## Changelog


:cl:
spellcheck: The slime management console no longer reads a variable name out incorrectly.
/:cl:

