### PR TITLE
Secure prosthetic surgery ignores clothing

### DIFF
--- a/code/modules/surgery/operations/operation_add_limb.dm
+++ b/code/modules/surgery/operations/operation_add_limb.dm
@@ -173,7 +173,7 @@
 		/obj/item/stack/sticky_tape = 2,
 	)
 	time = 4.8 SECONDS
-	operation_flags = OPERATION_SELF_OPERABLE | OPERATION_STANDING_ALLOWED
+	operation_flags = OPERATION_SELF_OPERABLE | OPERATION_STANDING_ALLOWED | OPERATION_IGNORE_CLOTHES
 	all_surgery_states_required = SURGERY_PROSTHETIC_UNSECURED
 
 /datum/surgery_operation/limb/secure_arbitrary_prosthetic/get_default_radial_image()


### PR DESCRIPTION
## About The Pull Request

Sets `OPERATION_IGNORE_CLOTHES` on "secure prosthetic"

## Why It's Good For The Game

Bit silly that whatever you replaced your arm with gets covered by gloves 

## Changelog

:cl: Melbert
qol: Secure prosthetic surgical operation ignores clothing
/:cl:
