### PR TITLE
Moth and felinid mutation toxins can be part of random recipes.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -703,7 +703,7 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/human/felinid
 	taste_description = "something nyat good"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/mutationtoxin/lizard
 	name = "Lizard Mutation Toxin"
@@ -727,7 +727,7 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/moth
 	taste_description = "clothing"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/mutationtoxin/pod
 	name = "Podperson Mutation Toxin"


### PR DESCRIPTION
## About The Pull Request

A small nitpick I noticed when looking through mutation toxin code. Moth and felinid mutation toxins, at some point, were made reactable in green extracts using cellulose and milk, respectively, so there's less justification for them not appearing in random recipes.

## Why It's Good For The Game

For consistency's sake, mutation toxins that can be made from green extracts should be allowed to be part of random recipes.

## Changelog

:cl:
qol: Moth Mutation Toxin and Felinid Mutation Toxin may be required for randomized recipes. Remember, they are each obtained using cellulose and milk in a green slime extract, respectively.
/:cl:
