### PR TITLE
Construction bags can hold normal-sized stacks

### DIFF
--- a/code/datums/storage/subtypes/bags.dm
+++ b/code/datums/storage/subtypes/bags.dm
@@ -214,11 +214,11 @@
 		/obj/item/electronics,
 		/obj/item/reagent_containers/cup/beaker,
 		/obj/item/stack/cable_coil,
+		/obj/item/stack/ore/bluespace_crystal,
 		/obj/item/stock_parts,
 		/obj/item/wallframe/camera,
 		/obj/item/rcd_ammo,
 	), exception_hold_list = list(
-		/obj/item/stack/ore/bluespace_crystal,
 		/obj/item/stack/sheet,
 		/obj/item/stack/rods,
 	))

--- a/code/datums/storage/subtypes/bags.dm
+++ b/code/datums/storage/subtypes/bags.dm
@@ -214,11 +214,12 @@
 		/obj/item/electronics,
 		/obj/item/reagent_containers/cup/beaker,
 		/obj/item/stack/cable_coil,
-		/obj/item/stack/ore/bluespace_crystal,
 		/obj/item/stock_parts,
 		/obj/item/wallframe/camera,
-		/obj/item/stack/sheet,
 		/obj/item/rcd_ammo,
+	), exception_hold_list = list(
+		/obj/item/stack/ore/bluespace_crystal,
+		/obj/item/stack/sheet,
 		/obj/item/stack/rods,
 	))
 


### PR DESCRIPTION
## About The Pull Request

Construction bags now make a weight class exemption for sheets and rods.

## Why It's Good For The Game

For a construction bag, you'd think it'd be able to hold quantities of materials sufficient for various construction projects. But due to the way storage size limits work, if you put more than a certain amount of a single stack type in a bag, the stack just falls out. This, needless to say, is awfully inconvenient.

Also this makes construction bags a good complement to BSRPEDs for mass construction.

## Changelog

:cl:
qol: (Most) stacks will no longer fall right out of bags if you put enough in to make the stack normal-sized.
/:cl:
