### PR TITLE
Minor shock() refactor

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -169,15 +169,13 @@
 				A.regainMainPower()
 			else
 				A.loseMainPower()
-			if(isliving(usr))
-				A.shock(usr, 50)
+			A.shock(usr, 50)
 		if(WIRE_BACKUP1, WIRE_BACKUP2) // Cut to lose backup power, repair all to gain backup power.
 			if(mend && !is_cut(WIRE_BACKUP1) && !is_cut(WIRE_BACKUP2))
 				A.regainBackupPower()
 			else
 				A.loseBackupPower()
-			if(isliving(usr))
-				A.shock(usr, 50)
+			A.shock(usr, 50)
 		if(WIRE_BOLTS) // Cut to engage bolts, mend does nothing.
 			if(!mend)
 				A.bolt()
@@ -214,8 +212,7 @@
 			A.feedback = mend
 			A.update_appearance()
 		if(WIRE_ZAP1, WIRE_ZAP2) // Ouch.
-			if(isliving(usr))
-				A.shock(usr, 50)
+			A.shock(usr, 50)
 		if(WIRE_UNRESTRICTED_EXIT) // If this wire is cut, the unrestricted helper goes away. If you mend it, it'll go "haywire" and pick a new direction at random. Might have to cut/mend a time or two to get the direction you want.
 			if(!A.unres_latch) //only works if the "latch" is installed (a variable that we assign to the door either upon creation of a door with unrestricted directions, or if an unrestricted helper is added to a door in mapping)
 				return

--- a/code/datums/wires/mod.dm
+++ b/code/datums/wires/mod.dm
@@ -53,7 +53,7 @@
 /datum/wires/mod/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	var/obj/item/mod/control/mod = holder
 	var/mob/user = ui.user
-	if(!HAS_SILICON_ACCESS(user) && mod.seconds_electrified && mod.shock(user))
+	if(!HAS_SILICON_ACCESS(user) && mod.seconds_electrified && mod.shock(user, 100))
 		return FALSE
 	return ..()
 

--- a/code/datums/wires/roulette.dm
+++ b/code/datums/wires/roulette.dm
@@ -33,8 +33,7 @@
 	var/obj/machinery/roulette/R = holder
 	switch(wire)
 		if(WIRE_SHOCK)
-			if(isliving(usr))
-				R.shock(usr, 50)
+			R.shock(usr, 50)
 		if(WIRE_BOLTS) // Pulse to toggle bolts (but only raise if power is on).
 			if(!R.on)
 				return
@@ -44,8 +43,7 @@
 			R.audible_message(span_warning("Owner reset!"))
 			R.locked = FALSE
 		if(WIRE_PRIZEVEND)
-			if(isliving(usr))
-				R.shock(usr, 70)
+			R.shock(usr, 70)
 			if(R.locked)
 				return
 			R.audible_message(span_warning("Unauthorized prize vend detected! Locking down machine!"))
@@ -55,8 +53,7 @@
 	var/obj/machinery/roulette/R = holder
 	switch(wire)
 		if(WIRE_SHOCK)
-			if(isliving(usr))
-				R.shock(usr, 60)
+			R.shock(usr, 60)
 			if(mend)
 				R.on = TRUE
 			else
@@ -66,13 +63,10 @@
 				return
 			R.set_anchored(TRUE)
 		if(WIRE_RESETOWNER)
-			if(isliving(usr))
-				R.shock(usr, 70)
+			R.shock(usr, 70)
 		if(WIRE_PRIZEVEND)
-			if(isliving(usr))
-				R.shock(usr, 75)
+			R.shock(usr, 75)
 			if(R.locked)
 				return
 			R.audible_message(span_warning("Unauthorized prize vend detected! Locking down machine!"))
 			R.prize_theft(0.10)
-

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -32,8 +32,7 @@
 		if(WIRE_SAFETY)
 			SSU.safeties = !SSU.safeties
 		if(WIRE_ZAP)
-			if(usr)
-				SSU.shock(usr)
+			SSU.shock(usr, 100)
 
 /datum/wires/suit_storage_unit/on_cut(wire, mend, source)
 	var/obj/machinery/suit_storage_unit/SSU = holder
@@ -43,5 +42,4 @@
 		if(WIRE_SAFETY)
 			SSU.safeties = mend
 		if(WIRE_ZAP)
-			if(usr)
-				SSU.shock(usr)
+			SSU.shock(usr, 100)

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -94,23 +94,9 @@
 		if(WIRE_SPEAKER)
 			vending_machine.shut_up = mend
 
-
-/**
- * Shock the passed in user
- *
- * This checks we have power and that the passed in prob is passed, then generates some sparks
- * and calls electrocute_mob on the user
- *
- * Arguments:
- * * user - the user to shock
- * * shock_chance - probability the shock happens
- */
-/obj/machinery/vending/proc/shock(mob/living/user, shock_chance)
-	if(!istype(user) || machine_stat & (BROKEN|NOPOWER)) // unpowered, no shock
+/obj/machinery/vending/shock(mob/living/shocking, chance, shock_source, siemens_coeff)
+	if(machine_stat & (BROKEN|NOPOWER))
 		return FALSE
-	if(!prob(shock_chance))
-		return FALSE
-	do_sparks(5, TRUE, src)
-	if(electrocute_mob(user, get_area(src), src, 0.7, dist_check = TRUE))
-		return TRUE
-	return FALSE
+	if(isnull(siemens_coeff))
+		siemens_coeff = 0.7
+	return ..()

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -506,20 +506,12 @@
 			if(!wires.is_cut(wire))
 				disabled = FALSE
 
-/**
- * Shock a mob who is trying to interact with the autolathe
- * Arguments
- *
- * * mob/user - the mob we are trying to shock
- * * prb - the probability of getting shocked
- */
-/obj/machinery/autolathe/proc/shock(mob/user, prb)
+/obj/machinery/autolathe/shock(mob/living/shocking, chance, shock_source, siemens_coeff)
 	if(machine_stat & (BROKEN|NOPOWER)) // unpowered, no shock
 		return FALSE
-	if(!prob(prb))
-		return FALSE
-	do_sparks(5, TRUE, src)
-	return electrocute_mob(user, get_area(src), src, 0.7, TRUE)
+	if(isnull(siemens_coeff))
+		siemens_coeff = 0.7
+	return ..()
 
 /**
  * Is the autolathe hacked. Allowing us to acess hidden designs

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -274,11 +274,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 	src.view_range = num
 	SScameras.update_visibility(src)
 
-/obj/machinery/camera/proc/shock(mob/living/user)
-	if(!istype(user))
-		return
-	user.electrocute_act(10, src)
-
 /obj/machinery/camera/singularity_pull(atom/singularity, current_size)
 	if (camera_enabled && current_size >= STAGE_FIVE) // If the singulo is strong enough to pull anchored objects and the camera is still active, turn off the camera as it gets ripped off the wall.
 		toggle_cam(null, 0)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -483,28 +483,20 @@
 /obj/machinery/door/airlock/proc/regainBackupPower()
 	set_backup_outage(0 SECONDS)
 
-// shock user with probability prb (if all connections & power are working)
-// returns TRUE if shocked, FALSE otherwise
-// The preceding comment was borrowed from the grille's shock script
-/obj/machinery/door/airlock/proc/shock(mob/living/user, prb)
-	if(!istype(user) || !hasPower()) // unpowered, no shock
+/obj/machinery/door/airlock/shock(mob/living/shocking, chance, shock_source, siemens_coeff)
+	if(!hasPower()) // unpowered, no shock
 		return FALSE
-	if(HAS_TRAIT(user, TRAIT_AIRLOCK_SHOCKIMMUNE)) // Be a bit more clever man come on
+	if(HAS_TRAIT(shocking, TRAIT_AIRLOCK_SHOCKIMMUNE)) // Be a bit more clever man come on
 		return FALSE
 	if(!COOLDOWN_FINISHED(src, shockCooldown))
 		return FALSE //Already shocked someone recently?
-	if(!prob(prb))
-		return FALSE //you lucked out, no shock for you
-	do_sparks(5, TRUE, src)
-	var/check_range = TRUE
-	if(electrocute_mob(user, get_area(src), src, 1, check_range))
-		COOLDOWN_START(src, shockCooldown, 1 SECONDS)
-		// Provides timed airlock shock immunity, to prevent overly cheesy deathtraps
-		ADD_TRAIT(user, TRAIT_AIRLOCK_SHOCKIMMUNE, REF(src))
-		addtimer(TRAIT_CALLBACK_REMOVE(user, TRAIT_AIRLOCK_SHOCKIMMUNE, REF(src)), 1 SECONDS)
-		return TRUE
-	else
+	if(!..())
 		return FALSE
+	COOLDOWN_START(src, shockCooldown, 1 SECONDS)
+	// Provides timed airlock shock immunity, to prevent overly cheesy deathtraps
+	ADD_TRAIT(shocking, TRAIT_AIRLOCK_SHOCKIMMUNE, REF(src))
+	addtimer(TRAIT_CALLBACK_REMOVE(shocking, TRAIT_AIRLOCK_SHOCKIMMUNE, REF(src)), 1 SECONDS)
+	return TRUE
 
 /obj/machinery/door/airlock/proc/is_secure()
 	return (security_level > 0)

--- a/code/game/machinery/roulette_machine.dm
+++ b/code/game/machinery/roulette_machine.dm
@@ -441,16 +441,10 @@
 			set_machine_stat(machine_stat | MAINT)
 			icon_state = "open"
 
-/obj/machinery/roulette/proc/shock(mob/user, prb)
+/obj/machinery/roulette/shock(mob/living/shocking, chance, shock_source, siemens_coeff)
 	if(!on) // unpowered, no shock
 		return FALSE
-	if(!prob(prb))
-		return FALSE //you lucked out, no shock for you
-	do_sparks(5, TRUE, src)
-	if(electrocute_mob(user, get_area(src), src, 1, TRUE))
-		return TRUE
-	else
-		return FALSE
+	return ..()
 
 /obj/item/roulette_wheel_beacon
 	name = "roulette wheel beacon"

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -565,13 +565,6 @@
 	for(var/obj/item/stock_parts/power_store/cell as anything in cells_to_charge)
 		charge_cell(charge_per_item, cell, grid_only = TRUE)
 
-/obj/machinery/suit_storage_unit/proc/shock(mob/user, prb)
-	if(prob(prb))
-		return
-	do_sparks(5, TRUE, src)
-	if(electrocute_mob(user, src, src, 1, TRUE))
-		return TRUE
-
 /obj/machinery/suit_storage_unit/relaymove(mob/living/user, direction)
 	if(locked)
 		if(message_cooldown <= world.time)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -366,3 +366,28 @@ GLOBAL_LIST_EMPTY(objects_by_id_tag)
 /// Called when UNIQUE_RENAME is reset
 /obj/proc/rename_reset()
 	return
+
+/**
+ * Used to deliver a shock to a mob from this object
+ * The target must be adjacent to this object, or else the shock will fail
+ *
+ * * shocking - who are we zapping
+ * * chance - probability the shock fails
+ * * shock_source - used for determining where to get the power to zap them.
+ * can be an apc, a cable, an area, a cell, or even a powernet datum
+ * defaults to our cell or our current area/apc if it doesn't
+ * subtypes may override this proc to pass this up to the parent
+ * * siemens_coeff - multiplier to how much shock is delivered
+ *
+ * Returns TRUE if the shock was successfully delivered
+ * Returns FALSE if the shock failed for any reason
+ */
+/obj/proc/shock(mob/living/shocking, chance = 100, shock_source, siemens_coeff = 1)
+	SHOULD_CALL_PARENT(TRUE)
+	if(!isliving(shocking))
+		return FALSE
+	if(!prob(chance))
+		return FALSE // you lucked out, no shock for you
+
+	do_sparks(5, TRUE, src)
+	return electrocute_mob(shocking, shock_source || get_cell() || get_area(src), src, siemens_coeff, TRUE)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -372,12 +372,14 @@ GLOBAL_LIST_EMPTY(objects_by_id_tag)
  * The target must be adjacent to this object, or else the shock will fail
  *
  * * shocking - who are we zapping
- * * chance - probability the shock fails
+ * * chance - probability the shock succeeds
+ * defaults to 100 (guaranteed to shock)
  * * shock_source - used for determining where to get the power to zap them.
  * can be an apc, a cable, an area, a cell, or even a powernet datum
- * defaults to our cell or our current area/apc if it doesn't
  * subtypes may override this proc to pass this up to the parent
+ * defaults to our cell or our current area/apc
  * * siemens_coeff - multiplier to how much shock is delivered
+ * default to a 1x modifier
  *
  * Returns TRUE if the shock was successfully delivered
  * Returns FALSE if the shock failed for any reason

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -322,28 +322,21 @@
 	update_appearance()
 	return TRUE
 
-// shock user with probability prb (if all connections & power are working)
-// returns 1 if shocked, 0 otherwise
-
-/obj/structure/grille/proc/shock(mob/user, prb)
+/obj/structure/grille/shock(mob/living/shocking, chance = 100, shock_source, siemens_coeff = 1)
 	if(!anchored || broken) // anchored/broken grilles are never connected
 		return FALSE
-	if(!prob(prb))
+	var/turf/grill_loc = get_turf(src)
+	if(grill_loc.overfloor_placed)//cant be a floor in the way!
 		return FALSE
-	if(!in_range(src, user))//To prevent TK and mech users from getting shocked
+	var/obj/structure/cable/grill_cable = grill_loc.get_cable_node()
+	if(isnull(grill_cable))
 		return FALSE
-	var/turf/T = get_turf(src)
-	if(T.overfloor_placed)//cant be a floor in the way!
+	shock_source = grill_cable
+	if(!..())
 		return FALSE
-
-	var/obj/structure/cable/cable_node = T.get_cable_node()
-	if(isnull(cable_node))
-		return FALSE
-	if(!electrocute_mob(user, cable_node, src, 1, TRUE))
-		return FALSE
-	if(prob(50)) // Shocking hurts the grille (to weaken monkey powersinks)
+	// Shocking hurts the grille (to weaken monkey powersinks)
+	if(prob(50))
 		take_damage(1, BURN, FIRE, sound_effect = FALSE)
-	do_sparks(3, TRUE, src)
 	return TRUE
 
 /obj/structure/grille/should_atmos_process(datum/gas_mixture/air, exposed_temperature)

--- a/code/modules/antagonists/wizard/equipment/wizard_hammer.dm
+++ b/code/modules/antagonists/wizard/equipment/wizard_hammer.dm
@@ -102,7 +102,7 @@
 	icon_state = "[base_icon_state]0"
 	return ..()
 
-/obj/item/mjollnir/proc/shock(mob/living/target)
+/obj/item/mjollnir/proc/yeet_shock(mob/living/target)
 	target.Stun(1.5 SECONDS)
 	target.Knockdown(10 SECONDS)
 	var/datum/effect_system/basic/lightning_spread/lightning = new(target.loc, 5, TRUE)
@@ -120,9 +120,9 @@
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		return
 	if(HAS_TRAIT(src, TRAIT_WIELDED))
-		shock(target_mob)
+		yeet_shock(target_mob)
 
 /obj/item/mjollnir/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
 	if(!QDELETED(hit_atom) && isliving(hit_atom))
-		shock(hit_atom)
+		yeet_shock(hit_atom)

--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_interact.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_interact.dm
@@ -162,15 +162,10 @@
 			if(!wires.is_cut(WIRE_AI))
 				aidisabled = FALSE
 
-/obj/machinery/airalarm/proc/shock(mob/user, prb)
-	if((machine_stat & (NOPOWER))) // unpowered, no shock
+/obj/machinery/airalarm/shock(mob/living/shocking, chance, shock_source, siemens_coeff)
+	if(machine_stat & NOPOWER) // unpowered, no shock
 		return FALSE
-	if(!prob(prb))
-		return FALSE //you lucked out, no shock for you
-	do_sparks(5, TRUE, src)
-	if (electrocute_mob(user, get_area(src), src, 1, TRUE))
-		return TRUE
-	return FALSE
+	return ..()
 
 /obj/item/electronics/airalarm
 	name = "air alarm electronics"

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -231,7 +231,7 @@
 	return ..()
 
 /obj/item/mod/control/wrench_act(mob/living/user, obj/item/wrench)
-	if(seconds_electrified && get_charge() && shock(user))
+	if(seconds_electrified && get_charge() && shock(user, 100))
 		return ITEM_INTERACT_BLOCKING
 	if(open)
 		if(!core)

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -541,12 +541,12 @@
 		return
 	picked_module.on_select()
 
-/obj/item/mod/control/proc/shock(mob/living/user)
-	if(!istype(user) || get_charge() < 1)
+/obj/item/mod/control/shock(mob/living/shocking, chance, shock_source, siemens_coeff)
+	if(get_charge() < 1)
 		return FALSE
-	do_sparks(5, TRUE, src)
-	var/check_range = TRUE
-	return electrocute_mob(user, get_charge_source(), src, 0.7, check_range)
+	if(isnull(siemens_coeff))
+		siemens_coeff = 0.7
+	return ..()
 
 /obj/item/mod/control/proc/install(obj/item/mod/module/new_module, mob/user)
 	for(var/obj/item/mod/module/old_module as anything in modules)

--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -227,7 +227,7 @@
 /obj/item/mod/core/standard/proc/on_attack_hand(datum/source, mob/living/user)
 	SIGNAL_HANDLER
 
-	if(mod.seconds_electrified && charge_amount() && mod.shock(user))
+	if(mod.seconds_electrified && charge_amount() && mod.shock(user, 100))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 	if(mod.open && mod.loc == user)
 		INVOKE_ASYNC(src, PROC_REF(mod_uninstall_cell), user)

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -500,21 +500,12 @@ GLOBAL_VAR_INIT(fax_autoprinting, FALSE)
 			return TRUE
 	return FALSE
 
-/**
- * Attempts to shock the passed user, returns true if they are shocked.
- *
- * Arguments:
- * * user - the user to shock
- * * chance - probability the shock happens
- */
-/obj/machinery/fax/proc/shock(mob/living/user, chance)
-	if(!istype(user) || machine_stat & (BROKEN|NOPOWER))
+/obj/machinery/fax/shock(mob/living/shocking, chance = 100, shock_source, siemens_coeff = 1)
+	if( machine_stat & (BROKEN|NOPOWER))
 		return FALSE
-	if(!prob(chance))
-		return FALSE
-	do_sparks(5, TRUE, src)
-	var/check_range = TRUE
-	return electrocute_mob(user, get_area(src), src, 0.7, check_range)
+	if(isnull(siemens_coeff))
+		siemens_coeff = 0.7
+	return ..()
 
 
 /obj/machinery/fax/add_context(atom/source, list/context, obj/item/held_item, mob/user)

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -155,16 +155,11 @@
 		balloon_alert(user, "it's disabled!")
 	return .
 
-/obj/machinery/power/apc/proc/shock(mob/user, prb)
-	if(!prob(prb))
+/obj/machinery/power/apc/shock(mob/living/shocking, chance, shock_source, siemens_coeff)
+	if(isalien(shocking))
 		return FALSE
-	do_sparks(5, TRUE, src)
-	if(isalien(user))
-		return FALSE
-	if(electrocute_mob(user, src, src, 1, TRUE))
-		return TRUE
-	else
-		return FALSE
+	shock_source = src
+	return ..()
 
 #undef ETHEREAL_APC_DRAIN_TIME
 #undef ETHEREAL_APC_POWER_GAIN

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -269,7 +269,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 		return NONE
 	add_fingerprint(user)
 	to_chat(user, get_power_info())
-	shock(user, 5, 0.2)
+	shock(user, 5, null, 0.2)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/cable/proc/get_power_info()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -279,13 +279,9 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 		return span_danger("The cable is not powered.")
 
 // shock the user with probability prb
-/obj/structure/cable/proc/shock(mob/user, prb, siemens_coeff = 1)
-	if(!prob(prb))
-		return FALSE
-	if(electrocute_mob(user, powernet, src, siemens_coeff))
-		do_sparks(5, TRUE, src)
-		return TRUE
-	return FALSE
+/obj/structure/cable/shock(mob/living/shocking, chance, shock_source, siemens_coeff)
+	shock_source = powernet
+	return ..()
 
 /obj/structure/cable/singularity_pull(atom/singularity, current_size)
 	..()
@@ -722,9 +718,8 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 
 	use(1)
 
-	if(C.shock(user, 50))
-		if(prob(50)) //fail
-			C.deconstruct()
+	if(C.shock(user, 50) && prob(50)) //fail
+		C.deconstruct()
 
 	return C
 

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -47,11 +47,11 @@
 	if(get_dist(src, user) > 1)
 		return FALSE
 	else
-		shock(user)
+		yeet_shock(user)
 		return TRUE
 
 /obj/machinery/field/containment/attackby(obj/item/W, mob/user, list/modifiers, list/attack_modifiers)
-	shock(user)
+	yeet_shock(user)
 	return TRUE
 
 /obj/machinery/field/containment/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
@@ -83,7 +83,7 @@
 	if(isliving(considered_atom))
 		var/mob/living/living_moving_through_field = considered_atom
 		if(!living_moving_through_field.incorporeal_move)
-			shock(considered_atom)
+			yeet_shock(considered_atom)
 
 	if(ismachinery(considered_atom) || isstructure(considered_atom) || ismecha(considered_atom))
 		bump_field(considered_atom)
@@ -100,7 +100,7 @@
 
 	return SINGULARITY_TRY_MOVE_BLOCK
 
-/obj/machinery/field/containment/shock(mob/living/user)
+/obj/machinery/field/containment/yeet_shock(mob/living/user)
 	if(!field_gen_1 || !field_gen_2)
 		qdel(src)
 		return FALSE

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -122,7 +122,7 @@
 	if(has_shocked)
 		return
 	if(isliving(mover))
-		shock(mover)
+		yeet_shock(mover)
 		return
 	if(ismachinery(mover) || isstructure(mover) || isvehicle(mover))
 		bump_field(mover)
@@ -134,7 +134,7 @@
 	if(has_shocked || isliving(mover) || ismachinery(mover) || isstructure(mover) || ismecha(mover))
 		return FALSE
 
-/obj/machinery/field/proc/shock(mob/living/user)
+/obj/machinery/field/proc/yeet_shock(mob/living/user)
 	var/shock_damage = min(rand(30,40),rand(30,40))
 
 	if(iscarbon(user))

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -945,11 +945,12 @@
 	req_one_access = one_access ? accesses : list()
 
 /// Electrocute user from power celll
-/obj/vehicle/sealed/mecha/proc/shock(mob/living/user)
-	if(!istype(user) || get_charge() < 1)
+/obj/vehicle/sealed/mecha/shock(mob/living/shocking, chance = 100, shock_source, siemens_coeff)
+	if(get_charge() < 1)
 		return FALSE
-	do_sparks(5, TRUE, src)
-	return electrocute_mob(user, cell, src, 0.7, TRUE)
+	if(isnull(siemens_coeff))
+		siemens_coeff = 0.7
+	return ..()
 
 /// Toggle mech overclock with a button or by hacking
 /obj/vehicle/sealed/mecha/proc/toggle_overclock(forced_state = null)

--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -67,7 +67,7 @@
 				return
 			var/obj/vehicle/sealed/mecha/our_mecha = our_mecha_tracker.chassis
 			if(our_mecha)
-				our_mecha_tracker.shock()
+				our_mecha_tracker.remote_emp_triggered()
 				usr.log_message("has activated remote EMP on exosuit [our_mecha], located at [loc_name(our_mecha)], which is currently [LAZYLEN(our_mecha.occupants) ? "occupied by [our_mecha.occupants.Join(", ")]." : "without a pilot."]", LOG_ATTACK)
 				usr.log_message("has activated remote EMP on exosuit [our_mecha], located at [loc_name(our_mecha)], which is currently [LAZYLEN(our_mecha.occupants) ? "occupied by [our_mecha.occupants.Join(", ")]." : "without a pilot."]", LOG_GAME, log_globally = FALSE)
 				message_admins("[key_name_admin(usr)][ADMIN_FLW(usr)] has activated remote EMP on exosuit [our_mecha][ADMIN_JMP(our_mecha)], which is currently [LAZYLEN(our_mecha.occupants) ? "occupied by [our_mecha.occupants.Join(",")][ADMIN_FLW(our_mecha)]." : "without a pilot."]")
@@ -137,7 +137,7 @@
 /**
  * Attempts to EMP mech that the tracker is attached to, if there is one and tracker is not on cooldown
  */
-/obj/item/mecha_parts/mecha_tracking/proc/shock()
+/obj/item/mecha_parts/mecha_tracking/proc/remote_emp_triggered()
 	if(recharging)
 		return
 	if(!chassis)


### PR DESCRIPTION
## About The Pull Request

`shock` was copy pasted across a bunch of base types
I needed the behavior unified and it was fairly trivial to do 
So now we have `/obj/proc/shock` which all the old implementations call 

## Changelog

:cl: Melbert
refactor: Made some minor changes to how things like airlocks, vendors, and autolathes shock you. Report any wierdness with that
/:cl:

