### PR TITLE
Realigns components in chemical reaction debugger

### DIFF
--- a/tgui/packages/tgui/interfaces/ChemRecipeDebug.tsx
+++ b/tgui/packages/tgui/interfaces/ChemRecipeDebug.tsx
@@ -136,13 +136,13 @@ export const ChemRecipeDebug = (props) => {
                     </LabeledList.Item>
                   </LabeledList>
                 </Stack.Item>
-                <Stack.Item>
+                <Stack.Item ml="20px">
                   <LabeledList>
                     <LabeledList.Item
                       label={
                         <Box
                           style={{
-                            transform: 'translate(0%, -50%)',
+                            transform: 'translate(0%, -15%)',
                           }}
                         >
                           Temp Mode:
@@ -184,12 +184,13 @@ export const ChemRecipeDebug = (props) => {
                     </LabeledList.Item>
                   </LabeledList>
                 </Stack.Item>
-                <Stack.Item ml="0px">
+                <Stack.Item ml="20px">
                   <LabeledList>
                     <LabeledList.Item label="Force Ph">
                       <Button.Checkbox
                         checked={use_forced_ph}
                         onClick={() => act('toggle_forced_ph')}
+                        ml="20px"
                       >
                         {use_forced_ph ? 'Disable' : 'Enable'}
                       </Button.Checkbox>
@@ -218,7 +219,7 @@ export const ChemRecipeDebug = (props) => {
                     </LabeledList.Item>
                   </LabeledList>
                 </Stack.Item>
-                <Stack.Item ml="10px">
+                <Stack.Item ml="20px">
                   <LabeledList>
                     <LabeledList.Item label="Force Purity">
                       <Button.Checkbox
@@ -284,7 +285,7 @@ export const ChemRecipeDebug = (props) => {
                       label={
                         <Box
                           style={{
-                            transform: 'translate(0%, -50%)',
+                            transform: 'translate(0%, -10%)',
                           }}
                         >
                           Direction:
@@ -344,7 +345,7 @@ export const ChemRecipeDebug = (props) => {
                       label={
                         <Box
                           style={{
-                            transform: 'translate(0%, -50%)',
+                            transform: 'translate(0%, -10%)',
                             width: '57px',
                           }}
                         >


### PR DESCRIPTION
## About The Pull Request
Fixes the chemical reaction recipe debugger UI. It had some components misaligned

<details><summary>Before</summary>
<p>

<img width="494" height="246" alt="Screenshot (8)" src="https://github.com/user-attachments/assets/2063c9ba-894c-4841-be7d-d147e38054aa" />

<img width="500" height="288" alt="Screenshot (9)" src="https://github.com/user-attachments/assets/ff9fa173-74fe-45ae-8f2a-ccb38a7da7eb" />

<img width="500" height="287" alt="Screenshot (10)" src="https://github.com/user-attachments/assets/1980941b-f6ab-44a1-b141-52c5a9dce799" />

</p>
</details> 

<details><summary>After</summary>
<p>
<img width="497" height="238" alt="Screenshot (11)" src="https://github.com/user-attachments/assets/03fbc392-6335-44f2-a3ad-28525da8339d" />

<img width="501" height="288" alt="Screenshot (12)" src="https://github.com/user-attachments/assets/9c4e457f-a675-4523-be19-86b2ca987d97" />

<img width="500" height="291" alt="Screenshot (13)" src="https://github.com/user-attachments/assets/fb40887c-da0b-4ffe-b1cb-18dd8c4f7af1" />


</p>
</details> 

Looks nicer. In my opinion at least

## Changelog
N/A
