### PR TITLE
Adds glowstick functionality to ethereals

### DIFF
--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -51,6 +51,16 @@
 		return NONE
 	if(!source.can_unarmed_attack())
 		return COMPONENT_SKIP_ATTACK
+
+	// Hulks can crack an ethereal's spine
+	if(isethereal(target) && ishuman(target))
+		var/mob/living/carbon/human/ethereal_target = target
+		if(ethereal_target.pulledby == source && source.grab_state >= GRAB_NECK)
+			var/datum/species/ethereal/eth_species = ethereal_target.dna.species
+			if(!eth_species.spine_cracked)
+				INVOKE_ASYNC(src, PROC_REF(hulk_crack_spine), source, ethereal_target)
+				return COMPONENT_CANCEL_ATTACK_CHAIN
+
 	if(!target.attack_hulk(owner))
 		return NONE
 
@@ -246,6 +256,33 @@
 		yeeted_person.emote("scream")
 	yeeted_person.throw_at(T, 10, 6, the_hulk, TRUE, TRUE)
 	log_combat(the_hulk, yeeted_person, "has thrown by tail")
+
+/// Hulks can like snap spines of ethereals
+/datum/mutation/hulk/proc/hulk_crack_spine(mob/living/carbon/human/source, mob/living/carbon/human/ethereal_target)
+	to_chat(source, span_warning("You seize [ethereal_target]'s crystalline spine in your massive hands..."))
+	ethereal_target.visible_message(
+		span_danger("[source] seizes [ethereal_target]'s spine with both hands!"),
+		span_userdanger("[source] seizes your crystalline spine with both hands!"),
+	)
+	if(!do_after(source, 2 SECONDS, target = ethereal_target))
+		to_chat(source, span_warning("Your grip slips!"))
+		return
+	if(!isethereal(ethereal_target) || QDELETED(ethereal_target) || ethereal_target.pulledby != source || source.grab_state < GRAB_NECK)
+		to_chat(source, span_warning("You lose your grip!"))
+		return
+	log_combat(source, ethereal_target, "cracked the spine of", "hulk powers")
+	playsound(source, 'sound/effects/snap.ogg', 75, TRUE)
+	to_chat(source, span_danger("You wrench [ethereal_target]'s crystalline spine: light floods out of them!"))
+	ethereal_target.visible_message(
+		span_danger("[source] wrenches [ethereal_target]'s crystalline spine, causing light to burst out!"),
+		span_userdanger("Your crystalline spine cracks as [source] wrenches it, flooding you with light!"),
+		span_hear("You hear a sharp crackling snap!"),
+		COMBAT_MESSAGE_RANGE,
+		source,
+		ignored_mobs = source,
+	)
+	var/datum/species/ethereal/eth_species = ethereal_target.dna.species
+	eth_species.start_spine_crack_overload(ethereal_target)
 
 /datum/mutation/hulk/wizardly
 	name = "Hulk (Magical)"

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -45,6 +45,7 @@
 	var/rangemult = 1
 	var/flickering = FALSE
 	var/currently_flickered
+	var/spine_cracked = FALSE
 	var/obj/effect/dummy/lighting_obj/ethereal_light
 
 /datum/species/ethereal/Destroy(force)
@@ -223,6 +224,26 @@
 /datum/species/ethereal/proc/stop_flicker(mob/living/carbon/human/ethereal)
 	flickering = FALSE
 	currently_flickered = FALSE
+
+/datum/species/ethereal/proc/start_spine_crack_overload(mob/living/carbon/human/ethereal)
+	spine_cracked = TRUE
+	powermult = 10
+	rangemult = 10
+	refresh_light_color(ethereal)
+	ethereal.apply_damage(20, BRUTE)
+	to_chat(ethereal, span_userdanger("Light pours involuntarily out of your cracked spine!"))
+	// Flash everyone nearby
+	for(var/mob/living/nearby in range(8, ethereal))
+		if(nearby == ethereal)
+			continue
+		nearby.flash_act(intensity = 2, length = 4 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(stop_spine_crack_overload), ethereal), 2 MINUTES, TIMER_UNIQUE|TIMER_OVERRIDE)
+
+/datum/species/ethereal/proc/stop_spine_crack_overload(mob/living/carbon/human/ethereal)
+	powermult = 1
+	rangemult = 1
+	refresh_light_color(ethereal)
+	to_chat(ethereal, span_notice("The excess light bleeding from your spine finally fades."))
 
 /datum/species/ethereal/get_features()
 	var/list/features = ..()

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -45,6 +45,7 @@
 	var/rangemult = 1
 	var/flickering = FALSE
 	var/currently_flickered
+	///Is the ethereal's spine currently cracked?
 	var/spine_cracked = FALSE
 	var/obj/effect/dummy/lighting_obj/ethereal_light
 

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -230,7 +230,7 @@
 	powermult = 10
 	rangemult = 10
 	refresh_light_color(ethereal)
-	ethereal.apply_damage(20, BRUTE)
+	ethereal.apply_damage(20, BRUTE, BODY_ZONE_CHEST)
 	to_chat(ethereal, span_userdanger("Light pours involuntarily out of your cracked spine!"))
 	// Flash everyone nearby
 	for(var/mob/living/nearby in range(8, ethereal))

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -233,7 +233,7 @@
 	ethereal.apply_damage(20, BRUTE, BODY_ZONE_CHEST)
 	to_chat(ethereal, span_userdanger("Light pours involuntarily out of your cracked spine!"))
 	// Flash everyone nearby
-	for(var/mob/living/nearby in range(8, ethereal))
+	for(var/mob/living/nearby in view(8, ethereal))
 		if(nearby == ethereal)
 			continue
 		nearby.flash_act(intensity = 2, length = 4 SECONDS)

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -424,6 +424,7 @@
 	)
 
 #define DOAFTER_SOURCE_STRONGARM_INTERACTION "strongarm interaction"
+#define DOAFTER_SOURCE_STRONGARM_CRACKSPINE "strongarm spine crack"
 
 // Strong-Arm Implant //
 
@@ -515,6 +516,15 @@
 		return NONE
 	if(!isliving(target))
 		return NONE
+
+	if(isethereal(target))
+		var/mob/living/carbon/human/ethereal_target = target
+		if(ethereal_target.pulledby == source && source.grab_state >= GRAB_NECK)
+			var/datum/species/ethereal/eth_species = ethereal_target.dna.species
+			if(!eth_species.spine_cracked)
+				crack_spine_attempt(source, ethereal_target)
+				return COMPONENT_CANCEL_ATTACK_CHAIN
+
 	if(HAS_TRAIT(source, TRAIT_HULK)) //NO HULK
 		return NONE
 	if(!COOLDOWN_FINISHED(src, slam_cooldown) && ishuman(target))
@@ -613,6 +623,35 @@
 
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
+/// Attempt to crack the spine of a grabbed ethereal
+/obj/item/organ/cyberimp/arm/strongarm/proc/crack_spine_attempt(mob/living/carbon/human/source, mob/living/carbon/human/ethereal_target)
+	if(organ_flags & ORGAN_FAILING)
+		to_chat(source, span_danger("Your arm spasms before you can act!"))
+		return
+	to_chat(source, span_warning("You grip [ethereal_target]'s crystalline spine, preparing to crack it..."))
+	ethereal_target.visible_message(
+		span_danger("[source] seizes [ethereal_target]'s spine with both hands!"),
+		span_userdanger("[source] seizes your crystalline spine with both hands!"),
+	)
+	if(!do_after(source, 3 SECONDS, target = ethereal_target, interaction_key = DOAFTER_SOURCE_STRONGARM_CRACKSPINE))
+		to_chat(source, span_warning("Your grip slips!"))
+		return
+	if(!isethereal(ethereal_target) || QDELETED(ethereal_target) || ethereal_target.pulledby != source || source.grab_state < GRAB_NECK)
+		to_chat(source, span_warning("You lose your grip!"))
+		return
+	log_combat(source, ethereal_target, "cracked the spine of", "strongarm implants")
+	playsound(source, 'sound/effects/snap.ogg', 75, TRUE)
+	to_chat(source, span_danger("You wrench [ethereal_target]'s crystalline spine — light floods out of them!"))
+	ethereal_target.visible_message(
+		span_danger("[source] wrenches [ethereal_target]'s crystalline spine, causing light to burst out!"),
+		span_userdanger("Your crystalline spine cracks as [source] wrenches it, flooding you with light!"),
+		span_hear("You hear a sharp crackling snap!"),
+		COMBAT_MESSAGE_RANGE,
+		source,
+	)
+	var/datum/species/ethereal/eth_species = ethereal_target.dna.species
+	eth_species.start_spine_crack_overload(ethereal_target)
+
 /datum/status_effect/organ_set_bonus/strongarm
 	id = "organ_set_bonus_strongarm"
 	organs_needed = 2
@@ -631,3 +670,4 @@
 	owner.RemoveElement(/datum/element/door_pryer, pry_time = 6 SECONDS, interaction_key = DOAFTER_SOURCE_STRONGARM_INTERACTION)
 
 #undef DOAFTER_SOURCE_STRONGARM_INTERACTION
+#undef DOAFTER_SOURCE_STRONGARM_CRACKSPINE

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -522,7 +522,7 @@
 		if(ethereal_target.pulledby == source && source.grab_state >= GRAB_NECK)
 			var/datum/species/ethereal/eth_species = ethereal_target.dna.species
 			if(!eth_species.spine_cracked)
-				crack_spine_attempt(source, ethereal_target)
+				INVOKE_ASYNC(src, PROC_REF(crack_spine_attempt), source, ethereal_target)
 				return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	if(HAS_TRAIT(source, TRAIT_HULK)) //NO HULK

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -648,6 +648,7 @@
 		span_hear("You hear a sharp crackling snap!"),
 		COMBAT_MESSAGE_RANGE,
 		source,
+		ignored_mobs = source,
 	)
 	var/datum/species/ethereal/eth_species = ethereal_target.dna.species
 	eth_species.start_spine_crack_overload(ethereal_target)


### PR DESCRIPTION

## About The Pull Request

If you have a strongarm implant, or if you are a hulk, you can now crack the spine of a ethereal to release a ton of light from them

## Why It's Good For The Game

I think that having new functionality for implants and letting them interact with ethereal's is always good. Also it's REALLY funny.

## Changelog
:cl:
add: You can now crack the spines of ethereals to release light
/:cl:
