### PR TITLE
Removes Spells tab

### DIFF
--- a/code/__DEFINES/actions.dm
+++ b/code/__DEFINES/actions.dm
@@ -28,15 +28,6 @@ DEFINE_BITFIELD(check_flags, list(
 ///Action triggered to ignore any availability checks
 #define TRIGGER_FORCE_AVAILABLE (1<<1)
 
-// Defines for formatting cooldown actions for the stat panel.
-/// The stat panel the action is displayed in.
-#define PANEL_DISPLAY_PANEL "panel"
-/// The status shown in the stat panel.
-/// Can be stuff like "ready", "on cooldown", "active", "charges", "charge cost", etc.
-#define PANEL_DISPLAY_STATUS "status"
-/// The name shown in the stat panel.
-#define PANEL_DISPLAY_NAME "name"
-
 #define ACTION_BUTTON_DEFAULT_BACKGROUND "_use_ui_default_background"
 
 #define UPDATE_BUTTON_NAME (1<<0)

--- a/code/__DEFINES/dcs/signals/signals_action.dm
+++ b/code/__DEFINES/dcs/signals/signals_action.dm
@@ -24,9 +24,6 @@
 /// From base of /datum/action/cooldown/proc/PreActivate(), sent to the action owner: (datum/action/cooldown/finished)
 #define COMSIG_MOB_ABILITY_FINISHED "mob_ability_base_finished"
 
-/// From base of /datum/action/cooldown/proc/set_statpanel_format(): (list/stat_panel_data)
-#define COMSIG_ACTION_SET_STATPANEL "ability_set_statpanel"
-
 // Specific cooldown action signals
 
 /// From base of /datum/action/cooldown/mob_cooldown/blood_warp/proc/blood_warp(): ()

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -90,23 +90,6 @@ SUBSYSTEM_DEF(statpanels)
 			else if(length(GLOB.sdql2_queries) && (target.stat_tab == "SDQL2" || !("SDQL2" in target.panel_tabs)) && num_fires % default_wait == 0)
 				set_SDQL2_tab(target)
 
-		if(target.mob)
-			var/mob/target_mob = target.mob
-
-			// Handle the action panels of the stat panel
-
-			var/update_actions = FALSE
-			// We're on a spell tab, update the tab so we can see cooldowns progressing and such
-			if(target.stat_tab in target.spell_tabs)
-				update_actions = TRUE
-			// We're not on a spell tab per se, but we have cooldown actions, and we've yet to
-			// set up our spell tabs at all
-			if(!length(target.spell_tabs) && locate(/datum/action/cooldown) in target_mob.actions)
-				update_actions = TRUE
-
-			if(update_actions && num_fires % default_wait == 0)
-				set_action_tabs(target, target_mob)
-
 		if(MC_TICK_CHECK)
 			return
 
@@ -177,17 +160,6 @@ SUBSYSTEM_DEF(statpanels)
 	sdql2A += sdql2B
 	target.stat_panel.send_message("update_sdql2", sdql2A)
 
-/// Set up the various action tabs.
-/datum/controller/subsystem/statpanels/proc/set_action_tabs(client/target, mob/target_mob)
-	var/list/actions = target_mob.get_actions_for_statpanel()
-	target.spell_tabs.Cut()
-
-	for(var/action_data in actions)
-		target.spell_tabs |= action_data[1]
-
-	target.stat_panel.send_message("update_spells", list(spell_tabs = target.spell_tabs, actions = actions))
-
-
 /datum/controller/subsystem/statpanels/proc/generate_mc_data()
 	mc_data = list(
 		list("", "CPU:", world.cpu),
@@ -228,21 +200,6 @@ SUBSYSTEM_DEF(statpanels)
 
 	if(target.stat_tab == "Status")
 		set_status_tab(target)
-		return TRUE
-
-	var/mob/target_mob = target.mob
-
-	// Handle actions
-
-	var/update_actions = FALSE
-	if(target.stat_tab in target.spell_tabs)
-		update_actions = TRUE
-
-	if(!length(target.spell_tabs) && locate(/datum/action/cooldown) in target_mob.actions)
-		update_actions = TRUE
-
-	if(update_actions)
-		set_action_tabs(target, target_mob)
 		return TRUE
 
 	if(!target.holder)

--- a/code/datums/actions/cooldown_action.dm
+++ b/code/datums/actions/cooldown_action.dm
@@ -7,8 +7,6 @@
 
 	/// The actual next time this ability can be used
 	var/next_use_time = 0
-	/// The stat panel this action shows up in the stat panel in. If null, will not show up.
-	var/panel
 	/// The default cooldown applied when StartCooldown() is called
 	var/cooldown_time = 0
 	/// The default melee cooldown applied after the ability ends. If set to null, copies cooldown_time.

--- a/code/datums/actions/cooldown_action.dm
+++ b/code/datums/actions/cooldown_action.dm
@@ -330,40 +330,4 @@
 	build_all_button_icons(UPDATE_BUTTON_STATUS)
 	return TRUE
 
-/// Formats the action to be returned to the stat panel.
-/datum/action/cooldown/proc/set_statpanel_format()
-	if(!panel)
-		return null
-
-	var/time_remaining = max(next_use_time - world.time, 0)
-	var/time_remaining_in_seconds = round(time_remaining / 10, 0.1)
-	var/cooldown_time_in_seconds =  round(cooldown_time / 10, 0.1)
-
-	var/list/stat_panel_data = list()
-
-	// Pass on what panel we should be displayed in.
-	stat_panel_data[PANEL_DISPLAY_PANEL] = panel
-	// Also pass on the name of the spell, with some spacing
-	stat_panel_data[PANEL_DISPLAY_NAME] = " - [name]"
-
-	// No cooldown time at all, just show the ability
-	if(cooldown_time_in_seconds <= 0)
-		stat_panel_data[PANEL_DISPLAY_STATUS] = ""
-
-	// It's a toggle-active ability, show if it's active
-	else if(click_to_activate && owner.click_intercept == src)
-		stat_panel_data[PANEL_DISPLAY_STATUS] = "ACTIVE"
-
-	// It's on cooldown, show the cooldown
-	else if(time_remaining_in_seconds > 0)
-		stat_panel_data[PANEL_DISPLAY_STATUS] = "CD - [time_remaining_in_seconds]s / [cooldown_time_in_seconds]s"
-
-	// It's not on cooldown, show that it is ready
-	else
-		stat_panel_data[PANEL_DISPLAY_STATUS] = "READY"
-
-	SEND_SIGNAL(src, COMSIG_ACTION_SET_STATPANEL, stat_panel_data)
-
-	return stat_panel_data
-
 #undef COOLDOWN_NO_DISPLAY_TIME

--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -224,7 +224,6 @@
 	new_power.active_background_icon_state = "[new_power.base_background_icon_state]_active"
 	new_power.overlay_icon_state = "bg_tech_blue_border"
 	new_power.active_overlay_icon_state = "bg_spell_border_active_blue"
-	new_power.panel = "Genetic"
 	new_power.Grant(owner)
 
 	return new_power

--- a/code/modules/antagonists/voidwalker/voidwalker_abilities.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker_abilities.dm
@@ -6,7 +6,6 @@
 	button_icon_state = "unsettle"
 	background_icon_state = "bg_void"
 	overlay_icon_state = null
-	panel = null
 	spell_requirements = NONE
 	cooldown_time = 12 SECONDS
 	cast_range = 9
@@ -82,7 +81,6 @@
 	background_icon_state = "bg_void"
 	button_icon = 'icons/mob/actions/actions_voidwalker.dmi'
 	button_icon_state = "telepathy"
-	panel = null
 	overlay_icon_state = null
 
 /datum/action/cooldown/spell/list_target/telepathy/voidwalker/sunwalker

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -186,8 +186,6 @@
 
 	/// list of all tabs
 	var/list/panel_tabs = list()
-	/// list of tabs containing spells and abilities
-	var/list/spell_tabs = list()
 	///A lazy list of atoms we've examined in the last RECENT_EXAMINE_MAX_WINDOW (default 2) seconds, so that we will call [/atom/proc/examine_more] instead of [/atom/proc/examine] on them when examining
 	var/list/recent_examines
 

--- a/code/modules/mob/living/basic/space_fauna/revenant/revenant_abilities.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/revenant_abilities.dm
@@ -4,7 +4,6 @@
 //Transmit: the revemant's only direct way to communicate. Sends a single message silently to a single mob
 /datum/action/cooldown/spell/list_target/telepathy/revenant
 	name = "Revenant Transmit"
-	panel = "Revenant Abilities"
 	background_icon_state = "bg_revenant"
 	overlay_icon_state = "bg_revenant_border"
 
@@ -14,7 +13,6 @@
 	antimagic_flags = MAGIC_RESISTANCE_HOLY|MAGIC_RESISTANCE_MIND
 
 /datum/action/cooldown/spell/aoe/revenant
-	panel = "Revenant Abilities (Locked)"
 	background_icon_state = "bg_revenant"
 	overlay_icon_state = "bg_revenant_border"
 	button_icon = 'icons/mob/actions/actions_revenant.dmi'
@@ -80,7 +78,6 @@
 
 		name = "[initial(name)] ([cast_amount]E)"
 		to_chat(cast_on, span_revennotice("You have unlocked [initial(name)]!"))
-		panel = "Revenant Abilities"
 		locked = FALSE
 		reset_spell_cooldown()
 		return . | SPELL_CANCEL_CAST

--- a/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
@@ -8,7 +8,6 @@ Doesn't work on other aliens/AI.*/
 
 /datum/action/cooldown/alien
 	name = "Alien Power"
-	panel = "Alien"
 	background_icon_state = "bg_alien"
 	overlay_icon_state = "bg_alien_border"
 	button_icon = 'icons/mob/actions/actions_xeno.dmi'
@@ -345,7 +344,6 @@ Doesn't work on other aliens/AI.*/
 
 /datum/action/cooldown/mob_cooldown/sneak/alien
 	name = "Alien Sentinel Sneak"
-	panel = "Alien"
 	desc = "Blend into the shadows to stalk your prey."
 	button_icon = 'icons/mob/actions/actions_xeno.dmi'
 	button_icon_state = "alien_sneak"

--- a/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
@@ -18,6 +18,12 @@ Doesn't work on other aliens/AI.*/
 	/// How much plasma this action uses.
 	var/plasma_cost = 0
 
+/datum/action/cooldown/alien/New(Target)
+	. = ..()
+	//not free
+	if(plasma_cost != 0)
+		name = "[initial(name)] ([plasma_cost]P)"
+
 /datum/action/cooldown/alien/IsAvailable(feedback = FALSE)
 	. = ..()
 	if(!.)
@@ -49,13 +55,6 @@ Doesn't work on other aliens/AI.*/
 		unset_click_ability(owner, refund_cooldown = FALSE)
 
 	return TRUE
-
-/datum/action/cooldown/alien/set_statpanel_format()
-	. = ..()
-	if(!islist(.))
-		return
-
-	.[PANEL_DISPLAY_STATUS] = "PLASMA - [plasma_cost]"
 
 /datum/action/cooldown/alien/make_structure
 	/// The type of structure the action makes on use

--- a/code/modules/mob/living/carbon/alien/adult/queen.dm
+++ b/code/modules/mob/living/carbon/alien/adult/queen.dm
@@ -94,12 +94,11 @@
 	/// The promotion only takes plasma when completed, not on activation.
 	var/promotion_plasma_cost = 500
 
-/datum/action/cooldown/alien/promote/set_statpanel_format()
+/datum/action/cooldown/alien/promote/New(Target)
 	. = ..()
-	if(!islist(.))
-		return
-
-	.[PANEL_DISPLAY_STATUS] = "PLASMA - [promotion_plasma_cost]"
+	//not free
+	if(promotion_plasma_cost != 0)
+		name = "[initial(name)] ([promotion_plasma_cost]P)"
 
 /datum/action/cooldown/alien/promote/IsAvailable(feedback = FALSE)
 	. = ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -911,33 +911,6 @@
 	SEND_SIGNAL(src, COMSIG_MOB_GET_STATUS_TAB_ITEMS, .)
 	return .
 
-/**
- * Convert a list of spells into a displyable list for the statpanel
- *
- * Shows charge and other important info
- */
-/mob/proc/get_actions_for_statpanel()
-	var/list/data = list()
-	for(var/datum/action/cooldown/action in actions)
-		var/list/action_data = action.set_statpanel_format()
-		if(!length(action_data))
-			return
-
-		data += list(list(
-			// the panel the action gets displayed to
-			// in the future, this could probably be replaced with subtabs (a la admin tabs)
-			action_data[PANEL_DISPLAY_PANEL],
-			// the status of the action, - cooldown, charges, whatever
-			action_data[PANEL_DISPLAY_STATUS],
-			// the name of the action
-			action_data[PANEL_DISPLAY_NAME],
-			// a ref to the action button of this action for this mob
-			// it's a ref to the button specifically, instead of the action itself,
-			// because statpanel href calls click(), which the action button (not the action itself) handles
-			REF(action.viewers[hud_used]),
-		))
-
-	return data
 
 /mob/proc/swap_hand(held_index, silent = FALSE)
 	SHOULD_NOT_OVERRIDE(TRUE) // Override perform_hand_swap instead

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -49,7 +49,6 @@
 	overlay_icon_state = "bg_spell_border"
 	active_overlay_icon_state = "bg_spell_border_active_red"
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_PHASED
-	panel = "Spells"
 
 	/// The sound played on cast.
 	var/sound = null

--- a/code/modules/spells/spell_types/aoe_spell/repulse.dm
+++ b/code/modules/spells/spell_types/aoe_spell/repulse.dm
@@ -90,7 +90,6 @@
 	overlay_icon_state = "bg_alien_border"
 	button_icon = 'icons/mob/actions/actions_xeno.dmi'
 	button_icon_state = "tailsweep"
-	panel = "Alien"
 	sound = 'sound/effects/magic/tail_swing.ogg'
 
 	cooldown_time = 15 SECONDS

--- a/code/modules/spells/spell_types/charged/_charged.dm
+++ b/code/modules/spells/spell_types/charged/_charged.dm
@@ -90,14 +90,6 @@
 	. = ..()
 	stop_channel_effect(cast_on)
 
-/datum/action/cooldown/spell/charged/set_statpanel_format()
-	. = ..()
-	if(!islist(.))
-		return
-
-	if(currently_channeling)
-		.[PANEL_DISPLAY_STATUS] = "CHANNELING"
-
 /// Interrupts the chanelling effect, removing any overlay or sound playing (for the passed mob)
 /datum/action/cooldown/spell/charged/proc/stop_channel_effect(mob/for_who)
 	if(charge_overlay_instance)

--- a/code/modules/spells/spell_types/conjure/invisible_chair.dm
+++ b/code/modules/spells/spell_types/conjure/invisible_chair.dm
@@ -6,7 +6,6 @@
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
 	button_icon_state = "invisible_chair"
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED
-	panel = "Mime"
 	sound = null
 
 	school = SCHOOL_MIME

--- a/code/modules/spells/spell_types/conjure/invisible_wall.dm
+++ b/code/modules/spells/spell_types/conjure/invisible_wall.dm
@@ -6,7 +6,6 @@
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
 	button_icon_state = "invisible_wall"
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED
-	panel = "Mime"
 	sound = null
 
 	school = SCHOOL_MIME

--- a/code/modules/spells/spell_types/conjure_item/invisible_box.dm
+++ b/code/modules/spells/spell_types/conjure_item/invisible_box.dm
@@ -8,7 +8,6 @@
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
 	button_icon_state = "invisible_box"
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED
-	panel = "Mime"
 	sound = null
 
 	school = SCHOOL_MIME

--- a/code/modules/spells/spell_types/pointed/finger_guns.dm
+++ b/code/modules/spells/spell_types/pointed/finger_guns.dm
@@ -7,7 +7,6 @@
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
 	button_icon_state = "finger_guns"
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED
-	panel = "Mime"
 	sound = null
 
 	school = SCHOOL_MIME

--- a/code/modules/spells/spell_types/pointed/terrorize.dm
+++ b/code/modules/spells/spell_types/pointed/terrorize.dm
@@ -7,7 +7,6 @@
 	background_icon_state = "bg_alien"
 	overlay_icon_state = "bg_alien_border"
 	antimagic_flags = MAGIC_RESISTANCE_MIND
-	panel = null
 	spell_requirements = NONE
 	cooldown_time = 25 SECONDS
 	cast_range = 9

--- a/code/modules/spells/spell_types/self/forcewall.dm
+++ b/code/modules/spells/spell_types/self/forcewall.dm
@@ -50,7 +50,6 @@
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
 	button_icon_state = "invisible_blockade"
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED
-	panel = "Mime"
 	sound = null
 
 	school = SCHOOL_MIME

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -5,7 +5,6 @@
 	overlay_icon_state = "bg_mime_border"
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
 	button_icon_state = "mime_speech"
-	panel = "Mime"
 
 	school = SCHOOL_MIME
 	//MMI mimes should be able to break their vow

--- a/code/modules/spells/spell_types/self/spacetime_distortion.dm
+++ b/code/modules/spells/spell_types/self/spacetime_distortion.dm
@@ -27,14 +27,6 @@
 /datum/action/cooldown/spell/spacetime_dist/can_cast_spell(feedback = TRUE)
 	return ..() && ready
 
-/datum/action/cooldown/spell/spacetime_dist/set_statpanel_format()
-	. = ..()
-	if(!islist(.))
-		return
-
-	if(!ready)
-		.[PANEL_DISPLAY_STATUS] = "NOT READY"
-
 /datum/action/cooldown/spell/spacetime_dist/cast(atom/cast_on)
 	. = ..()
 	var/list/turf/to_switcharoo = get_targets_to_scramble(cast_on)

--- a/code/modules/spells/spell_types/touch/_touch.dm
+++ b/code/modules/spells/spell_types/touch/_touch.dm
@@ -52,14 +52,6 @@
 /datum/action/cooldown/spell/touch/is_action_active(atom/movable/screen/movable/action_button/current_button)
 	return !!attached_hand
 
-/datum/action/cooldown/spell/touch/set_statpanel_format()
-	. = ..()
-	if(!islist(.))
-		return
-
-	if(attached_hand)
-		.[PANEL_DISPLAY_STATUS] = "ACTIVE"
-
 /datum/action/cooldown/spell/touch/can_cast_spell(feedback = TRUE)
 	. = ..()
 	if(!.)

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -23,8 +23,6 @@ var current_tab = null;
 //with just "loading" to not appear broken.
 var mc_tab_parts = [["Loading..."]];
 var href_token = null;
-var spells = [];
-var spell_tabs = [];
 var verb_tabs = [];
 var verbs = [["", ""]]; // list with a list inside
 var tickets = [];
@@ -211,21 +209,6 @@ function TakeTabFromByond(tab) {
   Byond.sendMessage("Remove-Tabs", { tab: tab });
 }
 
-function spell_cat_check(cat) {
-  var spells_in_cat = 0;
-  var spellcat = "";
-  for (var s = 0; s < spells.length; s++) {
-    var spell = spells[s];
-    spellcat = spell[0];
-    if (spellcat == cat) {
-      spells_in_cat++;
-    }
-  }
-  if (spells_in_cat < 1) {
-    removeStatusTab(cat);
-  }
-}
-
 function tab_change(tab) {
   if (tab == current_tab) return;
   if (document.getElementById(current_tab))
@@ -234,15 +217,12 @@ function tab_change(tab) {
   set_byond_tab(tab);
   if (document.getElementById(tab))
     document.getElementById(tab).className = "button active"; // make current button active
-  var spell_tabs_thingy = spell_tabs.includes(tab);
   var verb_tabs_thingy = verb_tabs.includes(tab);
   statcontentdiv.className = "statcontent";
   if (tab == "Status") {
     draw_status();
   } else if (tab == "MC") {
     draw_mc();
-  } else if (spell_tabs_thingy) {
-    draw_spells(tab);
   } else if (verb_tabs_thingy) {
     draw_verbs(tab);
   } else if (tab == "Debug Stat Panel") {
@@ -655,31 +635,6 @@ function draw_interviews() {
   document.getElementById("statcontent").appendChild(table);
 }
 
-function draw_spells(cat) {
-  statcontentdiv.textContent = "";
-  var table = document.createElement("table");
-  for (var i = 0; i < spells.length; i++) {
-    var part = spells[i];
-    if (part[0] != cat) continue;
-    var tr = document.createElement("tr");
-    var td1 = document.createElement("td");
-    td1.textContent = part[1];
-    var td2 = document.createElement("td");
-    if (part[3]) {
-      var a = document.createElement("a");
-      a.href = "byond://?src=" + part[3] + ";statpanel_item_click=left";
-      a.textContent = part[2];
-      td2.appendChild(a);
-    } else {
-      td2.textContent = part[2];
-    }
-    tr.appendChild(td1);
-    tr.appendChild(td2);
-    table.appendChild(tr);
-  }
-  document.getElementById("statcontent").appendChild(table);
-}
-
 function make_verb_onclick(command) {
   return function () {
     run_after_focus(function () {
@@ -822,17 +777,6 @@ function add_verb_list(payload) {
   }
 }
 
-function init_spells() {
-  var cat = "";
-  for (var i = 0; i < spell_tabs.length; i++) {
-    cat = spell_tabs[i];
-    if (cat.length > 0) {
-      verb_tabs.push(cat);
-      createStatusTab(cat);
-    }
-  }
-}
-
 document.addEventListener("mouseup", restoreFocus);
 document.addEventListener("keyup", restoreFocus);
 
@@ -844,23 +788,6 @@ if (!current_tab) {
 window.onload = function () {
   Byond.sendMessage("Update-Verbs");
 };
-
-Byond.subscribeTo("update_spells", function (payload) {
-  spell_tabs = payload.spell_tabs;
-  var do_update = false;
-  if (spell_tabs.includes(current_tab)) {
-    do_update = true;
-  }
-  init_spells();
-  if (payload.actions) {
-    spells = payload.actions;
-    if (do_update) {
-      draw_spells(current_tab);
-    }
-  } else {
-    remove_spells();
-  }
-});
 
 Byond.subscribeTo("remove_verb_list", function (v) {
   var to_remove = v;
@@ -930,29 +857,6 @@ Byond.subscribeTo("update_mc", function (payload) {
 
   if (current_tab == "MC") {
     draw_mc();
-  }
-});
-
-Byond.subscribeTo("remove_spells", function () {
-  for (var s = 0; s < spell_tabs.length; s++) {
-    removeStatusTab(spell_tabs[s]);
-  }
-});
-
-Byond.subscribeTo("init_spells", function () {
-  var cat = "";
-  for (var i = 0; i < spell_tabs.length; i++) {
-    cat = spell_tabs[i];
-    if (cat.length > 0) {
-      verb_tabs.push(cat);
-      createStatusTab(cat);
-    }
-  }
-});
-
-Byond.subscribeTo("check_spells", function () {
-  for (var v = 0; v < spell_tabs.length; v++) {
-    spell_cat_check(spell_tabs[v]);
   }
 });
 


### PR DESCRIPTION
## About The Pull Request

Removes the spells tab from the stat panel and all associated code

This is "Mime", "Revenant Abilities", "Spells", "Genetic", and "Alien" tab that was a 1:1 list of the spells you have in the top left corner.

Closes https://github.com/tgstation/tgstation/issues/71902
Closes https://github.com/tgstation/tgstation/issues/94546

Puts Xenos' plasma cost in the name of the ability, like Revenants do.

## Why It's Good For The Game

You already have a list of spells as action buttons, which have been significantly improved in the past recent years. I think we've gotten it to the point where it's overshadowed the old stat panel tab, and we can finally (safely) put it to rest.
It does not help that this feature flip flops between either breaking observers' stat panels (which is a mild annoyance at most) to fully not working (which is another mild annoyance). Current testings on my locally hosted branch cannot actually manage to get these ability tabs to show up at all, which has led me to wonder if people actually use this.

Spells that can be active/inactive already show with an outline that they're on/off, the only thing this had use for was allowing Revenants to see the cost to unlock a spell, but even that is no longer the case.

Perhaps if we wish to cut down on the stat panel, we should finally rid ourselves of some of these features?

## Changelog

:cl:
del: Removed showing spells as their own tab in the stat panel.
qol: Xenos now show the cost of their abilities when you hover over the action button.
/:cl: