### PR TITLE
Adds a balloon alert to Slime Link messages

### DIFF
--- a/code/datums/components/mind_linker.dm
+++ b/code/datums/components/mind_linker.dm
@@ -58,7 +58,7 @@
 		src.signals_which_destroy_us = signals_which_destroy_us
 	if(post_unlink_callback)
 		src.post_unlink_callback = post_unlink_callback
-	if(isnull(show_balloon_alert))
+	if(!isnull(show_balloon_alert))
 		src.show_balloon_alert = show_balloon_alert
 
 	master_speech = new(src)

--- a/code/datums/components/mind_linker.dm
+++ b/code/datums/components/mind_linker.dm
@@ -22,6 +22,8 @@
 	var/speech_action_background_icon_state = "bg_alien"
 	/// The border icon state for the speech action handed out.
 	var/speech_action_overlay_state = "bg_alien_border"
+	/// Whether messages should show a balloon alert or not.
+	var/show_balloon_alert = FALSE
 	/// The master's speech action. The owner of the link shouldn't lose this as long as the link remains.
 	VAR_FINAL/datum/action/innate/linked_speech/master_speech
 	/// An assoc list of [mob/living]s to [datum/action/innate/linked_speech]s. All the mobs that are linked to our network.
@@ -38,6 +40,7 @@
 	// Optional
 	signals_which_destroy_us,
 	datum/callback/post_unlink_callback,
+	show_balloon_alert,
 )
 
 	if(!isliving(parent))
@@ -55,6 +58,8 @@
 		src.signals_which_destroy_us = signals_which_destroy_us
 	if(post_unlink_callback)
 		src.post_unlink_callback = post_unlink_callback
+	if(isnull(show_balloon_alert))
+		src.show_balloon_alert = show_balloon_alert
 
 	master_speech = new(src)
 	master_speech.Grant(owner)
@@ -156,6 +161,7 @@
 	// Optional
 	signals_which_destroy_us,
 	datum/callback/post_unlink_callback,
+	show_balloon_alert,
 	// Optional for this subtype
 	link_message,
 	unlink_message,
@@ -258,6 +264,8 @@
 	for(var/mob/living/recipient as anything in all_who_can_hear)
 		var/avoid_highlighting = (recipient == owner) || (recipient == linker_parent)
 		to_chat(recipient, formatted_message, type = MESSAGE_TYPE_RADIO, avoid_highlighting = avoid_highlighting)
+		if(linker.show_balloon_alert && recipient != owner)
+			recipient.balloon_alert(recipient, "you hear a voice from your [linker.network_name]")
 
 	for(var/mob/recipient as anything in GLOB.dead_mob_list)
 		to_chat(recipient, "[FOLLOW_LINK(recipient, owner)] [formatted_message]", type = MESSAGE_TYPE_RADIO)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -694,6 +694,7 @@
 		/datum/component/mind_linker/active_linking, \
 		network_name = "Slime Link", \
 		signals_which_destroy_us = list(COMSIG_SPECIES_LOSS), \
+		show_balloon_alert = TRUE, \
 		linker_action_path = /datum/action/innate/link_minds, \
 	)
 


### PR DESCRIPTION

## About The Pull Request

Partial port of https://github.com/Monkestation/Monkestation2.0/pull/6764

Simply makes it so that Slime Link messages will display a balloon alert saying "you hear a voice from your Slime Link" whenever someone else speaks over it.

Technically supports anything that uses `/datum/component/mind_linker`, but only enabled for Slime Link currently, unless anyone else desires it be enabled for mansus link or carp wavespeak.

## Why It's Good For The Game

very easy to accidentally miss slime link messages, so like, this helps a lot with that, and if you're in a slime link, you presumably _want_ to know when someone speaks over it.

## Changelog
:cl:
qol: Slime Link messages now notify listeners with a balloon alert.
/:cl:
