### PR TITLE
Fixes improvised mounted weaponry dropping way too much cable

### DIFF
--- a/code/game/objects/structures/cannons/mounted_guns/mounted_gun.dm
+++ b/code/game/objects/structures/cannons/mounted_guns/mounted_gun.dm
@@ -148,9 +148,13 @@
 /obj/structure/mounted_gun/atom_deconstruct(disassembled = TRUE)
 	. = ..()
 	dump_contents()
+	var/droploc = drop_location()
 	for (var/type in debris)
+		if(ispath(type, /obj/item/stack))
+			new type(droploc, debris[type])
+			continue
 		for (var/i in 1 to debris[type])
-			new type(drop_location())
+			new type(droploc)
 
 /obj/structure/mounted_gun/dump_contents()
 	return // Generally we don't have contents to dump but some children do.


### PR DESCRIPTION

## About The Pull Request

Because cable coils are by default 30 cable, what was presumably intended to drop four cable actually dropped four stacks of cable. This modifies the deconstruction logic of improvised mounted weapons to spawn `/obj/item/stack`s once, with their count set in `new()`, rather than repeatedly spawning single stacks and having them merge, which allows granularity when it comes to cable.

## Why It's Good For The Game

Unless you're deconstructing something via a wiremill, it shouldn't produce eight times as much cable as it cost.

## Changelog
:cl:

fix: Improvised mounted weaponry now drops a reasonable amount of cable

/:cl:
