### PR TITLE
Deletes Icebox engi circuit lab window firelocks

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -4054,6 +4054,8 @@
 "bec" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
 "ben" = (
@@ -8591,7 +8593,6 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/mining)
 "coc" = (
-/obj/structure/cable,
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
@@ -8728,7 +8729,6 @@
 /area/station/service/kitchen)
 "cqa" = (
 /obj/item/radio/intercom/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
 "cqb" = (
@@ -9655,7 +9655,6 @@
 /area/station/maintenance/starboard/aft)
 "cDt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
 "cDv" = (
@@ -21977,7 +21976,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/storage/art)
 "gfV" = (
-/obj/structure/cable,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
@@ -25431,8 +25429,6 @@
 /turf/open/floor/iron/textured,
 /area/station/maintenance/starboard/fore)
 "hfo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -34817,7 +34813,7 @@
 /area/station/cargo/storage)
 "jPf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+	dir = 1
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -39439,7 +39435,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
 "lch" = (
@@ -39455,13 +39450,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/gateway)
 "lco" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing/corner/end/flip{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
 "lcs" = (
@@ -40388,6 +40383,11 @@
 "lpM" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/captain)
+"lpQ" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/lobby)
 "lpS" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -42370,12 +42370,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/office)
-"lRH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/smooth,
-/area/station/engineering/lobby)
 "lRI" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -49160,7 +49154,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -54911,6 +54904,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
 "prs" = (
@@ -68491,7 +68486,6 @@
 "tfC" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -82675,7 +82669,6 @@
 "xob" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
 "xow" = (
@@ -84240,8 +84233,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "xJY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
@@ -182584,7 +182575,7 @@ thA
 iDt
 iDt
 bID
-jJI
+iWW
 thq
 xob
 gjq
@@ -182842,7 +182833,7 @@ iDt
 scw
 bID
 gfV
-muJ
+lpQ
 bID
 bID
 bID
@@ -183099,7 +183090,7 @@ thA
 ppY
 bID
 cqa
-iWW
+jJI
 tiJ
 uSA
 ayC
@@ -183873,8 +183864,8 @@ bID
 lbF
 bID
 xJY
-cDt
-lRH
+iWW
+muJ
 cDt
 hfo
 oWy


### PR DESCRIPTION

## About The Pull Request

Deletes firelocks placed within the windows of Icebox's engineering circuit lab, as is standard because if you put firelocks in windows to the outside they will go off and be unfixable at a slight breeze. Also tightens up the piping and cabling there.

## Why It's Good For The Game

You shouldn't have to deconstruct firelocks to get alarms to go away

## Changelog
:cl:

map: Icebox engineering circuit lab no longer has firelocks placed in the windows

/:cl:
