### PR TITLE
Make beartraps more lethal

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -561,7 +561,8 @@
 			INVOKE_ASYNC(carbon_victim, TYPE_PROC_REF(/mob/living/carbon, equip_to_slot), src, ITEM_SLOT_LEGCUFFED)
 			SSblackbox.record_feedback("tally", "handcuffs", 1, type)
 
-	victim.apply_damage(trap_damage, BRUTE, def_zone, wound_bonus=trap_damage, exposed_wound_bonus=trap_damage*2)
+	var/randomize_sharpness = prob(50) ? SHARP_POINTY : NONE
+	victim.apply_damage(trap_damage, BRUTE, def_zone, sharpness=randomize_sharpness, wound_bonus=trap_damage, exposed_wound_bonus=trap_damage*2)
 
 /**
  * # Energy snare

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -578,7 +578,9 @@
 		qdel(src)
 
 /obj/item/restraints/legcuffs/beartrap/energy/attack_hand(mob/user, list/modifiers)
-	spring_trap(user)
+	if(!isturf(loc))
+		spring_trap(user)
+
 	return ..()
 
 /obj/item/restraints/legcuffs/beartrap/energy/cyborg

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -499,6 +499,7 @@
 
 	armed = !armed
 	update_appearance()
+	playsound(loc, 'sound/items/weapons/handcuffs.ogg', 30, TRUE, -3)
 	to_chat(user, span_notice("[src] is now [armed ? "armed" : "disarmed"]"))
 
 	return ..()

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -561,8 +561,7 @@
 			INVOKE_ASYNC(carbon_victim, TYPE_PROC_REF(/mob/living/carbon, equip_to_slot), src, ITEM_SLOT_LEGCUFFED)
 			SSblackbox.record_feedback("tally", "handcuffs", 1, type)
 
-	var/randomize_sharpness = prob(50) ? SHARP_POINTY : NONE
-	victim.apply_damage(trap_damage, BRUTE, def_zone, sharpness=randomize_sharpness, wound_bonus=trap_damage, exposed_wound_bonus=trap_damage*2)
+	victim.apply_damage(trap_damage, BRUTE, def_zone, sharpness=SHARP_POINTY, wound_bonus=trap_damage, exposed_wound_bonus=trap_damage*2)
 
 /**
  * # Energy snare

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -561,7 +561,7 @@
 			INVOKE_ASYNC(carbon_victim, TYPE_PROC_REF(/mob/living/carbon, equip_to_slot), src, ITEM_SLOT_LEGCUFFED)
 			SSblackbox.record_feedback("tally", "handcuffs", 1, type)
 
-	victim.apply_damage(trap_damage, BRUTE, def_zone, sharpness=SHARP_POINTY, wound_bonus=trap_damage, exposed_wound_bonus=trap_damage*2)
+	victim.apply_damage(trap_damage, BRUTE, def_zone, sharpness=SHARP_POINTY, wound_bonus=trap_damage/2, exposed_wound_bonus=trap_damage)
 
 /**
  * # Energy snare

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -466,7 +466,7 @@
 	armed = !armed
 	update_appearance()
 
-	if((HAS_TRAIT(user, TRAIT_DUMB) || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(25))
+	if(armed && (HAS_TRAIT(user, TRAIT_DUMB) || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(25))
 		to_chat(user, span_warning("Your hand slips, setting off the trigger!"))
 		var/hand_zone = user.held_index_to_dir(user.active_hand_index) == "r" ? BODY_ZONE_PRECISE_R_HAND : BODY_ZONE_PRECISE_L_HAND
 		spring_trap(user, def_zone = hand_zone)
@@ -512,7 +512,7 @@
  * If ignore_movetypes is FALSE, does not trigger on floating / flying / etc. mobs.
  */
 /obj/item/restraints/legcuffs/beartrap/proc/spring_trap(atom/movable/target, ignore_movetypes = FALSE, hit_prone = FALSE, def_zone = BODY_ZONE_CHEST)
-	if(!armed || !isturf(loc) || !isliving(target))
+	if(!armed || !isliving(target))
 		return
 
 	var/mob/living/victim = target

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -463,15 +463,10 @@
 
 	playsound(loc, 'sound/items/weapons/handcuffs.ogg', 30, TRUE, -3)
 
-	if(!do_after(user, 5 SECONDS, src))
-		user.balloon_alert(user, "interrupted!")
-		return
-
 	armed = !armed
 	update_appearance()
-	user.dropItemToGround(src)
 
-	if((HAS_TRAIT(user, TRAIT_DUMB) || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(35))
+	if((HAS_TRAIT(user, TRAIT_DUMB) || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(25))
 		to_chat(user, span_warning("Your hand slips, setting off the trigger!"))
 		var/hand_zone = user.held_index_to_dir(user.active_hand_index) == "r" ? BODY_ZONE_PRECISE_R_HAND : BODY_ZONE_PRECISE_L_HAND
 		spring_trap(user, def_zone = hand_zone)
@@ -484,23 +479,11 @@
 	if(!armed)
 		return ..()
 
-	if(!ishuman(user) || user.stat != CONSCIOUS || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-		return TRUE
-
-	if(!do_after(user, 2 SECONDS, src))
-		user.balloon_alert(user, "interrupted!")
-		return TRUE
-
-	if((HAS_TRAIT(user, TRAIT_DUMB) || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(35))
+	if((HAS_TRAIT(user, TRAIT_DUMB) || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(25))
 		to_chat(user, span_warning("Your hand slips, setting off the trigger!"))
 		var/hand_zone = user.held_index_to_dir(user.active_hand_index) == "r" ? BODY_ZONE_PRECISE_R_HAND : BODY_ZONE_PRECISE_L_HAND
 		spring_trap(user, def_zone = hand_zone)
 		return TRUE
-
-	armed = !armed
-	update_appearance()
-	playsound(loc, 'sound/items/weapons/handcuffs.ogg', 30, TRUE, -3)
-	to_chat(user, span_notice("[src] is now [armed ? "armed" : "disarmed"]"))
 
 	return ..()
 

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -456,13 +456,52 @@
 	playsound(loc, 'sound/items/weapons/bladeslice.ogg', 50, TRUE, -1)
 	return BRUTELOSS
 
-/obj/item/restraints/legcuffs/beartrap/attack_self(mob/user)
+/obj/item/restraints/legcuffs/beartrap/attack_self(mob/living/user)
 	. = ..()
 	if(!ishuman(user) || user.stat != CONSCIOUS || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
+
+	playsound(loc, 'sound/items/weapons/handcuffs.ogg', 30, TRUE, -3)
+
+	if(!do_after(user, 5 SECONDS, src))
+		user.balloon_alert(user, "interrupted!")
+		return
+
+	armed = !armed
+	update_appearance()
+	user.dropItemToGround(src)
+
+	if((HAS_TRAIT(user, TRAIT_DUMB) || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(35))
+		to_chat(user, span_warning("Your hand slips, setting off the trigger!"))
+		var/hand_zone = user.held_index_to_dir(user.active_hand_index) == "r" ? BODY_ZONE_PRECISE_R_HAND : BODY_ZONE_PRECISE_L_HAND
+		spring_trap(user, def_zone = hand_zone)
+		return
+
+	to_chat(user, span_notice("[src] is now [armed ? "armed" : "disarmed"]"))
+
+
+/obj/item/restraints/legcuffs/beartrap/attempt_pickup(mob/user)
+	if(!armed)
+		return ..()
+
+	if(!ishuman(user) || user.stat != CONSCIOUS || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		return TRUE
+
+	if(!do_after(user, 2 SECONDS, src))
+		user.balloon_alert(user, "interrupted!")
+		return TRUE
+
+	if((HAS_TRAIT(user, TRAIT_DUMB) || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(35))
+		to_chat(user, span_warning("Your hand slips, setting off the trigger!"))
+		var/hand_zone = user.held_index_to_dir(user.active_hand_index) == "r" ? BODY_ZONE_PRECISE_R_HAND : BODY_ZONE_PRECISE_L_HAND
+		spring_trap(user, def_zone = hand_zone)
+		return TRUE
+
 	armed = !armed
 	update_appearance()
 	to_chat(user, span_notice("[src] is now [armed ? "armed" : "disarmed"]"))
+
+	return ..()
 
 /**
  * Closes a bear trap
@@ -488,7 +527,7 @@
  * Does not trigger on tiny mobs.
  * If ignore_movetypes is FALSE, does not trigger on floating / flying / etc. mobs.
  */
-/obj/item/restraints/legcuffs/beartrap/proc/spring_trap(atom/movable/target, ignore_movetypes = FALSE, hit_prone = FALSE)
+/obj/item/restraints/legcuffs/beartrap/proc/spring_trap(atom/movable/target, ignore_movetypes = FALSE, hit_prone = FALSE, def_zone = BODY_ZONE_CHEST)
 	if(!armed || !isturf(loc) || !isliving(target))
 		return
 
@@ -513,15 +552,15 @@
 	else
 		victim.visible_message(span_danger("[victim] triggers \the [src]."), \
 				span_userdanger("You trigger \the [src]!"))
-	var/def_zone = BODY_ZONE_CHEST
-	if(iscarbon(victim) && (victim.body_position == STANDING_UP || hit_prone))
+
+	if(iscarbon(victim) && (victim.body_position == STANDING_UP || hit_prone) && !((def_zone == BODY_ZONE_PRECISE_R_HAND) || (def_zone == BODY_ZONE_PRECISE_L_HAND)))
 		var/mob/living/carbon/carbon_victim = victim
 		def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 		if(!carbon_victim.legcuffed && carbon_victim.num_legs >= 2) //beartrap can't cuff your leg if there's already a beartrap or legcuffs, or you don't have two legs.
 			INVOKE_ASYNC(carbon_victim, TYPE_PROC_REF(/mob/living/carbon, equip_to_slot), src, ITEM_SLOT_LEGCUFFED)
 			SSblackbox.record_feedback("tally", "handcuffs", 1, type)
 
-	victim.apply_damage(trap_damage, BRUTE, def_zone)
+	victim.apply_damage(trap_damage, BRUTE, def_zone, wound_bonus=25, exposed_wound_bonus=40)
 
 /**
  * # Energy snare

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -560,7 +560,7 @@
 			INVOKE_ASYNC(carbon_victim, TYPE_PROC_REF(/mob/living/carbon, equip_to_slot), src, ITEM_SLOT_LEGCUFFED)
 			SSblackbox.record_feedback("tally", "handcuffs", 1, type)
 
-	victim.apply_damage(trap_damage, BRUTE, def_zone, wound_bonus=25, exposed_wound_bonus=40)
+	victim.apply_damage(trap_damage, BRUTE, def_zone, wound_bonus=trap_damage, exposed_wound_bonus=trap_damage*2)
 
 /**
  * # Energy snare

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -578,7 +578,7 @@
 		qdel(src)
 
 /obj/item/restraints/legcuffs/beartrap/energy/attack_hand(mob/user, list/modifiers)
-	if(!isturf(loc))
+	if(isturf(loc))
 		spring_trap(user)
 
 	return ..()


### PR DESCRIPTION

## About The Pull Request
This is an old object that existed before wounds were created. This PR reworks beartraps to:
- Wound chance is determined by how much damage the bear trap does (default bear traps do 20 damage)
- Wound chance is doubled on exposed limbs (ie. unarmored)
- Damage dealt is considered sharp via `SHARP_POINTY` so this will trigger bleeding and can crush bones
- Adds a 25% chance for mobs with `TRAIT_CLUMSY` or `TRAIT_DUMB` to accidentally set off the trap when arming or picking up an armed trap
- Adds some mousetrap sounds when traps are armed or disarmed

## Why It's Good For The Game
Bear traps were niche items that seemed more silly than threatening because they mainly just caused slowdown. By adding the new wound effects, they are much more lethal.

Clowns getting maimed by the traps is also hilarious.

## Changelog
:cl:
balance: Beartraps are now much more lethal and can cause wounds. Space OSHA has also issued a warning that any clumsy people should avoid handling them after repeated mishaps. 
/:cl:
