### PR TITLE
Changes the access and contents from the shuttle engine crate, and adds a circuitboard/flatpack for it

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -63,6 +63,12 @@
 	req_components = list(
 		/datum/stock_part/servo = 1,)
 
+/obj/item/circuitboard/machine/shuttle_engine
+	name = "Shuttle Engine"
+	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
+	build_path = /obj/machinery/power/shuttle_engine/propulsion/burst
+	needs_anchored = FALSE
+
 /obj/item/circuitboard/machine/autolathe
 	name = "Autolathe"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -63,12 +63,6 @@
 	req_components = list(
 		/datum/stock_part/servo = 1,)
 
-/obj/item/circuitboard/machine/shuttle_engine
-	name = "Shuttle Engine"
-	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
-	build_path = /obj/machinery/power/shuttle_engine/propulsion/burst
-	needs_anchored = FALSE
-
 /obj/item/circuitboard/machine/autolathe
 	name = "Autolathe"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING

--- a/code/game/objects/items/flatpacks.dm
+++ b/code/game/objects/items/flatpacks.dm
@@ -172,6 +172,11 @@
 	board = /obj/item/circuitboard/machine/flatpacker
 	custom_premium_price = PAYCHECK_COMMAND
 
+/obj/item/flatpack/shuttle_engine
+	name = "shuttle engine"
+	board = /obj/item/circuitboard/machine/shuttle_engine
+	custom_premium_price = PAYCHECK_CREW * 2
+
 // Cargo flatpacks
 
 /obj/item/flatpack/mailsorter // to have a roundstart mail sorter at cargo

--- a/code/game/objects/items/flatpacks.dm
+++ b/code/game/objects/items/flatpacks.dm
@@ -173,8 +173,8 @@
 	custom_premium_price = PAYCHECK_COMMAND
 
 /obj/item/flatpack/shuttle_engine
-	name = "shuttle engine"
-	board = /obj/item/circuitboard/machine/shuttle_engine
+	name = "shuttle propulsion engine"
+	board = /obj/item/circuitboard/machine/engine/propulsion
 	custom_premium_price = PAYCHECK_CREW * 2
 
 // Cargo flatpacks

--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -99,11 +99,11 @@
 /datum/supply_pack/engineering/shuttle_engine
 	name = "Shuttle Engine Crate"
 	desc = "Through advanced bluespace-shenanigans, our engineers have managed to fit an entire \
-		shuttle engine into one tiny little crate."
+		shuttle engine into one tiny little box."
 	cost = CARGO_CRATE_VALUE * 6
-	access = ACCESS_CE
-	access_view = ACCESS_CE
-	contains = list(/obj/machinery/power/shuttle_engine/propulsion/burst)
+	access = ACCESS_ENGINEERING
+	access_view = ACCESS_ENGINEERING
+	contains = list(/obj/item/flatpack/shuttle_engine)
 	crate_name = "shuttle engine crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 


### PR DESCRIPTION
## About The Pull Request
This pr changes the access from CE access to Engineering
This pr adds a flatpack for the shuttle engine

## Why It's Good For The Game
I think from a worldbuilding perspective shuttle engine being CE locked is kinda rough since its mostly used for crew fueled projects which usually doesn't involve the CE and the least an engineer, i also made it a box which might be memier then the engine in a crate (engine in a comical small box) which lets you move it easier and conceal it easier when the crate open/closes unlike the engine itself

## Changelog
:cl: Ezel
qol: Shuttle engine access requirement changed from CE access to Engineering access.
qol: Shuttle engine now comes in a flatpack box (it does not come with a multitool)
/:cl:
