### PR TITLE
Fixes the wire bundle component

### DIFF
--- a/code/datums/wires/wire_bundle_component.dm
+++ b/code/datums/wires/wire_bundle_component.dm
@@ -11,7 +11,7 @@
 		CRASH("Holder does not have a shell component!")
 	var/wire_count = clamp(round(shell_comp.capacity / CAPACITY_PER_WIRE, 1), 1, MAX_WIRE_COUNT)
 	for(var/index in 1 to wire_count)
-		wires += "Port [index]"
+		LAZYADD(wires, "Port [index]")
 	..()
 
 /datum/wires/wire_bundle_component/always_reveal_wire(color)


### PR DESCRIPTION
## About The Pull Request

I discovered that wire bundle components weren't populating their ports properly while working on another PR. This fixes that.

## Why It's Good For The Game

It would be nice if a circuit component worked, you know, at all.

## Changelog

:cl:
fix: wire bundle circuit components work once again
/:cl: