### PR TITLE
Paddy overclocks when sirens are on (Cleans the blood from my hands) 

### DIFF
--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -153,8 +153,13 @@
 	chassis.update_icon_state()
 
 /datum/action/vehicle/sealed/mecha/mech_overclock
-	name = "Toggle overclocking"
+	name = "Toggle Overclocking"
+	desc = "Increases mech speed and power at the cost of heat generation."
 	button_icon_state = "mech_overload_off"
+
+/datum/action/vehicle/sealed/mecha/mech_overclock/siren/New()
+	. = ..()
+	build_all_button_icons()
 
 /datum/action/vehicle/sealed/mecha/mech_overclock/Trigger(mob/clicker, trigger_flags, forced_state = null)
 	if(!..())
@@ -162,8 +167,14 @@
 	if(!chassis || !(owner in chassis.occupants))
 		return
 	chassis.toggle_overclock(forced_state)
-	button_icon_state = "mech_overload_[chassis.overclock_mode ? "on" : "off"]"
 	build_all_button_icons()
+
+/datum/action/vehicle/sealed/mecha/mech_overclock/apply_button_icon(atom/movable/screen/movable/action_button/current_button, force)
+	button_icon_state = get_button_icon_state()
+	return ..()
+
+/datum/action/vehicle/sealed/mecha/mech_overclock/proc/get_button_icon_state()
+	return "mech_overload_[chassis.overclock_mode ? "on" : "off"]"
 
 /datum/action/vehicle/sealed/mecha/equipment
 	name = "Mech Equipment"


### PR DESCRIPTION
## About The Pull Request

When the Paddy enables its sirens, it also enables overclock mode, speeding it up 1.5x. 

Note: its overclock safeties are forced on and cannot be disabled, meaning it will be forced to slow down eventually. 

## Why It's Good For The Game

While I saw people make good use of the Paddy even post nerf, yeah I can understand now how sad it is to be forced to slug around everywhere. It just feels bad. 
And Goof never finished his PR so here we are.

You can use the siren to better position yourself while giving antags a warning a stompy mech is approaching. 
However you can't have them on forever, giving said antags a break eventually.

## Changelog

:cl: Melbert
balance: When the Paddy enables its sirens, it also enables overclock mode, speeding it up 1.5x. 
balance: Paddy is forced onto overclock safety mode, meaning said overclock will self-disable eventually.
/:cl:

