### PR TITLE
Refactors the PR autostale discord announcement to actually work

### DIFF
--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -1,12 +1,11 @@
 name: "Discord PR Notification"
 on:
   pull_request_target:
-    types: [opened, closed, labeled]
+    types: [opened, closed]
 
 jobs:
   notify:
     runs-on: ubuntu-24.04
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'Stale' }}
     steps:
       - name: "Check for DISCORD_WEBHOOK"
         id: secrets_set
@@ -20,13 +19,13 @@ jobs:
         uses: tgstation/discord-notify@v3
         if: >
           steps.secrets_set.outputs.SECRETS_ENABLED &&
-          (github.event.pull_request.merged == true || github.event.action == 'opened' || github.event.action == 'labeled') &&
+          (github.event.pull_request.merged == true || github.event.action == 'opened') &&
           github.event.pull_request.author_association != 'FIRST_TIMER' &&
           github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR'
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
           title: ${{ github.event.pull_request.user.login }} - ${{ github.event.pull_request.title }}
-          message: ${{ github.event.action != 'labeled' && 'GET_ACTION' || format('**Pull Request {0} automatically marked as stale.**', github.event.pull_request.number) }}
+          message: GET_ACTION
           include_image: false
           show_author: false
           avatar_url: https://avatars.githubusercontent.com/u/1363778?s=200&v=4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,9 +13,13 @@ jobs:
       issues: write # for actions/stale to close stale issues
       pull-requests: write # for actions/stale to close stale PRs
     runs-on: ubuntu-24.04
+    outputs:
+      staled_prs: ${{ steps.filter-prs.outputs.result }}
 
     steps:
-      - uses: actions/stale@v10
+      - name: Mark stale issues and pull requests
+        uses: actions/stale@v10
+        id: stale
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being auto closed in ~7 days. Please address any outstanding review items and ensure your PR is finished - if both are true, and you have auto-staled anyway, you need to actively ask maintainers (by pinging them in the /tg/station Discord) to (re)review or merge your PR. If no maintainer responds to your request, you may wish to close this PR yourself while you seek maintainer comment, as you will later be able to reopen the PR yourself."
@@ -31,3 +35,37 @@ jobs:
           exempt-issue-labels: "RED LABEL"
           exempt-pr-labels: "RED LABEL,Good First PR"
           operations-per-run: 300
+      - name: Filter staled pull requests for announcement
+        id: filter-prs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            return JSON.parse(context.job.steps.stale.outputs.staled-issues-prs).filter(issue => !!issue.pull_request)
+
+  announce:
+    runs-on: ubuntu-24.04
+    if: ${{ jobs.stale.outputs.staled_prs != '[]' }}
+    matrix:
+      pull_request: ${{ fromJSON(jobs.stale.outputs.staled_prs) }}
+    steps:
+      - name: "Check for DISCORD_WEBHOOK"
+        id: secrets_set
+        env:
+          ENABLER_SECRET: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          unset SECRET_EXISTS
+          if [ -n "$ENABLER_SECRET" ]; then SECRET_EXISTS=true ; fi
+          echo "SECRETS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
+      - name: Send Discord notification
+        uses: tgstation/discord-notify@v3
+        if: >
+          steps.secrets_set.outputs.SECRETS_ENABLED
+        with:
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
+          title: ${{ pull_request.user.login }} - ${{ pull_request.title }}
+          message: ${{ format('**Pull Request {0} automatically marked as stale.**', pull_request.number) }}
+          include_image: false
+          show_author: false
+          avatar_url: https://avatars.githubusercontent.com/u/1363778?s=200&v=4
+          username: GitHub
+          title_url: "${{ pull_request.html_url }}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
           title: ${{ pull_request.user.login }} - ${{ pull_request.title }}
-          message: ${{ format('**Pull Request {0} automatically marked as stale.**', pull_request.number) }}
+          message: ${{ format('**Pull Request \#{0} automatically marked as stale.**', pull_request.number) }}
           include_image: false
           show_author: false
           avatar_url: https://avatars.githubusercontent.com/u/1363778?s=200&v=4


### PR DESCRIPTION
## About The Pull Request

I found out that the labeled event isn't triggered when an action does the labeling. So I moved the behavior for announcing auto-staled PRs into a new job in the staling workflow.

## Why It's Good For The Game

At least maintainers should be able to see that a PR has auto-staled if the author themselves can't be bothered to ping them.

## Changelog

No player-facing changes.
