### PR TITLE
Add an equivalent to balloon_alert_to_viewers, but for hearing

### DIFF
--- a/code/datums/components/houlihan_teleport.dm
+++ b/code/datums/components/houlihan_teleport.dm
@@ -47,12 +47,12 @@
 	var/turf/user_turf = get_turf(user)
 	var/atom/movable/dragged = user.pulling
 	user.forceMove(destination_turf)
-	user_turf.balloon_alert_to_viewers("(pop)")
+	user_turf.balloon_alert_to_hearers("*pop*")
 	if(dragged)
 		var/turf/dragged_turf = get_turf(dragged)
 		dragged.forceMove(destination_turf)
 		user.start_pulling(dragged, force = TRUE)
-		dragged_turf.balloon_alert_to_viewers("(pop)")
+		dragged_turf.balloon_alert_to_hearers("*pop*")
 
 	to_chat(list(user, dragged), span_notice("You blink and find yourself in <b>[get_area_name(destination_turf)]</b>."))
 	user.emote("blink")

--- a/code/datums/components/interaction_booby_trap.dm
+++ b/code/datums/components/interaction_booby_trap.dm
@@ -75,7 +75,7 @@
 	if (explode_timer)
 		return
 	explode_timer = addtimer(CALLBACK(src, PROC_REF(explode), source), 0.5 SECONDS)
-	source.balloon_alert_to_viewers("beep")
+	source.balloon_alert_to_hearers("*beep*")
 	playsound(parent, triggered_sound, 50, FALSE)
 	return
 

--- a/code/datums/components/usb_port.dm
+++ b/code/datums/components/usb_port.dm
@@ -259,7 +259,7 @@
 
 	var/atom/atom_parent = parent
 	usb_cable.forceMove(atom_parent.drop_location())
-	usb_cable.balloon_alert_to_viewers("snap")
+	usb_cable.balloon_alert_to_hearers("*snap*")
 
 	physical_object = null
 	attached_circuit = null

--- a/code/game/objects/effects/decals/turfdecal/weakpoint.dm
+++ b/code/game/objects/effects/decals/turfdecal/weakpoint.dm
@@ -34,7 +34,7 @@
 		/turf/open/misc/snow,
 	))
 	if(severity < required_strength)
-		balloon_alert_to_viewers("crack!")
+		balloon_alert_to_hearers("*crack*")
 		playsound(source = src, soundin = SFX_HULL_CREAKING, vol = 50, vary = TRUE, pressure_affected = FALSE, ignore_walls = TRUE)
 		return //return ominous sounds when we're under the threshold.
 

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -353,7 +353,7 @@
  */
 /turf/open/lava/proc/drop_contents_into_lava()
 	SIGNAL_HANDLER
-	balloon_alert_to_viewers("[pick("splash","pshhhh","hiss","blorble")]!")
+	balloon_alert_to_hearers("[pick("splash","pshhhh","hiss","blorble")]!")
 	playsound(src, 'sound/items/match_strike.ogg', 15, TRUE)
 	for(var/atom/movable/each_content as anything in contents)
 		on_atom_inited(src, each_content)

--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -45,6 +45,7 @@
 	for (var/mob/hearer in hearers)
 		if(HAS_TRAIT(hearer, TRAIT_DEAF))
 			continue
+
 		balloon_alert(hearer, (hearer == src && self_message) || message)
 
 // Do not use.

--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -34,6 +34,19 @@
 
 		balloon_alert(hearer, (hearer == src && self_message) || message)
 
+/// Create balloon alerts (text that floats up) to everything within range.
+/// Will only display to people who can hear.
+/atom/proc/balloon_alert_to_hearers(message, self_message, hearing_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs)
+	SHOULD_NOT_SLEEP(TRUE)
+
+	var/list/hearers = get_hearers_in_view(hearing_distance, src, RECURSIVE_CONTENTS_CLIENT_MOBS)
+	hearers -= ignored_mobs
+
+	for (var/mob/hearer in hearers)
+		if(HAS_TRAIT(hearer, TRAIT_DEAF))
+			continue
+		balloon_alert(hearer, (hearer == src && self_message) || message)
+
 // Do not use.
 // MeasureText blocks. I have no idea for how long.
 // I would've made the maptext_height update on its own, but I don't know

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -224,7 +224,7 @@
 	return !user.contains(src)
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
-	balloon_alert_to_viewers("*click*")
+	balloon_alert_to_hearers("*click*")
 	playsound(src, dry_fire_sound, dry_fire_sound_volume, TRUE)
 
 /obj/item/gun/proc/fire_sounds()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -472,7 +472,7 @@
 
 /obj/item/gun/ballistic/automatic/battle_rifle/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	if(chambered.loaded_projectile && prob(75) && (emp_malfunction || degradation_stage == degradation_stage_max))
-		balloon_alert_to_viewers("*click*")
+		balloon_alert_to_hearers("*click*")
 		playsound(src, dry_fire_sound, dry_fire_sound_volume, TRUE)
 		return
 

--- a/code/modules/vehicles/mecha/mecha_construction_paths.dm
+++ b/code/modules/vehicles/mecha/mecha_construction_paths.dm
@@ -615,7 +615,7 @@
 /datum/component/construction/mecha/honker/custom_action(obj/item/I, mob/living/user, diff)
 	if(istype(I, /obj/item/bikehorn))
 		playsound(parent, 'sound/items/bikehorn.ogg', 50, TRUE)
-		user.balloon_alert_to_viewers("HONK!")
+		user.balloon_alert_to_hearers("*HONK*")
 		return TRUE
 
 	return ..()


### PR DESCRIPTION

## About The Pull Request

This adds a new proc, `balloon_alert_to_hearers`, that checks for hearing mobs in range instead of checking for blindness.

## Why It's Good For The Game

Several instances of `balloon_alert_to_viewers` covered things like sounds that someone who is blind should be able to recognize, but won't due to the limitations of that proc. Conversely, people who are deaf shouldn't be able to recognize these sounds. This new proc covers these instances.

## Changelog
:cl:
add: Added `balloon_alert_to_hearers`, which is similar to `balloon_alert_to_viewers` but for audible things.
qol: Existing instances of `balloon_alert_to_viewers` which covered sounds, now uses `balloon_alert_to_hearers`.
/:cl:
