### PR TITLE
Fixes integrated circuit composite types appearing incorrectly

### DIFF
--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/Port.jsx
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/Port.jsx
@@ -102,6 +102,7 @@ export class Port extends Component {
                 width: '100%',
                 height: '100%',
                 position: 'absolute',
+                overflow: 'visible',
               }}
               viewBox="0, 0, 100, 100"
             >
@@ -117,7 +118,7 @@ export class Port extends Component {
                       -index * (100 * (Math.PI / composite_types.length))
                     }
                     className={`color-stroke-${compositeColor}`}
-                    strokeWidth="50px"
+                    strokeWidth="40px"
                     cx="50"
                     cy="50"
                     r="50"


### PR DESCRIPTION

## About The Pull Request

Fixes the following:
<img width="310" height="214" alt="image" src="https://github.com/user-attachments/assets/0bed7c57-830f-4518-b1fa-d4f9624afed8" />
into
<img width="268" height="191" alt="image" src="https://github.com/user-attachments/assets/81df6f09-3464-4076-8cde-2efffb454cf9" />

## Changelog
:cl:
fix: Fixed composite types appearing incorrectly in the IC editor.
/:cl:
