### PR TITLE
Fixes newly created objects not appearing in auto updating lootpanel

### DIFF
--- a/code/modules/lootpanel/_lootpanel.dm
+++ b/code/modules/lootpanel/_lootpanel.dm
@@ -45,7 +45,7 @@
 /datum/lootpanel/ui_close(mob/user)
 	. = ..()
 
-	UnregisterSignal(source_turf, COMSIG_ATOM_ENTERED)
+	UnregisterSignal(source_turf, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON))
 	source_turf = null
 	reset_contents()
 

--- a/code/modules/lootpanel/misc.dm
+++ b/code/modules/lootpanel/misc.dm
@@ -2,8 +2,8 @@
 /datum/lootpanel/proc/open(turf/tile)
 	if (tile != source_turf)
 		if (source_turf)
-			UnregisterSignal(source_turf, COMSIG_ATOM_ENTERED)
-		RegisterSignal(tile, COMSIG_ATOM_ENTERED, PROC_REF(on_source_turf_entered))
+			UnregisterSignal(source_turf, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON))
+		RegisterSignals(tile, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON), PROC_REF(on_source_turf_entered))
 
 	source_turf = tile
 


### PR DESCRIPTION

## About The Pull Request

Makes the auto updating lootpanel listen for `COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON` in addition to `COMSIG_ATOM_ENTERED`, allowing it to pick up newly created objects. 

## Why It's Good For The Game

fixes #95038

## Changelog
:cl:

fix: the auto updating lootpanel now automatically shows new items that haven't moved yet.

/:cl:
