### PR TITLE
Buffs blue and purple raptors a bit, and fixes chasm immunity bugs

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -145,6 +145,7 @@
 		return // We're already handling this
 
 	if(SEND_SIGNAL(dropped_thing, COMSIG_MOVABLE_CHASM_DROPPED, parent) & COMPONENT_NO_CHASM_DROP)
+		LAZYREMOVE(falling_atoms, falling_ref)
 		return
 
 	// Free (if possible) and drop all buckled mobs separately, so drivers can escape their doomed vehicle if they're not glued to it
@@ -184,6 +185,7 @@
 		if (get_turf(falling_mob) != get_turf(parent))
 			REMOVE_TRAIT(falling_mob, TRAIT_NO_TRANSFORM, REF(src))
 			falling_mob.Paralyze(17 SECONDS, ignore_canstun = TRUE) // Wow nice job
+			LAZYREMOVE(falling_atoms, falling_ref)
 			return
 
 	dropped_thing.visible_message(span_boldwarning("[dropped_thing] falls into [parent]!"), span_userdanger("[oblivion_message]"))
@@ -213,6 +215,7 @@
 		storage = (locate() in parent) || new(parent)
 
 	if(storage.contains(dropped_thing))
+		LAZYREMOVE(falling_atoms, falling_ref)
 		return
 
 	dropped_thing.alpha = oldalpha

--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_color.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_color.dm
@@ -197,8 +197,8 @@ GLOBAL_LIST_INIT(raptor_colors, init_raptor_colors())
 		COMSIG_RAPTOR_WINGS_OPENED, \
 		COMSIG_RAPTOR_WINGS_CLOSED, \
 		null, \
-		CALLBACK(src, PROC_REF(can_fly)), \
-		CALLBACK(src, PROC_REF(can_fly)), \
+		CALLBACK(src, PROC_REF(check_flight)), \
+		CALLBACK(src, PROC_REF(check_flight)), \
 	)
 
 /obj/item/mob_holder/purple_raptor/Destroy()
@@ -212,9 +212,11 @@ GLOBAL_LIST_INIT(raptor_colors, init_raptor_colors())
 	if ((slot & ITEM_SLOT_BACK) && ishuman(user) && flight_action)
 		flight_action.Grant(held_mob)
 		flight_action.GiveAction(user)
+		RegisterSignal(user, COMSIG_MOVABLE_CHASM_DROPPED, PROC_REF(chasm_react))
 
 /obj/item/mob_holder/purple_raptor/dropped(mob/user, silent)
 	. = ..()
+	UnregisterSignal(user, COMSIG_MOVABLE_CHASM_DROPPED)
 	if (wings_open)
 		toggle_wings(user)
 	// Removed in Destroy()
@@ -232,7 +234,7 @@ GLOBAL_LIST_INIT(raptor_colors, init_raptor_colors())
 		source.remove_movespeed_modifier(/datum/movespeed_modifier/jetpack/raptor)
 		source.add_movespeed_modifier(/datum/movespeed_modifier/jetpack/raptor/slow)
 
-/obj/item/mob_holder/purple_raptor/proc/can_fly()
+/obj/item/mob_holder/purple_raptor/proc/can_fly(silent = FALSE)
 	var/mob/living/carbon/human/user = loc
 	if (!istype(user) || user.stat || user.body_position == LYING_DOWN || isnull(user.client))
 		return FALSE
@@ -245,8 +247,12 @@ GLOBAL_LIST_INIT(raptor_colors, init_raptor_colors())
 	if (environment?.return_pressure() >= HAZARD_LOW_PRESSURE + 10)
 		return TRUE
 
-	to_chat(user, span_warning("The atmosphere is too thin for you to fly!"))
+	if (!silent)
+		to_chat(user, span_warning("The atmosphere is too thin for you to fly!"))
 	return FALSE
+
+/obj/item/mob_holder/purple_raptor/proc/check_flight()
+	return can_fly(silent = TRUE)
 
 /obj/item/mob_holder/purple_raptor/proc/toggle_wings(mob/living/carbon/human/user)
 	// In case something goes wrong
@@ -299,8 +305,18 @@ GLOBAL_LIST_INIT(raptor_colors, init_raptor_colors())
 	UnregisterSignal(user, list(COMSIG_HUMAN_HEIGHT_UPDATED, SIGNAL_ADDTRAIT(TRAIT_FAT), SIGNAL_REMOVETRAIT(TRAIT_FAT)))
 	SEND_SIGNAL(src, COMSIG_RAPTOR_WINGS_CLOSED, user)
 
+/obj/item/mob_holder/purple_raptor/proc/chasm_react(mob/living/user, turf/chasm)
+	SIGNAL_HANDLER
+
+	if (wings_open || !can_fly())
+		return
+
+	toggle_wings(user)
+	if (wings_open)
+		return COMPONENT_NO_CHASM_DROP
+
 /obj/item/mob_holder/purple_raptor/process(seconds_per_tick)
-	if (!can_fly())
+	if (!can_fly(silent = TRUE))
 		toggle_wings(loc)
 		return PROCESS_KILL
 
@@ -406,6 +422,7 @@ GLOBAL_LIST_INIT(raptor_colors, init_raptor_colors())
 /datum/raptor_color/blue
 	color = "blue"
 	description = "Covered in tough, lava-resistant feathers with thick insulated fur underneath, this breed is capable of marching through lava and fire alike."
+	health = 300
 	guaranteed_crossbreeds = list(
 		/datum/raptor_color/red = /datum/raptor_color/purple,
 		/datum/raptor_color/white = /datum/raptor_color/green,


### PR DESCRIPTION

## About The Pull Request

Increases blue raptors' HP to 300, and makes purple raptors automatically initiate flight if you are about to fall into a chasm while wearing one on your back.

Also fixes 2 exploits involving chasms which would render you immune to that particular chasm.

## Why It's Good For The Game

I've had some feedback on raptors, and more specifically how blue and purples are rather underwhelming, former only being a single feature from old raptors and latter not providing much of a benefit to non-settlers. This should address both of those, making blues a bit tankier and purples being able to save you from an instant death.

## Changelog
:cl:
balance: Blue raptors had their HP increased from 220 to 300
balance: Purple raptors now automatically start flying if the owner is about to fall into a chasm.
fix: Fixed 2 exploits which would render you immune to falling down a specific chasm.
/:cl:
