### PR TITLE
Replaces outdated word usage from heckacious.json

### DIFF
--- a/strings/heckacious.json
+++ b/strings/heckacious.json
@@ -76,7 +76,6 @@
 		"great": "choice",
 		"look": "lonk",
 		"battery": "babbery",
-		"retard": "dicktard",
 		"gay": "homo",
 		"close": "closte",
 		"wrong": "wrog",

--- a/strings/heckacious.json
+++ b/strings/heckacious.json
@@ -77,6 +77,7 @@
 		"look": "lonk",
 		"battery": "babbery",
 		"gay": "homo",
+		"retard": "boneheafd",
 		"close": "closte",
 		"wrong": "wrog",
 		"who": "whoof",

--- a/strings/heckacious.json
+++ b/strings/heckacious.json
@@ -77,7 +77,6 @@
 		"look": "lonk",
 		"battery": "babbery",
 		"gay": "homo",
-		"retard": "boneheafd",
 		"close": "closte",
 		"wrong": "wrog",
 		"who": "whoof",


### PR DESCRIPTION

## About The Pull Request
Replaces the usage of "Dicktard" in heckacious.json with "boneheafd", fitting more with the general theme of the mutation. As well as not being something some people consider a slur nowadays.

Also as goofball pointed out. Github TOS.

If the word is decided to be kept, it can be done in a server-side json override. Just not in the repo.
## Why It's Good For The Game
This language is not needed at all in current day and a good amount of people consider it a slur. After a code review, changed it to be a (more fitting) replacement of the word said instead of a downright removal of the word.

Also TOS Violation Bad.
## Changelog
:cl:
spellcheck: Heckacious Larincks no longer uses a github-TOS-breaking word as one of it's transforms
/:cl:
