### PR TITLE
fixes crushing gravity around the grav gen when it goes offline

### DIFF
--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -335,7 +335,8 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	soundloop.start()
 	var/old_gravity = gravity_in_level()
 	complete_state_update()
-	gravity_field = new(src, 2, TRUE, 6)
+	if (isnull(gravity_field))	// because if it isn't null, we have just overwritten it
+		gravity_field = new(src, 2, TRUE, 6)
 
 	if (!old_gravity)
 		if(SSticker.current_state == GAME_STATE_PLAYING)


### PR DESCRIPTION
## About The Pull Request

The Phantastic Swan comes out of the shadow realm to fix some shit again. One liners baby.

Whenever the grav gen went offline, the crushing gravity effect around it stayed active. This was because the gravity generator seems to override it's own gravity field on round start, removing the connection between it's status and the forced gravity around it.

## Why It's Good For The Game

Fixes a bug. I think it also closes #76403 

## Changelog

:cl: Swan
fix: fixes the gravity generator's crushing gravity effect not disappearing when the gen goes offline
/:cl: