### PR TITLE
Prevent chat highlights for your own ASay messages

### DIFF
--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -21,10 +21,13 @@ ADMIN_VERB(cmd_admin_say, R_NONE, "ASay", "Send a message to other admins", ADMI
 	var/asay_color = user.prefs.read_preference(/datum/preference/color/asay_color)
 	var/custom_asay_color = (CONFIG_GET(flag/allow_admin_asaycolor) && asay_color) ? "<font color=[asay_color]>" : "<font color='[DEFAULT_ASAY_COLOR]'>"
 	message = "[span_adminsay("[span_prefix("ADMIN:")] <EM>[key_name_admin(user)]</EM> [ADMIN_FLW(user.mob)]: [custom_asay_color]<span class='message linkify'>[message]")]</span>[custom_asay_color ? "</font>":null]"
-	to_chat(GLOB.admins,
-		type = MESSAGE_TYPE_ADMINCHAT,
-		html = message,
-		confidential = TRUE)
+	for(var/client/admin as anything in GLOB.admins)
+		to_chat(admin,
+			type = MESSAGE_TYPE_ADMINCHAT,
+			html = message,
+			avoid_highlighting = (admin == user),
+			confidential = TRUE,
+		)
 
 	BLACKBOX_LOG_ADMIN_VERB("Asay")
 


### PR DESCRIPTION

## About The Pull Request

ports https://github.com/Monkestation/Monkestation2.0/pull/9762, also the thing i said i'd upstream in https://github.com/NovaSector/NovaSector/pull/7018

pretty simple, this makes it so your own Asay messages won't be highlighted

## Why It's Good For The Game

if you have your ckey highlighted, you don't really need to highlight that in the ASay message that you just sent yourself.

## Changelog
:cl:
admin: Your own ASay messages will no longer trigger your highlights.
/:cl:
