### PR TITLE
Item fortification scroll no longer requires combat mode in order to be used

### DIFF
--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -34,10 +34,9 @@
 	can_backfire = TRUE
 	return ..()
 
-
 /obj/item/upgradescroll/pre_attack(obj/item/target, mob/living/user, list/modifiers, list/attack_modifiers)
 	. = ..()
-	if(. || !istype(target) || !user.combat_mode)
+	if(. || !istype(target))
 		return
 	target.AddComponent(/datum/component/fantasy, upgrade_amount, null, null, can_backfire, TRUE)
 	uses -= 1


### PR DESCRIPTION

## About The Pull Request

Closes #94996

## Why It's Good For The Game

Its extremely counterintuitive and inverse to how all other interactions work, so its probably best if we get rid of it for good.

## Changelog
:cl:
qol: Item fortification scroll no longer requires combat mode in order to be used
/:cl:
