### PR TITLE
Fixes paper making bodybags inescapable

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1057,7 +1057,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 		movable_parent.relay_container_resist_act(user, src)
 		return
 	if(!welded && !locked)
-		open()
+		open(user)
 		return
 
 	if(DOING_INTERACTION_WITH_TARGET(user, src))

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -235,9 +235,9 @@
 
 /obj/structure/closet/body_bag/before_open(mob/living/user, force)
 	if(pinned)
-		if(force || user.loc == src)
+		if(force || !user || user.loc == src)
 			pinned.forceMove(drop_location())
-			return TRUE // force open, or we can't take the note out from inside
+			return TRUE // force open, no user, or we can't take the note out from inside
 		balloon_alert(user, "paper removed")
 		if(!user.put_in_inactive_hand(pinned) && pinned.loc == src)
 			pinned.forceMove(drop_location())

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -235,11 +235,11 @@
 
 /obj/structure/closet/body_bag/before_open(mob/living/user, force)
 	if(pinned)
-		if(force)
+		if(force || user.loc == src)
 			pinned.forceMove(drop_location())
-			return TRUE // force open
+			return TRUE // force open, or we can't take the note out from inside
 		balloon_alert(user, "paper removed")
-		if(!user.put_in_inactive_hand(pinned) || pinned.loc == src)
+		if(!user.put_in_inactive_hand(pinned) && pinned.loc == src)
 			pinned.forceMove(drop_location())
 		return FALSE // blocked the open action
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

passes `user` in the `open()` for when someone attempts to leave an unlocked, unwelded container such as a bodyag. The reason for the bug was attempting to give a null user the pinned piece of paper. 

Also adds an exception for no user being passed into `open()` for the sake of revenant's defile & likely other things in the future.

Also fixes an unrelated bug where the reason that taking off the pinned paper from a bodybag would stop it opening was a runtime rather than returning false. Behaviour remains identical.

## Why It's Good For The Game

fixes #95247

## Changelog
:cl:

fix: Pieces of paper no longer make bodybags inescapable

/:cl:
