### PR TITLE
Language manuals correctly refer to the person using them up to viewers

### DIFF
--- a/code/modules/language/_language_manuals.dm
+++ b/code/modules/language/_language_manuals.dm
@@ -45,10 +45,9 @@
 /obj/item/language_manual/proc/use_charge(mob/user)
 	charges--
 	if(!charges)
-		var/turf/T = get_turf(src)
-		T.visible_message(span_warning("The cover and contents of [src] start shifting and changing! It slips out of your hands!"))
-
-		new /obj/item/book/manual/random(T)
+		user.visible_message(span_notice("The cover of [user]'s book start shifting and changing! It falls out of [user.p_their()] hands!"),
+							span_warning("The cover and contents of [src] start shifting and changing! It slips out of your hands!"))
+		new /obj/item/book/manual/random(get_turf(src))
 		qdel(src)
 
 /obj/item/language_manual/codespeak_manual


### PR DESCRIPTION

## About The Pull Request

Tells people viewing someone using up a language manual that the person reading the manual drops it, not that the viewing themselves dropped it

## Why It's Good For The Game

closes #93364

## Changelog
:cl:

spellcheck: Language manuals correctly refer to the person using them up to viewers

/:cl:
