### PR TITLE
`sqrt()` the volume of reagents transferred to crafted food (kinda experimental-ish)

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -342,7 +342,7 @@ Behavior that's still missing from this component that original food items had t
 	for(var/obj/item/food/crafted_part in components)
 		if(!crafted_part.reagents)
 			continue
-		var/transferred_volume = min(round(sqrt(crafted_part.reagents.total_volume), 0.5), crafted_part.reagents.total_volume)
+		var/transferred_volume = min(round(sqrt(2 * crafted_part.reagents.total_volume), 0.05), crafted_part.reagents.total_volume)
 		this_food.reagents.maximum_volume += transferred_volume
 		crafted_part.reagents.trans_to(this_food.reagents, transferred_volume)
 

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -346,7 +346,7 @@ Behavior that's still missing from this component that original food items had t
 		this_food.reagents.maximum_volume += transferred_volume
 		crafted_part.reagents.trans_to(this_food.reagents, transferred_volume)
 
-	this_food.reagents.maximum_volume = ceil(crafted_part.reagents.maximum_volume)
+	this_food.reagents.maximum_volume = ceil(this_food.reagents.maximum_volume)
 
 	BLACKBOX_LOG_FOOD_MADE(parent.type)
 

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -342,9 +342,11 @@ Behavior that's still missing from this component that original food items had t
 	for(var/obj/item/food/crafted_part in components)
 		if(!crafted_part.reagents)
 			continue
-		var/transferred_volume = ceil(sqrt(crafted_part.reagents.total_volume))
+		var/transferred_volume = min(round(sqrt(crafted_part.reagents.total_volume), 0.5), crafted_part.reagents.total_volume)
 		this_food.reagents.maximum_volume += transferred_volume
 		crafted_part.reagents.trans_to(this_food.reagents, transferred_volume)
+
+	this_food.reagents.maximum_volume = ceil(crafted_part.reagents.maximum_volume)
 
 	BLACKBOX_LOG_FOOD_MADE(parent.type)
 

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -342,10 +342,9 @@ Behavior that's still missing from this component that original food items had t
 	for(var/obj/item/food/crafted_part in components)
 		if(!crafted_part.reagents)
 			continue
-		this_food.reagents.maximum_volume += crafted_part.reagents.maximum_volume
-		crafted_part.reagents.trans_to(this_food.reagents, crafted_part.reagents.maximum_volume)
-
-	this_food.reagents.maximum_volume = ROUND_UP(this_food.reagents.maximum_volume) // Just because I like whole numbers for this.
+		var/transferred_volume = ceil(sqrt(crafted_part.reagents.total_volume))
+		this_food.reagents.maximum_volume += transferred_volume
+		crafted_part.reagents.trans_to(this_food.reagents, transferred_volume)
 
 	BLACKBOX_LOG_FOOD_MADE(parent.type)
 


### PR DESCRIPTION
## About The Pull Request

Rather than transferring 100% of all reagents of food components to crafted food, transfer only the sqrt of the volume of reagents (rounded to the nearest 0.5u)

Example: Fruit salad 
Total input volume (50 potency): 32.3u
Total input volume (100 potency): 64.6u
| | Total volume |
| - | - |
| "Expected" amount | 14u |
| Pre PR, 50 potency | 42u |
| Post PR, 50 potency | 25u |
| Pre PR, 100 potency | 84u |
| Post PR, 100 potency | 32u |

## Why It's Good For The Game

Chef has had this ongoing issue where using the best available produce from botany results in food no human can eat in one sitting.

(This is because botany food scales linearly - an apple has 14u of reagents at 100 potency, which is on par with how much nutrition many fully finished recipes are "expected" to give you on their own. Reducing the amount of nutrition across all botany produce is an option, but at the end of the day we are still combining upwards of twelve produce items into one, we're gonna have extreme volume numbers.)

This means chef players tend to actively *want* worse botanists as the crew cannot feasibly eat any of the food they are making! Which is sad. 

Changing to an exponential scaling attempts to bring food closer to the "expected" volume of reagents without unnecessarily hampering chefs who don't have access to max potency foods. If you only have store bought apples available, each one will only offer 3u of reagents. Compared to prime botany apples which only offer 4u of reagents. 

## Changelog

:cl: Melbert
balance: The amount of reagents transferred from food components to food results when cooking has been reduced from (1 * volume) to (volume ^ 0.5). In other words, food the chef makes will have roughly 30%-50% fewer bites of reagents on average. While this seems like a stark change, the difference tends to be in the ballpark of 40u->25u of nutriments, which is still a lot. 
/:cl:
