### PR TITLE
Guards against shapechanging while being deleted

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -299,10 +299,6 @@
 /datum/action/cooldown/spell/proc/before_cast(atom/cast_on)
 	SHOULD_CALL_PARENT(TRUE)
 
-	// If the owner is being deleted, we shouldn't be able to cast a spell
-	if(QDELETED(owner))
-		return SPELL_CANCEL_CAST
-
 	// Bonus invocation check done here:
 	// If the caster has no tongue and it's a verbal spell,
 	// Or has no hands and is a gesture spell - cancel it,

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -299,6 +299,10 @@
 /datum/action/cooldown/spell/proc/before_cast(atom/cast_on)
 	SHOULD_CALL_PARENT(TRUE)
 
+	// If the owner is being deleted, we shouldn't be able to cast a spell
+	if(QDELETED(owner))
+		return SPELL_CANCEL_CAST
+
 	// Bonus invocation check done here:
 	// If the caster has no tongue and it's a verbal spell,
 	// Or has no hands and is a gesture spell - cancel it,
@@ -323,10 +327,6 @@
 					to_chat(caster, span_warning("You can't position your hands correctly to invoke [src][caster.num_hands > 0 ? "" : ", as you have none"]..."))
 					StartCooldown(2 SECONDS)
 					return SPELL_CANCEL_CAST
-
-	// If the owner is being deleted, we shouldn't be able to cast a spell
-	if(QDELETED(owner))
-		return SPELL_CANCEL_CAST
 
 	var/sig_return = SEND_SIGNAL(src, COMSIG_SPELL_BEFORE_CAST, cast_on)
 	if(owner)

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -324,6 +324,10 @@
 					StartCooldown(2 SECONDS)
 					return SPELL_CANCEL_CAST
 
+	// If the owner is being deleted, we shouldn't be able to cast a spell
+	if(QDELETED(owner))
+		return SPELL_CANCEL_CAST
+
 	var/sig_return = SEND_SIGNAL(src, COMSIG_SPELL_BEFORE_CAST, cast_on)
 	if(owner)
 		sig_return |= SEND_SIGNAL(owner, COMSIG_MOB_BEFORE_SPELL_CAST, src, cast_on)

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -14,6 +14,11 @@
 	var/already_restored = FALSE
 
 /datum/status_effect/shapechange_mob/on_creation(mob/living/new_owner, mob/living/caster)
+	// If the mob is shapechanging while being deleted (for example, a bitrunning avatar dying and getting booted out)
+	if(QDELETED(caster))
+		qdel(src)
+		return
+
 	// If any type or subtype of shapeshift mob is on the new_owner already throw an error and self-delete
 	if(locate(type) in new_owner.status_effects)
 		stack_trace("Mob shapechange status effect applied to a mob which already was shapechanged, which will definitely cause issues.")


### PR DESCRIPTION
## About The Pull Request

Tin. If you shapechange while being deleted, such as if your bitrunning avatar is dying, you get runtimes which interrupt the process and bug your mob permanently. 


<img width="2035" height="697" alt="image" src="https://github.com/user-attachments/assets/ebe7b502-bec5-44f9-bf5f-398e81c82dbb" />

For shapechanging, it creates a cascade of issues where you runtime midway through the mind transfer, making the shapechange incomplete and leaving the caster in a permadead state. Which is very bad.

## Why It's Good For The Game

Fixes a gnarly bug

## Changelog

:cl:
fix: fixes an issue where casting spells after your mob gets deleted can leave you in a permanently bugged state.
/:cl: