### PR TITLE
Monkey Dust no longer can provide permanent stun immunity

### DIFF
--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -986,6 +986,8 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	if(is_simian(affected_mob))
 		affected_mob.gain_trauma(/datum/brain_trauma/special/primal_instincts, TRAUMA_RESILIENCE_ABSOLUTE)
 		affected_mob.add_traits(list(TRAIT_STUNIMMUNE, TRAIT_SLEEPIMMUNE, TRAIT_ANALGESIA, TRAIT_STIMULATED), type)
+		if(jungle_arts)
+			return
 		jungle_arts = new(src)
 		jungle_arts.locked_to_use = TRUE
 		jungle_arts.teach(affected_mob)
@@ -993,10 +995,11 @@ Basically, we fill the time between now and 2s from now with hands based off the
 /datum/reagent/inverse/bath_salts/on_mob_end_metabolize(mob/living/carbon/affected_mob)
 	. = ..()
 	QDEL_NULL(jungle_arts)
+	affected_mob.remove_traits(list(TRAIT_STUNIMMUNE, TRAIT_SLEEPIMMUNE, TRAIT_ANALGESIA, TRAIT_STIMULATED), type)
+	affected_mob.Sleeping(30 SECONDS)
 	if(is_simian(affected_mob))
 		affected_mob.cure_trauma_type(/datum/brain_trauma/special/primal_instincts, resilience = TRAUMA_RESILIENCE_ABSOLUTE)
-		affected_mob.remove_traits(list(TRAIT_STUNIMMUNE, TRAIT_SLEEPIMMUNE, TRAIT_ANALGESIA, TRAIT_STIMULATED), type)
-		affected_mob.Sleeping(30 SECONDS)
+
 
 /datum/reagent/inverse/bath_salts/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -1016,9 +1016,13 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 		if(need_mob_update)
 			. = UPDATE_MOB_HEALTH
+		return
 
-	else if(SPT_PROB(10, seconds_per_tick))
+	if(SPT_PROB(10, seconds_per_tick))
 		affected_mob.emote(pick("screech","scratch","jump","look"))
+
+	QDEL_NULL(jungle_arts)
+	affected_mob.remove_traits(list(TRAIT_STUNIMMUNE, TRAIT_SLEEPIMMUNE, TRAIT_ANALGESIA, TRAIT_STIMULATED), type)
 
 /datum/reagent/inverse/aranesp
 	name = "Epoetin Alfa"


### PR DESCRIPTION

## About The Pull Request

Monkey dust now removes its related traits, including anti-stun, on end metabolize regardless of whether the metabolizing mob is a monkey at the moment or not. It also removes these traits & the martial art at any point the metabolizing mob is not a monkey.

It doesn't remove the brain trauma unless the user is a monkey, however. Otherwise, it would become just an actual medicine for the trauma. It still kind of is, but with more effort involved. If only traumas held sources.

## Why It's Good For The Game

fixes #91742
fixes #94403

## Changelog
:cl:

fix: Monkey dust now properly removes anti-stun properties when its imbiber is no longer a monkey

/:cl:
