### PR TITLE
[NO GBP] Hotfix for the autostale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -44,9 +44,10 @@ jobs:
 
   announce:
     runs-on: ubuntu-24.04
-    if: ${{ jobs.stale.outputs.staled_prs != '[]' }}
+    needs: stale
+    if: ${{ needs.stale.outputs.staled_prs != '[]' }}
     matrix:
-      pull_request: ${{ fromJSON(jobs.stale.outputs.staled_prs) }}
+      pull_request: ${{ fromJSON(needs.stale.outputs.staled_prs) }}
     steps:
       - name: "Check for DISCORD_WEBHOOK"
         id: secrets_set


### PR DESCRIPTION
## About The Pull Request

I was using the wrong context in the expressions for the announcement job

## Why It's Good For The Game

While the real meat and potatoes of the autostale workflow still works, we don't want the workflow showing up as failed.

## Changelog

No player-facing changes
