### PR TITLE
Fixes the game trying to give you a bounty for a chemical reaction instead of a drink

### DIFF
--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -83,7 +83,7 @@
 		/datum/reagent/consumable/ethanol/blue_blazer,
 		/datum/reagent/consumable/ethanol/flip_cocktail,
 		/datum/reagent/consumable/ethanol/bitters_soda,
-		/datum/chemical_reaction/drink/star,
+		/datum/reagent/consumable/ethanol/star,
 	)
 
 	var/reagent_type = pick(possible_reagents)
@@ -121,7 +121,7 @@
 		/datum/reagent/consumable/ethanol/ramos_gin_fizz,
 		/datum/reagent/consumable/ethanol/sangria,
 		/datum/reagent/consumable/ethanol/tizirian_sour,
-		/datum/chemical_reaction/drink/suffering_bastard,
+		/datum/reagent/consumable/ethanol/suffering_bastard,
 	)
 
 	var/reagent_type = pick(possible_reagents)


### PR DESCRIPTION

## About The Pull Request

- Changes 2 chemical reaction datums in the public bounty alcohol list to the actual drinks

## Why It's Good For The Game

> Changes 2 chemical reaction datums in the public bounty alcohol list to the actual drinks
- No runtimes trying to read the name of a nameless datum anymore, that and the bounty working i quess.

## Changelog

:cl:
fix: fixed the game trying to make you sell chemical reactions for a public bounty
/:cl:
