### PR TITLE
avoid regenerating character preview for preferences that don't affect appearance at all

### DIFF
--- a/code/datums/personality/personality_preference.dm
+++ b/code/datums/personality/personality_preference.dm
@@ -3,6 +3,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	can_randomize = TRUE
 	randomize_by_default = FALSE
+	should_update_preview = FALSE
 
 /datum/preference/personality/apply_to_human(mob/living/carbon/human/target, value)
 	if(isdummy(target) || !ishuman(target) || isnull(target.mob_mood))

--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -127,6 +127,10 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 	/// will show the feature as selectable.
 	var/relevant_head_flag = null
 
+	/// If this is a character preference, should we update the character preview
+	/// when this preference is updated?
+	var/should_update_preview = TRUE
+
 /// Called on the saved input when retrieving.
 /// Also called by the value sent from the user through UI. Do not trust it.
 /// Input is the value inside the savefile, output is to tell other code
@@ -307,7 +311,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 
 	if (preference.savefile_identifier == PREFERENCE_PLAYER)
 		preference.apply_to_client_updated(parent, read_preference(preference.type))
-	else
+	else if (preference.should_update_preview)
 		character_preview_view?.update_body()
 
 	return TRUE

--- a/code/modules/client/preferences/addict.dm
+++ b/code/modules/client/preferences/addict.dm
@@ -14,6 +14,7 @@
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
 	savefile_key = "junkie"
 	savefile_identifier = PREFERENCE_CHARACTER
+	should_update_preview = FALSE
 
 /datum/preference/choiced/junkie/init_possible_values()
 	return list("Random") + assoc_to_keys(GLOB.possible_junkie_addictions)
@@ -33,6 +34,7 @@
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
 	savefile_key = "smoker"
 	savefile_identifier = PREFERENCE_CHARACTER
+	should_update_preview = FALSE
 
 /datum/preference/choiced/smoker/init_possible_values()
 	return list("Random") + assoc_to_keys(GLOB.possible_smoker_addictions)
@@ -52,6 +54,7 @@
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
 	savefile_key = "alcoholic"
 	savefile_identifier = PREFERENCE_CHARACTER
+	should_update_preview = FALSE
 
 /datum/preference/choiced/alcoholic/init_possible_values()
 	return list("Random") + assoc_to_keys(GLOB.possible_alcoholic_addictions)

--- a/code/modules/client/preferences/ai_emote_display.dm
+++ b/code/modules/client/preferences/ai_emote_display.dm
@@ -4,6 +4,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "preferred_ai_emote_display"
 	should_generate_icons = TRUE
+	should_update_preview = FALSE
 
 /datum/preference/choiced/ai_emote_display/init_possible_values()
 	if(!length(GLOB.ai_status_display_all_options))

--- a/code/modules/client/preferences/ai_hologram_display.dm
+++ b/code/modules/client/preferences/ai_hologram_display.dm
@@ -4,6 +4,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "preferred_ai_hologram_display"
 	should_generate_icons = TRUE
+	should_update_preview = FALSE
 
 /datum/preference/choiced/ai_hologram_display/init_possible_values()
 	return assoc_to_keys(GLOB.ai_hologram_icons) + "Random"

--- a/code/modules/client/preferences/chipped.dm
+++ b/code/modules/client/preferences/chipped.dm
@@ -2,6 +2,7 @@
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
 	savefile_key = "chipped"
 	savefile_identifier = PREFERENCE_CHARACTER
+	should_update_preview = FALSE
 
 /datum/preference/choiced/chipped/create_default_value()
 	return "Random"

--- a/code/modules/client/preferences/food_allergy.dm
+++ b/code/modules/client/preferences/food_allergy.dm
@@ -3,6 +3,7 @@
 	savefile_key = "food_allergy"
 	savefile_identifier = PREFERENCE_CHARACTER
 	can_randomize = FALSE
+	should_update_preview = FALSE
 
 /datum/preference/choiced/food_allergy/init_possible_values()
 	return list("Random") + assoc_to_keys(GLOB.possible_food_allergies)

--- a/code/modules/client/preferences/hemiplegic.dm
+++ b/code/modules/client/preferences/hemiplegic.dm
@@ -2,6 +2,7 @@
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
 	savefile_key = "hemiplegic"
 	savefile_identifier = PREFERENCE_CHARACTER
+	should_update_preview = FALSE
 
 /datum/preference/choiced/hemiplegic/init_possible_values()
 	return list("Random") + GLOB.side_choice_hemiplegic

--- a/code/modules/client/preferences/language.dm
+++ b/code/modules/client/preferences/language.dm
@@ -3,6 +3,7 @@
 	savefile_key = "language"
 	savefile_identifier = PREFERENCE_CHARACTER
 	should_generate_icons = TRUE
+	should_update_preview = FALSE
 
 /datum/preference/choiced/language/create_default_value()
 	return "Random"
@@ -50,6 +51,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	default_value = TRUE
 	can_randomize = FALSE
+	should_update_preview = FALSE
 
 /datum/preference/toggle/language_speakable/is_accessible(datum/preferences/preferences)
 	if(!..())
@@ -65,6 +67,7 @@
 	savefile_key = "language_skill"
 	savefile_identifier = PREFERENCE_CHARACTER
 	can_randomize = FALSE
+	should_update_preview = FALSE
 
 /datum/preference/choiced/language_skill/create_default_value()
 	return "100%"
@@ -88,6 +91,7 @@
 	savefile_key = "csl_strength"
 	savefile_identifier = PREFERENCE_CHARACTER
 	can_randomize = FALSE
+	should_update_preview = FALSE
 
 /datum/preference/choiced/csl_strength/create_default_value()
 	return "90%"

--- a/code/modules/client/preferences/operative_species.dm
+++ b/code/modules/client/preferences/operative_species.dm
@@ -6,6 +6,7 @@
 	default_value = TRUE
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "operative_species"
+	should_update_preview = FALSE
 
 /datum/preference/toggle/nuke_ops_species/is_accessible(datum/preferences/preferences)
 	. = ..()

--- a/code/modules/client/preferences/paint_color.dm
+++ b/code/modules/client/preferences/paint_color.dm
@@ -3,6 +3,7 @@
 	savefile_key = "paint_color"
 	savefile_identifier = PREFERENCE_CHARACTER
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	should_update_preview = FALSE
 
 /datum/preference/color/paint_color/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))

--- a/code/modules/client/preferences/pda.dm
+++ b/code/modules/client/preferences/pda.dm
@@ -8,6 +8,7 @@
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER
 	maximum_value_length = MESSENGER_RINGTONE_MAX_LENGTH
+	should_update_preview = FALSE
 
 
 /datum/preference/text/pda_ringtone/create_default_value()
@@ -24,6 +25,7 @@
 	savefile_key = "pda_theme"
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER
+	should_update_preview = FALSE
 
 /datum/preference/choiced/pda_theme/init_possible_values()
 	var/list/values = list()

--- a/code/modules/client/preferences/persistent_scars.dm
+++ b/code/modules/client/preferences/persistent_scars.dm
@@ -2,6 +2,7 @@
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_key = "persistent_scars"
 	savefile_identifier = PREFERENCE_CHARACTER
+	should_update_preview = FALSE
 
 /datum/preference/toggle/persistent_scars/apply_to_human(mob/living/carbon/human/target, value)
 	// This proc doesn't do anything, due to the nature of persistent scars, we ALWAYS need to have a client to be able to use them properly. Or at the very least, a ckey.

--- a/code/modules/client/preferences/phobia.dm
+++ b/code/modules/client/preferences/phobia.dm
@@ -2,6 +2,7 @@
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
 	savefile_key = "phobia"
 	savefile_identifier = PREFERENCE_CHARACTER
+	should_update_preview = FALSE
 
 /datum/preference/choiced/phobia/init_possible_values()
 	return GLOB.phobia_types

--- a/code/modules/client/preferences/prisoner_crime.dm
+++ b/code/modules/client/preferences/prisoner_crime.dm
@@ -3,6 +3,7 @@
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "prisoner_crime"
+	should_update_preview = FALSE
 
 /datum/preference/choiced/prisoner_crime/init_possible_values()
 	return assoc_to_keys(GLOB.prisoner_crimes) + "Random"
@@ -98,7 +99,7 @@ GLOBAL_LIST_INIT(prisoner_crimes, init_prisoner_crimes())
 	name = "Identity Theft of High-Ranking Figure"
 	desc = "Impersonated a high-ranking figure."
 	tattoos = 0 //well, obviously can't impersonate people with tats. if they want to go back to doing that
-	
+
 /datum/prisoner_crime/jaywalker
 	name = "Jaywalker"
 	desc = "Jaywalked across non-green tram crossings, shuttle docking zones, and/or through space."

--- a/code/modules/client/preferences/prosthetic_organ.dm
+++ b/code/modules/client/preferences/prosthetic_organ.dm
@@ -2,6 +2,7 @@
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
 	savefile_key = "prosthetic_organ"
 	savefile_identifier = PREFERENCE_CHARACTER
+	should_update_preview = FALSE
 
 /datum/preference/choiced/prosthetic_organ/create_default_value()
 	return "Random"

--- a/code/modules/client/preferences/rds_limit.dm
+++ b/code/modules/client/preferences/rds_limit.dm
@@ -3,6 +3,7 @@
 	savefile_key = "rds_limit"
 	savefile_identifier = PREFERENCE_CHARACTER
 	default_value = FALSE
+	should_update_preview = FALSE
 
 /datum/preference/toggle/rds_limit/apply_to_human(mob/living/carbon/human/target, value)
 	return

--- a/code/modules/client/preferences/security_department.dm
+++ b/code/modules/client/preferences/security_department.dm
@@ -4,6 +4,7 @@
 	can_randomize = FALSE
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "prefered_security_department"
+	should_update_preview = FALSE
 
 // This is what that #warn wants you to remove :)
 /datum/preference/choiced/security_department/deserialize(input, datum/preferences/preferences)

--- a/code/modules/client/preferences/silicon_gender.dm
+++ b/code/modules/client/preferences/silicon_gender.dm
@@ -7,6 +7,7 @@
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "silicon_gender"
+	should_update_preview = FALSE
 	var/static/use_character_gender = "Use character gender"
 	///Used to convert the read value of this preference into a gender
 	var/static/list/pronouns_to_genders = list(

--- a/code/modules/client/preferences/species_features/vampire.dm
+++ b/code/modules/client/preferences/species_features/vampire.dm
@@ -6,6 +6,7 @@
 	main_feature_name = "Vampire status"
 	should_generate_icons = TRUE
 	relevant_inherent_trait = TRAIT_BLOOD_CLANS
+	should_update_preview = FALSE
 
 /datum/preference/choiced/vampire_status/create_default_value()
 	return "Inoculated" //eh, have em try out the mechanic first

--- a/code/modules/client/preferences/uplink_location.dm
+++ b/code/modules/client/preferences/uplink_location.dm
@@ -3,6 +3,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "uplink_loc"
 	can_randomize = FALSE
+	should_update_preview = FALSE
 
 /datum/preference/choiced/uplink_location/init_possible_values()
 	return list(UPLINK_PDA, UPLINK_RADIO, UPLINK_PEN, UPLINK_IMPLANT)

--- a/code/modules/client/preferences/voice.dm
+++ b/code/modules/client/preferences/voice.dm
@@ -3,6 +3,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "tts_voice"
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	should_update_preview = FALSE
 
 /datum/preference/choiced/voice/is_accessible(datum/preferences/preferences)
 	if(!SStts.tts_enabled)
@@ -31,6 +32,7 @@
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	minimum = -12
 	maximum = 12
+	should_update_preview = FALSE
 
 /datum/preference/numeric/tts_voice_pitch/is_accessible(datum/preferences/preferences)
 	if(!SStts.tts_enabled || !SStts.pitch_enabled)


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/Monkestation/Monkestation2.0/pull/10634

simply makes it so updating a character preference that is unrelated to character appearance won't regenerate/update the character preview, by adding a `should_update_preview` var to `/datum/preference`.

## Why It's Good For The Game

Avoids wasting precious tick time on regenerating a whole-ass human and equipping them when you're just changing your PDA ringtone or whatever.

## Changelog

No player-facing changes, as well, none of these affect appearance anyways.