### PR TITLE
Initialization time is now properly deducted from lobby time

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -31,6 +31,8 @@ GLOBAL_REAL(Master, /datum/controller/master)
 	// Vars for keeping track of tick drift.
 	var/init_timeofday
 	var/init_time
+	/// Time in deciseconds for how long initializations are taking, updated per subsystem initialized
+	var/initializations_duration_real
 	var/tickdrift = 0
 	/// Tickdrift as of last tick, w no averaging going on
 	var/olddrift = 0
@@ -434,6 +436,7 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 	var/evaluated_order = 1
 	sortTim(subsystems, GLOBAL_PROC_REF(cmp_subsystem_display))
 	var/start_timeofday = REALTIMEOFDAY
+	initializations_duration_real = 0
 	for (var/current_init_stage in 1 to INITSTAGE_MAX)
 
 		// Initialize subsystems.
@@ -441,7 +444,7 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 			subsystem.init_order = evaluated_order
 			evaluated_order++
 			init_subsystem(subsystem)
-
+			initializations_duration_real = REALTIMEOFDAY - start_timeofday
 			CHECK_TICK
 		current_initializing_subsystem = null
 		init_stage_completed = current_init_stage
@@ -452,9 +455,7 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 			// Loop.
 			Master.StartProcessing(0)
 
-	var/time = (REALTIMEOFDAY - start_timeofday) / 10
-
-
+	var/time = initializations_duration_real / 10
 
 	var/msg = "Initializations complete within [time] second[time == 1 ? "" : "s"]!"
 	to_chat(world, span_boldannounce("[msg]"), MESSAGE_TYPE_DEBUG)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -156,7 +156,7 @@ SUBSYSTEM_DEF(ticker)
 		if(GAME_STATE_PREGAME)
 				//lobby stats for statpanels
 			if(isnull(timeLeft))
-				timeLeft = max(0,start_at - world.time)
+				timeLeft = GetTimeLeft()
 			totalPlayers = LAZYLEN(GLOB.new_player_list)
 			totalPlayersReady = 0
 			total_admins_ready = 0
@@ -789,7 +789,7 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/GetTimeLeft()
 	if(isnull(SSticker.timeLeft))
-		return max(0, start_at - world.time)
+		return (CONFIG_GET(number/lobby_countdown) * (1 SECONDS)) - Master.initializations_duration_real
 	return timeLeft
 
 /datum/controller/subsystem/ticker/proc/SetTimeLeft(newtime)

--- a/config/config.txt
+++ b/config/config.txt
@@ -30,7 +30,7 @@ STATIONNAME Space Station 13
 ## Put on byond hub: Uncomment this to put your server on the byond hub.
 #HUB
 
-## Lobby time: This is the amount of time between rounds that players have to setup their characters and be ready. This is inclusive of initialization time, if initializations take longer, the round will start immediately once they complete
+## Lobby time: This is the amount of time in seconds between rounds that players have to setup their characters and be ready. This is inclusive of initialization time, if initializations take longer, the round will start immediately once they complete
 LOBBY_COUNTDOWN 120
 
 ## Round End Time: This is the amount of time after the round ends that players have to murder death kill each other.

--- a/config/config.txt
+++ b/config/config.txt
@@ -30,7 +30,7 @@ STATIONNAME Space Station 13
 ## Put on byond hub: Uncomment this to put your server on the byond hub.
 #HUB
 
-## Lobby time: This is the amount of time between rounds that players have to setup their characters and be ready.
+## Lobby time: This is the amount of time between rounds that players have to setup their characters and be ready. This is inclusive of initialization time, if initializations take longer, the round will start immediately once they complete
 LOBBY_COUNTDOWN 120
 
 ## Round End Time: This is the amount of time after the round ends that players have to murder death kill each other.


### PR DESCRIPTION
## About The Pull Request

Have the initializations real time deducted from the ticker's configured `timeLeft` after they complete.

## Why It's Good For The Game

Deterministic lobby times good.

## Changelog

:cl: Dominion
qol: The configured lobby time is now the actual amount of time spent in the lobby including initializations.
/:cl: