### PR TITLE
Blood drunk miner bitrunner domain drops the cache correctly

### DIFF
--- a/code/modules/bitrunning/server/signal_handlers.dm
+++ b/code/modules/bitrunning/server/signal_handlers.dm
@@ -76,6 +76,11 @@
 				boss.make_virtual_megafauna()
 				continue
 
+			if(istype(creature, /mob/living/basic/boss))
+				var/mob/living/basic/boss/boss = creature
+				boss.make_virtual_megafauna()
+				continue
+
 			mutation_candidate_refs.Add(WEAKREF(creature))
 			continue
 

--- a/code/modules/bitrunning/util/virtual_megafauna.dm
+++ b/code/modules/bitrunning/util/virtual_megafauna.dm
@@ -1,4 +1,4 @@
-/// Removes all the loot and achievements from megafauna for bitrunning related
+/// Removes all the loot and achievements from megafauna for bitrunning related (/simple_animal/hostile/megafauna version)
 /mob/living/simple_animal/hostile/megafauna/proc/make_virtual_megafauna()
 	var/new_max = clamp(maxHealth * 0.5, 600, 1300)
 	maxHealth = new_max
@@ -26,3 +26,26 @@
 
 	loot.Cut()
 	loot += /obj/structure/closet/crate/secure/bitrunning/encrypted
+
+/// Removes all the loot and achievements from megafauna for bitrunning related (/basic/boss version)
+/mob/living/basic/boss/proc/make_virtual_megafauna()
+	var/new_max = clamp(maxHealth * 0.5, 600, 1300)
+	maxHealth = new_max
+	health = new_max
+
+	// rebuild the achievement element's arguments to remove it appropriately
+	if (achievements)
+		var/list/achievements_list = list(/datum/award/achievement/boss/boss_killer, /datum/award/score/boss_score)
+		achievements_list += achievements
+		RemoveElement(/datum/element/kill_achievement, string_list(achievements_list), crusher_achievement_type, /datum/memory/megafauna_slayer)
+
+	// remove the crusher loot element's arguments also to remove it appropriately
+	RemoveElement(\
+		/datum/element/crusher_loot,\
+		trophy_type = string_list(crusher_loot),\
+		guaranteed_drop = 0.6,\
+		drop_immediately = DEL_ON_DEATH,\
+	)
+
+	RemoveElement(/datum/element/death_drops, string_list(regular_loot))
+	AddElement(/datum/element/death_drops, /obj/structure/closet/crate/secure/bitrunning/encrypted)

--- a/code/modules/mob/living/basic/boss/blood_drunk_miner/_blood_drunk_miner.dm
+++ b/code/modules/mob/living/basic/boss/blood_drunk_miner/_blood_drunk_miner.dm
@@ -43,9 +43,7 @@ Difficulty: Medium
 	victor_memory_type = /datum/memory/megafauna_slayer
 
 	crusher_loot = list(/obj/item/crusher_trophy/miner_eye, /obj/item/knife/hunting/wildhunter)
-
-	/// Loot dropped on death in normal circumstances
-	var/list/regular_loot = list(/obj/item/melee/cleaving_saw, /obj/item/gun/energy/recharge/kinetic_accelerator)
+	regular_loot = list(/obj/item/melee/cleaving_saw, /obj/item/gun/energy/recharge/kinetic_accelerator)
 
 	/// Their little saw
 	var/obj/item/melee/cleaving_saw/miner/miner_saw
@@ -71,7 +69,6 @@ Difficulty: Medium
 	ai_controller.set_blackboard_key(BB_BDM_RANGED_ATTACK_COOLDOWN, ranged_attack_cooldown_duration)
 	RegisterSignals(ai_controller, list(AI_CONTROLLER_BEHAVIOR_QUEUED(/datum/ai_behavior/basic_melee_attack), AI_CONTROLLER_BEHAVIOR_QUEUED(/datum/ai_behavior/targeted_mob_ability)), PROC_REF(handle_saw_transformation))
 
-	AddElement(/datum/element/death_drops, string_list(regular_loot))
 	RegisterSignal(src, COMSIG_LIVING_DROP_LOOT, PROC_REF(death_effect))
 
 	AddComponent(/datum/component/boss_music, 'sound/music/boss/bdm_boss.ogg', COMSIG_AI_BLACKBOARD_KEY_SET(BB_BASIC_MOB_CURRENT_TARGET))

--- a/code/modules/mob/living/basic/boss/boss.dm
+++ b/code/modules/mob/living/basic/boss/boss.dm
@@ -23,6 +23,8 @@
 	/// What crusher trophy/trophies this mob drops, if any
 	/// Should be wrapped in a list for sanity when we pass it to the element.
 	var/list/crusher_loot = null
+	/// Loot dropped on death in normal circumstances
+	var/list/regular_loot = list()
 
 	/// What achievements do we give our defeater?
 	var/list/achievements = null
@@ -40,6 +42,7 @@
 	add_traits(list(TRAIT_NO_TELEPORT, TRAIT_MARTIAL_ARTS_IMMUNE, TRAIT_LAVA_IMMUNE, TRAIT_ASHSTORM_IMMUNE, TRAIT_NO_FLOATING_ANIM), MEGAFAUNA_TRAIT)
 	AddComponent(/datum/component/seethrough_mob)
 	AddElement(/datum/element/simple_flying)
+	AddElement(/datum/element/death_drops, string_list(regular_loot))
 	handle_crusher_loot()
 	handle_achievements()
 


### PR DESCRIPTION

## About The Pull Request

Added support for turning basic mob bosses into virtual megafauna. Moved blood drunk miner's loot dropping behaviour up to /basic/boss to support this better in future.

Fixes #94878 

## Why It's Good For The Game

It's not very useful if admins have to spawn the cache manually or lose the time and points spent on the domain.

## Changelog
:cl:
fix: The Sanguine Excavation bitrunning domain will drop the cache on killing the boss again.
/:cl:
