### PR TITLE
Remove rock the vote config entry [NO GBP]

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -185,11 +185,6 @@
 /// allow votes to change map
 /datum/config_entry/flag/allow_vote_map
 
-/// the number of times we allow players to rock the vote
-/datum/config_entry/number/max_rocking_votes
-	default = 1
-	min_val = 1
-
 /// minimum time between voting sessions (deciseconds, 10 minute default)
 /datum/config_entry/number/vote_delay
 	default = 10 MINUTES

--- a/config/config.txt
+++ b/config/config.txt
@@ -119,9 +119,6 @@ RETA_DEPT_COOLDOWN_DS 150
 ## allow players to initiate a map-change vote
 #ALLOW_VOTE_MAP
 
-## the number of times you wish to allow players to rock the vote in a given shift
-MAX_ROCKING_VOTES 1
-
 ## min delay (deciseconds) between voting sessions (default 10 minutes)
 VOTE_DELAY 6000
 


### PR DESCRIPTION
## About The Pull Request

Rock the vote was removed in https://github.com/tgstation/tgstation/pull/86788, removes a leftover config entry for it.

## Why It's Good For The Game

Code cleanup

## Changelog

:cl: LT3
code: Removed unused rock the vote config entry
/:cl: