### PR TITLE
Converts crossbreeds/anomacores/RND machinery to item_interaction

### DIFF
--- a/code/modules/research/anomaly/anomaly_core.dm
+++ b/code/modules/research/anomaly/anomaly_core.dm
@@ -31,10 +31,9 @@
 /obj/item/assembly/signaler/anomaly/attack_self()
 	return
 
-/obj/item/assembly/signaler/anomaly/attackby(obj/item/I, mob/user, list/modifiers, list/attack_modifiers)
-	if(I.tool_behaviour == TOOL_ANALYZER)
-		to_chat(user, span_notice("Analyzing... [src]'s stabilized field is fluctuating along frequency [format_frequency(frequency)], code [code]."))
-	return ..()
+/obj/item/assembly/signaler/anomaly/analyzer_act(mob/living/user, obj/item/analyzer/tool)
+	to_chat(user, span_notice("Analyzing... [src]'s stabilized field is fluctuating along frequency [format_frequency(frequency)], code [code]."))
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/assembly/signaler/anomaly/on_mail_unwrap(atom/source, mob/user, obj/item/mail/traitor/letter)
 	return NONE

--- a/code/modules/research/anomaly/anomaly_refinery.dm
+++ b/code/modules/research/anomaly/anomaly_refinery.dm
@@ -73,41 +73,49 @@
 	var/radius = clamp(round(MIN_RADIUS_REQUIRED + radius_increase_per_core * already_made, 1), MIN_RADIUS_REQUIRED, MAX_RADIUS_REQUIRED)
 	return radius
 
-/obj/machinery/research/anomaly_refinery/attackby(obj/item/tool, mob/living/user, list/modifiers, list/attack_modifiers)
+/obj/machinery/research/anomaly_refinery/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(active)
 		to_chat(user, span_warning("You can't insert [tool] into [src] while [p_theyre()] currently active."))
-		return
+		return ITEM_INTERACT_BLOCKING
+
 	if(istype(tool, /obj/item/raw_anomaly_core))
 		if(inserted_core)
 			to_chat(user, span_warning("There is already a core in [src]."))
-			return
+			return ITEM_INTERACT_BLOCKING
+
 		if(!user.transferItemToLoc(tool, src))
 			to_chat(user, span_warning("[tool] is stuck to your hand."))
-			return
+			return ITEM_INTERACT_BLOCKING
+
 		var/obj/item/raw_anomaly_core/raw_core = tool
 		if(!get_required_radius(raw_core.anomaly_type))
 			say("Unfortunately, due to diminishing supplies of condensed anomalous matter, [raw_core] and any cores of its type are no longer of a sufficient quality level to be compressed into a working core.")
-			return
+			return ITEM_INTERACT_BLOCKING
+
 		inserted_core = raw_core
 		to_chat(user, span_notice("You insert [raw_core] into [src]."))
-		return
-	if(istype(tool, /obj/item/transfer_valve))
-		if(inserted_bomb)
-			to_chat(user, span_warning("There is already a bomb in [src]."))
-			return
-		var/obj/item/transfer_valve/valve = tool
-		if(!valve.ready())
-			to_chat(user, span_warning("[valve] is incomplete."))
-			return
-		if(!user.transferItemToLoc(tool, src))
-			to_chat(user, span_warning("[tool] is stuck to your hand."))
-			return
-		inserted_bomb = tool
-		tank_to_target = inserted_bomb.tank_two
-		to_chat(user, span_notice("You insert [tool] into [src]"))
-		return
-	update_appearance()
-	return ..()
+		return ITEM_INTERACT_SUCCESS
+
+	if(!istype(tool, /obj/item/transfer_valve))
+		return NONE
+
+	if(inserted_bomb)
+		to_chat(user, span_warning("There is already a bomb in [src]."))
+		return ITEM_INTERACT_BLOCKING
+
+	var/obj/item/transfer_valve/valve = tool
+	if(!valve.ready())
+		to_chat(user, span_warning("[valve] is incomplete."))
+		return ITEM_INTERACT_BLOCKING
+
+	if(!user.transferItemToLoc(tool, src))
+		to_chat(user, span_warning("[tool] is stuck to your hand."))
+		return ITEM_INTERACT_BLOCKING
+
+	inserted_bomb = tool
+	tank_to_target = inserted_bomb.tank_two
+	to_chat(user, span_notice("You insert [tool] into [src]"))
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/research/anomaly_refinery/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()

--- a/code/modules/research/ordnance/doppler_array.dm
+++ b/code/modules/research/ordnance/doppler_array.dm
@@ -48,17 +48,15 @@
 	. = ..()
 	. += span_notice("It is currently facing [dir2text(dir)]")
 
-/obj/machinery/doppler_array/attackby(obj/item/item, mob/user, list/modifiers, list/attack_modifiers)
-	if(istype(item, /obj/item/disk/computer))
-		var/obj/item/disk/computer/disk = item
-		eject_disk(user)
-		if(user.transferItemToLoc(disk, src))
-			inserted_disk = disk
-			return
-		else
-			balloon_alert(user, "it's stuck to your hand!")
-			return ..()
-	return ..()
+/obj/machinery/doppler_array/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/disk/computer))
+		return NONE
+	eject_disk(user)
+	if(!user.transferItemToLoc(tool, src))
+		balloon_alert(user, "it's stuck to your hand!")
+		return ITEM_INTERACT_BLOCKING
+	inserted_disk = tool
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/doppler_array/wrench_act(mob/living/user, obj/item/tool)
 	default_unfasten_wrench(user, tool)

--- a/code/modules/research/ordnance/tank_compressor.dm
+++ b/code/modules/research/ordnance/tank_compressor.dm
@@ -42,33 +42,35 @@
 	var/list/gas_data = list()
 	var/timestamp
 
-/obj/machinery/atmospherics/components/binary/tank_compressor/attackby(obj/item/item, mob/living/user)
-	if (panel_open)
-		return ..()
+/obj/machinery/atmospherics/components/binary/tank_compressor/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if (user.combat_mode || panel_open)
+		return NONE
 
-	if(istype(item, /obj/item/tank))
-		var/obj/item/tank/tank_item = item
-		if(inserted_tank)
-			if(!eject_tank(user))
-				balloon_alert(user, "it's stuck inside!")
-				return ..()
-		if(!user.transferItemToLoc(tank_item, src))
-			balloon_alert(user, "it's stuck to your hand!")
-			return ..()
-		inserted_tank = tank_item
-		last_recorded_pressure = 0
-		RegisterSignal(inserted_tank, COMSIG_QDELETING, PROC_REF(tank_destruction))
-		update_appearance()
-		return
-	if(istype(item, /obj/item/disk/computer))
-		var/obj/item/disk/computer/attacking_disk = item
+	if(istype(tool, /obj/item/disk/computer))
 		eject_disk(user)
-		if(user.transferItemToLoc(attacking_disk, src))
-			inserted_disk = attacking_disk
-		else
+		if(user.transferItemToLoc(tool, src))
 			balloon_alert(user, "it's stuck to your hand!")
-		return
-	return ..()
+			return ITEM_INTERACT_BLOCKING
+		inserted_disk = tool
+		return ITEM_INTERACT_SUCCESS
+
+	if(!istype(tool, /obj/item/tank))
+		return NONE
+
+	if(inserted_tank)
+		if(!eject_tank(user))
+			balloon_alert(user, "it's stuck inside!")
+			return ITEM_INTERACT_BLOCKING
+
+	if(!user.transferItemToLoc(tool, src))
+		balloon_alert(user, "it's stuck to your hand!")
+		return ITEM_INTERACT_BLOCKING
+
+	inserted_tank = tool
+	last_recorded_pressure = 0
+	RegisterSignal(inserted_tank, COMSIG_QDELETING, PROC_REF(tank_destruction))
+	update_appearance()
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/atmospherics/components/binary/tank_compressor/wrench_act(mob/living/user, obj/item/tool)
 	if(active || inserted_tank)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -70,31 +70,38 @@ Nothing else in the console has ID requirements.
 		d_disk = null
 	return ..()
 
-/obj/machinery/computer/rdconsole/attackby(obj/item/D, mob/user, list/modifiers, list/attack_modifiers)
-	//Loading a disk into it.
-	if(istype(D, /obj/item/disk))
-		if(istype(D, /obj/item/disk/tech_disk))
-			if(t_disk)
-				to_chat(user, span_warning("A technology disk is already loaded!"))
-				return
-			if(!user.transferItemToLoc(D, src))
-				to_chat(user, span_warning("[D] is stuck to your hand!"))
-				return
-			t_disk = D
-		else if (istype(D, /obj/item/disk/design_disk))
-			if(d_disk)
-				to_chat(user, span_warning("A design disk is already loaded!"))
-				return
-			if(!user.transferItemToLoc(D, src))
-				to_chat(user, span_warning("[D] is stuck to your hand!"))
-				return
-			d_disk = D
-		else
-			to_chat(user, span_warning("Machine cannot accept disks in that format."))
-			return
-		to_chat(user, span_notice("You insert [D] into \the [src]!"))
-		return
-	return ..()
+/obj/machinery/computer/rdconsole/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/disk))
+		return NONE
+
+	if(istype(tool, /obj/item/disk/tech_disk))
+		if(t_disk)
+			to_chat(user, span_warning("A technology disk is already loaded!"))
+			return ITEM_INTERACT_BLOCKING
+
+		if(!user.transferItemToLoc(tool, src))
+			to_chat(user, span_warning("[tool] is stuck to your hand!"))
+			return ITEM_INTERACT_BLOCKING
+
+		t_disk = tool
+		to_chat(user, span_notice("You insert [tool] into \the [src]!"))
+		return ITEM_INTERACT_SUCCESS
+
+	if (!istype(tool, /obj/item/disk/design_disk))
+		to_chat(user, span_warning("Machine cannot accept disks in that format."))
+		return ITEM_INTERACT_BLOCKING
+
+	if(d_disk)
+		to_chat(user, span_warning("A design disk is already loaded!"))
+		return ITEM_INTERACT_BLOCKING
+
+	if(!user.transferItemToLoc(tool, src))
+		to_chat(user, span_warning("[tool] is stuck to your hand!"))
+		return ITEM_INTERACT_BLOCKING
+
+	d_disk = tool
+	to_chat(user, span_notice("You insert [tool] into \the [src]!"))
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/computer/rdconsole/multitool_act(mob/living/user, obj/item/multitool/tool)
 	. = ..()

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -165,41 +165,37 @@
 		return ITEM_INTERACT_BLOCKING
 	return ..()
 
-/obj/machinery/rnd/server/master/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
-	if(istype(attacking_item, /obj/item/disk/computer/hdd_theft))
-		switch(deconstruction_state)
-			if(HDD_PANEL_CLOSED)
-				balloon_alert(user, "you can't find a place to insert it!")
-				return TRUE
-			if(HDD_PANEL_OPEN)
-				balloon_alert(user, "you weren't trained to install this!")
-				return TRUE
-			if(HDD_PRIED)
-				balloon_alert(user, "the HDD housing is completely broken, it won't fit!")
-				return TRUE
-			if(HDD_CUT_LOOSE)
-				balloon_alert(user, "the HDD housing is completely broken and all the wires are cut!")
-				return TRUE
-			if(HDD_OVERLOADED)
-				balloon_alert(user, "the inside is scorched and all the wires are burned!")
-				return TRUE
-	return ..()
+/obj/machinery/rnd/server/master/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/disk/computer/hdd_theft))
+		return NONE
+	switch(deconstruction_state)
+		if(HDD_PANEL_CLOSED)
+			balloon_alert(user, "you can't find a place to insert it!")
+		if(HDD_PANEL_OPEN)
+			balloon_alert(user, "you weren't trained to install this!")
+		if(HDD_PRIED)
+			balloon_alert(user, "the HDD housing is completely broken, it won't fit!")
+		if(HDD_CUT_LOOSE)
+			balloon_alert(user, "the HDD housing is completely broken and all the wires are cut!")
+		if(HDD_OVERLOADED)
+			balloon_alert(user, "the inside is scorched and all the wires are burned!")
+	return ITEM_INTERACT_BLOCKING
 
 /obj/machinery/rnd/server/master/screwdriver_act(mob/living/user, obj/item/tool)
 	if(deconstruction_state != HDD_PANEL_CLOSED || user.combat_mode)
-		return FALSE
+		return NONE
 
 	to_chat(user, span_notice("You can see [front_panel_screws] screw\s. You start unscrewing [front_panel_screws == 1 ? "it" : "them"]..."))
 	while(tool.use_tool(src, user, 7.5 SECONDS, volume=100))
 		front_panel_screws--
-
-		if(front_panel_screws <= 0)
-			deconstruction_state = HDD_PANEL_OPEN
-			to_chat(user, span_notice("You remove the last screw from [src]'s front panel."))
-			add_overlay("RD-server-hdd-panel-open")
-			return TRUE
-		to_chat(user, span_notice("The screw breaks as you remove it. Only [front_panel_screws] left..."))
-	return TRUE
+		if(front_panel_screws > 0)
+			to_chat(user, span_notice("The screw breaks as you remove it. Only [front_panel_screws] left..."))
+			continue
+		deconstruction_state = HDD_PANEL_OPEN
+		to_chat(user, span_notice("You remove the last screw from [src]'s front panel."))
+		add_overlay("RD-server-hdd-panel-open")
+		break
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/rnd/server/master/crowbar_act(mob/living/user, obj/item/tool)
 	if(deconstruction_state != HDD_PANEL_OPEN || user.combat_mode)

--- a/code/modules/research/xenobiology/crossbreeding/consuming.dm
+++ b/code/modules/research/xenobiology/crossbreeding/consuming.dm
@@ -15,30 +15,36 @@ Consuming extracts:
 	var/cookies = 5 //Number of cookies to spawn
 	var/cookietype = /obj/item/slime_cookie
 
-/obj/item/slimecross/consuming/attackby(obj/item/O, mob/user)
-	if(IS_EDIBLE(O))
-		if(last_produced + cooldown > world.time)
-			to_chat(user, span_warning("[src] is still digesting after its last meal!"))
-			return
-		var/datum/reagent/N = O.reagents.has_reagent(/datum/reagent/consumable/nutriment)
-		if(N)
-			nutriment_eaten += N.volume
-			to_chat(user, span_notice("[src] opens up and swallows [O] whole!"))
-			qdel(O)
-			playsound(src, 'sound/items/eatfood.ogg', 20, TRUE)
-		else
-			to_chat(user, span_warning("[src] burbles unhappily at the offering."))
-		if(nutriment_eaten >= nutriment_required)
-			nutriment_eaten = 0
-			user.visible_message(span_notice("[src] swells up and produces a small pile of cookies!"))
-			playsound(src, 'sound/effects/splat.ogg', 40, TRUE)
-			last_produced = world.time
-			for(var/i in 1 to cookies)
-				var/obj/item/S = spawncookie()
-				S.pixel_x = base_pixel_x + rand(-5, 5)
-				S.pixel_y = base_pixel_y + rand(-5, 5)
-		return
-	..()
+/obj/item/slimecross/consuming/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!IS_EDIBLE(tool))
+		return NONE
+
+	if(last_produced + cooldown > world.time)
+		to_chat(user, span_warning("[src] is still digesting after its last meal!"))
+		return ITEM_INTERACT_BLOCKING
+
+	var/datum/reagent/nutriments = tool.reagents.has_reagent(/datum/reagent/consumable/nutriment)
+	if(!nutriments)
+		to_chat(user, span_warning("[src] burbles unhappily at the offering."))
+		return ITEM_INTERACT_BLOCKING
+
+	nutriment_eaten += nutriments.volume
+	to_chat(user, span_notice("[src] opens up and swallows [tool] whole!"))
+	qdel(tool)
+	playsound(src, 'sound/items/eatfood.ogg', 20, TRUE)
+
+	if(nutriment_eaten < nutriment_required)
+		return ITEM_INTERACT_SUCCESS
+
+	nutriment_eaten = 0
+	user.visible_message(span_notice("[src] swells up and produces a small pile of cookies!"))
+	playsound(src, 'sound/effects/splat.ogg', 40, TRUE)
+	last_produced = world.time
+	for(var/i in 1 to cookies)
+		var/obj/item/cookie = spawncookie()
+		cookie.pixel_x = base_pixel_x + rand(-5, 5)
+		cookie.pixel_y = base_pixel_y + rand(-5, 5)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/slimecross/consuming/proc/spawncookie()
 	return new cookietype(get_turf(src))

--- a/code/modules/research/xenobiology/crossbreeding/reproductive.dm
+++ b/code/modules/research/xenobiology/crossbreeding/reproductive.dm
@@ -24,39 +24,42 @@ Reproductive extracts:
 	. = ..()
 	create_storage(storage_type = /datum/storage/extract_inventory)
 
-/obj/item/slimecross/reproductive/attackby(obj/item/O, mob/user)
+/obj/item/slimecross/reproductive/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	var/datum/storage/extract_inventory/slime_storage = atom_storage
-	if(!istype(slime_storage))
-		return
+	if(!istype(slime_storage)) // what
+		return NONE
 
 	if((last_produce + cooldown) > world.time)
 		to_chat(user, span_warning("[src] is still digesting!"))
-		return
+		return ITEM_INTERACT_BLOCKING
 
 	if(length(contents) >= feedAmount) //if for some reason the contents are full, but it didnt digest, attempt to digest again
 		to_chat(user, span_warning("[src] appears to be full but is not digesting! Maybe poking it stimulated it to digest."))
 		slime_storage?.processCubes(user)
-		return
+		return ITEM_INTERACT_BLOCKING
 
-	if(istype(O, /obj/item/storage/bag/xeno))
+	if(istype(tool, /obj/item/storage/bag/xeno))
 		var/list/inserted = list()
-		O.atom_storage.remove_type(/obj/item/food/monkeycube, src, feedAmount - length(contents), TRUE, FALSE, user, inserted)
-		if(inserted.len)
-			to_chat(user, span_notice("You feed [length(inserted)] Monkey Cube[p_s()] to [src], and it pulses gently."))
-			playsound(src, 'sound/items/eatfood.ogg', 20, TRUE)
-			slime_storage?.processCubes(user)
-		else
+		tool.atom_storage.remove_type(/obj/item/food/monkeycube, src, feedAmount - length(contents), TRUE, FALSE, user, inserted)
+		if(!inserted.len)
 			to_chat(user, span_warning("There are no monkey cubes in the bio bag!"))
-		return
+			return ITEM_INTERACT_BLOCKING
+		to_chat(user, span_notice("You feed [length(inserted)] monkey cube[length(inserted) > 1 ? "s" : ""] to [src], and it pulses gently."))
+		playsound(src, 'sound/items/eatfood.ogg', 20, TRUE)
+		slime_storage?.processCubes(user)
+		return ITEM_INTERACT_SUCCESS
 
-	else if(istype(O, /obj/item/food/monkeycube))
-		if(atom_storage?.attempt_insert(O, user, override = TRUE, force = STORAGE_FULLY_LOCKED))
-			to_chat(user, span_notice("You feed 1 Monkey Cube to [src], and it pulses gently."))
-			slime_storage?.processCubes(user)
-			playsound(src, 'sound/items/eatfood.ogg', 20, TRUE)
-			return
-		else
-			to_chat(user, span_notice("The [src] rejects the Monkey Cube!")) //in case it fails to insert for whatever reason you get feedback
+	if(!istype(tool, /obj/item/food/monkeycube))
+		return NONE
+
+	if(!atom_storage?.attempt_insert(tool, user, override = TRUE, force = STORAGE_FULLY_LOCKED))
+		to_chat(user, span_notice("The [src] rejects [tool]!")) //in case it fails to insert for whatever reason you get feedback
+		return ITEM_INTERACT_BLOCKING
+
+	to_chat(user, span_notice("You feed [tool] to [src], and it pulses gently."))
+	slime_storage?.processCubes(user)
+	playsound(src, 'sound/items/eatfood.ogg', 20, TRUE)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/slimecross/reproductive/grey
 	extract_type = /obj/item/slime_extract/grey

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -189,13 +189,18 @@ Stabilized extracts:
 /obj/item/slimecross/stabilized/rainbow
 	colour = SLIME_TYPE_RAINBOW
 	effect_desc = "Accepts a regenerative extract and automatically uses it if the owner enters a critical condition."
+	/// Regenerative crossbreed stored to be autoused on critted owner
 	var/obj/item/slimecross/regenerative/regencore
 
-/obj/item/slimecross/stabilized/rainbow/attackby(obj/item/O, mob/user)
-	var/obj/item/slimecross/regenerative/regen = O
-	if(istype(regen) && !regencore)
-		to_chat(user, span_notice("You place [O] in [src], prepping the extract for automatic application!"))
-		regencore = regen
-		regen.forceMove(src)
-		return
-	return ..()
+/obj/item/slimecross/stabilized/rainbow/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/slimecross/regenerative))
+		return NONE
+
+	if(regencore)
+		to_chat(user, span_warning("[src] already has a regenerative crossbreed stored in it!"))
+		return ITEM_INTERACT_BLOCKING
+
+	to_chat(user, span_notice("You place [tool] in [src], prepping the extract for automatic application!"))
+	regencore = tool
+	tool.forceMove(src)
+	return ITEM_INTERACT_SUCCESS

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -226,11 +226,11 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 			return 200
 		if(SLIME_ACTIVATE_MAJOR)
 			var/drink_type = get_random_drink()
-			var/obj/tool = new drink_type
-			if(!user.put_in_active_hand(tool))
-				tool.forceMove(user.drop_location())
+			var/obj/O = new drink_type
+			if(!user.put_in_active_hand(O))
+				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
+			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
 			return 200
 
 /obj/item/slime_extract/metal
@@ -241,19 +241,19 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 /obj/item/slime_extract/metal/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
-			var/obj/item/stack/sheet/glass/tool = new(null, 5)
-			if(!user.put_in_active_hand(tool))
-				tool.forceMove(user.drop_location())
+			var/obj/item/stack/sheet/glass/O = new(null, 5)
+			if(!user.put_in_active_hand(O))
+				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
+			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
 			return 150
 
 		if(SLIME_ACTIVATE_MAJOR)
-			var/obj/item/stack/sheet/iron/tool = new(null, 5)
-			if(!user.put_in_active_hand(tool))
-				tool.forceMove(user.drop_location())
+			var/obj/item/stack/sheet/iron/O = new(null, 5)
+			if(!user.put_in_active_hand(O))
+				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
+			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
 			return 200
 
 /obj/item/slime_extract/purple
@@ -282,11 +282,11 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 /obj/item/slime_extract/darkpurple/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
-			var/obj/item/stack/sheet/mineral/plasma/tool = new(null, 1)
-			if(!user.put_in_active_hand(tool))
-				tool.forceMove(user.drop_location())
+			var/obj/item/stack/sheet/mineral/plasma/O = new(null, 1)
+			if(!user.put_in_active_hand(O))
+				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
+			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
 			return 150
 
 		if(SLIME_ACTIVATE_MAJOR)
@@ -455,19 +455,19 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 /obj/item/slime_extract/lightpink/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
-			var/obj/item/slimepotion/renaming/tool = new(null, 1)
-			if(!user.put_in_active_hand(tool))
-				tool.forceMove(user.drop_location())
+			var/obj/item/slimepotion/renaming/O = new(null, 1)
+			if(!user.put_in_active_hand(O))
+				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
+			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
 			return 150
 
 		if(SLIME_ACTIVATE_MAJOR)
-			var/obj/item/slimepotion/sentience/tool = new(null, 1)
-			if(!user.put_in_active_hand(tool))
-				tool.forceMove(user.drop_location())
+			var/obj/item/slimepotion/sentience/O = new(null, 1)
+			if(!user.put_in_active_hand(O))
+				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
+			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
 			return 450
 
 /obj/item/slime_extract/black
@@ -586,21 +586,21 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
 			var/chosen = pick(difflist(subtypesof(/obj/item/toy/crayon),typesof(/obj/item/toy/crayon/spraycan)))
-			var/obj/item/tool = new chosen(null)
-			if(!user.put_in_active_hand(tool))
-				tool.forceMove(user.drop_location())
+			var/obj/item/O = new chosen(null)
+			if(!user.put_in_active_hand(O))
+				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
+			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
 			return 150
 
 		if(SLIME_ACTIVATE_MAJOR)
 			var/blacklisted_cans = list(/obj/item/toy/crayon/spraycan/borg, /obj/item/toy/crayon/spraycan/infinite)
 			var/chosen = pick(subtypesof(/obj/item/toy/crayon/spraycan) - blacklisted_cans)
-			var/obj/item/tool = new chosen(null)
-			if(!user.put_in_active_hand(tool))
-				tool.forceMove(user.drop_location())
+			var/obj/item/O = new chosen(null)
+			if(!user.put_in_active_hand(O))
+				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
+			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
 			return 250
 
 /obj/item/slime_extract/cerulean
@@ -630,11 +630,11 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 /obj/item/slime_extract/sepia/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
-			var/obj/item/camera/tool = new(null, 1)
-			if(!user.put_in_active_hand(tool))
-				tool.forceMove(user.drop_location())
+			var/obj/item/camera/O = new(null, 1)
+			if(!user.put_in_active_hand(O))
+				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
+			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
 			return 150
 
 		if(SLIME_ACTIVATE_MAJOR)
@@ -660,11 +660,11 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 
 		if(SLIME_ACTIVATE_MAJOR)
 			var/chosen = pick(subtypesof(/obj/item/slime_extract))
-			var/obj/item/tool = new chosen(null)
-			if(!user.put_in_active_hand(tool))
-				tool.forceMove(user.drop_location())
+			var/obj/item/O = new chosen(null)
+			if(!user.put_in_active_hand(O))
+				O.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
+			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
 			return 150
 
 ////Slime-derived potions///

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -29,19 +29,20 @@
 	if(extract_uses > 1)
 		. += "It has [extract_uses] uses remaining."
 
-/obj/item/slime_extract/attackby(obj/item/O, mob/user)
-	if(istype(O, /obj/item/slimepotion/enhancer))
-		if(extract_uses >= 5 || recurring)
-			to_chat(user, span_warning("You cannot enhance this extract further!"))
-			return ..()
-		if(O.type == /obj/item/slimepotion/enhancer) //Seriously, why is this defined here...?
-			to_chat(user, span_notice("You apply the enhancer to the slime extract. It may now be reused one more time."))
-			extract_uses++
-		if(O.type == /obj/item/slimepotion/enhancer/max)
-			to_chat(user, span_notice("You dump the maximizer on the slime extract. It can now be used a total of 5 times!"))
-			extract_uses = 5
-		qdel(O)
-	..()
+/obj/item/slime_extract/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/slimepotion/enhancer))
+		return NONE
+	if(extract_uses >= 5 || recurring)
+		to_chat(user, span_warning("You cannot enhance this extract further!"))
+		return ITEM_INTERACT_BLOCKING
+	if(istype(tool, /obj/item/slimepotion/enhancer/max))
+		to_chat(user, span_notice("You dump the maximizer on the slime extract. It can now be used a total of 5 times!"))
+		extract_uses = 5
+	else
+		to_chat(user, span_notice("You apply the enhancer to the slime extract. It may now be reused one more time."))
+		extract_uses++
+	qdel(tool)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/slime_extract/Initialize(mapload)
 	. = ..()
@@ -225,11 +226,11 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 			return 200
 		if(SLIME_ACTIVATE_MAJOR)
 			var/drink_type = get_random_drink()
-			var/obj/O = new drink_type
-			if(!user.put_in_active_hand(O))
-				O.forceMove(user.drop_location())
+			var/obj/tool = new drink_type
+			if(!user.put_in_active_hand(tool))
+				tool.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
+			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
 			return 200
 
 /obj/item/slime_extract/metal
@@ -240,19 +241,19 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 /obj/item/slime_extract/metal/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
-			var/obj/item/stack/sheet/glass/O = new(null, 5)
-			if(!user.put_in_active_hand(O))
-				O.forceMove(user.drop_location())
+			var/obj/item/stack/sheet/glass/tool = new(null, 5)
+			if(!user.put_in_active_hand(tool))
+				tool.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
+			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
 			return 150
 
 		if(SLIME_ACTIVATE_MAJOR)
-			var/obj/item/stack/sheet/iron/O = new(null, 5)
-			if(!user.put_in_active_hand(O))
-				O.forceMove(user.drop_location())
+			var/obj/item/stack/sheet/iron/tool = new(null, 5)
+			if(!user.put_in_active_hand(tool))
+				tool.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
+			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
 			return 200
 
 /obj/item/slime_extract/purple
@@ -281,11 +282,11 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 /obj/item/slime_extract/darkpurple/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
-			var/obj/item/stack/sheet/mineral/plasma/O = new(null, 1)
-			if(!user.put_in_active_hand(O))
-				O.forceMove(user.drop_location())
+			var/obj/item/stack/sheet/mineral/plasma/tool = new(null, 1)
+			if(!user.put_in_active_hand(tool))
+				tool.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
+			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
 			return 150
 
 		if(SLIME_ACTIVATE_MAJOR)
@@ -454,19 +455,19 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 /obj/item/slime_extract/lightpink/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
-			var/obj/item/slimepotion/renaming/O = new(null, 1)
-			if(!user.put_in_active_hand(O))
-				O.forceMove(user.drop_location())
+			var/obj/item/slimepotion/renaming/tool = new(null, 1)
+			if(!user.put_in_active_hand(tool))
+				tool.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
+			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
 			return 150
 
 		if(SLIME_ACTIVATE_MAJOR)
-			var/obj/item/slimepotion/sentience/O = new(null, 1)
-			if(!user.put_in_active_hand(O))
-				O.forceMove(user.drop_location())
+			var/obj/item/slimepotion/sentience/tool = new(null, 1)
+			if(!user.put_in_active_hand(tool))
+				tool.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
+			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
 			return 450
 
 /obj/item/slime_extract/black
@@ -585,21 +586,21 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
 			var/chosen = pick(difflist(subtypesof(/obj/item/toy/crayon),typesof(/obj/item/toy/crayon/spraycan)))
-			var/obj/item/O = new chosen(null)
-			if(!user.put_in_active_hand(O))
-				O.forceMove(user.drop_location())
+			var/obj/item/tool = new chosen(null)
+			if(!user.put_in_active_hand(tool))
+				tool.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
+			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
 			return 150
 
 		if(SLIME_ACTIVATE_MAJOR)
 			var/blacklisted_cans = list(/obj/item/toy/crayon/spraycan/borg, /obj/item/toy/crayon/spraycan/infinite)
 			var/chosen = pick(subtypesof(/obj/item/toy/crayon/spraycan) - blacklisted_cans)
-			var/obj/item/O = new chosen(null)
-			if(!user.put_in_active_hand(O))
-				O.forceMove(user.drop_location())
+			var/obj/item/tool = new chosen(null)
+			if(!user.put_in_active_hand(tool))
+				tool.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
+			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
 			return 250
 
 /obj/item/slime_extract/cerulean
@@ -629,11 +630,11 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 /obj/item/slime_extract/sepia/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
-			var/obj/item/camera/O = new(null, 1)
-			if(!user.put_in_active_hand(O))
-				O.forceMove(user.drop_location())
+			var/obj/item/camera/tool = new(null, 1)
+			if(!user.put_in_active_hand(tool))
+				tool.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
+			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
 			return 150
 
 		if(SLIME_ACTIVATE_MAJOR)
@@ -659,11 +660,11 @@ GLOBAL_LIST_INIT(slime_extract_auto_activate_reactions, init_slime_auto_activate
 
 		if(SLIME_ACTIVATE_MAJOR)
 			var/chosen = pick(subtypesof(/obj/item/slime_extract))
-			var/obj/item/O = new chosen(null)
-			if(!user.put_in_active_hand(O))
-				O.forceMove(user.drop_location())
+			var/obj/item/tool = new chosen(null)
+			if(!user.put_in_active_hand(tool))
+				tool.forceMove(user.drop_location())
 			playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
-			user.visible_message(span_warning("[user] spits out [O]!"), span_notice("You spit out [O]!"))
+			user.visible_message(span_warning("[user] spits out [tool]!"), span_notice("You spit out [tool]!"))
 			return 150
 
 ////Slime-derived potions///


### PR DESCRIPTION

## About The Pull Request

Converts anomaly refineries, tank compressors, doppler arrays, anomacores, slime extracts and crossbreeds from attackby() to item_interaction.

## Changelog
:cl:
refactor: Converted crossbreeds/anomacores/RND machinery to item_interaction
/:cl:
