### PR TITLE
Adds defibs back to the tech tree. Adds compact defibs as a purchase option from Cargo.

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -78,7 +78,7 @@
 /datum/supply_pack/medical/compact_defib
 	name = "Compact Defibrillator Crate"
 	desc = "Contains a compact defibrillator, small enough to attach to your waist, for bringing the recently deceased back to life."
-	cost = CARGO_CRATE_VALUE * 12
+	cost = CARGO_CRATE_VALUE * 8
 	contains = list(/obj/item/defibrillator/compact/loaded = 1)
 	crate_name = "compact defibrillator crate"
 	crate_type = /obj/structure/closet/crate/medical

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -77,7 +77,7 @@
 
 /datum/supply_pack/medical/compact_defib
 	name = "Compact Defibrillator Crate"
-	desc = "Contains a compact defibrillator for bringing the recently deceased back to life."
+	desc = "Contains a compact defibrillator, small enough to attach to your waist, for bringing the recently deceased back to life."
 	cost = CARGO_CRATE_VALUE * 12
 	contains = list(/obj/item/defibrillator/compact/loaded = 1)
 	crate_name = "compact defibrillator crate"

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -75,6 +75,14 @@
 	crate_name = "defibrillator crate"
 	crate_type = /obj/structure/closet/crate/medical
 
+/datum/supply_pack/medical/compact_defib
+	name = "Compact Defibrillator Crate"
+	desc = "Contains a compact defibrillator for bringing the recently deceased back to life."
+	cost = CARGO_CRATE_VALUE * 12
+	contains = list(/obj/item/defibrillator/compact/loaded = 1)
+	crate_name = "compact defibrillator crate"
+	crate_type = /obj/structure/closet/crate/medical
+
 /datum/supply_pack/medical/iv_drip
 	name = "IV Drip Crate"
 	desc = "Contains a single IV drip for administering blood to patients."

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1387,9 +1387,9 @@
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/defib
 	materials = list(
-		/datum/material/iron =SHEET_MATERIAL_AMOUNT*4,
-		/datum/material/glass =SHEET_MATERIAL_AMOUNT * 2.5,
-		/datum/material/silver =SHEET_MATERIAL_AMOUNT*2,
+		/datum/material/iron =SHEET_MATERIAL_AMOUNT * 4,
+		/datum/material/glass =SHEET_MATERIAL_AMOUNT * 2,
+		/datum/material/silver =SHEET_MATERIAL_AMOUNT* 1.5,
 		/datum/material/gold =SHEET_MATERIAL_AMOUNT * 1.5,
 	)
 	construction_time = 8 SECONDS

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -202,6 +202,18 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
+/datum/design/defibrillator
+	name = "Defibrillator"
+	desc = "A portable defibrillator, used for resuscitating recently deceased crew."
+	id = "defibrillator"
+	build_type = PROTOLATHE | AWAY_LATHE
+	build_path = /obj/item/defibrillator
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*4, /datum/material/glass = SHEET_MATERIAL_AMOUNT*2, /datum/material/silver =SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/gold =HALF_SHEET_MATERIAL_AMOUNT * 1.5)
+	category = list(
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
 /datum/design/defibrillator_mount
 	name = "Defibrillator Wall Mount"
 	desc = "A mounted frame for holding defibrillators, providing easy security."

--- a/code/modules/research/techweb/nodes/medbay_nodes.dm
+++ b/code/modules/research/techweb/nodes/medbay_nodes.dm
@@ -13,6 +13,7 @@
 		"chem_pack",
 		"circular_saw",
 		"defibmountdefault",
+		"defibrillator",
 		"dropper",
 		"hemostat",
 		"jerrycan",


### PR DESCRIPTION
## About The Pull Request

Somewhat of a soft revert of #94182

Adds Defibs back to the tech tree and thus back as a printable in medical's lathe.
Keeps compact defibs out of the tech tree and instead puts them behind Cargo as a high-cost item.
Rebalances the cyborg defib upgrade to match the cost of a regular defib.

## Why It's Good For The Game

I think it's healthy and fun to have multiple ways of obtaining items, especially something as important as the defibrillator.

The original PR mentions that defibs were removed from the tech lathe before... ~~But as far as I can tell defibs were always in the tech tree and never removed. Defib crates were added in 2016 and I found a PR that lists the defib research design all the way back in 2014 (when it was destructive research). The original PR that adds the defib crates wasn't meant to replace them from the lathe, and~~ there has never been any PR that lists defibs as being removed for any reason whatsoever.

Small edit: I misread destructive analyzer code. Defibs were not printable until #35454

The original PR also mentions #48805 vaguely. I do agree that it's a weird issue but the printing behavior of defibrillators has very little to do with the cyborg upgrade. Regardless, I thought it was a little silly that the cyborg module was more expensive than a regular defib, so I lowered the cost of it to mirror the defib's.

With that said, I love Cargo and I love giving Cargo things to do. If the goal of the original PR was to give cargo more to do I think the better option would have been to add Compact Defibs as a purchase option. They're a pretty cool side-upgrade to the regular defib and in reality they're not *that* powerful (unless you emag them lol). The original PR also adds the compact defib as a steal objective so that traitors can purchase it from the black market but my reasoning is the same: Having multiple ways to obtain items is fun and healthy for the game.

## Changelog

:cl:
balance: added defibs back to the tech tree/medical lathe
balance: added compact defibs to cargo as a purchasable item
balance: lowered the cost of the cyborg defib upgrade to match the cost of a regular defib
/:cl:
closes #95141 