### PR TITLE
fix Tgui error year display

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -10,6 +10,9 @@
 /// Define that just has the current in-universe year for use in whatever context you might want to display that in. (For example, 2022 -> 2562 given a 540 year offset)
 #define CURRENT_STATION_YEAR (GLOB.year_integer + STATION_YEAR_OFFSET)
 
+/// Used in the GLOB year and tgui PreInit
+#define UTC_YEAR time2text(world.realtime,"YYYY",NO_TIMEZONE)
+
 /// In-universe, SS13 is set 540 years in the future from the real-world day, hence this number for determining the year-offset for the in-game year.
 #define STATION_YEAR_OFFSET 540
 

--- a/code/_globalvars/time_vars.dm
+++ b/code/_globalvars/time_vars.dm
@@ -2,5 +2,5 @@
 /// The difference betwen midnight (of the host computer) and 0 world.ticks.
 GLOBAL_VAR_INIT(timezoneOffset, 0)
 
-GLOBAL_VAR_INIT(year, time2text(world.realtime, "YYYY", NO_TIMEZONE))
+GLOBAL_VAR_INIT(year, UTC_YEAR)
 GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(tgui)
 	ntos_error = "<style type='text/css'>\n[ntos_error]\n</style>"
 	basehtml = replacetextEx(basehtml, "<!-- tgui:ntos-error -->", ntos_error)
 
-	basehtml = replacetextEx(basehtml, "<!-- tgui:nt-copyright -->", "Nanotrasen (c) 2525-[CURRENT_STATION_YEAR]")
+	basehtml = replacetextEx(basehtml, "<!-- tgui:nt-copyright -->", "Nanotrasen (c) 2525-[UTC_YEAR + STATION_YEAR_OFFSET]") // This can't use the GLOB as it runs before those are populated
 
 /datum/controller/subsystem/tgui/OnConfigLoad()
 	var/storage_iframe = CONFIG_GET(string/storage_cdn_iframe)

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(tgui)
 	ntos_error = "<style type='text/css'>\n[ntos_error]\n</style>"
 	basehtml = replacetextEx(basehtml, "<!-- tgui:ntos-error -->", ntos_error)
 
-	basehtml = replacetextEx(basehtml, "<!-- tgui:nt-copyright -->", "Nanotrasen (c) 2525-[UTC_YEAR + STATION_YEAR_OFFSET]") // This can't use the GLOB as it runs before those are populated
+	basehtml = replacetextEx(basehtml, "<!-- tgui:nt-copyright -->", "Nanotrasen (c) 2525-[text2num(UTC_YEAR) + STATION_YEAR_OFFSET]") // This can't use the GLOB as it runs before those are populated
 
 /datum/controller/subsystem/tgui/OnConfigLoad()
 	var/storage_iframe = CONFIG_GET(string/storage_cdn_iframe)


### PR DESCRIPTION

## About The Pull Request
If we look closely at the world init, we clearly see that GLOBS are not populated by the time Subsystem PreInit is called. This led to the current year never being properly displayed in the TGUI bluescreen
```
 * WORLD INITIALIZATION
 * THIS IS THE INIT ORDER:
 *
 * BYOND =>
 * - (secret init native) =>
 *   - world.Genesis() =>
 *     - world.init_byond_tracy()
 *     - (Start native profiling)
 *     - world.init_debugger()
 *     - Master =>
 *       - config *unloaded
 *       - (all subsystems) PreInit()
 *       - GLOB =>
 *         - make_datum_reference_lists()
 *   - (/static variable inits, reverse declaration order)
 * - (all pre-mapped atoms) /atom/New()
 * - world.New() =>
 *   - config.Load()
 *   - world.InitTgs() =>
 *     - TgsNew() *may sleep
 *     - GLOB.rev_data.load_tgs_info()
 *   - world.ConfigLoaded() =>
 *     - SSdbcore.InitializeRound()
 *     - world.SetupLogs()
 *     - load_admins()
 *     - ...
 *   - Master.Initialize() =>
 *     - (all subsystems) Initialize()
 *     - Master.StartProcessing() =>
 *       - Master.Loop() =>
 *         - Failsafe
 *   - world.RunUnattendedFunctions()
 ```
## Why It's Good For The Game
## Changelog
:cl:
fix: tgui error year display
/:cl:
