### PR TITLE
Dock Pay smite logs to audit log and also always notifies card holder

### DIFF
--- a/code/modules/admin/smites/dock_pay.dm
+++ b/code/modules/admin/smites/dock_pay.dm
@@ -18,10 +18,14 @@
 	if (card.registered_account.account_balance == 0)
 		to_chat(user,  span_warning("ID Card lacks any funds. No pay to dock."))
 		return
-	var/new_cost = input("How much pay are we docking? Current balance: [card.registered_account.account_balance] [MONEY_NAME].", "BUDGET CUTS") as num|null
+	var/new_cost = input("How much pay are we docking? Negative = giving money. Current balance: [card.registered_account.account_balance] [MONEY_NAME].", "BUDGET CUTS") as num|null
 	if (!new_cost)
 		return
-	SSeconomy.add_audit_entry(card.registered_account, new_cost, "Central Command")
-	card.registered_account.adjust_money(-new_cost, "Central Command: Pay Cut")
-	card.registered_account.bank_card_talk("[new_cost] [MONEY_NAME] deducted from your account based on performance review.", force = TRUE)
+	if(new_cost < 0)
+		card.registered_account.adjust_money(new_cost, "Central Command: Pay Bonus")
+		card.registered_account.bank_card_talk("[new_cost] [MONEY_NAME] added to your account based on performance review by Central Command.", force = TRUE)
+	else
+		SSeconomy.add_audit_entry(card.registered_account, new_cost, "Central Command")
+		card.registered_account.adjust_money(-new_cost, "Central Command: Pay Cut")
+		card.registered_account.bank_card_talk("[new_cost] [MONEY_NAME] deducted from your account based on performance review by Central Command.", force = TRUE)
 	SEND_SOUND(target, 'sound/machines/buzz/buzz-sigh.ogg')

--- a/code/modules/admin/smites/dock_pay.dm
+++ b/code/modules/admin/smites/dock_pay.dm
@@ -21,7 +21,7 @@
 	var/new_cost = input("How much pay are we docking? Current balance: [card.registered_account.account_balance] [MONEY_NAME].", "BUDGET CUTS") as num|null
 	if (!new_cost)
 		return
-	SSeconomy.add_audit_entry(card.registered_account, new_cost, "Central Command: Pay Cut")
+	SSeconomy.add_audit_entry(card.registered_account, new_cost, "Central Command")
 	card.registered_account.adjust_money(-new_cost, "Central Command: Pay Cut")
 	card.registered_account.bank_card_talk("[new_cost] [MONEY_NAME] deducted from your account based on performance review.", force = TRUE)
 	SEND_SOUND(target, 'sound/machines/buzz/buzz-sigh.ogg')

--- a/code/modules/admin/smites/dock_pay.dm
+++ b/code/modules/admin/smites/dock_pay.dm
@@ -21,11 +21,7 @@
 	var/new_cost = input("How much pay are we docking? Current balance: [card.registered_account.account_balance] [MONEY_NAME].", "BUDGET CUTS") as num|null
 	if (!new_cost)
 		return
-	if (!(card.registered_account.has_money(new_cost)))
-		to_chat(user,  span_warning("ID Card lacked funds. Emptying account."))
-		card.registered_account.bank_card_talk("[new_cost] [MONEY_NAME] deducted from your account based on performance review.")
-		card.registered_account.account_balance = 0
-	else
-		card.registered_account.account_balance = card.registered_account.account_balance - new_cost
-		card.registered_account.bank_card_talk("[new_cost] [MONEY_NAME] deducted from your account based on performance review.")
+	SSeconomy.add_audit_entry(card.registered_account, new_cost, "Central Command: Pay Cut")
+	card.registered_account.adjust_money(-new_cost, "Central Command: Pay Cut")
+	card.registered_account.bank_card_talk("[new_cost] [MONEY_NAME] deducted from your account based on performance review.", force = TRUE)
 	SEND_SOUND(target, 'sound/machines/buzz/buzz-sigh.ogg')


### PR DESCRIPTION
## About The Pull Request

1. Dock Pay smite now adds to audit and transaction log 

2. Dock Pay smite now always notifies card holder regardless of bank alert preference

3. Adds better support for negative money (ie, giving money)

## Why It's Good For The Game

1. Allows for people to trace where money is going, even if it is vanishing

2. So people can actually know the smite hit them

3. Request

## Changelog

:cl: Melbert
qol: If your pay gets docked by Central Command, it is noted in audit and transaction log
qol: If your pay gets docked by Central Command, you will always be notified, regardless of bank alert preference
admin: Dock Pay smite supports negatives better (for an easy way to give someone money) 
/:cl:
