### PR TITLE
Fixes setting a custom font screwing up some spans, such as robotic speech

### DIFF
--- a/tgui/packages/tgui-panel/settings/helpers.ts
+++ b/tgui/packages/tgui-panel/settings/helpers.ts
@@ -10,30 +10,19 @@ import type { SettingsState } from './types';
 
 let statFontTimer: NodeJS.Timeout;
 let statTabsTimer: NodeJS.Timeout;
-let overrideRule: HTMLStyleElement;
 let overrideFontFamily: string | undefined;
 let overrideFontSize: string;
 
 /** Updates the global CSS rule to override the font family and size. */
 function updateGlobalOverrideRule(): void {
-  let fontFamily = '';
+  let fontFamily: string | null = null;
 
   if (overrideFontFamily !== undefined) {
-    fontFamily = `font-family: ${overrideFontFamily} !important;`;
+    fontFamily = overrideFontFamily;
   }
 
-  const constructedRule = `body * :not(.Icon) {
-    ${fontFamily}
-  }`;
-
-  if (overrideRule === undefined) {
-    overrideRule = document.createElement('style');
-    document.querySelector('head')!.append(overrideRule);
-  }
-
-  // no other way to force a CSS refresh other than to update its innerText
-  overrideRule.innerText = constructedRule;
-
+  document.documentElement.style.setProperty('font-family', fontFamily);
+  document.body.style.setProperty('font-family', fontFamily);
   document.body.style.setProperty('font-size', overrideFontSize);
 }
 


### PR DESCRIPTION
## About The Pull Request

fixes a bug where having a custom chat font set breaks certain spans, most notably anything with robotic speech.

## Why It's Good For The Game

it looks weird having the automated announcer and such speak normally

## Changelog
:cl:
fix: Fixed setting a custom chat font screwing up some spans, such as robotic speech.
/:cl:
