### PR TITLE
Vended glasses in the Beach Bar virtual domain count towards domain completion when drank

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -659,5 +659,8 @@
 #define COMSIG_VENDING_UI_INTERACT "vending_ui_interact"
 	#define VENDING_DENIED (1<<0)
 
+/// From /obj/machinery/vending/dispense(): (obj/item/vended_item)
+#define COMSIG_VENDING_DISPENSED "vending_dispensed"
+
 /// Sent from /datum/component/reflection when the reflection is updated to the mob reflecting: (atom/movable/reflecting_in, obj/effect/abstract/reflection)
 #define COMSIG_REFLECTION_UPDATED "reflection_updated"

--- a/code/modules/bitrunning/virtual_domain/domains/beach_bar.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/beach_bar.dm
@@ -13,6 +13,14 @@
 
 	for(var/obj/item/reagent_containers/cup/glass/drink in created_atoms)
 		RegisterSignal(drink, COMSIG_GLASS_DRANK, PROC_REF(on_drink_drank))
+	for(var/obj/machinery/vending/vending_machine in created_atoms)
+		RegisterSignal(vending_machine, COMSIG_VENDING_DISPENSED, PROC_REF(on_vended_item))
+
+
+/datum/lazy_template/virtual_domain/beach_bar/proc/on_vended_item(obj/item/vended_item)
+	if(istype(vended_item, obj/item/reagent_containers/cup/glass))
+		RegisterSignal(vended_item, COMSIG_GLASS_DRANK, PROC_REF(on_drink_drank))
+
 
 /// Eventually reveal the cache
 /datum/lazy_template/virtual_domain/beach_bar/proc/on_drink_drank(datum/source)

--- a/code/modules/bitrunning/virtual_domain/domains/beach_bar.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/beach_bar.dm
@@ -17,8 +17,8 @@
 		RegisterSignal(vending_machine, COMSIG_VENDING_DISPENSED, PROC_REF(on_vended_item))
 
 
-/datum/lazy_template/virtual_domain/beach_bar/proc/on_vended_item(obj/item/vended_item)
-	if(istype(vended_item, obj/item/reagent_containers/cup/glass))
+/datum/lazy_template/virtual_domain/beach_bar/proc/on_vended_item(obj/machinery/vending/vending_machine, obj/item/vended_item)
+	if(istype(vended_item, /obj/item/reagent_containers/cup/glass))
 		RegisterSignal(vended_item, COMSIG_GLASS_DRANK, PROC_REF(on_drink_drank))
 
 

--- a/code/modules/vending/vendor/inventory.dm
+++ b/code/modules/vending/vendor/inventory.dm
@@ -239,6 +239,8 @@
 	on_dispense(vended_item, dispense_returned)
 	use_energy(active_power_usage)
 
+	SEND_SIGNAL(src, COMSIG_VENDING_DISPENSED, vended_item)
+
 	return vended_item
 
 /**


### PR DESCRIPTION

## About The Pull Request

Previously, when one drank out of a glass of booze that the virtual bartender graciously offered, one would not get any closer to domain completion, because said bartender got his glasses new out of a vending machine. These glasses never were registered on domain creation, due to not existing on domain creation. This pr registers the vending machines within the domain with a new signal that allows newly created glasses to also be registered, and count towards domain completion.

## Why It's Good For The Game

A bitrunner dying of liver failure due to the obtuse distinction between glasses that were in a vending machine and glasses that were on the table sounds very annoying. Also, you could very easily make the domain not completable within seconds by spawning as a ghostrole and breaking the table glasses. You can still do that, but you have to break an entire vending machine's worth of glasses too.

## Changelog
:cl:

fix: Glasses that were in the vending machine now still count for the completion of the Beach Bar virtual domain

/:cl:
