### PR TITLE
Disassemble finished and unfinished Golem shells with a crowbar (Not Golem species)

### DIFF
--- a/code/modules/mapfluff/ruins/lavaland_ruin_code.dm
+++ b/code/modules/mapfluff/ruins/lavaland_ruin_code.dm
@@ -48,7 +48,7 @@
 		playsound(src,'sound/items/tools/crowbar.ogg', 70)
 		if(!do_after(user, delay = 1 SECONDS, target = src))
 			return
-		if(!src)
+		if(QDELETED(src))
 			return
 		new /obj/item/stack/sheet/mineral/adamantine(get_turf(src), 1) //Return less than was used to construct the shell
 		to_chat(user, span_notice("The shell collapses in on itself!"))

--- a/code/modules/mapfluff/ruins/lavaland_ruin_code.dm
+++ b/code/modules/mapfluff/ruins/lavaland_ruin_code.dm
@@ -43,6 +43,17 @@
 
 /obj/item/golem_shell/attackby(obj/item/potential_food, mob/user, list/modifiers, list/attack_modifiers)
 	. = ..()
+	if(istype(potential_food, /obj/item/crowbar)) //Dissasemble the shell, crowbar_act is overriden by attackby.
+		to_chat(user, span_notice("You begin dislodging structurally integral chunks."))
+		playsound(src,'sound/items/tools/crowbar.ogg', 70)
+		if(!do_after(user, delay = 1 SECONDS, target = src))
+			return
+		if(!src)
+			return
+		new /obj/item/stack/sheet/mineral/adamantine(get_turf(src), 1) //Return less than was used to construct the shell
+		to_chat(user, span_notice("The shell collapses in on itself!"))
+		playsound(src, 'sound/effects/rock/rock_break.ogg', 40)
+		qdel(src)
 	if(!isstack(potential_food))
 		balloon_alert(user, "not a mineral!")
 		return

--- a/code/modules/mapfluff/ruins/lavaland_ruin_code.dm
+++ b/code/modules/mapfluff/ruins/lavaland_ruin_code.dm
@@ -43,17 +43,6 @@
 
 /obj/item/golem_shell/attackby(obj/item/potential_food, mob/user, list/modifiers, list/attack_modifiers)
 	. = ..()
-	if(istype(potential_food, /obj/item/crowbar)) //Dissasemble the shell, crowbar_act is overriden by attackby.
-		to_chat(user, span_notice("You begin dislodging structurally integral chunks."))
-		playsound(src,'sound/items/tools/crowbar.ogg', 70)
-		if(!do_after(user, delay = 1 SECONDS, target = src))
-			return
-		if(!src)
-			return
-		new /obj/item/stack/sheet/mineral/adamantine(get_turf(src), 1) //Return less than was used to construct the shell
-		to_chat(user, span_notice("The shell collapses in on itself!"))
-		playsound(src, 'sound/effects/rock/rock_break.ogg', 40)
-		qdel(src)
 	if(!isstack(potential_food))
 		balloon_alert(user, "not a mineral!")
 		return
@@ -72,6 +61,21 @@
 		return
 	new shell_type(get_turf(src), /* creator = */ user, /* made_of = */ stack_type)
 	qdel(src)
+
+/obj/item/golem_shell/crowbar_act(mob/living/user, obj/item/tool)
+	. = ..()
+
+	to_chat(user, span_notice("You begin dislodging structurally integral chunks."))
+	playsound(src, 'sound/items/tools/crowbar.ogg',  70)
+	if(!do_after(user, delay = 1 SECONDS, target = src))
+		return
+	if(QDELETED(src))
+		return
+	new /obj/item/stack/sheet/mineral/adamantine(get_turf(src), 1) //Return less than was used to construct the shell
+	to_chat(user, span_notice("The shell collapses in on itself!"))
+	playsound(src, 'sound/effects/rock/rock_break.ogg', 40)
+	qdel(src)
+	return
 
 ///made with xenobiology, the golem obeys its creator
 /obj/item/golem_shell/servant

--- a/code/modules/mob_spawn/ghost_roles/golem_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/golem_roles.dm
@@ -22,14 +22,6 @@
 	var/list/obj/item/stack/drop_on_deconstruct
 	//Time it takes to deconstruct a completed shell.	 Note : You can dissssemble multiple at once
 	var/deconstruct_time = 4 SECONDS
-	//Message to player when beginning deconstruction
-	var/start_deconstruct_text = "You begin prying load-bearing chunks from the completed shell."
-	//Message to player when sucessfully deconstructing the Shell
-	var/successful_deconstruct_text = "The Golem crumbles in on itself!"
-	//Sound to play when attempting Deconstruction
-	var/tool_deconstruct_sound = 'sound/items/tools/crowbar.ogg'
-	//Sound to play on successful deconstruction
-	var/deconstruct_success_sound = 'sound/effects/rock/rock_break.ogg'
 
 
 /obj/effect/mob_spawn/ghost_role/human/golem/Initialize(mapload, mob/living/creator, made_of)
@@ -125,13 +117,12 @@
 /obj/effect/mob_spawn/ghost_role/human/golem/crowbar_act(mob/living/user, obj/item/tool)
 
 	if(DOING_INTERACTION_WITH_TARGET(user, src))
-		return
+		return ITEM_INTERACT_SUCCESS
 
-	var/mob/living/typecast_user = user
-	if(typecast_user.combat_mode)
+	if(user.combat_mode)
 		return
-	to_chat(user, span_notice(start_deconstruct_text))
-	playsound(user, tool_deconstruct_sound, 70)
+	to_chat(user, span_notice("You begin prying load-bearing chunks from the completed shell."))
+	playsound(user, 'sound/items/tools/crowbar.ogg', 70)
 
 	if(do_after(user, delay = deconstruct_time, target = src))
 		new /obj/item/stack/sheet/mineral/adamantine(get_turf(src))
@@ -140,8 +131,8 @@
 		else
 			new /obj/item/stack/sheet/iron/five(get_turf(src))
 
-		to_chat(user, span_notice(successful_deconstruct_text))
-		playsound(src, deconstruct_success_sound, 60)
+		to_chat(user, span_notice("The Golem crumbles in on itself!"))
+		playsound(src, 'sound/effects/rock/rock_break.ogg', 60)
 		qdel(src)
 
-	return
+	return ITEM_INTERACT_SUCCESS

--- a/code/modules/mob_spawn/ghost_roles/golem_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/golem_roles.dm
@@ -145,28 +145,3 @@
 		qdel(src)
 
 	return
-
-/*
-/obj/effect/mob_spawn/ghost_role/human/golem/proc/on_attackby(datum/source, obj/item/used_item, mob/user)
-
-	if(DOING_INTERACTION_WITH_TARGET(user, src))
-		return COMPONENT_CANCEL_ATTACK_CHAIN
-	if(istype(used_item, deconstruct_tool))
-		var/mob/living/typecast_user = user
-		if(typecast_user.combat_mode)
-			return NONE
-	to_chat(user, span_notice(start_deconstruct_text))
-	playsound(user, tool_deconstruct_sound, 70)
-
-	if(do_after(user, delay = deconstruct_time, target = src))
-		new /obj/item/stack/sheet/mineral/adamantine(get_turf(src))
-		if(initial_type)
-			new initial_type(get_turf(src), 5)
-		else
-			new /obj/item/stack/sheet/iron/five(get_turf(src))
-
-		to_chat(user, span_notice(successful_deconstruct_text))
-		playsound(src, deconstruct_success_sound, 60)
-		qdel(src)
-
-	return COMPONENT_CANCEL_ATTACK_CHAIN*/

--- a/code/modules/mob_spawn/ghost_roles/golem_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/golem_roles.dm
@@ -20,11 +20,15 @@
 
 	//Deconstruction var's
 	var/list/obj/item/stack/drop_on_deconstruct
+	//Time it takes to deconstruct a completed shell.	 Note : You can dissssemble multiple at once
 	var/deconstruct_time = 4 SECONDS
+	//Message to player when beginning deconstruction
 	var/start_deconstruct_text = "You begin prying load-bearing chunks from the completed shell."
+	//Message to player when sucessfully deconstructing the Shell
 	var/successful_deconstruct_text = "The Golem crumbles in on itself!"
-	var/obj/item/deconstruct_tool = /obj/item/crowbar
+	//Sound to play when attempting Deconstruction
 	var/tool_deconstruct_sound = 'sound/items/tools/crowbar.ogg'
+	//Sound to play on successful deconstruction
 	var/deconstruct_success_sound = 'sound/effects/rock/rock_break.ogg'
 
 
@@ -41,13 +45,6 @@
 			ignore_key = POLL_IGNORE_GOLEM,
 			notify_flags = NOTIFY_CATEGORY_NOFLASH,
 		)
-
-		RegisterSignal(src, COMSIG_ATOM_ATTACKBY, PROC_REF(on_attackby))
-
-/obj/effect/mob_spawn/ghost_role/human/golem/Destroy()
-	. = ..()
-
-		UnregisterSignal(src, COMSIG_ATOM_ATTACKBY)
 
 /obj/effect/mob_spawn/ghost_role/human/golem/special(mob/living/new_spawn, mob/mob_possessor, apply_prefs)
 	. = ..()
@@ -124,6 +121,32 @@
 		forced_name =  "Golem ([rand(1,999)])"
 	return ..()
 
+
+/obj/effect/mob_spawn/ghost_role/human/golem/crowbar_act(mob/living/user, obj/item/tool)
+
+	if(DOING_INTERACTION_WITH_TARGET(user, src))
+		return
+
+	var/mob/living/typecast_user = user
+	if(typecast_user.combat_mode)
+		return
+	to_chat(user, span_notice(start_deconstruct_text))
+	playsound(user, tool_deconstruct_sound, 70)
+
+	if(do_after(user, delay = deconstruct_time, target = src))
+		new /obj/item/stack/sheet/mineral/adamantine(get_turf(src))
+		if(initial_type)
+			new initial_type(get_turf(src), 5)
+		else
+			new /obj/item/stack/sheet/iron/five(get_turf(src))
+
+		to_chat(user, span_notice(successful_deconstruct_text))
+		playsound(src, deconstruct_success_sound, 60)
+		qdel(src)
+
+	return
+
+/*
 /obj/effect/mob_spawn/ghost_role/human/golem/proc/on_attackby(datum/source, obj/item/used_item, mob/user)
 
 	if(DOING_INTERACTION_WITH_TARGET(user, src))
@@ -146,4 +169,4 @@
 		playsound(src, deconstruct_success_sound, 60)
 		qdel(src)
 
-	return COMPONENT_CANCEL_ATTACK_CHAIN
+	return COMPONENT_CANCEL_ATTACK_CHAIN*/


### PR DESCRIPTION

## About The Pull Request

Lets players disassemble unfinished Golem shells in `lavaland_ruin_code` and finished Golem shells in `golem_roles` by using a crowbar on them. Both dropping a single adamantine on successful deconstruction, with the finished shell dropping half of whatever was originally used to create it.

## Why It's Good For The Game

If a Xenobiologist is able to set up a golem factory. (Chemistry IV drip into industrial adamantine + 1u plasma dropper on metal extract) players have no way to counter this as non living Golems are immune to damage.
This gives players counterplay, letting them disassemble Golem shells if they can reach the factory, and scare off the creator.

## Changelog

:cl: DaddyChristmas
balance: Golem shells can now be deconstructed with a crowbar (Not Golem the species!)
/:cl:
