### PR TITLE
Some changes to icebox portal loot

### DIFF
--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	/obj/item/stack/ore/bananium = 5,
 	/obj/item/stack/ore/titanium = 75,
 	))
+
 GLOBAL_VAR_INIT(tumors_spawned, 0)
 
 /obj/structure/spawner/ice_moon

--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	/obj/item/stack/ore/bananium = 5,
 	/obj/item/stack/ore/titanium = 75,
 	))
+GLOBAL_VAR_INIT(tumors_spawned, 0)
 
 /obj/structure/spawner/ice_moon
 	name = "cave entrance"
@@ -143,9 +144,18 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	visible_message(span_warning("Something slips out of [src]!"))
 	var/loot = rand(1, 100)
 	switch(loot)
-		if(1 to 80)
+		if(1 to 75)
 			new /obj/structure/closet/crate/necropolis/tendril/demonic(loc)
+		if(76 to 80)
+			new /mob/living/basic/mining/brimdemon(loc) // demons from a demonic portal
 		if(81 to 90)
-			new /mob/living/basic/boss/blood_drunk_miner/doom(loc)
+			if(world.time-SSticker.round_start_time > 15 MINUTES) // imagine destroying your first portal and being ambushed by a fucking doomslayer
+				new /mob/living/basic/boss/blood_drunk_miner/doom(loc) // demon hunter from a demonic portal
+				return
+			new /obj/structure/closet/crate/necropolis/tendril/demonic(loc)
 		if(91 to INFINITY)
-			new /obj/structure/elite_tumor(loc)
+			if(GLOB.tumors_spawned < 3)
+				new /obj/structure/elite_tumor(loc) // so you wont get like 10 tumors and no other loot
+				GLOB.tumors_spawned ++
+				return
+			new /obj/structure/closet/crate/necropolis/tendril/demonic(loc)


### PR DESCRIPTION
## About The Pull Request

adds a brimdemon to portal loot (demons from demonic portal 😎)
prevents doomslayer boss (blooddrunk miner but a bit harder) spawning from demonic portals before 15 minutes round time
adds a limit of 3 tumors spawning from demonic portals
if something breaks throw rocks at me and revert this (and please ping me in discord)

## Why It's Good For The Game

1. brimdemons drop a reagent that you cant get on icebox (now you can)
2. you can no longer be ambushed by a boss before you are prepared (or should be)
3. no more this:
<img width="441" height="71" alt="image" src="https://github.com/user-attachments/assets/dd1ec9bd-61ea-436d-be25-ea3a2be30895" />

## Changelog

:cl:
balance: brimdust is no longer unobtainable on icebox
balance: you have 15 minutes to prepare before hostile-enviromental miners can spawn from demonic portals
balance: added a limit of 3 tumors spawned from demonic portals
/:cl:
