### PR TITLE
Makes the Staff of Storms normal-sized

### DIFF
--- a/code/modules/mining/lavaland/mining_loot/megafauna/legion.dm
+++ b/code/modules/mining/lavaland/mining_loot/megafauna/legion.dm
@@ -10,7 +10,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 	slot_flags = ITEM_SLOT_BACK
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	force = 20
 	damtype = BURN
 	hitsound = 'sound/items/weapons/taserhit.ogg'


### PR DESCRIPTION

## About The Pull Request

Exactly what it says on the tin - the Staff of Storms is now normal sized instead of bulky, and will fit in a backpack.

## Why It's Good For The Game

The Staff of Lava fits in a backpack, and it arguably has far more destructive/abuse capability than the Staff of Storms. The main use of the Staff of Storms is dealing with ash storms, and like, I don't want to take up my back slot for that.

## Changelog
:cl:
balance: The Staff of Storms is now normal-sized, and fits in a backpack.
/:cl:
