### PR TITLE
Playsound to_chat respects admin music preferences

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -144,8 +144,7 @@ GLOBAL_VAR_INIT(web_sound_cooldown, 0)
 		for(var/client/client as anything in GLOB.clients)
 			if(client.prefs.read_preference(/datum/preference/numeric/volume/sound_midi) > 0)
 				recipients += client
-		if(!(user.client in recipients))
-			recipients += user.client
+		recipients |= user.client
 		to_chat(recipients, fieldset_block("Now Playing: [span_bold(music_extra_data["title"])] by [span_bold(music_extra_data["artist"])]", jointext(to_chat_message, ""), "boxed_message"))
 
 		SSblackbox.record_feedback("nested tally", "played_url", 1, list("[user.ckey]", "[input]"))

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -140,7 +140,13 @@ GLOBAL_VAR_INIT(web_sound_cooldown, 0)
 		if(credit)
 			to_chat_message += span_notice("<br>[credit]")
 
-		to_chat(world, fieldset_block("Now Playing: [span_bold(music_extra_data["title"])] by [span_bold(music_extra_data["artist"])]", jointext(to_chat_message, ""), "boxed_message"))
+		var/list/recipients = list()
+		for(var/client/client as anything in GLOB.clients)
+			if(client.prefs.read_preference(/datum/preference/numeric/volume/sound_midi) > 0)
+				recipients += client
+		if(!(user.client in recipients))
+			recipients += user.client
+		to_chat(recipients, fieldset_block("Now Playing: [span_bold(music_extra_data["title"])] by [span_bold(music_extra_data["artist"])]", jointext(to_chat_message, ""), "boxed_message"))
 
 		SSblackbox.record_feedback("nested tally", "played_url", 1, list("[user.ckey]", "[input]"))
 		log_admin("[key_name(user)] played web sound: [input]")


### PR DESCRIPTION

## About The Pull Request

When requesting an internet sound, all clients connected to the world receive a 'to_chat' with song information, even if they have 'Admin music volume' set to 0.

This PR makes it so this 'to_chat' isn't sent to players who have 'admin music volume' at 0. Why add a very intrusive chat-spam if I do not want to listen to admin MIDIs?

Marking this as a fix because I can only imagine that this not being the default behavior is unintended from the get-go.
## Why It's Good For The Game

Reduces chat spam for users who opt-out of listening to admin songs.
## Video Proof of Testing:

https://github.com/user-attachments/assets/4f8e3cf6-37e3-4f84-a3e1-e702e6e0b94c

## Changelog
:cl: Bugwasabi
fix: Play Internet Sounds will now only display song details to users who have admin music enabled.
/:cl:
