### PR TITLE
Respond properly to null SSjob.get_department_type

### DIFF
--- a/code/datums/elements/art.dm
+++ b/code/datums/elements/art.dm
@@ -72,6 +72,8 @@
 	var/list/haters = list()
 	for(var/hater_department_type in list(/datum/job_department/security, /datum/job_department/command))
 		var/datum/job_department/hater_department = SSjob.get_department_type(hater_department_type)
+		if (isnull(hater_department))
+			continue
 		for(var/datum/job/hater_job as anything in hater_department.department_jobs)
 			haters += hater_job.title
 	var/datum/job/quartermaster/fucking_quartermaster = SSjob.get_job_type(/datum/job/quartermaster)

--- a/code/modules/modular_computers/file_system/programs/dept_order.dm
+++ b/code/modules/modular_computers/file_system/programs/dept_order.dm
@@ -48,6 +48,8 @@ GLOBAL_VAR(department_cd_override)
 /datum/computer_file/program/department_order/proc/set_linked_department(datum/job_department/department)
 	linked_department = department
 	var/datum/job_department/linked_department_real = SSjob.get_department_type(linked_department)
+	if (isnull(linked_department_real))
+		return
 	// Heads of staff can download
 	LAZYOR(download_access, linked_department_real.head_of_staff_access)
 	// Heads of staff + anyone in the dept can run it


### PR DESCRIPTION
`get_department_type` can return null if all jobs in that department are disabled. This can't happen in normal gameplay, but is being triggered in event-base, which disables everything except assistant and cyborg.

This appears to be an expected invariant as job checks it within itself, and even part of the department_order console code as well.