### PR TITLE
Makes vitals display available in ancient lathes

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -1400,7 +1400,7 @@
 		Links to stasis beds, operating tables, and other machines that can hold patients \
 		such as cryo cells, sleepers, and more."
 	id = "vitals_monitor"
-	build_type = PROTOLATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 4,
 		/datum/material/glass = SHEET_MATERIAL_AMOUNT * 2,


### PR DESCRIPTION

## About The Pull Request
Not sure if it is oversight or because of some valid balancing concern, but this PR just enables display's design to be able to be printed in golems and charlie station lathes
## Why It's Good For The Game
Existence of this item in ghostroles' hands wont impact balancing in any way, as opposed to other locked items such as shuttle parts crew pointers (which, gonna be honest, wont impact said balance either, but whatever). Vitals display is just too cool of a thing to make it limited just for station's people.
## Changelog
:cl:
add: Vitals display can be printed in ancient lathes
/:cl:
