### PR TITLE
Fixed materials not being applied when crafting while holding just enough sheets

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -461,8 +461,8 @@
 	builder.investigate_log("crafted [recipe.title]", INVESTIGATE_CRAFTING)
 
 	// Apply mat datums
-	if(LAZYLEN(mats_per_unit) && !(recipe.crafting_flags & CRAFT_NO_MATERIALS))
-		var/list/result_mats = mats_per_unit.Copy()
+	if(LAZYLEN(used_stack.mats_per_unit) && !(recipe.crafting_flags & CRAFT_NO_MATERIALS))
+		var/list/result_mats = used_stack.mats_per_unit.Copy()
 		for(var/mat in recipe.removed_mats)
 			var/to_remove = recipe.removed_mats[mat]
 			var/datum/material/ref_mat = locate(mat) in result_mats


### PR DESCRIPTION
## About The Pull Request
This will fix #95009. split_stack() calls qdel when the amount reaches zero, and mats_per_unit is unset, so we shouldn't be accessing src for materials logic here.

## Why It's Good For The Game
This will fix #95009.

## Changelog

:cl:
fix: Fixed materials not being applied when crafting with stacks if said stack is zero'd in the process.
/:cl:
