### PR TITLE
Revert part of #95140 (`/mob/living/basic/bee/toxin` can generate any toxin reagent) 

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
+++ b/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
@@ -235,7 +235,7 @@
 
 /mob/living/basic/bee/toxin/Initialize(mapload)
 	. = ..()
-	assign_random_toxin_reagent()
+	assign_random_toxin_reagent(respect_can_synth = FALSE)
 
 /// A bee which despawns after a short amount of time (beespawns?)
 /mob/living/basic/bee/timed


### PR DESCRIPTION
## About The Pull Request

Reverts https://github.com/tgstation/tgstation/pull/95140/changes/c6b2609280e6887ebb5fe86b29a85e63b360a4df

Puts `respect_can_synth = FALSE` back on `/mob/living/basic/bee/toxin`

## Why It's Good For The Game

Time-Green added this commit into the branch before merging and I don't think it was appropriate

If they have a problem with wizard being able to summon bees of any toxin type, they should make a pr to remove it rather than put it in my pr.
