### PR TITLE
Revenants are perpetually visible in the chapel (but retain incorporeality) 

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
@@ -492,4 +492,15 @@
 	if(!HAS_TRAIT(src, TRAIT_REVENANT_REVEALED) && !istype(reflecting_in, /obj/structure/mirror/magic))
 		apply_wibbly_filters(reflection)
 
+/mob/living/basic/revenant/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
+	. = ..()
+	if(istype(get_area(src), /area/station/service/chapel))
+		if(invisibility)
+			to_chat(src, span_revennotice("Your connection to the world strengthens due to the latent spiritual energy in this area - you are now visible."))
+		SetInvisibility(INVISIBILITY_NONE, id = "chapel")
+	else
+		if(!invisibility)
+			to_chat(src, span_revennotice("Your connection to the world weakens as you leave the spiritual energy of the chapel behind - you are no longer visible."))
+		RemoveInvisibility(id = "chapel")
+
 #undef REVENANT_STUNNED_TRAIT

--- a/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
@@ -498,7 +498,7 @@
 		if(invisibility)
 			to_chat(src, span_revennotice("Your connection to the world strengthens due to the latent spiritual energy in this area - you are now visible."))
 		SetInvisibility(INVISIBILITY_NONE, id = "chapel")
-	else
+	else if(istype(get_area(old_loc), /area/station/service/chapel))
 		if(!invisibility)
 			to_chat(src, span_revennotice("Your connection to the world weakens as you leave the spiritual energy of the chapel behind - you are no longer visible."))
 		RemoveInvisibility(id = "chapel")


### PR DESCRIPTION
## About The Pull Request

If you enter the chapel as a Revenant you are perpetually visible to the crew.

You are still incorporeal (meaning you can't take damage). 

And of course if you use an ability, you become corporeal as normal. 

## Why It's Good For The Game

Allows for Revenants to confront Chaplains in their place of worship, just for fun. 

## Changelog

:cl: Melbert
add: Revenants are perpetually visible while in the Chapel. They retain their incorporeal state, meaning they can't be attacked. Of course, using an ability in this state will make them corporeal as normal.
/:cl:

