### PR TITLE
Adds stacked metabolization effects for beverages

### DIFF
--- a/code/datums/mood_events/drink_events.dm
+++ b/code/datums/mood_events/drink_events.dm
@@ -88,7 +88,7 @@
 	timeout = 7 MINUTES
 
 /datum/mood_event/sweetcoffee
-	description = "The coffee was not to bitter and a little sweet. Maybe i like it"
+	description = "The bitter sweet taste of coffee was not too bad"
 	mood_change = 2
 	timeout = 5 MINUTES
 

--- a/code/datums/mood_events/drink_events.dm
+++ b/code/datums/mood_events/drink_events.dm
@@ -86,3 +86,13 @@
 	description = "What a tasty can of Wellcheers! The salty grape flavor is a great pick-me-up."
 	mood_change = 3
 	timeout = 7 MINUTES
+
+/datum/mood_event/sweetcoffee
+	description = "The coffee was not to bitter and a little sweet. Maybe i like it"
+	mood_change = 2
+	timeout = 5 MINUTES
+
+/datum/mood_event/sweettea
+	description = "Let your worries dissolve like sugar in tea."
+	mood_change = 4
+	timeout = 2.5 MINUTES

--- a/code/modules/reagents/stacked_effects/bevarages.dm
+++ b/code/modules/reagents/stacked_effects/bevarages.dm
@@ -38,3 +38,12 @@
 /datum/stacked_metabolization_effect/coffee_oxidise_triple/apply(list/reagents_metabolized, mob/living/carbon/owner, seconds_per_tick)
 	if(SPT_PROB(70, seconds_per_tick))
 		return owner.adjust_oxy_loss(-3 * average(reagents_metabolized), updating_health = FALSE)
+
+/datum/stacked_metabolization_effect/astrotame_cream
+	requirements = list(
+		/datum/reagent/consumable/astrotame = 1,
+		/datum/reagent/consumable/cream = 1,
+	)
+
+/datum/stacked_metabolization_effect/astrotame_cream/apply(list/reagents_metabolized, mob/living/carbon/owner, seconds_per_tick)
+	owner.adjust_disgust(-1.5 * average(reagents_metabolized) * seconds_per_tick)

--- a/code/modules/reagents/stacked_effects/bevarages.dm
+++ b/code/modules/reagents/stacked_effects/bevarages.dm
@@ -1,0 +1,40 @@
+/datum/stacked_metabolization_effect/sweet_coffee
+	requirements = list(
+		/datum/reagent/consumable/coffee = 1,
+		/datum/reagent/consumable/sugar = 1,
+	)
+
+/datum/stacked_metabolization_effect/sweet_coffee/apply(list/reagents_metabolized, mob/living/carbon/owner, seconds_per_tick)
+	if(!owner.mob_mood.mood_events["sweet_coffee"])
+		owner.add_mood_event("sweet_coffee", /datum/mood_event/sweetcoffee)
+
+/datum/stacked_metabolization_effect/sweet_tea
+	requirements = list(
+		/datum/reagent/consumable/tea = 1,
+		/datum/reagent/consumable/sugar = 1,
+	)
+
+/datum/stacked_metabolization_effect/sweet_tea/apply(list/reagents_metabolized, mob/living/carbon/owner, seconds_per_tick)
+	if(!owner.mob_mood.mood_events["sweet_tea"])
+		owner.add_mood_event("sweet_tea", /datum/mood_event/sweettea)
+
+/datum/stacked_metabolization_effect/coffee_oxidise
+	requirements = list(
+		/datum/reagent/consumable/coffee = 1,
+		/datum/reagent/consumable/icecoffee = 1,
+	)
+
+/datum/stacked_metabolization_effect/coffee_oxidise/apply(list/reagents_metabolized, mob/living/carbon/owner, seconds_per_tick)
+	if(SPT_PROB(30, seconds_per_tick))
+		return owner.adjust_oxy_loss(-1 * average(reagents_metabolized) * seconds_per_tick, updating_health = FALSE)
+
+/datum/stacked_metabolization_effect/coffee_oxidise_triple
+	requirements = list(
+		/datum/reagent/consumable/coffee = 1,
+		/datum/reagent/consumable/icecoffee = 1,
+		/datum/reagent/consumable/hot_ice_coffee = 1,
+	)
+
+/datum/stacked_metabolization_effect/coffee_oxidise_triple/apply(list/reagents_metabolized, mob/living/carbon/owner, seconds_per_tick)
+	if(SPT_PROB(70, seconds_per_tick))
+		return owner.adjust_oxy_loss(-1.5 * average(reagents_metabolized) * seconds_per_tick, updating_health = FALSE)

--- a/code/modules/reagents/stacked_effects/bevarages.dm
+++ b/code/modules/reagents/stacked_effects/bevarages.dm
@@ -26,7 +26,7 @@
 
 /datum/stacked_metabolization_effect/coffee_oxidise/apply(list/reagents_metabolized, mob/living/carbon/owner, seconds_per_tick)
 	if(SPT_PROB(30, seconds_per_tick))
-		return owner.adjust_oxy_loss(-1 * average(reagents_metabolized) * seconds_per_tick, updating_health = FALSE)
+		return owner.adjust_oxy_loss(-2 * average(reagents_metabolized), updating_health = FALSE)
 
 /datum/stacked_metabolization_effect/coffee_oxidise_triple
 	requirements = list(
@@ -37,4 +37,4 @@
 
 /datum/stacked_metabolization_effect/coffee_oxidise_triple/apply(list/reagents_metabolized, mob/living/carbon/owner, seconds_per_tick)
 	if(SPT_PROB(70, seconds_per_tick))
-		return owner.adjust_oxy_loss(-1.5 * average(reagents_metabolized) * seconds_per_tick, updating_health = FALSE)
+		return owner.adjust_oxy_loss(-3 * average(reagents_metabolized), updating_health = FALSE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6139,6 +6139,7 @@
 #include "code\modules\reagents\reagent_containers\cups\mauna_mug.dm"
 #include "code\modules\reagents\reagent_containers\cups\organ_jar.dm"
 #include "code\modules\reagents\reagent_containers\cups\soda.dm"
+#include "code\modules\reagents\stacked_effects\bevarages.dm"
 #include "code\modules\reagents\stacked_effects\stacked_effects.dm"
 #include "code\modules\reagents\withdrawal\_addiction.dm"
 #include "code\modules\reagents\withdrawal\generic_addictions.dm"


### PR DESCRIPTION
## About The Pull Request
Adds an implementation for the framework in #95123 that relates tea, coffee & sugar

- If you mix coffee & sugar and ingest it, You get the "sweet_coffee" mood event which increases your mood by 2 for a total of 5 minutes
- If you mix tea & sugar and ingest it, You get the "sweet_tea" mood event which increases your mood by 4 for a total of 2.5 minutes
- astrotame and cream now heals 3 disgust per tick
- If you mix coffee & iced coffee and ingest it, during metab there is 30% chance to heal 2 oxy damage per tick
- If you mix coffee, iced coffee & hot ice coffee and ingest it, during metab there is 70% chance to heal 3 oxy damage per tick

## Why it's good for the game
Gives the bartender & beverage lovers more incentive to mix their drinks for health benefits. Coffee has antioxidizing properties so let's make it heal oxy damage`ish. Also mixing sugar with tea & coffee should make you happy and ow it does

## Changelog
:cl:
qol: mixing tea/coffee with sugar gives you a small mood buff. So like do it
qol: astrotame and cream now heals disgust
qol: mixing different types of coffee can heal oxy damage, because you know coffee has antioxidizing properties
/:cl:
