### PR TITLE
Fixes bioscrambler anomaly pulse activation

### DIFF
--- a/code/modules/research/anomaly/anomaly_core.dm
+++ b/code/modules/research/anomaly/anomaly_core.dm
@@ -140,7 +140,7 @@
 
 /obj/item/assembly/signaler/anomaly/bioscrambler/signal()
 	new /obj/effect/temp_visual/circle_wave/bioscrambler(get_turf(src))
-	for(var/mob/living/carbon/nearby in hearers(1, src))
+	for(var/mob/living/carbon/nearby in hearers(1, get_turf(src)))
 		nearby.bioscramble(name)
 
 /obj/item/assembly/signaler/anomaly/hallucination


### PR DESCRIPTION

## About The Pull Request

Swaps `src` for `get_turf(src)` in the `hearers()` in the bioscrambler core's pulse activation. The core will effectively always be inside an `assembly_holder`, so just `src` is basically never going to work. I'm assuming it's supposed to work inside anything given that the pulse effect also doesn't care about containers.

## Why It's Good For The Game

fixes #95239

## Changelog
:cl:

fix: Bioscrambler anomaly pulse activation works

/:cl:
