### PR TITLE
Fixes radio emotes runechat visibility for /mob/dead/observer and reuse is_custom_emote variable in living_say

### DIFF
--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -70,9 +70,10 @@
 		else
 			to_follow = V.source
 	var/link = FOLLOW_LINK(src, to_follow)
+	var/is_custom_emote = message_mods[MODE_CUSTOM_SAY_ERASE_INPUT]
 	// Create map text prior to modifying message for goonchat
 	if (safe_read_pref(client, /datum/preference/toggle/enable_runechat) && (safe_read_pref(client, /datum/preference/toggle/enable_runechat_non_mobs) || ismob(speaker)))
-		create_chat_message(speaker, message_language, raw_message, spans)
+		is_custom_emote ? create_chat_message(speaker, null, message_mods[MODE_CUSTOM_SAY_EMOTE], spans, EMOTE_MESSAGE) : create_chat_message(speaker, message_language, raw_message, spans)
 	// Recompose the message, because it's scrambled by default
 	var/message = compose_message(speaker, message_language, raw_message, radio_freq, radio_freq_name, radio_freq_color, spans, message_mods)
 	to_chat(src,

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -73,7 +73,10 @@
 	var/is_custom_emote = message_mods[MODE_CUSTOM_SAY_ERASE_INPUT]
 	// Create map text prior to modifying message for goonchat
 	if (safe_read_pref(client, /datum/preference/toggle/enable_runechat) && (safe_read_pref(client, /datum/preference/toggle/enable_runechat_non_mobs) || ismob(speaker)))
-		is_custom_emote ? create_chat_message(speaker, null, message_mods[MODE_CUSTOM_SAY_EMOTE], spans, EMOTE_MESSAGE) : create_chat_message(speaker, message_language, raw_message, spans)
+		if(is_custom_emote)
+			create_chat_message(speaker, null, message_mods[MODE_CUSTOM_SAY_EMOTE], spans, EMOTE_MESSAGE)
+		else
+			create_chat_message(speaker, message_language, raw_message, spans)
 	// Recompose the message, because it's scrambled by default
 	var/message = compose_message(speaker, message_language, raw_message, radio_freq, radio_freq_name, radio_freq_color, spans, message_mods)
 	to_chat(src,

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -338,7 +338,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 
 		// Create map text prior to modifying message for goonchat, sign lang edition
 		if (use_runechat && !is_blind())
-			if (message_mods[MODE_CUSTOM_SAY_ERASE_INPUT])
+			if (is_custom_emote)
 				create_chat_message(speaker, null, message_mods[MODE_CUSTOM_SAY_EMOTE], spans, EMOTE_MESSAGE)
 			else
 				create_chat_message(speaker, message_language, raw_message, spans)
@@ -361,7 +361,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 
 	// Create map text prior to modifying message for goonchat
 	if (use_runechat && !HAS_TRAIT(src, TRAIT_DEAF))
-		if (message_mods[MODE_CUSTOM_SAY_ERASE_INPUT])
+		if (is_custom_emote)
 			create_chat_message(speaker, null, message_mods[MODE_CUSTOM_SAY_EMOTE], spans, EMOTE_MESSAGE)
 		else
 			create_chat_message(speaker, message_language, raw_message, spans)


### PR DESCRIPTION

## About The Pull Request

During message hearing, mobs are displayed two versions of the message they hear, determined by the languages they understand, their mob type (AI's and ghosts get follow buttons, for example), and special handling for runechat. 

It's a bit of a deep drive, but this bug's been present since #62130. This implements a check for the flag being sent down, so that when the runechat is generated, we don't get the cleared placeholder string set in `/mob/proc/check_for_custom_say_emote()` - set because the message is never meant to be parsed as a chat message. 

Before, the message string sent down `/mob/dead/observer/Hear()` did not know the message was an emote, so the message passed to the function that generates the runechat receives the placeholder string. With this PR, that function now receives the correct string, the same as living would handle it. 

While searching for this bug, I found that a variable was set, but never used more than once in  `/mob/living/Hear()` - I changed the code that accesses this variable to access the saved inline version instead (hopefully saving some cpu!!). 
## Why It's Good For The Game
## Changelog
:cl:
fix: fixed runechat's for radio emotes appearing incorrectly for observers
code: reuse the emote check from living's hearing function
/:cl:
