### PR TITLE
Improves performance of reagent transfer & removal operations

### DIFF
--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -449,11 +449,15 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		reagents.flags |= NO_REACT
 
 	// allowing reagents to react after being lit
+	reagents.handle_reactions()
+	if(QDELETED(src))
+		return
+	START_PROCESSING(SSobj, src)
+
 	update_appearance(UPDATE_ICON)
 	if(flavor_text)
 		var/turf/T = get_turf(src)
 		T.visible_message(flavor_text)
-	START_PROCESSING(SSobj, src)
 
 	if(iscarbon(loc))
 		var/mob/living/carbon/smoker = loc
@@ -536,8 +540,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	reagents.expose_temperature(heat, 0.05)
 	if(!reagents.total_volume) //may have reacted and gone to 0 after expose_temperature
 		return
-
-	reagents.handle_reactions()
 
 	var/to_smoke = smoke_all ? (reagents.total_volume * (dragtime / smoketime)) : REAGENTS_METABOLISM
 	var/mob/living/carbon/smoker = loc
@@ -1147,8 +1149,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	to_chat(user, span_notice("You start puffing on the vape."))
 	reagents.flags &= ~(NO_REACT)
-	START_PROCESSING(SSobj, src)
+	reagents.handle_reactions()
+	if(QDELETED(src))
+		return
 	set_light_on(TRUE)
+	START_PROCESSING(SSobj, src)
 
 /obj/item/vape/dropped(mob/user)
 	. = ..()
@@ -1160,8 +1165,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/vape/proc/handle_reagents()
 	if(!reagents.total_volume)
 		return
-
-	reagents.handle_reactions()
 
 	var/mob/living/carbon/vaper = loc
 	if(!iscarbon(vaper) || src != vaper.wear_mask)

--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -536,6 +536,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	reagents.expose_temperature(heat, 0.05)
 	if(!reagents.total_volume) //may have reacted and gone to 0 after expose_temperature
 		return
+
+	reagents.handle_reactions()
+
 	var/to_smoke = smoke_all ? (reagents.total_volume * (dragtime / smoketime)) : REAGENTS_METABOLISM
 	var/mob/living/carbon/smoker = loc
 	// These checks are a bit messy but at least they're fairly readable
@@ -1157,6 +1160,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/vape/proc/handle_reagents()
 	if(!reagents.total_volume)
 		return
+
+	reagents.handle_reactions()
 
 	var/mob/living/carbon/vaper = loc
 	if(!iscarbon(vaper) || src != vaper.wear_mask)

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -225,8 +225,9 @@
 	var/bad_food_amount = 0
 	for(var/datum/reagent/consumable/food_reagent in reagents.reagent_list)
 		var/amount_to_remove = food_reagent.volume * rand(6, 8) * 0.1 //around 60% to 80% of the volume is to be converted.
-		reagents.remove_reagent(food_reagent.type, amount_to_remove, safety = FALSE)
+		food_reagent.volume -= amount_to_remove
 		bad_food_amount += amount_to_remove
+	reagents.update_total()
 	reagents.add_reagent(/datum/reagent/toxin/bad_food, bad_food_amount, reagtemp = reagents.chem_temp)
 
 /obj/item/food/badrecipe/Destroy(force)

--- a/code/modules/reagents/chemistry/holder/holder.dm
+++ b/code/modules/reagents/chemistry/holder/holder.dm
@@ -533,7 +533,6 @@
 		log_combat(transferred_by, log_target, "transferred reagents to", my_atom, "which had [english_list(transfer_log)]")
 
 	if(!no_react)
-		transfer_reactions(target_holder)
 		target_holder.handle_reactions()
 
 	return total_transfered_amount

--- a/code/modules/reagents/chemistry/holder/holder.dm
+++ b/code/modules/reagents/chemistry/holder/holder.dm
@@ -534,8 +534,6 @@
 
 	if(!no_react)
 		transfer_reactions(target_holder)
-		if(!copy_only)
-			handle_reactions()
 		target_holder.handle_reactions()
 
 	return total_transfered_amount

--- a/code/modules/reagents/chemistry/holder/holder.dm
+++ b/code/modules/reagents/chemistry/holder/holder.dm
@@ -209,10 +209,9 @@
  *
  * * [reagent_type][datum/reagent] - the type of reagent
  * * amount - the volume to remove
- * * safety - if FALSE will initiate reactions upon removing. used for trans_id_to
  * * include_subtypes - if TRUE will remove the specified amount from all subtypes of reagent_type as well
  */
-/datum/reagents/proc/remove_reagent(datum/reagent/reagent_type, amount, safety = TRUE, include_subtypes = FALSE)
+/datum/reagents/proc/remove_reagent(datum/reagent/reagent_type, amount, include_subtypes = FALSE)
 	if(!ispath(reagent_type))
 		stack_trace("invalid reagent passed to remove reagent [reagent_type]")
 		return FALSE
@@ -248,8 +247,6 @@
 
 	//update the holder & handle reactions
 	update_total()
-	if(!safety)
-		handle_reactions()
 
 	return total_removed_amount
 
@@ -294,7 +291,6 @@
 
 		total_removed_amount += remove_amount
 	update_total()
-	handle_reactions()
 
 	return round(total_removed_amount, CHEMICAL_QUANTISATION_LEVEL)
 

--- a/code/modules/reagents/chemistry/holder/reactions.dm
+++ b/code/modules/reagents/chemistry/holder/reactions.dm
@@ -260,34 +260,6 @@
 		my_atom.audible_message(span_notice("[icon2html(my_atom, viewers(DEFAULT_MESSAGE_RANGE, src))][mix_message.Join()]"))
 	return any_stopped
 
-/*
-* Transfers the reaction_list to a new reagents datum
-*
-* Arguments:
-* * target - the datum/reagents that this src is being transferred into
-*/
-/datum/reagents/proc/transfer_reactions(datum/reagents/target)
-	if(QDELETED(target))
-		CRASH("transfer_reactions() had a [target] ([target.type]) passed to it when it was set to qdel, or it isn't a reagents datum.")
-	if(!reaction_list)
-		return
-	for(var/datum/equilibrium/reaction_source as anything in reaction_list)
-		var/exists = FALSE
-		for(var/datum/equilibrium/reaction_target as anything in target.reaction_list) //Don't add duplicates
-			if(reaction_source.reaction.type == reaction_target.reaction.type)
-				exists = TRUE
-		if(exists)
-			continue
-		if(!reaction_source.holder)
-			CRASH("reaction_source is missing a holder in transfer_reactions()!")
-
-		var/datum/equilibrium/new_E = new (reaction_source.reaction, target)//addition to reaction_list is done in new()
-		if(new_E.to_delete)//failed startup checks
-			qdel(new_E)
-
-	target.previous_reagent_list = LAZYLISTDUPLICATE(previous_reagent_list)
-	target.is_reacting = is_reacting
-
 /**
  * Old reaction mechanics, edited to work on one only
  * This is changed from the old - purity of the reagents will affect yield

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -146,7 +146,8 @@
 		var/cached_purity = reagent.purity
 		if((reaction_flags & REACTION_CLEAR_INVERSE) && reagent.inverse_chem)
 			if(reagent.inverse_chem_val > reagent.purity)
-				holder.remove_reagent(reagent.type, cached_volume, safety = FALSE)
+				reagent.volume = 0
+				holder.update_total()
 				holder.add_reagent(reagent.inverse_chem, cached_volume, FALSE, added_purity = reagent.get_inverse_purity(cached_purity))
 				return
 

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -142,13 +142,14 @@
 		if(reagent.purity == 1)
 			return
 
-		var/cached_volume = reagent.volume
-		var/cached_purity = reagent.purity
 		if((reaction_flags & REACTION_CLEAR_INVERSE) && reagent.inverse_chem)
 			if(reagent.inverse_chem_val > reagent.purity)
+				var/inverse_chem = reagent.inverse_chem
+				var/cached_volume = reagent.volume
+				var/cached_purity = reagent.get_inverse_purity(reagent.purity)
 				reagent.volume = 0
 				holder.update_total()
-				holder.add_reagent(reagent.inverse_chem, cached_volume, FALSE, added_purity = reagent.get_inverse_purity(cached_purity))
+				holder.add_reagent(inverse_chem, cached_volume, FALSE, added_purity = cached_purity)
 				return
 
 /**


### PR DESCRIPTION
## About The Pull Request
- Removing reagents now won't trigger new chemical reactions. This has always been the default behaviour in code and if you think about it logically if the reagents failed to react to begin with then removing already present reagents doesn't help in starting new reactions.

- Transferring reactions has now been removed because it made no sense. We call `handle_reactions()` on the target holder anyway which will create new reactions for us with the reagents we have just transferred

**Note**: Please Test merge first as it does effect a lot of reagent related stuff

## Changelog
:cl:
code: reagent transfer & removal operations now have faster cpu performance
/:cl:

