### PR TITLE
Barcode scanner now lets you check books out

### DIFF
--- a/code/__DEFINES/paper.dm
+++ b/code/__DEFINES/paper.dm
@@ -14,9 +14,6 @@
 /// Should be able to stamp paper.
 #define MODE_STAMPING 2
 
-#define BARCODE_SCANNER_CHECKIN "check_in"
-#define BARCODE_SCANNER_INVENTORY "inventory"
-
 #define IS_WRITING_UTENSIL(thing) (thing?.get_writing_implement_details()?["interaction_mode"] == MODE_WRITING)
 
 /**

--- a/code/modules/library/barcode_scanner.dm
+++ b/code/modules/library/barcode_scanner.dm
@@ -1,3 +1,7 @@
+#define BARCODE_SCANNER_CHECKIN "check_in"
+#define BARCODE_SCANNER_CHECKOUT "check_out"
+#define BARCODE_SCANNER_INVENTORY "inventory"
+
 /obj/item/barcodescanner
 	name = "barcode scanner"
 	icon = 'icons/obj/service/library.dmi'
@@ -9,7 +13,7 @@
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2)
 	///Weakref to the library computer we are connected to.
 	var/datum/weakref/computer_ref
-	///The current scanning mode (BARCODE_SCANNER_CHECKIN|BARCODE_SCANNER_INVENTORY)
+	///The current scanning mode (BARCODE_SCANNER_CHECKIN|BARCODE_SCANNER_CHECKOUT|BARCODE_SCANNER_INVENTORY)
 	var/scan_mode = BARCODE_SCANNER_CHECKIN
 
 /obj/item/barcodescanner/Initialize(mapload)
@@ -24,6 +28,8 @@
 	switch(scan_mode)
 		if(BARCODE_SCANNER_CHECKIN)
 			context[SCREENTIP_CONTEXT_LMB] = "Check in"
+		if(BARCODE_SCANNER_CHECKOUT)
+			context[SCREENTIP_CONTEXT_LMB] = "Check out"
 		if(BARCODE_SCANNER_INVENTORY)
 			context[SCREENTIP_CONTEXT_LMB] = "Add to inventory"
 	return CONTEXTUAL_SCREENTIP_SET
@@ -61,6 +67,23 @@
 			user.balloon_alert(user, "isn't checked out!")
 			return ITEM_INTERACT_BLOCKING
 
+		if(BARCODE_SCANNER_CHECKOUT)
+			var/list/checkouts = linked_computer.checkouts
+			for(var/checkout_ref in checkouts)
+				var/datum/borrowbook/maybe_ours = checkouts[checkout_ref]
+				if(target_book.book_data.compare(maybe_ours.book_data))
+					user.balloon_alert(user, "already checked out!")
+					return ITEM_INTERACT_BLOCKING
+			for(var/copy_ref in linked_computer.inventory)
+				if(!target_book.book_data.compare(linked_computer.inventory[copy_ref]))
+					continue
+				linked_computer.checking_out_book = target_book.book_data
+				balloon_alert(user, "set for check out")
+				playsound(src, 'sound/items/barcodebeep.ogg', 20, FALSE)
+				return ITEM_INTERACT_SUCCESS
+			user.balloon_alert(user, "not in inventory!")
+			return ITEM_INTERACT_BLOCKING
+
 		if(BARCODE_SCANNER_INVENTORY)
 			var/datum/book_info/our_copy = target_book.book_data.return_copy()
 			linked_computer.inventory[ref(our_copy)] = our_copy
@@ -80,9 +103,16 @@
 		return
 	switch(scan_mode)
 		if(BARCODE_SCANNER_CHECKIN)
+			scan_mode = BARCODE_SCANNER_CHECKOUT
+			balloon_alert(user, "check-out mode")
+		if(BARCODE_SCANNER_CHECKOUT)
 			scan_mode = BARCODE_SCANNER_INVENTORY
 			balloon_alert(user, "inventory adding mode")
 		if(BARCODE_SCANNER_INVENTORY)
 			scan_mode = BARCODE_SCANNER_CHECKIN
 			balloon_alert(user, "check-in mode")
 	playsound(loc, 'sound/items/click.ogg', 20, TRUE)
+
+#undef BARCODE_SCANNER_CHECKIN
+#undef BARCODE_SCANNER_CHECKOUT
+#undef BARCODE_SCANNER_INVENTORY

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -309,6 +309,8 @@ GLOBAL_VAR_INIT(library_table_modified, 0)
 	var/dynamic_inv_load = FALSE
 	///Book scanner that will be used when uploading books to the Archive
 	var/datum/weakref/scanner
+	///Name of the book we're checking out, given by barcodes or the UI.
+	var/datum/book_info/checking_out_book
 	///Our cooldown on using the printer
 	COOLDOWN_DECLARE(printer_cooldown)
 	///Our cooldown on publishing books to the newscaster's "book club" channel
@@ -370,6 +372,7 @@ GLOBAL_VAR_INIT(library_table_modified, 0)
 			data["has_checkout"] = !!checkout_len
 			data["checkout_page"] = checkout_page + 1
 			data["checkout_page_count"] = checkout_page_count + 1
+			data["checkout_title"] = checking_out_book?.get_title() || null
 
 		//Copypasta from the visitor console
 		if(LIBRARY_ARCHIVE)
@@ -449,6 +452,19 @@ GLOBAL_VAR_INIT(library_table_modified, 0)
 			update_static_data_for_all_viewers()
 			return TRUE
 		if("checkout")
+			if(isnull(checking_out_book))
+				return TRUE
+			var/datum/borrowbook/loan = new /datum/borrowbook
+			var/loan_to = copytext(sanitize(params["loaned_to"]), 1, MAX_NAME_LEN)
+			var/checkoutperiod = max(params["checkout_time"], 1)
+			loan.book_data = checking_out_book.return_copy()
+			loan.loanedto = loan_to
+			loan.checkout = world.time
+			loan.duedate = world.time + (checkoutperiod MINUTES)
+			checkouts[ref(loan)] = loan
+			checkout_update()
+			return TRUE
+		if("set_checkout")
 			var/list/available = list()
 			for(var/id in inventory)
 				var/datum/book_info/book_infos = inventory[id]
@@ -459,17 +475,7 @@ GLOBAL_VAR_INIT(library_table_modified, 0)
 			var/datum/book_info/book_info = available[book_name]
 			if(!istype(book_info))
 				return
-			var/datum/borrowbook/loan = new /datum/borrowbook
-
-			var/loan_to = copytext(sanitize(params["loaned_to"]), 1, MAX_NAME_LEN)
-			var/checkoutperiod = max(params["checkout_time"], 1)
-
-			loan.book_data = book_info.return_copy()
-			loan.loanedto = loan_to
-			loan.checkout = world.time
-			loan.duedate = world.time + (checkoutperiod MINUTES)
-			checkouts[ref(loan)] = loan
-			checkout_update()
+			checking_out_book = book_info
 			return TRUE
 		if("checkin")
 			var/id = params["checked_out_id"]

--- a/tgui/packages/tgui/interfaces/LibraryConsole/screens/Checkout.tsx
+++ b/tgui/packages/tgui/interfaces/LibraryConsole/screens/Checkout.tsx
@@ -65,6 +65,7 @@ export function Checkout(props) {
 
 function CheckoutModal(props) {
   const { act, data } = useBackend<LibraryConsoleData>();
+  const { checkout_title } = data;
 
   const inventory = data.inventory
     .map((book, i) => ({
@@ -77,7 +78,6 @@ function CheckoutModal(props) {
   const { checkoutBookState } = useLibraryContext();
   const [checkoutBook, setCheckoutBook] = checkoutBookState;
 
-  const [bookName, setBookName] = useState('Insert Book name...');
   const [checkoutee, setCheckoutee] = useState('Recipient');
   const [checkoutPeriod, setCheckoutPeriod] = useState(5);
 
@@ -91,9 +91,15 @@ function CheckoutModal(props) {
           <Dropdown
             over
             width="100%"
-            selected={bookName}
+            selected={checkout_title}
+            placeholder="Insert Book name..."
+            displayText={checkout_title}
             options={inventory.map((book) => book.title)}
-            onSelected={(e) => setBookName(e)}
+            onSelected={(e) => {
+              act('set_checkout', {
+                book_name: e,
+              });
+            }}
           />
         </Stack.Item>
         <Stack.Item>
@@ -110,7 +116,7 @@ function CheckoutModal(props) {
                 value={checkoutPeriod}
                 unit=" Minutes"
                 minValue={1}
-                maxValue={1440}
+                maxValue={120}
                 step={1}
                 stepPixelSize={10}
                 onChange={(value) => setCheckoutPeriod(value)}
@@ -128,7 +134,6 @@ function CheckoutModal(props) {
                 onClick={() => {
                   setCheckoutBook(false);
                   act('checkout', {
-                    book_name: bookName,
                     loaned_to: checkoutee,
                     checkout_time: checkoutPeriod,
                   });


### PR DESCRIPTION
## About The Pull Request

The barcode scanner has a check-in mode, but to checkout you have to scroll through a (potentially) large list of books. This aims to fix that by letting you skip the UI using the same item you use to check-in.


https://github.com/user-attachments/assets/916b743e-d974-4e7d-a9f2-a407562c5123


Also limits library book borrowing time to 2 hours, cause the UI looked really weird with it uncapped (also any round that goes more than 2 hours you should bring your books back)

## Why It's Good For The Game

Better UX I think.

## Changelog

:cl:
qol: The Curator's barcode scanner now lets you check books out.
fix: The library console can no longer borrow books for an infinite amount of time.
/:cl: