### PR TITLE
Cannabis and Nictone makes monkeys less angry, Booze makes them more angry

### DIFF
--- a/code/__DEFINES/monkeys.dm
+++ b/code/__DEFINES/monkeys.dm
@@ -35,5 +35,10 @@
 /// probability of reducing aggro by one when the monkey attacks
 #define MONKEY_HATRED_REDUCTION_PROB 20
 
+/// Monkey was calmed, such as from weed
+#define MONKEY_CALMED_HATRED_AMOUNT -2
+/// Monkey was angered, such as from alcohol
+#define MONKEY_ANGERED_HATRED_AMOUNT 2
+
 ///Monkey recruit cooldown
 #define MONKEY_RECRUIT_COOLDOWN (1 MINUTES)

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -74,6 +74,9 @@
 		if(combined_dilute_volume) // safety check to prevent division by zero
 			booze_power *= (total_alcohol_volume / combined_dilute_volume)
 
+		for(var/mob/living/enemy as anything in drinker.ai_controller?.blackboard[BB_MONKEY_ENEMIES])
+			drinker.ai_controller.add_blackboard_key_assoc(BB_MONKEY_ENEMIES, enemy, MONKEY_ANGERED_HATRED_AMOUNT * (boozepwr / 100) * metabolization_ratio * seconds_per_tick)
+
 		// Volume, power, and server alcohol rate effect how quickly one gets drunk
 		drinker.adjust_drunk_effect(1 * sqrt(volume) * booze_power * ALCOHOL_RATE * metabolization_ratio * seconds_per_tick)
 		if(boozepwr > 0)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -45,6 +45,8 @@
 	ph = 6
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
+	/// tracks if we cleared a monkey's aggressiveness value
+	var/cleared_aggressive = FALSE
 
 /datum/reagent/drug/cannabis/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
@@ -61,6 +63,18 @@
 	if(SPT_PROB(4, seconds_per_tick) && affected_mob.buckled && affected_mob.body_position != LYING_DOWN && !affected_mob.IsParalyzed()) //chance to be couchlocked if sitting
 		to_chat(affected_mob, span_warning("It's too comfy to move..."))
 		affected_mob.Paralyze(10 SECONDS)
+
+	var/list/enemies = affected_mob.ai_controller?.blackboard[BB_MONKEY_ENEMIES]
+	for(var/mob/living/enemy as anything in enemies)
+		affected_mob.ai_controller.add_blackboard_key_assoc(BB_MONKEY_ENEMIES, enemy, MONKEY_CALMED_HATRED_AMOUNT * metabolization_ratio * seconds_per_tick)
+		if(affected_mob.ai_controller.blackboard[BB_MONKEY_AGGRESSIVE] && SPT_PROB(10 - values_sum(enemies), seconds_per_tick))
+			affected_mob.ai_controller.set_blackboard_key(BB_MONKEY_AGGRESSIVE, FALSE)
+			cleared_aggressive = TRUE
+
+/datum/reagent/drug/cannabis/on_mob_delete(mob/living/affected_mob)
+	. = ..()
+	if(cleared_aggressive)
+		affected_mob.ai_controller?.set_blackboard_key(BB_MONKEY_AGGRESSIVE, TRUE)
 
 /datum/reagent/drug/nicotine
 	name = "Nicotine"
@@ -86,7 +100,10 @@
 		to_chat(affected_mob, span_notice("[smoke_message]"))
 	affected_mob.add_mood_event("smoked", /datum/mood_event/smoked)
 	affected_mob.remove_status_effect(/datum/status_effect/jitter)
-	affected_mob.AdjustAllImmobility(-200 * metabolization_ratio * seconds_per_tick)
+	affected_mob.AdjustAllImmobility(-20 SECONDS * metabolization_ratio * seconds_per_tick)
+
+	for(var/mob/living/enemy as anything in affected_mob.ai_controller?.blackboard[BB_MONKEY_ENEMIES])
+		affected_mob.ai_controller.add_blackboard_key_assoc(BB_MONKEY_ENEMIES, enemy, MONKEY_CALMED_HATRED_AMOUNT * 0.1 * metabolization_ratio * seconds_per_tick)
 
 	return UPDATE_MOB_HEALTH
 


### PR DESCRIPTION
## About The Pull Request

Cannabis will slowly calm monkies down, removing enemies from their enemies list over time and eventually making them docile while it is in their system

Nicotine does similar, but does not make them docile

Booze on the other hand makes monkeys see enemies as greater enemies depending on strength of the drink

## Why It's Good For The Game

Adding interactions between reagents that modify "player behavior" and actual "ai behavior" seems like fun to me, 

## Changelog

:cl: Melbert
add: Cannabis will calm down an angry monkey, eventually even turning them docile (not pacifist!) temporarily
add: Nicotine will also calm down an angry monkey, albiet slower than Cannabis and will never turn them entirely docile
add: Booze on the other hand will make a monkey even angrier (though only if they are already upset with someone)
/:cl:

