### PR TITLE
Add tap all ore vents admin secret

### DIFF
--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -328,26 +328,28 @@
 /**
  * Handles winning the event, gives everyone a payout and start boulder production
  */
-/obj/structure/ore_vent/proc/initiate_wave_win()
+/obj/structure/ore_vent/proc/initiate_wave_win(forced = FALSE)
 	tapped = TRUE //The Node Drone has survived the wave defense, and the ore vent is tapped.
 	SSore_generation.processed_vents += src
-	log_game("Ore vent [key_name_and_tag(src)] was tapped")
-	SSblackbox.record_feedback("tally", "ore_vent_completed", 1, type)
-	balloon_alert_to_viewers("vent tapped!")
+	if(!forced)
+		log_game("Ore vent [key_name_and_tag(src)] was tapped")
+		SSblackbox.record_feedback("tally", "ore_vent_completed", 1, type)
+		balloon_alert_to_viewers("vent tapped!")
 	icon_state = icon_state_tapped
 	update_appearance(UPDATE_ICON_STATE)
 	qdel(GetComponent(/datum/component/gps))
 
-	for(var/mob/living/miner in range(7, src)) //Give the miners who are near the vent points and xp.
-		var/obj/item/card/id/user_id_card = miner.get_idcard(TRUE)
-		if(miner.stat <= SOFT_CRIT)
-			miner.mind?.adjust_experience(/datum/skill/mining, MINING_SKILL_BOULDER_SIZE_XP * boulder_size)
-		if(!user_id_card)
-			continue
-		var/point_reward_val = (MINER_POINT_MULTIPLIER * boulder_size) - MINER_POINT_MULTIPLIER // We remove the base value of discovering the vent
-		if(user_id_card.registered_account)
-			user_id_card.registered_account.mining_points += point_reward_val
-			user_id_card.registered_account.bank_card_talk("You have been awarded [point_reward_val] mining points for your efforts.")
+	if(!forced)
+		for(var/mob/living/miner in range(7, src)) //Give the miners who are near the vent points and xp.
+			var/obj/item/card/id/user_id_card = miner.get_idcard(TRUE)
+			if(miner.stat <= SOFT_CRIT)
+				miner.mind?.adjust_experience(/datum/skill/mining, MINING_SKILL_BOULDER_SIZE_XP * boulder_size)
+			if(!user_id_card)
+				continue
+			var/point_reward_val = (MINER_POINT_MULTIPLIER * boulder_size) - MINER_POINT_MULTIPLIER // We remove the base value of discovering the vent
+			if(user_id_card.registered_account)
+				user_id_card.registered_account.mining_points += point_reward_val
+				user_id_card.registered_account.bank_card_talk("You have been awarded [point_reward_val] mining points for your efforts.")
 	reset_drone(success = TRUE)
 	add_overlay(mutable_appearance('icons/obj/mining_zones/terrain.dmi', "well", ABOVE_MOB_LAYER))
 

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -377,6 +377,18 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 				addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(return_escape_shuttle), make_announcement), new_timer SECONDS)
 			else
 				INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(return_escape_shuttle), make_announcement)
+		if("ore_vents")
+			if(!is_funmin)
+				return
+			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Tap Ore Vents"))
+			var/vent_count = 0
+			for(var/obj/structure/ore_vent/vent as anything in SSore_generation.possible_vents)
+				if(vent.tapped || !COOLDOWN_FINISHED(vent, wave_cooldown) || vent.node) // skip if already tapped or currently being tapped
+					continue
+				vent.initiate_wave_win(forced = TRUE)
+				vent_count++
+			message_admins("[key_name_admin(holder)] tapped [vent_count] ore vents")
+			log_admin("[key_name_admin(holder)] tapped [vent_count] ore vents")
 		if("blackout")
 			if(!is_funmin)
 				return

--- a/tgui/packages/tgui/interfaces/Secrets.jsx
+++ b/tgui/packages/tgui/interfaces/Secrets.jsx
@@ -424,6 +424,15 @@ const FunTab = (props) => {
               onClick={() => act('send_shuttle_back')}
             />
           </Stack.Item>
+          <Stack.Item>
+            <Button
+              icon="oil-well"
+              lineHeight={lineHeightNormal}
+              width={buttonWidthNormal}
+              content="Tap Ore Vents"
+              onClick={() => act('ore_vents')}
+            />
+          </Stack.Item>
         </Stack>
       </Stack.Item>
       <Stack.Item>


### PR DESCRIPTION

## About The Pull Request

Add a new button to the fun tab of admin secrets that taps every ore vent 

## Why It's Good For The Game

Quick button to get steady stream of ore flowing into the station is nice

## Changelog
:cl:
admin: added tap all ore vents button to secrets panel
/:cl:
