### PR TITLE
Fix Pun Pun's name

### DIFF
--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -55,24 +55,19 @@ GLOBAL_DATUM(the_one_and_only_punpun, /mob/living/carbon/human/species/monkey/pu
 		new /obj/effect/landmark/start/pun_pun(loc) //Pun Pun is a crewmember, and may late-join.
 		return INITIALIZE_HINT_QDEL
 
-	Read_Memory()
+	equip_to_slot_or_del(new /obj/item/clothing/under/suit/waiter(src), ITEM_SLOT_ICLOTHING)
+
 	if(!GLOB.the_one_and_only_punpun && mapload)
 		GLOB.the_one_and_only_punpun = src
+		Read_Memory()
+
 	else if(GLOB.the_one_and_only_punpun)
 		ADD_TRAIT(src, TRAIT_DONT_WRITE_MEMORY, INNATE_TRAIT) //faaaaaaake!
 
+	// Everything past here MUST be called AFTER memory has been read
 	give_special_name()
-
-	//These have to be after the parent new to ensure that the monkey
-	//bodyparts are actually created before we try to equip things to
-	//those slots
-	if(ancestor_chain > 1)
-		generate_fake_scars(rand(ancestor_chain, ancestor_chain * 4))
-	if(relic_hat)
-		equip_to_slot_or_del(new relic_hat, ITEM_SLOT_HEAD)
-	if(relic_mask)
-		equip_to_slot_or_del(new relic_mask, ITEM_SLOT_MASK)
-	equip_to_slot_or_del(new /obj/item/clothing/under/suit/waiter(src), ITEM_SLOT_ICLOTHING)
+	give_scars()
+	give_special_equipment()
 
 /mob/living/carbon/human/species/monkey/punpun/Destroy()
 	if(GLOB.the_one_and_only_punpun == src)
@@ -131,14 +126,15 @@ GLOBAL_DATUM(the_one_and_only_punpun, /mob/living/carbon/human/species/monkey/pu
 	WRITE_FILE(json_file, json_encode(file_data))
 
 
-/// Gives pun pun a special name based on various factors
+/// Gives pun pun a special name based on various factors such as their past
 /mob/living/carbon/human/species/monkey/punpun/proc/give_special_name()
-	var/name_to_use = name
+	var/name_to_use = initial(name)
 
 	if(ancestor_name)
 		name_to_use = ancestor_name
 		if(ancestor_chain > 1)
 			name_to_use += " \Roman[ancestor_chain]"
+
 	else if(prob(10))
 		name_to_use = pick(list("Professor Bobo", "Deempisi's Revenge", "Furious George", "King Louie", "Dr. Zaius", "Jimmy Rustles", "Dinner", "Lanky"))
 		if(name_to_use == "Furious George")
@@ -146,3 +142,15 @@ GLOBAL_DATUM(the_one_and_only_punpun, /mob/living/carbon/human/species/monkey/pu
 			ai_controller = new /datum/ai_controller/monkey/angry(src) //hes always mad
 
 	fully_replace_character_name(real_name, name_to_use)
+
+/// Gives pun pun scars based on how many times he's died in the past
+/mob/living/carbon/human/species/monkey/punpun/proc/give_scars()
+	if(ancestor_chain > 1)
+		generate_fake_scars(rand(ancestor_chain, ancestor_chain * 4))
+
+/// Gives pun pun special equipment from their past
+/mob/living/carbon/human/species/monkey/punpun/proc/give_special_equipment()
+	if(relic_hat)
+		equip_to_slot_or_del(new relic_hat, ITEM_SLOT_HEAD)
+	if(relic_mask)
+		equip_to_slot_or_del(new relic_mask, ITEM_SLOT_MASK)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -263,6 +263,7 @@
 #include "preference_species.dm"
 #include "preferences.dm"
 #include "projectiles.dm"
+#include "punpun.dm"
 #include "quirks.dm"
 #include "range_return.dm"
 #include "rcd.dm"

--- a/code/modules/unit_tests/punpun.dm
+++ b/code/modules/unit_tests/punpun.dm
@@ -1,0 +1,5 @@
+/datum/unit_test/punpun_name
+
+/datum/unit_test/punpun_name/Run()
+	var/mob/living/carbon/human/species/monkey/punpun/punpun = EASY_ALLOCATE()
+	TEST_ASSERT_EQUAL(punpun.name, initial(punpun.name), "Pun Pun did not have [punpun.p_their()] name set")


### PR DESCRIPTION

## About The Pull Request

Moving Pun Pun's name handling in #94463 broke their name assignment as it used `var/name_to_use = name`

Prior, it would save `var/name_to_use = "Pun Pun"`. But after moving it, it would use `var/name_to_use = "monkey (842)"`, as name is randomized in human init. 

I will note that I think `use_random_name` var is broken... that may require future investigation. 

## Changelog

:cl: Melbert
fix: Pun Pun is Pun Pun again
/:cl:

