### PR TITLE
Replaced loot spawner in Catwalk's space to prevent flaky errors

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -14785,11 +14785,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"dUz" = (
-/obj/effect/spawner/random/maintenance,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "dUF" = (
 /obj/structure/cable,
 /obj/machinery/power/smes,
@@ -126881,7 +126876,7 @@ gcb
 ohG
 heR
 dcE
-dUz
+jPs
 eap
 eqT
 nHY


### PR DESCRIPTION
## About The Pull Request

changed subtype of spawner to not spawn decals in space
closes #95211

## Changelog

:cl:
fix: Replaced loot spawner in Catwalk's space to prevent flaky errors.
/:cl: