### PR TITLE
Fix right clicking a closet with an ID in hand toggling locks twice in one tick

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1133,7 +1133,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 
 /obj/structure/closet/proc/togglelock(mob/living/user, silent)
 	if(!secure || broken)
-		return
+		return FALSE
 
 	if(locked) //only apply checks while unlocking else allow anyone to lock it
 		var/error_msg = ""
@@ -1145,8 +1145,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 				id_card = null
 				req_access = list()
 				req_one_access = null
-				togglelock(user, silent)
-				return
+				return togglelock(user, silent)
 			if(!can_unlock(user, user.get_idcard(), registered_id))
 				error_msg = "not your locker!"
 		else if(!can_unlock(user, user.get_idcard()))
@@ -1154,7 +1153,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 		if(error_msg)
 			if(!silent)
 				balloon_alert(user, error_msg)
-			return
+			return TRUE
 
 	if(iscarbon(user))
 		add_fingerprint(user)
@@ -1165,6 +1164,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 		span_notice("You [locked ? "locked" : "unlocked"] [src]."),
 	)
 	update_appearance()
+	return TRUE
 
 /// toggles the lock state of a closet
 /obj/structure/closet/proc/lock()


### PR DESCRIPTION
`togglelock` is called in both tool_interact and attack_hand. Aborting on the first success here prevents the double toggle

:cl:
fix: Fixed right clicking a closet with an ID in hand toggling locks twice in one tick
/:cl: