### PR TITLE
Food clears base reagents before transferring produce reagents in again

### DIFF
--- a/code/__DEFINES/crafting.dm
+++ b/code/__DEFINES/crafting.dm
@@ -26,8 +26,9 @@
 #define CRAFT_ON_SOLID_GROUND (1<<4)
 /// If the craft checks that there are objects with density in the same turf when being built
 #define CRAFT_CHECK_DENSITY (1<<5)
-/// Crafting passes reagents of components to the finished product
-#define CRAFT_TRANSFERS_REAGENTS (1<<6)
+/// Any reagent inputs to the craft will be transferred to the finishing product instead of being deleted
+/// Note this only handles reagents that are SPECIFICALLY ASKED FOR in the component list, not all reagents in all components
+#define CRAFT_TRANSFERS_REAGENT_COMPONENTS (1<<6)
 /// Crafting clears all reagents present in the finished product
 #define CRAFT_CLEARS_REAGENTS (1<<7)
 /// For the crafting unit test, we don't check if the custom materials of an item are the same when crafted and spawned should its recipe have this flag.

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -278,13 +278,12 @@
 			for(var/obj/item/thing in result)
 				qdel(thing)
 	result.setDir(crafter.dir)
+	if(recipe.crafting_flags & CRAFT_CLEARS_REAGENTS)
+		result.reagents.clear_reagents()
 	var/datum/reagents/holder = locate() in stuff_to_use
 	if(holder) //transfer reagents from ingredients to result
-		if(!ispath(recipe.result, /obj/item/reagent_containers) && result.reagents)
-			if(recipe.crafting_flags & CRAFT_CLEARS_REAGENTS)
-				result.reagents.clear_reagents()
-			if(recipe.crafting_flags & CRAFT_TRANSFERS_REAGENTS)
-				holder.trans_to(result.reagents, holder.total_volume, no_react = TRUE)
+		if(!ispath(recipe.result, /obj/item/reagent_containers) && result.reagents && (recipe.crafting_flags & CRAFT_TRANSFERS_REAGENT_COMPONENTS))
+			holder.trans_to(result.reagents, holder.total_volume, no_react = TRUE)
 		stuff_to_use -= holder //This is the only non-movable in our list, we need to remove it.
 		qdel(holder)
 	result.on_craft_completion(stuff_to_use, recipe, crafter)

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -282,7 +282,7 @@
 		result.reagents?.clear_reagents()
 	var/datum/reagents/holder = locate() in stuff_to_use
 	if(holder) //transfer reagents from ingredients to result
-		if(!ispath(recipe.result, /obj/item/reagent_containers) && result.reagents && (recipe.crafting_flags & CRAFT_TRANSFERS_REAGENT_COMPONENTS))
+		if(result.reagents && (recipe.crafting_flags & CRAFT_TRANSFERS_REAGENT_COMPONENTS))
 			holder.trans_to(result.reagents, holder.total_volume, no_react = TRUE)
 		stuff_to_use -= holder //This is the only non-movable in our list, we need to remove it.
 		qdel(holder)

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -279,7 +279,7 @@
 				qdel(thing)
 	result.setDir(crafter.dir)
 	if(recipe.crafting_flags & CRAFT_CLEARS_REAGENTS)
-		result.reagents.clear_reagents()
+		result.reagents?.clear_reagents()
 	var/datum/reagents/holder = locate() in stuff_to_use
 	if(holder) //transfer reagents from ingredients to result
 		if(!ispath(recipe.result, /obj/item/reagent_containers) && result.reagents && (recipe.crafting_flags & CRAFT_TRANSFERS_REAGENT_COMPONENTS))

--- a/code/game/objects/items/food/frozen.dm
+++ b/code/game/objects/items/food/frozen.dm
@@ -110,6 +110,15 @@
 	crafting_complexity = FOOD_COMPLEXITY_2
 	crafted_food_buff = /datum/status_effect/food/chilling
 
+/obj/item/food/snowcones/on_craft_completion(list/components, datum/crafting_recipe/food/current_recipe, atom/crafter)
+	. = ..()
+	// replaces the ice from the input with water
+	reagents.remove_reagent(/datum/reagent/consumable/ice, 15)
+	reagents.add_reagent(/datum/reagent/water, 11)
+	// then add 1u nutriment for free
+	reagents.add_reagent(/datum/reagent/consumable/nutriment, 1)
+	// the juice component will be transferred in from crafting
+
 /obj/item/food/snowcones/lime
 	name = "lime snowcone"
 	desc = "Lime syrup drizzled over a snowball in a paper cup."

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -6,7 +6,7 @@
 		/obj/item/stack/rods,
 		/obj/item/reagent_containers/cup/glass/sillycup,
 	)
-	crafting_flags = parent_type::crafting_flags | CRAFT_TRANSFERS_REAGENTS | CRAFT_CLEARS_REAGENTS
+	crafting_flags = parent_type::crafting_flags | CRAFT_TRANSFERS_REAGENT_COMPONENTS | CRAFT_CLEARS_REAGENTS
 	///The food types that are added to the result when the recipe is completed
 	var/added_foodtypes = NONE
 	///The food types that are removed to the result when the recipe is completed

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
@@ -196,7 +196,7 @@
 	result = /obj/item/food/rootdough
 	added_foodtypes = NUTS
 	category = CAT_LIZARD
-	crafting_flags = CRAFT_CLEARS_REAGENTS
+	crafting_flags = parent_type::crafting_flags & ~CRAFT_TRANSFERS_REAGENT_COMPONENTS // prevents water from reacting immediately, clearing the dish
 
 /datum/crafting_recipe/food/rootdough/with_eggs
 	name = "Rootdough (With Eggs)"
@@ -222,7 +222,7 @@
 		/obj/item/reagent_containers/cup/beaker/slime = 1,
 		/obj/item/reagent_containers/applicator/patch/synthflesh = 1,
 	)
-	crafting_flags = CRAFT_CLEARS_REAGENTS
+	crafting_flags = parent_type::crafting_flags & ~CRAFT_TRANSFERS_REAGENT_COMPONENTS // prevents water from reacting immediately, clearing the dish
 
 /datum/crafting_recipe/food/snail_nizaya
 	name = "Desert snail nizaya"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
@@ -28,7 +28,7 @@
 	)
 	result = /obj/item/food/toasted_seeds
 	category = CAT_MOTH
-	crafting_flags = CRAFT_TRANSFERS_REAGENT_COMPONENTS
+	crafting_flags = parent_type::crafting_flags & ~CRAFT_CLEARS_REAGENTS // seeds don't have nutriment
 
 /datum/crafting_recipe/food/engine_fodder
 	name = "Engine fodder"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
@@ -28,6 +28,7 @@
 	)
 	result = /obj/item/food/toasted_seeds
 	category = CAT_MOTH
+	crafting_flags = CRAFT_TRANSFERS_REAGENT_COMPONENTS
 
 /datum/crafting_recipe/food/engine_fodder
 	name = "Engine fodder"


### PR DESCRIPTION
## About The Pull Request

When you craft food, the food's base reagents are cleared and replaced with all the produce's foods

https://github.com/tgstation/tgstation/blob/a2af8930399a73e2b668ff8689c7288e9cc28bc3/code/datums/components/food/edible.dm#L338-L350

Then we made crafting also transfer in reagents used in crafting for full parity

https://github.com/tgstation/tgstation/commit/74761fd023d968c7e07261670645d13b39bf9231

This caused a few bugs, but this commit in particular had a major effect in that it made it so the "clear reagents" step was only invoked when a reagent is used in crafting, which few food actually uses

https://github.com/tgstation/tgstation/commit/5970b6722bdd7413d812d46e874cc26e7d75c777

This PR moves the check back outside of the `holder` check

I don't think it'll cause any regressions for the second linked commit, as the only recipes that have the `clear_reagents` flag is food

However I felt pretty certain the first commit would regress, so I made sure the recipes mentioned in it would continue to work

## Changelog

:cl: Melbert
fix: Food items no longer "duplicate" their intended reagents when crafted
/:cl:

