### PR TITLE
Hand surgery depends on surgeon combat mode not patient

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -477,7 +477,7 @@
 	if(.)
 		return TRUE
 
-	if(!combat_mode && HAS_TRAIT(src, TRAIT_READY_TO_OPERATE) && user.perform_surgery(src))
+	if(!user.combat_mode && HAS_TRAIT(src, TRAIT_READY_TO_OPERATE) && user.perform_surgery(src))
 		return TRUE
 
 	return FALSE


### PR DESCRIPTION
## About The Pull Request

This one's pretty self explanatory

## Changelog

:cl: Melbert
fix: Fix hand surgery (stomach pump, etc) being blocked by the patient being on combat mode rather than the surgeon
/:cl:

