### PR TITLE
Adds pigs and goats to cytology

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -56,6 +56,7 @@
 #define CELL_LINE_TABLE_BUTTERFLY "cell_line_butterfly_table"
 #define CELL_LINE_TABLE_MEGA_ARACHNID "cell_line_table_mega_arachnid"
 #define CELL_LINE_TABLE_GOAT "cell_line_table_goat"
+#define CELL_LINE_TABLE_PIG "cell_line_table_pig"
 
 //! Biopsy cell line organ types
 #define CELL_LINE_ORGAN_HEART "cell_line_organ_heart"

--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -55,6 +55,7 @@
 #define CELL_LINE_TABLE_QUEEN_BEE "cell_line_bee_queen_table"
 #define CELL_LINE_TABLE_BUTTERFLY "cell_line_butterfly_table"
 #define CELL_LINE_TABLE_MEGA_ARACHNID "cell_line_table_mega_arachnid"
+#define CELL_LINE_TABLE_GOAT "cell_line_table_goat"
 
 //! Biopsy cell line organ types
 #define CELL_LINE_ORGAN_HEART "cell_line_organ_heart"

--- a/code/_globalvars/lists/xenobiology.dm
+++ b/code/_globalvars/lists/xenobiology.dm
@@ -38,6 +38,7 @@ GLOBAL_LIST_INIT_TYPED(cell_line_tables, /list, list(
 		/datum/micro_organism/cell_line/mouse = 2,
 		/datum/micro_organism/cell_line/slime = 1,
 		/datum/micro_organism/cell_line/vat_beast = 2,
+		/datum/micro_organism/cell_line/pig = 1,
 	),
 
 	CELL_LINE_TABLE_BEAR = list(/datum/micro_organism/cell_line/bear = 1),
@@ -79,6 +80,7 @@ GLOBAL_LIST_INIT_TYPED(cell_line_tables, /list, list(
 	CELL_LINE_TABLE_BUTTERFLY = list(/datum/micro_organism/cell_line/butterfly = 1),
 	CELL_LINE_TABLE_MEGA_ARACHNID = list(/datum/micro_organism/cell_line/mega_arachnid = 1),
 	CELL_LINE_TABLE_GOAT = list(/datum/micro_organism/cell_line/goat = 1),
+	CELL_LINE_TABLE_PIG = list(/datum/micro_organism/cell_line/pig = 1),
 	CELL_LINE_TABLE_ALGAE = list(
 		/datum/micro_organism/cell_line/frog = 2,
 		/datum/micro_organism/cell_line/mega_arachnid = 1,

--- a/code/_globalvars/lists/xenobiology.dm
+++ b/code/_globalvars/lists/xenobiology.dm
@@ -10,6 +10,7 @@ GLOBAL_LIST_INIT_TYPED(cell_line_tables, /list, list(
 		/datum/micro_organism/cell_line/mouse = 1,
 		/datum/micro_organism/cell_line/sholean_grapes = 2,
 		/datum/micro_organism/cell_line/slime = 2,
+		/datum/micro_organism/cell_line/goat = 1,
 	),
 
 	CELL_LINE_TABLE_MOIST = list(
@@ -77,6 +78,7 @@ GLOBAL_LIST_INIT_TYPED(cell_line_tables, /list, list(
 	CELL_LINE_TABLE_QUEEN_BEE = list(/datum/micro_organism/cell_line/queen_bee = 1),
 	CELL_LINE_TABLE_BUTTERFLY = list(/datum/micro_organism/cell_line/butterfly = 1),
 	CELL_LINE_TABLE_MEGA_ARACHNID = list(/datum/micro_organism/cell_line/mega_arachnid = 1),
+	CELL_LINE_TABLE_GOAT = list(/datum/micro_organism/cell_line/goat = 1),
 	CELL_LINE_TABLE_ALGAE = list(
 		/datum/micro_organism/cell_line/frog = 2,
 		/datum/micro_organism/cell_line/mega_arachnid = 1,

--- a/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
+++ b/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
@@ -51,6 +51,7 @@
 	AddElement(/datum/element/cliff_walking) //we walk the cliff
 	AddElement(/datum/element/footstep, footstep_type = FOOTSTEP_MOB_SHOE)
 	AddElement(/datum/element/ai_retaliate)
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_GOAT, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
 
 	RegisterSignal(src, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, PROC_REF(on_pre_attack))
 	RegisterSignal(src, COMSIG_ATOM_WAS_ATTACKED, PROC_REF(on_attacked))

--- a/code/modules/mob/living/basic/farm_animals/pig.dm
+++ b/code/modules/mob/living/basic/farm_animals/pig.dm
@@ -44,6 +44,7 @@
 	AddElement(/datum/element/pet_bonus, "oink")
 	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/ai_flee_while_injured)
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_PIG, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
 	make_tameable()
 
 ///wrapper for the tameable component addition so you can have non tamable cow subtypes

--- a/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
@@ -112,6 +112,27 @@
 	virus_suspectibility = 1
 	resulting_atom = /mob/living/basic/goat
 
+/datum/micro_organism/cell_line/pig
+	desc = "Porcine stem cells"
+	required_reagents = list(
+	/datum/reagent/consumable/nutriment/protein
+	)
+
+	supplementary_reagents = list(
+	/datum/reagent/growthserum = 4,
+	/datum/reagent/consumable/nutriment/vitamin = 2,
+	/datum/reagent/consumable/bbqsauce = 4
+	)
+
+	suppressive_reagents = list(
+	/datum/reagent/toxin = -2,
+	/datum/reagent/toxin/carpotoxin = -2,
+	/datum/reagent/acetone = -1
+	)
+
+	virus_suspectibility = 1
+	resulting_atom = /mob/living/basic/pig
+
 /datum/micro_organism/cell_line/cat
 	desc = "Feliform cells"
 	required_reagents = list(

--- a/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
@@ -90,6 +90,28 @@
 	virus_suspectibility = 1
 	resulting_atom = /mob/living/basic/cow/moonicorn
 
+/datum/micro_organism/cell_line/goat
+	desc = "Caprine cells"
+	required_reagents = list(
+	/datum/reagent/consumable/nutriment/protein,
+	/datum/reagent/cellulose
+	)
+
+	supplementary_reagents = list(
+	/datum/reagent/growthserum = 4,
+	/datum/reagent/consumable/nutriment/vitamin = 2,
+	/datum/reagent/barbers_aid = 3
+	)
+
+	suppressive_reagents = list(
+	/datum/reagent/toxin = -2,
+	/datum/reagent/baldium = -2,
+	/datum/reagent/consumable/sugar = -1
+	)
+
+	virus_suspectibility = 1
+	resulting_atom = /mob/living/basic/goat
+
 /datum/micro_organism/cell_line/cat
 	desc = "Feliform cells"
 	required_reagents = list(


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tag. Lets you vat-grow goats with a sample of their cells and a couple reagents.
These cells can be found in both living goats and maintenance sludge, similar to cows and chickens.

## Why It's Good For The Game

Goats are a common animal and there's no real reason not to have them be grown by cytology.
Additionally, #95022 gave me the idea of fighting kudzu with an endless army of goats and I was pretty disappointed to find out you couldn't do it.

## Changelog

:cl:
add: Pigs and goats can now be grown in a cytology vat
/:cl:

