### PR TITLE
Only call `updatehealth` once for `heal_ordered_damage`

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -541,5 +541,5 @@
 			amount -= amount_to_heal //remove what we healed from our current amount
 		if(!amount)
 			break
-	if(.)
+	if(. && update_health)
 		updateHealth()

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -122,20 +122,20 @@
  * Simply a wrapper for calling mob adjustXLoss() procs to heal a certain damage type,
  * when you don't know what damage type you're healing exactly.
  */
-/mob/living/proc/heal_damage_type(heal_amount = 0, damagetype = BRUTE)
+/mob/living/proc/heal_damage_type(heal_amount = 0, damagetype = BRUTE, update_health = TRUE)
 	heal_amount = abs(heal_amount) * -1
 
 	switch(damagetype)
 		if(BRUTE)
-			return adjust_brute_loss(heal_amount)
+			return adjust_brute_loss(heal_amount, update_health)
 		if(BURN)
-			return adjust_fire_loss(heal_amount)
+			return adjust_fire_loss(heal_amount, update_health)
 		if(TOX)
-			return adjust_tox_loss(heal_amount)
+			return adjust_tox_loss(heal_amount, update_health)
 		if(OXY)
-			return adjust_oxy_loss(heal_amount)
+			return adjust_oxy_loss(heal_amount, update_health)
 		if(STAMINA)
-			return adjust_stamina_loss(heal_amount)
+			return adjust_stamina_loss(heal_amount, update_health)
 
 /// return the damage amount for the type given
 /**
@@ -532,12 +532,14 @@
 		updatehealth()
 
 ///heal up to amount damage, in a given order
-/mob/living/proc/heal_ordered_damage(amount, list/damage_types)
+/mob/living/proc/heal_ordered_damage(amount, list/damage_types, update_health = TRUE)
 	. = 0 //we'll return the amount of damage healed
 	for(var/damagetype in damage_types)
 		var/amount_to_heal = min(abs(amount), get_current_damage_of_type(damagetype)) //heal only up to the amount of damage we have
 		if(amount_to_heal)
-			. += heal_damage_type(amount_to_heal, damagetype)
+			. += heal_damage_type(amount_to_heal, damagetype, FALSE)
 			amount -= amount_to_heal //remove what we healed from our current amount
 		if(!amount)
 			break
+	if(.)
+		updateHealth()

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -542,4 +542,4 @@
 		if(!amount)
 			break
 	if(. && update_health)
-		updateHealth()
+		updatehealth()


### PR DESCRIPTION

## About The Pull Request
micro op opportunity i noticed.
## Why It's Good For The Game
you can pass up to 5 damage types into the ordered list. It makes sense to only `updateHealth` after going through all of them.

also having the args to not update health for `heal_ordered_damage` and `heal_damage_type` for similar reasons (However I skimmed through usecases them and didnt see any that call `updateHeath` after it
## Changelog
N/A
