### PR TITLE
singletank bombs are normal size again

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -460,10 +460,6 @@
 	if(LAZYLEN(assembly.assemblies) == igniter_count)
 		return
 
-	if(isitem(loc)) // we are in a storage item
-		balloon_alert(user, "can't reach!")
-		return
-
 	if((src in user.get_equipped_items(INCLUDE_POCKETS | INCLUDE_ACCESSORIES)) && !user.canUnEquip(src))
 		balloon_alert(user, "it's stuck!")
 		return
@@ -479,7 +475,7 @@
 	tank_assembly = assembly //Tell the tank about its assembly part
 	assembly.master = src //Tell the assembly about its new owner
 	assembly.on_attach()
-	update_weight_class(WEIGHT_CLASS_BULKY)
+	
 
 	balloon_alert(user, "bomb assembled")
 	update_appearance(UPDATE_OVERLAYS)
@@ -493,7 +489,6 @@
 	user.put_in_hands(tank_assembly)
 	tank_assembly.master = null
 	tank_assembly = null
-	update_weight_class(initial(w_class))
 	update_appearance(UPDATE_OVERLAYS)
 
 /// Ignites the contents of the tank. Called when receiving a signal if the tank is welded and has an igniter attached.

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -475,7 +475,7 @@
 	tank_assembly = assembly //Tell the tank about its assembly part
 	assembly.master = src //Tell the assembly about its new owner
 	assembly.on_attach()
-	
+
 
 	balloon_alert(user, "bomb assembled")
 	update_appearance(UPDATE_OVERLAYS)


### PR DESCRIPTION

## About The Pull Request
You are able to put single tanks in backpack storage again.
## Why It's Good For The Game
TG has undergone a cascade of removal of danger due to the occasional player using a tactic into the ground. i think that more danger being present on the station increases the atmosphere and can create more stories. i miss mass series single tank bombings and well placed precision strikes.
## Changelog
:cl:
balance: single tanks are normal size again
/:cl:
