### PR TITLE
Banners drop centered

### DIFF
--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -10,6 +10,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT)
+	item_flags = NO_PIXEL_RANDOM_DROP
 	var/inspiration_available = TRUE //If this banner can be used to inspire crew
 	var/morale_time = 0
 	var/morale_cooldown = 600 //How many deciseconds between uses


### PR DESCRIPTION
## About The Pull Request

Adds no_pixel_random_drop to banners (so they drop to the middle of the tile)

## Why It's Good For The Game

Recent prs reminded me how annoying this is 

## Changelog

:cl: Melbert
qol: Banners drop centered
/:cl:
