### PR TITLE
Add handheld crew monitors to cargo

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -434,3 +434,13 @@
 	desc = "If you in your carelessness lost the key to your golfcart you can purchase one. Unfortunately not covered by warranty."
 	cost = PAYCHECK_CREW * 5
 	contains = list(/obj/item/key/golfcart)
+
+
+/datum/supply_pack/goody/handheld_crew_monitor
+	name = "Handheld Crew Monitor"
+	desc = "A crate containing a handheld crew monitor"
+	cost = /obj/item/sensor_device::custom_premium_price * 1.25 // 1.25X base vending machine value
+	contains = list(
+		/obj/item/sensor_device,
+	)
+	crate_name = "handheld crew monitor crate"

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -234,3 +234,13 @@
 	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/reagent_containers/cup/bottle/inversing_buffer)
 	crate_name = "chiral inversing buffer crate"
+
+/datum/supply_pack/medical/handheld_crew_monitor
+	name = "Handheld Crew Monitor Crate"
+	desc = "A crate containing two handheld crew monitors"
+	cost = (CARGO_CRATE_VALUE * /obj/item/sensor_device::custom_premium_price * 2 * 1.125) / 280 // 1.125X base /tg/ vending machine value with the CARGO_CRATE_VALUE modifier
+	contains = list(
+		/obj/item/sensor_device,
+		/obj/item/sensor_device,
+	)
+	crate_name = "handheld crew monitor crate"

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -238,7 +238,7 @@
 /datum/supply_pack/medical/handheld_crew_monitor
 	name = "Handheld Crew Monitor Crate"
 	desc = "A crate containing three handheld crew monitors"
-	cost = (CARGO_CRATE_VALUE * /obj/item/sensor_device::custom_premium_price * 3 * .8) / 280 // Bulk discount .8X base /tg/ vending machine value with the CARGO_CRATE_VALUE modifier
+	cost = (CARGO_CRATE_VALUE * /obj/item/sensor_device::custom_premium_price * 3 * 0.8) / 280 // Bulk discount .8X base /tg/ vending machine value with the CARGO_CRATE_VALUE modifier
 	contains = list(
 		/obj/item/sensor_device,
 		/obj/item/sensor_device,

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -237,9 +237,10 @@
 
 /datum/supply_pack/medical/handheld_crew_monitor
 	name = "Handheld Crew Monitor Crate"
-	desc = "A crate containing two handheld crew monitors"
-	cost = (CARGO_CRATE_VALUE * /obj/item/sensor_device::custom_premium_price * 2 * 1.125) / 280 // 1.125X base /tg/ vending machine value with the CARGO_CRATE_VALUE modifier
+	desc = "A crate containing three handheld crew monitors"
+	cost = (CARGO_CRATE_VALUE * /obj/item/sensor_device::custom_premium_price * 3 * .8) / 280 // Bulk discount .8X base /tg/ vending machine value with the CARGO_CRATE_VALUE modifier
 	contains = list(
+		/obj/item/sensor_device,
 		/obj/item/sensor_device,
 		/obj/item/sensor_device,
 	)


### PR DESCRIPTION
## About The Pull Request

Adds a crate of 2 handheld crew monitors to cargo. at 1.125X their station vending machine value. This currently works out to 675cr per crate.

## Why It's Good For The Game

I joined medical late and the 2 initial vending machine crew monitors were gone and I was sad. Game not making players sad = good :)

## Changelog

:cl: Dominion
add: Added a 3x handheld crew monitor medical crate to cargo.
add: Added a goodie crate with a handheld crew monitor to cargo.
/:cl: