### PR TITLE
Moon heretics hate vendors (fixes moon heretic robes not converting vendor damage)

### DIFF
--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -602,6 +602,9 @@
 	RegisterSignal(human_user, COMSIG_SEND_ITEM_ATTACK_MESSAGE_CARBON, PROC_REF(item_attack_response))
 	signal_registered += COMSIG_SEND_ITEM_ATTACK_MESSAGE_CARBON
 
+	RegisterSignal(human_user, COMSIG_CARBON_LIMB_DAMAGED, PROC_REF(limb_damage))
+	signal_registered += COMSIG_CARBON_LIMB_DAMAGED
+
 	var/obj/item/organ/brain/our_brain = human_user.get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(!our_brain)
 		return
@@ -637,8 +640,15 @@
 	return COMPONENT_IGNORE_CHANGE
 
 /obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/proc/handle_damage(mob/living/user, damage)
+	if(damage <= 0 || braindead)
+		return
 	user.adjust_organ_loss(ORGAN_SLOT_BRAIN, damage * damage_modifier)
 	check_braindeath(user)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/proc/limb_damage(mob/living/user, obj/item/bodypart/part, brute, burn)
+	SIGNAL_HANDLER
+	handle_damage(user, max(brute, 0) + max(burn, 0))
+	return COMPONENT_PREVENT_LIMB_DAMAGE
 
 /// Gives the health HUD to the wearer
 /obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/proc/on_hud_created(mob/living/carbon/human/wearer)

--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -645,6 +645,7 @@
 	user.adjust_organ_loss(ORGAN_SLOT_BRAIN, damage * damage_modifier)
 	check_braindeath(user)
 
+/// Some sources of damage directly damage the limbs, so we have to handle physical damage on the limbs, not just mob-level damage
 /obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/proc/limb_damage(mob/living/user, obj/item/bodypart/part, brute, burn)
 	SIGNAL_HANDLER
 	handle_damage(user, max(brute, 0) + max(burn, 0))

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -69,7 +69,7 @@
 
 /datum/heretic_knowledge/limited_amount/starting/base_moon/on_gain(mob/user, datum/antagonist/heretic/our_heretic)
 	. = ..()
-	user.AddComponentFrom(REF(src), /datum/component/empathy, TRUE, ALL, FALSE, FALSE, TRUE, FALSE)
+	user.AddComponentFrom(REF(src), /datum/component/empathy, seen_it = TRUE, visible_info = ALL, self_empath = FALSE, sense_dead = FALSE, sense_whisper = TRUE, smite_target = FALSE)
 
 /datum/heretic_knowledge/limited_amount/starting/base_moon/on_mansus_grasp(mob/living/source, mob/living/target)
 	. = ..()

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -69,7 +69,7 @@
 
 /datum/heretic_knowledge/limited_amount/starting/base_moon/on_gain(mob/user, datum/antagonist/heretic/our_heretic)
 	. = ..()
-	user.AddComponentFrom(REF(src), /datum/component/empathy, seen_it = TRUE, visible_info = ALL, self_empath = FALSE, sense_dead = FALSE, sense_whisper = TRUE, smite_target = FALSE)
+	user.AddComponentFrom(REF(src), /datum/component/empathy, TRUE, ALL, FALSE, FALSE, TRUE, FALSE)
 
 /datum/heretic_knowledge/limited_amount/starting/base_moon/on_mansus_grasp(mob/living/source, mob/living/target)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Fixes moon heretic robes not converting vendor damage, though, unfortunately, it does mean it'll straight up kill (sometimes) them with the hilarious amount of damage vendors do.

fixes https://github.com/tgstation/tgstation/issues/95063

## Why It's Good For The Game
Oversight fix good, the balance (dying) thing is a separate thing I can resolve.
## Changelog
:cl:
fix: moon heretics getting hit by things that target limbs specifically (like vendors) will no longer bypass moon robe protection, but, good luck surviving that.
fix: fix moon heretic's empathy runtiming on when they gain their initial knowledge
/:cl:
