### PR TITLE
Adds 1/500 chance for a pizza crate to contain a Romerol pizza

### DIFF
--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -183,6 +183,8 @@
 	var/anomalous_box_provided = FALSE
 	/// one percent chance for a pizza box to be the ininfite pizza box
 	var/infinite_pizza_chance = 1
+	/// chance that any one of the pizzas in the crate will have romerol added to it
+	var/romerol_chance = 0.2
 	///Whether we've provided a bomb pizza box already this shift or not.
 	var/boombox_provided = FALSE
 	/// three percent chance for a pizza box to be the pizza bomb box
@@ -207,7 +209,7 @@
 /datum/supply_pack/organic/pizza/fill(obj/structure/closet/crate/new_crate)
 	. = ..()
 	var/list/rng_pizza_list = pizza_types.Copy()
-	var/add_romerol = prob(0.2)
+	var/add_romerol = prob(romerol_chance)
 	for(var/i in 1 to 5)
 		if(add_anomalous(new_crate))
 			continue

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -217,6 +217,8 @@
 		if(add_romerol && pizzabox.pizza)
 			pizzabox.pizza.reagents.add_reagent(/datum/reagent/romerol, pizzabox.pizza.slices_left)
 			add_romerol = FALSE
+			log_game("A romerol pizza (as [pizzabox.pizza]) was created in a pizza crate delivery.")
+			message_admins("A romerol pizza (as [pizzabox.pizza]) was created in a pizza crate delivery.")
 
 /// adds the chance for an infinite pizza box
 /datum/supply_pack/organic/pizza/proc/add_anomalous(obj/structure/closet/crate/new_crate)

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -207,12 +207,16 @@
 /datum/supply_pack/organic/pizza/fill(obj/structure/closet/crate/new_crate)
 	. = ..()
 	var/list/rng_pizza_list = pizza_types.Copy()
+	var/add_romerol = prob(0.2)
 	for(var/i in 1 to 5)
 		if(add_anomalous(new_crate))
 			continue
 		if(add_boombox(new_crate))
 			continue
-		add_normal_pizza(new_crate, rng_pizza_list)
+		var/obj/item/pizzabox/pizzabox = add_normal_pizza(new_crate, rng_pizza_list)
+		if(add_romerol && pizzabox.pizza)
+			pizzabox.pizza.reagents.add_reagent(/datum/reagent/romerol, pizzabox.pizza.slices_left)
+			add_romerol = FALSE
 
 /// adds the chance for an infinite pizza box
 /datum/supply_pack/organic/pizza/proc/add_anomalous(obj/structure/closet/crate/new_crate)
@@ -253,6 +257,7 @@
 	new_pizza_box.boxtag = new_pizza_box.pizza.boxtag
 	new_pizza_box.boxtag_set = TRUE
 	new_pizza_box.update_appearance(UPDATE_ICON | UPDATE_DESC)
+	return new_pizza_box
 
 /// tells crew that an infinite pizza box exists, half of the time, based on a roll in the anamolous box proc
 /datum/supply_pack/organic/pizza/proc/anomalous_pizza_report()
@@ -445,4 +450,3 @@
 	contains = list(
 		/obj/item/soil_sack/worm = 3,
 	)
-


### PR DESCRIPTION
## About The Pull Request

There's a 1/500 chance that 1 pizza in a pizza crate will have 6u Romerol (1u per slice). It otherwise looks like a normal pizza and comes in a normal box.  

## Why It's Good For The Game

Ok to start this probably isn't a good idea. This will only cause problems.

But between the Nanomachine Pizza, the Bomb Pizza, the Anomalous Pizza, and the Arnold pizza I have this funny idea in my head of pizza orders just constantly go wrong in universe. 

And the thought is, right, if you eat Romerol... nothing happens....... immediately.
So the crew orders pizza for a pizza party and goes off on their day, then 30 minutes later it turns out the entire cargo team has risen from the dead after being killed in a welder bomb accident. 

In the post-mortem they're looking through the leftover slices and they find trace Romerol. 

Maybe that's kinda funny? 

## Changelog

:cl: Melbert
add: Adds a 1/500 chance that the grain used to create a pizza in a pizza crate was cursed by an evil lich. 
/:cl:
