### PR TITLE
Fixes "Pick up" in the shift-right-click menu not working in rare cases

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -837,7 +837,7 @@
 			return
 
 	if(usr.get_active_held_item() == null) // Let me know if this has any problems -Yota
-		usr.UnarmedAttack(src)
+		usr.UnarmedAttack(src, 1)
 
 /**
  *This proc is executed when someone clicks the on-screen UI button.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -837,7 +837,7 @@
 			return
 
 	if(usr.get_active_held_item() == null) // Let me know if this has any problems -Yota
-		usr.UnarmedAttack(src, 1)
+		usr.UnarmedAttack(src, TRUE)
 
 /**
  *This proc is executed when someone clicks the on-screen UI button.


### PR DESCRIPTION
## About The Pull Request

Fixes it so if you're playing a basic mob with the dextrous component (eg. gorilla, dextrous holoparasite), you can still use "Pick up" in the shift-right-click menu. 
This is a rare situation, and I don't know how many people even use the old right click menu anymore, but it was annoying me while testing something else so I fixed it.
This doesn't impact telekinesis, because you don't get that option on the right click menu from a distance anyway.

## Why It's Good For The Game

I think the "pick up" option in the menu on an item should probably pick up the item.

## Changelog

:cl:
fix: Fixed right-click menu pick up of items not working in rare cases.
/:cl:
