### PR TITLE
Reverts "EMP no longer turns off defib safeties 74018"

### DIFF
--- a/code/game/objects/items/tools/medical/defib.dm
+++ b/code/game/objects/items/tools/medical/defib.dm
@@ -181,15 +181,15 @@
 
 	if(combat) // Elite agents do not subscribe to your notion of "Safety"
 		visible_message(span_notice("[src] beeps: Safety protocols nonexistent!"))
-		playsound(src, 'sound/machines/defib_saftyOff.ogg', 50, FALSE)
+		playsound(src, 'sound/machines/defib/defib_saftyOff.ogg', 50, FALSE)
 	else if(safety)
 		safety = FALSE
 		visible_message(span_notice("[src] beeps: Safety protocols disabled!"))
-		playsound(src, 'sound/machines/defib_saftyOff.ogg', 50, FALSE)
+		playsound(src, 'sound/machines/defib/defib_saftyOff.ogg', 50, FALSE)
 	else
 		safety = TRUE
 		visible_message(span_notice("[src] beeps: Safety protocols enabled!"))
-		playsound(src, 'sound/machines/defib_saftyOn.ogg', 50, FALSE)
+		playsound(src, 'sound/machines/defib/defib_SaftyOn.ogg', 50, FALSE)
 	update_power()
 
 /obj/item/defibrillator/proc/toggle_paddles()

--- a/code/game/objects/items/tools/medical/defib.dm
+++ b/code/game/objects/items/tools/medical/defib.dm
@@ -179,6 +179,17 @@
 	if (. & EMP_PROTECT_SELF)
 		return
 
+	if(combat) // Elite agents do not subscribe to your notion of "Safety"
+		visible_message(span_notice("[src] beeps: Safety protocols nonexistent!"))
+		playsound(src, 'sound/machines/defib_saftyOff.ogg', 50, FALSE)
+	else if(safety)
+		safety = FALSE
+		visible_message(span_notice("[src] beeps: Safety protocols disabled!"))
+		playsound(src, 'sound/machines/defib_saftyOff.ogg', 50, FALSE)
+	else
+		safety = TRUE
+		visible_message(span_notice("[src] beeps: Safety protocols enabled!"))
+		playsound(src, 'sound/machines/defib_saftyOn.ogg', 50, FALSE)
 	update_power()
 
 /obj/item/defibrillator/proc/toggle_paddles()


### PR DESCRIPTION
## About The Pull Request
Reverts the PR #74018 that made it so you couldn't emp to disable defib safeties anymore
And an alternative to #95138 if it doesn't get merged

closes #95138 
## Why It's Good For The Game
Now that defibs are more scarce i think its fair to allow them to be emped again to disable their safeties.
Compact Defib is limited to CMO (with edge cases of very rare sources of it)
and bulky defibs which you have to wear in your back to even use properly which kills your backpack slot for a stunbaton like weapon

## Changelog

:cl: Ezel
balance: You can now disable defib safeties with emps again
/:cl:
