### PR TITLE
The random supply drop event can now contain goodies and will not runtime.

### DIFF
--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -62,6 +62,10 @@
 	user.visible_message(span_suicide("[user] looks overwhelmed with paperwork! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return OXYLOSS
 
+// Empty subtype
+/obj/item/storage/briefcase/empty/PopulateContents()
+	return
+
 /obj/item/storage/briefcase/sniper
 	desc = "Its label reads \"genuine hardened Captain leather\", but suspiciously has no other tags or branding. Smells like L'Air du Temps."
 	force = 10

--- a/code/modules/cargo/packs/_packs.dm
+++ b/code/modules/cargo/packs/_packs.dm
@@ -54,7 +54,7 @@
  * @ datum/bank_account/paying_account: The account to associate the supply pack with when going and generating the crate. Only the paying account can open said secure crate/case.
  * @ crate_override: If defined, we will fill our supply pack with this object. This is used for when we need to spawn a random crate but the contents are goodies or we don't need a full crate.
  */
-/datum/supply_pack/proc/generate(atom/A, datum/bank_account/paying_account, crate_override = null)
+/datum/supply_pack/proc/generate(atom/A, datum/bank_account/paying_account, crate_override)
 	var/obj/structure/closet/crate/C
 	if(paying_account)
 		C = new /obj/structure/closet/crate/secure/owned(A, paying_account)

--- a/code/modules/cargo/packs/_packs.dm
+++ b/code/modules/cargo/packs/_packs.dm
@@ -52,14 +52,20 @@
  *
  * @ atom/A: The location or turf that the pack is being generated onto. Cargo shuttle provides an empty turf, other generate()s call this either null or otherwise.
  * @ datum/bank_account/paying_account: The account to associate the supply pack with when going and generating the crate. Only the paying account can open said secure crate/case.
+ * @ crate_override: If defined, we will fill our supply pack with this object. This is used for when we need to spawn a random crate but the contents are goodies or we don't need a full crate.
  */
-/datum/supply_pack/proc/generate(atom/A, datum/bank_account/paying_account)
+/datum/supply_pack/proc/generate(atom/A, datum/bank_account/paying_account, crate_override = null)
 	var/obj/structure/closet/crate/C
 	if(paying_account)
 		C = new /obj/structure/closet/crate/secure/owned(A, paying_account)
 		C.name = "[crate_name] - Purchased by [paying_account.account_holder]"
-	else if(!crate_type)
+	else if(!crate_type && !crate_override)
 		CRASH("tried to generate a supply pack without a valid crate type")
+	else if(crate_override)
+		var/obj/unique_container = new crate_override
+		fill(unique_container)
+		return unique_container
+
 	else
 		C = new crate_type(A)
 		C.name = crate_name
@@ -75,12 +81,16 @@
 	. = cost
 	. *= SSeconomy.pack_price_modifier
 
-/datum/supply_pack/proc/fill(obj/structure/closet/crate/C)
+/**
+ * Takes a provided container, iterates, and spawns the full quantity of items within it, and applies and necessary status effects when the crate is populated.
+ * @ container: The container holding the contents of the supply pack. Most typically a obj/structure/closet/crate, but can technically be anything.
+ */
+/datum/supply_pack/proc/fill(obj/container)
 	for(var/item in contains)
 		if(!contains[item])
 			contains[item] = 1
 		for(var/iteration = 1 to contains[item])
-			var/atom/A = new item(C)
+			var/atom/A = new item(container)
 			if(!(order_flags & ORDER_ADMIN_SPAWNED))
 				continue
 			A.flags_1 |= ADMIN_SPAWNED_1
@@ -165,13 +175,13 @@
 		//We decrease the quantity only after adjusting our prices for accurate values
 		SSstock_market.adjust_material_quantity(material_type, -available_quantity)
 
-/datum/supply_pack/custom/minerals/fill(obj/structure/closet/crate/C)
+/datum/supply_pack/custom/minerals/fill(obj/container)
 	for(var/obj/item/stack/sheet/possible_stack as anything in contains)
 		//spawn the ordered stack inside the crate
 		var/sheets_to_spawn = contains[possible_stack]
 		while(sheets_to_spawn)
 			var/spawn_quantity = min(sheets_to_spawn, MAX_STACK_SIZE)
-			var/obj/item/stack/sheet/ordered_stack = new possible_stack(C, spawn_quantity)
+			var/obj/item/stack/sheet/ordered_stack = new possible_stack(container, spawn_quantity)
 			if(order_flags & ORDER_ADMIN_SPAWNED)
 				ordered_stack.flags_1 |= ADMIN_SPAWNED_1
 			sheets_to_spawn -= spawn_quantity

--- a/code/modules/cargo/packs/costumes_toys.dm
+++ b/code/modules/cargo/packs/costumes_toys.dm
@@ -33,11 +33,11 @@
 	discountable = SUPPLY_PACK_RARE_DISCOUNTABLE
 	test_ignored = TRUE
 
-/datum/supply_pack/costumes_toys/randomised/fill(obj/structure/closet/crate/C)
+/datum/supply_pack/costumes_toys/randomised/fill(obj/container)
 	var/list/L = contains.Copy()
 	for(var/i in 1 to num_contained)
 		var/item = pick_n_take(L)
-		new item(C)
+		new item(container)
 
 /datum/supply_pack/costumes_toys/formalwear
 	name = "Formalwear Crate"
@@ -167,11 +167,11 @@
 	crate_name = "standard costume crate"
 	crate_type = /obj/structure/closet/crate/wooden
 
-/datum/supply_pack/costumes_toys/costume/fill(obj/structure/closet/crate/C)
+/datum/supply_pack/costumes_toys/costume/fill(obj/container)
 	..()
 	var/funny_gas_internals
 	funny_gas_internals = pick(subtypesof(/obj/item/tank/internals/emergency_oxygen/engi/clown) - /obj/item/tank/internals/emergency_oxygen/engi/clown)
-	new funny_gas_internals(C)
+	new funny_gas_internals(container)
 
 /datum/supply_pack/costumes_toys/randomised/toys
 	name = "Toy Crate"
@@ -184,14 +184,14 @@
 	crate_name = "toy crate"
 	crate_type = /obj/structure/closet/crate/wooden
 
-/datum/supply_pack/costumes_toys/randomised/toys/fill(obj/structure/closet/crate/C)
+/datum/supply_pack/costumes_toys/randomised/toys/fill(obj/container)
 	var/the_toy
 	for(var/i in 1 to num_contained)
 		if(prob(50))
 			the_toy = pick_weight(GLOB.arcade_prize_pool)
 		else
 			the_toy = /obj/effect/spawner/random/entertainment/plushie_delux
-		new the_toy(C)
+		new the_toy(container)
 
 /datum/supply_pack/costumes_toys/wizard
 	name = "Wizard Costume Crate"
@@ -237,11 +237,11 @@
 	crate_name = "booster pack pack"
 	discountable = SUPPLY_PACK_STD_DISCOUNTABLE
 
-/datum/supply_pack/costumes_toys/randomised/tcg/fill(obj/structure/closet/crate/C)
+/datum/supply_pack/costumes_toys/randomised/tcg/fill(obj/container)
 	var/cardpacktype
 	for(var/i in 1 to 10)
 		cardpacktype = pick(subtypesof(/obj/item/cardpack))
-		new cardpacktype(C)
+		new cardpacktype(container)
 
 /datum/supply_pack/costumes_toys/stickers
 	name = "Sticker Pack Crate"

--- a/code/modules/cargo/packs/exploration.dm
+++ b/code/modules/cargo/packs/exploration.dm
@@ -37,6 +37,6 @@
 	crate_name = "shrubbery crate"
 	var/shrub_amount = 8
 
-/datum/supply_pack/exploration/shrubbery/fill(obj/structure/closet/crate/C)
+/datum/supply_pack/exploration/shrubbery/fill(obj/container)
 	for(var/i in 1 to shrub_amount)
-		new /obj/item/grown/shrub(C)
+		new /obj/item/grown/shrub(container)

--- a/code/modules/cargo/packs/general.dm
+++ b/code/modules/cargo/packs/general.dm
@@ -221,7 +221,7 @@
 	var/contents_uplink_type = UPLINK_TRAITORS
 
 ///Generate assorted uplink items, taking into account the same surplus modifiers used for surplus crates
-/datum/supply_pack/misc/syndicate/fill(obj/structure/closet/crate/C)
+/datum/supply_pack/misc/syndicate/fill(obj/container)
 	var/list/uplink_items = list()
 	for(var/datum/uplink_item/item as anything in SStraitor.uplink_items)
 		if(item.purchasable_from & contents_uplink_type && item.item)
@@ -236,7 +236,7 @@
 		if(crate_value < uplink_item.cost)
 			continue
 		crate_value -= uplink_item.cost
-		new uplink_item.item(C)
+		new uplink_item.item(container)
 
 ///Syndicate supply crate that can have its contents value changed by admins, uses a seperate datum to avoid having admins touch the original one.
 /datum/supply_pack/misc/syndicate/custom_value

--- a/code/modules/cargo/packs/general.dm
+++ b/code/modules/cargo/packs/general.dm
@@ -159,7 +159,7 @@
 	crate_type = null
 	special_pod = /obj/structure/closet/supplypod/bluespacepod
 
-/datum/supply_pack/misc/empty/generate(atom/A, datum/bank_account/paying_account)
+/datum/supply_pack/misc/empty/generate(atom/A, datum/bank_account/paying_account, crate_override)
 	return
 
 /datum/supply_pack/misc/religious_supplies

--- a/code/modules/cargo/packs/imports.dm
+++ b/code/modules/cargo/packs/imports.dm
@@ -89,7 +89,7 @@
 	crate_name = "putrid dumpster"
 	crate_type = /obj/structure/closet/crate/trashcart
 
-/datum/supply_pack/imports/dumpstercorpse/generate()
+/datum/supply_pack/imports/dumpstercorpse/generate(atom/A, datum/bank_account/paying_account, crate_override)
 	. = ..()
 	var/mob/living/carbon/human/corpse = locate() in .
 	corpse.death()

--- a/code/modules/cargo/packs/livestock.dm
+++ b/code/modules/cargo/packs/livestock.dm
@@ -9,7 +9,7 @@
 	contains = list(/mob/living/basic/parrot)
 	crate_name = "parrot crate"
 
-/datum/supply_pack/critter/parrot/generate()
+/datum/supply_pack/critter/parrot/generate(atom/A, datum/bank_account/paying_account, crate_override)
 	. = ..()
 	for(var/i in 1 to 4)
 		new /mob/living/basic/parrot(.)
@@ -22,7 +22,7 @@
 	contains = list(/mob/living/basic/butterfly)
 	crate_name = "entomology samples crate"
 
-/datum/supply_pack/critter/butterfly/generate()
+/datum/supply_pack/critter/butterfly/generate(atom/A, datum/bank_account/paying_account, crate_override)
 	. = ..()
 	for(var/i in 1 to 49)
 		new /mob/living/basic/butterfly(.)
@@ -38,7 +38,7 @@
 	)
 	crate_name = "cat crate"
 
-/datum/supply_pack/critter/cat/generate()
+/datum/supply_pack/critter/cat/generate(atom/A, datum/bank_account/paying_account, crate_override)
 	. = ..()
 	if(!prob(50))
 		return
@@ -65,7 +65,7 @@
 				)
 	crate_name = "corgi crate"
 
-/datum/supply_pack/critter/corgi/generate()
+/datum/supply_pack/critter/corgi/generate(atom/A, datum/bank_account/paying_account, crate_override)
 	. = ..()
 	if(prob(50))
 		var/mob/living/basic/pet/dog/corgi/D = locate() in .
@@ -115,7 +115,7 @@
 	crate_name = "look sir free crabs"
 	order_flags = ORDER_POD_ONLY
 
-/datum/supply_pack/critter/crab/generate()
+/datum/supply_pack/critter/crab/generate(atom/A, datum/bank_account/paying_account, crate_override)
 	. = ..()
 	for(var/i in 1 to 49)
 		new /mob/living/basic/crab(.)
@@ -224,7 +224,7 @@
 	crate_name = "garden gnome crate"
 	discountable = SUPPLY_PACK_RARE_DISCOUNTABLE
 
-/datum/supply_pack/critter/garden_gnome/generate()
+/datum/supply_pack/critter/garden_gnome/generate(atom/A, datum/bank_account/paying_account, crate_override)
 	. = ..()
 	for(var/i in 1 to 2)
 		new /mob/living/basic/garden_gnome(.)

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -116,10 +116,10 @@
 	crate_type = /obj/structure/closet/crate/medical
 	test_ignored = TRUE
 
-/datum/supply_pack/medical/supplies/fill(obj/structure/closet/crate/C)
+/datum/supply_pack/medical/supplies/fill(obj/container)
 	for(var/i in 1 to 10)
 		var/item = pick(contains)
-		new item(C)
+		new item(container)
 
 /datum/supply_pack/medical/experimentalmedicine
 	name = "Experimental Medicine Crate"

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -36,10 +36,10 @@
 	test_ignored = TRUE
 	crate_name = "food crate"
 
-/datum/supply_pack/organic/randomized/fill(obj/structure/closet/crate/C)
+/datum/supply_pack/organic/randomized/fill(obj/container)
 	for(var/i in 1 to 15)
 		var/item = pick(contains)
-		new item(C)
+		new item(container)
 
 /datum/supply_pack/organic/randomized/chef
 	name = "Excellent Meat Crate"

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -230,10 +230,10 @@
 	crate_name = "donk pocket crate"
 	crate_type = /obj/structure/closet/crate/freezer/food
 
-/datum/supply_pack/service/randomized/donkpockets/fill(obj/structure/closet/crate/C)
+/datum/supply_pack/service/randomized/donkpockets/fill(obj/container)
 	for(var/i in 1 to 3)
 		var/item = pick(contains)
-		new item(C)
+		new item(container)
 
 /datum/supply_pack/service/randomized/ready_donk
 	name = "Ready-Donk Variety Crate"
@@ -252,10 +252,10 @@
 	crate_type = /obj/structure/closet/crate/freezer/donk
 	discountable = SUPPLY_PACK_UNCOMMON_DISCOUNTABLE
 
-/datum/supply_pack/service/randomized/ready_donk/fill(obj/structure/closet/crate/C)
+/datum/supply_pack/service/randomized/ready_donk/fill(obj/container)
 	for(var/i in 1 to 3)
 		var/item = pick(contains)
-		new item(C)
+		new item(container)
 
 /datum/supply_pack/service/coffeekit
 	name = "Coffee Equipment Crate"

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -96,12 +96,18 @@
 			supply_pack = admin_override_contents //Syndicate crates create a new datum while being customized which will result in this being triggered. Outside of this situation this should never trigger
 		else
 			supply_pack = SSshuttle.supply_packs[pack_type]
-	var/obj/structure/closet/crate/crate = supply_pack.generate(null)
-	if(crate) //empty supply packs are a thing! get memed on.
+
+	var/storage_override
+	if(initial(supply_pack.order_flags) & ORDER_GOODY) // We offer goody items inside of briefcases, but regular crates still default to their standard crates.
+		storage_override = /obj/item/storage/briefcase/empty
+	var/obj/container = supply_pack.generate(null, crate_override = storage_override)
+
+	if(container && istype(container, /obj/structure/closet/crate)) //empty supply packs are a thing! get memed on.
+		var/obj/structure/closet/crate/crate = container
 		crate.locked = FALSE //Unlock secure crates
 		crate.update_appearance()
 	var/obj/structure/closet/supplypod/pod = make_pod()
-	var/obj/effect/pod_landingzone/landing_marker = new(landing_zone, pod, crate)
+	var/obj/effect/pod_landingzone/landing_marker = new(landing_zone, pod, container)
 	var/static/mutable_appearance/target_appearance = mutable_appearance('icons/obj/supplypods_32x32.dmi', "LZ")
 	notify_ghosts("[control.name] has summoned a supply crate!", source = get_turf(landing_marker), header = "Cargo Inbound", alert_overlay = target_appearance)
 


### PR DESCRIPTION
## About The Pull Request

This PR tweaks how supply_packs' `generate` and `fill` procs function, so that they do not default to needing to be spawned with a crate specifically in order to properly spawn.

What this allows is for the random supply drop event to be able to spawn in with a non-crate container, such as an empty briefcase.

## Why It's Good For The Game

Ran into the random runtime while I was testing something non-cargo related, and was considering having a non-crate supply crate for #95393, but decided against it. Took this as a sign that I should implement it anyway.

Plus, this will add even more variety to the random supply drop event's results.

## Changelog

:cl:
code: supply packs can now be spawned using containers different than a crate.
fix: The Random Supply Drop event can now spawn their items as opposed to runtiming.
/:cl: