### PR TITLE
Honorifics don't mangle runechat color

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -50,11 +50,11 @@
 		return signal_face // no need to null-check, because force_set will always set a signal_face
 
 	var/face_name = isnull(signal_face) ? get_face_name("") : signal_face
-	var/id_name = isnull(signal_id) ? get_id_name("",  honorifics = TRUE) : signal_id
+	var/id_name = isnull(signal_id) ? get_id_name("",  honorifics = add_id_name) : signal_id
 
 	// We need to account for real name
 	if(force_real_name)
-		var/disguse_name = get_visible_name(add_id_name = TRUE, force_real_name = FALSE)
+		var/disguse_name = get_visible_name(add_id_name = add_id_name, force_real_name = FALSE)
 		return "[real_name][disguse_name == real_name ? "" : " (as [disguse_name])"]"
 
 	// We're just some unknown guy


### PR DESCRIPTION
## About The Pull Request

Vocal runechat uses voice name but emote runechat uses face name with `add_id_name = FALSE`
Honorifics were being added onto it despite it asking to ignore ID which meant it gave you a different color
Fixes it by not including honorifics when ignoring ID

## Changelog

:cl: Melbert
fix: Having an active honorific no longer changes your runechat emote color 
/:cl:
