### PR TITLE
Corrects mispelled "sheering" pain in spine implant emp text

### DIFF
--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -301,7 +301,7 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
-	to_chat(owner, span_warning("You feel sheering pain as your body is crushed like a soda can!"))
+	to_chat(owner, span_warning("You feel shearing pain as your body is crushed like a soda can!"))
 	owner.apply_damage(20/severity, BRUTE, def_zone = BODY_ZONE_CHEST)
 
 /obj/item/organ/cyberimp/chest/spine/on_mob_insert(mob/living/carbon/organ_owner, special, movement_flags)


### PR DESCRIPTION

## About The Pull Request

sheering -> shearing

## Why It's Good For The Game

I assume they meant shearing & not searing, cause it's the body being smushed. They definitely didn't mean sheering.

## Changelog
:cl:

spellcheck: spine implant emp damaging text spells "shearing" correctly

/:cl:
