### PR TITLE
Fix Kommand reset not updating action icon

### DIFF
--- a/code/modules/library/skill_learning/generic_skillchips/point.dm
+++ b/code/modules/library/skill_learning/generic_skillchips/point.dm
@@ -80,13 +80,15 @@
 	build_all_button_icons(update_flags = UPDATE_BUTTON_ICON, force = TRUE)
 
 /datum/action/change_pointer_color/apply_button_icon(atom/movable/screen/movable/action_button/current_button, force = FALSE)
+	var/initial_icon = /obj/effect/temp_visual/point::icon
+	current_button.cut_overlay(arrow_overlay)
 	if(!arrow_color)
+		current_button.icon = initial_icon
+		current_button.icon_state = /obj/effect/temp_visual/point::icon_state
 		return ..()
 
 	current_button.icon = current_button.icon_state = null
-	current_button.cut_overlay(arrow_overlay)
-
-	arrow_overlay = mutable_appearance(icon = /obj/effect/temp_visual/point::icon, icon_state = "arrow_large_white_still")
+	arrow_overlay = mutable_appearance(icon = initial_icon, icon_state = "arrow_large_white_still")
 	arrow_overlay.color = arrow_color
-	arrow_overlay.overlays += mutable_appearance(icon = /obj/effect/temp_visual/point::icon, icon_state = "arrow_large_white_still_highlights", appearance_flags = RESET_COLOR)
+	arrow_overlay.overlays += mutable_appearance(icon = initial_icon, icon_state = "arrow_large_white_still_highlights", appearance_flags = RESET_COLOR)
 	current_button.add_overlay(arrow_overlay)


### PR DESCRIPTION
## About The Pull Request

Fix Kommand reset not updating action icon.

## Why It's Good For The Game

Fixes the Kommand icon staying the set color even after being reset.

## Changelog

:cl:
fix: The Kommand action icon will now properly reflect your pointer colour after being reset.
/:cl: