### PR TITLE
Fixes revival surgery with augmented heads

### DIFF
--- a/code/modules/surgery/operations/operation_revival.dm
+++ b/code/modules/surgery/operations/operation_revival.dm
@@ -15,7 +15,6 @@
 		/obj/item = null,
 	)
 	success_sound = 'sound/machines/defib/defib_zap.ogg'
-	required_biotype = NONE
 	target_zone = BODY_ZONE_HEAD
 	all_surgery_states_required = SURGERY_SKIN_OPEN|SURGERY_BONE_SAWED
 
@@ -110,10 +109,10 @@
 
 /datum/surgery_operation/basic/revival/mechanic
 	name = "full system reboot"
-	required_biotype = MOB_ROBOTIC
+	required_bodytype = BODYTYPE_ROBOTIC
 
 /datum/surgery_operation/basic/revival/mechanic/brain_check(obj/item/organ/brain/brain)
-	return !..()
+	return TRUE // We may have an organic brain (in the case of augmentation) or a robotic brain
 
 /datum/surgery_operation/basic/revival/mechanic/mob_check(mob/living/patient)
-	return !..()
+	return TRUE // We may just be an organic with a augmented robotic head, or full android


### PR DESCRIPTION
## About The Pull Request

Fixes #94918 
The mechanical version of the revival surgery was pretty "take no survivors", only really letting the mechanical version go through if the patient was a full on robot.
Im not completely sure this is the correct fix, it seems to me that the rigidity of the mechanical revival surgery was more an oversight than anything (like requiring a robotic biotype instead of bodytype). If I misunderstood the intentions of this surgery let me know.

## Why It's Good For The Game

Fix. Doesn't really make sense that you cant get a brain revival surgery if you have an augmented head.

## Changelog

:cl: Seven
fix: Fixed not being able to perform brain revival surgery on patients with augmented heads.
/:cl:
