### PR TITLE
Fixes lipoplasty being usable to dupe infinite meat

### DIFF
--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -250,7 +250,7 @@
 			if (reagents_in_produced)
 				if (target.owner.reagents)
 					target.owner.reagents.trans_to(result, target.owner.reagents.total_volume / reagents_in_produced / length(target.owner.bodyparts), remove_blacklisted = TRUE)
-				result.reagents?.add_reagent(/datum/reagent/consumable/nutriment/fat, target.owner.nutrition / 15 / reagents_in_produced)
+				result.reagents?.add_reagent(/datum/reagent/consumable/nutriment/fat, target.owner.nutrition / /datum/reagent/consumable/nutriment/fat::nutriment_factor / reagents_in_produced)
 
 			if(LAZYLEN(diseases))
 				var/list/datum/disease/diseases_to_add = list()

--- a/code/modules/food_and_drinks/machinery/gibber.dm
+++ b/code/modules/food_and_drinks/machinery/gibber.dm
@@ -297,7 +297,7 @@
 	for(var/obj/item/result as anything in results)
 		if (victim.reagents)
 			victim.reagents.trans_to(result, victim.reagents.total_volume / reagents_in_produced, remove_blacklisted = TRUE)
-		result.reagents?.add_reagent(/datum/reagent/consumable/nutriment/fat, victim.nutrition / 15 / reagents_in_produced)
+		result.reagents?.add_reagent(/datum/reagent/consumable/nutriment/fat, victim.nutrition / /datum/reagent/consumable/nutriment/fat::nutriment_factor / reagents_in_produced)
 
 /obj/machinery/gibber/proc/finish_gibbing(list/obj/item/results, gibs_type, list/datum/disease/diseases)
 	playsound(src.loc, 'sound/effects/splat.ogg', 50, TRUE)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1324,3 +1324,18 @@
 	if(!CAN_HAVE_BLOOD(src))
 		return
 	return dna?.blood_type
+
+/mob/living/carbon/update_nutrition()
+	. = ..()
+	// Force a weight update in case we're stasis'd and don't tick
+	if (HAS_TRAIT_FROM(src, TRAIT_FAT, OBESITY))
+		if (overeatduration >= 200 SECONDS)
+			return
+
+		to_chat(src, span_notice("You feel fit again!"))
+		remove_traits(list(TRAIT_FAT, TRAIT_OFF_BALANCE_TACKLER), OBESITY)
+		return
+
+	if (overeatduration >= 200 SECONDS)
+		to_chat(src, span_danger("You suddenly feel blubbery!"))
+		add_traits(list(TRAIT_FAT, TRAIT_OFF_BALANCE_TACKLER), OBESITY)


### PR DESCRIPTION

## About The Pull Request

Closes #95010
A) Fatness was only updated in stomach's life cycle, which was not called if the patient was stasis'd. It should also be called in update_nutrition on carbons (can't be exclusive to there as it also relies on ticking from stomachs)
B) Lipoplasty AND checked obesity and nutrition rather than OR checking which could allow you to ***increase*** the target's nutrition if they were obese but hungry (from not being hungry for long enough)
C) It also didn't check for NOHUNGER which also would prevent hunger updates.
D) It also used old species system for picking the meat type rather than spawning chest's meat type.

Also converted magic numbers in lipoplasty/butchering/gibbers to fetch nutrition_factor from nutriments they fill the meat with.

## Changelog
:cl:
fix: Lipoplasty can no longer be used to infinitely farm meat or increase patient's nutrition level
fix: If your chest has somehow been swapped, you will drop the correct type of meat when undergoing lipoplasty
code: Removed magic numbers in human meat related code
/:cl:
