### PR TITLE
remove ferry console from away mission

### DIFF
--- a/_maps/RandomZLevels/heretic.dmm
+++ b/_maps/RandomZLevels/heretic.dmm
@@ -5809,9 +5809,6 @@
 /turf/open/misc/grass/jungle/station,
 /area/awaymission/beach/heretic)
 "EH" = (
-/obj/machinery/computer/shuttle/ferry/request{
-	dir = 4
-	},
 /turf/open/floor/pod/light,
 /area/awaymission/beach/heretic)
 "EI" = (


### PR DESCRIPTION

## About The Pull Request

Removes a ferry console from the heretic beach away mission

## Why It's Good For The Game

It allows players to call the ferry shuttle to the station and access CC, which shouldn't be possible outside of admin intervention

## Changelog

:cl:
fix: Removed a ferry console which should not be at the heretic beach
:cl:
