### PR TITLE
Moves Reboot timer to the game screen

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -229,7 +229,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 			C?.playtitlemusic(volume_multiplier = 0.5)
 		if(speed_round && was_forced != ADMIN_FORCE_END_ROUND)
 			C?.give_award(/datum/award/achievement/misc/speed_round, C?.mob)
-		C.screen += reboot_hud
+		C?.screen += reboot_hud
 		HandleRandomHardcoreScore(C)
 
 	var/popcount = gather_roundend_feedback()

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -757,7 +757,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 	var/award_location
 
 /atom/movable/screen/reboot_timer
-	screen_loc = "CENTER:-120,TOP:-42"
+	screen_loc = "CENTER:-140,TOP:-42"
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	maptext_width = 340
 	maptext_height = 64

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -220,6 +220,8 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 
 	var/speed_round = (STATION_TIME_PASSED() <= 10 MINUTES)
 
+	if(isnull(reboot_hud))
+		reboot_hud = new()
 	for(var/client/C in GLOB.clients)
 		if(!C?.credits)
 			C?.RollCredits()
@@ -227,6 +229,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 			C?.playtitlemusic(volume_multiplier = 0.5)
 		if(speed_round && was_forced != ADMIN_FORCE_END_ROUND)
 			C?.give_award(/datum/award/achievement/misc/speed_round, C?.mob)
+		C.screen += reboot_hud
 		HandleRandomHardcoreScore(C)
 
 	var/popcount = gather_roundend_feedback()
@@ -752,3 +755,11 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 	var/winner_key
 	///The name of the area we earned this cheevo in
 	var/award_location
+
+/atom/movable/screen/reboot_timer
+	screen_loc = "CENTER:-120,TOP:-42"
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	maptext_width = 340
+	maptext_height = 64
+	maptext = ""
+	layer = SCREENTIP_LAYER //This is basically an extra screentip

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -48,14 +48,6 @@ SUBSYSTEM_DEF(statpanels)
 			if(ETA)
 				global_data += "[ETA] [SSshuttle.emergency.getTimerStr()]"
 
-		if(SSticker.reboot_timer)
-			var/reboot_time = timeleft(SSticker.reboot_timer)
-			if(reboot_time)
-				global_data += "Reboot: [DisplayTimeText(reboot_time, 1)]"
-		// admin must have delayed round end
-		else if(SSticker.ready_for_reboot)
-			global_data += "Reboot: DELAYED"
-
 		src.currentrun = GLOB.clients.Copy()
 		mc_data = null
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -5,7 +5,7 @@ SUBSYSTEM_DEF(ticker)
 	name = "Ticker"
 	priority = FIRE_PRIORITY_TICKER
 	flags = SS_KEEP_TIMING
-	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME
+	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	/// state of current round (used by process()) Use the defines GAME_STATE_* !
 	var/current_state = GAME_STATE_STARTUP
@@ -69,6 +69,8 @@ SUBSYSTEM_DEF(ticker)
 	/// Why an emergency shuttle was called
 	var/emergency_reason
 
+	///The display of how much time is left before a reboot, given to all clients post-game.
+	var/atom/movable/screen/reboot_timer/reboot_hud
 	/// ID of round reboot timer, if it exists
 	var/reboot_timer = null
 
@@ -203,6 +205,13 @@ SUBSYSTEM_DEF(ticker)
 				toggle_dooc(TRUE)
 				declare_completion(force_ending)
 				Master.SetRunLevel(RUNLEVEL_POSTGAME)
+
+		if(GAME_STATE_FINISHED)
+			if(ready_for_reboot)
+				if(isnull(reboot_timer))
+					reboot_hud.maptext = "<span class='context'>Server reboot DELAYED</span>"
+				else
+					reboot_hud.maptext = "<span class='context'>Server rebooting in: [DisplayTimeText(timeleft(SSticker.reboot_timer), 1)]</span>"
 
 /// Checks if the round should be ending, called every ticker tick
 /datum/controller/subsystem/ticker/proc/check_finished()
@@ -833,6 +842,8 @@ SUBSYSTEM_DEF(ticker)
 
 	var/start_wait = world.time
 	UNTIL(round_end_sound_sent || (world.time - start_wait) > (delay * 2)) //don't wait forever
+	if(!isnull(reboot_timer)) //Override existing reboot timers.
+		deltimer(reboot_timer)
 	reboot_timer = addtimer(CALLBACK(src, PROC_REF(reboot_callback), reason, end_string), delay - (world.time - start_wait), TIMER_STOPPABLE)
 
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -209,9 +209,9 @@ SUBSYSTEM_DEF(ticker)
 		if(GAME_STATE_FINISHED)
 			if(ready_for_reboot)
 				if(isnull(reboot_timer))
-					reboot_hud.maptext = "<span class='context'>Server reboot DELAYED</span>"
+					reboot_hud.maptext = MAPTEXT_PIXELLARI("<center>Server reboot \n\ DELAYED</center>")
 				else
-					reboot_hud.maptext = "<span class='context'>Server rebooting in: [DisplayTimeText(timeleft(SSticker.reboot_timer), 1)]</span>"
+					reboot_hud.maptext = MAPTEXT_PIXELLARI("<center>Server rebooting in:\n\ [DisplayTimeText(timeleft(SSticker.reboot_timer), 1)]</center>")
 
 /// Checks if the round should be ending, called every ticker tick
 /datum/controller/subsystem/ticker/proc/check_finished()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -134,6 +134,9 @@
 
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_LOGGED_IN, src)
 
+	if(SSticker.IsPostgame())
+		client.screen += SSticker.reboot_hud
+
 	return TRUE
 
 


### PR DESCRIPTION
## About The Pull Request

Since I'm trying to move away from the stat panel as part of my project here - https://hackmd.io/443_dE5lRWeEAp9bjGcKYw?view - I thought the reboot timer should be moved out before the stat panel could be made optional, due to its importance to post-round players (especially to know if the round is rebooted).

Once the round is over the whole screen kinda becomes pointless, so we can take as much screen space as we can.

I put this under the tooltips, using similar behavior to it, like the layer & outline.

This is inspired by the Goon roundend, which does pretty much 1:1 what this is.

#### Goon's, for reference:

<img width="1397" height="787" alt="image" src="https://github.com/user-attachments/assets/309b5d6e-c4dd-4f6f-8b83-2256eecd4569" />

#### Ours:


https://github.com/user-attachments/assets/b14efae2-e280-47e9-b3db-f57b2060cce7


It's also non-widescreen friendly


## Why It's Good For The Game

Moving things away from the stat panel and to being more player visible is a positive IMO.
It's also a necessary step to taking away from reliance away from said stat panel.

## Changelog

:cl:
add: The endround timer telling you when a reboot is happening has been taken out of the stat panel and is instead text over your screen (similar to Goon)
/:cl: