### PR TITLE
Fixes a few feedback messages with vendor insertion failures

### DIFF
--- a/code/modules/vending/vendor/interaction.dm
+++ b/code/modules/vending/vendor/interaction.dm
@@ -86,7 +86,7 @@
 			continue
 
 		if(product_datum.amount == product_datum.max_amount)
-			to_chat(user, span_warning("[src] can't accept any more [inserted_item][inserted_item.p_s()]!"))
+			to_chat(user, span_warning("[src] can't accept any more [inserted_item.name][inserted_item.p_s()]!"))
 			return FALSE
 
 		if(!user.transferItemToLoc(inserted_item, src))

--- a/code/modules/vending/vendor/interaction.dm
+++ b/code/modules/vending/vendor/interaction.dm
@@ -86,7 +86,8 @@
 	for(var/datum/data/vending_product/product_datum in product_records + coin_records + hidden_records)
 		if(inserted_item.type == product_datum.product_path)
 			if(product_datum.amount == product_datum.max_amount)
-				to_chat(user, span_warning("no space for any more [product_datum.category || "Products"]!"))
+				var/category_name_string = product_datum.category ? "[product_datum.category["name"]] " : ""
+				to_chat(user, span_warning("No space for any more [category_name_string]products!"))
 				return FALSE
 
 			if(!user.transferItemToLoc(inserted_item, src))

--- a/code/modules/vending/vendor/interaction.dm
+++ b/code/modules/vending/vendor/interaction.dm
@@ -79,24 +79,24 @@
 
 	. = TRUE
 	if(!canLoadItem(inserted_item, user))
-		to_chat(user, span_warning("[src] does not accept [inserted_item]!"))
 		return FALSE
 
-	to_chat(user, span_notice("You insert [inserted_item] into [src]'s input compartment."))
 	for(var/datum/data/vending_product/product_datum in product_records + coin_records + hidden_records)
-		if(inserted_item.type == product_datum.product_path)
-			if(product_datum.amount == product_datum.max_amount)
-				var/category_name_string = product_datum.category ? "[product_datum.category["name"]] " : ""
-				to_chat(user, span_warning("No space for any more [category_name_string]products!"))
-				return FALSE
+		if(inserted_item.type != product_datum.product_path)
+			continue
 
-			if(!user.transferItemToLoc(inserted_item, src))
-				to_chat(user, span_warning("[inserted_item] is stuck in your hand!"))
-				return FALSE
+		if(product_datum.amount == product_datum.max_amount)
+			to_chat(user, span_warning("[src] can't accept any more [inserted_item][inserted_item.p_s()]!"))
+			return FALSE
 
-			product_datum.amount++
-			LAZYADD(product_datum.returned_products, inserted_item)
-			break
+		if(!user.transferItemToLoc(inserted_item, src))
+			to_chat(user, span_warning("[inserted_item] is stuck in your hand!"))
+			return FALSE
+
+		product_datum.amount++
+		LAZYADD(product_datum.returned_products, inserted_item)
+		to_chat(user, span_notice("You insert [inserted_item] into [src]'s input compartment."))
+		break
 
 /obj/machinery/vending/item_interaction(mob/living/user, obj/item/attack_item, list/modifiers)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

<img width="196" height="24" alt="image" src="https://github.com/user-attachments/assets/bcfbdd1b-7ebe-4ea7-815a-526b3316396e" />

Fixes a few odd bits regarding vendor feedback, mostly clear from the diff and changelog.

Bits of note:
- `canLoadItem(...)` defaults to sending a message, to the `to_chat(...)` after was just duplicating it.
- It was trying to warn about it not being able to accept any more products for a given category, but looking at the check before it it's checking not against the category but against the individual product record. Here we make it actually mention it's an issue with that item.
## Why It's Good For The Game

Fixes jank.
## Changelog
:cl:
fix: Trying to insert an item into a vendor that has reached its maximum capacity for that item no longer says "no space for any more /list", and no longer TRIES to say it has too much of that category. It now correctly says it can't accept any more of that item.
fix: Trying to insert an item into a vendor that can hold it but you can't put it in no longer both says you insert the item into its input compartment while also sending an error message about not being able to put it in.
fix: Trying to insert an item into a vendor that can't hold it no longer sends the error message twice.
/:cl:
