### PR TITLE
[FIX] 1 worm candidate in blood worm works again

### DIFF
--- a/code/modules/antagonists/blood_worm/actions/cocoon.dm
+++ b/code/modules/antagonists/blood_worm/actions/cocoon.dm
@@ -336,6 +336,10 @@
 		amount_to_pick = num_hatchlings
 	)
 
+	// poll_ghost_candidates returns a single mob instead of a list when exactly 1 candidate signs up, even with amount_to_pick > 1.
+	if (!islist(candidates) && candidates)
+		candidates = list(candidates)
+
 	var/num_candidates = length(candidates)
 
 	if (QDELETED(cocoon))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

poll_ghost_candidates (via poll_candidates) has a special case at [polling.dm:203-205](vscode-webview://16hovrg85nmqe1hehg1ln4r0gntccfr3ka52s58red7hfq8u6epn/code/controllers/subsystem/polling.dm#L203-L205), when exactly 1 candidate is chosen, it unwraps the list and returns the single mob directly. The blood worm code then calls length() on that mob, which returns 0 instead of 1, causing the "no candidates!" auto-cancel without any prompt.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Fix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Blood worm can reproduce one hatchling now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
