### PR TITLE
[MDB Ignore] Medical larp: Adds the IDC-27 as an analog to the SDSM-35 for viruses

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -695,8 +695,12 @@
 	},
 /obj/item/reagent_containers/syringe/antiviral,
 /obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/spray/cleaner,
 /obj/structure/cable,
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 9;
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -52,6 +52,10 @@
 /area/ruin/space/has_grav/abandonedzoo)
 "aG" = (
 /obj/structure/table/reinforced,
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 4;
+	pixel_x = 3
+	},
 /obj/item/gun/energy/floragun,
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -13663,6 +13663,14 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/mid_joiner,
 /obj/structure/table/glass,
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 2;
+	pixel_x = 3
+	},
+/obj/item/book/manual/wiki/infections{
+	name = "The Evil Doctor's How-To";
+	pixel_y = 6
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/virology)
 "dCm" = (
@@ -19666,11 +19674,6 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/item/book/manual/wiki/infections{
-	name = "The Evil Doctor's How-To";
-	pixel_x = 5;
-	pixel_y = 15
-	},
 /obj/item/binoculars{
 	pixel_y = 1
 	},
@@ -45999,7 +46002,7 @@
 	},
 /obj/item/book/manual/wiki/medicine{
 	pixel_x = 1;
-	pixel_y = 5
+	pixel_y = -2
 	},
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
@@ -46008,6 +46011,10 @@
 /obj/item/tgui_book/manual/dsm{
 	pixel_x = 5;
 	pixel_y = -2
+	},
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 2;
+	pixel_x = 3
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
@@ -76169,6 +76176,10 @@
 /obj/item/storage/briefcase/secure{
 	pixel_x = 5;
 	pixel_y = 9
+	},
+/obj/item/tgui_book/manual/idc{
+	pixel_y = -3;
+	pixel_x = 3
 	},
 /obj/item/clothing/head/soft/blue{
 	pixel_x = 10;

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -14098,6 +14098,10 @@
 	pixel_x = -4;
 	pixel_y = 3
 	},
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 3;
+	pixel_x = 3
+	},
 /obj/item/clothing/neck/stethoscope{
 	pixel_y = 4
 	},
@@ -41712,6 +41716,9 @@
 	pixel_y = 4;
 	pixel_x = -6
 	},
+/obj/item/tgui_book/manual/idc{
+	pixel_x = 4
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/cmo)
 "khZ" = (
@@ -50902,10 +50909,14 @@
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = -6
 	},
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 3;
+	pixel_x = 3
+	},
 /obj/item/book/manual/wiki/infections,
+/obj/item/reagent_containers/syringe/antiviral,
 /obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/syringe/antiviral,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "mzu" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -43450,6 +43450,10 @@
 	pixel_x = -4;
 	pixel_y = 12
 	},
+/obj/item/tgui_book/manual/idc{
+	pixel_x = 4;
+	pixel_y = 13
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/cmo)
 "miS" = (
@@ -77532,6 +77536,10 @@
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/blue/full,
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 3;
+	pixel_x = 3
+	},
 /obj/item/tgui_book/manual/dsm,
 /turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
@@ -79414,10 +79422,14 @@
 	pixel_y = 7
 	},
 /obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/spray/cleaner,
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/reagent_dispensers/wall/virusfood/directional/south,
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 3;
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "wsN" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2381,8 +2381,12 @@
 	pixel_y = 3;
 	pixel_x = -2
 	},
-/obj/item/book/manual/wiki/medicine,
 /obj/machinery/newscaster/directional/west,
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 3;
+	pixel_x = 3
+	},
+/obj/item/book/manual/wiki/medicine,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aQR" = (
@@ -6181,6 +6185,10 @@
 /obj/item/tgui_book/manual/dsm{
 	pixel_y = 3;
 	pixel_x = -2
+	},
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 3;
+	pixel_x = 3
 	},
 /obj/item/book/manual/wiki/medicine,
 /turf/open/floor/iron/white,
@@ -41230,13 +41238,17 @@
 	pixel_y = 7
 	},
 /obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/spray/cleaner,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 4
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 3;
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ocP" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -35766,6 +35766,10 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/syringe/antiviral,
 /obj/machinery/status_display/ai/directional/west,
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 9;
+	pixel_x = 3
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "lrG" = (
@@ -40482,6 +40486,9 @@
 /obj/item/tgui_book/manual/dsm{
 	pixel_x = -6;
 	pixel_y = 4
+	},
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 3
 	},
 /obj/item/storage/briefcase/secure,
 /turf/open/floor/iron/white,
@@ -52597,6 +52604,10 @@
 	},
 /obj/item/tgui_book/manual/dsm{
 	pixel_y = 6;
+	pixel_x = 3
+	},
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 9;
 	pixel_x = 3
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -22468,11 +22468,12 @@
 	pixel_y = -3
 	},
 /obj/item/book/manual/wiki/infections,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
+	},
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 2;
+	pixel_x = 3
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -36221,6 +36222,10 @@
 	pixel_x = -6;
 	pixel_y = 4
 	},
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 2;
+	pixel_x = 3
+	},
 /obj/item/food/sandwich/cheese,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/cmo)
@@ -37652,6 +37657,9 @@
 /obj/item/tgui_book/manual/dsm{
 	pixel_y = 3;
 	pixel_x = 3
+	},
+/obj/item/tgui_book/manual/idc{
+	pixel_y = 7
 	},
 /obj/item/clothing/neck/stethoscope{
 	pixel_y = 4
@@ -47574,6 +47582,9 @@
 	},
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 3
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)

--- a/code/__DEFINES/diseases.dm
+++ b/code/__DEFINES/diseases.dm
@@ -4,11 +4,13 @@
 //Visibility Flags
 #define HIDDEN_SCANNER (1<<0)
 #define HIDDEN_PANDEMIC (1<<1)
+#define HIDDEN_BOOK (1<<2)
 
 //Bitfield for Visibility Flags
 DEFINE_BITFIELD(visibility_flags, list(
 	"HIDDEN_FROM_ANALYZER" = HIDDEN_SCANNER,
 	"HIDDEN_FROM_PANDEMIC" = HIDDEN_PANDEMIC,
+	"HIDDEN_FROM_BOOK" = HIDDEN_BOOK,
 ))
 
 //Disease Flags

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -13,7 +13,7 @@
 	/// The description of what the disease is and does
 	var/desc = ""
 	/// The agent that causes the disease, for example "virus", "bacteria", "parasite", "curse"
-	var/agent = "some microbes"
+	var/agent = "Unknown"
 	/// A string describing how the disease spreads, for example "Airborne", "Blood", "Skin contact", "Magic"
 	/// (Keep this strictly for how it spreads BETWEEN hosts, NOT how it affected the initial host. Use agent var for that)
 	var/spread_text = ""

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -5,11 +5,19 @@
 	var/spread_flags = DISEASE_SPREAD_AIRBORNE | DISEASE_SPREAD_CONTACT_FLUIDS | DISEASE_SPREAD_CONTACT_SKIN
 
 	//Fluff
+
+	/// What type of disease this is
 	var/form = "Virus"
+	/// The name of the disease (this one's kind of important)
 	var/name = "No disease"
+	/// The description of what the disease is and does
 	var/desc = ""
+	/// The agent that causes the disease, for example "virus", "bacteria", "parasite", "curse"
 	var/agent = "some microbes"
+	/// A string describing how the disease spreads, for example "Airborne", "Blood", "Skin contact", "Magic"
+	/// (Keep this strictly for how it spreads BETWEEN hosts, NOT how it affected the initial host. Use agent var for that)
 	var/spread_text = ""
+	/// A string describing how the disease can be cured, for example "Toxin remover", "Antibiotics", "Rest and hydration", "Prayers to the gods"
 	var/cure_text = ""
 
 	//Stages
@@ -411,3 +419,16 @@
 			return 6
 		if(DISEASE_SEVERITY_BIOHAZARD)
 			return 7
+
+/proc/get_disease_spread_text(spread_flags)
+	if(spread_flags & DISEASE_SPREAD_AIRBORNE)
+		return "Airborne"
+	if(spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
+		return "Skin contact"
+	if(spread_flags & DISEASE_SPREAD_CONTACT_FLUIDS)
+		return "Fluid contact"
+	if(spread_flags & DISEASE_SPREAD_BLOOD)
+		return "Blood"
+	if(spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS)
+		return "None (Non-contagious)"
+	return "Unknown"

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -430,5 +430,5 @@
 	if(spread_flags & DISEASE_SPREAD_BLOOD)
 		return "Blood"
 	if(spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS)
-		return "None (Non-contagious)"
+		return "None"
 	return "Unknown"

--- a/code/datums/diseases/adrenal_crisis.dm
+++ b/code/datums/diseases/adrenal_crisis.dm
@@ -2,16 +2,17 @@
 	form = "Condition"
 	name = "Adrenal Crisis"
 	max_stages = 2
-	cure_text = "Trauma"
+	cure_text = "Trauma (Adrenaline / \"" + /datum/reagent/determination::name + "\")"
 	cures = list(/datum/reagent/determination)
 	cure_chance = 10
-	agent = "Shitty Adrenal Glands"
+	agent = "Kronkaine Abuse"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spreading_modifier = 1
-	desc = "If left untreated the subject will suffer from lethargy, dizziness and periodic loss of consciousness."
+	desc = "A rare condition caused by continued abuse of Kronkaine. \
+		If left untreated the subject will suffer from lethargy, dizziness and periodic loss of consciousness."
 	severity = DISEASE_SEVERITY_MEDIUM
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
-	spread_text = "Organ failure"
+	spread_text = "None"
 	visibility_flags = HIDDEN_PANDEMIC
 	bypasses_immunity = TRUE
 

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -25,6 +25,7 @@
 	spread_text = "Unknown"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	cures = null
+	visibility_flags = HIDDEN_BOOK // we have unique handling for advance diseases in the book
 
 	// NEW VARS
 	var/list/properties = list()

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -1,4 +1,5 @@
 /datum/symptom/heal
+	abstract_type = /datum/symptom/heal
 	name = "Basic Healing (does nothing)" //warning for adminspawn viruses
 	desc = "You should not be seeing this."
 	stealth = 0

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -40,7 +40,7 @@
 	///If the symptom requires an organ for the effects to function, robotic organs are immune to disease unless inorganic biology symptom is present
 	var/required_organ
 	///The remedy for this symptom
-	var/symptom_cure = /datum/reagent/medicine/spaceacillin
+	var/datum/reagent/symptom_cure = /datum/reagent/medicine/spaceacillin
 	///What color the cure text shows up in the pandemic UI
 	var/cure_color = "green"
 	///A remedied symptom has no effect and contributes to the cure

--- a/code/datums/diseases/anaphylaxis.dm
+++ b/code/datums/diseases/anaphylaxis.dm
@@ -3,7 +3,7 @@
 	name = "Anaphylaxis"
 	desc = "Patient is undergoing a life-threatening allergic reaction and will die if not treated."
 	max_stages = 3
-	cure_text = "Epinephrine"
+	cure_text = /datum/reagent/medicine/epinephrine::name
 	cures = list(/datum/reagent/medicine/epinephrine)
 	cure_chance = 20
 	agent = "Allergy"

--- a/code/datums/diseases/anaphylaxis.dm
+++ b/code/datums/diseases/anaphylaxis.dm
@@ -1,5 +1,5 @@
 /datum/disease/anaphylaxis
-	form = "Shock"
+	form = "Condition"
 	name = "Anaphylaxis"
 	desc = "Patient is undergoing a life-threatening allergic reaction and will die if not treated."
 	max_stages = 3

--- a/code/datums/diseases/anxiety.dm
+++ b/code/datums/diseases/anxiety.dm
@@ -1,14 +1,14 @@
 /datum/disease/anxiety
 	name = "Severe Anxiety"
-	form = "Infection"
+	form = "Condition"
 	max_stages = 4
-	spread_text = "On contact"
+	spread_text = "Skin contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS
-	cure_text = "Ethanol (Liquid Courage)"
+	cure_text = /datum/reagent/consumable/ethanol::name + " (Liquid Courage)"
 	cures = list(/datum/reagent/consumable/ethanol)
 	agent = "Excess Lepidopticides"
 	viable_mobtypes = list(/mob/living/carbon/human)
-	desc = "If left untreated subject will regurgitate butterflies."
+	desc = "A well documented condition leading to 'butterflies in the stomach' in a literal sense, which are often regurgitated."
 	severity = DISEASE_SEVERITY_MINOR
 
 

--- a/code/datums/diseases/anxiety.dm
+++ b/code/datums/diseases/anxiety.dm
@@ -1,6 +1,6 @@
 /datum/disease/anxiety
 	name = "Severe Anxiety"
-	form = "Condition"
+	form = "Infection"
 	max_stages = 4
 	spread_text = "Skin contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS

--- a/code/datums/diseases/anxiety.dm
+++ b/code/datums/diseases/anxiety.dm
@@ -1,6 +1,6 @@
 /datum/disease/anxiety
 	name = "Severe Anxiety"
-	form = "Infection"
+	form = "Condition"
 	max_stages = 4
 	spread_text = "Skin contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS

--- a/code/datums/diseases/asthma_attack.dm
+++ b/code/datums/diseases/asthma_attack.dm
@@ -3,14 +3,14 @@
 	name = "Asthma attack"
 	desc = "Subject is undergoing a autoimmune response which threatens to close the esophagus and halt all respiration, leading to death. \
 	Minor asthma attacks may disappear on their own, but all are dangerous."
-	cure_text = "Albuterol/Surgical intervention"
+	cure_text = /datum/reagent/medicine/albuterol::name + " or surgical intervention"
 	cures = list(/datum/reagent/medicine/albuterol)
 	agent = "Inflammatory"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	disease_flags = CURABLE
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
-	spread_text = "Inflammatory"
-	visibility_flags = HIDDEN_PANDEMIC
+	spread_text = "None"
+	visibility_flags = HIDDEN_PANDEMIC|HIDDEN_BOOK
 	bypasses_immunity = TRUE
 	disease_flags = CURABLE|INCREMENTAL_CURE
 	required_organ = ORGAN_SLOT_LUNGS

--- a/code/datums/diseases/beesease.dm
+++ b/code/datums/diseases/beesease.dm
@@ -1,6 +1,6 @@
 /datum/disease/beesease
 	name = "Beesease"
-	form = "Infection"
+	form = "Parasite"
 	max_stages = 4
 	spread_text = "Skin contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS

--- a/code/datums/diseases/beesease.dm
+++ b/code/datums/diseases/beesease.dm
@@ -2,13 +2,13 @@
 	name = "Beesease"
 	form = "Infection"
 	max_stages = 4
-	spread_text = "On contact"
+	spread_text = "Skin contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS
-	cure_text = "Sugar"
+	cure_text = /datum/reagent/consumable/sugar::name
 	cures = list(/datum/reagent/consumable/sugar)
 	agent = "Apidae Infection"
 	viable_mobtypes = list(/mob/living/carbon/human)
-	desc = "If left untreated subject will regurgitate bees."
+	desc = "A strange disease that leads to the gestation of bees in the subject's stomach, which are often regurgitated."
 	severity = DISEASE_SEVERITY_MEDIUM
 	infectable_biotypes = MOB_ORGANIC|MOB_UNDEAD //bees nesting in corpses
 

--- a/code/datums/diseases/brainrot.dm
+++ b/code/datums/diseases/brainrot.dm
@@ -1,14 +1,14 @@
 /datum/disease/brainrot
 	name = "Brainrot"
 	max_stages = 4
-	spread_text = "On contact"
+	spread_text = "Skin contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS
-	cure_text = "Mannitol"
+	cure_text = /datum/reagent/medicine/mannitol::name
 	cures = list(/datum/reagent/medicine/mannitol)
 	agent = "Cryptococcus Cosmosis"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	cure_chance = 7.5 //higher chance to cure, since two reagents are required
-	desc = "This disease destroys the brain cells, causing brain fever, brain necrosis and general intoxication."
+	desc = "A disease which targets brain cells, leading to brain fog - though it is otherwise non-lethal."
 	required_organ = ORGAN_SLOT_BRAIN
 	severity = DISEASE_SEVERITY_HARMFUL
 	bypasses_immunity = TRUE

--- a/code/datums/diseases/chronic_illness.dm
+++ b/code/datums/diseases/chronic_illness.dm
@@ -1,7 +1,7 @@
 /datum/disease/chronic_illness
 	name = "Hereditary Manifold Sickness"
 	max_stages = 5
-	spread_text = "None (Non-contagious)"
+	spread_text = "None"
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 	disease_flags = CHRONIC
 	infectable_biotypes = MOB_ORGANIC | MOB_MINERAL | MOB_ROBOTIC

--- a/code/datums/diseases/chronic_illness.dm
+++ b/code/datums/diseases/chronic_illness.dm
@@ -1,18 +1,21 @@
 /datum/disease/chronic_illness
 	name = "Hereditary Manifold Sickness"
 	max_stages = 5
-	spread_text = "Non-communicable disease"
+	spread_text = "None (Non-contagious)"
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 	disease_flags = CHRONIC
 	infectable_biotypes = MOB_ORGANIC | MOB_MINERAL | MOB_ROBOTIC
 	process_dead = TRUE
 	stage_prob = 0.25
-	cure_text = "Sansufentanyl"
+	cure_text = "Abated by " + /datum/reagent/medicine/sansufentanyl::name
 	cures = list(/datum/reagent/medicine/sansufentanyl)
 	infectivity = 0
 	agent = "Quantum Entanglement"
 	viable_mobtypes = list(/mob/living/carbon/human)
-	desc = "A disease discovered in an Interdyne laboratory caused by subjection to timestream correction technology."
+	desc = "A disease discovered in an Interdyne laboratory caused by subjection to timestream correction technology. \
+		It is completely uncurable - though it can be treated to reverse its progression - and non-contagious. \
+		If left untreated the subject will suffer from a variety of symptoms, \
+		including but not limited to dizziness, nausea, heart palpitations, and in the final stages, death."
 	severity = DISEASE_SEVERITY_UNCURABLE
 	bypasses_immunity = TRUE
 

--- a/code/datums/diseases/cold.dm
+++ b/code/datums/diseases/cold.dm
@@ -1,8 +1,8 @@
 /datum/disease/cold
 	name = "The Cold"
-	desc = "If left untreated the subject will contract the flu."
+	desc = "A common, mildly annoying contagion. If left untreated the subject will contract the flu."
 	max_stages = 3
-	cure_text = "Rest & Spaceacillin"
+	cure_text = /datum/reagent/medicine/spaceacillin::name + " or rest"
 	cures = list(/datum/reagent/medicine/spaceacillin)
 	agent = "XY-rhinovirus"
 	viable_mobtypes = list(/mob/living/carbon/human)
@@ -11,6 +11,11 @@
 	severity = DISEASE_SEVERITY_NONTHREAT
 	required_organ = ORGAN_SLOT_LUNGS
 
+/datum/disease/cold/cure(add_resistance)
+	// buy one, get one free
+	if(add_resistance && affected_mob)
+		LAZYOR(affected_mob.disease_resistances, "[/datum/disease/cold9]")
+	return ..()
 
 /datum/disease/cold/stage_act(seconds_per_tick)
 	. = ..()

--- a/code/datums/diseases/cold9.dm
+++ b/code/datums/diseases/cold9.dm
@@ -1,15 +1,22 @@
 /datum/disease/cold9
 	name = "The Cold"
 	max_stages = 3
-	spread_text = "On contact"
+	spread_text = "Skin contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS
-	cure_text = "Common Cold Anti-bodies & Spaceacillin"
+	cure_text = /datum/reagent/medicine/spaceacillin::name + " or common Cold antibodies"
 	cures = list(/datum/reagent/medicine/spaceacillin)
 	agent = "ICE9-rhinovirus"
 	viable_mobtypes = list(/mob/living/carbon/human)
-	desc = "If left untreated the subject will slow, as if partly frozen."
+	desc = "An adaption of the common cold, slightly more dangerous in nature. \
+		If left untreated the subject will slow, as if partly frozen."
 	severity = DISEASE_SEVERITY_HARMFUL
 	required_organ = ORGAN_SLOT_LUNGS
+
+/datum/disease/cold9/cure(add_resistance)
+	// buy one, get one free
+	if(add_resistance && affected_mob)
+		LAZYOR(affected_mob.disease_resistances, "[/datum/disease/cold]")
+	return ..()
 
 /datum/disease/cold9/stage_act(seconds_per_tick)
 	. = ..()

--- a/code/datums/diseases/death_sandwich_poisoning.dm
+++ b/code/datums/diseases/death_sandwich_poisoning.dm
@@ -2,12 +2,12 @@
 	name = "Death Sandwich Poisoning"
 	desc = "If left untreated the subject will ultimately perish."
 	form = "Condition"
-	spread_text = "Unknown"
 	max_stages = 3
-	cure_text = "Anacea" // I ain't about to make a second sandwich to counteract the first one, so closest thing I'm going for is this.
+	cure_text = /datum/reagent/toxin/anacea::name // I ain't about to make a second sandwich to counteract the first one, so closest thing I'm going for is this.
 	cures = list(/datum/reagent/toxin/anacea)
 	cure_chance = 4
-	agent = "eating the Death Sandwich wrong"
+	agent = "Eating the Death Sandwich wrong"
+	spread_text = "None"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	severity = DISEASE_SEVERITY_DANGEROUS
 	disease_flags = CURABLE
@@ -57,4 +57,3 @@
 			if(SPT_PROB(1.5, seconds_per_tick))
 				to_chat(affected_mob, span_danger("You try to scream, but nothing comes out!"))
 				affected_mob.set_silence_if_lower(5 SECONDS)
-

--- a/code/datums/diseases/decloning.dm
+++ b/code/datums/diseases/decloning.dm
@@ -3,14 +3,14 @@
 	name = "Cellular Degeneration"
 	max_stages = 5
 	stage_prob = 0.5
-	cure_text = "Rezadone, Mutadone for prolonging, or death."
+	cure_text = /datum/reagent/medicine/rezadone::name + ", abated by " + /datum/reagent/medicine/mutadone::name + ", or death"
 	agent = "Severe Genetic Damage"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	desc = @"If left untreated the subject will [REDACTED]!"
 	severity = "Dangerous!"
 	cures = list(/datum/reagent/medicine/rezadone)
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
-	spread_text = "Organic meltdown"
+	spread_text = "None"
 	process_dead = TRUE
 	bypasses_immunity = TRUE
 

--- a/code/datums/diseases/dna_spread.dm
+++ b/code/datums/diseases/dna_spread.dm
@@ -6,7 +6,7 @@
 	cure_text = /datum/reagent/medicine/mutadone::name
 	cures = list(/datum/reagent/medicine/mutadone)
 	disease_flags = CAN_CARRY|CAN_RESIST|CURABLE
-	agent = "S4E1 retrovirus"
+	agent = "S4E1 Retrovirus"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	var/datum/dna/original_dna = null
 	var/transformed = 0

--- a/code/datums/diseases/dna_spread.dm
+++ b/code/datums/diseases/dna_spread.dm
@@ -1,16 +1,18 @@
 /datum/disease/dnaspread
 	name = "Space Retrovirus"
 	max_stages = 4
-	spread_text = "On contact"
+	spread_text = "Skin contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS
-	cure_text = "Mutadone"
+	cure_text = /datum/reagent/medicine/mutadone::name
 	cures = list(/datum/reagent/medicine/mutadone)
 	disease_flags = CAN_CARRY|CAN_RESIST|CURABLE
 	agent = "S4E1 retrovirus"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	var/datum/dna/original_dna = null
 	var/transformed = 0
-	desc = "This disease transplants the genetic code of the initial vector into new hosts."
+	desc = "A disease which transplants the genetic code of the initial vector into new hosts. \
+		While patient zero will be asymptomatic, all subsequent hosts will shows symptoms similar to that of a common cold or flu \
+		- until eventually transforming into a genetic copy of patient zero."
 	severity = DISEASE_SEVERITY_MEDIUM
 	bypasses_immunity = TRUE
 

--- a/code/datums/diseases/fake_gbs.dm
+++ b/code/datums/diseases/fake_gbs.dm
@@ -1,15 +1,15 @@
 /datum/disease/fake_gbs
 	name = "GBS"
+	desc = "An extremely rare and dangerous disease that has been researched little due to its potentially apocalyptic nature."
 	max_stages = 5
-	spread_text = "On contact"
+	spread_text = "Skin contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS
-	cure_text = "Synaptizine & Sulfur"
+	cure_text = /datum/reagent/medicine/synaptizine::name + " & " + /datum/reagent/sulfur::name
 	cures = list(/datum/reagent/medicine/synaptizine,/datum/reagent/sulfur)
 	agent = "Gravitokinetic Bipotential SADS-"
 	viable_mobtypes = list(/mob/living/carbon/human)
-	desc = "If left untreated death will occur."
 	severity = DISEASE_SEVERITY_BIOHAZARD
-
+	visibility_flags = HIDDEN_BOOK
 
 /datum/disease/fake_gbs/stage_act(seconds_per_tick)
 	. = ..()

--- a/code/datums/diseases/floor_diseases/carpellosis.dm
+++ b/code/datums/diseases/floor_diseases/carpellosis.dm
@@ -3,10 +3,12 @@
 /// Caused by dirty food. Makes you growl at people and bite them spontaneously.
 /datum/disease/carpellosis
 	name = "Carpellosis"
-	desc = "You have an angry space carp inside."
+	desc = "An angry space carp inside has infested the host's stomach, \
+		leading to an uncontrollable urge to gnash at people and wag your tail."
 	form = "Parasite"
 	agent = "Carp Ella"
-	cure_text = "Chlorine"
+	cure_text = /datum/reagent/chlorine::name
+	spread_text = "None"
 	cures = list(/datum/reagent/chlorine)
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS

--- a/code/datums/diseases/floor_diseases/gastritium.dm
+++ b/code/datums/diseases/floor_diseases/gastritium.dm
@@ -2,9 +2,10 @@
 /datum/disease/gastritium
 	name = "Gastritium"
 	desc = "If left untreated, may manifest in severe Tritium heartburn."
-	form = "Infection"
+	form = "Bacteria"
 	agent = "Atmobacter Polyri"
-	cure_text = "Milk"
+	cure_text = /datum/reagent/consumable/milk::name
+	spread_text = "None"
 	cures = list(/datum/reagent/consumable/milk)
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS

--- a/code/datums/diseases/floor_diseases/nebula_nausea.dm
+++ b/code/datums/diseases/floor_diseases/nebula_nausea.dm
@@ -4,7 +4,8 @@
 	desc = "You can't contain the colorful beauty of the cosmos inside."
 	form = "Condition"
 	agent = "Stars"
-	cure_text = "Space Cleaner"
+	cure_text = /datum/reagent/space_cleaner::name
+	spread_text = "None"
 	cures = list(/datum/reagent/space_cleaner)
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS

--- a/code/datums/diseases/flu.dm
+++ b/code/datums/diseases/flu.dm
@@ -2,15 +2,21 @@
 	name = "The Flu"
 	max_stages = 3
 	spread_text = "Airborne"
-	cure_text = "Spaceacillin"
+	cure_text = /datum/reagent/medicine/spaceacillin::name + ", abated by rest"
 	cures = list(/datum/reagent/medicine/spaceacillin)
 	cure_chance = 5
 	agent = "H13N1 flu virion"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spreading_modifier = 0.75
-	desc = "If left untreated the subject will feel quite unwell."
+	desc = "A common, mildly annoying contagion. If left untreated the subject will feel quite unwell."
 	severity = DISEASE_SEVERITY_MINOR
 	required_organ = ORGAN_SLOT_LUNGS
+
+/datum/disease/flu/cure(add_resistance)
+	// buy one, get one free
+	if(add_resistance && affected_mob)
+		LAZYOR(affected_mob.disease_resistances, "[/datum/disease/fluspanish]")
+	return ..()
 
 /datum/disease/flu/stage_act(seconds_per_tick)
 	. = ..()

--- a/code/datums/diseases/flu.dm
+++ b/code/datums/diseases/flu.dm
@@ -5,7 +5,7 @@
 	cure_text = /datum/reagent/medicine/spaceacillin::name + ", abated by rest"
 	cures = list(/datum/reagent/medicine/spaceacillin)
 	cure_chance = 5
-	agent = "H13N1 flu virion"
+	agent = "H13N1 Flu Virion"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spreading_modifier = 0.75
 	desc = "A common, mildly annoying contagion. If left untreated the subject will feel quite unwell."

--- a/code/datums/diseases/fluspanish.dm
+++ b/code/datums/diseases/fluspanish.dm
@@ -5,7 +5,7 @@
 	cure_text = /datum/reagent/medicine/spaceacillin::name + " or common Flu antibodies"
 	cures = list(/datum/reagent/medicine/spaceacillin)
 	cure_chance = 5
-	agent = "1nqu1s1t10n flu virion"
+	agent = "1nqu1s1t10n Flu Virion"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spreading_modifier = 0.75
 	desc = "An adaptation of the common flu, slightly more dangerous in nature. \

--- a/code/datums/diseases/fluspanish.dm
+++ b/code/datums/diseases/fluspanish.dm
@@ -2,15 +2,22 @@
 	name = "Spanish inquisition Flu"
 	max_stages = 3
 	spread_text = "Airborne"
-	cure_text = "Spaceacillin & Anti-bodies to the common flu"
+	cure_text = /datum/reagent/medicine/spaceacillin::name + " or common Flu antibodies"
 	cures = list(/datum/reagent/medicine/spaceacillin)
 	cure_chance = 5
 	agent = "1nqu1s1t10n flu virion"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spreading_modifier = 0.75
-	desc = "If left untreated the subject will burn to death for being a heretic."
+	desc = "An adaptation of the common flu, slightly more dangerous in nature. \
+		If left untreated the subject will burn to death for being a heretic."
 	severity = DISEASE_SEVERITY_DANGEROUS
 	required_organ = ORGAN_SLOT_LUNGS
+
+/datum/disease/fluspanish/cure(add_resistance)
+	// buy one, get one free
+	if(add_resistance && affected_mob)
+		LAZYOR(affected_mob.disease_resistances, "[/datum/disease/flu]")
+	return ..()
 
 /datum/disease/fluspanish/stage_act(seconds_per_tick)
 	. = ..()

--- a/code/datums/diseases/gastrolisis.dm
+++ b/code/datums/diseases/gastrolisis.dm
@@ -5,7 +5,7 @@
 	spread_text = "None"
 	spread_flags = DISEASE_SPREAD_SPECIAL
 	cure_text = /datum/reagent/consumable/salt::name + " & " + /datum/reagent/medicine/mutadone::name
-	agent = "Agent S and DNA restructuring"
+	agent = "Agent S and DNA Restructuring"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	stage_prob = 0.5
 	disease_flags = CURABLE

--- a/code/datums/diseases/gastrolisis.dm
+++ b/code/datums/diseases/gastrolisis.dm
@@ -1,9 +1,10 @@
 /datum/disease/gastrolosis
 	name = "Invasive Gastrolosis"
+	desc = "A bizarre disease that causes the host to grow snail-like features, eventually turning into a human-snail hybrid."
 	max_stages = 4
-	spread_text = "Unknown"
+	spread_text = "None"
 	spread_flags = DISEASE_SPREAD_SPECIAL
-	cure_text = "Salt and mutadone"
+	cure_text = /datum/reagent/consumable/salt::name + " & " + /datum/reagent/medicine/mutadone::name
 	agent = "Agent S and DNA restructuring"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	stage_prob = 0.5

--- a/code/datums/diseases/gbs.dm
+++ b/code/datums/diseases/gbs.dm
@@ -1,9 +1,10 @@
 /datum/disease/gbs
 	name = "GBS"
+	desc = "An extremely rare and dangerous disease that has been researched little due to its potentially apocalyptic nature."
 	max_stages = 4
-	spread_text = "On contact"
+	spread_text = "Skin contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS
-	cure_text = "Synaptizine & Sulfur"
+	cure_text = /datum/reagent/medicine/synaptizine::name + " & " + /datum/reagent/sulfur::name
 	cures = list(/datum/reagent/medicine/synaptizine,/datum/reagent/sulfur)
 	cure_chance = 7.5 //higher chance to cure, since two reagents are required
 	agent = "Gravitokinetic Bipotential SADS+"

--- a/code/datums/diseases/magnitis.dm
+++ b/code/datums/diseases/magnitis.dm
@@ -2,13 +2,14 @@
 	name = "Magnitis"
 	max_stages = 4
 	spread_text = "Airborne"
-	cure_text = "Iron"
+	cure_text = /datum/reagent/iron
 	cures = list(/datum/reagent/iron)
 	agent = "Fukkos Miracos"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	disease_flags = CAN_CARRY|CAN_RESIST|CURABLE
 	spreading_modifier = 0.75
-	desc = "This disease disrupts the magnetic field of your body, making it act as if a powerful magnet. Injections of iron help stabilize the field."
+	desc = "This disease disrupts the magnetic field of the subjects body, making it act as if a powerful magnet. \
+		Injections of iron will help stabilize the field."
 	severity = DISEASE_SEVERITY_MEDIUM
 	infectable_biotypes = MOB_ORGANIC|MOB_ROBOTIC
 	bypasses_immunity = TRUE

--- a/code/datums/diseases/parasitic_infection.dm
+++ b/code/datums/diseases/parasitic_infection.dm
@@ -2,12 +2,13 @@
 	form = "Parasite"
 	name = "Parasitic Infection"
 	max_stages = 4
-	cure_text = "Surgical removal of the liver."
-	agent = "Consuming Live Parasites"
-	spread_text = "Non-Biological"
+	cure_text = "Surgical removal of the liver"
+	agent = "Food-bourne Parasite"
+	spread_text = "None"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spreading_modifier = 1
-	desc = "If left untreated the subject will passively lose nutrients, and eventually lose their liver."
+	desc = "An unknown parasite, likely entering the body via improperly prepared food, has infected the subject's liver. \
+		If left untreated the subject will passively lose nutrients, and eventually lose their liver."
 	severity = DISEASE_SEVERITY_HARMFUL
 	disease_flags = CAN_CARRY|CAN_RESIST
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS

--- a/code/datums/diseases/parrotpossession.dm
+++ b/code/datums/diseases/parrotpossession.dm
@@ -1,15 +1,15 @@
 /datum/disease/parrot_possession
 	name = "Parrot Possession"
 	max_stages = 1
-	spread_text = "Paranormal"
+	spread_text = "None"
 	spread_flags = DISEASE_SPREAD_SPECIAL
 	disease_flags = CURABLE
-	cure_text = "Holy Water."
+	cure_text = /datum/reagent/water/holywater::name
 	cures = list(/datum/reagent/water/holywater)
 	cure_chance = 10
 	agent = "Avian Vengence"
 	viable_mobtypes = list(/mob/living/carbon/human)
-	desc = "Subject is possessed by the vengeful spirit of a parrot. Call the priest."
+	desc = "Subject is possessed by the vengeful spirit of a parrot. Call the Chaplain."
 	severity = DISEASE_SEVERITY_MEDIUM
 	infectable_biotypes = MOB_ORGANIC|MOB_UNDEAD|MOB_ROBOTIC|MOB_MINERAL
 	bypasses_immunity = TRUE //2spook

--- a/code/datums/diseases/pierrot_throat.dm
+++ b/code/datums/diseases/pierrot_throat.dm
@@ -8,7 +8,7 @@
 	agent = "H0NI<42 Virus"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spreading_modifier = 0.75
-	desc = "A strange virus rumored to originate from unwaashed clown costumes. \
+	desc = "A strange virus rumored to originate from unwashed clown costumes. \
 		If left untreated the subject's vocal cords will be affected, likely driving others to insanity."
 	severity = DISEASE_SEVERITY_MEDIUM
 	required_organ = ORGAN_SLOT_TONGUE

--- a/code/datums/diseases/pierrot_throat.dm
+++ b/code/datums/diseases/pierrot_throat.dm
@@ -8,7 +8,8 @@
 	agent = "H0NI<42 Virus"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spreading_modifier = 0.75
-	desc = "If left untreated the subject will probably drive others to insanity."
+	desc = "A strange virus rumored to originate from unwaashed clown costumes. \
+		If left untreated the subject's vocal cords will be affected, likely driving others to insanity."
 	severity = DISEASE_SEVERITY_MEDIUM
 	required_organ = ORGAN_SLOT_TONGUE
 

--- a/code/datums/diseases/retrovirus.dm
+++ b/code/datums/diseases/retrovirus.dm
@@ -3,9 +3,9 @@
 	max_stages = 4
 	spread_text = "Contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS
-	cure_text = "Rest or an injection of mutadone"
+	cure_text = /datum/reagent/medicine/mutadone::name + " or rest"
 	cure_chance = 3
-	agent = ""
+	agent = "Virus"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	desc = "A DNA-altering retrovirus that scrambles the structural and unique enzymes of a host constantly."
 	severity = DISEASE_SEVERITY_HARMFUL

--- a/code/datums/diseases/rhumba_beat.dm
+++ b/code/datums/diseases/rhumba_beat.dm
@@ -1,15 +1,17 @@
 /datum/disease/rhumba_beat
 	name = "The Rhumba Beat"
+	desc = "They call me Cuban Pete - I'm the king of the Rumba Beat - When I play the maracas I go chick-chicky-boom, chick-chicky-boom."
 	max_stages = 5
-	spread_text = "On contact"
+	spread_text = "Skin contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS
 	cure_text = "Chick Chicky Boom!"
-	cures = list("plasma")
+	cures = list(/datum/reagent/toxin/plasma)
 	agent = "Unknown"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spreading_modifier = 1
 	severity = DISEASE_SEVERITY_BIOHAZARD
 	bypasses_immunity = TRUE
+	visibility_flags = HIDDEN_BOOK
 
 /datum/disease/rhumba_beat/stage_act(seconds_per_tick)
 	. = ..()

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -1,7 +1,8 @@
 /datum/disease/transformation
+	abstract_type = /datum/disease/transformation
 	name = "Transformation"
 	max_stages = 5
-	spread_text = "Acute"
+	spread_text = "None"
 	spread_flags = DISEASE_SPREAD_SPECIAL
 	cure_text = "A coder's love (theoretical)."
 	agent = "Shenanigans"
@@ -99,7 +100,7 @@
 
 /datum/disease/transformation/jungle_flu
 	name = "Jungle Flu"
-	cure_text = "Death."
+	cure_text = "Death"
 	cures = list(/datum/reagent/medicine/adminordrazine)
 	spread_text = "Unknown"
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
@@ -148,7 +149,7 @@
 
 /datum/disease/transformation/robot
 	name = "Robotic Transformation"
-	cure_text = "An injection of copper."
+	cure_text = /datum/reagent/copper::name
 	cures = list(/datum/reagent/copper)
 	cure_chance = 2.5
 	agent = "R2D2 Nanomachines"
@@ -188,7 +189,7 @@
 /datum/disease/transformation/xeno
 
 	name = "Xenomorph Transformation"
-	cure_text = "Spaceacillin & Glycerol"
+	cure_text = /datum/reagent/medicine/spaceacillin::name + " & " + /datum/reagent/glycerol::name
 	cures = list(/datum/reagent/medicine/spaceacillin, /datum/reagent/glycerol)
 	cure_chance = 2.5
 	agent = "Rip-LEY Alien Microbes"
@@ -229,7 +230,7 @@
 
 /datum/disease/transformation/slime
 	name = "Advanced Mutation Transformation"
-	cure_text = "Frost oil"
+	cure_text = /datum/reagent/consumable/frostoil::name
 	cures = list(/datum/reagent/consumable/frostoil)
 	cure_chance = 55
 	agent = "Advanced Mutation Toxin"
@@ -317,7 +318,7 @@
 
 /datum/disease/transformation/gondola
 	name = "Gondola Transformation"
-	cure_text = "Condensed Capsaicin, ingested or injected." //getting pepper sprayed doesn't help
+	cure_text = /datum/reagent/consumable/condensedcapsaicin::name + " (not applied via vapor)"
 	cures = list(/datum/reagent/consumable/condensedcapsaicin) //beats the hippie crap right out of your system
 	cure_chance = 55
 	stage_prob = 2.5

--- a/code/datums/diseases/tuberculosis.dm
+++ b/code/datums/diseases/tuberculosis.dm
@@ -1,5 +1,5 @@
 /datum/disease/tuberculosis
-	form = "Bacteria"
+	form = "Fungus"
 	name = "Fungal Tuberculosis"
 	max_stages = 5
 	spread_text = "Airborne"
@@ -8,7 +8,7 @@
 	agent = "Fungal Tubercle Bacillus Cosmosis"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	cure_chance = 2.5 //like hell are you getting out of hell
-	desc = "A rare and highly transmissible virulent bacteria. \
+	desc = "A rare and highly transmissible virulent fungus. \
 		Few samples exist, rumoured to be carefully grown and cultured by clandestine bio-weapon specialists. \
 		Causes fever, blood vomiting, lung damage, weight loss, fatigue, and eventually death."
 	required_organ = ORGAN_SLOT_LUNGS

--- a/code/datums/diseases/tuberculosis.dm
+++ b/code/datums/diseases/tuberculosis.dm
@@ -1,14 +1,16 @@
 /datum/disease/tuberculosis
-	form = "Disease"
-	name = "Fungal tuberculosis"
+	form = "Bacteria"
+	name = "Fungal Tuberculosis"
 	max_stages = 5
 	spread_text = "Airborne"
-	cure_text = "Spaceacillin & Convermol"
+	cure_text = /datum/reagent/medicine/spaceacillin::name + " & " + /datum/reagent/medicine/c2/convermol::name
 	cures = list(/datum/reagent/medicine/spaceacillin, /datum/reagent/medicine/c2/convermol)
-	agent = "Fungal Tubercle bacillus Cosmosis"
+	agent = "Fungal Tubercle Bacillus Cosmosis"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	cure_chance = 2.5 //like hell are you getting out of hell
-	desc = "A rare highly transmissible virulent virus. Few samples exist, rumoured to be carefully grown and cultured by clandestine bio-weapon specialists. Causes fever, blood vomiting, lung damage, weight loss, and fatigue."
+	desc = "A rare and highly transmissible virulent bacteria. \
+		Few samples exist, rumoured to be carefully grown and cultured by clandestine bio-weapon specialists. \
+		Causes fever, blood vomiting, lung damage, weight loss, fatigue, and eventually death."
 	required_organ = ORGAN_SLOT_LUNGS
 	severity = DISEASE_SEVERITY_BIOHAZARD
 	bypasses_immunity = TRUE // TB primarily impacts the lungs; it's also bacterial or fungal in nature; viral immunity should do nothing.

--- a/code/datums/diseases/weightlessness.dm
+++ b/code/datums/diseases/weightlessness.dm
@@ -1,9 +1,9 @@
 /datum/disease/weightlessness
 	name = "Localized Weightloss Malfunction"
 	max_stages = 4
-	spread_text = "On Contact"
+	spread_text = "Skin contact"
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS
-	cure_text = "Liquid dark matter"
+	cure_text = /datum/reagent/liquid_dark_matter::name
 	cures = list(/datum/reagent/liquid_dark_matter)
 	agent = "Sub-quantum DNA Repulsion"
 	viable_mobtypes = list(/mob/living/carbon/human)

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -2,7 +2,7 @@
 	name = "Wizarditis"
 	max_stages = 4
 	spread_text = "Airborne"
-	cure_text = "The Manly Dorf"
+	cure_text = /datum/reagent/consumable/ethanol/manly_dorf::name + ", abated by magical grounding"
 	cures = list(/datum/reagent/consumable/ethanol/manly_dorf)
 	cure_chance = 100
 	agent = "Rincewindus Vulgaris"

--- a/code/datums/elements/blood_reagent.dm
+++ b/code/datums/elements/blood_reagent.dm
@@ -91,7 +91,7 @@
 		return
 
 	for(var/datum/disease/strain as anything in source.data["viruses"])
-		if ((strain.spread_flags & DISEASE_SPREAD_SPECIAL) || (strain.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
+		if ((strain.spread_flags & (DISEASE_SPREAD_SPECIAL|DISEASE_SPREAD_NON_CONTAGIOUS)))
 			continue
 
 		if (methods & INGEST)

--- a/code/modules/antagonists/revenant/revenant_blight.dm
+++ b/code/modules/antagonists/revenant/revenant_blight.dm
@@ -3,8 +3,8 @@
 	max_stages = 5
 	stage_prob = 5
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
-	cure_text = "Holy water or extensive rest."
-	spread_text = "A burst of unholy energy"
+	cure_text = /datum/reagent/water/holywater::name + " or rest"
+	spread_text = "None"
 	cures = list(/datum/reagent/water/holywater)
 	cure_chance = 30 //higher chance to cure, because revenants are assholes
 	agent = "Unholy Forces"

--- a/code/modules/bitrunning/virtual_domain/domains/gondola_asteroid.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/gondola_asteroid.dm
@@ -36,3 +36,4 @@
 /datum/disease/transformation/gondola/virtual_domain
 	stage_prob = 9
 	new_form = /mob/living/basic/pet/gondola/virtual_domain
+	visibility_flags = parent_type::visibility_flags | HIDDEN_BOOK

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -369,3 +369,45 @@
 
 	data["traumas"] = trauma_info
 	return data
+
+/obj/item/tgui_book/manual/idc
+	name = "\improper IDC-27"
+	desc = "The Interplanetary Classification of Diseases, \
+		a comprehensive book on all known diseases and ailments. \
+		On its 27th edition - though it's due for an update..."
+	icon_state = "book7"
+	ui_name = "IDCBook"
+
+/obj/item/tgui_book/manual/idc/ui_static_data(mob/user)
+	var/list/data = list()
+
+	var/static/list/disease_info
+	if(!disease_info)
+		disease_info = list()
+
+		for(var/datum/disease/disease_type as anything in valid_subtypesof(/datum/disease))
+			if(disease_type::visibility_flags & HIDDEN_BOOK)
+				continue
+
+			var/list/disease_data = list()
+			disease_data["form"] = disease_type::form
+			disease_data["agent"] = disease_type::agent
+			disease_data["name"] = disease_type::name
+			disease_data["desc"] = disease_type::desc
+			disease_data["spread_by"] = disease_type::spread_text || get_disease_spread_text(disease_type::spread_flags)
+			disease_data["cured_by"] = disease_type::cure_text
+			disease_data["id"] = disease_type
+			disease_info += list(disease_data)
+
+		for(var/datum/symptom/symptom_type as anything in valid_subtypesof(/datum/symptom))
+			var/list/symptom_data = list()
+			symptom_data["form"] = "Symptom"
+			symptom_data["name"] = symptom_type::name
+			symptom_data["desc"] = symptom_type::desc
+			symptom_data["illness"] = symptom_type::illness
+			symptom_data["cured_by"] = symptom_type::symptom_cure::name
+			symptom_data["id"] = symptom_type
+			disease_info += list(symptom_data)
+
+	data["diseases"] = disease_info
+	return data

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -297,6 +297,10 @@
 /obj/item/tgui_book/manual
 	abstract_type = /obj/item/tgui_book/manual
 
+/// Asserts a field is present in a list, stack traces if not
+#define ASSERT_DATA(data_list, data_field) \
+	if(!data_list[data_field]) { stack_trace("[type] - [data_list["id"]] lacks [data_field] information!"); }
+
 /obj/item/tgui_book/manual/dsm
 	name = "\improper SDSM-35"
 	desc = "The Space Diagnostic and Statistical Manual of Mental Disorders, \
@@ -360,10 +364,15 @@
 
 		// validate
 		for(var/list/trauma_data as anything in trauma_info)
-			if(isnull(trauma_data["desc"]))
+			// these are asserted to be present, no matter what
+			ASSERT_DATA(trauma_data, "full_name")
+			ASSERT_DATA(trauma_data, "scan_name")
+			ASSERT_DATA(trauma_data, "id")
+			// these start as null, so there is a chance they are missing
+			if(!trauma_data["desc"])
 				trauma_data["desc"] = "No description recorded - this is an error. Report this lack of research."
 				stack_trace("[type] - [trauma_data["id"]] lacks a description!")
-			if(isnull(trauma_data["symptoms"]))
+			if(!trauma_data["symptoms"])
 				trauma_data["symptoms"] = "No symptoms recorded - this is an error. Report this lack of research."
 				stack_trace("[type] - [trauma_data["id"]] lacks symptom information!")
 
@@ -394,6 +403,7 @@
 			disease_data["agent"] = disease_type::agent
 			disease_data["name"] = disease_type::name
 			disease_data["desc"] = disease_type::desc
+			disease_data["illness"] = "N/A"
 			disease_data["spread_by"] = disease_type::spread_text || get_disease_spread_text(disease_type::spread_flags)
 			disease_data["cured_by"] = disease_type::cure_text
 			disease_data["id"] = disease_type
@@ -402,12 +412,47 @@
 		for(var/datum/symptom/symptom_type as anything in valid_subtypesof(/datum/symptom))
 			var/list/symptom_data = list()
 			symptom_data["form"] = "Symptom"
+			symptom_data["agent"] = "N/A"
 			symptom_data["name"] = symptom_type::name
 			symptom_data["desc"] = symptom_type::desc
 			symptom_data["illness"] = symptom_type::illness
+			symptom_data["spread_by"] = "N/A"
 			symptom_data["cured_by"] = symptom_type::symptom_cure::name
 			symptom_data["id"] = symptom_type
 			disease_info += list(symptom_data)
 
+		var/list/advanced_virus_info = list(
+			"form" = "Virus",
+			"agent" = "Microbes",
+			"name" = "Advanced Disease",
+			"desc" = "A catch-all category for diseases that are too complex to document in their entirety. \
+				The Virology department is known for bio-engineering these diseases, as such their danger can vary wildly. \
+				These diseases are often a combination of various symptoms, each cataloged in this book individually.",
+			"illness" = "N/A",
+			"spread_by" = "Varies by symptom combination",
+			"cured_by" = "Varies by symptom combination",
+			"id" = /datum/disease/advance,
+		)
+		disease_info += advanced_virus_info
+
+		// validate
+		for(var/list/disease_data as anything in disease_info)
+			// these are asserted to be present, no matter what
+			ASSERT_DATA(disease_data, "form")
+			ASSERT_DATA(disease_data, "agent")
+			ASSERT_DATA(disease_data, "name")
+			ASSERT_DATA(disease_data, "spread_by")
+			ASSERT_DATA(disease_data, "illness")
+			ASSERT_DATA(disease_data, "id")
+			// these start as null, so there is a chance they are missing
+			if(!disease_data["desc"])
+				disease_data["desc"] = "No description recorded - this is an error. Report this lack of research."
+				stack_trace("[type] - [disease_data["id"]] lacks a description!")
+			if(!disease_data["cured_by"])
+				disease_data["cured_by"] = "Unknown"
+				stack_trace("[type] - [disease_data["id"]] lacks cure information!")
+
 	data["diseases"] = disease_info
 	return data
+
+#undef ASSERT_DATA

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -302,7 +302,7 @@
 	if(!data_list[data_field]) { stack_trace("[type] - [data_list["id"]] lacks [data_field] information!"); }
 
 /obj/item/tgui_book/manual/dsm
-	name = "\improper SDSM-35"
+	name = "\improper SDSM-35" // 35 was picked based on the current edition plus the average years between edition divided by 500
 	desc = "The Space Diagnostic and Statistical Manual of Mental Disorders, \
 		a comprehensive book on all known mental disorders. \
 		On its 35th edition - though it's due for an update..."
@@ -380,7 +380,7 @@
 	return data
 
 /obj/item/tgui_book/manual/idc
-	name = "\improper IDC-27"
+	name = "\improper IDC-27" // 27 was picked based on the current edition plus the average years between edition divided by 500
 	desc = "The Interplanetary Classification of Diseases, \
 		a comprehensive book on all known diseases and ailments. \
 		On its 27th edition - though it's due for an update..."

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -400,7 +400,7 @@
 
 	if(blood_data["viruses"] && transfer_viruses)
 		for(var/datum/disease/blood_disease as anything in blood_data["viruses"])
-			if((blood_disease.spread_flags & DISEASE_SPREAD_SPECIAL) || (blood_disease.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
+			if((blood_disease.spread_flags & (DISEASE_SPREAD_SPECIAL|DISEASE_SPREAD_NON_CONTAGIOUS)))
 				continue
 			target.ForceContractDisease(blood_disease)
 

--- a/tgui/packages/tgui/interfaces/DSMBook.tsx
+++ b/tgui/packages/tgui/interfaces/DSMBook.tsx
@@ -1,421 +1,122 @@
-import { useState } from 'react';
 import { useBackend } from 'tgui/backend';
-import { Box, Button, Section, Stack } from 'tgui-core/components';
-import { Window } from '../layouts';
-import deforest_logo from '../styles/assets/bg-deforest.svg';
+import { Box, Section, Stack } from 'tgui-core/components';
+import { type BookEntry, BookUI, type TOCEntry } from './common/PaginatedBook';
+import '../styles/interfaces/DeForestLogo.scss';
 
 type Trauma = {
-  full_name: string; // full "medical" name
-  scan_name: string; // shortened name shown on scan
-  desc: string; // short description of trauma effect
-  symptoms: string; // longer description of how it affects people
-  id: string; // typepath
-};
-
-type TraumaPage = Trauma & {
-  page: number; // page to put the trauma on
-};
-
-type TOCEntry = {
-  trauma: Trauma;
-  displayed_page: number; // page to put the toc entry on
-  entry_page: number; // page the trauma is on
+  full_name: string;
+  scan_name: string;
+  desc: string;
+  symptoms: string;
+  id: string;
 };
 
 type TraumaData = {
   traumas: Trauma[];
 };
 
-// fits as many traumas as possible on a page
-function getTOCWithPages(traumas: Trauma[], windowheight: number) {
-  const page_height = windowheight - 50;
-  const pages: TOCEntry[] = [];
-  let current_page = 1;
-  let current_page_height = 0;
-
-  for (const trauma of traumas) {
-    // estimate height of toc entry
-    const estimated_height = 30;
-
-    if (current_page_height + estimated_height > page_height) {
-      // move to next page
-      current_page += 1;
-      current_page_height = 0;
-    }
-
-    const pageentry: TOCEntry = {
-      trauma: trauma,
-      displayed_page: current_page,
-      entry_page: -1, // to be filled later
-    };
-
-    pages.push(pageentry);
-
-    current_page_height += estimated_height;
-  }
-
-  return pages;
+function checkIdenticalTraumaNames(trauma: BookEntry<Trauma>) {
+  return trauma.full_name.toLowerCase() === trauma.scan_name.toLowerCase();
 }
 
-function getTraumasWithPages(
-  traumas: Trauma[],
-  windowheight: number,
-  start_page: number,
-) {
-  const page_height = windowheight - 50;
-  const pages: TraumaPage[] = [];
-  let current_page = start_page;
-  let current_page_height = 0;
-
-  for (const trauma of traumas) {
-    // estimate height of trauma entry
-    const title_height = 40;
-    const subttitle_height = checkIdenticalTraumaNames(trauma) ? 0 : 20;
-    const desc_height = Math.ceil(trauma.desc.length / 50) * 12.5;
-    const symptoms_height = Math.ceil(trauma.symptoms.length / 50) * 12.5;
-    const extra_spacing = 40;
-
-    const estimated_height =
-      title_height +
-      subttitle_height +
-      desc_height +
-      symptoms_height +
-      extra_spacing;
-
-    if (current_page_height + estimated_height > page_height) {
-      // move to next page
-      current_page += 1;
-      current_page_height = 0;
-    }
-
-    const pageentry: TraumaPage = {
-      ...trauma,
-      page: current_page,
-    };
-
-    pages.push(pageentry);
-
-    current_page_height += estimated_height;
-  }
-
-  return pages;
-}
-
-function checkIdenticalTraumaNames(traumas: Trauma) {
-  return traumas.full_name.toLowerCase() === traumas.scan_name.toLowerCase();
-}
-
-type DSMEntryComponentProps = {
-  trauma: TraumaPage;
-};
-
-const DSMEntryComponent = (props: DSMEntryComponentProps) => {
-  const { trauma } = props;
+function estimateHeight(entry: BookEntry<Trauma>) {
+  const title_height = 40;
+  const subttitle_height = checkIdenticalTraumaNames(entry) ? 0 : 20;
+  const desc_height = Math.ceil(entry.desc.length / 50) * 12.5;
+  const symptoms_height = Math.ceil(entry.symptoms.length / 50) * 12.5;
+  const extra_spacing = 40;
 
   return (
+    title_height +
+    subttitle_height +
+    desc_height +
+    symptoms_height +
+    extra_spacing
+  );
+}
+
+function renderDSMEntry(entry: BookEntry<Trauma>) {
+  return (
     <Section
+      width="100%"
       fitted
+      pt={0.2}
+      pl={1}
       title={
         <Stack vertical>
-          <Stack.Item>{trauma.full_name}</Stack.Item>
-          {!checkIdenticalTraumaNames(trauma) && (
-            <Stack.Item fontSize="10px">...aka "{trauma.scan_name}"</Stack.Item>
+          <Stack.Item>{entry.full_name}</Stack.Item>
+          {!checkIdenticalTraumaNames(entry) && (
+            <Stack.Item fontSize="10px">...aka "{entry.scan_name}"</Stack.Item>
           )}
         </Stack>
       }
     >
-      <Stack vertical backgroundColor="white" p={1}>
+      <Stack vertical backgroundColor="white" p={1} width="100%">
         <Stack.Item>
           <Box inline color="label">
             Description:
           </Box>{' '}
-          {trauma.desc}
+          {entry.desc}
         </Stack.Item>
         <Stack.Item>
           <Box inline color="label">
             Diagnosis:
           </Box>{' '}
-          {trauma.symptoms}
+          {entry.symptoms}
         </Stack.Item>
       </Stack>
     </Section>
   );
-};
+}
 
-type TocEntryComponentProps = {
-  entry: TOCEntry;
-  setPage: (page: number) => void;
-};
-
-const TOCEntryComponent = (props: TocEntryComponentProps) => {
-  const { entry, setPage } = props;
-
+function renderTOCEntry(tocentry: TOCEntry<Trauma>) {
   return (
-    <Stack textAlign="center" fontSize="13px">
-      <Stack.Item>
-        <Stack align="end">
-          <Stack.Item>{entry.trauma.full_name}</Stack.Item>
-          {!checkIdenticalTraumaNames(entry.trauma) && (
-            <Stack.Item
-              fontSize="10px"
-              italic
-              maxWidth={`${(50 - entry.trauma.full_name.length) * 5}px`}
-              style={{
-                overflow: 'hidden',
-                whiteSpace: 'nowrap',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              ({entry.trauma.scan_name})
-            </Stack.Item>
-          )}
-        </Stack>
-      </Stack.Item>
-      <Stack.Item grow>
-        <Box
-          height="50%"
+    <Stack align="end">
+      <Stack.Item>{tocentry.entry.full_name}</Stack.Item>
+      {!checkIdenticalTraumaNames(tocentry.entry) && (
+        <Stack.Item
+          fontSize="10px"
+          italic
+          maxWidth={`${(50 - tocentry.entry.full_name.length) * 5}px`}
           style={{
-            borderBottom: '2px dotted rgba(255, 255, 255)',
-            borderColor: 'black',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
           }}
-        />
-      </Stack.Item>
-      <Stack.Item width="10%">
-        <Button
-          fluid
-          onClick={() => setPage(entry.entry_page - (entry.entry_page % 2))}
         >
-          {entry.entry_page}
-        </Button>
-      </Stack.Item>
+          ({tocentry.entry.scan_name})
+        </Stack.Item>
+      )}
     </Stack>
   );
-};
+}
 
-type PageTurnProps = {
-  page: number;
-  setPage: (page: number) => void;
-  title: string;
-  maxPage: number;
-};
-
-const PageTurn = (props: PageTurnProps) => {
-  const { page, setPage, title, maxPage } = props;
-  const { act } = useBackend();
-
-  return (
-    <Stack>
-      <Stack.Item>
-        <Button
-          icon="angles-left"
-          onClick={() => {
-            setPage(1);
-            act('play_flip_sound');
-          }}
-          fluid
-          disabled={page <= 1}
-        />
-      </Stack.Item>
-      <Stack.Item>
-        <Button
-          icon="angle-left"
-          onClick={() => {
-            setPage(page - 2);
-            act('play_flip_sound');
-          }}
-          fluid
-          disabled={page <= 1}
-        />
-      </Stack.Item>
-      <Stack.Item textAlign="center" grow>
-        <Stack fill fontSize="15px">
-          <Stack.Item grow bold>
-            {page}
-          </Stack.Item>
-          <Stack.Item color="label">~ {title} ~</Stack.Item>
-          <Stack.Item grow bold>
-            {page + 1}
-          </Stack.Item>
-        </Stack>
-      </Stack.Item>
-      <Stack.Item>
-        <Button
-          icon="angle-right"
-          onClick={() => {
-            setPage(page + 2);
-            act('play_flip_sound');
-          }}
-          fluid
-          disabled={page + 1 >= maxPage}
-        />
-      </Stack.Item>
-      <Stack.Item>
-        <Button
-          icon="angles-right"
-          onClick={() => {
-            setPage(maxPage - (maxPage % 2));
-            act('play_flip_sound');
-          }}
-          fluid
-          disabled={page + 1 >= maxPage}
-        />
-      </Stack.Item>
-    </Stack>
-  );
-};
-
-type FakePageProps = {
-  tocDisplay?: TOCEntry[];
-  traumaDisplay?: TraumaPage[];
-  setPage: (page: number) => void;
-};
-
-const FakePage = (props: FakePageProps) => {
-  const { tocDisplay, traumaDisplay, setPage } = props;
-
-  return (
-    <Section fill>
-      <Stack vertical fill>
-        {tocDisplay?.map((entry) => (
-          <Stack.Item key={entry.trauma.id}>
-            <TOCEntryComponent entry={entry} setPage={setPage} />
-          </Stack.Item>
-        ))}
-        {traumaDisplay?.map((trauma) => (
-          <Stack.Item key={trauma.id}>
-            <DSMEntryComponent trauma={trauma} />
-          </Stack.Item>
-        ))}
-        {!tocDisplay?.length && !traumaDisplay?.length && (
-          <Stack.Item textAlign="center" color="label" grow mt={13}>
-            <img src={deforest_logo} width={256} height={256} />
-          </Stack.Item>
-        )}
-      </Stack>
-    </Section>
-  );
-};
-
-type FakePagesProps = {
-  tocDisplay?: TOCEntry[];
-  traumaDisplay?: TraumaPage[];
-  page: number;
-  setPage: (page: number) => void;
-};
-
-const FakePages = (props: FakePagesProps) => {
-  const { tocDisplay, traumaDisplay, page, setPage } = props;
-
-  const leftTOC = tocDisplay?.filter((entry) => entry.displayed_page === page);
-  const rightTOC = tocDisplay?.filter(
-    (entry) => entry.displayed_page === page + 1,
-  );
-
-  const leftTrauma = traumaDisplay?.filter((trauma) => trauma.page === page);
-  const rightTrauma = traumaDisplay?.filter(
-    (trauma) => trauma.page === page + 1,
-  );
-
-  return (
-    <Stack fill>
-      <Stack.Item grow>
-        <FakePage
-          tocDisplay={leftTOC}
-          traumaDisplay={leftTrauma}
-          setPage={setPage}
-        />
-      </Stack.Item>
-      <Stack.Item grow>
-        <FakePage
-          tocDisplay={rightTOC}
-          traumaDisplay={rightTrauma}
-          setPage={setPage}
-        />
-      </Stack.Item>
-    </Stack>
-  );
-};
+const blankDSMPage = (
+  <Stack.Item textAlign="center" grow className="deforest_logo" />
+);
 
 export const DSMBook = () => {
   const { data } = useBackend<TraumaData>();
   const { traumas } = data;
 
-  // abc it up
-  const traumasSorted = [...traumas].sort((a, b) =>
-    a.full_name > b.full_name ? 1 : -1,
-  );
-
-  const windowheight = 565; // used in measurements below
-  const allTOCWithPages = getTOCWithPages(traumasSorted, windowheight);
-
-  // determine what page toc ends and traumas begin on
-  let finalTOCPage = allTOCWithPages.reduce(
-    (maxpage, entry) => Math.max(maxpage, entry.displayed_page),
-    1,
-  );
-
-  // if final toc page is odd, make it even, so traumas start on the left
-  if (finalTOCPage % 2 !== 0) {
-    finalTOCPage += 1;
-  }
-
-  const allTraumaWithPages = getTraumasWithPages(
-    traumasSorted,
-    windowheight,
-    finalTOCPage + 1,
-  );
-
-  // determine final page number for each TOC entry
-  for (const trauma of traumas) {
-    const traumaPage = allTraumaWithPages.find((t) => t.id === trauma.id);
-    const tocEntry = allTOCWithPages.find((e) => e.trauma.id === trauma.id);
-    if (traumaPage && tocEntry) {
-      tocEntry.entry_page = traumaPage.page;
-    }
-  }
-
-  const lastPage = allTraumaWithPages.reduce(
-    (maxpage, trauma) => Math.max(maxpage, trauma.page),
-    finalTOCPage,
-  );
-
-  // two pages are shown at once, so front page is 1+2
-  const [page, setPage] = useState(1);
+  const traumaEntries: BookEntry<Trauma>[] = traumas
+    .map((trauma) => ({
+      id: trauma.id,
+      full_name: trauma.full_name,
+      scan_name: trauma.scan_name,
+      desc: trauma.desc,
+      symptoms: trauma.symptoms,
+    }))
+    .sort((a, b) => (a.full_name > b.full_name ? 1 : -1));
 
   return (
-    <Window
-      height={windowheight}
-      width={765}
+    <BookUI
+      bookData={traumaEntries}
       title="SDSM-35"
-      theme="ntos_lightmode"
-    >
-      <Window.Content
-        style={{
-          backgroundImage: 'none',
-        }}
-      >
-        <Stack vertical fill>
-          <Stack.Item>
-            <Section>
-              <PageTurn
-                page={page}
-                setPage={setPage}
-                maxPage={lastPage}
-                title={page <= finalTOCPage ? `Table of Contents` : `SDSM-35`}
-              />
-            </Section>
-          </Stack.Item>
-
-          <Stack.Item grow>
-            <FakePages
-              tocDisplay={allTOCWithPages}
-              traumaDisplay={allTraumaWithPages}
-              page={page}
-              setPage={setPage}
-            />
-          </Stack.Item>
-        </Stack>
-      </Window.Content>
-    </Window>
+      estimateHeight={estimateHeight}
+      renderEntry={renderDSMEntry}
+      renderTOCEntry={renderTOCEntry}
+      blankPage={blankDSMPage}
+    />
   );
 };

--- a/tgui/packages/tgui/interfaces/IDCBook.tsx
+++ b/tgui/packages/tgui/interfaces/IDCBook.tsx
@@ -1,0 +1,224 @@
+import { useBackend } from 'tgui/backend';
+import { Box, Section, Stack } from 'tgui-core/components';
+import { type BookEntry, BookUI, type TOCEntry } from './common/PaginatedBook';
+import '../styles/interfaces/DeForestLogo.scss';
+
+type Disease = {
+  name: string; // used by symptoms and diseases - name of the disease or symptom
+  desc: string; // used by symptoms and diseases - description of the disease or symptom
+  form: string; // used by symptoms and diseases - something like symptom, virus, bacteria, etc
+  agent?: string; // used by diseases - the agent that causes the disease, like a virus or bacteria name
+  spread_by?: string; // used by diseases - how the disease is spread, like "Airborne" or "Contact"
+  cured_by: string; // used by symptoms and diseases - how the disease or symptom is cured, like a medicine name or "Unknown"
+  illness?: string; // used by symptoms - the common illness associated with the symptom, like "Flu" for "Fever"
+  id: string;
+};
+
+type DiseaseData = {
+  diseases: Disease[];
+};
+
+function formatSpreadBy(spread_by: string) {
+  switch (spread_by.toLowerCase()) {
+    case 'airborne':
+      return (
+        <Stack align="end">
+          <Stack.Item>Airborne</Stack.Item>
+          <Stack.Item fontSize="10px" pb={0.2}>
+            (e.g. coughing, sneezing)
+          </Stack.Item>
+        </Stack>
+      );
+    case 'skin contact':
+    case 'contact':
+      return (
+        <Stack align="end">
+          <Stack.Item>Contact</Stack.Item>
+          <Stack.Item fontSize="10px" pb={0.2}>
+            (e.g. touching infected persons)
+          </Stack.Item>
+        </Stack>
+      );
+    case 'liquids':
+      return (
+        <Stack align="end">
+          <Stack.Item>Liquids</Stack.Item>
+          <Stack.Item fontSize="10px" pb={0.2}>
+            (e.g. blood, saliva)
+          </Stack.Item>
+        </Stack>
+      );
+    case 'none':
+      return (
+        <Stack align="end">
+          <Stack.Item>None</Stack.Item>
+          <Stack.Item fontSize="10px" pb={0.2}>
+            (not contagious)
+          </Stack.Item>
+        </Stack>
+      );
+    default:
+      return spread_by;
+  }
+}
+
+function estimateHeight(entry: BookEntry<Disease>) {
+  const title_height = 40;
+  const extra_spacing = 40;
+  if (entry.form === 'Symptom') {
+    const desc_height = Math.ceil(entry.desc.length / 50) * 14;
+    const illness_height = entry.illness !== 'Unidentified' ? 10 : 0;
+    const cured_by_height = 10;
+
+    return (
+      title_height +
+      desc_height +
+      illness_height +
+      cured_by_height +
+      extra_spacing
+    );
+  }
+
+  const desc_height = Math.ceil(entry.desc.length / 50) * 14;
+  const agent_height = 15;
+  const spread_by_height = 15;
+  const cured_by_height = 15;
+
+  return (
+    title_height +
+    desc_height +
+    agent_height +
+    spread_by_height +
+    cured_by_height +
+    extra_spacing
+  );
+}
+
+function renderDSMEntry(entry: BookEntry<Disease>) {
+  return (
+    <Section
+      width="100%"
+      fitted
+      pt={0.2}
+      pl={1}
+      title={
+        <Stack align="end">
+          <Stack.Item grow>{entry.name}</Stack.Item>
+          <Stack.Item italic fontSize="10px" pb={0.2} pr={0.5}>
+            ({entry.form})
+          </Stack.Item>
+        </Stack>
+      }
+    >
+      <Stack vertical backgroundColor="white" p={1}>
+        {entry.form === 'Symptom' ? (
+          <>
+            <Stack.Item>
+              <Box inline color="label">
+                Description:
+              </Box>{' '}
+              {entry.desc}
+            </Stack.Item>
+            {entry.illness !== 'Unidentified' && (
+              <Stack.Item>
+                <Box inline color="label">
+                  Common associated illness:
+                </Box>{' '}
+                "{entry.illness}"
+              </Stack.Item>
+            )}
+            <Stack.Item>
+              <Box inline color="label">
+                Common cures:
+              </Box>{' '}
+              {entry.cured_by || 'Unknown'}
+            </Stack.Item>
+          </>
+        ) : (
+          <>
+            <Stack.Item>
+              <Box inline color="label">
+                Agent:
+              </Box>{' '}
+              {entry.agent}
+            </Stack.Item>
+            <Stack.Item>
+              <Box inline color="label">
+                Description:
+              </Box>{' '}
+              {entry.desc}
+            </Stack.Item>
+            <Stack.Item>
+              <Box inline color="label">
+                Spread By:
+              </Box>{' '}
+              <Box inline>{formatSpreadBy(entry.spread_by || 'Unknown')}</Box>
+            </Stack.Item>
+            <Stack.Item>
+              <Box inline color="label">
+                Cured By:
+              </Box>{' '}
+              {entry.cured_by || 'No known cure'}
+            </Stack.Item>
+          </>
+        )}
+      </Stack>
+    </Section>
+  );
+}
+
+function renderTOCEntry(tocentry: TOCEntry<Disease>) {
+  return (
+    <Stack align="end">
+      <Stack.Item>{tocentry.entry.name}</Stack.Item>
+      <Stack.Item
+        fontSize="10px"
+        italic
+        maxWidth={`${(50 - tocentry.entry.name.length) * 5}px`}
+        style={{
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+        }}
+        pb={0.2}
+      >
+        ({tocentry.entry.form})
+      </Stack.Item>
+    </Stack>
+  );
+}
+
+const blankIDCPage = (
+  <Stack.Item textAlign="center" grow className="deforest_logo" />
+);
+
+export const IDCBook = () => {
+  const { data } = useBackend<DiseaseData>();
+  const { diseases } = data;
+
+  const diseaseEntries: BookEntry<Disease>[] = diseases
+    .map((disease) => ({
+      id: disease.id,
+      name: disease.name,
+      desc: disease.desc,
+      form: disease.form,
+      agent: disease.agent,
+      spread_by: disease.spread_by,
+      cured_by: disease.cured_by,
+      illness: disease.illness,
+    }))
+    .sort((a, b) =>
+      a.form > b.form ? 1 : a.form < b.form ? -1 : a.name > b.name ? 1 : -1,
+    );
+
+  return (
+    <BookUI
+      bookData={diseaseEntries}
+      title="IDC-27"
+      estimateHeight={estimateHeight}
+      renderEntry={renderDSMEntry}
+      renderTOCEntry={renderTOCEntry}
+      blankPage={blankIDCPage}
+    />
+  );
+};

--- a/tgui/packages/tgui/interfaces/IDCBook.tsx
+++ b/tgui/packages/tgui/interfaces/IDCBook.tsx
@@ -7,10 +7,10 @@ type Disease = {
   name: string; // used by symptoms and diseases - name of the disease or symptom
   desc: string; // used by symptoms and diseases - description of the disease or symptom
   form: string; // used by symptoms and diseases - something like symptom, virus, bacteria, etc
-  agent?: string; // used by diseases - the agent that causes the disease, like a virus or bacteria name
-  spread_by?: string; // used by diseases - how the disease is spread, like "Airborne" or "Contact"
+  agent: string; // used by diseases - the agent that causes the disease, like a virus or bacteria name
+  spread_by: string; // used by diseases - how the disease is spread, like "Airborne" or "Contact"
   cured_by: string; // used by symptoms and diseases - how the disease or symptom is cured, like a medicine name or "Unknown"
-  illness?: string; // used by symptoms - the common illness associated with the symptom, like "Flu" for "Fever"
+  illness: string; // used by symptoms - the common illness associated with the symptom, like "Flu" for "Fever"
   id: string;
 };
 
@@ -161,7 +161,7 @@ function renderDSMEntry(entry: BookEntry<Disease>) {
               <Box inline color="label">
                 Common cures:
               </Box>{' '}
-              {entry.cured_by || 'Unknown'}
+              {entry.cured_by}
             </Stack.Item>
           </>
         ) : (
@@ -182,13 +182,13 @@ function renderDSMEntry(entry: BookEntry<Disease>) {
               <Box inline color="label">
                 Spread By:
               </Box>{' '}
-              <Box inline>{formatSpreadBy(entry.spread_by || 'Unknown')}</Box>
+              <Box inline>{formatSpreadBy(entry.spread_by)}</Box>
             </Stack.Item>
             <Stack.Item>
               <Box inline color="label">
                 Cured By:
               </Box>{' '}
-              {entry.cured_by || 'No known cure'}
+              {entry.cured_by}
             </Stack.Item>
           </>
         )}

--- a/tgui/packages/tgui/interfaces/IDCBook.tsx
+++ b/tgui/packages/tgui/interfaces/IDCBook.tsx
@@ -18,6 +18,23 @@ type DiseaseData = {
   diseases: Disease[];
 };
 
+function isSymptom(entry: BookEntry<Disease>) {
+  return entry.form.toLowerCase() === 'symptom';
+}
+
+function formToColor(form: string) {
+  switch (form.toLowerCase()) {
+    case 'symptom':
+      return 'lightgreen';
+    case 'condition':
+    case 'infection':
+    case 'parasite':
+      return 'lightsalmon';
+    default:
+      return 'lightblue';
+  }
+}
+
 function formatSpreadBy(spread_by: string) {
   switch (spread_by.toLowerCase()) {
     case 'airborne':
@@ -39,12 +56,21 @@ function formatSpreadBy(spread_by: string) {
           </Stack.Item>
         </Stack>
       );
-    case 'liquids':
+    case 'fluid contact':
       return (
         <Stack align="end">
           <Stack.Item>Liquids</Stack.Item>
           <Stack.Item fontSize="10px" pb={0.2}>
-            (e.g. blood, saliva)
+            (e.g. touching contaminated fluids)
+          </Stack.Item>
+        </Stack>
+      );
+    case 'blood':
+      return (
+        <Stack align="end">
+          <Stack.Item>Blood</Stack.Item>
+          <Stack.Item fontSize="10px" pb={0.2}>
+            (e.g. tranfusion of infected blood)
           </Stack.Item>
         </Stack>
       );
@@ -53,7 +79,7 @@ function formatSpreadBy(spread_by: string) {
         <Stack align="end">
           <Stack.Item>None</Stack.Item>
           <Stack.Item fontSize="10px" pb={0.2}>
-            (not contagious)
+            (non-contagious)
           </Stack.Item>
         </Stack>
       );
@@ -65,7 +91,7 @@ function formatSpreadBy(spread_by: string) {
 function estimateHeight(entry: BookEntry<Disease>) {
   const title_height = 40;
   const extra_spacing = 40;
-  if (entry.form === 'Symptom') {
+  if (isSymptom(entry)) {
     const desc_height = Math.ceil(entry.desc.length / 50) * 14;
     const illness_height = entry.illness !== 'Unidentified' ? 10 : 0;
     const cured_by_height = 10;
@@ -110,8 +136,8 @@ function renderDSMEntry(entry: BookEntry<Disease>) {
         </Stack>
       }
     >
-      <Stack vertical backgroundColor="white" p={1}>
-        {entry.form === 'Symptom' ? (
+      <Stack vertical backgroundColor={formToColor(entry.form)} p={1}>
+        {isSymptom(entry) ? (
           <>
             <Stack.Item>
               <Box inline color="label">

--- a/tgui/packages/tgui/interfaces/IDCBook.tsx
+++ b/tgui/packages/tgui/interfaces/IDCBook.tsx
@@ -30,8 +30,12 @@ function formToColor(form: string) {
     case 'infection':
     case 'parasite':
       return 'lightsalmon';
-    default:
+    case 'virus':
+    case 'bacteria':
+    case 'fungus':
       return 'lightblue';
+    default:
+      return 'white';
   }
 }
 

--- a/tgui/packages/tgui/interfaces/common/PaginatedBook.tsx
+++ b/tgui/packages/tgui/interfaces/common/PaginatedBook.tsx
@@ -1,0 +1,404 @@
+import { useState } from 'react';
+import { useBackend } from 'tgui/backend';
+import { Box, Button, Section, Stack } from 'tgui-core/components';
+import { Window } from '../../layouts';
+
+export type BookEntry<Type> = {
+  id: string;
+} & Type;
+
+export type TOCEntry<Type> = {
+  entry: BookEntry<Type>;
+  displayedPage: number;
+  entryPage: number;
+};
+
+type PageEntry<Type> = BookEntry<Type> & {
+  page: number;
+};
+
+function getTOCWithPages<Type>(
+  entries: BookEntry<Type>[],
+  windowHeight: number,
+) {
+  const pageHeight = windowHeight - 50;
+  const pages: TOCEntry<Type>[] = [];
+  let currentPage = 1;
+  let currentPageHeight = 0;
+
+  for (const entry of entries) {
+    const estimatedHeight = 30;
+
+    if (currentPageHeight + estimatedHeight > pageHeight) {
+      currentPage += 1;
+      currentPageHeight = 0;
+    }
+
+    pages.push({
+      entry,
+      displayedPage: currentPage,
+      entryPage: -1,
+    });
+
+    currentPageHeight += estimatedHeight;
+  }
+
+  return pages;
+}
+
+function getEntriesWithPages<Type>(
+  entries: BookEntry<Type>[],
+  windowHeight: number,
+  startPage: number,
+  estimateHeight: (entry: BookEntry<Type>) => number,
+) {
+  const pageHeight = windowHeight - 50;
+  const pages: PageEntry<Type>[] = [];
+  let currentPage = startPage;
+  let currentPageHeight = 0;
+
+  for (const entry of entries) {
+    const estimatedHeight = estimateHeight(entry);
+
+    if (currentPageHeight + estimatedHeight > pageHeight) {
+      currentPage += 1;
+      currentPageHeight = 0;
+    }
+
+    pages.push({
+      ...entry,
+      page: currentPage,
+    });
+
+    currentPageHeight += estimatedHeight;
+  }
+
+  return pages;
+}
+
+type EntryComponentProps<Type> = {
+  entry: PageEntry<Type>;
+  renderEntry: (entry: PageEntry<Type>) => React.ReactNode;
+};
+
+const EntryComponent = <Type,>(props: EntryComponentProps<Type>) => {
+  const { entry, renderEntry } = props;
+  return <Section fitted>{renderEntry(entry)}</Section>;
+};
+
+type TOCEntryComponentProps<Type> = {
+  entry: TOCEntry<Type>;
+  setPage: (page: number) => void;
+  renderTOCEntry: (entry: TOCEntry<Type>) => React.ReactNode;
+};
+
+const TOCEntryComponent = <Type,>(props: TOCEntryComponentProps<Type>) => {
+  const { entry, setPage, renderTOCEntry } = props;
+  return (
+    <Stack textAlign="center" fontSize="13px">
+      <Stack.Item>{renderTOCEntry(entry)}</Stack.Item>
+      <Stack.Item grow>
+        <Box
+          height="50%"
+          style={{
+            borderBottom: '2px dotted rgba(255, 255, 255)',
+            borderColor: 'black',
+          }}
+        />
+      </Stack.Item>
+      <Stack.Item width="10%">
+        <Button
+          fluid
+          onClick={() =>
+            setPage(
+              entry.entryPage % 2 === 0 ? entry.entryPage - 1 : entry.entryPage,
+            )
+          }
+        >
+          {entry.entryPage}
+        </Button>
+      </Stack.Item>
+    </Stack>
+  );
+};
+
+type FakePageProps<Type> = {
+  tocDisplay?: TOCEntry<Type>[];
+  entryDisplay?: PageEntry<Type>[];
+  setPage: (page: number) => void;
+  renderEntry: (entry: PageEntry<Type>) => React.ReactNode;
+  renderTOCEntry: (entry: TOCEntry<Type>) => React.ReactNode;
+  blankPage?: React.ReactNode;
+};
+
+const FakePage = <Type,>(props: FakePageProps<Type>) => {
+  const {
+    tocDisplay,
+    entryDisplay,
+    setPage,
+    renderEntry,
+    renderTOCEntry,
+    blankPage,
+  } = props;
+
+  return (
+    <Section fill fitted pt={1} pl={1} pb={0.5}>
+      <Stack vertical fill>
+        {tocDisplay?.map((entry) => (
+          <Stack.Item key={entry.entry.id} mr={1}>
+            <TOCEntryComponent
+              entry={entry}
+              setPage={setPage}
+              renderTOCEntry={renderTOCEntry}
+            />
+          </Stack.Item>
+        ))}
+        {entryDisplay?.map((entry) => (
+          <Stack.Item key={entry.id}>
+            <EntryComponent entry={entry} renderEntry={renderEntry} />
+          </Stack.Item>
+        ))}
+        {!tocDisplay?.length &&
+          !entryDisplay?.length &&
+          (blankPage || (
+            <Stack.Item>This page intentionally left blank.</Stack.Item>
+          ))}
+      </Stack>
+    </Section>
+  );
+};
+
+type FakePagesProps<Type> = {
+  tocDisplay?: TOCEntry<Type>[];
+  entryDisplay?: PageEntry<Type>[];
+  page: number;
+  setPage: (page: number) => void;
+  renderEntry: (entry: PageEntry<Type>) => React.ReactNode;
+  renderTOCEntry: (entry: TOCEntry<Type>) => React.ReactNode;
+  blankPage?: React.ReactNode;
+};
+
+const FakePages = <Type,>(props: FakePagesProps<Type>) => {
+  const {
+    tocDisplay,
+    entryDisplay,
+    page,
+    setPage,
+    renderEntry,
+    renderTOCEntry,
+    blankPage,
+  } = props;
+
+  const leftTOC = tocDisplay?.filter((entry) => entry.displayedPage === page);
+  const rightTOC = tocDisplay?.filter(
+    (entry) => entry.displayedPage === page + 1,
+  );
+
+  const leftEntries = entryDisplay?.filter((entry) => entry.page === page);
+  const rightEntries = entryDisplay?.filter((entry) => entry.page === page + 1);
+
+  return (
+    <Stack fill>
+      <Stack.Item grow>
+        <FakePage
+          tocDisplay={leftTOC}
+          entryDisplay={leftEntries}
+          setPage={setPage}
+          renderEntry={renderEntry}
+          renderTOCEntry={renderTOCEntry}
+          blankPage={blankPage}
+        />
+      </Stack.Item>
+      <Stack.Item grow>
+        <FakePage
+          tocDisplay={rightTOC}
+          entryDisplay={rightEntries}
+          setPage={setPage}
+          renderEntry={renderEntry}
+          renderTOCEntry={renderTOCEntry}
+          blankPage={blankPage}
+        />
+      </Stack.Item>
+    </Stack>
+  );
+};
+
+type PageTurnProps = {
+  page: number;
+  setPage: (page: number) => void;
+  title: string;
+  maxPage: number;
+};
+
+const PageTurn = (props: PageTurnProps) => {
+  const { page, setPage, title, maxPage } = props;
+  const { act } = useBackend();
+
+  return (
+    <Stack>
+      <Stack.Item>
+        <Button
+          icon="angles-left"
+          onClick={() => {
+            setPage(1);
+            act('play_flip_sound');
+          }}
+          fluid
+          disabled={page <= 1}
+        />
+      </Stack.Item>
+      <Stack.Item>
+        <Button
+          icon="angle-left"
+          onClick={() => {
+            setPage(page - 2);
+            act('play_flip_sound');
+          }}
+          fluid
+          disabled={page <= 1}
+        />
+      </Stack.Item>
+      <Stack.Item textAlign="center" grow>
+        <Stack fill fontSize="15px">
+          <Stack.Item grow bold>
+            {page}
+          </Stack.Item>
+          <Stack.Item color="label">~ {title} ~</Stack.Item>
+          <Stack.Item grow bold>
+            {page + 1}
+          </Stack.Item>
+        </Stack>
+      </Stack.Item>
+      <Stack.Item>
+        <Button
+          icon="angle-right"
+          onClick={() => {
+            setPage(page + 2);
+            act('play_flip_sound');
+          }}
+          fluid
+          disabled={page + 1 >= maxPage}
+        />
+      </Stack.Item>
+      <Stack.Item>
+        <Button
+          icon="angles-right"
+          onClick={() => {
+            setPage(maxPage - (maxPage % 2));
+            act('play_flip_sound');
+          }}
+          fluid
+          disabled={page + 1 >= maxPage}
+        />
+      </Stack.Item>
+    </Stack>
+  );
+};
+
+type BookUIProps<Type> = {
+  bookData: BookEntry<Type>[];
+  title: string;
+  theme?: string;
+  estimateHeight: (entry: BookEntry<Type>) => number;
+  renderEntry: (entry: PageEntry<Type>) => React.ReactNode;
+  renderTOCEntry: (entry: TOCEntry<Type>) => React.ReactNode;
+  blankPage?: React.ReactNode;
+};
+
+/**
+ * Provides a basic paginated book UI
+ *
+ * @prop bookData The data to be displayed in the book. Must be a list of BookEntry objects.
+ * @prop title The title of the book, displayed on the page turner.
+ * @prop theme The theme of the book window. Defaults to 'ntos_lightmode'.
+ * @prop estimateHeight A function that estimates the height of a given entry. Used for pagination.
+ * @prop renderEntry A function that renders a given entry. Used for displaying entries on pages.
+ * @prop renderTOCEntry A function that renders a given entry for the table of contents. Used for displaying entries in the TOC.
+ * @prop blankPage An optional React node to display on blank pages. If not provided, blank pages will display "This page intentionally left blank."
+ *
+ */
+export const BookUI = <Type,>(props: BookUIProps<Type>) => {
+  const {
+    bookData,
+    title,
+    theme,
+    estimateHeight,
+    renderEntry,
+    renderTOCEntry,
+    blankPage,
+  } = props;
+
+  const windowHeight = 565;
+  const allTOCWithPages = getTOCWithPages(bookData, windowHeight);
+
+  let finalTOCPage = allTOCWithPages.reduce(
+    (maxPage, entry) => Math.max(maxPage, entry.displayedPage),
+    1,
+  );
+
+  if (finalTOCPage % 2 !== 0) {
+    finalTOCPage += 1;
+  }
+
+  const allEntriesWithPages = getEntriesWithPages(
+    bookData,
+    windowHeight,
+    finalTOCPage + 1,
+    estimateHeight,
+  );
+
+  for (const entry of bookData) {
+    const entryPage = allEntriesWithPages.find((e) => e.id === entry.id);
+    const tocEntry = allTOCWithPages.find((e) => e.entry.id === entry.id);
+    if (entryPage && tocEntry) {
+      tocEntry.entryPage = entryPage.page;
+    }
+  }
+
+  const lastPage = allEntriesWithPages.reduce(
+    (maxPage, entry) => Math.max(maxPage, entry.page),
+    finalTOCPage,
+  );
+
+  const [page, setPage] = useState(1);
+
+  return (
+    <Window
+      height={windowHeight}
+      width={765}
+      title={title}
+      theme={theme || 'ntos_lightmode'}
+    >
+      <Window.Content
+        style={{
+          backgroundImage: 'none',
+        }}
+      >
+        <Stack vertical fill>
+          <Stack.Item>
+            <Section>
+              <PageTurn
+                page={page}
+                setPage={setPage}
+                maxPage={lastPage}
+                title={page <= finalTOCPage ? `Table of Contents` : title}
+              />
+            </Section>
+          </Stack.Item>
+
+          <Stack.Item grow>
+            <FakePages
+              tocDisplay={allTOCWithPages}
+              entryDisplay={allEntriesWithPages}
+              page={page}
+              setPage={setPage}
+              renderEntry={renderEntry}
+              renderTOCEntry={renderTOCEntry}
+              blankPage={blankPage}
+            />
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/common/PaginatedBook.tsx
+++ b/tgui/packages/tgui/interfaces/common/PaginatedBook.tsx
@@ -161,7 +161,7 @@ const FakePage = <Type,>(props: FakePageProps<Type>) => {
         {!tocDisplay?.length &&
           !entryDisplay?.length &&
           (blankPage || (
-            <Stack.Item>This page intentionally left blank.</Stack.Item>
+            <Stack.Item italic>This page intentionally left blank.</Stack.Item>
           ))}
       </Stack>
     </Section>

--- a/tgui/packages/tgui/styles/interfaces/DeForestLogo.scss
+++ b/tgui/packages/tgui/styles/interfaces/DeForestLogo.scss
@@ -1,0 +1,7 @@
+.deforest_logo {
+  background-color: hsl(150, 100%, 18%);
+  -webkit-mask-image: url('../assets/bg-deforest.svg');
+  mask-image: url('../assets/bg-deforest.svg');
+  mask-repeat: no-repeat;
+  mask-position: center;
+}


### PR DESCRIPTION
## About The Pull Request

Continues the work of #94761 by adding an analog for virus references

It contains a majority of viruses - including some that are not-quite-viruses like parrot possession
Some are excluded, some are combined into others

It also contains all advanced virus symptoms

<img width="859" height="509" alt="image" src="https://github.com/user-attachments/assets/c73f56c0-5a11-4643-9a97-1e2a06ade0c1" />

Other changes

- Refactored the SDSM to have use a generic "PaginatedBook" component for reuse
- Adjusted flavor of all of the diseases
- Flu / Spanish Flu and Cold / Cold 9 now properly act as antibodies for one another as implied by cure text

## Why It's Good For The Game

Refer to #94761 : De-wikification and larp. This one is a reference to the IDC-11.

## Changelog

:cl: Melbert
refactor: Refactored the SDSM-35 to allow for new books of similar styles, report any oddities with it.
fix: Fixes the broken image(s) in the SDSM-35. 
add: Adds the IDC-27 in Medbay, the CMO's office, Virology, and possibly the Library. It's a reference book to all viruses you may experience, similar to the SDSM-35. 
add: Several diseases/viruses received minor flavor adjustments, primarily to cure text, agent, description, and form. 
add: Getting cured of the Flu provides immunity to Spanish Flu (and visa versa) as implied in cure text. 
add: Getting cured of a Cold provides immunity to Cold-9 (and visa versa) as implied in cure text. 
/:cl:
