### PR TITLE
Prevents metalgen from morphing abstract turfs

### DIFF
--- a/code/_globalvars/lists/reagents.dm
+++ b/code/_globalvars/lists/reagents.dm
@@ -52,7 +52,15 @@ GLOBAL_LIST(fake_reagent_blacklist)
 /// Turfs metalgen can't touch
 GLOBAL_LIST_INIT(blacklisted_metalgen_types, typecacheof(list(
 	/turf/closed/indestructible, //indestructible turfs should be indestructible, metalgen transmutation to plasma allows them to be destroyed
-	/turf/open/indestructible
+	/turf/open/indestructible,
+	/turf/open/ai_visible,
+	/turf/open/chasm,
+	/turf/open/genturf,
+	/turf/open/lava,
+	/turf/open/mirage,
+	/turf/open/openspace,
+	/turf/open/space,
+	/turf/open/water,
 )))
 /// Map of reagent names to its datum path
 GLOBAL_LIST_INIT(name2reagent, build_name2reagentlist())

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2808,11 +2808,15 @@
 
 /datum/reagent/metalgen/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
 	. = ..()
-	metal_morph(exposed_obj)
+	// Don't morph holographic or abstract objects
+	if (!(exposed_obj.flags_1 & HOLOGRAM_1) && exposed_obj.invisibility < INVISIBILITY_ABSTRACT)
+		metal_morph(exposed_obj)
 
 /datum/reagent/metalgen/expose_turf(turf/exposed_turf, volume)
 	. = ..()
-	metal_morph(exposed_turf)
+	// Or non-real turfs
+	if (isclosedturf(exposed_turf) || isopenturf(exposed_turf))
+		metal_morph(exposed_turf)
 
 ///turn an object into a special material
 /datum/reagent/metalgen/proc/metal_morph(atom/target)


### PR DESCRIPTION

## About The Pull Request

Adds some safeties to metalgen, preventing it from morphing abstract tiles like space or liquids like lava/water. Space being morphed is ***really*** bad, and may have been the culprit behind the crashes.

Possibly? fixes #95230, I have not been able to reproduce the issue and we don't really know what exactly is going on but I suspect its something to do with turf scraping on said space tiles.

## Changelog
:cl:
fix: Metalgen can no longer morph abstract turfs like space or chasms
/:cl:
