### PR TITLE
Fix pda cargo app being unable to order autogenerated supply packs

### DIFF
--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -215,7 +215,7 @@
 				user.log_message("accepted a shuttle loan event.", LOG_GAME)
 				. = TRUE
 		if("add")
-			var/id = text2path(params["id"])
+			var/id = text2path(params["id"]) || params["id"]
 			var/datum/supply_pack/pack = SSshuttle.supply_packs[id]
 			if(!istype(pack))
 				return


### PR DESCRIPTION
## About The Pull Request

No one ever added support for supply packs that use a non-standard id to the app. 

~~This could all be avoided if we didn't **copy paste ordering code in two places**~~

## Changelog

:cl: Melbert
fix: Fix cargo ordering app (on pdas and modular computers) from being unable to order some things
/:cl:

