### PR TITLE
Fix bugs with area contents system

### DIFF
--- a/code/controllers/subsystem/area_contents.dm
+++ b/code/controllers/subsystem/area_contents.dm
@@ -63,6 +63,8 @@ SUBSYSTEM_DEF(area_contents)
 				if(MC_TICK_CHECK)
 					cut_from.Cut(1, amount_cut + 1)
 					return
+			// avoid double removals if we return early on a subsequent z-level
+			clear.turfs_to_uncontain_by_zlevel[area_zlevel] = list()
 
 		clear.turfs_to_uncontain_by_zlevel = list()
 		marked_for_clearing.len--

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -484,8 +484,8 @@ GLOBAL_VAR(restart_counter)
 	LISTASSERTLEN(global_area.turfs_by_zlevel, map_load_z_cutoff, list())
 	for (var/zlevel in 1 to map_load_z_cutoff)
 		var/list/to_add = block(
-			1, old_maxy + 1, 1,
-			maxx, maxy, map_load_z_cutoff
+			1, old_maxy + 1, zlevel,
+			maxx, maxy, zlevel
 		)
 		global_area.turfs_by_zlevel[zlevel] += to_add
 


### PR DESCRIPTION
## About The Pull Request
Contains two changes cherry-picked from my CM PR, https://github.com/cmss13-devs/cmss13/pull/11826.

1) Fixes incorrect args to `block()` in `increase_max_y()` that caused it to add turfs to every z-level's world.area contents list instead of just the correct one. This is probably left over from when the area contents list wasn't split by z-level.

2) Avoids a case where turfs could be removed from area contents twice if the subsystem returned early on a later Z-level.

## Why It's Good For The Game
Fixes two bugs with the area contents system.

## Changelog

:cl: MoondancerPony
fix: fixed turfs sometimes not being in any area's contents
/:cl: