### PR TITLE
status bar is now a pref

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -175,9 +175,6 @@
 	/// Messages currently seen by this client
 	var/list/seen_messages
 
-	//Hide status bar (bottom left)
-	var/show_status_bar = TRUE
-
 	/// datum wrapper for client view
 	var/datum/view_data/view_size
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1242,17 +1242,6 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 	winset(src, "mainwindow", "menu=;is-fullscreen=[fullscreen ? "true" : "false"]")
 	attempt_auto_fit_viewport()
 
-/client/verb/toggle_status_bar()
-	set name = "Toggle Status Bar"
-	set category = "OOC"
-
-	show_status_bar = !show_status_bar
-
-	if (show_status_bar)
-		winset(src, "mapwindow.status_bar", "is-visible=true")
-	else
-		winset(src, "mapwindow.status_bar", "is-visible=false")
-
 /// Clears the client's screen, aside from ones that opt out
 /client/proc/clear_screen()
 	for (var/object in screen)

--- a/code/modules/client/preferences/status_bar.dm
+++ b/code/modules/client/preferences/status_bar.dm
@@ -5,4 +5,6 @@
 	savefile_identifier = PREFERENCE_PLAYER
 
 /datum/preference/toggle/status_bar/apply_to_client(client/client, value)
+	if(isnull(client))
+		return
 	winset(client, "mapwindow.status_bar", "is-visible=[value]")

--- a/code/modules/client/preferences/status_bar.dm
+++ b/code/modules/client/preferences/status_bar.dm
@@ -1,0 +1,8 @@
+/datum/preference/toggle/status_bar
+	default_value = TRUE
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "status_bar"
+	savefile_identifier = PREFERENCE_PLAYER
+
+/datum/preference/toggle/status_bar/apply_to_client(client/client, value)
+	winset(client, "mapwindow.status_bar", "is-visible=[value]")

--- a/code/modules/client/preferences/status_bar.dm
+++ b/code/modules/client/preferences/status_bar.dm
@@ -5,6 +5,6 @@
 	savefile_identifier = PREFERENCE_PLAYER
 
 /datum/preference/toggle/status_bar/apply_to_client(client/client, value)
-	if(isnull(client))
+	if(isnull(client) || istype(client, /datum/client_interface)) //no winset on mock clients.
 		return
 	winset(client, "mapwindow.status_bar", "is-visible=[value]")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4084,6 +4084,7 @@
 #include "code\modules\client\preferences\sounds.dm"
 #include "code\modules\client\preferences\species.dm"
 #include "code\modules\client\preferences\statpanel.dm"
+#include "code\modules\client\preferences\status_bar.dm"
 #include "code\modules\client\preferences\tgui.dm"
 #include "code\modules\client\preferences\tooltips.dm"
 #include "code\modules\client\preferences\trans_prosthetic.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/status_bar.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/status_bar.tsx
@@ -1,0 +1,11 @@
+import { CheckboxInput, type FeatureToggle } from '../base';
+
+export const status_bar: FeatureToggle = {
+  name: 'Enable status bar',
+  category: 'UI',
+  description: `
+      When toggled, a bar at the bottom left of the screen will display
+      the name of what your mouse cursor is hovering over.
+    `,
+  component: CheckboxInput,
+};


### PR DESCRIPTION
## About The Pull Request

An easy point for https://hackmd.io/443_dE5lRWeEAp9bjGcKYw?view

Status bar is now a preference instead of a verb in OOC.

I thought I would have to make a migration for this but then I found out this is straight up just a client verb and doesn't persist through rounds, so I'm adding that too ig.

## Why It's Good For The Game

This is literally just a pref but as a verb for some reason.

## Changelog

:cl:
qol: The Status bar is now a preference instead of a verb in the OOC tab, which means you can permanently turn it off if you're not a fan (or use tooltips instead)
/:cl: