### PR TITLE
Fix laser rifle recharger runtime

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -167,7 +167,7 @@
 			if(power_pack.stored_ammo.len < power_pack.max_ammo)
 				power_pack.stored_ammo += new power_pack.ammo_type(power_pack)
 				use_energy(active_power_usage * seconds_per_tick)
-				if(power_pack.stored_ammo >= power_pack.max_ammo)
+				if(power_pack.stored_ammo.len >= power_pack.max_ammo)
 					playsound(src, 'sound/machines/ping.ogg', 30, TRUE)
 					say("[charging] has finished recharging!")
 				else


### PR DESCRIPTION

## About The Pull Request

Putting the power pack from the laser rifle into the recharger causes runtimes every process call because it's comparing a list to a number

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
fix: fixed recharger not properly charging the laser rifle power pack
/:cl:
