### PR TITLE
Makes sure the cutter download fails safe by adding a temp file

### DIFF
--- a/tools/build/build.ts
+++ b/tools/build/build.ts
@@ -90,6 +90,7 @@ export const CutterTarget = new Juke.Target({
     const ver = dependencies.CUTTER_VERSION;
     const suffix = process.platform === 'win32' ? '.exe' : '';
     const download_from = `https://github.com/${repo}/releases/download/${ver}/hypnagogic${suffix}`;
+    // We're delaying "comitting" to the final filename here in case downloading fails/is interrupted
     const temp_path = `${cutter_path}_temp`; // yes this means its file extension is .exe_temp I don't really care
     await downloadFile(download_from, temp_path);
     fs.copyFileSync(temp_path, cutter_path);

--- a/tools/build/build.ts
+++ b/tools/build/build.ts
@@ -90,7 +90,10 @@ export const CutterTarget = new Juke.Target({
     const ver = dependencies.CUTTER_VERSION;
     const suffix = process.platform === 'win32' ? '.exe' : '';
     const download_from = `https://github.com/${repo}/releases/download/${ver}/hypnagogic${suffix}`;
-    await downloadFile(download_from, cutter_path);
+    const temp_path = `${cutter_path}_temp`; // yes this means its file extension is .exe_temp I don't really care
+    await downloadFile(download_from, temp_path);
+    fs.copyFileSync(temp_path, cutter_path);
+    fs.rmSync(temp_path)
     if (process.platform !== 'win32') {
       await Juke.exec('chmod', ['+x', cutter_path]);
     }


### PR DESCRIPTION

## About The Pull Request

If the download failed or if the cmd was canceled midway through we'd just well, keep the halfway downloaded file, and fail in an obtuse way when trying to execute it. 

Moth yelled at me about making it temporary on download so it fails safely, this pr well, does that.
