### PR TITLE
Holopads no longer runtime or delete holodisks when destroyed

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -189,15 +189,13 @@ Possible to do for anyone motivated enough:
 	for(var/datum/holocall/holocall_to_disconnect as anything in holo_calls)
 		holocall_to_disconnect.ConnectionFailure(src)
 
-	for (var/I in masters)
-		clear_holo(I)
-
 	if(replay_mode)
 		replay_stop()
 	if(record_mode)
 		record_stop()
 
-	QDEL_NULL(disk)
+	for (var/I in masters)
+		clear_holo(I)
 
 	holopads -= src
 	return ..()

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -197,6 +197,8 @@ Possible to do for anyone motivated enough:
 	for (var/I in masters)
 		clear_holo(I)
 
+	QDEL_NULL(disk)
+
 	holopads -= src
 	return ..()
 
@@ -214,6 +216,11 @@ Possible to do for anyone motivated enough:
 	. = ..()
 	if(outgoing_call)
 		outgoing_call.ConnectionFailure(src)
+
+/obj/machinery/holopad/on_deconstruction(dissassembled)
+	disk?.forceMove(drop_location())
+	disk = null
+	return ..()
 
 /obj/machinery/holopad/RefreshParts()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Fixes a runtime when holopads are destroyed while playing back due to attempting to `qdel()` the same thing twice, and removes holopads deleting their disks when being destroyed

## Why It's Good For The Game

fixes / closes #95127 (IDK why the disk was being deleted, it was presumably on purpose, but it's weird, bug-looking behaviour for no good reason I can discern. Holodisks can take not insignificant amounts of time to make, and them being randomly deleted is strange.)
fixes runtime

## Changelog
:cl:

fix: Holopads no longer runtime or delete their disks when being destroyed

/:cl:
