### PR TITLE
Gavel hammer is now just called a gavel

### DIFF
--- a/code/game/objects/items/courtroom.dm
+++ b/code/game/objects/items/courtroom.dm
@@ -1,9 +1,9 @@
 // Contains:
-// Gavel Hammer
-// Gavel Block
+// Gavel
+// Sound Block
 
 /obj/item/gavelhammer
-	name = "gavel hammer"
+	name = "gavel"
 	desc = "Order, order! No bombs in my courthouse."
 	icon = 'icons/obj/weapons/hammer.dmi'
 	icon_state = "gavelhammer"
@@ -26,8 +26,8 @@
 	return BRUTELOSS
 
 /obj/item/gavelblock
-	name = "gavel block"
-	desc = "Smack it with a gavel hammer when the assistants get rowdy."
+	name = "sound block"
+	desc = "Smack it with a gavel when the assistants get rowdy."
 	icon = 'icons/obj/weapons/hammer.dmi'
 	icon_state = "gavelblock"
 	force = 2


### PR DESCRIPTION

## About The Pull Request

Renames the gavel hammer and gavel block to gavel and sound block, respectively.
## Why It's Good For The Game

This is what these objects are called irl; gavel hammer is also a bit redundant.

## Changelog
:cl:
spellcheck: gavel hammer and gavel block are now gavel and sound block
/:cl:
