### PR TITLE
Airlock pumps unbolt if the link is broken

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
@@ -566,6 +566,8 @@
 
 ///Find airlocks and link up with them
 /obj/machinery/atmospherics/components/unary/airlock_pump/proc/unlink_airlock(airlock)
+	SIGNAL_HANDLER
+
 	UnregisterSignal(airlock, COMSIG_QDELETING)
 
 	if(airlock in internal_airlocks)
@@ -581,6 +583,7 @@
 /obj/machinery/atmospherics/components/unary/airlock_pump/proc/break_all_links()
 	for(var/obj/machinery/door/airlock/airlock as anything in (internal_airlocks + external_airlocks))
 		UnregisterSignal(airlock, COMSIG_QDELETING)
+		airlock.unbolt()
 
 	external_airlocks = list()
 	internal_airlocks = list()


### PR DESCRIPTION
## About The Pull Request

If an airlock pump's link is broken, it unbolts all airlocks

Closes #95232 - while it technically fixes the issue, the airlock should really still be automatically opened even if the pumps are unlinked

## Why It's Good For The Game

Stop them from getting perma-stuck if strange things happen

## Changelog

:cl: Melbert
qol: If an airlock pump's link is broken, it unbolts all airlocks
/:cl:
