### PR TITLE
Fixes sechailer pepperspray protection

### DIFF
--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	w_class = WEIGHT_CLASS_SMALL
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	visor_flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDESNOUT
-	flags_cover = MASKCOVERSMOUTH
+	flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
 	visor_flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
 	tint = 0
 	fishing_modifier = 0

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -63,7 +63,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	var/aggressiveness = AGGR_BAD_COP
 	///Whether the hailer has been broken due to overuse or not
 	var/broken_hailer = FALSE
-	///Whether the hailer is currently` in cooldown for resetting recent_uses
+	///Whether the hailer is currently in cooldown for resetting recent_uses
 	var/overuse_cooldown = FALSE
 	///How many times was the hailer used in the last OVERUSE_COOLDOWN seconds
 	var/recent_uses = 0

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -63,7 +63,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	var/aggressiveness = AGGR_BAD_COP
 	///Whether the hailer has been broken due to overuse or not
 	var/broken_hailer = FALSE
-	///Whether the hailer is currently in cooldown for resetting recent_uses
+	///Whether the hailer is currently` in cooldown for resetting recent_uses
 	var/overuse_cooldown = FALSE
 	///How many times was the hailer used in the last OVERUSE_COOLDOWN seconds
 	var/recent_uses = 0


### PR DESCRIPTION
## About The Pull Request

Fixes #95344
Sechailers block pepperspray when up, not down.

## Why It's Good For The Game

This is the intended behavior. 

## Changelog

:cl: Seven
fix: Sechailers now block pepperspray when up, not when they are down.
/:cl:

