### PR TITLE
Fixes 2 floor light instances not mounting

### DIFF
--- a/code/game/objects/items/rcd/RLD.dm
+++ b/code/game/objects/items/rcd/RLD.dm
@@ -173,6 +173,7 @@
 					return ITEM_INTERACT_BLOCKING
 				var/obj/machinery/light/L = new /obj/machinery/light(get_turf(winner))
 				L.setDir(get_dir(winner, interacting_with))
+				L.find_and_mount_on_atom()
 				L.color = color_choice
 				L.set_light_color(color_choice)
 				useResource(cost, user)
@@ -185,6 +186,7 @@
 				var/obj/machinery/light/floor/FL = new /obj/machinery/light/floor(target)
 				FL.color = color_choice
 				FL.set_light_color(color_choice)
+				FL.find_and_mount_on_atom()
 				useResource(cost, user)
 				return ITEM_INTERACT_SUCCESS
 

--- a/code/game/objects/items/rcd/RLD.dm
+++ b/code/game/objects/items/rcd/RLD.dm
@@ -173,9 +173,9 @@
 					return ITEM_INTERACT_BLOCKING
 				var/obj/machinery/light/L = new /obj/machinery/light(get_turf(winner))
 				L.setDir(get_dir(winner, interacting_with))
-				L.find_and_mount_on_atom()
 				L.color = color_choice
 				L.set_light_color(color_choice)
+				L.find_and_mount_on_atom()
 				useResource(cost, user)
 				return ITEM_INTERACT_SUCCESS
 

--- a/code/modules/power/lighting/light_construct.dm
+++ b/code/modules/power/lighting/light_construct.dm
@@ -184,3 +184,9 @@
 	icon_state = "floor-construct-stage1"
 	fixture_type = "floor"
 	sheets_refunded = 1
+
+/obj/structure/light_construct/floor/get_turfs_to_mount_on()
+	return list(get_turf(src))
+
+/obj/structure/light_construct/floor/is_mountable_turf(turf/target)
+	return !isgroundlessturf(target)


### PR DESCRIPTION
## About The Pull Request
- Fixes floor light constructs not mounting on floor
- Fixes RLD created lights not mounting

See the discussion in https://github.com/tgstation/tgstation/pull/94611#issuecomment-3793090467

## Changelog
:cl:
fix: floor light constructs now deconstruct when floor is deconstructed
fix: RLD created lights now fall off when floor/wall is destroyed
/:cl:

