### PR TITLE
Sleep immune people avoid the effects of the force_say()

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -39,6 +39,11 @@
 	if(!.)
 		return
 
+	force_say()
+
+/datum/status_effect/incapacitating/proc/force_say()
+	SHOULD_CALL_PARENT(TRUE)
+
 	var/mob/living/carbon/human/human = owner
 	if(istype(human))
 		human.force_say(alter_phrases, immediate = TRUE)
@@ -165,6 +170,10 @@
 		REMOVE_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
 		tick_interval = initial(tick_interval)
 	return ..()
+
+/datum/status_effect/incapacitating/sleeping/force_say()
+	if(!HAS_TRAIT(owner, TRAIT_SLEEPIMMUNE))
+		..()
 
 ///If the mob is sleeping and gain the TRAIT_SLEEPIMMUNE we remove the TRAIT_KNOCKEDOUT and stop the tick() from happening
 /datum/status_effect/incapacitating/sleeping/proc/on_owner_insomniac(mob/living/source)


### PR DESCRIPTION
## About The Pull Request

Fixes force_say() triggering when sleep immune people had the sleeping status effect applied.

## Why It's Good For The Game

Fixes #95271 

## Changelog

:cl:
fix: Fixed chat interference when you would be put to sleep but were sleep immune.
/:cl: