### PR TITLE
Chem scanning removes achievements from maint pills

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_medical.dm
+++ b/code/__DEFINES/dcs/signals/signals_medical.dm
@@ -26,3 +26,6 @@
 #define COMSIG_LIVING_OPERATING_ON "living_operating_on"
 /// Sent from /mob/living/perform_surgery: (mob/living/surgeon, list/possible_operations)
 #define COMSIG_ATOM_BEING_OPERATED_ON "atom_being_operated_on"
+
+/// From /obj/item/ph_meter/interact_with_atom(): (atom/source, mob/user)
+#define COMSIG_ON_REAGENT_SCAN "on_reagent_scan"

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -142,6 +142,7 @@
 			log_entry.add_data_entry(DETSCAN_CATEGORY_FINGERS, atom_fingerprints.Copy())
 
 		// Only get reagents from non-mobs.
+		SEND_SIGNAL(scanned_atom, COMSIG_ON_REAGENT_SCAN, user)
 		for(var/datum/reagent/present_reagent as anything in scanned_atom.reagents?.reagent_list)
 			log_entry.add_data_entry(DETSCAN_CATEGORY_REAGENTS, list(present_reagent.name = present_reagent.volume))
 

--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -119,6 +119,7 @@
 	var/obj/item/reagent_containers/cont = interacting_with
 	if(!LAZYLEN(cont.reagents.reagent_list))
 		return NONE
+	SEND_SIGNAL(interacting_with, COMSIG_ON_REAGENT_SCAN, user)
 	var/list/out_message = list()
 	to_chat(user, "<i>The chemistry meter beeps and displays:</i>")
 	out_message += "<b>Total volume: [round(cont.volume, 0.01)] Current temperature: [round(cont.reagents.chem_temp, 0.1)]K Total pH: [round(cont.reagents.ph, 0.01)]\n"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -353,8 +353,6 @@
 	name = "maintenance pill"
 	desc = "A strange pill found in the depths of maintenance."
 	icon_state = "pill21"
-	///Boolean on whether this will count towards your achievement score if you consume it.
-	var/count_towards_achievement = FALSE
 	var/static/list/names = list(
 		"maintenance pill",
 		"floor pill",
@@ -379,20 +377,24 @@
 	name = pick(names)
 	if(prob(30))
 		desc = pick(descs)
+
+/obj/item/reagent_containers/applicator/pill/maintenance/achievement
+	///Boolean on whether this will count towards your achievement score if you consume it.
+	var/count_towards_achievement = TRUE
+
+/obj/item/reagent_containers/applicator/pill/maintenance/achievement/Initialize(mapload)
+	. = ..()
 	RegisterSignal(src, COMSIG_ON_REAGENT_SCAN, PROC_REF(on_chemical_scan))
 
-/obj/item/reagent_containers/applicator/pill/maintenance/on_consumption(mob/consumer, mob/user)
+/obj/item/reagent_containers/applicator/pill/maintenance/achievement/on_consumption(mob/consumer, mob/user)
 	. = ..()
 	if(count_towards_achievement)
 		consumer.client?.give_award(/datum/award/score/maintenance_pill, consumer)
 
 ///called when we are chemically scanned, we no longer grant an achievement.
-/obj/item/reagent_containers/pill/maintenance/achievement/proc/on_chemical_scan(atom/source, mob/user)
+/obj/item/reagent_containers/applicator/pill/maintenance/achievement/proc/on_chemical_scan(atom/source, mob/user)
 	SIGNAL_HANDLER
 	count_towards_achievement = FALSE
-
-/obj/item/reagent_containers/applicator/pill/maintenance/achievement
-	count_towards_achievement = TRUE
 
 /obj/item/reagent_containers/applicator/pill/potassiodide
 	name = "potassium iodide pill"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -353,9 +353,25 @@
 	name = "maintenance pill"
 	desc = "A strange pill found in the depths of maintenance."
 	icon_state = "pill21"
-	var/static/list/names = list("maintenance pill", "floor pill", "mystery pill", "suspicious pill", "strange pill", "lucky pill", "ominous pill", "eerie pill")
-	var/static/list/descs = list("Your feeling is telling you no, but...","Drugs are expensive, you can't afford not to eat any pills that you find."\
-	, "Surely, there's no way this could go bad.", "Winners don't do dr- oh what the heck!", "Free pills? At no cost, how could I lose?")
+	///Boolean on whether this will count towards your achievement score if you consume it.
+	var/count_towards_achievement = FALSE
+	var/static/list/names = list(
+		"maintenance pill",
+		"floor pill",
+		"mystery pill",
+		"suspicious pill",
+		"strange pill",
+		"lucky pill",
+		"ominous pill",
+		"eerie pill",
+	)
+	var/static/list/descs = list(
+		"Your feeling is telling you no, but...",
+		"Drugs are expensive, you can't afford not to eat any pills that you find.",
+		"Surely, there's no way this could go bad.",
+		"Winners don't do dr- oh what the heck!",
+		"Free pills? At no cost, how could I lose?",
+	)
 
 /obj/item/reagent_containers/applicator/pill/maintenance/Initialize(mapload)
 	list_reagents = list(get_random_reagent_id() = rand(10,50)) //list_reagents is called before init, because init generates the reagents using list_reagents
@@ -363,10 +379,20 @@
 	name = pick(names)
 	if(prob(30))
 		desc = pick(descs)
+	RegisterSignal(src, COMSIG_ON_REAGENT_SCAN, PROC_REF(on_chemical_scan))
 
-/obj/item/reagent_containers/applicator/pill/maintenance/achievement/on_consumption(mob/consumer, mob/user)
+/obj/item/reagent_containers/applicator/pill/maintenance/on_consumption(mob/consumer, mob/user)
 	. = ..()
-	consumer.client?.give_award(/datum/award/score/maintenance_pill, consumer)
+	if(count_towards_achievement)
+		consumer.client?.give_award(/datum/award/score/maintenance_pill, consumer)
+
+///called when we are chemically scanned, we no longer grant an achievement.
+/obj/item/reagent_containers/pill/maintenance/achievement/proc/on_chemical_scan(atom/source, mob/user)
+	SIGNAL_HANDLER
+	count_towards_achievement = FALSE
+
+/obj/item/reagent_containers/applicator/pill/maintenance/achievement
+	count_towards_achievement = TRUE
 
 /obj/item/reagent_containers/applicator/pill/potassiodide
 	name = "potassium iodide pill"


### PR DESCRIPTION
## About The Pull Request

Chem scanning a maint pill now removes the achievement for eating it.

## Why It's Good For The Game

cheater.

You can still scour maints for pills with stuff you'd like, but you lose the achievement for doing so.

## Changelog

:cl:
fix: Chem scanning a maintenance pill removes the achievement value.
/:cl: