### PR TITLE
Fixes delta damage calculation for organs (and brain getting traumas not from damage, but from mannitol healing)

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -356,7 +356,7 @@
 	var/delta_dam = . //for the sake of clarity
 	if(isnull(bodypart_owner)) // no need to color it if it's in someone's noggin
 		update_brain_color()
-	if(delta_dam > 0 && damage > BRAIN_DAMAGE_MILD)
+	if(delta_dam < 0 && damage > BRAIN_DAMAGE_MILD)
 		roll_for_brain_trauma(delta_dam)
 
 /// Rolls a random chance to gain a brain trauma based on damage taken and current damage level

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -357,7 +357,7 @@
 	if(isnull(bodypart_owner)) // no need to color it if it's in someone's noggin
 		update_brain_color()
 	if(delta_dam < 0 && damage > BRAIN_DAMAGE_MILD)
-		roll_for_brain_trauma(delta_dam)
+		roll_for_brain_trauma(-delta_dam) // parent call returns negative numbers if take damage and positive if we heal
 
 /// Rolls a random chance to gain a brain trauma based on damage taken and current damage level
 /obj/item/organ/brain/proc/roll_for_brain_trauma(delta_dam)

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -255,7 +255,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		return FALSE
 	damage = clamp(damage + damage_amount, 0, maximum)
 	SEND_SIGNAL(src, COMSIG_ORGAN_ADJUST_DAMAGE, damage_amount, maximum, required_organ_flag)
-	. = (damage - prev_damage) // return net damage
+	. = (prev_damage - damage) // return net damage
 	var/message = check_damage_thresholds()
 	prev_damage = damage
 

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -255,7 +255,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		return FALSE
 	damage = clamp(damage + damage_amount, 0, maximum)
 	SEND_SIGNAL(src, COMSIG_ORGAN_ADJUST_DAMAGE, damage_amount, maximum, required_organ_flag)
-	. = (prev_damage - damage) // return net damage
+	. = (damage - prev_damage) // return net damage
 	var/message = check_damage_thresholds()
 	prev_damage = damage
 

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -468,7 +468,7 @@
 	. = ..()
 	// So after a while, or a bunch of stomach meds, even a cut stomach can recover
 	if (. > 0)
-		cut_open_damage = max(0, cut_open_damage + .)
+		cut_open_damage = max(0, cut_open_damage - .)
 
 /obj/item/organ/stomach/examine(mob/user)
 	. = ..()

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -467,7 +467,7 @@
 /obj/item/organ/stomach/apply_organ_damage(damage_amount, maximum, required_organ_flag)
 	. = ..()
 	// So after a while, or a bunch of stomach meds, even a cut stomach can recover
-	if (. < 0)
+	if (. > 0)
 		cut_open_damage = max(0, cut_open_damage + .)
 
 /obj/item/organ/stomach/examine(mob/user)


### PR DESCRIPTION
## About The Pull Request
Equation been wrong, we were getting negative numbers for increase in damage. Only two child calls were affected by this (brain and stomach) and booth expected positive for increase in damage and negative for healing. Did it mostly for brain traumas, but turned out we had a broken interaction for stomachs for about 2 years now.

UPD: entirety of mob damage system is build on an assumption of positive delta damage being healed damage, judging by shear amount of `-1 *`. Unfortunately, I do not posses enough energy to figure out ins and outs of it. And I don't think it's worth refactoring to make it more logical in my (maybe someones' elses too) eyes. In the end, i just swapped checks to work properly with that assumption.
## Why It's Good For The Game
bugs are bad
## Changelog
:cl:
fix: fixed brain not getting traumas from brain damage (including rotting or chemicals)
fix: brains should no longer be getting traumas from mannitol healing
fix: apparently cut stomach healing had been broken too, and it should be fixed now.
/:cl:
