### PR TITLE
Adjusts all get_temperature() accesses to compare it to a value

### DIFF
--- a/code/datums/components/combustible_flooder.dm
+++ b/code/datums/components/combustible_flooder.dm
@@ -82,14 +82,14 @@
 /datum/component/combustible_flooder/proc/hotspots_react(datum/source, air, exposed_temperature)
 	SIGNAL_HANDLER
 
-	if(exposed_temperature > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
+	if(exposed_temperature >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		flood(null, exposed_temperature)
 
 /// Being attacked by something
 /datum/component/combustible_flooder/proc/attackby_react(datum/source, obj/item/thing, mob/user, params)
 	SIGNAL_HANDLER
 
-	if(thing.get_temperature() > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
+	if(thing.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		flood(user, thing.get_temperature())
 
 /// Shot by something

--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -136,7 +136,7 @@
 	if(!isitem(target))
 		return
 	var/obj/item/I = target
-	if(I.get_temperature() > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
+	if(I.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		detonate() //If we're touching a hot item we go boom
 		return TRUE
 

--- a/code/datums/elements/easy_ignite.dm
+++ b/code/datums/elements/easy_ignite.dm
@@ -65,7 +65,7 @@
 /datum/element/easy_ignite/proc/attackby_react(obj/item/source, mob/user, obj/item/tool, modifiers)
 	SIGNAL_HANDLER
 
-	if(!tool.get_temperature())
+	if(tool.get_temperature() < FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		return NONE
 
 	if (!item_ignition(source, tool, user))
@@ -83,7 +83,7 @@
 /datum/element/easy_ignite/proc/welder_react(obj/item/source, mob/user, obj/item/tool)
 	SIGNAL_HANDLER
 
-	if(!tool.get_temperature())
+	if(tool.get_temperature() < FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		return NONE
 
 	if (!item_ignition(source, tool, user))

--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -132,10 +132,10 @@
 /datum/wound/pierce/bleed/check_grab_treatments(obj/item/tool, mob/user)
 	// if we're using something hot but not a cautery, we need to be aggro grabbing them first,
 	// so we don't try treating someone we're eswording
-	return tool.get_temperature()
+	return tool.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST
 
 /datum/wound/pierce/bleed/treat(obj/item/tool, mob/user)
-	if(tool.tool_behaviour == TOOL_CAUTERY || tool.get_temperature())
+	if(tool.tool_behaviour == TOOL_CAUTERY || tool.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		tool_cauterize(tool, user)
 
 /datum/wound/pierce/bleed/on_xadone(power)

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -168,14 +168,14 @@
 /datum/wound/slash/flesh/check_grab_treatments(obj/item/tool, mob/user)
 	if(istype(tool, /obj/item/gun/energy/laser))
 		return TRUE
-	if(tool.get_temperature()) // if we're using something hot but not a cautery, we need to be aggro grabbing them first, so we don't try treating someone we're eswording
+	if(tool.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST) // if we're using something hot but not a cautery, we need to be aggro grabbing them first, so we don't try treating someone we're eswording
 		return TRUE
 	return FALSE
 
 /datum/wound/slash/flesh/treat(obj/item/tool, mob/user)
 	if(istype(tool, /obj/item/gun/energy/laser))
 		las_cauterize(tool, user)
-	else if(tool.tool_behaviour == TOOL_CAUTERY || tool.get_temperature())
+	else if(tool.tool_behaviour == TOOL_CAUTERY || tool.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		tool_cauterize(tool, user)
 
 /datum/wound/slash/flesh/try_handling(mob/living/user)

--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -62,7 +62,7 @@
 		if(IS_WRITING_UTENSIL(held_item))
 			context[SCREENTIP_CONTEXT_LMB] = "Scribble"
 			return CONTEXTUAL_SCREENTIP_SET
-		if(held_item.get_temperature())
+		if(held_item.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 			context[SCREENTIP_CONTEXT_LMB] = "Burn"
 			return CONTEXTUAL_SCREENTIP_SET
 

--- a/code/game/objects/effects/decals/cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/cleanable/fuel.dm
@@ -99,7 +99,7 @@
 
 	if(isitem(enflammable_atom))
 		var/obj/item/enflamed_item = enflammable_atom
-		if(enflamed_item.get_temperature() > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
+		if(enflamed_item.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 			ignite()
 		return
 	else if(isliving(enflammable_atom))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -972,7 +972,7 @@
 
 /// If an object can successfully be used as a fire starter it will return a message
 /obj/item/proc/ignition_effect(atom/A, mob/user)
-	if(get_temperature())
+	if(get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		. = span_notice("[user] lights [A] with [src].")
 	else
 		. = ""

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -106,7 +106,7 @@
 		var/obj/item/tank/air_tank = item
 		blow(air_tank, user)
 		return
-	if(item.get_sharpness() || item.get_temperature())
+	if(item.get_sharpness() || item.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		burst()
 		return
 

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -499,7 +499,7 @@ GLOBAL_LIST_INIT(abductor_recipes, list ( \
 	return list(/datum/reagent/carbon = 20)
 
 /obj/item/stack/sheet/mineral/coal/attackby(obj/item/W, mob/user, list/modifiers, list/attack_modifiers)
-	if(W.get_temperature() > 300)//If the temperature of the object is over 300, then ignite
+	if(W.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST) //If the temperature of the object is hot enough to start a fire, then ignite
 		var/turf/T = get_turf(src)
 		message_admins("Coal ignited by [ADMIN_LOOKUPFLW(user)] in [ADMIN_VERBOSEJMP(T)]")
 		user.log_message("ignited coal", LOG_GAME)

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -61,7 +61,7 @@
 				add_overlay("bonfire_grill")
 			else
 				return ..()
-	if(used_item.get_temperature())
+	if(used_item.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		start_burning()
 	if(grill)
 		if(istype(used_item, /obj/item/melee/roastingstick))

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -282,7 +282,7 @@
 	return crowbar_door(user, I)
 
 /obj/structure/mineral_door/wood/attackby(obj/item/I, mob/living/user)
-	if(I.get_temperature())
+	if(I.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		fire_act(I.get_temperature())
 		return
 
@@ -318,7 +318,7 @@
 	return crowbar_door(user, I)
 
 /obj/structure/mineral_door/paperframe/attackby(obj/item/I, mob/living/user)
-	if(I.get_temperature()) //BURN IT ALL DOWN JIM
+	if(I.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST) //BURN IT ALL DOWN JIM
 		fire_act(I.get_temperature())
 		return
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -985,11 +985,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tinted/frosted/spaw
 	. += (atom_integrity < max_integrity) ? torn : paper
 
 /obj/structure/window/paperframe/attackby(obj/item/W, mob/living/user)
-	if(W.get_temperature())
+	if(W.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		fire_act(W.get_temperature())
 		return
+
 	if(user.combat_mode)
 		return ..()
+
 	if(istype(W, /obj/item/paper) && atom_integrity < max_integrity)
 		user.visible_message(span_notice("[user] starts to patch the holes in \the [src]."))
 		if(do_after(user, 2 SECONDS, target = src))

--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -211,7 +211,7 @@
 
 	else if(isitem(interacting_with))
 		var/obj/item/item = interacting_with
-		if(item.get_temperature() > 1000)
+		if(item.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 			set_lit(TRUE)
 			user.visible_message(span_notice("[user] lights up [src]."), span_notice("You light up [src]."))
 			return ITEM_INTERACT_SUCCESS

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -921,8 +921,9 @@
 		new /obj/effect/hotspot(get_turf(target))
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/item_interaction(mob/living/user, obj/item/item, list/modifiers)
-	if(!item.get_temperature() || active)
+	if(item.get_temperature() < FIRE_MINIMUM_TEMPERATURE_TO_EXIST || active)
 		return NONE
+
 	active = TRUE
 	log_bomber(user, "has primed a", src, "for detonation")
 

--- a/code/modules/surgery/operations/_operation.dm
+++ b/code/modules/surgery/operations/_operation.dm
@@ -185,7 +185,7 @@
 		if(suture_tool.amount <= 0)
 			return FALSE
 	else if(tool.tool_behaviour != TOOL_CAUTERY)
-		if(tool.get_temperature() <= 0)
+		if(tool.get_temperature() <= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 			return FALSE
 
 	// we need to have a surgery state worth closing

--- a/code/modules/surgery/operations/operation_generic.dm
+++ b/code/modules/surgery/operations/operation_generic.dm
@@ -186,7 +186,7 @@
 		var/obj/item/gun/energy/laser/lasergun = tool
 		return lasergun.cell?.charge > 0
 
-	return tool.get_temperature() > 0
+	return tool.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST
 
 /datum/surgery_operation/limb/close_skin/on_preop(obj/item/bodypart/limb, mob/living/surgeon, obj/item/tool, list/operation_args)
 	display_results(

--- a/code/modules/surgery/operations/operation_generic_basic.dm
+++ b/code/modules/surgery/operations/operation_generic_basic.dm
@@ -167,7 +167,7 @@
 		var/obj/item/gun/energy/laser/lasergun = tool
 		return lasergun.cell?.charge > 0
 
-	return tool.get_temperature() > 0
+	return tool.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST
 
 /datum/surgery_operation/basic/close_skin/on_preop(mob/living/patient, mob/living/surgeon, obj/item/tool, list/operation_args)
 	display_results(

--- a/code/modules/surgery/operations/operation_puncture.dm
+++ b/code/modules/surgery/operations/operation_puncture.dm
@@ -108,7 +108,7 @@
 		var/obj/item/gun/energy/laser/lasergun = tool
 		return lasergun.cell?.charge > 0
 
-	return tool.get_temperature() > 0
+	return tool.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST
 
 /datum/surgery_operation/limb/seal_veins/state_check(obj/item/bodypart/limb)
 	var/datum/wound/pierce/bleed/pierce_wound = locate() in limb.wounds

--- a/code/modules/surgery/operations/operation_virus.dm
+++ b/code/modules/surgery/operations/operation_virus.dm
@@ -42,7 +42,7 @@
 	return FALSE
 
 /datum/surgery_operation/basic/viral_bonding/tool_check(obj/item/tool)
-	return tool.get_temperature() > 0
+	return tool.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST
 
 /datum/surgery_operation/basic/viral_bonding/on_preop(mob/living/patient, mob/living/surgeon, obj/item/tool, list/operation_args)
 	display_results(


### PR DESCRIPTION

## About The Pull Request

``get_temperature()`` returns a value in kelvins, not a boolean. Trying to treat it as such will result in ***any*** item with a thermal value, like condensers, being treated as a lighter.

## Why It's Good For The Game

Consistency, allows us to have actually functioning cooling items that don't act like lighters all the time.

## Changelog
:cl:
fix: Condensers can no longer be used to ignite things
/:cl:
