### PR TITLE
Removes hard cap for plumbing machines

### DIFF
--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -16,9 +16,6 @@
 	var/demand_color = COLOR_RED
 	///What color is our supply connect?
 	var/supply_color = COLOR_BLUE
-	/// How many distinct reagents can we accept at once
-	/// Ex - if this was set to "3", our component would only request the first 3 reagents found, even if more are available
-	var/distinct_reagent_cap = INFINITY
 
 /datum/component/plumbing/Initialize(ducting_layer)
 	if(!ismovable(parent))
@@ -57,7 +54,6 @@
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(create_overlays))
 	RegisterSignal(parent, COMSIG_ATOM_POST_DIR_CHANGE, PROC_REF(on_parent_dir_change))
 	RegisterSignal(parent, COMSIG_MOVABLE_CHANGE_DUCT_LAYER, PROC_REF(change_ducting_layer))
-	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 
 /datum/component/plumbing/UnregisterFromParent()
 	UnregisterSignal(parent, list(
@@ -67,7 +63,6 @@
 		COMSIG_ATOM_UPDATE_OVERLAYS,
 		COMSIG_ATOM_POST_DIR_CHANGE,
 		COMSIG_MOVABLE_CHANGE_DUCT_LAYER,
-		COMSIG_ATOM_EXAMINE,
 	))
 
 /datum/component/plumbing/Destroy()
@@ -256,42 +251,9 @@
 			if(dir & demand_connects)
 				send_request(dir)
 
-/datum/component/plumbing/proc/on_examine(atom/movable/source, mob/user, list/examine_list)
-	SIGNAL_HANDLER
-
-	if(distinct_reagent_cap != INFINITY)
-		examine_list += span_notice("This plumbing component will only accept up to [distinct_reagent_cap] distinct reagents at once.")
-
 ///called from in process(). only calls process_request(), but can be overwritten for children with special behaviour
 /datum/component/plumbing/proc/send_request(dir)
-	var/amount_to_give = MACHINE_REAGENT_TRANSFER
-	// infinite cap means we need to special handling, process_request will just grab as much as it wants.
-	if(distinct_reagent_cap == INFINITY)
-		process_request(amount_to_give, null, dir) // null for no specific reagent, we're not picky.
-		return
-
-	// we have a cap, so we need to figure out what reagents we want
-	var/list/all_allowed_reagents = get_all_network_reagents(ducts["[dir]"])
-	if(length(all_allowed_reagents) > distinct_reagent_cap)
-		all_allowed_reagents.Cut(distinct_reagent_cap + 1)
-	else if(!length(all_allowed_reagents))
-		return
-
-	// request an even amount of each allowed reagent
-	var/amount_per_reagent = round(amount_to_give / length(all_allowed_reagents), CHEMICAL_VOLUME_ROUNDING)
-	for(var/allowed_reagent in all_allowed_reagents)
-		process_request(amount_per_reagent, allowed_reagent, dir)
-
-/// Returns a list of all distinct reagent types available in the passed duct network.
-/// The passed net can be null, it is handled.
-/datum/component/plumbing/proc/get_all_network_reagents(datum/ductnet/net)
-	var/list/distinct_reagents = list()
-	for(var/datum/reagent/existing_regent as anything in reagents.reagent_list)
-		distinct_reagents |= existing_regent.type
-	for(var/datum/component/plumbing/supplier as anything in net?.suppliers)
-		for(var/datum/reagent/chemical as anything in supplier.reagents.reagent_list)
-			distinct_reagents |= chemical.type
-	return distinct_reagents
+	process_request(dir = dir)
 
 ///check who can give us what we want, and how many each of them will give us
 /datum/component/plumbing/proc/process_request(amount = MACHINE_REAGENT_TRANSFER, reagent, dir, round_robin = TRUE)

--- a/code/datums/components/plumbing/automated_iv.dm
+++ b/code/datums/components/plumbing/automated_iv.dm
@@ -1,7 +1,6 @@
 /datum/component/plumbing/automated_iv
 	demand_connects = SOUTH
 	supply_connects = NORTH
-	distinct_reagent_cap = 3
 	///Temporary holder to store all the reagents from the iv drip before transferring to the ducts
 	var/datum/reagents/plumbing/holder
 

--- a/code/datums/components/plumbing/simple_components.dm
+++ b/code/datums/components/plumbing/simple_components.dm
@@ -3,10 +3,6 @@
 /datum/component/plumbing/simple_demand
 	demand_connects = SOUTH
 
-/datum/component/plumbing/simple_demand/Initialize(ducting_layer, distinct_reagent_cap = INFINITY)
-	src.distinct_reagent_cap = distinct_reagent_cap
-	return ..()
-
 ///Component for adding an extended overlay on wall mounts
 /datum/component/plumbing/simple_demand/extended/create_overlays(atom/movable/parent_movable, list/overlays)
 	. = ..()
@@ -23,7 +19,7 @@
 ///For disposing reagents
 /datum/component/plumbing/simple_demand/disposer
 
-/datum/component/plumbing/simple_demand/disposer/Initialize(ducting_layer, distinct_reagent_cap)
+/datum/component/plumbing/simple_demand/disposer/Initialize(ducting_layer)
 	if(!istype(parent, /obj/machinery/plumbing/disposer))
 		return COMPONENT_INCOMPATIBLE
 	return ..()

--- a/code/modules/plumbing/plumbers/bottler.dm
+++ b/code/modules/plumbing/plumbers/bottler.dm
@@ -21,7 +21,7 @@
 
 /obj/machinery/plumbing/bottler/Initialize(mapload, layer)
 	. = ..()
-	AddComponent(/datum/component/plumbing/simple_demand, layer, distinct_reagent_cap = 3)
+	AddComponent(/datum/component/plumbing/simple_demand, layer)
 	setDir(dir)
 
 /obj/machinery/plumbing/bottler/examine(mob/user)

--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -57,7 +57,7 @@
 	max_volume = initial(packaging_type.volume)
 	current_volume = clamp(current_volume, MIN_VOLUME, max_volume)
 
-	AddComponent(/datum/component/plumbing/simple_demand, layer, distinct_reagent_cap = 3)
+	AddComponent(/datum/component/plumbing/simple_demand, layer)
 
 /obj/machinery/plumbing/pill_press/Destroy(force)
 	QDEL_LAZYLIST(stored_products)

--- a/code/modules/plumbing/plumbers/simple_machines.dm
+++ b/code/modules/plumbing/plumbers/simple_machines.dm
@@ -21,7 +21,7 @@
 
 /obj/machinery/plumbing/output/Initialize(mapload, layer)
 	. = ..()
-	AddComponent(/datum/component/plumbing/simple_demand, layer, distinct_reagent_cap = 5)
+	AddComponent(/datum/component/plumbing/simple_demand, layer)
 
 ///For pouring reagents from ducts directly into cups
 /obj/machinery/plumbing/output/tap

--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -35,7 +35,7 @@
 
 	. = ..()
 
-	AddComponent(/datum/component/plumbing/simple_demand, distinct_reagent_cap = 5)
+	AddComponent(/datum/component/plumbing/simple_demand)
 	AddElement(/datum/element/simple_rotation)
 
 	register_context()


### PR DESCRIPTION
## About The Pull Request
Reverts #93991 in favour of #95123. This PR should stay in draft state till that gets merged.

The following machines 
- Bottlers
- Presses
- IV drips
- Smoke machines
- Output gates

Now have all their hard caps of 3 to 5 reagents removed. They can now accept any level of reagents freely again

## Why It's Good For The Game
- Makes plumbing machines behave like large factories. The limit of 3 to 5 reagents was really frustrating chemists and made factories needlessly large to achieve the same outcome
- PR #95123 adds consequences for metabolizing multiple medicine reagents so the problem with heal all patches, pills, bottles or even smoke containing multiple reagents has been solved hence there's no reason for these limits to exist anymore

## Changelog
:cl:
del: removes the hard cap of 3 or 5 reagents from plumbing machines. They can now accept any amount of reagents again
/:cl:
