### PR TITLE
Fish can be scanned for dna vault (+target number tweaks)

### DIFF
--- a/code/game/objects/items/dna_probe.dm
+++ b/code/game/objects/items/dna_probe.dm
@@ -27,6 +27,13 @@
 	var/list/stored_dna_human = list()
 	///weak ref to the dna vault
 	var/datum/weakref/dna_vault_ref
+	/// Things we consider to be animals
+	var/static/list/animal_typecache = typecacheof(list(
+		/mob/living/basic,
+		/mob/living/carbon/alien,
+		/mob/living/simple_animal,
+		/obj/item/fish,
+	))
 
 /obj/item/dna_probe/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(istype(interacting_with, /obj/machinery/dna_vault))
@@ -148,8 +155,7 @@
 	if((allowed_scans & DNA_PROBE_SCAN_HUMANS) && ishuman(target))
 		return TRUE
 	if((allowed_scans & DNA_PROBE_SCAN_ANIMALS) && isliving(target))
-		var/static/list/non_simple_animals = typecacheof(list(/mob/living/carbon/alien))
-		if(isanimal_or_basicmob(target) || is_type_in_typecache(target, non_simple_animals) || ismonkey(target))
+		if(is_type_in_typecache(target, animal_typecache) || ismonkey(target))
 			return TRUE
 	return FALSE
 

--- a/code/game/objects/items/dna_probe.dm
+++ b/code/game/objects/items/dna_probe.dm
@@ -108,7 +108,7 @@
 		balloon_alert(user, "data added")
 		return TRUE
 
-	if(ishuman(target))
+	if(ishuman(target) && !ismonkey(target))
 		var/mob/living/carbon/human/human_target = target
 		if(our_vault.human_dna[human_target.dna.unique_identity])
 			balloon_alert(user, "data already in vault!")
@@ -124,12 +124,6 @@
 		balloon_alert(user, "data added")
 		return TRUE
 
-	var/static/list/animal_typecache = typecacheof(list(
-		/mob/living/basic,
-		/mob/living/carbon/alien,
-		/mob/living/simple_animal,
-		/obj/item/fish,
-	))
 	if(!is_type_in_typecache(target, animal_typecache) && !ismonkey(target))
 		return FALSE
 	if(our_vault.animal_dna[target.type])
@@ -152,11 +146,10 @@
 /obj/item/dna_probe/proc/valid_scan_target(atom/target)
 	if((allowed_scans & DNA_PROBE_SCAN_PLANTS) && istype(target, /obj/machinery/hydroponics))
 		return TRUE
-	if((allowed_scans & DNA_PROBE_SCAN_HUMANS) && ishuman(target))
+	if((allowed_scans & DNA_PROBE_SCAN_HUMANS) && (ishuman(target) && !ismonkey(target)))
 		return TRUE
-	if((allowed_scans & DNA_PROBE_SCAN_ANIMALS) && isliving(target))
-		if(is_type_in_typecache(target, animal_typecache) || ismonkey(target))
-			return TRUE
+	if((allowed_scans & DNA_PROBE_SCAN_ANIMALS) && (is_type_in_typecache(target, animal_typecache) || ismonkey(target)))
+		return TRUE
 	return FALSE
 
 #define CARP_MIX_DNA_TIMER (15 SECONDS)

--- a/code/game/objects/items/dna_probe.dm
+++ b/code/game/objects/items/dna_probe.dm
@@ -82,57 +82,61 @@
 	if(!our_vault)
 		playsound(user, 'sound/machines/buzz/buzz-sigh.ogg', 50)
 		balloon_alert(user, "need database!")
-		return
+		return FALSE
 	if(istype(target, /obj/machinery/hydroponics))
 		var/obj/machinery/hydroponics/hydro_tray = target
 		if(!hydro_tray.myseed)
-			return
+			return FALSE
 		if(our_vault.plant_dna[hydro_tray.myseed.type])
-			to_chat(user, span_notice("Plant data is already present in vault storage."))
-			return
+			balloon_alert(user, "data already in vault!")
+			return FALSE
 		if(stored_dna_plants[hydro_tray.myseed.type])
-			to_chat(user, span_notice("Plant data already present in local storage."))
-			return
+			balloon_alert(user, "data already in scanner!")
+			return FALSE
 		if(hydro_tray.plant_status != HYDROTRAY_PLANT_HARVESTABLE) // So it's bit harder.
-			to_chat(user, span_alert("Plant needs to be ready to harvest to perform full data scan.")) //Because space dna is actually magic
-			return
+			balloon_alert(user, "plant is not harvestable!")
+			return FALSE
 		stored_dna_plants[hydro_tray.myseed.type] = TRUE
 		playsound(src, 'sound/machines/compiler/compiler-stage2.ogg', 50)
 		balloon_alert(user, "data added")
 		return TRUE
-	else if(ishuman(target))
+
+	if(ishuman(target))
 		var/mob/living/carbon/human/human_target = target
 		if(our_vault.human_dna[human_target.dna.unique_identity])
-			to_chat(user, span_notice("Humanoid data already present in vault storage."))
-			return
+			balloon_alert(user, "data already in vault!")
+			return FALSE
 		if(stored_dna_human[human_target.dna.unique_identity])
-			to_chat(user, span_notice("Humanoid data already present in local storage."))
-			return
+			balloon_alert(user, "data already in scanner!")
+			return FALSE
 		if(!(human_target.mob_biotypes & MOB_ORGANIC))
-			to_chat(user, span_alert("No compatible DNA detected."))
-			return .
+			balloon_alert(user, "no compatible dna!")
+			return FALSE
 		stored_dna_human[human_target.dna.unique_identity] = TRUE
 		playsound(src, 'sound/machines/compiler/compiler-stage2.ogg', 50)
 		balloon_alert(user, "data added")
 		return TRUE
 
-	if(!isliving(target))
-		return
+	var/static/list/animal_typecache = typecacheof(list(
+		/mob/living/basic,
+		/mob/living/carbon/alien,
+		/mob/living/simple_animal,
+		/obj/item/fish,
+	))
+	if(!is_type_in_typecache(target, animal_typecache) && !ismonkey(target))
+		return FALSE
+	if(our_vault.animal_dna[target.type])
+		balloon_alert(user, "data already in vault!")
+		return FALSE
+	if(stored_dna_animal[target.type])
+		balloon_alert(user, "data already in scanner!")
+		return FALSE
+	if(isliving(target))
+		var/mob/living/living_target = target
+		if(!(living_target.mob_biotypes & MOB_ORGANIC))
+			balloon_alert(user, "no compatible dna!")
+			return FALSE
 
-	var/static/list/non_simple_animals = typecacheof(list(/mob/living/carbon/alien))
-	if(!isanimal_or_basicmob(target) && !is_type_in_typecache(target, non_simple_animals) && !ismonkey(target))
-		return
-
-	var/mob/living/living_target = target
-	if(our_vault.animal_dna[living_target.type])
-		to_chat(user, span_notice("Animal data already present in vault storage."))
-		return
-	if(stored_dna_animal[living_target.type])
-		to_chat(user, span_notice("Animal data already present in local storage."))
-		return
-	if(!(living_target.mob_biotypes & MOB_ORGANIC))
-		to_chat(user, span_alert("No compatible DNA detected."))
-		return .
 	stored_dna_animal[living_target.type] = TRUE
 	playsound(src, 'sound/machines/compiler/compiler-stage2.ogg', 50)
 	balloon_alert(user, "data added")

--- a/code/game/objects/items/dna_probe.dm
+++ b/code/game/objects/items/dna_probe.dm
@@ -137,7 +137,7 @@
 			balloon_alert(user, "no compatible dna!")
 			return FALSE
 
-	stored_dna_animal[living_target.type] = TRUE
+	stored_dna_animal[target.type] = TRUE
 	playsound(src, 'sound/machines/compiler/compiler-stage2.ogg', 50)
 	balloon_alert(user, "data added")
 	return TRUE

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -22,7 +22,7 @@
 	animal_count = rand(12, 18) //might be too few given ~15 roundstart stationside ones
 	human_count = rand(round(0.75 * SSticker.totalPlayersReady) , SSticker.totalPlayersReady) // 75%+ roundstart population.
 	var/non_standard_plants = non_standard_plants_count()
-	plant_count = rand(round(0.2 * non_standard_plants),round(0.4 * non_standard_plants))
+	plant_count = rand(round(0.15 * non_standard_plants), round(0.3 * non_standard_plants))
 
 /datum/station_goal/dna_vault/proc/non_standard_plants_count()
 	. = 0

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -19,7 +19,7 @@
 
 /datum/station_goal/dna_vault/New()
 	..()
-	animal_count = rand(10,15) //might be too few given ~15 roundstart stationside ones
+	animal_count = rand(12, 18) //might be too few given ~15 roundstart stationside ones
 	human_count = rand(round(0.75 * SSticker.totalPlayersReady) , SSticker.totalPlayersReady) // 75%+ roundstart population.
 	var/non_standard_plants = non_standard_plants_count()
 	plant_count = rand(round(0.2 * non_standard_plants),round(0.4 * non_standard_plants))

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -19,7 +19,7 @@
 
 /datum/station_goal/dna_vault/New()
 	..()
-	animal_count = rand(12, 18) //might be too few given ~15 roundstart stationside ones
+	animal_count = rand(16, 20) //might be too few given ~15 roundstart stationside ones
 	human_count = rand(round(0.75 * SSticker.totalPlayersReady) , SSticker.totalPlayersReady) // 75%+ roundstart population.
 	var/non_standard_plants = non_standard_plants_count()
 	plant_count = rand(round(0.15 * non_standard_plants), round(0.3 * non_standard_plants))


### PR DESCRIPTION
## About The Pull Request

Fish can be scanned as animals for the DNA vault

Increases the average number of animals needed by ~6-10

Reduces the average number of plants needed by like... ~8-12 or something?

## Why It's Good For The Game

Fish are animals. It makes sense to me. 

Because fishing is pretty darn easy I increased the animal count to compensate. I see this as fine anyways because there are more than enough animals on station to fulfill the vault as-is.

While I was tweaking the numbers, I budged the plant count down because it's quite a  lot of plants to wait to be fully grown - upwards of 30 at times. 

## Changelog

:cl: Melbert
balance: Fish can be scanned for the dna vault. 
balance: You need more animals on average to complete a dna vault.
balance: You need less plants on average to complete a dna vault.
/:cl:
