### PR TITLE
Meta wires fix

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -52457,6 +52457,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"rTp" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/medical/medbay/central)
 "rTw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -94360,7 +94367,7 @@ nNY
 hPM
 ttV
 pJU
-duu
+rTp
 vGI
 xxU
 lpk


### PR DESCRIPTION
## About The Pull Request
Adds missing wires and pipes to meta
<img width="430" height="442" alt="dreamseeker_jGKaIR1m1u" src="https://github.com/user-attachments/assets/8d86d7db-a58d-4318-888c-501dd2412236" />

<img width="1023" height="514" alt="StrongDMM_QyDXunPfQQ" src="https://github.com/user-attachments/assets/815205cf-a9a3-4969-9dfe-8833c2a6601e" />

## Why It's Good For The Game
This is a bug fix

## Changelog
:cl:
map: Adds missing wires and pipes to meta
/:cl:
