### PR TITLE
You can no longer runtime selling ghosts

### DIFF
--- a/code/modules/shuttle/mobile_port/variants/supply.dm
+++ b/code/modules/shuttle/mobile_port/variants/supply.dm
@@ -292,6 +292,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 				for(var/atom/movable/exporting_atom in shuttle_turf)
 					if(iseyemob(exporting_atom))
 						continue
+					if(isobserver(exporting_atom))
+						continue
 					if(exporting_atom.anchored)
 						continue
 					export_item_and_contents(exporting_atom, apply_elastic = TRUE, dry_run = FALSE, external_report = report)


### PR DESCRIPTION
## About The Pull Request

Ran into while testing, if you have an observer on the cargo shuttle and ride it the entire way to centcom, the shuttle will attempt to sell your ghost and qdel it. This adds an additional check to the sell/export_item loop to verify that observers are not included in the loop in the same place where we check for eye-mobs.

## Why It's Good For The Game

One fewer runtime, but I'm curious if there's a better way to handle this in order to avoid overhead.

## Changelog

:cl:
fix: The cargo shuttle can no longer qdel your ghost mob.
/:cl:
