### PR TITLE
Fixes random slimes not being random & slimes not being revived with the correct icon

### DIFF
--- a/code/__DEFINES/research/slimes.dm
+++ b/code/__DEFINES/research/slimes.dm
@@ -62,5 +62,8 @@
 #define SLIME_TYPE_SILVER "silver"
 #define SLIME_TYPE_YELLOW "yellow"
 
+// Not a real slime type, used to create random slimes
+#define SLIME_TYPE_RANDOM "random"
+
 // The alpha value of transperent slime types
 #define SLIME_TRANSPARENCY_ALPHA 180

--- a/code/modules/mob/living/basic/slime/slime.dm
+++ b/code/modules/mob/living/basic/slime/slime.dm
@@ -157,7 +157,7 @@
 /mob/living/basic/slime/random
 
 /mob/living/basic/slime/random/Initialize(mapload, new_colour, new_life_stage)
-	return ..(mapload, null, prob(50) ? SLIME_LIFE_STAGE_ADULT : SLIME_LIFE_STAGE_BABY)
+	return ..(mapload, SLIME_TYPE_RANDOM, prob(50) ? SLIME_LIFE_STAGE_ADULT : SLIME_LIFE_STAGE_BABY)
 
 ///Friendly docile subtype
 /mob/living/basic/slime/pet
@@ -197,10 +197,11 @@
 	if(slime_type.transparent)
 		alpha = SLIME_TRANSPARENCY_ALPHA
 
+	icon_living = "[slime_type.colour]-[life_stage]"
 	icon_dead = !cores ? "[slime_type.colour]-cut" : "[slime_type.colour]-[life_stage]-dead"
 
 	if(stat != DEAD)
-		icon_state = "[slime_type.colour]-[life_stage]"
+		icon_state = icon_living
 		if(current_mood && current_mood != SLIME_MOOD_NONE && !stat)
 			add_overlay("aslime-[current_mood]")
 	else
@@ -273,8 +274,8 @@
 
 /// Sets the slime's type, name and its icons.
 /// If not provided with a type it will instead be random
-/mob/living/basic/slime/proc/set_slime_type(new_type = null)
-	if(isnull(new_type))
+/mob/living/basic/slime/proc/set_slime_type(new_type = SLIME_TYPE_RANDOM)
+	if(new_type == SLIME_TYPE_RANDOM)
 		new_type = pick(subtypesof(/datum/slime_type))
 
 	slime_type = possible_slime_types[new_type]


### PR DESCRIPTION

## About The Pull Request

Random slimes didn't have their type randomized because the check in `set_slime_type()` that causes randomization is checking for `null`, and the way this was supposed to be activating was passing `null` through the `/random` subtype's `Initialize()` arguments, but apparently even if you pass `null` in the arguments explicitly, default values get applied(in this case, grey slime). This has been resolved by switching out `null` for a non-null define.

Also, slimes revived via aheals and probably other stuff would have their icon reset to grey slime baby, regardless of their actual state, because `icon_living` was not being set. `icon_living` is now being set along with `icon_dead`.

## Why It's Good For The Game

fixes #95072
fixes fake grey slimes

## Changelog
:cl:

fix: Sources of random slimes will now produce random slimes
fix: Slimes revived via magic will now continue to look as they should

/:cl:
