### PR TITLE
Adds some special case interactions with the mail counterfitter device 

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -642,3 +642,7 @@
 /// Sent from /obj/effect/rune/convert/try_sacrifice_item(obj/effect/rune/convert/rune)
 #define COMSIG_ITEM_CULT_SACRIFICE "item_cult_sacrifice"
 	#define COMPONENT_SACRIFICE_SUCCESSFUL (1<<0)
+
+/// Sent from /obj/item/mail/traitor/after_unwrap(mob/user, obj/item/mail/traitor/letter)
+#define COMSIG_ITEM_IN_UNWRAPPED_TRAITOR_MAIL "traitor_mail_opened"
+	#define COMPONENT_TRAITOR_MAIL_HANDLED (1<<0)

--- a/code/game/objects/items/food/monkeycube.dm
+++ b/code/game/objects/items/food/monkeycube.dm
@@ -13,6 +13,10 @@
 	/// Whether we've been wetted and are expanding
 	var/expanding = FALSE
 
+/obj/item/food/monkeycube/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_ITEM_IN_UNWRAPPED_TRAITOR_MAIL, PROC_REF(on_mail_unwrap))
+
 /obj/item/food/monkeycube/attempt_pickup(mob/user)
 	if(expanding)
 		return FALSE
@@ -76,6 +80,11 @@
 	Expand()
 	user.visible_message(span_danger("[user]'s torso bursts open as a primate emerges!"))
 	user.gib(DROP_BRAIN|DROP_BODYPARTS|DROP_ITEMS) // just remove the organs
+
+/obj/item/food/monkeycube/proc/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
+	to_chat(user, span_danger("As you open [letter], its contents rapidly expand!"))
+	Expand()
+	return COMPONENT_TRAITOR_MAIL_HANDLED
 
 /obj/item/food/monkeycube/syndicate
 	faction = list(FACTION_NEUTRAL, ROLE_SYNDICATE)

--- a/code/game/objects/items/food/monkeycube.dm
+++ b/code/game/objects/items/food/monkeycube.dm
@@ -82,6 +82,7 @@
 	user.gib(DROP_BRAIN|DROP_BODYPARTS|DROP_ITEMS) // just remove the organs
 
 /obj/item/food/monkeycube/proc/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
+	SIGNAL_HANDLER
 	to_chat(user, span_danger("As you open [letter], its contents rapidly expand!"))
 	Expand()
 	return COMPONENT_TRAITOR_MAIL_HANDLED

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -408,6 +408,7 @@
 		if(istype(stuff, /obj/item/clothing/mask/facehugger)) //Alien has to go first because if its put in user's hands, it'll trigger attach() which will make attached TRUE which will make valid_to_attach() fail which will make Leap() fail
 			var/obj/item/clothing/mask/facehugger/alien = stuff
 			if(alien.stat == UNCONSCIOUS)
+				user.put_in_hands(alien)
 				continue
 			to_chat(user, span_danger("There's something moving inside of \the [src]!"))
 			alien.Leap(user)
@@ -417,7 +418,16 @@
 			continue
 
 		if(istype(stuff, /obj/item/gun))
-			to_chat(user, span_danger("As you open [src] you see [stuff] inside! [istype(stuff, /obj/item/gun/magic) ? "It's humming with energy!" : "Its trigger is already pulled!"]"))
+			if(istype(stuff, /obj/item/gun/magic/hook) || istype(stuff, /obj/item/gun/medbeam))
+				continue // "Gun"
+			var/itsabouttoshoottext = "Its trigger is already pulled!"
+			if(istype(stuff, /obj/item/gun/magic))
+				itsabouttoshoottext = "It's humming with energy!"
+			else if (istype(stuff, /obj/item/gun/ballistic/bow))
+				itsabouttoshoottext = "Its bowstring is pulled back!"
+			else if (istype(stuff, /obj/item/gun/syringe/blowgun))
+				itsabouttoshoottext = "The air in the envelope is rushing out!"
+			to_chat(user, span_danger("As you open [src], you see [stuff] inside! [itsabouttoshoottext]"))
 			var/obj/item/gun/realgun = stuff
 			if(!realgun.can_shoot())
 				realgun.shoot_with_empty_chamber(user)
@@ -433,6 +443,38 @@
 				continue
 			to_chat(user, span_danger("As you open [src], a very bright light shoots out from inside!"))
 			realflash.flash_mob(user)
+			continue
+
+		if(istype(stuff, /obj/item/clothing/gloves/boxing))
+			var/evil = istype(stuff, /obj/item/clothing/gloves/boxing/evil)
+			to_chat(user, span_danger("As you open [src], boxing gloves spring out and deliver you a swift uppercut!"))
+			var/mob/living/userasliving = user
+			playsound(user, SFX_PUNCH, 25, TRUE)
+			userasliving.Knockdown(evil? 2 : 4 SECONDS, evil? 4 : 6 SECONDS)
+			userasliving.adjust_stamina_loss(evil? 40: 80)
+			continue
+
+		if(istype(stuff, /obj/item/reagent_containers/syringe))
+			var/obj/item/reagent_containers/syringe/real_syringe = stuff
+			var/mob/living/userasliving = user
+			if(!real_syringe.reagents.total_volume || !user.reagents || !userasliving.try_inject(user, user.get_active_hand()))
+				continue
+			to_chat(user, span_danger("As you open [src], you prick yourself on a syringe inside!"))
+			real_syringe.reagents.trans_to(user, min(real_syringe.reagents.total_volume, 15))
+			continue
+
+		if(istype(stuff, /obj/item/reagent_containers/spray))
+			var/obj/item/reagent_containers/spray/real_spray = stuff
+			if(real_spray.reagents.total_volume < real_spray.amount_per_transfer_from_this)
+				continue
+			to_chat(user, span_danger("As you open [src], a mist spritzes out from inside!"))
+			real_spray.spray(user, user)
+			playsound(user, real_spray.spray_sound, 50, TRUE, -6)
+			continue
+
+		if(stuff.type == /obj/item/assembly/signaler) // No istype() because we don't want anomaly cores
+			to_chat(user, span_danger("As you open [src], you accidentally press a button on [stuff]!"))
+			astype(stuff, /obj/item/assembly/signaler).signal() // No need to check for cooldown, the cooldown is shorter than the do_after for opening mail
 			continue
 
 		INVOKE_ASYNC(stuff, TYPE_PROC_REF(/obj/item, attack_self), user)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -28,6 +28,10 @@
 	var/cooldown = 0
 	var/last_trigger = 0 //Last time it was successfully triggered.
 
+/obj/item/assembly/flash/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_ITEM_IN_UNWRAPPED_TRAITOR_MAIL, PROC_REF(on_mail_unwrap))
+
 /obj/item/assembly/flash/suicide_act(mob/living/user)
 	if(burnt_out)
 		user.visible_message(span_suicide("[user] raises \the [src] up to [user.p_their()] eyes and activates it ... but it's burnt out!"))
@@ -264,6 +268,15 @@
 	// - - -
 	// Attacker lateral to the victim.
 	return DEVIATION_PARTIAL
+
+/obj/item/assembly/flash/proc/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
+	SIGNAL_HANDLER
+	if(!try_use_flash())
+		return
+	to_chat(user, span_danger("As you open [letter], a very bright light shoots out from inside!"))
+	flash_mob(user)
+	forceMove(user.loc)
+	return COMPONENT_TRAITOR_MAIL_HANDLED
 
 /obj/item/assembly/flash/attack(mob/living/target, mob/user)
 	if(!try_use_flash(user))

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -272,7 +272,7 @@
 /obj/item/assembly/flash/proc/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
 	SIGNAL_HANDLER
 	if(!try_use_flash())
-		return
+		return NONE
 	to_chat(user, span_danger("As you open [letter], a very bright light shoots out from inside!"))
 	flash_mob(user)
 	forceMove(user.loc)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -53,6 +53,7 @@
 /obj/item/assembly/signaler/Initialize(mapload)
 	. = ..()
 	set_frequency(frequency)
+	RegisterSignal(src, COMSIG_ITEM_IN_UNWRAPPED_TRAITOR_MAIL, PROC_REF(on_mail_unwrap))
 
 /obj/item/assembly/signaler/Destroy()
 	SSradio.remove_object(src,frequency)
@@ -180,6 +181,12 @@
 	frequency = new_frequency
 	radio_connection = SSradio.add_object(src, frequency, RADIO_SIGNALER)
 	return
+
+/obj/item/assembly/signaler/proc/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
+	SIGNAL_HANDLER
+	to_chat(user, span_danger("As you open [letter], you accidentally press a button on [src]!"))
+	INVOKE_ASYNC(src, PROC_REF(signal)) // No need to check for cooldown, the cooldown is shorter than the do_after for opening mail
+	return //don't return handled, we want in hands and open ui
 
 /obj/item/assembly/signaler/cyborg
 

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -186,7 +186,7 @@
 	SIGNAL_HANDLER
 	to_chat(user, span_danger("As you open [letter], you accidentally press a button on [src]!"))
 	INVOKE_ASYNC(src, PROC_REF(signal)) // No need to check for cooldown, the cooldown is shorter than the do_after for opening mail
-	return //don't return handled, we want in hands and open ui
+	return NONE //don't return handled, we want in hands and open ui
 
 /obj/item/assembly/signaler/cyborg
 

--- a/code/modules/clothing/gloves/boxing.dm
+++ b/code/modules/clothing/gloves/boxing.dm
@@ -9,6 +9,8 @@
 	equip_sound = 'sound/items/equip/glove_equip.ogg'
 	/// Determines the version of boxing (or any martial art for that matter) that the boxing gloves gives
 	var/style_to_give = /datum/martial_art/boxing
+	/// Specifically for whether they get longer knockdown when they jump out of traitor mail
+	var/extrapower = FALSE
 
 /obj/item/clothing/gloves/boxing/Initialize(mapload)
 	. = ..()
@@ -21,12 +23,24 @@
 
 	AddComponent(/datum/component/martial_art_giver, style_to_give)
 	AddElement(/datum/element/adjust_fishing_difficulty, 19)
+	RegisterSignal(src, COMSIG_ITEM_IN_UNWRAPPED_TRAITOR_MAIL, PROC_REF(on_mail_unwrap))
+
+/obj/item/clothing/gloves/boxing/proc/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
+	SIGNAL_HANDLER
+	to_chat(user, span_danger("As you open [letter], boxing gloves spring out and deliver you a swift uppercut!"))
+	var/mob/living/userasliving = user
+	playsound(user, SFX_PUNCH, 25, TRUE)
+	userasliving.Knockdown(extrapower? 2 : 4 SECONDS, extrapower? 4 : 6 SECONDS)
+	userasliving.adjust_stamina_loss(extrapower? 40: 80)
+	forceMove(user.loc)
+	return COMPONENT_TRAITOR_MAIL_HANDLED
 
 /obj/item/clothing/gloves/boxing/evil
 	name = "evil boxing gloves"
 	desc = "These strange gloves radiate an unusually evil aura."
 	greyscale_colors = "#21211f"
 	style_to_give = /datum/martial_art/boxing/evil
+	extrapower = TRUE
 
 /obj/item/clothing/gloves/boxing/green
 	icon_state = "boxinggreen"
@@ -48,6 +62,7 @@
 	material_flags = MATERIAL_EFFECTS | MATERIAL_AFFECT_STATISTICS
 	equip_delay_other = 12 SECONDS
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE
+	extrapower = TRUE
 
 /obj/item/clothing/gloves/boxing/golden/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/gloves/boxing.dm
+++ b/code/modules/clothing/gloves/boxing.dm
@@ -30,8 +30,8 @@
 	to_chat(user, span_danger("As you open [letter], boxing gloves spring out and deliver you a swift uppercut!"))
 	var/mob/living/userasliving = user
 	playsound(user, SFX_PUNCH, 25, TRUE)
-	userasliving.Knockdown(extrapower? 2 : 4 SECONDS, extrapower? 4 : 6 SECONDS)
-	userasliving.adjust_stamina_loss(extrapower? 40: 80)
+	userasliving.Knockdown((extrapower ? 2 : 4) SECONDS, (extrapower ? 4 : 6) SECONDS)
+	userasliving.adjust_stamina_loss(extrapower ? 40 : 80)
 	forceMove(user.loc)
 	return COMPONENT_TRAITOR_MAIL_HANDLED
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -43,6 +43,7 @@
 	AddElement(/datum/element/muffles_speech)
 
 	RegisterSignal(src, COMSIG_LIVING_TRYING_TO_PULL, PROC_REF(react_to_mob))
+	RegisterSignal(src, COMSIG_ITEM_IN_UNWRAPPED_TRAITOR_MAIL, PROC_REF(on_mail_unwrap))
 
 /obj/item/clothing/mask/facehugger/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	..()
@@ -293,6 +294,14 @@
 			return FALSE
 		return TRUE
 	return FALSE
+
+/obj/item/clothing/mask/facehugger/proc/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
+	SIGNAL_HANDLER
+	if(stat != CONSCIOUS)
+		return
+	to_chat(user, span_danger("There's something moving inside of \the [letter]!"))
+	Leap(user)
+	return COMPONENT_TRAITOR_MAIL_HANDLED
 
 /obj/item/clothing/mask/facehugger/lamarr
 	name = "Lamarr"

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -298,7 +298,7 @@
 /obj/item/clothing/mask/facehugger/proc/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
 	SIGNAL_HANDLER
 	if(stat != CONSCIOUS)
-		return
+		return NONE
 	to_chat(user, span_danger("There's something moving inside of \the [letter]!"))
 	Leap(user)
 	return COMPONENT_TRAITOR_MAIL_HANDLED

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -110,6 +110,9 @@
 
 	var/pb_knockback = 0
 
+	/// What this gun says when it's gonna shoot inside mail.
+	var/about_to_shoot_inside_mail_text = "Its trigger is already pulled!"
+
 	/// Cooldown for the visible message sent from gun flipping.
 	COOLDOWN_DECLARE(flip_cooldown)
 
@@ -121,6 +124,7 @@
 
 	add_seclight_point()
 	add_bayonet_point()
+	RegisterSignal(src, COMSIG_ITEM_IN_UNWRAPPED_TRAITOR_MAIL, PROC_REF(on_mail_unwrap))
 
 /obj/item/gun/Destroy()
 	if(isobj(pin)) //Can still be the initial path, then we skip
@@ -712,6 +716,17 @@
 //Happens before the actual projectile creation
 /obj/item/gun/proc/before_firing(atom/target,mob/user)
 	return
+
+/obj/item/gun/proc/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
+	user.put_in_hands(src) // It doesn't matter if this fails
+	to_chat(user, span_danger("As you open [letter], you see [src] inside! [about_to_shoot_inside_mail_text]"))
+	if(!can_shoot())
+		shoot_with_empty_chamber(user)
+		return COMPONENT_TRAITOR_MAIL_HANDLED
+	if(process_fire(user, user, FALSE, zone_override = BODY_ZONE_HEAD))
+		forceMove(user.loc)
+		throw_at(pick(get_step(user, user.dir)), 1, 3)
+	return COMPONENT_TRAITOR_MAIL_HANDLED
 
 #undef FIRING_PIN_REMOVAL_DELAY
 #undef DUALWIELD_PENALTY_EXTRA_MULTIPLIER

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -718,15 +718,20 @@
 	return
 
 /obj/item/gun/proc/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
-	user.put_in_hands(src) // It doesn't matter if this fails
+	SIGNAL_HANDLER
+	INVOKE_ASYNC(src, PROC_REF(fire_at_opener), user, letter)
+	return COMPONENT_TRAITOR_MAIL_HANDLED
+
+/obj/item/gun/proc/fire_at_opener(mob/user, obj/item/mail/traitor/letter)
+	if(!user.put_in_hands(src)) //this won't ever fail under normal circumstances, but will happen with the admin versions
+		forceMove(user.loc)
 	to_chat(user, span_danger("As you open [letter], you see [src] inside! [about_to_shoot_inside_mail_text]"))
 	if(!can_shoot())
 		shoot_with_empty_chamber(user)
-		return COMPONENT_TRAITOR_MAIL_HANDLED
+		return
 	if(process_fire(user, user, FALSE, zone_override = BODY_ZONE_HEAD))
 		forceMove(user.loc)
 		throw_at(pick(get_step(user, user.dir)), 1, 3)
-	return COMPONENT_TRAITOR_MAIL_HANDLED
 
 #undef FIRING_PIN_REMOVAL_DELAY
 #undef DUALWIELD_PENALTY_EXTRA_MULTIPLIER

--- a/code/modules/projectiles/guns/ballistic/bows/_bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/_bow.dm
@@ -23,6 +23,7 @@
 	click_on_low_ammo = FALSE
 	must_hold_to_load = TRUE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
+	about_to_shoot_inside_mail_text = "Its bowstring is pulled back!"
 	/// whether the bow is drawn back
 	var/drawn = FALSE
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -370,7 +370,7 @@
 	return .
 
 /obj/item/gun/ballistic/revolver/russian/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
-	if(get_ammo(FALSE, FALSE) > 1)
+	if((get_ammo(FALSE, FALSE) > 1) || (get_ammo(TRUE, TRUE) < 6))
 		return
 	return ..()
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -369,6 +369,11 @@
 	shoot_self(user, check_zone(user.zone_selected))
 	return .
 
+/obj/item/gun/ballistic/revolver/russian/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
+	if(get_ammo(FALSE, FALSE) > 1)
+		return
+	return ..()
+
 /// Called after successfully(if you can call it that) shooting ourselves
 /obj/item/gun/ballistic/revolver/russian/proc/shoot_self(mob/living/carbon/human/user, affecting = BODY_ZONE_HEAD)
 	user.add_mood_event(

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -371,7 +371,7 @@
 
 /obj/item/gun/ballistic/revolver/russian/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
 	if((get_ammo(FALSE, FALSE) > 1) || (get_ammo(TRUE, TRUE) < 6))
-		return
+		return NONE
 	return ..()
 
 /// Called after successfully(if you can call it that) shooting ourselves

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -98,7 +98,7 @@
 			return FALSE
 	return ..()
 
-/obj/item/gun/ballistic/rifle/boltaction/process_fire(mob/user)
+/obj/item/gun/ballistic/rifle/boltaction/process_fire(atom/target, mob/living/user, message, params, zone_override, bonus_spread)
 	if(can_jam)
 		if(chambered.loaded_projectile)
 			if(prob(jamming_chance))

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -13,6 +13,7 @@
 	clumsy_check = FALSE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL // Has no trigger at all, uses magic instead
 	pin = /obj/item/firing_pin/magic
+	about_to_shoot_inside_mail_text = "It's humming with energy!"
 	/// If true, our fire sound gets lower as our charges decrease
 	var/pitch_with_charges = TRUE
 	/// What kind of magic is this

--- a/code/modules/projectiles/guns/special/meat_hook.dm
+++ b/code/modules/projectiles/guns/special/meat_hook.dm
@@ -42,6 +42,9 @@
 	removable.dismember(silent = FALSE)
 	return BRUTELOSS
 
+/obj/item/gun/magic/hook/on_mail_unwrap(mob/user, obj/item/mail/traitor/letter)
+	return
+
 /obj/item/ammo_casing/magic/hook
 	name = "hook"
 	desc = "A hook."

--- a/code/modules/projectiles/guns/special/meat_hook.dm
+++ b/code/modules/projectiles/guns/special/meat_hook.dm
@@ -43,7 +43,7 @@
 	return BRUTELOSS
 
 /obj/item/gun/magic/hook/on_mail_unwrap(mob/user, obj/item/mail/traitor/letter)
-	return
+	return NONE
 
 /obj/item/ammo_casing/magic/hook
 	name = "hook"

--- a/code/modules/projectiles/guns/special/medbeam.dm
+++ b/code/modules/projectiles/guns/special/medbeam.dm
@@ -93,6 +93,9 @@
 	if(current_target)
 		on_beam_tick(current_target)
 
+/obj/item/gun/medbeam/on_mail_unwrap(mob/user, obj/item/mail/traitor/letter)
+	return
+
 /obj/item/gun/medbeam/proc/mid_los_check(atom/movable/user, mob/target, pass_args = PASSTABLE|PASSGLASS|PASSGRILLE, turf/next_step, obj/dummy)
 	for(var/obj/effect/ebeam/medical/B in next_step)// Don't cross the str-beams!
 		if(QDELETED(current_beam))

--- a/code/modules/projectiles/guns/special/medbeam.dm
+++ b/code/modules/projectiles/guns/special/medbeam.dm
@@ -94,7 +94,7 @@
 		on_beam_tick(current_target)
 
 /obj/item/gun/medbeam/on_mail_unwrap(mob/user, obj/item/mail/traitor/letter)
-	return
+	return NONE
 
 /obj/item/gun/medbeam/proc/mid_los_check(atom/movable/user, mob/target, pass_args = PASSTABLE|PASSGLASS|PASSGRILLE, turf/next_step, obj/dummy)
 	for(var/obj/effect/ebeam/medical/B in next_step)// Don't cross the str-beams!

--- a/code/modules/projectiles/guns/special/syringe_gun.dm
+++ b/code/modules/projectiles/guns/special/syringe_gun.dm
@@ -225,6 +225,7 @@
 	force = 4
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 	custom_materials = list(/datum/material/bamboo = SHEET_MATERIAL_AMOUNT * 10)
+	about_to_shoot_inside_mail_text = "The air in the envelope is rushing out!"
 
 /obj/item/gun/syringe/blowgun/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -30,6 +30,7 @@
 /obj/item/reagent_containers/spray/Initialize(mapload, vol)
 	. = ..()
 	AddElement(/datum/element/reagents_item_heatable)
+	RegisterSignal(src, COMSIG_ITEM_IN_UNWRAPPED_TRAITOR_MAIL, PROC_REF(on_mail_unwrap))
 
 /obj/item/reagent_containers/spray/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	return try_spray(interacting_with, user) ? ITEM_INTERACT_SUCCESS : ITEM_INTERACT_BLOCKING
@@ -149,6 +150,16 @@
 		reagents.expose(usr.loc)
 		log_combat(usr, usr.loc, "emptied onto", src, addition="which had [reagents.get_reagent_log_string()]")
 		src.reagents.clear_reagents()
+
+/obj/item/reagent_containers/spray/proc/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
+	SIGNAL_HANDLER
+	if(reagents.total_volume < amount_per_transfer_from_this)
+		return
+	to_chat(user, span_danger("As you open [letter], a mist spritzes out from inside!"))
+	spray(user, user)
+	playsound(user, spray_sound, 50, TRUE, -6)
+	forceMove(user.loc)
+	return COMPONENT_TRAITOR_MAIL_HANDLED
 
 /// Handles updating the spray distance when the reagents change.
 /obj/item/reagent_containers/spray/on_reagent_change(datum/reagents/holder, ...)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -33,6 +33,7 @@
 		dart_insert_projectile_icon_state, \
 		CALLBACK(src, PROC_REF(get_dart_var_modifiers))\
 	)
+	RegisterSignal(src, COMSIG_ITEM_IN_UNWRAPPED_TRAITOR_MAIL, PROC_REF(on_mail_unwrap))
 
 /obj/item/reagent_containers/syringe/proc/try_syringe(atom/target, mob/user)
 	if(!target.reagents)
@@ -192,6 +193,15 @@
 		"exposed_wound_bonus" = exposed_wound_bonus,
 		"demolition_mod" = demolition_mod,
 	)
+
+/obj/item/reagent_containers/syringe/proc/on_mail_unwrap(atom/source, mob/living/user, obj/item/mail/traitor/letter)
+	SIGNAL_HANDLER
+	if(!reagents.total_volume || !user.reagents || !user.try_inject(user, user.get_active_hand()))
+		return
+	to_chat(user, span_danger("As you open [letter], you prick yourself on a syringe inside!"))
+	reagents.trans_to(user, min(reagents.total_volume, 15))
+	forceMove(user.loc)
+	return COMPONENT_TRAITOR_MAIL_HANDLED
 
 /datum/embedding/syringe
 	embed_chance = 85

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -199,7 +199,7 @@
 	if(!reagents.total_volume || !user.reagents || !user.try_inject(user, user.get_active_hand()))
 		return
 	to_chat(user, span_danger("As you open [letter], you prick yourself on a syringe inside!"))
-	reagents.trans_to(user, min(reagents.total_volume, 15))
+	reagents.trans_to(user, min(reagents.total_volume, 5))
 	forceMove(user.loc)
 	return COMPONENT_TRAITOR_MAIL_HANDLED
 

--- a/code/modules/research/anomaly/anomaly_core.dm
+++ b/code/modules/research/anomaly/anomaly_core.dm
@@ -35,6 +35,9 @@
 		to_chat(user, span_notice("Analyzing... [src]'s stabilized field is fluctuating along frequency [format_frequency(frequency)], code [code]."))
 	return ..()
 
+/obj/item/assembly/signaler/anomaly/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
+	return
+
 //Anomaly cores
 /obj/item/assembly/signaler/anomaly/pyro
 	name = "\improper pyroclastic anomaly core"

--- a/code/modules/research/anomaly/anomaly_core.dm
+++ b/code/modules/research/anomaly/anomaly_core.dm
@@ -36,7 +36,7 @@
 	return ..()
 
 /obj/item/assembly/signaler/anomaly/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
-	return
+	return NONE
 
 //Anomaly cores
 /obj/item/assembly/signaler/anomaly/pyro


### PR DESCRIPTION
## About The Pull Request

Adds some type specific interactions to the mail produced by the GLA-2 mail counterfit device. Currently, it applies `attack_self()` to all items when armed. The new interactions are, currently:

- Facehuggers jump on your face
- Flashes flash you
- Boxing gloves uppercut you
- Syringes prick you with poison
- Sprays spray you
- Signallers signal
- Monkey cubes/other cubes expand 
- Guns shoot you in the head

There'll be more, probably. Leave your ideas(only good ones though).

## Why It's Good For The Game

First of all, none of these are strenuous from a balance perspective. The primary use of this device is an instant bomb, and none of these things are bombs. Easy delineation, I doubt this will become a problem.

As said already, the primary use of this device is a bomb. I've seen it used for another thing once ever, and while that thing was incredibly cool, the counterfit device is still a one-trick pony for the most part. While none of these can compete with the lethality of the bomb, the hope is that they will collectively help bring variety to an item that feels built for variety. 

## Changelog
:cl:

add: Several items have been given special interactions when placed inside counterfit mail. 

/:cl:
