### PR TITLE
Lowers the necessary pressure needed to activate the Space Furnace a smidge

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -1197,7 +1197,7 @@
 		return FALSE
 	var/datum/gas_mixture/environment = loc?.return_air()
 	var/affected_pressure = environment.return_pressure()
-	if(!light_on && (affected_pressure < 100)) //normal pressure minus 1.325 kpa of wiggle room
+	if(!light_on && (affected_pressure < ONE_ATMOSPHERE - 1))
 		user.balloon_alert(user, "[affected_pressure < HAZARD_LOW_PRESSURE? "no" : "low"] pressure!")
 		return FALSE
 	. = ..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -1197,8 +1197,8 @@
 		return FALSE
 	var/datum/gas_mixture/environment = loc?.return_air()
 	var/affected_pressure = environment.return_pressure()
-	if(!light_on && (affected_pressure < ONE_ATMOSPHERE))
-		user.balloon_alert(user, "no pressure!")
+	if(!light_on && (affected_pressure < 100)) //normal pressure minus 1.325 kpa of wiggle room
+		user.balloon_alert(user, "[affected_pressure < HAZARD_LOW_PRESSURE? "no" : "low"] pressure!")
 		return FALSE
 	. = ..()
 	if(light_on)


### PR DESCRIPTION
## About The Pull Request

Currently, the space furnace requires exactly one atmosphere or more of pressure in order to activate. This means that, because of how tiny the increments of pressure can be, that if a room ever loses any pressure at all for any reason, the general air in that room will never be enough to activate the furnace again(unless you turn up the vents), because it'll always be like 1 pascal too low. The only way to activate a furnace in these conditions is spam activating it on top of vent, and getting lucky. This sucks. Lowering it by 1 kpa means that it still requires an almost perfect atmos situation in order to activate.

Also, makes the low pressure message change between "low pressure" & "no pressure", which'll make it more clear to people what it's talking about. 

## Why It's Good For The Game

I can't imagine that standing over a vent spamming z in a perfectly habitable room was the intended outcome of this restriction.

## Changelog
:cl:

fix: the Space Furnace is now usable in rooms that have previously been breached, provided they have recovered enough air.

/:cl:
