### PR TITLE
Fixes Tequila Sunrise Lighting Effect

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -714,7 +714,7 @@
 	. = ..()
 	to_chat(drinker, span_notice("You feel gentle warmth spread through your body!"))
 	light_holder = drinker.mob_light()
-	light_holder.set_light(3, 0.7, COLOR_TANGERINE_YELLOW) //Tequila Sunrise makes you radiate dim light, like a sunrise!
+	light_holder.set_light_range_power_color(3, 0.7, COLOR_TANGERINE_YELLOW) //Tequila Sunrise makes you radiate dim light, like a sunrise!
 
 /datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_end_metabolize(mob/living/drinker)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -713,15 +713,8 @@
 /datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_metabolize(mob/living/drinker)
 	. = ..()
 	to_chat(drinker, span_notice("You feel gentle warmth spread through your body!"))
-	light_holder = new(drinker)
+	light_holder = drinker.mob_light()
 	light_holder.set_light(3, 0.7, COLOR_TANGERINE_YELLOW) //Tequila Sunrise makes you radiate dim light, like a sunrise!
-
-/datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, metabolization_ratio)
-	if(QDELETED(light_holder))
-		holder.del_reagent(type) //If we lost our light object somehow, remove the reagent
-	else if(light_holder.loc != drinker)
-		light_holder.forceMove(drinker)
-	return ..()
 
 /datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_end_metabolize(mob/living/drinker)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Title. 

How long has it been broken for? Who knows! All the drink has apparently been doing is creating a spotlight on the tile you first drink it. Whoops.
## Why It's Good For The Game
Bugs bad, bartenders good.
## Proof of Testing
<details>
<summary>crummy gif of a not-so-blind roboticist drinking a glass of tequila sunrise</summary>
  
![bygone memories](https://github.com/user-attachments/assets/d8958bf1-711e-4071-a0c0-d812f01fdbf8)

</details>

## Changelog
:cl:
fix: Drinking a tequila sunrise now properly makes YOU glow, instead of creating a spotlight at the place you first drank it. 
/:cl:
