### PR TITLE
Lootpanel Improvements

### DIFF
--- a/code/modules/lootpanel/_lootpanel.dm
+++ b/code/modules/lootpanel/_lootpanel.dm
@@ -38,9 +38,14 @@
 		ui.open()
 
 
+/datum/lootpanel/ui_host(mob/user)
+	return source_turf
+
+
 /datum/lootpanel/ui_close(mob/user)
 	. = ..()
 
+	UnregisterSignal(source_turf, COMSIG_ATOM_ENTERED)
 	source_turf = null
 	reset_contents()
 
@@ -55,13 +60,6 @@
 	return data
 
 
-/datum/lootpanel/ui_status(mob/user, datum/ui_state/state)
-	if(user.incapacitated)
-		return UI_DISABLED
-
-	return UI_INTERACTIVE
-
-
 /datum/lootpanel/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
@@ -70,7 +68,5 @@
 	switch(action)
 		if("grab")
 			return grab(usr, params)
-		if("refresh")
-			return populate_contents()
 
 	return FALSE

--- a/code/modules/lootpanel/misc.dm
+++ b/code/modules/lootpanel/misc.dm
@@ -1,5 +1,10 @@
 /// Helper to open the panel
 /datum/lootpanel/proc/open(turf/tile)
+	if (tile != source_turf)
+		if (source_turf)
+			UnregisterSignal(source_turf, COMSIG_ATOM_ENTERED)
+		RegisterSignal(tile, COMSIG_ATOM_ENTERED, PROC_REF(on_source_turf_entered))
+
 	source_turf = tile
 
 #if !defined(OPENDREAM) && !defined(UNIT_TESTS)

--- a/tgui/packages/tgui/interfaces/LootPanel/index.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/index.tsx
@@ -1,9 +1,7 @@
-import { useState } from 'react';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Button, Input, Section, Stack } from 'tgui-core/components';
 import { isEscape } from 'tgui-core/keys';
 import { clamp } from 'tgui-core/math';
-import type { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../../backend';
 import { Window } from '../../layouts';
@@ -13,12 +11,11 @@ import type { SearchItem } from './types';
 
 type Data = {
   contents: SearchItem[];
-  searching: BooleanLike;
 };
 
 export function LootPanel(props) {
-  const { act, data } = useBackend<Data>();
-  const { contents = [], searching } = data;
+  const { data } = useBackend<Data>();
+  const { contents = [] } = data;
 
   // limitations: items with different stack counts, charges etc.
   const contentsByPathName = useMemo(() => {
@@ -70,11 +67,6 @@ export function LootPanel(props) {
             selected={grouping}
             onClick={() => setGrouping(!grouping)}
             tooltip="Toggle Grouping"
-          />
-          <Button
-            icon="sync"
-            onClick={() => act('refresh')}
-            tooltip="Refresh"
           />
         </Stack>
       }


### PR DESCRIPTION
## About The Pull Request

Makes the lootpanel act like you'd expect it to.

## Why It's Good For The Game

You should not need to manually refresh the loot panel. You should not be able to monitor a turf on the other side of the station.

## Changelog

:cl:
fix: The lootpanel will now properly close with distance from the target like most other tguis.
qol: The lootpanel will now automatically refresh when new items enter it. Removed the manual refresh button.
/:cl:
