### PR TITLE
Change spiderwebs to drain stamina when mobs enter

### DIFF
--- a/code/game/objects/effects/spiderwebs.dm
+++ b/code/game/objects/effects/spiderwebs.dm
@@ -107,7 +107,7 @@
 		if(!victim.IsKnockdown())
 			to_chat(victim, span_warning("You trip over \the [src] due to exhaustion!"))
 
-		victim.SetKnockdown(3 SECONDS, 3 SECONDS)
+		victim.SetKnockdown(3 SECONDS)
 		return
 
 	if(prob(25))

--- a/code/game/objects/effects/spiderwebs.dm
+++ b/code/game/objects/effects/spiderwebs.dm
@@ -114,7 +114,7 @@
 		loc.balloon_alert(victim, "stuck in web!")
 		victim.Shake(duration = 0.2 SECONDS)
 
-	victim.adjust_stamina_loss(rand(7, 10))
+	victim.adjust_stamina_loss(rand(10, 15))
 
 /// Web made by geneticists, needs special handling to allow them to pass through their own webs
 /obj/structure/spider/stickyweb/genetic

--- a/code/game/objects/effects/spiderwebs.dm
+++ b/code/game/objects/effects/spiderwebs.dm
@@ -103,9 +103,18 @@
 
 /// Drains stamina and shows feedback when you get stuck moving thru a web
 /obj/structure/spider/stickyweb/proc/stuck_react(mob/living/victim)
-	loc.balloon_alert(victim, "stuck in web!")
-	victim.Shake(duration = 0.2 SECONDS)
-	victim.adjust_stamina_loss(rand(10, 15))
+	if(victim.get_stamina_loss() > 90)
+		if(!victim.IsKnockdown())
+			to_chat(victim, span_warning("You trip over \the [src] due to exhaustion!"))
+
+		victim.SetKnockdown(3 SECONDS, 3 SECONDS)
+		return
+
+	if(prob(25))
+		loc.balloon_alert(victim, "stuck in web!")
+		victim.Shake(duration = 0.2 SECONDS)
+
+	victim.adjust_stamina_loss(rand(7, 10))
 
 /// Web made by geneticists, needs special handling to allow them to pass through their own webs
 /obj/structure/spider/stickyweb/genetic

--- a/code/game/objects/effects/spiderwebs.dm
+++ b/code/game/objects/effects/spiderwebs.dm
@@ -104,7 +104,7 @@
 /// Drains stamina and shows feedback when you get stuck moving thru a web
 /obj/structure/spider/stickyweb/proc/stuck_react(mob/living/victim)
 	if(victim.get_stamina_loss() > 90)
-		if(!victim.IsKnockdown())
+		if(victim.body_position != LYING_DOWN)
 			to_chat(victim, span_warning("You trip over \the [src] due to exhaustion!"))
 
 		victim.SetKnockdown(3 SECONDS)


### PR DESCRIPTION

## About The Pull Request
This changes spiderwebs to drain stamina from mobs whenever they enter a turf filled with spiderwebs.

## Why It's Good For The Game
The old movement code was very janky and buggy. Because it used the `CanAllowThrough` proc, a mob could spam several dozens of movement attempts per second, resulting in a massive amount of shaking and `stuck in the web` messages. This had the effect of not really slowing or stopping movement, since the RNG was being rolled so fast that it was a minor inconvenience.

I feel like the stamina drain effect makes more sense and feels more natural. 

## Changelog
:cl:
balance: Sticky spider webs now drain stamina when mobs enter the turf
/:cl:
