### PR TITLE
AIs can now rotate their hologram

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -736,6 +736,15 @@
 
 	to_chat(src, "Camera lights activated.")
 
+// Allows AIs to turn their hologram instead on alt-move
+/mob/living/silicon/ai/keybind_face_direction(direction)
+	var/obj/machinery/holopad/active_pad = current
+	if(istype(active_pad) && active_pad.masters[src])
+		var/obj/effect/overlay/holo_pad_hologram/ai_holo = active_pad.masters[src]
+		ai_holo.setDir(direction)
+		return
+	return ..()
+
 //AI_CAMERA_LUMINOSITY
 
 /mob/living/silicon/ai/proc/light_cameras()


### PR DESCRIPTION

## About The Pull Request

Code taken from downstream.

Basically what it says on the tin, AIs can now change the direction of the hologram the same way a living mob can by (with default keybinds) holding alt and pressing a direction.

## Why It's Good For The Game

The AI can now look directly into your soul when giving their menacing speech, allowing for more expression.

## Changelog

:cl:
add: AIs can now rotate their hologram by using the "block movement" keybind.
/:cl:

