### PR TITLE
Fixes material turfs not functioning for 3+ years

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -177,12 +177,12 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	if (opacity)
 		directional_opacity = ALL_CARDINALS
 
+	if(uses_integrity)
+		atom_integrity = max_integrity
+
 	// apply materials properly from the default custom_materials value
 	if (length(custom_materials))
 		set_custom_materials(custom_materials)
-
-	if(uses_integrity)
-		atom_integrity = max_integrity
 
 	return INITIALIZE_HINT_NORMAL
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -178,7 +178,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		directional_opacity = ALL_CARDINALS
 
 	// apply materials properly from the default custom_materials value
-	if (!length(custom_materials))
+	if (length(custom_materials))
 		set_custom_materials(custom_materials)
 
 	if(uses_integrity)


### PR DESCRIPTION

## About The Pull Request

A flipped length check prevented turfs from initializing their materials, and made all non-material turfs initialize theirs instead. Also, the integrity needs to be set before materials are applied, not after.

Yeeeeah.

## Changelog
:cl:
fix: Material turfs, such as plasma floors, now function again after 3+ years.
/:cl:
