### PR TITLE
Super stable bomb payloads actually don't blow up when burnt

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -363,13 +363,15 @@
 	var/range_medium = 9
 	var/range_light = 17
 	var/range_flame = 17
+	/// Whether this core explodes when burnt
+	var/explodes_when_burnt = TRUE
 
 /obj/item/bombcore/ex_act(severity, target) // Little boom can chain a big boom.
 	detonate()
 	return TRUE
 
 /obj/item/bombcore/burn()
-	if(!istype(src, /obj/item/bombcore/syndicate))
+	if(explodes_when_burnt)
 		detonate()
 	..()
 
@@ -391,6 +393,7 @@
 /obj/item/bombcore/syndicate
 	name = "Donk Co. Super-Stable Bomb Payload"
 	desc = "After a string of unwanted detonations, this payload has been specifically redesigned to not explode unless triggered electronically by a bomb shell."
+	explodes_when_burnt = FALSE
 
 /obj/item/bombcore/syndicate/ex_act(severity, target)
 	return FALSE

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -369,7 +369,8 @@
 	return TRUE
 
 /obj/item/bombcore/burn()
-	detonate()
+	if(!istype(src, /obj/item/bombcore/syndicate))
+		detonate()
 	..()
 
 /obj/item/bombcore/proc/detonate()
@@ -393,9 +394,6 @@
 
 /obj/item/bombcore/syndicate/ex_act(severity, target)
 	return FALSE
-
-/obj/item/bombcore/syndicate/burn()
-	return ..()
 
 /obj/item/bombcore/syndicate/large
 	name = "Donk Co. Super-Stable Bomb Payload XL"


### PR DESCRIPTION
## About The Pull Request

Super stable bomb payloads aren't supposed to detonate when burnt, but because making a subtype proc that calls parent does literally nothing that wasn't the case.

I can't for the life of me remember a way to call two parents down, so it's just a check on `/obj/item/bombcore/burn()`.

## Why It's Good For The Game

"Super-stable" my ass
This was already supposed to be the case, as evidenced by both its description & the code comment above it.

## Changelog
:cl:

fix: The "Super-Stable" line of Donk Co. Bomb Payloads are now stable when exposed to extreme temperatures

/:cl:
