### PR TITLE
Immobile mobile defibrillator mounts are no longer called mobile

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -34519,9 +34519,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/defibrillator_mount/mobile{
-	anchored = 1
-	},
+/obj/machinery/defibrillator_mount/mobile/immobile,
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 4
 	},

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -259,3 +259,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/defibrillator_mount, 28)
 		new /obj/item/stack/cable_coil(drop, 15)
 	else
 		new /obj/item/stack/sheet/iron(drop, 5)
+
+///For mapping
+/obj/machinery/defibrillator_mount/mobile/immobile
+	anchored = TRUE
+	name = "defibrillator mount"


### PR DESCRIPTION

## About The Pull Request

Mapped-in mobile defibrillator mounts that have set `anchored` true are now a subtype with "mobile" removed from their name

## Why It's Good For The Game

Confusing

## Changelog
:cl:

spellcheck: Immobile mobile defibrillator mounts are no longer called mobile

/:cl:
