### PR TITLE
Breathing tube no longer bypasses nonfunctional lungs

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -80,8 +80,10 @@
 
 	var/datum/gas_mixture/breath
 
-	if(!get_organ_slot(ORGAN_SLOT_BREATHING_TUBE))
-		if(health <= HEALTH_THRESHOLD_FULLCRIT || (pulledby?.grab_state >= GRAB_KILL) || (lungs?.organ_flags & ORGAN_FAILING))
+	if(lungs?.organ_flags & ORGAN_FAILING)
+		losebreath++
+	else if(!get_organ_slot(ORGAN_SLOT_BREATHING_TUBE))
+		if(health <= HEALTH_THRESHOLD_FULLCRIT || pulledby?.grab_state >= GRAB_KILL)
 			losebreath++  //You can't breath at all when in critical or when being choked, so you're going to miss a breath
 
 		else if(health <= crit_threshold)


### PR DESCRIPTION

## About The Pull Request

Closes #95091

## Why It's Good For The Game

It makes sense for the tube to stop suffocation from a closing throat/being choked to death, but if your lungs can't absorb that oxygen being cybernetically intubated won't help.

## Changelog
:cl:
fix: Breathing tube no longer bypasses nonfunctional lungs
/:cl:
