### PR TITLE
Removes these incredible offending slurs from tourretes

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -220,7 +220,7 @@
 			if(1)
 				owner.emote("twitch")
 			if(2 to 3)
-				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced=name)
+				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "TITS")]", forced=name)
 		var/w_offset =  rand(-2, 2)
 		var/z_offset = rand(-1, 1)
 		animate(owner, pixel_w = w_offset, pixel_z = z_offset, time = 0.1 SECONDS, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)


### PR DESCRIPTION
Relates to #95317

## About The Pull Request
Removes these big slurs from tourretes thats used to offend people

## Why It's Good For The Game
If dicktard is being removed because its a slur then we should be fair and remove these slurs too!

## Changelog
:cl: Ezel
del: Removes tourretes slurs
/:cl:
