### PR TITLE
A bullet to the brain has a rare chance of providing a free lobotomy

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -70,6 +70,11 @@
 
 	return null
 
+/mob/living/carbon/apply_projectile_effects(obj/projectile/proj, def_zone, armor_check)
+	. = ..()
+	if(proj.damage_type == BRUTE && proj.damage > 10 && proj.speed > 1 && prob(0.1))
+		cure_trauma_type(resilience = TRAUMA_RESILIENCE_LOBOTOMY)
+
 /mob/living/carbon/check_projectile_dismemberment(obj/projectile/proj, def_zone)
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)
 	if(affecting && affecting.can_dismember() && !(affecting.bodypart_flags & BODYPART_UNREMOVABLE) && affecting.get_damage() >= (affecting.max_damage - proj.dismemberment))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -70,11 +70,6 @@
 
 	return null
 
-/mob/living/carbon/apply_projectile_effects(obj/projectile/proj, def_zone, armor_check)
-	. = ..()
-	if(def_zone == BODY_ZONE_HEAD && proj.damage_type == BRUTE && proj.damage > 10 && proj.speed > 1 && prob(0.1))
-		cure_trauma_type(resilience = TRAUMA_RESILIENCE_LOBOTOMY)
-
 /mob/living/carbon/check_projectile_dismemberment(obj/projectile/proj, def_zone)
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)
 	if(affecting && affecting.can_dismember() && !(affecting.bodypart_flags & BODYPART_UNREMOVABLE) && affecting.get_damage() >= (affecting.max_damage - proj.dismemberment))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -72,7 +72,7 @@
 
 /mob/living/carbon/apply_projectile_effects(obj/projectile/proj, def_zone, armor_check)
 	. = ..()
-	if(proj.damage_type == BRUTE && proj.damage > 10 && proj.speed > 1 && prob(0.1))
+	if(def_zone == BODY_ZONE_HEAD && proj.damage_type == BRUTE && proj.damage > 10 && proj.speed > 1 && prob(0.1))
 		cure_trauma_type(resilience = TRAUMA_RESILIENCE_LOBOTOMY)
 
 /mob/living/carbon/check_projectile_dismemberment(obj/projectile/proj, def_zone)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -142,7 +142,7 @@
 		apply_projectile_effects(proj, def_zone, blocked)
 
 /mob/living/proc/apply_projectile_effects(obj/projectile/proj, def_zone, armor_check)
-	apply_damage(
+	var/damage_dealt = apply_damage(
 		damage = proj.damage,
 		damagetype = proj.damage_type,
 		def_zone = def_zone,
@@ -153,6 +153,10 @@
 		attack_direction = get_dir(proj.starting, src),
 		attacking_item = proj,
 	)
+
+	if(proj.damage_type == BRUTE && damage_dealt >= 10 && proj.speed >= 1 && prob(0.1))
+		var/obj/item/organ/brain/a_brain = locate() in get_bodypart(def_zone)
+		a_brain?.cure_trauma_type(resilience = TRAUMA_RESILIENCE_LOBOTOMY)
 
 	apply_effects(
 		stun = proj.stun,


### PR DESCRIPTION
## About The Pull Request

Adds a 1/1000 chance of a sufficiently fast and damaging (brute) projectile removing a lobotomy tier brain trauma on hitting whatever bodypart has your brain in it (HARS acknowledged) 

## Why It's Good For The Game

From where you're kneeling it must seem like an 18-carat run of ~~bad~~ good luck.
Truth is... the game was rigged from the start.

## Changelog

:cl: Melbert
add: A bullet to the brain has a rare chance of providing a free lobotomy
/:cl:
