### PR TITLE
Adds ethereal mutation toxin

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -729,6 +729,14 @@
 	taste_description = "clothing"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
+/datum/reagent/mutationtoxin/ethereal
+	name = "Ethereal Mutation Toxin"
+	description = "An electrifying toxin."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/ethereal
+	taste_description = "static"
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+
 /datum/reagent/mutationtoxin/pod
 	name = "Podperson Mutation Toxin"
 	description = "A vegetalizing toxin."

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -75,6 +75,11 @@
 	required_reagents = list(/datum/reagent/cellulose = 1)
 	required_container = /obj/item/slime_extract/green
 
+/datum/chemical_reaction/slime/slimeethereal
+	results = list(/datum/reagent/mutationtoxin/ethereal = 1)
+	required_reagents = list(/datum/reagent/consumable/liquidelectricity/enriched = 1)
+	required_container = /obj/item/slime_extract/green
+
 //Metal
 /datum/chemical_reaction/slime/slimemetal
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)


### PR DESCRIPTION
## About The Pull Request

Exactly what the title says. It is created using enriched liquid electricity in a green extract.

## Why It's Good For The Game

There are situations where an ethereal may need their brain put in a new, non-ethereal body. It should at least be theoretically within the crew's means to restore such unfortunate individuals to their original state through a combination of sandbox elements such as genetics and xenobiology.

## Changelog

:cl:
add: Adds ethereal mutation toxin, created by injecting enriched liquid electricity into a green slime extract.
/:cl:
