### PR TITLE
Fixes friendly wisps, wizard orbiting gravity anomalies & tesla periphery balls being disabled on shuttle transit

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -126,7 +126,7 @@
 	UnregisterSignal(source, COMSIG_ATOM_AFTER_SHUTTLE_MOVE)
 	begin_orbit(arglist(list(source) + orbiter_params[source]))
 
-/datum/component/orbiter/proc/end_orbit(atom/movable/orbiter, refreshing=FALSE)
+/datum/component/orbiter/proc/end_orbit(atom/movable/orbiter, refreshing = FALSE)
 	if(!orbiter_list[orbiter])
 		return
 	UnregisterSignal(orbiter, list(COMSIG_MOVABLE_MOVED, COMSIG_ATOM_BEFORE_SHUTTLE_MOVE, COMSIG_ATOM_AFTER_SHUTTLE_MOVE))
@@ -137,7 +137,7 @@
 	orbiter_list -= orbiter
 	if(!refreshing)
 		orbiter_params -= orbiter
-	orbiter.stop_orbit(src)
+	orbiter.stop_orbit(src, refreshing)
 	orbiter.orbiting = null
 
 	if(ismob(orbiter))
@@ -200,9 +200,11 @@
 	orbit_target = A
 	return A.AddComponent(/datum/component/orbiter, src, radius, clockwise, rotation_speed, rotation_segments, pre_rotation)
 
-/atom/movable/proc/stop_orbit(datum/component/orbiter/orbits)
+/atom/movable/proc/stop_orbit(datum/component/orbiter/orbits, refreshing = FALSE)
+	if(refreshing)
+		return //Only null the target if we're actually stopping the orbit for real, not if we're merely shuttle moving(or orbiting the same thing again). We will never get it back unless the orbit is fully deleted and reinstated.
 	orbit_target = null
-	return // We're just a simple hook
+
 
 /atom/proc/transfer_observers_to(atom/target)
 	if(!orbiters || !istype(target) || !get_turf(target) || target == src)

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
@@ -219,7 +219,7 @@
 		if(!living_mov.mob_negates_gravity())
 			step_towards(living_mov, wizard)
 
-/obj/effect/wizard_magnetism/stop_orbit(/datum/component/orbiter/orbiter, refreshing = FALSE)
+/obj/effect/wizard_magnetism/stop_orbit(datum/component/orbiter/orbiter, refreshing = FALSE)
 	if(refreshing)
 		return ..()
 	STOP_PROCESSING(SSprocessing, src)

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
@@ -219,7 +219,9 @@
 		if(!living_mov.mob_negates_gravity())
 			step_towards(living_mov, wizard)
 
-/obj/effect/wizard_magnetism/stop_orbit()
+/obj/effect/wizard_magnetism/stop_orbit(/datum/component/orbiter/orbiter, refreshing = FALSE)
+	if(refreshing)
+		return ..()
 	STOP_PROCESSING(SSprocessing, src)
 	qdel(src)
 

--- a/code/modules/mining/lavaland/mining_loot/consumables.dm
+++ b/code/modules/mining/lavaland/mining_loot/consumables.dm
@@ -96,8 +96,8 @@
 	ADD_TRAIT(being, TRAIT_THERMAL_VISION, REF(src))
 	being.update_sight()
 
-/obj/effect/wisp/stop_orbit(datum/component/orbiter/orbits)
-	if(!ismob(orbit_target))
+/obj/effect/wisp/stop_orbit(datum/component/orbiter/orbits, refreshing = FALSE)
+	if(!ismob(orbit_target) || refreshing)
 		return ..()
 	var/mob/being = orbit_target
 	UnregisterSignal(being, COMSIG_MOB_UPDATE_SIGHT)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -176,7 +176,9 @@
 		target.orbiting_balls += src
 	. = ..()
 
-/obj/energy_ball/stop_orbit()
+/obj/energy_ball/stop_orbit(/datum/component/orbiter/orbiters, refreshing = FALSE)
+	if(refreshing)
+		return ..()
 	if (orbiting && istype(orbiting.parent, /obj/energy_ball))
 		var/obj/energy_ball/orbitingball = orbiting.parent
 		orbitingball.orbiting_balls -= src

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -176,7 +176,7 @@
 		target.orbiting_balls += src
 	. = ..()
 
-/obj/energy_ball/stop_orbit(/datum/component/orbiter/orbiters, refreshing = FALSE)
+/obj/energy_ball/stop_orbit(datum/component/orbiter/orbiters, refreshing = FALSE)
 	if(refreshing)
 		return ..()
 	if (orbiting && istype(orbiting.parent, /obj/energy_ball))


### PR DESCRIPTION

## About The Pull Request

When something that is orbiting something travels on a shuttle with that thing, its orbit is temporarily removed and then put back right after. To make this happen, the orbiting component calls `stop_orbit()` (on the orbiting object) & then `begin_orbit()` (on itself, the component). This means that effects that begin in `orbit()` & delete their effects in `stop_orbit()` simply lose their effect without putting them back, because `orbit()` is never called again.

The solution presented is to pass the `refreshing` argument given in the component's `end_orbit()` into the atom's `stop_orbit()`, and condition actual deletion on that. The `refreshing` argument is `TRUE` only during shuttle movements and re-orbits of the same thing.

## Why It's Good For The Game

fixes #95331 & wizard grav anoms & tesla periphery balls

## Changelog
:cl:

fix: Friendly wisps, wizard gravity balls, & tesla periphery balls are no longer disabled due to shuttle transit

/:cl:
