### PR TITLE
Makes the parallax not jump randomly when reloaded with swap_out_random_parallax_layer

### DIFF
--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -175,17 +175,12 @@
 	// Update the movement direction of the parallax if necessary (for shuttles)
 	set_parallax_movedir(areaobj.parallax_movedir, FALSE, screenmob)
 
-	var/force = FALSE
 	if(!C.previous_turf || (C.previous_turf.z != posobj.z))
 		C.previous_turf = posobj
-		force = TRUE
 
 	//Doing it this way prevents parallax layers from "jumping" when you change Z-Levels.
 	var/offset_x = posobj.x - C.previous_turf.x
 	var/offset_y = posobj.y - C.previous_turf.y
-
-	if(!offset_x && !offset_y && !force)
-		return
 
 	var/glide_rate = round(ICON_SIZE_ALL / screenmob.glide_size * world.tick_lag, world.tick_lag)
 	C.previous_turf = posobj


### PR DESCRIPTION
## About The Pull Request

Turns out `/datum/hud/proc/update_parallax` still had a lot of remnant code back from when it ticked an update on every tick, even though it now only gets called on movement/z level changes. This prevented it from updating the locations of parallax layers unless you move, which is usually not an issue and goes unnoticed in the case of hud reloads or pref changes, since the parallax layer cache keeps the correct offsets.

Except in the one specific case that needs to clear this cache entirely (`swap_out_random_parallax_layer`), which causes it to regenerate with no offsets, and jump to the correct position abrubtly when you move.

This fixes that

## Why It's Good For The Game

Fixes a bug. I tested when the proc gets called extensively and it's exclusively on movement and on hud/pref updates concerning the parallax, which all should get a full reload and not a half-attempt.

## Changelog

:cl:
fix: Parallax layers no longer snap to and from the center of the screen abrubtly when changing the random parallax layer.
/:cl: