### PR TITLE
Fixes taller heights clipping hair (or ears/horns)

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -852,15 +852,18 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 	// These two are cached, and have their appearance shared(?), so it's safer to just not touch it
 	"[MUTATIONS_LAYER]" = NO_MODIFY,
 	"[FRONT_MUTATIONS_LAYER]" = NO_MODIFY,
+	//So mutant parts get offsets applied too.
+	"[BODY_FRONT_LAYER]" = UPPER_BODY,
+	"[OUTER_HAIR_LAYER]" = UPPER_BODY,
+	"[BODY_ADJ_LAYER]" = UPPER_BODY,
+	"[BODY_BEHIND_LAYER]" = UPPER_BODY,
 	// These DO get a filter, I'm leaving them here as reference,
 	// to show how many filters are added at a glance
 	// BACK_LAYER (backpacks are big)
 	// BODYPARTS_HIGH_LAYER (arms)
 	// BODY_LAYER (body markings (full body), underwear (full body))
 	// EYES_LAYER,
-	// BODY_ADJ_LAYER (external organs like wings)
-	// BODY_BEHIND_LAYER (external organs like wings)
-	// BODY_FRONT_LAYER (external organs like wings)
+
 	// DAMAGE_LAYER (full body)
 	// HIGHEST_LAYER (full body)
 	// UNIFORM_LAYER (full body)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -863,7 +863,6 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 	// BODYPARTS_HIGH_LAYER (arms)
 	// BODY_LAYER (body markings (full body), underwear (full body))
 	// EYES_LAYER,
-
 	// DAMAGE_LAYER (full body)
 	// HIGHEST_LAYER (full body)
 	// UNIFORM_LAYER (full body)

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -1036,7 +1036,8 @@ generate/load female uniform sprites matching all previously decided variables
 		else
 			return
 
-	appearance.pixel_z = initial(appearance.pixel_z) + final_offset
+	appearance.pixel_z = initial(appearance.pixel_z)
+	appearance.pixel_z += final_offset
 	return appearance
 
 /**

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -1003,7 +1003,11 @@ generate/load female uniform sprites matching all previously decided variables
 	if(isnull(offset_type))
 		if(islist(raw_applied))
 			for(var/image/applied_appearance in raw_applied)
-				apply_height_filters(applied_appearance)
+				var/sub_offset_type = GLOB.layers_to_offset[num2text(-applied_appearance.layer)]
+				if(!isnull(sub_offset_type))
+					apply_height_offsets(applied_appearance, sub_offset_type)
+				else
+					apply_height_filters(applied_appearance)
 		else if(isimage(raw_applied))
 			apply_height_filters(raw_applied)
 	else
@@ -1032,6 +1036,7 @@ generate/load female uniform sprites matching all previously decided variables
 		else
 			return
 
+	appearance.pixel_z = initial(appearance.pixel_z)
 	appearance.pixel_z += final_offset
 	return appearance
 

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -1036,8 +1036,7 @@ generate/load female uniform sprites matching all previously decided variables
 		else
 			return
 
-	appearance.pixel_z = initial(appearance.pixel_z)
-	appearance.pixel_z += final_offset
+	appearance.pixel_z = initial(appearance.pixel_z) + final_offset
 	return appearance
 
 /**

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -1004,10 +1004,7 @@ generate/load female uniform sprites matching all previously decided variables
 		if(islist(raw_applied))
 			for(var/image/applied_appearance in raw_applied)
 				var/sub_offset_type = GLOB.layers_to_offset[num2text(-applied_appearance.layer)]
-				if(!isnull(sub_offset_type))
-					apply_height_offsets(applied_appearance, sub_offset_type)
-				else
-					apply_height_filters(applied_appearance)
+				apply_height_offsets(applied_appearance, sub_offset_type)
 		else if(isimage(raw_applied))
 			apply_height_filters(raw_applied)
 	else

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -1004,7 +1004,10 @@ generate/load female uniform sprites matching all previously decided variables
 		if(islist(raw_applied))
 			for(var/image/applied_appearance in raw_applied)
 				var/sub_offset_type = GLOB.layers_to_offset[num2text(-applied_appearance.layer)]
-				apply_height_offsets(applied_appearance, sub_offset_type)
+				if(!isnull(sub_offset_type))
+					apply_height_offsets(applied_appearance, sub_offset_type)
+				else
+					apply_height_filters(applied_appearance)
 		else if(isimage(raw_applied))
 			apply_height_filters(raw_applied)
 	else


### PR DESCRIPTION

## About The Pull Request


When characters set their height to tall, taller, or tallest, the height system uses BYOND displacement map filters to stretch the sprite. However, displacement filters push pixels within a 32×32 icon boundary, and any pixels pushed beyond that boundary are permanently clipped; this caused the tops of hair, ears, and horns to be cut off on tall characters. The fix adds the affected overlay layers (OUTER_HAIR_LAYER, BODY_FRONT_LAYER, BODY_ADJ_LAYER, and BODY_BEHIND_LAYER) to the layers_to_offset global list so they use simple pixel_z offsets instead of displacement filters, which shift the entire image without any clipping. Additionally, because external organs like horns are packed as multiple sub-images into BODYPARTS_LAYER (which itself still needs a displacement filter for the body), a per-image layer check was added to apply_overlay in human_update_icons.dm that iterates through each image in the list, checks its individual layer against layers_to_offset, and routes it to either apply_height_offsets or apply_height_filters accordingly, ensuring horn/ear/hair sub-images get offsets while body parts still get the filter they need.

Disclaimer: I relied heavily on AI to fix this and I tested it shows chars fine but, I didn't personally come up with the actual solution.
## Why It's Good For The Game

Fix of a long standing bug with tall characters. Finally fixes #77440 


<img width="180" height="122" alt="debug" src="https://github.com/user-attachments/assets/7121c5f0-6a8e-45a4-8a43-a695b1a85c6b" />

Regular height vs spacer
## Changelog
:cl:
fix: Fixes tall characters getting their hair or mutant parts clipped
/:cl:
