### PR TITLE
Prevents a runtime when something other than a player mob breaks an airlock

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -486,6 +486,8 @@
 /obj/machinery/door/airlock/shock(mob/living/shocking, chance, shock_source, siemens_coeff)
 	if(!hasPower()) // unpowered, no shock
 		return FALSE
+	if(!isliving(shocking))
+		return FALSE
 	if(HAS_TRAIT(shocking, TRAIT_AIRLOCK_SHOCKIMMUNE)) // Be a bit more clever man come on
 		return FALSE
 	if(!COOLDOWN_FINISHED(src, shockCooldown))


### PR DESCRIPTION

## About The Pull Request

adds an `isliving()` check in airlock's `shock()`. Wires generally call `[object].shock(usr, ...)`. The `shocking` argument is `isliving()`ed in the base `shock()`, but airlocks need it checked before that. Unfortunate that it must be checked twice in quick succession, but I can think of no less wasteful way. 

## Why It's Good For The Game

closes #95385

## Changelog
:cl:

code: fixed a runtime when something other than a player breaks an airlock

/:cl:
