### PR TITLE
Minor refactors on some health and harm procs

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -820,7 +820,7 @@
 		uses -= round(blood_needed / USES_TO_BLOOD)
 		to_chat(user,span_warning("Your blood rites have restored [human_bloodbag == user ? "your" : "[human_bloodbag.p_their()]"] blood to safe levels!"))
 
-	var/overall_damage = human_bloodbag.get_brute_loss() + human_bloodbag.get_fire_loss() + human_bloodbag.get_tox_loss() + human_bloodbag.get_oxy_loss()
+	var/overall_damage = human_bloodbag.get_total_damage()
 	if(overall_damage == 0)
 		if(blood_donor)
 			return TRUE

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -101,7 +101,7 @@
 /// The actual proc that will apply the damage to the suiciding mob. damage_type is the actual type of damage we want to deal, if that matters.
 /// Return TRUE if we actually apply any real damage, FALSE otherwise.
 /mob/living/proc/apply_suicide_damage(obj/item/suicide_tool, damage_type = NONE)
-	adjust_oxy_loss(max(maxHealth * 2 - get_tox_loss() - get_fire_loss() - get_brute_loss() - get_oxy_loss(), 0))
+	adjust_oxy_loss(max(maxHealth * 2 - get_total_damage(), 0))
 	return TRUE
 
 /// If we want to apply multiple types of damage to a carbon mob based on the way they suicide, this is the proc that handles that.

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -95,12 +95,10 @@
 	return round(amount, DAMAGE_PRECISION)
 
 // Micro op so we only search limbs once.
-/mob/living/carbon/proc/get_brute_and_fire_loss()
+/mob/living/carbon/proc/get_all_body_damage()
 	var/amount = 0
 	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
-		// We could use get_damage() here but we are assuming you only want these two.
-		amount += bodypart.brute_dam
-		amount += bodypart.burn_dam
+		amount += bodypart.get_damage()
 	return round(amount, DAMAGE_PRECISION)
 
 /**

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -94,6 +94,14 @@
 		amount += bodypart.burn_dam
 	return round(amount, DAMAGE_PRECISION)
 
+// Micro op so we only search limbs once.
+/mob/living/carbon/proc/get_brute_and_fire_loss()
+	var/amount = 0
+	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
+		// We could use get_damage() here but we are assuming you only want these two.
+		amount += bodypart.brute_dam
+		amount += bodypart.burn_dam
+	return round(amount, DAMAGE_PRECISION)
 
 /**
  * Returns the amount of bruteloss across all bodyparts meeting the matching bodytype.

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -779,9 +779,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/atk_effect = attacking_bodypart.unarmed_attack_effect
 
 	if(atk_effect == ATTACK_EFFECT_BITE)
-		if(!user.is_mouth_covered(ITEM_SLOT_MASK))
-			EMPTY_BLOCK_GUARD
-		else if(user.get_active_hand()) //In the event we can't bite, emergency swap to see if we can attack with a hand.
+		if(user.is_mouth_covered(ITEM_SLOT_MASK) && user.get_active_hand())
 			attacking_bodypart = user.get_active_hand()
 			atk_verb_index = rand(1, length(attacking_bodypart.unarmed_attack_verbs))
 			atk_verb = attacking_bodypart.unarmed_attack_verbs[atk_verb_index]
@@ -789,7 +787,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			if (length(attacking_bodypart.unarmed_attack_verbs_continuous) >= atk_verb_index) // Just in case
 				atk_verb_continuous = attacking_bodypart.unarmed_attack_verbs_continuous[atk_verb_index]
 			atk_effect = attacking_bodypart.unarmed_attack_effect
-		else  //Nothing? Okay. Fail.
+		else //Nothing? Okay. Fail.
 			user.balloon_alert(user, "can't attack!")
 			return FALSE
 
@@ -827,10 +825,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		limb_accuracy = floor(limb_accuracy * pummel_bonus)
 
 	//Get our puncher's combined brute and burn damage.
-	var/puncher_brute_and_burn = user.get_brute_and_fire_loss()
+	var/puncher_brute_and_burn = user.get_all_body_damage()
 
 	//Get our targets combined brute and burn damage.
-	var/target_brute_and_burn = target.get_brute_and_fire_loss()
+	var/target_brute_and_burn = target.get_all_body_damage()
 
 	// In a brawl, drunkenness can make you swing more wildly and with more force, and thus catch your opponent off guard, but it could also totally throw you off if you're too intoxicated
 	// But god is it going to make you sick moving too much while drunk

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -908,16 +908,15 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/attack_direction = get_dir(user, target)
 	var/attack_type = attacking_bodypart.attack_type
 	var/final_armor_block = armor_block
+
+	if(damage >= 9)
+		target.force_say()
 	if(kicking || grappled) //kicks and punches when grappling bypass armor slightly.
-		if(damage >= 9)
-			target.force_say()
 		final_armor_block -= limb_accuracy
 		target.apply_damage(damage, attack_type, affecting, final_armor_block, attack_direction = attack_direction, sharpness = limb_sharpness)
 		log_combat(user, target, grappled ? "grapple punched" : "kicked")
 	else // Normal attacks do not gain the benefit of armor penetration.
 		target.apply_damage(damage, attack_type, affecting, armor_block, attack_direction = attack_direction, sharpness = limb_sharpness)
-		if(damage >= 9)
-			target.force_say()
 		log_combat(user, target, "punched")
 
 	if(user != target && biting && (target.mob_biotypes & MOB_ORGANIC)) //Good for you. You probably just ate someone alive.

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -911,9 +911,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(kicking || grappled) //kicks and punches when grappling bypass armor slightly.
 		if(damage >= 9)
 			target.force_say()
-		log_combat(user, target, grappled ? "grapple punched" : "kicked")
 		final_armor_block -= limb_accuracy
 		target.apply_damage(damage, attack_type, affecting, final_armor_block, attack_direction = attack_direction, sharpness = limb_sharpness)
+		log_combat(user, target, grappled ? "grapple punched" : "kicked")
 	else // Normal attacks do not gain the benefit of armor penetration.
 		target.apply_damage(damage, attack_type, affecting, armor_block, attack_direction = attack_direction, sharpness = limb_sharpness)
 		if(damage >= 9)

--- a/code/modules/mob/living/carbon/human/suicides.dm
+++ b/code/modules/mob/living/carbon/human/suicides.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/human/proc/delayed_suicide()
 	suicide_log()
-	adjust_brute_loss(max(200 - get_tox_loss() - get_fire_loss() - get_brute_loss() - get_oxy_loss(), 0))
+	adjust_brute_loss(max(200 - get_total_damage(), 0))
 	investigate_log("has died from committing suicide.", INVESTIGATE_DEATHS)
 	death(FALSE)
 	ghostize(FALSE) // Disallows reentering body and disassociates mind

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -822,7 +822,7 @@
 /mob/living/proc/updatehealth()
 	if(HAS_TRAIT(src, TRAIT_GODMODE))
 		return
-	set_health(maxHealth - get_oxy_loss() - get_tox_loss() - get_fire_loss() - get_brute_loss())
+	set_health(maxHealth - get_total_damage())
 	update_stat()
 	med_hud_set_health()
 	med_hud_set_status()

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -26,7 +26,7 @@
 
 /datum/reagent/medicine/c2/helbital/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
-	var/death_is_coming = (affected_mob.get_tox_loss() + affected_mob.get_oxy_loss() + affected_mob.get_fire_loss() + affected_mob.get_brute_loss())*normalise_creation_purity()
+	var/death_is_coming = affected_mob.get_total_damage() * normalise_creation_purity()
 	var/thou_shall_heal = 0
 	var/good_kind_of_healing = FALSE
 	var/need_mob_update = FALSE


### PR DESCRIPTION

## About The Pull Request
Was studying the main harm proc for punching and noticed some things

When it gets damage for brute and burn it ought to do it in the same for loop for a free micro op. This made me realize  we also weren't using the helper for total damage in a few places so I fixed that.

Combing the harm proc i noticed that `biter` was a bit redundant to set when we can just directly check the attack type the same as we do for kicker.

The log combat for kicking was also put BEFORE the damage which would mean the "newhealth" log would display the health BEFORE the damage was dealt
## Why It's Good For The Game
Some nice code cleanup and micro micro micro ops
## Changelog
:cl:
admin: Logging for kicks and grapple punches show the new health properly
/:cl:
