### PR TITLE
Lets sinks mount to floors

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_battle_site.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_battle_site.dmm
@@ -105,10 +105,6 @@
 /obj/item/stack/sheet/sinew,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"L" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "M" = (
 /obj/structure/statue/bone/skull,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -253,7 +249,7 @@ I
 G
 G
 q
-L
+x
 G
 s
 g

--- a/_maps/RandomZLevels/heretic.dmm
+++ b/_maps/RandomZLevels/heretic.dmm
@@ -5808,9 +5808,6 @@
 /obj/effect/spawner/random/food_or_drink/seed_rare,
 /turf/open/misc/grass/jungle/station,
 /area/awaymission/beach/heretic)
-"EH" = (
-/turf/open/floor/pod/light,
-/area/awaymission/beach/heretic)
 "EI" = (
 /turf/open/water/beach,
 /area/awaymission/caves/heretic_laboratory_clean)
@@ -42214,7 +42211,7 @@ wf
 wf
 wf
 bb
-EH
+BV
 gT
 wf
 wf

--- a/code/datums/components/atom_mounted.dm
+++ b/code/datums/components/atom_mounted.dm
@@ -113,7 +113,7 @@
 	return isclosedturf(target)
 
 /// Returns an list of object types we can mount on if the turf is unmountable
-/obj/proc/get_moutable_objects()
+/obj/proc/get_mountable_objects()
 	PROTECTED_PROC(TRUE)
 	SHOULD_BE_PURE(TRUE)
 	RETURN_TYPE(/list/obj)
@@ -156,7 +156,7 @@
 		if(is_mountable_turf(target))
 			attachable_atom = target //your usual wallmount
 		else
-			var/list/obj/attachables = get_moutable_objects()
+			var/list/obj/attachables = get_mountable_objects()
 			for(var/obj/attachable in target)
 				if(is_type_in_list(attachable, attachables))
 					attachable_atom = attachable

--- a/code/game/objects/structures/plaques/static_plaques.dm
+++ b/code/game/objects/structures/plaques/static_plaques.dm
@@ -9,7 +9,7 @@
 		SET_PLANE_IMPLICIT(src, FLOOR_PLANE)
 		layer = HIGH_TURF_LAYER
 
-/obj/structure/plaque/static_plaque/get_moutable_objects()
+/obj/structure/plaque/static_plaque/get_mountable_objects()
 	return list()
 
 /obj/structure/plaque/static_plaque/find_and_mount_on_atom(mark_for_late_init, late_init)

--- a/code/game/objects/structures/water_structures/sink.dm
+++ b/code/game/objects/structures/water_structures/sink.dm
@@ -52,16 +52,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 /obj/structure/sink/get_turfs_to_mount_on()
 	return list(get_turf(src))
 
-/obj/structure/sink/is_mountable_turf(turf/target)
-	return !isgroundlessturf(target)
-
-/obj/structure/sink/get_moutable_objects()
-	var/static/list/sink_structures = null
-	if(isnull(sink_structures))
-		sink_structures = list()
-		sink_structures += ..()
-		sink_structures += /obj/machinery/smartfridge //medbay sometimes have sinks attached to fridges
-	return sink_structures
+/obj/structure/sink/get_mountable_objects()
+	return list()
 
 /obj/structure/sink/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	. = NONE

--- a/code/game/objects/structures/water_structures/sink.dm
+++ b/code/game/objects/structures/water_structures/sink.dm
@@ -52,13 +52,15 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 /obj/structure/sink/get_turfs_to_mount_on()
 	return list(get_step(src, REVERSE_DIR(dir)))
 
+/obj/structure/sink/is_mountable_turf(turf/target)
+	return !isgroundlessturf(target)
+
 /obj/structure/sink/get_moutable_objects()
 	var/static/list/sink_structures = null
 	if(isnull(sink_structures))
 		sink_structures = list()
 		sink_structures += ..()
 		sink_structures += /obj/machinery/smartfridge //medbay sometimes have sinks attached to fridges
-		sink_structures += /obj/structure/window // lets sinks mount to windows
 	return sink_structures
 
 /obj/structure/sink/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)

--- a/code/game/objects/structures/water_structures/sink.dm
+++ b/code/game/objects/structures/water_structures/sink.dm
@@ -58,6 +58,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 		sink_structures = list()
 		sink_structures += ..()
 		sink_structures += /obj/machinery/smartfridge //medbay sometimes have sinks attached to fridges
+		sink_structures += /obj/structure/window // lets sinks mount to windows
 	return sink_structures
 
 /obj/structure/sink/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)

--- a/code/game/objects/structures/water_structures/sink.dm
+++ b/code/game/objects/structures/water_structures/sink.dm
@@ -50,7 +50,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 		new /obj/item/stock_parts/water_recycler(drop_location())
 
 /obj/structure/sink/get_turfs_to_mount_on()
-	return list(get_step(src, REVERSE_DIR(dir)))
+	return list(get_turf(src))
 
 /obj/structure/sink/is_mountable_turf(turf/target)
 	return !isgroundlessturf(target)

--- a/code/game/objects/structures/water_structures/sink.dm
+++ b/code/game/objects/structures/water_structures/sink.dm
@@ -49,6 +49,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 	if(has_water_reclaimer)
 		new /obj/item/stock_parts/water_recycler(drop_location())
 
+/obj/structure/sink/is_mountable_turf(turf/target)
+	return !isgroundlessturf(target)
+
 /obj/structure/sink/get_turfs_to_mount_on()
 	return list(get_turf(src))
 

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -757,7 +757,7 @@
 /obj/machinery/light/floor/is_mountable_turf(turf/target)
 	return !isgroundlessturf(target)
 
-/obj/machinery/light/floor/get_moutable_objects()
+/obj/machinery/light/floor/get_mountable_objects()
 	var/static/list/attachables = list(
 		/obj/structure/thermoplastic,
 		/obj/structure/lattice/catwalk,


### PR DESCRIPTION
## About The Pull Request

That's all. 

The sprites clearly have a pedestal which is attached to the floor. They shouldn't behave as if they are free floating wash basins.

<details><summary>example: a barber shop</summary>

<img width="614" height="818" alt="StrongDMM_ahHbCymkjR" src="https://github.com/user-attachments/assets/aeee4090-e209-4ad7-8d1d-fef9dcbb36e2" />

</details>

Also runs the UpdatePaths script so it can collapse some duplicate tiles which have been annoying me with diffs each time it's run.

## Why It's Good For The Game

More mapping flexibility for bathrooms and medical spaces.

## Changelog

:cl:
code: sinks can be mounted to floors
/:cl: