### PR TITLE
Replaces Changeling's stat panel entry

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -37,6 +37,32 @@
 	name = "chemical storage"
 	icon_state = "power_display"
 	screen_loc = ui_lingchemdisplay
+	///Boolean on whether a mouse is being hovered over us right now.
+	var/hovering = FALSE
+
+/atom/movable/screen/ling/chems/Click(location, control, params)
+	. = ..()
+	to_chat(usr, span_notice("Shows you how many chemicals you have. While hovering over this, it will show the max amount of chemicals you can hold."))
+
+/atom/movable/screen/ling/chems/MouseEntered(location,control,params)
+	if(usr != get_mob())
+		return
+	var/datum/antagonist/changeling/antagonist_datum = IS_CHANGELING(hud.mymob)
+	if(!antagonist_datum)
+		return
+	. = ..()
+	hovering = TRUE
+	antagonist_datum.update_chemical_hud()
+
+/atom/movable/screen/ling/chems/MouseExited(location, control, params)
+	if(usr != get_mob())
+		return
+	var/datum/antagonist/changeling/antagonist_datum = IS_CHANGELING(hud.mymob)
+	if(!antagonist_datum)
+		return
+	. = ..()
+	hovering = FALSE
+	antagonist_datum.update_chemical_hud(antagonist_datum.chem_charges)
 
 /atom/movable/screen/ling/sting
 	name = "current sting"

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -1,4 +1,6 @@
 /// Helper to format the text that gets thrown onto the chem hud element.
+#define FORMAT_CHEM_MAX_TEXT(charges) MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#dd2828'>[round(charges)]</font></div>")
+/// Helper to format the text that gets thrown onto the chem hud element.
 #define FORMAT_CHEM_CHARGES_TEXT(charges) MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#dd66dd'>[round(charges)]</font></div>")
 
 /datum/antagonist/changeling
@@ -141,7 +143,6 @@
 	RegisterSignal(living_mob, COMSIG_MOB_LOGIN, PROC_REF(on_login))
 	RegisterSignal(living_mob, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 	RegisterSignal(living_mob, COMSIG_LIVING_POST_FULLY_HEAL, PROC_REF(on_fullhealed))
-	RegisterSignal(living_mob, COMSIG_MOB_GET_STATUS_TAB_ITEMS, PROC_REF(get_status_tab_item))
 	RegisterSignal(living_mob, COMSIG_CARBON_GAIN_ORGAN, PROC_REF(new_brain))
 	RegisterSignals(living_mob, list(COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON), PROC_REF(on_click_sting))
 	ADD_TRAIT(living_mob, TRAIT_FAKE_SOULLESS, CHANGELING_TRAIT)
@@ -215,7 +216,6 @@
 		COMSIG_MOB_LOGIN,
 		COMSIG_LIVING_LIFE,
 		COMSIG_LIVING_POST_FULLY_HEAL,
-		COMSIG_MOB_GET_STATUS_TAB_ITEMS,
 		COMSIG_MOB_MIDDLECLICKON,
 		COMSIG_MOB_ALTCLICKON,
 		COMSIG_MOB_HUD_CREATED,
@@ -338,11 +338,6 @@
 
 	return COMSIG_MOB_CANCEL_CLICKON
 
-/datum/antagonist/changeling/proc/get_status_tab_item(mob/living/source, list/items)
-	SIGNAL_HANDLER
-	items += "Chemical Storage: [chem_charges]/[total_chem_storage]"
-	items += "Absorbed DNA: [absorbed_count]"
-
 /*
  * Adjust the chem charges of the ling by [amount]
  * and clamp it between 0 and override_cap (if supplied) or total_chem_storage (if no override supplied)
@@ -352,8 +347,16 @@
 		return
 	var/cap_to = isnum(override_cap) ? override_cap : total_chem_storage
 	chem_charges = clamp(chem_charges + amount, 0, cap_to)
+	update_chemical_hud(chem_charges)
 
-	lingchemdisplay?.maptext = FORMAT_CHEM_CHARGES_TEXT(chem_charges)
+///Updates the Changeling's chemical HUD to display the information we want it to (chem charges, or max if hovered over).
+/datum/antagonist/changeling/proc/update_chemical_hud(amount)
+	if(isnull(lingchemdisplay))
+		return
+	if(lingchemdisplay.hovering)
+		lingchemdisplay.maptext = FORMAT_CHEM_MAX_TEXT(total_chem_storage)
+	else
+		lingchemdisplay.maptext = FORMAT_CHEM_CHARGES_TEXT(amount)
 
 /*
  * Remove changeling powers from the current Changeling's purchased_powers list.
@@ -1040,6 +1043,7 @@
 	data["hive_name"] = hive_name
 	data["stolen_antag_info"] = antag_memory
 	data["objectives"] = get_objectives()
+	data["absorbed_dna"] = absorbed_count
 	return data
 
 // Changelings spawned from non-changeling headslugs (IE, due to being transformed into a headslug as a non-ling). Weaker than a normal changeling.
@@ -1082,4 +1086,5 @@
 	name = "Changeling (Space)"
 	l_hand = /obj/item/melee/arm_blade
 
+#undef FORMAT_CHEM_MAX_TEXT
 #undef FORMAT_CHEM_CHARGES_TEXT

--- a/tgui/packages/tgui/interfaces/AntagInfoChangeling.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoChangeling.tsx
@@ -64,6 +64,7 @@ type Info = {
   memories: Memory[];
   objectives: Objective[];
   can_change_objective: BooleanLike;
+  absorbed_dna: number;
 };
 
 export const AntagInfoChangeling = (props) => {
@@ -130,9 +131,29 @@ const HivemindSection = (props) => {
 
 const IntroductionSection = (props) => {
   const { act, data } = useBackend<Info>();
-  const { true_name, hive_name, objectives, can_change_objective } = data;
+  const {
+    true_name,
+    hive_name,
+    objectives,
+    can_change_objective,
+    absorbed_dna,
+  } = data;
   return (
-    <Section fill title="Intro" style={{ overflowY: 'auto' }}>
+    <Section
+      fill
+      title="Intro"
+      style={{ overflowY: 'auto' }}
+      buttons={
+        <Button
+          icon="dna"
+          tooltipPosition="left"
+          tooltip={`Absorbed DNA`}
+          color="purple"
+        >
+          {absorbed_dna}
+        </Button>
+      }
+    >
       <Stack vertical fill>
         <Stack.Item fontSize="25px">
           You are {true_name} from the

--- a/tgui/packages/tgui/interfaces/AntagInfoChangeling.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoChangeling.tsx
@@ -82,9 +82,7 @@ export const AntagInfoChangeling = (props) => {
           <Stack.Item grow={4}>
             <AbilitiesSection />
           </Stack.Item>
-          <Stack.Item>
-            <HivemindSection />
-          </Stack.Item>
+          <BetrayalWarning />
           <Stack.Item grow={3}>
             <Stack fill>
               <Stack.Item grow>
@@ -98,34 +96,6 @@ export const AntagInfoChangeling = (props) => {
         </Stack>
       </Window.Content>
     </Window>
-  );
-};
-
-const HivemindSection = (props) => {
-  const { act, data } = useBackend<Info>();
-  const { true_name } = data;
-  return (
-    <Section fill title="Hivemind">
-      <Stack vertical fill>
-        <Stack.Item textColor="label">
-          All Changelings, regardless of origin, are linked together by the{' '}
-          <span style={hivemindstyle}>hivemind</span>. You may communicate to
-          other Changelings under your mental alias,{' '}
-          <span style={hivemindstyle}>{true_name}</span>, by starting a message
-          with <span style={hivemindstyle}>:g</span>. Work together, and you
-          will bring the station to new heights of terror.
-        </Stack.Item>
-        <Stack.Item>
-          <NoticeBox danger>
-            Other Changelings are strong allies, but some Changelings may betray
-            you. Changelings grow in power greatly by absorbing their kind, and
-            getting absorbed by another Changeling will leave you as a{' '}
-            <span style={fallenstyle}>Fallen Changeling</span>. There is no
-            greater humiliation.
-          </NoticeBox>
-        </Stack.Item>
-      </Stack>
-    </Section>
   );
 };
 
@@ -177,6 +147,8 @@ const IntroductionSection = (props) => {
 };
 
 const AbilitiesSection = () => {
+  const { act, data } = useBackend<Info>();
+  const { true_name } = data;
   return (
     <Section fill title="Abilities">
       <Stack fill>
@@ -220,8 +192,43 @@ const AbilitiesSection = () => {
             </Stack.Item>
           </Stack>
         </Stack.Item>
+        <Stack.Divider />
+        <Stack.Item grow>
+          <Stack fill vertical>
+            <Stack.Item textColor="label" grow>
+              All abilities require using{' '}
+              <span style={hivemindstyle}>chemicals</span>, you can see how much
+              you have with the HUD on the left side of the screen. You may also
+              hover your cursor over it to see the maximum amount of chemicals
+              you can hold. This number can increase by
+              <span style={absorbstyle}>&ensp;absorbing</span> other
+              Changelings.
+            </Stack.Item>
+            <Stack.Divider />
+            <Stack.Item textColor="label" grow>
+              All Changelings, regardless of origin, are linked together by the{' '}
+              <span style={hivemindstyle}>hivemind</span>. You may communicate
+              to other Changelings under your mental alias,{' '}
+              <span style={hivemindstyle}>{true_name}</span>, by starting a
+              message with <span style={hivemindstyle}>:g</span>. Work together,
+              and you will bring the station to new heights of terror.
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
       </Stack>
     </Section>
+  );
+};
+
+const BetrayalWarning = (props) => {
+  return (
+    <NoticeBox danger>
+      Other Changelings are strong allies, but some Changelings may betray you.
+      Changelings grow in power greatly by absorbing their kind, and getting
+      absorbed by another Changeling will leave you as a{' '}
+      <span style={fallenstyle}>Fallen Changeling</span>. There is no greater
+      humiliation.
+    </NoticeBox>
   );
 };
 


### PR DESCRIPTION
## About The Pull Request

The stat panel for Changelings shows how much DNA you have absorbed (for your objectives) & The upper limit to how many chemicals you can hold.

How many people you have absorbed now shows up in your Antag info page (which you'll already be there to see how many genomes you'll need for the objective anyways), and the upper limit to your ling chems is now shown when you hover your mouse on the HUD element.

This is also now explained when you click on the HUD & in the Antag Info page. Hovering over the icon also turns it red to indicate it's a different thing being shown, and that it is clickable (to get another explanation).


https://github.com/user-attachments/assets/71c935d3-2d21-4d4b-bb8c-cc183110e2e2


## Why It's Good For The Game

Moving things away from the stat panel is a goal I've been focusing on because it borderline hides information away from people who don't know when and what information is listed in the stat panel.

This hopes to make that information much easier to access and improving on Changeling's lackluster hud & explanations on things. My first time playing Changeling I remember clicking on the HUD, it not responding to my clicks, and being confused what the number was for. This is what gave me the idea to have this more dynamic & clickable HUD, and my hope is that this makes it easier for new players to understand.

We also now explain how a Changeling's max chem can increase much better now, than the current version's 'grows in power'.

This also pairs well with https://github.com/tgstation/tgstation/pull/95383 as it becomes one less source of forcefully giving people stat panels if they turn it off.

## Changelog

:cl:
qol: Changeling's stat panel entry has been moved to the HUD & Antag panel. Also added some extra explanations on how Changelings work in there.
/:cl: