### PR TITLE
Fixes default_pins list not clearing old refs to wearers

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -36,8 +36,7 @@
 
 /obj/item/mod/control/pre_equipped/uninstall(obj/item/mod/module/old_module, deleting)
 	. = ..()
-	if(default_pins[old_module.type])
-		default_pins -= old_module
+	default_pins -= old_module.type
 
 /obj/item/mod/control/pre_equipped/standard
 	applied_modules = list(


### PR DESCRIPTION
## About The Pull Request

This list is keyed by the `type` not instances. Does not have a visible effect apart from wasting memory and not doing what was indended

## Why It's Good For The Game

Bugfix

## Changelog

Nothing player-facing
