### PR TITLE
Vendors in audit log are no longer prefixed with "the"

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -216,7 +216,7 @@ SUBSYSTEM_DEF(economy)
 	audit_log += list(list(
 		"account" = "[account.account_holder]",
 		"cost" = price_to_use,
-		"vendor" = "[vendor]",
+		"vendor" = "[astype(vendor, /atom)?.name || vendor]",
 		"stationtime" = station_time_timestamp("hh:mm"),
 	))
 


### PR DESCRIPTION
## About The Pull Request

Uses `vendor.name` if possible, so it's referred to as "VendingMachine" rather than "The VendingMachine"

## Why It's Good For The Game

Reads a bit better with all the entries presented

## Changelog

:cl: Melbert
qol: Audit log formats vendors without "the"
/:cl:
