### PR TITLE
More abstract types

### DIFF
--- a/code/_globalvars/lists/keybindings.dm
+++ b/code/_globalvars/lists/keybindings.dm
@@ -20,7 +20,7 @@
 				LAZYADD(GLOB.default_hotkeys[instance.name], list(bound_key))
 
 /proc/init_emote_keybinds()
-	for(var/i in subtypesof(/datum/emote))
+	for(var/i in valid_subtypesof(/datum/emote))
 		var/datum/emote/faketype = i
 		if(!initial(faketype.key))
 			continue

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -124,7 +124,7 @@ GLOBAL_LIST_INIT(construct_radial_images, list(
 
 /proc/init_emote_list()
 	. = list()
-	for(var/path in subtypesof(/datum/emote))
+	for(var/path in valid_subtypesof(/datum/emote))
 		var/datum/emote/E = new path()
 		if(E.key)
 			if(!.[E.key])

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -73,7 +73,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	for(var/type in quirk_list)
 		var/datum/quirk/quirk_type = type
 
-		if(initial(quirk_type.abstract_parent_type) == type)
+		if(initial(quirk_type.abstract_type) == type)
 			continue
 
 		quirk_prototypes[type] = new type

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -68,13 +68,10 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 
 /datum/controller/subsystem/processing/quirks/proc/SetupQuirks()
 	// Sort by Positive, Negative, Neutral; and then by name
-	var/list/quirk_list = sort_list(subtypesof(/datum/quirk), GLOBAL_PROC_REF(cmp_quirk_asc))
+	var/list/quirk_list = sort_list(valid_subtypesof(/datum/quirk), GLOBAL_PROC_REF(cmp_quirk_asc))
 
 	for(var/type in quirk_list)
 		var/datum/quirk/quirk_type = type
-
-		if(initial(quirk_type.abstract_type) == type)
-			continue
 
 		quirk_prototypes[type] = new type
 		quirks[initial(quirk_type.name)] = quirk_type

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -10,6 +10,7 @@
  *
  */
 /datum/emote
+	abstract_type = /datum/emote
 	/// What calls the emote.
 	var/key = ""
 	/// This will also call the emote.

--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -1,6 +1,7 @@
 //every quirk in this folder should be coded around being applied on spawn
 //these are NOT "mob quirks" like GOTTAGOFAST, but exist as a medium to apply them and other different effects
 /datum/quirk
+	abstract_type = /datum/quirk
 	/// The name of the quirk
 	var/name = "Test Quirk"
 	/// The description of the quirk
@@ -26,8 +27,6 @@
 	/// This is used to pick the quirks assigned to a hardcore character.
 	//// 0 means its not available to hardcore draws.
 	var/hardcore_value = 0
-	/// When making an abstract quirk (in OOP terms), don't forget to set this var to the type path for that abstract quirk.
-	var/abstract_parent_type = /datum/quirk
 	/// The icon to show in the preferences menu.
 	/// This references a tgui icon, so it can be FontAwesome or a tgfont (with a tg- prefix).
 	var/icon
@@ -211,7 +210,7 @@
 	var/list/where_items_spawned
 	/// If true, the backpack automatically opens on post_add(). Usually set to TRUE when an item is equipped inside the player's backpack.
 	var/open_backpack = FALSE
-	abstract_parent_type = /datum/quirk/item_quirk
+	abstract_type = /datum/quirk/item_quirk
 
 /**
  * Handles inserting an item in any of the valid slots provided, then allows for post_add notification.

--- a/code/datums/quirks/negative_quirks/addict.dm
+++ b/code/datums/quirks/negative_quirks/addict.dm
@@ -3,7 +3,7 @@
 	desc = "You are addicted to something that doesn't exist. Suffer."
 	gain_text = span_danger("You suddenly feel the craving for... something? You're not sure what it is.")
 	medical_record_text = "Patient has a history with SOMETHING but he refuses to tell us what it is."
-	abstract_parent_type = /datum/quirk/item_quirk/addict
+	abstract_type = /datum/quirk/item_quirk/addict
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_PROCESSES
 	no_process_traits = list(TRAIT_LIVERLESS_METABOLISM)
 	var/datum/reagent/reagent_type //!If this is defined, reagent_id will be unused and the defined reagent type will be instead.

--- a/code/modules/antagonists/heretic/heretic_curses.dm
+++ b/code/modules/antagonists/heretic/heretic_curses.dm
@@ -3,7 +3,7 @@
  */
 
 /datum/heretic_knowledge/curse
-	abstract_parent_type = /datum/heretic_knowledge/curse
+	abstract_type = /datum/heretic_knowledge/curse
 	/// How far can we curse people?
 	var/max_range = 64
 	/// The duration of the curse
@@ -134,7 +134,7 @@
 //---- Curse of Paralysis
 
 /datum/heretic_knowledge/curse/paralysis
-	abstract_parent_type = /datum/heretic_knowledge/curse/paralysis
+	abstract_type = /datum/heretic_knowledge/curse/paralysis
 	name = "Curse of Paralysis"
 	desc = "Allows you to transmute a hatchet and both a left and right leg to cast a curse of immobility on a crew member. \
 		While cursed, the victim will be unable to walk. You can additionally supply an item that a victim has touched \
@@ -169,7 +169,7 @@
 //---- Curse of Corrosion
 
 /datum/heretic_knowledge/curse/corrosion
-	abstract_parent_type = /datum/heretic_knowledge/curse/corrosion
+	abstract_type = /datum/heretic_knowledge/curse/corrosion
 	name = "Curse of Corrosion"
 	desc = "Allows you to transmute wirecutters, a pool of vomit, and a heart to cast a curse of sickness on a crew member. \
 		While cursed, the victim will repeatedly vomit while their organs will take constant damage. You can additionally supply an item \
@@ -198,7 +198,7 @@
 //---- Curse of Transmutation
 
 /datum/heretic_knowledge/curse/transmutation
-	abstract_parent_type = /datum/heretic_knowledge/curse/transmutation
+	abstract_type = /datum/heretic_knowledge/curse/transmutation
 	name = "Curse of Transmutation"
 	duration = 0 // Infinite curse, it breaks when our codex is destroyed
 	curse_color = NONE
@@ -266,7 +266,7 @@
 //---- Curse of Indulgence
 
 /datum/heretic_knowledge/curse/indulgence
-	abstract_parent_type = /datum/heretic_knowledge/curse/indulgence
+	abstract_type = /datum/heretic_knowledge/curse/indulgence
 	name = "Curse of Indulgence"
 	duration = 8 MINUTES
 	curse_color = COLOR_MAROON

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -9,14 +9,14 @@
  *
  */
 /datum/heretic_knowledge
+	/// The abstract parent type of the knowledge, used in determine mutual exclusivity in some cases
+	abstract_type = /datum/heretic_knowledge
 	/// Name of the knowledge, shown to the heretic.
 	var/name = "Basic knowledge"
 	/// Description of the knowledge, shown to the heretic. Describes what it unlocks / does.
 	var/desc = "Basic knowledge of forbidden arts."
 	/// What's shown to the heretic when the knowledge is acquired
 	var/gain_text
-	/// The abstract parent type of the knowledge, used in determine mutual exclusivity in some cases
-	var/datum/heretic_knowledge/abstract_parent_type = /datum/heretic_knowledge
 	/// Assoc list of [typepaths we need] to [amount needed].
 	/// If set, this knowledge allows the heretic to do a ritual on a transmutation rune with the components set.
 	/// If one of the items in the list is a list, it's treated as 'any of these items will work'
@@ -191,7 +191,7 @@
  * A knowledge subtype that grants the heretic a certain spell.
  */
 /datum/heretic_knowledge/spell
-	abstract_parent_type = /datum/heretic_knowledge/spell
+	abstract_type = /datum/heretic_knowledge/spell
 	/// Spell path we add to the heretic. Type-path.
 	var/datum/action/action_to_add
 	/// The spell we actually created.
@@ -220,7 +220,7 @@
  * created at once.
  */
 /datum/heretic_knowledge/limited_amount
-	abstract_parent_type = /datum/heretic_knowledge/limited_amount
+	abstract_type = /datum/heretic_knowledge/limited_amount
 	/// The limit to how many items we can create at once.
 	var/limit = 1
 	/// A list of weakrefs to all items we've created.
@@ -262,7 +262,7 @@
  * and their ascension depends on whichever they chose.
  */
 /datum/heretic_knowledge/limited_amount/starting
-	abstract_parent_type = /datum/heretic_knowledge/limited_amount/starting
+	abstract_type = /datum/heretic_knowledge/limited_amount/starting
 	limit = 2
 	cost = 1
 	priority = MAX_KNOWLEDGE_PRIORITY - 5
@@ -362,7 +362,7 @@
  * A heretic can only learn one /blade_upgrade type knowledge.
  */
 /datum/heretic_knowledge/blade_upgrade
-	abstract_parent_type = /datum/heretic_knowledge/blade_upgrade
+	abstract_type = /datum/heretic_knowledge/blade_upgrade
 	cost = 1
 
 /datum/heretic_knowledge/blade_upgrade/on_gain(mob/user, datum/antagonist/heretic/our_heretic)
@@ -411,7 +411,7 @@
  * A knowledge subtype lets the heretic summon a monster with the ritual.
  */
 /datum/heretic_knowledge/summon
-	abstract_parent_type = /datum/heretic_knowledge/summon
+	abstract_type = /datum/heretic_knowledge/summon
 	/// Typepath of a mob to summon when we finish the recipe.
 	var/mob/living/mob_to_summon
 
@@ -476,7 +476,7 @@
 	name = "Ritual of Knowledge"
 	desc = "A randomly generated transmutation ritual that rewards knowledge points and can only be completed once."
 	gain_text = "Everything can be a key to unlocking the secrets behind the Gates. I must be wary and wise."
-	abstract_parent_type = /datum/heretic_knowledge/knowledge_ritual
+	abstract_type = /datum/heretic_knowledge/knowledge_ritual
 	cost = 1
 	priority = MAX_KNOWLEDGE_PRIORITY - 10 // A pretty important midgame ritual.
 	research_tree_icon_path = 'icons/obj/antags/eldritch.dmi'
@@ -564,7 +564,7 @@
  * The special final tier of knowledges that unlocks ASCENSION.
  */
 /datum/heretic_knowledge/ultimate
-	abstract_parent_type = /datum/heretic_knowledge/ultimate
+	abstract_type = /datum/heretic_knowledge/ultimate
 	cost = 2
 	priority = MAX_KNOWLEDGE_PRIORITY + 1 // Yes, the final ritual should be ABOVE the max priority.
 	required_atoms = list(/mob/living/carbon/human = 3)

--- a/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
+++ b/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
@@ -6,13 +6,15 @@ GLOBAL_LIST_INIT(heretic_path_datums, init_heretic_path_datums())
 /proc/init_heretic_path_datums()
 	var/list/paths = list()
 	for(var/datum/heretic_knowledge_tree_column/column_path as anything in subtypesof(/datum/heretic_knowledge_tree_column))
-		if(initial(column_path.abstract_parent_type) == column_path)
+		if(initial(column_path.abstract_type) == column_path)
 			continue
 		var/datum/heretic_knowledge_tree_column/heretic_route = new column_path()
 		paths[heretic_route.route] += heretic_route
 	return paths
 
 /datum/heretic_knowledge_tree_column
+	///Used to determine if this is a side path or a main path
+	abstract_type = /datum/heretic_knowledge_tree_column
 	///Route that symbolizes what path this is, MUST be unique between paths
 	var/route = PATH_START
 	var/icon_state = "dark_blade"
@@ -35,8 +37,6 @@ GLOBAL_LIST_INIT(heretic_path_datums, init_heretic_path_datums())
 	var/list/pros = list("Is bad", "Is very bad", "Is extremely bad")
 	var/list/cons = list("Smells bad", "Looks bad", "Tastes bad")
 	var/list/tips = list("Don't use it", "Don't touch it", "Don't look at it")
-	///Used to determine if this is a side path or a main path
-	var/abstract_parent_type = /datum/heretic_knowledge_tree_column
 	///UI background
 	var/ui_bgr = BGR_SIDE
 

--- a/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
+++ b/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
@@ -5,9 +5,7 @@ GLOBAL_LIST_INIT(heretic_path_datums, init_heretic_path_datums())
 
 /proc/init_heretic_path_datums()
 	var/list/paths = list()
-	for(var/datum/heretic_knowledge_tree_column/column_path as anything in subtypesof(/datum/heretic_knowledge_tree_column))
-		if(initial(column_path.abstract_type) == column_path)
-			continue
+	for(var/datum/heretic_knowledge_tree_column/column_path as anything in valid_subtypesof(/datum/heretic_knowledge_tree_column))
 		var/datum/heretic_knowledge_tree_column/heretic_route = new column_path()
 		paths[heretic_route.route] += heretic_route
 	return paths

--- a/code/modules/antagonists/heretic/knowledge/heretic_armor_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/heretic_armor_knowledge.dm
@@ -9,7 +9,7 @@
 		list(/obj/structure/table, /obj/item/clothing/suit) = 1,
 		/obj/item/clothing/mask = 1,
 	)
-	abstract_parent_type = /datum/heretic_knowledge/armor
+	abstract_type = /datum/heretic_knowledge/armor
 	result_atoms = list(/obj/item/clothing/suit/hooded/cultrobes/eldritch)
 	cost = 1
 

--- a/code/modules/library/skill_learning/job_skillchips/_job.dm
+++ b/code/modules/library/skill_learning/job_skillchips/_job.dm
@@ -2,5 +2,5 @@
 	skillchip_flags = SKILLCHIP_RESTRICTED_CATEGORIES
 	chip_category = SKILLCHIP_CATEGORY_JOB
 	incompatibility_list = list(SKILLCHIP_CATEGORY_JOB)
-	abstract_parent_type = /obj/item/skillchip/job
+	abstract_type = /obj/item/skillchip/job
 	slot_use = 2

--- a/code/modules/library/skill_learning/skillchip.dm
+++ b/code/modules/library/skill_learning/skillchip.dm
@@ -6,6 +6,10 @@
 	icon_state = "skillchip"
 	custom_price = PAYCHECK_CREW * 3
 	w_class = WEIGHT_CLASS_SMALL
+	/// Used to determine if this is an abstract type or not.
+	/// If this is meant to be an abstract type, set it to the type's path.
+	/// Will be overridden by subsequent abstract parents.
+	abstract_type = /obj/item/skillchip
 
 	/// Traits automatically granted by this chip, optional. Lazylist.
 	var/list/auto_traits
@@ -35,10 +39,6 @@
 	var/cooldown = 5 MINUTES
 	/// Cooldown for chip actions.
 	COOLDOWN_DECLARE(chip_cooldown)
-	/// Used to determine if this is an abstract type or not.
-	/// If this is meant to be an abstract type, set it to the type's path.
-	/// Will be overridden by subsequent abstract parents.
-	var/abstract_parent_type = /obj/item/skillchip
 	/// Set to TRUE when the skill chip's effects are applied. Set to FALSE when they're not.
 	var/active = FALSE
 	/// Brain that holds this skillchip.

--- a/code/modules/mob/living/basic/farm_animals/chicken/chick.dm
+++ b/code/modules/mob/living/basic/farm_animals/chicken/chick.dm
@@ -34,6 +34,7 @@
 	var/grow_as = /mob/living/basic/chicken
 
 /datum/emote/chick
+	abstract_type = /datum/emote/chick
 	mob_type_allowed_typecache = /mob/living/basic/chick
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/farm_animals/chicken/chicken.dm
+++ b/code/modules/mob/living/basic/farm_animals/chicken/chicken.dm
@@ -39,6 +39,7 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	var/fertile = TRUE
 
 /datum/emote/chicken
+	abstract_type = /datum/emote/chicken
 	mob_type_allowed_typecache = /mob/living/basic/chicken
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
@@ -37,6 +37,7 @@
 	var/milked_reagent = /datum/reagent/consumable/milk
 
 /datum/emote/cow
+	abstract_type = /datum/emote/cow
 	mob_type_allowed_typecache = /mob/living/basic/cow
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/farm_animals/gorilla/gorilla_emotes.dm
+++ b/code/modules/mob/living/basic/farm_animals/gorilla/gorilla_emotes.dm
@@ -1,4 +1,5 @@
 /datum/emote/gorilla
+	abstract_type = /datum/emote/gorilla
 	mob_type_allowed_typecache = /mob/living/basic/gorilla
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/farm_animals/pig.dm
+++ b/code/modules/mob/living/basic/farm_animals/pig.dm
@@ -29,6 +29,7 @@
 	ai_controller = /datum/ai_controller/basic_controller/pig
 
 /datum/emote/pig
+	abstract_type = /datum/emote/pig
 	mob_type_allowed_typecache = /mob/living/basic/pig
 	mob_type_blacklist_typecache = list()
 
@@ -39,6 +40,7 @@
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
 	vary = TRUE
 	sound = SFX_PIG_OINK
+
 /mob/living/basic/pig/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/pet_bonus, "oink")

--- a/code/modules/mob/living/basic/farm_animals/pony.dm
+++ b/code/modules/mob/living/basic/farm_animals/pony.dm
@@ -34,6 +34,7 @@
 	var/list/ponycolors = list("#cc8c5d", "#cc8c5d")
 
 /datum/emote/pony
+	abstract_type = /datum/emote/pony
 	mob_type_allowed_typecache = /mob/living/basic/pony
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/farm_animals/rabbit.dm
+++ b/code/modules/mob/living/basic/farm_animals/rabbit.dm
@@ -40,10 +40,11 @@
 	var/icon_prefix = "rabbit"
 
 /datum/emote/rabbit
+	abstract_type = /datum/emote/rabbit
 	mob_type_allowed_typecache = /mob/living/basic/rabbit
 	mob_type_blacklist_typecache = list()
 
-/datum/emote/rabbit
+/datum/emote/rabbit/hop
 	key = "hop"
 	key_third_person = "hops"
 	message = "hops around happily!"

--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
@@ -171,6 +171,7 @@
 	var/was_tamed = FALSE
 
 /datum/emote/lobstrosity_juvenile
+	abstract_type = /datum/emote/lobstrosity_juvenile
 	mob_type_allowed_typecache = /mob/living/basic/mining/lobstrosity/juvenile
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/pets/cat/cat.dm
+++ b/code/modules/mob/living/basic/pets/cat/cat.dm
@@ -63,6 +63,7 @@
 	var/datum/callback/post_birth_callback
 
 /datum/emote/cat
+	abstract_type = /datum/emote/cat
 	mob_type_allowed_typecache = /mob/living/basic/pet/cat
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/pets/dog/_dog.dm
+++ b/code/modules/mob/living/basic/pets/dog/_dog.dm
@@ -53,6 +53,7 @@
 	var/cult_icon_state
 
 /datum/emote/dog
+	abstract_type = /datum/emote/dog
 	mob_type_allowed_typecache = /mob/living/basic/pet/dog
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/pets/fox.dm
+++ b/code/modules/mob/living/basic/pets/fox.dm
@@ -39,6 +39,7 @@
 	)
 
 /datum/emote/fox
+	abstract_type = /datum/emote/fox
 	mob_type_allowed_typecache = /mob/living/basic/pet/fox
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/pets/penguin/penguin.dm
+++ b/code/modules/mob/living/basic/pets/penguin/penguin.dm
@@ -20,6 +20,7 @@
 	var/obj/carried_egg
 
 /datum/emote/penguin
+	abstract_type = /datum/emote/penguin
 	mob_type_allowed_typecache = /mob/living/basic/pet/penguin
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/pets/sloth.dm
+++ b/code/modules/mob/living/basic/pets/sloth.dm
@@ -38,6 +38,7 @@ GLOBAL_DATUM(cargo_sloth, /mob/living/basic/sloth)
 	ai_controller = /datum/ai_controller/basic_controller/sloth
 
 /datum/emote/sloth
+	abstract_type = /datum/emote/sloth
 	mob_type_allowed_typecache = /mob/living/basic/sloth
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/slime/emote.dm
+++ b/code/modules/mob/living/basic/slime/emote.dm
@@ -1,4 +1,5 @@
 /datum/emote/slime
+	abstract_type = /datum/emote/slime
 	mob_type_allowed_typecache = /mob/living/basic/slime
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/space_fauna/ant.dm
+++ b/code/modules/mob/living/basic/space_fauna/ant.dm
@@ -37,6 +37,7 @@
 	ai_controller = /datum/ai_controller/basic_controller/ant
 
 /datum/emote/ant
+	abstract_type = /datum/emote/ant
 	mob_type_allowed_typecache = /mob/living/basic/ant
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -84,6 +84,7 @@
 	))
 
 /datum/emote/carp
+	abstract_type = /datum/emote/carp
 	mob_type_allowed_typecache = /mob/living/basic/carp
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/space_fauna/roro.dm
+++ b/code/modules/mob/living/basic/space_fauna/roro.dm
@@ -37,6 +37,7 @@
 	ai_controller = /datum/ai_controller/basic_controller/simple/simple_retaliate
 
 /datum/emote/roro
+	abstract_type = /datum/emote/roro
 	mob_type_allowed_typecache = /mob/living/basic/roro
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/space_fauna/spider/spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider.dm
@@ -55,6 +55,7 @@
 	var/apply_spider_antag = TRUE
 
 /datum/emote/spider
+	abstract_type = /datum/emote/spider
 	mob_type_allowed_typecache = /mob/living/basic/spider
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/vermin/lizard.dm
+++ b/code/modules/mob/living/basic/vermin/lizard.dm
@@ -47,6 +47,7 @@
 	))
 
 /datum/emote/lizard
+	abstract_type = /datum/emote/lizard
 	mob_type_allowed_typecache = /mob/living/basic/lizard
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/vermin/mothroach/mothroach.dm
+++ b/code/modules/mob/living/basic/vermin/mothroach/mothroach.dm
@@ -42,6 +42,7 @@
 	)
 
 /datum/emote/mothroach
+	abstract_type = /datum/emote/mothroach
 	mob_type_allowed_typecache = /mob/living/basic/mothroach
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -45,6 +45,7 @@
 	)
 
 /datum/emote/mouse
+	abstract_type = /datum/emote/mouse
 	mob_type_allowed_typecache = /mob/living/basic/mouse
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/brain/emote.dm
+++ b/code/modules/mob/living/brain/emote.dm
@@ -1,4 +1,5 @@
 /datum/emote/brain
+	abstract_type = /datum/emote/brain
 	mob_type_allowed_typecache = list(/mob/living/brain)
 	mob_type_blacklist_typecache = list()
 	emote_type = EMOTE_AUDIBLE

--- a/code/modules/mob/living/carbon/alien/emote.dm
+++ b/code/modules/mob/living/carbon/alien/emote.dm
@@ -1,4 +1,5 @@
 /datum/emote/living/alien
+	abstract_type = /datum/emote/living/alien
 	mob_type_allowed_typecache = list(/mob/living/carbon/alien)
 
 /datum/emote/living/alien/gnarl

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -1,4 +1,5 @@
 /datum/emote/living/carbon
+	abstract_type = /datum/emote/living/carbon
 	mob_type_allowed_typecache = list(/mob/living/carbon)
 
 /datum/emote/living/carbon/airguitar

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -780,10 +780,8 @@
 		if(!check_rights(R_SPAWN))
 			return
 		var/list/options = list("Clear"="Clear")
-		for(var/type in subtypesof(/datum/quirk))
+		for(var/type in valid_subtypesof(/datum/quirk))
 			var/datum/quirk/quirk_type = type
-			if(initial(quirk_type.abstract_type) == type)
-				continue
 			var/qname = initial(quirk_type.name)
 			options[has_quirk(quirk_type) ? "[qname] (Remove)" : "[qname] (Add)"] = quirk_type
 		var/result = input(usr, "Choose quirk to add/remove","Quirk Mod") as null|anything in sort_list(options)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -782,7 +782,7 @@
 		var/list/options = list("Clear"="Clear")
 		for(var/type in subtypesof(/datum/quirk))
 			var/datum/quirk/quirk_type = type
-			if(initial(quirk_type.abstract_parent_type) == type)
+			if(initial(quirk_type.abstract_type) == type)
 				continue
 			var/qname = initial(quirk_type.name)
 			options[has_quirk(quirk_type) ? "[qname] (Remove)" : "[qname] (Add)"] = quirk_type

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -1,6 +1,7 @@
 
 /* EMOTE DATUMS */
 /datum/emote/living
+	abstract_type = /datum/emote/living
 	mob_type_allowed_typecache = /mob/living
 	mob_type_blacklist_typecache = list(/mob/living/brain)
 

--- a/code/modules/mob/living/silicon/ai/emote.dm
+++ b/code/modules/mob/living/silicon/ai/emote.dm
@@ -1,8 +1,9 @@
 /datum/emote/ai
+	abstract_type = /datum/emote/ai
 	mob_type_allowed_typecache = /mob/living/silicon/ai
 	mob_type_blacklist_typecache = list()
 
-
+// This might be worth making an abstract type.
 /datum/emote/ai/emotion_display
 	key = "blank"
 	var/emotion = AI_EMOTION_BLANK

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -1,4 +1,5 @@
 /datum/emote/silicon
+	abstract_type = /datum/emote/silicon
 	trait_required = TRAIT_SILICON_EMOTES_ALLOWED
 	emote_type = EMOTE_AUDIBLE
 

--- a/code/modules/unit_tests/font_awesome_icons.dm
+++ b/code/modules/unit_tests/font_awesome_icons.dm
@@ -33,7 +33,7 @@
  */
 /datum/unit_test/font_awesome_icons/proc/verify_quirk_icons()
 	for(var/datum/quirk/quirk as anything in subtypesof(/datum/quirk))
-		if(quirk == initial(quirk.abstract_parent_type))
+		if(quirk == initial(quirk.abstract_type))
 			continue
 
 		var/quirk_icon = initial(quirk.icon)

--- a/code/modules/unit_tests/font_awesome_icons.dm
+++ b/code/modules/unit_tests/font_awesome_icons.dm
@@ -32,10 +32,7 @@
  * Verifies that all quirk icons are valid.
  */
 /datum/unit_test/font_awesome_icons/proc/verify_quirk_icons()
-	for(var/datum/quirk/quirk as anything in subtypesof(/datum/quirk))
-		if(quirk == initial(quirk.abstract_type))
-			continue
-
+	for(var/datum/quirk/quirk as anything in valid_subtypesof(/datum/quirk))
 		var/quirk_icon = initial(quirk.icon)
 		if(findtext(quirk_icon, "tg-") == 1) // TODO: Validate these as well
 			continue

--- a/code/modules/unit_tests/heretic_knowledge.dm
+++ b/code/modules/unit_tests/heretic_knowledge.dm
@@ -29,7 +29,7 @@
 	var/list/all_possible_knowledge = typesof(/datum/heretic_knowledge)
 
 	for(var/datum/heretic_knowledge/knowledge_type as anything in all_possible_knowledge)
-		if(initial(knowledge_type.abstract_parent_type) == knowledge_type)
+		if(initial(knowledge_type.abstract_type) == knowledge_type)
 			all_possible_knowledge -= knowledge_type
 
 	var/list/list_to_check = get_knowledge_unlockables(start_knowledges, all_knowledges)

--- a/code/modules/unit_tests/heretic_knowledge.dm
+++ b/code/modules/unit_tests/heretic_knowledge.dm
@@ -26,11 +26,7 @@
 		all_knowledges += flatten_list(draft)
 
 
-	var/list/all_possible_knowledge = typesof(/datum/heretic_knowledge)
-
-	for(var/datum/heretic_knowledge/knowledge_type as anything in all_possible_knowledge)
-		if(initial(knowledge_type.abstract_type) == knowledge_type)
-			all_possible_knowledge -= knowledge_type
+	var/list/all_possible_knowledge = valid_subtypesof(/datum/heretic_knowledge)
 
 	var/list/list_to_check = get_knowledge_unlockables(start_knowledges, all_knowledges)
 

--- a/code/modules/unit_tests/quirks.dm
+++ b/code/modules/unit_tests/quirks.dm
@@ -4,10 +4,7 @@
 /datum/unit_test/quirk_icons/Run()
 	var/list/used_icons = list()
 
-	for (var/datum/quirk/quirk_type as anything in subtypesof(/datum/quirk))
-		if (initial(quirk_type.abstract_parent_type) == quirk_type)
-			continue
-
+	for (var/datum/quirk/quirk_type as anything in valid_subtypesof(/datum/quirk))
 		var/icon = initial(quirk_type.icon)
 
 		if (isnull(icon))
@@ -26,10 +23,7 @@
 /datum/unit_test/quirk_initial_medical_records/Run()
 	var/mob/living/carbon/human/patient = allocate(/mob/living/carbon/human/consistent)
 
-	for(var/datum/quirk/quirk_type as anything in subtypesof(/datum/quirk))
-		if (initial(quirk_type.abstract_parent_type) == quirk_type)
-			continue
-
+	for(var/datum/quirk/quirk_type as anything in valid_subtypesof(/datum/quirk))
 		if(!isnull(quirk_type.medical_record_text))
 			continue
 
@@ -89,7 +83,7 @@
 	GLOB.uncommon_roundstart_languages = list(/datum/language/uncommon)
 
 	for (var/datum/quirk/quirk_type as anything in subtypesof(/datum/quirk))
-		if (initial(quirk_type.abstract_parent_type) == quirk_type)
+		if (initial(quirk_type.abstract_type) == quirk_type)
 			continue
 
 		var/mob/dead/new_player/abstract_player = allocate(/mob/dead/new_player)

--- a/code/modules/unit_tests/quirks.dm
+++ b/code/modules/unit_tests/quirks.dm
@@ -82,10 +82,7 @@
 	// Assigning this manually as config is empty
 	GLOB.uncommon_roundstart_languages = list(/datum/language/uncommon)
 
-	for (var/datum/quirk/quirk_type as anything in subtypesof(/datum/quirk))
-		if (initial(quirk_type.abstract_type) == quirk_type)
-			continue
-
+	for (var/datum/quirk/quirk_type as anything in valid_subtypesof(/datum/quirk))
 		var/mob/dead/new_player/abstract_player = allocate(/mob/dead/new_player)
 		var/datum/client_interface/roundstart_mock_client = new()
 		abstract_player.mock_client = roundstart_mock_client


### PR DESCRIPTION

## About The Pull Request
adds abstract type to emotes, tho i maintained checking based off keys incase I missed any for now.
abstract_parent_type to abstract_type. There there 4 separate vars for abstract_parent_type. One of them was type casted but did not acctually use the type.
also noticed hop emote was not properly subtyped so fixed that.

Most of this was datums and thus has nearly no player facing affects but for the skill_chip that should fix the abstract skill chips spawning in gifts.
## Why It's Good For The Game
Consistently defining abstract types with the same variable allows for unified behavior like the usage of `valid_subtypesof`
## Changelog
N/A
