### PR TITLE
Updates reference tracking to properly find num keyed alists

### DIFF
--- a/code/modules/admin/view_variables/reference_tracking.dm
+++ b/code/modules/admin/view_variables/reference_tracking.dm
@@ -126,6 +126,7 @@
 
 	else if(islist(potential_container))
 		var/list/potential_cache = potential_container
+		var/is_alist = istype(potential_cache, /alist)
 		for(var/element_in_list in potential_cache)
 			//Check normal sublists
 			if(islist(element_in_list))
@@ -162,7 +163,7 @@
 					log_reftracker("All references to [type] [text_ref(src)] found, exiting.")
 					return
 
-			if(!isnum(element_in_list) && !is_special_list)
+			if((!isnum(element_in_list) || is_alist) && !is_special_list)
 				// This exists to catch an error that throws when we access a special list
 				// is_special_list is a hint, it can be wrong
 				try


### PR DESCRIPTION

## About The Pull Request

This is the most efficent way of doing it (I think), typeid checking is actually worse (it's 55 btw). I've also added alists to all the find reference unit tests.

This is a good step in making these things actually work in our codebase. The next thing to look into will be VV (or SDQL though I suspect that's just a matter of being able to use a stable version) which is gonna require playing around with IS_NORMAL_LIST's uses a good bit
