### PR TITLE
Ghosts now have runechat

### DIFF
--- a/code/modules/client/preferences/runechat.dm
+++ b/code/modules/client/preferences/runechat.dm
@@ -8,6 +8,11 @@
 	savefile_key = "see_chat_non_mob"
 	savefile_identifier = PREFERENCE_PLAYER
 
+/datum/preference/toggle/enable_runechat_ghosts
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "chat_on_ghosts"
+	savefile_identifier = PREFERENCE_PLAYER
+
 /datum/preference/toggle/see_rc_emotes
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "see_rc_emotes"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -437,6 +437,12 @@
 		return FALSE
 	return TRUE
 
+/mob/dead/observer/runechat_prefs_check(mob/target, visible_message_flags = NONE)
+	if(!target.client?.prefs.read_preference(/datum/preference/toggle/enable_runechat))
+		return FALSE
+	if(!target.client?.prefs.read_preference(/datum/preference/toggle/enable_runechat_ghosts))
+		return FALSE
+	return TRUE
 
 ///Get the item on the mob in the storage slot identified by the id passed in
 /mob/proc/get_item_by_slot(slot_id) as /obj/item

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -438,7 +438,7 @@
 	return TRUE
 
 /mob/dead/observer/runechat_prefs_check(mob/target, visible_message_flags = NONE)
-	if(!target.client?.prefs.read_preference(/datum/preference/toggle/enable_runechat))
+	if(!..())
 		return FALSE
 	if(!target.client?.prefs.read_preference(/datum/preference/toggle/enable_runechat_ghosts))
 		return FALSE

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -166,6 +166,11 @@
 	if(client?.holder?.fakekey)
 		displayed_key = null
 	deadchat_broadcast(rendered, source, follow_target = src, speaker_key = displayed_key)
+	for(var/mob/mobs_hearing as anything in GLOB.player_list)
+		if(SSticker.current_state != GAME_STATE_FINISHED && (mobs_hearing.see_invisible < invisibility || !isdead(mobs_hearing)))
+			continue
+		if(runechat_prefs_check(mobs_hearing))
+			mobs_hearing.create_chat_message(src, /datum/language/common, message)
 
 ///Check if this message is an emote
 /mob/proc/check_emote(message, forced)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/runechat.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/runechat.tsx
@@ -19,6 +19,13 @@ export const see_chat_non_mob: FeatureToggle = {
   component: CheckboxInput,
 };
 
+export const chat_on_ghosts: FeatureToggle = {
+  name: 'Enable Runechat on ghosts',
+  category: 'RUNECHAT',
+  description: 'Chat messages will show above ghosts when they speak.',
+  component: CheckboxInput,
+};
+
 export const see_rc_emotes: FeatureToggle = {
   name: 'Enable Runechat emotes',
   category: 'RUNECHAT',


### PR DESCRIPTION
## About The Pull Request

Ghosts now have runechat between eachother and when the round's over. Taken from https://github.com/Monkestation/Monkestation2.0/pull/797

## Why It's Good For The Game

It makes for better screenshots and for messages to not be drowned out between ghost convo.

## Changelog

:cl: dwasint
qol: Ghosts now have runechat.
/:cl: