### PR TITLE
Fixes changlings transformed into a Felinid losing decap immunity thanks to their newly shrunken brain

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -142,6 +142,7 @@
 	RegisterSignal(living_mob, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 	RegisterSignal(living_mob, COMSIG_LIVING_POST_FULLY_HEAL, PROC_REF(on_fullhealed))
 	RegisterSignal(living_mob, COMSIG_MOB_GET_STATUS_TAB_ITEMS, PROC_REF(get_status_tab_item))
+	RegisterSignal(living_mob, COMSIG_CARBON_GAIN_ORGAN, PROC_REF(new_brain))
 	RegisterSignals(living_mob, list(COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON), PROC_REF(on_click_sting))
 	ADD_TRAIT(living_mob, TRAIT_FAKE_SOULLESS, CHANGELING_TRAIT)
 	ADD_TRAIT(living_mob, TRAIT_BRAINLESS_CARBON, CHANGELING_TRAIT)
@@ -200,10 +201,26 @@
 
 	ling_hud.show_hud(ling_hud.hud_version)
 
+/datum/antagonist/changeling/proc/new_brain(mob/living/carbon/ling, obj/item/organ/new_brain)
+	SIGNAL_HANDLER
+
+	if(!istype(new_brain, /obj/item/organ/brain))
+		return
+	make_brain_decoy(ling)
+
 /datum/antagonist/changeling/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/living_mob = mob_override || owner.current
 	handle_clown_mutation(living_mob, removing = FALSE)
-	UnregisterSignal(living_mob, list(COMSIG_MOB_LOGIN, COMSIG_LIVING_LIFE, COMSIG_LIVING_POST_FULLY_HEAL, COMSIG_MOB_GET_STATUS_TAB_ITEMS, COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON))
+	UnregisterSignal(living_mob, list(
+		COMSIG_MOB_LOGIN,
+		COMSIG_LIVING_LIFE,
+		COMSIG_LIVING_POST_FULLY_HEAL,
+		COMSIG_MOB_GET_STATUS_TAB_ITEMS,
+		COMSIG_MOB_MIDDLECLICKON,
+		COMSIG_MOB_ALTCLICKON,
+		COMSIG_MOB_HUD_CREATED,
+		COMSIG_CARBON_GAIN_ORGAN,
+	))
 	REMOVE_TRAIT(living_mob, TRAIT_FAKE_SOULLESS, CHANGELING_TRAIT)
 	REMOVE_TRAIT(living_mob, TRAIT_BRAINLESS_CARBON, CHANGELING_TRAIT)
 	REMOVE_TRAIT(living_mob, TRAIT_CHANGELING_HIVEMIND, CHANGELING_TRAIT)

--- a/code/modules/unit_tests/ling_decap.dm
+++ b/code/modules/unit_tests/ling_decap.dm
@@ -34,7 +34,7 @@
 /datum/unit_test/ling_decap/post_species_change/test_setup(mob/living/carbon/human/ling)
 	// Regression test for a bug where changing to a species with a new brain would wipe the special changeling handling
 	var/obj/item/organ/brain/oldbrain = ling.get_organ_slot(ORGAN_SLOT_BRAIN)
-	ling.set_species(/datum/species/lizard)
+	ling.set_species(/datum/species/human/felinid)
 	var/obj/item/organ/brain/newbrain = ling.get_organ_slot(ORGAN_SLOT_BRAIN)
 	TEST_ASSERT(oldbrain.type != newbrain.type, "Changling decap test setup failed to change the ling's brain typepath when changing their species.")
 

--- a/code/modules/unit_tests/ling_decap.dm
+++ b/code/modules/unit_tests/ling_decap.dm
@@ -5,6 +5,7 @@
 	var/mob/living/carbon/human/ling = allocate(/mob/living/carbon/human/consistent)
 	ling.mind_initialize()
 	ling.mind.add_antag_datum(/datum/antagonist/changeling)
+	test_setup(ling)
 
 	var/obj/item/bodypart/head/noggin = ling.get_bodypart(BODY_ZONE_HEAD)
 	noggin.dismember()
@@ -23,6 +24,19 @@
 	qdel(noggin)
 	for(var/obj/item/organ/leftover in ling.loc)
 		qdel(leftover)
+
+/datum/unit_test/ling_decap/proc/test_setup(mob/living/carbon/human/ling)
+	return
+
+/// Test lings don't die when decapitated after transforming to a species with a new brain typepath
+/datum/unit_test/ling_decap/post_species_change
+
+/datum/unit_test/ling_decap/post_species_change/test_setup(mob/living/carbon/human/ling)
+	// Regression test for a bug where changing to a species with a new brain would wipe the special changeling handling
+	var/obj/item/organ/brain/oldbrain = ling.get_organ_slot(ORGAN_SLOT_BRAIN)
+	ling.set_species(/datum/species/lizard)
+	var/obj/item/organ/brain/newbrain = ling.get_organ_slot(ORGAN_SLOT_BRAIN)
+	TEST_ASSERT(oldbrain.type != newbrain.type, "Changling decap test setup failed to change the ling's brain typepath when changing their species.")
 
 /// Tests people get decapitated properly.
 /datum/unit_test/normal_decap

--- a/code/modules/unit_tests/ling_decap.dm
+++ b/code/modules/unit_tests/ling_decap.dm
@@ -36,7 +36,7 @@
 	var/obj/item/organ/brain/oldbrain = ling.get_organ_slot(ORGAN_SLOT_BRAIN)
 	ling.set_species(/datum/species/human/felinid)
 	var/obj/item/organ/brain/newbrain = ling.get_organ_slot(ORGAN_SLOT_BRAIN)
-	TEST_ASSERT(oldbrain.type != newbrain.type, "Changling decap test setup failed to change the ling's brain typepath when changing their species.")
+	TEST_ASSERT(oldbrain.type != newbrain.type, "Changeling decap test setup failed to change the ling's brain typepath when changing their species.")
 
 /// Tests people get decapitated properly.
 /datum/unit_test/normal_decap


### PR DESCRIPTION
## About The Pull Request

Fixes #95203

Changling "decoy brain" status was a behavior attached to the brain. 
However it never re-applied the "decoy brain" status at any point. Even if your brain changed. 

This was fine for the most part because all of our roundstart species used the same base brain type.
Which meant your brain didn't change and there was no reason to re-apply the behavior. 

But now Felinids (*and Lizardpeople*) have a different brain typepath. Changing into these species would give you an entirely new brain and wipe the "decoy brain" mechanic entirely without re-applying it.

This PR fixes the issue by re-applying "decoy brain" status the ling has a new brain added. 

## Changelog

:cl: Melbert
fix: Fixes Changlings transformed into a Felinid losing decap immunity thanks to their newly shrunken brain
/:cl:
