### PR TITLE
Healium crystals now properly update turf atmos

### DIFF
--- a/code/game/objects/items/grenades/atmos_grenades.dm
+++ b/code/game/objects/items/grenades/atmos_grenades.dm
@@ -43,6 +43,7 @@
 		if(turf_fix.blocks_air)
 			continue
 		turf_fix.copy_air(base_mix.copy())
+		turf_fix.air_update_turf(update = FALSE, remove = FALSE)
 	qdel(src)
 
 /obj/item/grenade/gas_crystal/proto_nitrate_crystal


### PR DESCRIPTION

## About The Pull Request

Port of https://github.com/Monkestation/Monkestation2.0/pull/10142

self-explanatory, makes it so healium crystals actually update the turfs atmos after "resetting" the air.

## Why It's Good For The Game

bugfix good

## Changelog
:cl:
fix: Healium crystals now properly update turf atmos.
/:cl:
