### PR TITLE
Strange Objects with discovered effects can now be renamed

### DIFF
--- a/code/modules/research/relics.dm
+++ b/code/modules/research/relics.dm
@@ -68,6 +68,7 @@
 			PROC_REF(dimensional_shift),
 			PROC_REF(disguiser),
 			)
+	obj_flags += UNIQUE_RENAME
 
 /obj/item/relic/attack_self(mob/user)
 	if(!activated)

--- a/code/modules/research/relics.dm
+++ b/code/modules/research/relics.dm
@@ -68,7 +68,7 @@
 			PROC_REF(dimensional_shift),
 			PROC_REF(disguiser),
 			)
-	obj_flags += UNIQUE_RENAME
+	obj_flags |= UNIQUE_RENAME
 
 /obj/item/relic/attack_self(mob/user)
 	if(!activated)


### PR DESCRIPTION
## About The Pull Request

Strange objects, who have had their effect discovered, can now be renamed with a Pen.

## Why It's Good For The Game

Ran into this while playing a round that when you receive several strange objects in a row, keeping track of them was a bit of a hassle. Allowing for them to be renamed after discovery seems like a valid QOL change.

## Changelog

:cl:
qol: After discovering a strange object's behavior, you can now rename it using a pen.
/:cl:
