### PR TITLE
Fixes Gas Compressor not being able to perform disk operations.

### DIFF
--- a/code/modules/research/ordnance/tank_compressor.dm
+++ b/code/modules/research/ordnance/tank_compressor.dm
@@ -48,7 +48,7 @@
 
 	if(istype(tool, /obj/item/disk/computer))
 		eject_disk(user)
-		if(user.transferItemToLoc(tool, src))
+		if(!user.transferItemToLoc(tool, src))
 			balloon_alert(user, "it's stuck to your hand!")
 			return ITEM_INTERACT_BLOCKING
 		inserted_disk = tool


### PR DESCRIPTION
## About The Pull Request

There was a flipped sign on an early return, causing disk operations to fail. Inverting it returns old functionality.

<img width="685" height="444" alt="image" src="https://github.com/user-attachments/assets/6c193fe9-ce6e-4c3b-8a48-1b65e5ce0ce6" />

## Why It's Good For The Game

Fixes #95435. 🐛 ‼️ 💥 

## Changelog
:cl:
fix: The gas compressor once again can perform disk operations.
/:cl:
