### PR TITLE
MOD soul core is slapcraftable and no longer needs to be learned

### DIFF
--- a/code/datums/components/crafting/robot.dm
+++ b/code/datums/components/crafting/robot.dm
@@ -192,4 +192,3 @@
 		/obj/item/soulstone = 1,
 	)
 	category = CAT_ROBOT
-	crafting_flags = parent_type::crafting_flags | CRAFT_MUST_BE_LEARNED

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -31,6 +31,12 @@
 		RegisterSignal(src, COMSIG_BIBLE_SMACKED, PROC_REF(on_bible_smacked))
 	if(!base_name)
 		base_name = initial(name)
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/mod_core_soul)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+	)
 
 /obj/item/soulstone/grind_results()
 	return list(/datum/reagent/hauntium = 25, /datum/reagent/silicon = 10) //can be ground into hauntium
@@ -158,43 +164,6 @@
 	. = ..()
 	if(!isliving(user) || isnull(user.mind))
 		return
-	if(!user.mind.has_crafting_recipe(/datum/crafting_recipe/mod_core_soul))
-		. += span_notice("You know... there might be <a href='byond://?src=[REF(src)];learn_soul_core_recipe=1'>alternate uses</a> for something like this.")
-
-/obj/item/soulstone/Topic(href, list/href_list)
-	. = ..()
-
-	if(href_list["learn_soul_core_recipe"])
-		learn_soul_core_recipe(usr)
-
-/obj/item/soulstone/proc/learn_soul_core_recipe(mob/user)
-	if(user.mind?.has_crafting_recipe(/datum/crafting_recipe/mod_core_soul))
-		return
-	if(!soul_core_learning_check(user))
-		return
-	var/list/remarks = list(
-		"You begin brainstorming...",
-		"Are constructs <i>powered</i> by souls?",
-		"Then wouldn't that mean...",
-		"Can that energy be turned into electricity?",
-		"You have an idea...",
-	)
-	for(var/remark in remarks)
-		to_chat(user, span_notice("[remark]"))
-		if(!do_after(
-			user,
-			5 SECONDS,
-			timed_action_flags = IGNORE_USER_LOC_CHANGE | IGNORE_HELD_ITEM,
-			extra_checks = CALLBACK(src, PROC_REF(soul_core_learning_check), user),
-			interaction_key = "soul_core_learn",
-			max_interact_count = 1
-			))
-			return
-	user.mind?.teach_crafting_recipe(/datum/crafting_recipe/mod_core_soul)
-	to_chat(user, span_notice("You learned to craft [/obj/item/mod/core/soul::name]."))
-
-/obj/item/soulstone/proc/soul_core_learning_check(mob/user)
-	return user.is_holding(src) || (user.loc == loc) || (isturf(loc) && user.Adjacent(loc))
 
 /obj/item/soulstone/Destroy() //Stops the shade from being qdel'd immediately and their ghost being sent back to the arrival shuttle.
 	for(var/mob/living/basic/shade/shade in src)

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -31,10 +31,11 @@
 		RegisterSignal(src, COMSIG_BIBLE_SMACKED, PROC_REF(on_bible_smacked))
 	if(!base_name)
 		base_name = initial(name)
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/mod_core_soul)
 
 	AddElement(
 		/datum/element/slapcrafting,\
-		slapcraft_recipes = list(/datum/crafting_recipe/mod_core_soul),\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/soulstone/grind_results()

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -31,11 +31,10 @@
 		RegisterSignal(src, COMSIG_BIBLE_SMACKED, PROC_REF(on_bible_smacked))
 	if(!base_name)
 		base_name = initial(name)
-	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/mod_core_soul)
 
 	AddElement(
 		/datum/element/slapcrafting,\
-		slapcraft_recipes = slapcraft_recipe_list,\
+		slapcraft_recipes = list(/datum/crafting_recipe/mod_core_soul),\
 	)
 
 /obj/item/soulstone/grind_results()


### PR DESCRIPTION
## About The Pull Request

I haven't really seen anyone craft soul cores. I suspect this is in large part due to the fact that learning the recipe requires an obscure interaction. So I removed the need to learn the recipe and the interaction through which it is learned. I also added the slapcrafting element so people can get the idea that the crafting recipe exists in the first place.

## Why It's Good For The Game

Looking back, I found the interaction to learn the soul core recipe to be awful snowflakey. Sure, anyone can learn it with minimal effort, but if nobody knows how to learn it, nobody's going to learn it, and if nobody learns it, nobody's gonna craft it.

## Changelog

:cl:
qol: You no longer need to learn the recipe for the MOD soul core.
qol: You can slapcraft MOD soul cores using soul shards.
/:cl:
