### PR TITLE
Addictions don't process in stasis

### DIFF
--- a/code/controllers/subsystem/addiction.dm
+++ b/code/controllers/subsystem/addiction.dm
@@ -6,7 +6,7 @@ SUBSYSTEM_DEF(addiction)
 	name = "Addiction"
 	flags = SS_NO_FIRE
 	///Dictionary of addiction.type || addiction ref
-	var/list/all_addictions = list()
+	var/list/datum/addiction/all_addictions = list()
 
 /datum/controller/subsystem/addiction/Initialize()
 	InitializeAddictions()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -26,16 +26,14 @@
 		if(.) //not dead
 			handle_blood(seconds_per_tick)
 
-		if(stat != DEAD)
+		if(stat != DEAD) // still not dead (blood could have changed that)
+			for(var/key in mind?.addiction_points)
+				GLOB.addictions[key].process_addiction(src, seconds_per_tick)
 			handle_brain_damage(seconds_per_tick)
 
 	if(stat != DEAD)
 		handle_bodyparts(seconds_per_tick)
 
-	if(. && mind) //. == not dead
-		for(var/key in mind.addiction_points)
-			var/datum/addiction/addiction = SSaddiction.all_addictions[key]
-			addiction.process_addiction(src, seconds_per_tick)
 	if(stat != DEAD)
 		return TRUE
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -28,7 +28,8 @@
 
 		if(stat != DEAD) // still not dead (blood could have changed that)
 			for(var/key in mind?.addiction_points)
-				GLOB.addictions[key].process_addiction(src, seconds_per_tick)
+				var/datum/addiction/addiction = SSaddiction.all_addictions[key]
+				addiction.process_addiction(src, seconds_per_tick)
 			handle_brain_damage(seconds_per_tick)
 
 	if(stat != DEAD)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -28,8 +28,7 @@
 
 		if(stat != DEAD) // still not dead (blood could have changed that)
 			for(var/key in mind?.addiction_points)
-				var/datum/addiction/addiction = SSaddiction.all_addictions[key]
-				addiction.process_addiction(src, seconds_per_tick)
+				SSaddiction.all_addictions[key].process_addiction(src, seconds_per_tick)
 			handle_brain_damage(seconds_per_tick)
 
 	if(stat != DEAD)


### PR DESCRIPTION
## About The Pull Request

Moves addiction processing in life to within the inverted stasis check 

Note, this includes both withdrawal effects and addiction healing

## Why It's Good For The Game

Addictions have several ticking maluses that you would expect stasis to stop, but doesn't

So it seems sensible, for consistency reasons, to stop addictions from ticking up or down while in stasis

## Changelog

:cl: Melbert
balance: Stasis now stops addiction ticks while active - meaning addictions will not apply their ticking withdrawal effects, but also won't heal over time
/:cl:
