### PR TITLE
Removes the "plural" bodytype

### DIFF
--- a/code/datums/personality/personality_preference.dm
+++ b/code/datums/personality/personality_preference.dm
@@ -13,7 +13,7 @@
 		var/datum/personality/personality = SSpersonalities.personalities_by_key[personality_key]
 		personality.apply_to_mob(target)
 
-/datum/preference/personality/is_valid(value)
+/datum/preference/personality/is_valid(value, datum/preferences/preferences)
 	return islist(value) || isnull(value)
 
 /datum/preference/personality/deserialize(input, datum/preferences/preferences)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -227,15 +227,15 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 			for (var/datum/preference_middleware/preference_middleware as anything in middleware)
 				if (preference_middleware.pre_set_preference(usr, requested_preference_key, value))
-					return TRUE
+					return
 
 			var/datum/preference/requested_preference = GLOB.preference_entries_by_key[requested_preference_key]
 			if (isnull(requested_preference))
-				return FALSE
+				return
 
 			// SAFETY: `update_preference` performs validation checks
 			if (!update_preference(requested_preference, value))
-				return FALSE
+				return
 
 			if (istype(requested_preference, /datum/preference/name))
 				tainted_character_profiles = TRUE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -227,15 +227,15 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 			for (var/datum/preference_middleware/preference_middleware as anything in middleware)
 				if (preference_middleware.pre_set_preference(usr, requested_preference_key, value))
-					return
+					return TRUE
 
 			var/datum/preference/requested_preference = GLOB.preference_entries_by_key[requested_preference_key]
 			if (isnull(requested_preference))
-				return
+				return FALSE
 
 			// SAFETY: `update_preference` performs validation checks
 			if (!update_preference(requested_preference, value))
-				return
+				return FALSE
 
 			if (istype(requested_preference, /datum/preference/name))
 				tainted_character_profiles = TRUE

--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -190,16 +190,23 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 /// Given a savefile, writes the inputted value.
 /// Returns TRUE for a successful application.
 /// Return FALSE if it is invalid.
-/datum/preference/proc/write(list/save_data, value)
+/datum/preference/proc/write(list/save_data, value, datum/preferences/preferences)
 	SHOULD_NOT_OVERRIDE(TRUE)
 
-	if (!is_valid(value))
+	if (!is_valid(value, preferences))
 		return FALSE
 
 	if (!isnull(save_data))
 		save_data[savefile_key] = serialize(value)
 
+	post_write(value, preferences)
+
 	return TRUE
+
+/// Called after a preference has been updated
+/datum/preference/proc/post_write(value, datum/preferences/preferences)
+	SHOULD_CALL_PARENT(TRUE)
+	return
 
 /// Apply this preference onto the given client.
 /// Called when the savefile_identifier == PREFERENCE_PLAYER.
@@ -277,7 +284,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 /datum/preferences/proc/write_preference(datum/preference/preference, preference_value)
 	var/save_data = get_save_data_for_savefile_identifier(preference.savefile_identifier)
 	var/new_value = preference.deserialize(preference_value, src)
-	var/success = preference.write(save_data, new_value)
+	var/success = preference.write(save_data, new_value, src)
 	if (success)
 		value_cache[preference.type] = new_value
 	return success
@@ -290,7 +297,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 		return FALSE
 
 	var/new_value = preference.deserialize(preference_value, src)
-	var/success = preference.write(null, new_value)
+	var/success = preference.write(null, new_value, src)
 
 	if (!success)
 		return FALSE
@@ -308,7 +315,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 /// Checks that a given value is valid.
 /// Must be overriden by subtypes.
 /// Any type can be passed through.
-/datum/preference/proc/is_valid(value)
+/datum/preference/proc/is_valid(value, datum/preferences/preferences)
 	SHOULD_NOT_SLEEP(TRUE)
 	SHOULD_CALL_PARENT(FALSE)
 	CRASH("`is_valid()` was not implemented for [type]!")
@@ -415,7 +422,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 	SHOULD_NOT_SLEEP(TRUE)
 	CRASH("`icon_for()` was not implemented for [type], even though should_generate_icons = TRUE!")
 
-/datum/preference/choiced/is_valid(value)
+/datum/preference/choiced/is_valid(value, datum/preferences/preferences)
 	return value in get_choices()
 
 /datum/preference/choiced/deserialize(input, datum/preferences/preferences)
@@ -497,7 +504,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 /datum/preference/color/serialize(input)
 	return sanitize_hexcolor(input)
 
-/datum/preference/color/is_valid(value)
+/datum/preference/color/is_valid(value, datum/preferences/preferences)
 	return findtext(value, GLOB.is_color)
 
 /// A numeric preference with a minimum and maximum value
@@ -524,7 +531,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 /datum/preference/numeric/create_default_value()
 	return rand(minimum, maximum)
 
-/datum/preference/numeric/is_valid(value)
+/datum/preference/numeric/is_valid(value, datum/preferences/preferences)
 	return isnum(value) && value >= round(minimum, step) && value <= round(maximum, step)
 
 /datum/preference/numeric/compile_constant_data()
@@ -547,7 +554,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 /datum/preference/toggle/deserialize(input, datum/preferences/preferences)
 	return !!input
 
-/datum/preference/toggle/is_valid(value)
+/datum/preference/toggle/is_valid(value, datum/preferences/preferences)
 	return value == TRUE || value == FALSE
 
 
@@ -568,7 +575,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 /datum/preference/text/create_default_value()
 	return ""
 
-/datum/preference/text/is_valid(value)
+/datum/preference/text/is_valid(value, datum/preferences/preferences)
 	return istext(value) && length(value) < maximum_value_length
 
 /datum/preference/text/compile_constant_data()

--- a/code/modules/client/preferences/body_type.dm
+++ b/code/modules/client/preferences/body_type.dm
@@ -15,9 +15,11 @@
 
 /datum/preference/choiced/body_type/apply_to_human(mob/living/carbon/human/target, value)
 	if (value == USE_GENDER)
-		target.physique = target.gender
-	else
-		target.physique = value
+		value = target.gender
+		if (value == PLURAL)
+			value = prob(50) ? MALE : FEMALE // non-binary physique does not work for several reasons, big refactor for whoever bites
+
+	target.physique = value
 
 /datum/preference/choiced/body_type/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))

--- a/code/modules/client/preferences/body_type.dm
+++ b/code/modules/client/preferences/body_type.dm
@@ -10,14 +10,19 @@
 /datum/preference/choiced/body_type/init_possible_values()
 	return list(USE_GENDER, MALE, FEMALE)
 
-/datum/preference/choiced/body_type/create_default_value()
+/datum/preference/choiced/body_type/is_valid(value, datum/preferences/preferences)
+	. = ..()
+	if(. && value == USE_GENDER)
+		return gender_has_physique(preferences.read_preference(/datum/preference/choiced/gender))
+
+/datum/preference/choiced/body_type/create_informed_default_value(datum/preferences/preferences)
 	return USE_GENDER
 
 /datum/preference/choiced/body_type/apply_to_human(mob/living/carbon/human/target, value)
 	if (value == USE_GENDER)
 		value = target.gender
-		if (value == PLURAL || value == NEUTER)
-			value = prob(50) ? MALE : FEMALE // non-binary physique does not work for several reasons, big refactor for whoever bites
+		if (!gender_has_physique(value))
+			value = FEMALE // non-binary physique does not work for several reasons, big refactor for whoever bites, female is the most common in this scenario
 
 	target.physique = value
 
@@ -27,5 +32,8 @@
 
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
 	return initial(species.sexes)
+
+/proc/gender_has_physique(gender)
+	return gender == MALE || gender == FEMALE
 
 #undef USE_GENDER

--- a/code/modules/client/preferences/body_type.dm
+++ b/code/modules/client/preferences/body_type.dm
@@ -16,7 +16,7 @@
 /datum/preference/choiced/body_type/apply_to_human(mob/living/carbon/human/target, value)
 	if (value == USE_GENDER)
 		value = target.gender
-		if (value == PLURAL)
+		if (value == PLURAL || value == NEUTER)
 			value = prob(50) ? MALE : FEMALE // non-binary physique does not work for several reasons, big refactor for whoever bites
 
 	target.physique = value

--- a/code/modules/client/preferences/body_type.dm
+++ b/code/modules/client/preferences/body_type.dm
@@ -16,7 +16,7 @@
 		return gender_has_physique(preferences.read_preference(/datum/preference/choiced/gender))
 
 /datum/preference/choiced/body_type/create_informed_default_value(datum/preferences/preferences)
-	return USE_GENDER
+	return gender_has_physique(preferences.read_preference(/datum/preference/choiced/gender)) ? USE_GENDER : FEMALE
 
 /datum/preference/choiced/body_type/apply_to_human(mob/living/carbon/human/target, value)
 	if (value == USE_GENDER)

--- a/code/modules/client/preferences/gender.dm
+++ b/code/modules/client/preferences/gender.dm
@@ -12,7 +12,16 @@
 		value = PLURAL //disregard gender preferences on this species
 	target.gender = value
 
-/datum/preference/choiced/gender/create_informed_default_value(datum/preferences/preferences)
+/datum/preference/choiced/gender/create_default_value()
 	// The only reason I'm limiting this to male or female
 	// is that hairstyle randomization handles enbies poorly
 	return pick(MALE, FEMALE)
+
+/datum/preference/choiced/gender/post_write(value, datum/preferences/preferences)
+	..()
+	if (gender_has_physique(value))
+		return
+
+	var/current_physique = preferences.read_preference(/datum/preference/choiced/body_type)
+	if(current_physique != MALE && current_physique != FEMALE)
+		preferences.update_preference(GLOB.preference_entries[/datum/preference/choiced/body_type], FEMALE)

--- a/code/modules/client/preferences/migrations/body_type_migration.dm
+++ b/code/modules/client/preferences/migrations/body_type_migration.dm
@@ -6,3 +6,21 @@
 	var/current_gender = save_data["gender"]
 	if (current_gender == MALE || current_gender == FEMALE)
 		save_data["body_type"] = "Use gender"
+
+/// Previously, physiques only supported binary characters, so "Use gender" on a non-binary character played havoc due to all checks being binary (some checked for females others for males)
+/// This caused inconsistencies when it was in play (male laughs and female screams)
+/// Force non-binary characters to have a female physique
+/datum/preferences/proc/migrate_gendered_nonbinary_physique(list/save_data)
+	var/current_gender = save_data["gender"]
+	if(current_gender == MALE || current_gender == FEMALE)
+		return
+
+	if(save_data["body_type"] != "Use gender")
+		return
+
+	save_data["body_type"] = FEMALE
+
+	// TODO: Remove this notification if we ever add non-binary physiques
+	// spawn b/c we need this to run during init but can't immediately because parent may still be initializing
+	spawn(1)
+		tgui_alert(parent, "The physique for [save_data["real_name"]] was previously set to \"Use gender\" but they have a non-binary gender. Non-binary physiques currently do not exist, so this character's physique has defaulted to female.", "Physique Migration for [save_data["real_name"]]")

--- a/code/modules/client/preferences/migrations/body_type_migration.dm
+++ b/code/modules/client/preferences/migrations/body_type_migration.dm
@@ -10,6 +10,7 @@
 /// Previously, physiques only supported binary characters, so "Use gender" on a non-binary character played havoc due to all checks being binary (some checked for females others for males)
 /// This caused inconsistencies when it was in play (male laughs and female screams)
 /// Force non-binary characters to have a female physique
+// TODO: Remove this entire migration if we ever add non-binary physiques
 /datum/preferences/proc/migrate_gendered_nonbinary_physique(list/save_data)
 	var/current_gender = save_data["gender"]
 	if(current_gender == MALE || current_gender == FEMALE)
@@ -20,7 +21,6 @@
 
 	save_data["body_type"] = FEMALE
 
-	// TODO: Remove this notification if we ever add non-binary physiques
 	// spawn b/c we need this to run during init but can't immediately because parent may still be initializing
 	spawn(1)
 		tgui_alert(parent, "The physique for [save_data["real_name"]] was previously set to \"Use gender\" but they have a non-binary gender. Non-binary physiques currently do not exist, so this character's physique has defaulted to female.", "Physique Migration for [save_data["real_name"]]")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -13,7 +13,7 @@
 /// You do not need to raise this if you are adding new values that have sane defaults.
 /// Only raise this value when changing the meaning/format/name/layout of an existing value
 /// where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX 51
+#define SAVEFILE_VERSION_MAX 52
 
 #define IS_DATA_OBSOLETE(version) (version == SAVE_DATA_OBSOLETE)
 #define SHOULD_UPDATE_DATA(version) (version >= SAVE_DATA_NO_ERROR && version < SAVEFILE_VERSION_MAX)
@@ -164,6 +164,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		)
 	if(current_version < 51)
 		migrate_felinid_feature_keys(save_data)
+
+	if(current_version < 52)
+		migrate_gendered_nonbinary_physique(save_data)
 
 /// checks through keybindings for outdated unbound keys and updates them
 /datum/preferences/proc/check_keybindings()

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -18,7 +18,11 @@ import {
 } from 'tgui-core/components';
 import type { BooleanLike } from 'tgui-core/react';
 
-import { createSetPreference, type PreferencesMenuData } from '../../types';
+import {
+  type CharacterPreferencesData,
+  createSetPreference,
+  type PreferencesMenuData,
+} from '../../types';
 import { useServerPrefs } from '../../useServerPrefs';
 
 export function sortChoices(array: [string, ReactNode][]) {
@@ -58,6 +62,7 @@ export type FeatureValueProps<
   serverData: TServerData | undefined;
   shrink?: boolean;
   value: TReceiving;
+  character_preferences: CharacterPreferencesData;
 }>;
 
 export function FeatureColorInput(props: FeatureValueProps<string>) {
@@ -237,6 +242,7 @@ export function FeatureValueInput(props: FeatureValueInputProps) {
     shrink: props.shrink,
     handleSetValue: changeValue,
     value: predictedValue,
+    character_preferences: data.character_preferences,
   });
 }
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/body_type.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/body_type.tsx
@@ -1,7 +1,28 @@
+import { Gender } from '../../gender';
 import type { FeatureChoiced } from '../base';
-import { FeatureDropdownInput } from '../dropdowns';
+import {
+  type DropdownInputProps,
+  FeatureDropdownInputCore,
+  generateOptions,
+} from '../dropdowns';
 
 export const body_type: FeatureChoiced = {
   name: 'Body type',
-  component: FeatureDropdownInput,
+  component: FeatureBodyTypeDropdownInput,
 };
+
+function FeatureBodyTypeDropdownInput(props: DropdownInputProps) {
+  return FeatureDropdownInputCore(props, (serverData, setDropdownOptions) => {
+    let options = generateOptions(serverData);
+
+    const current_gender = props.character_preferences.misc.gender;
+    if (current_gender !== Gender.Male && current_gender !== Gender.Female) {
+      options = options.filter(
+        (option) =>
+          option.value === Gender.Male || option.value === Gender.Female,
+      );
+    }
+
+    setDropdownOptions(options);
+  });
+}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
@@ -140,34 +140,36 @@ export enum PrefsWindow {
   Keybindings = 2,
 }
 
+export type CharacterPreferencesData = {
+  clothing: Record<string, string>;
+  features: Record<string, string>;
+  game_preferences: Record<string, unknown>;
+  non_contextual: {
+    random_body: RandomSetting;
+    [otherKey: string]: unknown;
+  };
+  secondary_features: Record<string, unknown>;
+  supplemental_features: Record<string, unknown>;
+  manually_rendered_features: Record<string, string>;
+
+  names: Record<string, string>;
+
+  misc: {
+    gender: Gender;
+    joblessrole: JoblessRole;
+    species: string;
+    loadout_list: LoadoutList;
+    job_clothes: BooleanLike;
+  };
+
+  randomization: Record<string, RandomSetting>;
+};
+
 export type PreferencesMenuData = {
   character_preview_view: string;
   character_profiles: (string | null)[];
 
-  character_preferences: {
-    clothing: Record<string, string>;
-    features: Record<string, string>;
-    game_preferences: Record<string, unknown>;
-    non_contextual: {
-      random_body: RandomSetting;
-      [otherKey: string]: unknown;
-    };
-    secondary_features: Record<string, unknown>;
-    supplemental_features: Record<string, unknown>;
-    manually_rendered_features: Record<string, string>;
-
-    names: Record<string, string>;
-
-    misc: {
-      gender: Gender;
-      joblessrole: JoblessRole;
-      species: string;
-      loadout_list: LoadoutList;
-      job_clothes: BooleanLike;
-    };
-
-    randomization: Record<string, RandomSetting>;
-  };
+  character_preferences: CharacterPreferencesData;
 
   content_unlocked: BooleanLike;
 


### PR DESCRIPTION
This is not politics. Having it be set as not `MALE` or `FEMALE` causes unsolvable inconsistencies in the code because everything assumes "if not MALE, then FEMALE" or vice versa.

- Migrated "Use gender" enby body types to female (alert user when this happens).
- Disabled "Use gender" in prefs menu when enby.

:cl:
fix: Fixed some inconsistencies with bodytypes when non-binary genders had it set to "Use gender". This is no longer possible. If you use have previously used this setting, your bodytype will be explicitly set to female.
/:cl: