### PR TITLE
Shift wand pitch instead of frequency as ammo decreases

### DIFF
--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -13,6 +13,8 @@
 	clumsy_check = FALSE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL // Has no trigger at all, uses magic instead
 	pin = /obj/item/firing_pin/magic
+	/// If true, our fire sound gets lower as our charges decrease
+	var/pitch_with_charges = TRUE
 	/// What kind of magic is this
 	var/school = SCHOOL_EVOCATION
 	/// What kind of antimagic resists this
@@ -49,11 +51,19 @@
 	return ..()
 
 /obj/item/gun/magic/fire_sounds()
-	var/frequency_to_use = sin((90/max_charges) * charges)
+	var/pitch_to_use = 1
+
+	if (pitch_with_charges && max_charges > 1)
+		var/min_pitch = self_charging ? 0.7 : 0.5 // If we are going to recharge don't make the sound quite as dire, because you might be firing it at 1 charge quite a lot
+		pitch_to_use = LERP(1, min_pitch, (1 - (charges/max_charges)) ** 2)
+
+	var/sound/playing_sound = sound(suppressed ? suppressed_sound : fire_sound)
+	playing_sound.pitch = pitch_to_use
+
 	if(suppressed)
-		playsound(src, suppressed_sound, suppressed_volume, vary_fire_sound, ignore_walls = FALSE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0, frequency = frequency_to_use)
+		playsound(src, playing_sound, suppressed_volume, vary_fire_sound, ignore_walls = FALSE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0)
 	else
-		playsound(src, fire_sound, fire_sound_volume, vary_fire_sound, frequency = frequency_to_use)
+		playsound(src, playing_sound, fire_sound_volume, vary_fire_sound)
 
 /**
  * Signal proc for [COMSIG_ITEM_MAGICALLY_CHARGED]

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -54,8 +54,7 @@
 	var/pitch_to_use = 1
 
 	if (pitch_with_charges && max_charges > 1)
-		var/min_pitch = self_charging ? 0.7 : 0.5 // If we are going to recharge don't make the sound quite as dire, because you might be firing it at 1 charge quite a lot
-		pitch_to_use = LERP(1, min_pitch, (1 - (charges/max_charges)) ** 2)
+		pitch_to_use = LERP(1, 0.4, (1 - (charges/max_charges)) ** 2)
 
 	var/sound/playing_sound = sound(suppressed ? suppressed_sound : fire_sound)
 	playing_sound.pitch = pitch_to_use


### PR DESCRIPTION
## About The Pull Request

I already did this for energy guns in #83102 but forgot about _magic_ guns.
This means that the sound gets lower in pitch without also getting longer in duration.

## Why It's Good For The Game

Example of dumping the full mag of a wand of polymorph

Before:

https://github.com/user-attachments/assets/6038869e-f818-43e4-9630-6fca3f2ddac3

After:

https://github.com/user-attachments/assets/26a04896-2543-4d55-bcf6-f9f4b7b1fb9b


## Changelog

:cl:
sound: wands and staffs adjust their fire sound pitch instead of frequency as charges are depleted
/:cl:
