### PR TITLE
Fix HTML special characters in recorded chem dispenser recipes

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -375,7 +375,7 @@
 		if("save_recording")
 			if(!is_operational)
 				return
-			var/name = tgui_input_text(ui.user, "What do you want to name this recipe?", "Recipe Name", max_length = MAX_NAME_LEN)
+			var/name = tgui_input_text(ui.user, "What do you want to name this recipe?", "Recipe Name", max_length = MAX_NAME_LEN, encode = FALSE)
 			if(!ui.user.can_perform_action(src, ALLOW_SILICON_REACH))
 				return
 			if(saved_recipes[name] && tgui_alert(ui.user, "\"[name]\" already exists, do you want to overwrite it?",, list("Yes", "No")) == "No")


### PR DESCRIPTION
## About The Pull Request

Fix this <img width="687" height="486" alt="image" src="https://github.com/user-attachments/assets/cf1ba1a6-e3fa-4a5a-810a-66e5a1e75237" />

## Why It's Good For The Game

Text encoding bug bad. Less bad = good.

## Changelog

:cl:
fix: Fixed encoding of special characters in chem dispenser recorded recipe names.
/:cl: