### PR TITLE
Revert "Replaces T2 Tools with T1 Versions in CE Toolbelt (#92872)"

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -55,23 +55,24 @@
 	preload = TRUE
 
 /obj/item/storage/belt/utility/chief/full/PopulateContents()
-	SSwardrobe.provide_type(/obj/item/screwdriver, src)
-	SSwardrobe.provide_type(/obj/item/wrench, src)
-	SSwardrobe.provide_type(/obj/item/weldingtool/hugetank, src)
-	SSwardrobe.provide_type(/obj/item/crowbar, src)
-	SSwardrobe.provide_type(/obj/item/wirecutters, src)
+	SSwardrobe.provide_type(/obj/item/screwdriver/power, src)
+	SSwardrobe.provide_type(/obj/item/crowbar/power, src)
+	SSwardrobe.provide_type(/obj/item/weldingtool/experimental, src)
 	SSwardrobe.provide_type(/obj/item/multitool, src)
 	SSwardrobe.provide_type(/obj/item/stack/cable_coil, src)
+	SSwardrobe.provide_type(/obj/item/extinguisher/mini, src)
+	SSwardrobe.provide_type(/obj/item/analyzer, src)
+	//much roomier now that we've managed to remove two tools
 
 /obj/item/storage/belt/utility/chief/full/get_types_to_preload()
 	var/list/to_preload = list() //Yes this is a pain. Yes this is the point
-	to_preload += /obj/item/screwdriver
-	to_preload += /obj/item/wrench
-	to_preload += /obj/item/weldingtool/hugetank
-	to_preload += /obj/item/crowbar
-	to_preload += /obj/item/wirecutters
+	to_preload += /obj/item/screwdriver/power
+	to_preload += /obj/item/crowbar/power
+	to_preload += /obj/item/weldingtool/experimental
 	to_preload += /obj/item/multitool
 	to_preload += /obj/item/stack/cable_coil
+	to_preload += /obj/item/extinguisher/mini
+	to_preload += /obj/item/analyzer
 	return to_preload
 
 /obj/item/storage/belt/utility/full/PopulateContents()

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -68,8 +68,6 @@
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic/silver = 1,
 		/obj/item/construction/rcd/ce = 1,
-		/obj/item/extinguisher/mini = 1,
-		/obj/item/analyzer = 1,
 	)
 	belt = /obj/item/storage/belt/utility/chief/full
 	ears = /obj/item/radio/headset/heads/ce


### PR DESCRIPTION

## About The Pull Request

Following an extensive conversation in maintainerbus that was about a lot of things, this PR was used as an example of something that probably shouldn't have been merged in the first place, in the context of a larger point about the relative merge chance of a change versus a revert to that change. (This is intentionally vague because I'm not even going to attempt to summarize the conversation it was long and you should probably just read it) From the way it was talked about there was vague support from other maints that it should be reverted, so I'm making this because I didn't agree with it being merged either and I want to re-open the floor.

## Why It's Good For The Game

There was a LOT of discussion about this both on GitHub and in the discord, but I'm going to focus on addressing the why it's good for the game given in the original PR and in the comment made by cobby (the maint who merged it). 

>It encourages heads to play their subdepartment’s roles instead of their own, which is to manage their department, delegate tasks, and teach newer players.

Heads *do* play their department's role, that is very much an aspect of being a head of staff. The majority of them get unique items designed specifically to make the duties of their department easier, and I don't think there's anything wrong with that! I'm not sure where this perspective of it as a zero-sum game where they can either delegate and manage the department or they can solo the department to the detriment of their subordinates came from, but any competent head can do both! 

>It encourages bad command players to take the role for the gear instead of leaving it for the people who want it for the command.

This is basically a continuation of the first point but with the framing that people who consider the gear a reason to play the job are Bad Players and are taking the role away from someone better who would play it Properly. Again, many heads can and do balance both aspects of the job, and I'm not sure why this framing was considered reasonable. Heads tend to be experienced in all aspects of the department they're a head of, and being able to step in when needed and get shit done because you have both the experience and better tools sells the fiction of you being the head honcho, someone that can be relied on and was put in charge for a reason.

With this in mind, I'm aware that these points were made with the unspoken assumption that the hypothetical player being described is bad because they're violating Rule 5: "Players in vital job roles require a minimum amount of effort." My problem with that is, why is this being solved with code? If a head of staff is failing to perform their duties so grossly that it feels necessary to take away anything that might tempt them to take the role, why are they not being dealt with administratively? Why do the majority that can handle the job have to take a downgrade because of it? Hell, Rule 5 even states "you should be a reliable worker for your department", and then after that states that "As an upside, being THE BOSS allows you to dictate the workflow of your department as you like", which to me sounds like it is explicitly expected that heads will both perform the duties of the department and delegate/manage their subordinates as needed. So why was the former seen as the wrong way to play the job?

>The heads should be about management of the department, and shouldnt have gear incentives to forgo that aspect if it is needed in the round. Giving them better tools FORCES them into job+ role or at best a loot pinata because otherwise theyre not making full use of their roundstart provided tools without it being awkward, and thats only if someone gets in that isnt seeking the free tool upgrades to begin with.

Cobby's comment broadly supported the points made in the PR body, with a few additions about how if a CE doesn't want to be "job+" then they're in an uncomfortable position because they have this desirable gear they're not going to make use of. This is a strange argument to me, because as I just said in the last paragraph, *as a head of staff you should be doing at least a little of the department's job*. There's room for varied play-styles obviously, but if you consistently feel like you're being forced into the position of doing Engineering as the Chief Engineer such that having the upgraded tools feels like it's wasted on you... Maybe you shouldn't be the Chief Engineer? I don't say that in a rude way, I just don't know what the appeal of the job would be otherwise, if you enjoy bureaucracy then the HoP is seen as the epitome of that with little to no formal duties otherwise, I just don't see why CE would appeal to someone who does so little Engineering they see the tools as an uncomfortable burden they'd rather not have.

>Also dislike the idea that heads just get to skip part of the research, they should want said research just as badly as the rest of the department.

The last point that was made repeatedly was the idea that existence of these tools cause a tech tree skip, and this is a bad thing because it means the CE has no incentive to push for unlocking the Experimental Tools node because they got theirs already. Setting aside that again, this framing applies only to absolute worst-case players who probably should be dealt with administratively, it doesn't even make sense if you have experience playing Engineering. Experimental Tools gates RCD upgrades, the node that gives you the silo link and the thing that lets you spawn already wired machine frames and air alarm, APC, and fire alarm circuits, even the most selfish, unfit, department soloer CE is going to get Experimental Tools unlocked so they (and their co-workers) can get RCD upgrades.

Overall it seems like a ton of the justification for this PR hinged on a false dichotomy that heads can either delegate and manage or do the job of their subordinates, and it just doesn't cohere. 

## Changelog
:cl:
balance: The CE spawns with upgraded tools again
/:cl:
