### PR TITLE
We made psyker hunters playable but now we need to make psyker hunters playable

### DIFF
--- a/_maps/shuttles/hunter_psyker.dmm
+++ b/_maps/shuttles/hunter_psyker.dmm
@@ -83,9 +83,6 @@
 /obj/item/pinpointer/shuttle{
 	pixel_y = 7
 	},
-/obj/item/clothing/glasses/thermal/monocle{
-	pixel_y = 2
-	},
 /turf/open/floor/iron/white/diagonal,
 /area/shuttle/hunter)
 "ek" = (
@@ -96,6 +93,10 @@
 	},
 /obj/item/gun/ballistic/revolver/c38,
 /obj/machinery/light/cold/directional/south,
+/obj/item/storage/belt/holster/psyker,
+/obj/item/storage/belt/holster/psyker,
+/obj/item/knife/combat/survival,
+/obj/item/knife/combat/survival,
 /turf/open/floor/iron/white/diagonal,
 /area/shuttle/hunter)
 "eO" = (
@@ -457,6 +458,8 @@
 /obj/item/gun/ballistic/shotgun/lethal{
 	pixel_y = 4
 	},
+/obj/item/storage/belt/bandolier,
+/obj/item/knife/combat/survival,
 /turf/open/floor/iron/white/diagonal,
 /area/shuttle/hunter)
 "wG" = (
@@ -555,6 +558,10 @@
 /area/shuttle/hunter)
 "AF" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/medkit/emergency{
+	pixel_y = 4
+	},
 /turf/open/floor/engine,
 /area/shuttle/hunter)
 "AH" = (
@@ -709,6 +716,9 @@
 "HO" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/bed/maint,
+/obj/item/storage/box/bandages{
+	pixel_y = -2
+	},
 /turf/open/floor/iron,
 /area/shuttle/hunter)
 "Id" = (
@@ -944,6 +954,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/garbage,
+/obj/structure/table_frame,
 /turf/open/floor/plating,
 /area/shuttle/hunter)
 "Tp" = (

--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -87,6 +87,7 @@
 #define FREQ_CTF_BLUE 1217 // CTF blue team comms frequency, blue
 #define FREQ_CTF_GREEN 1219 // CTF green team comms frequency, green
 #define FREQ_CTF_YELLOW 1221 // CTF yellow team comms frequency, yellow
+#define FREQ_FUGITIVE_HUNTER 1243
 #define FREQ_CENTCOM 1337 // CentCom comms frequency, gray
 #define FREQ_SUPPLY 1347 // Supply comms frequency, light brown
 #define FREQ_SERVICE 1349 // Service comms frequency, green

--- a/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
@@ -213,7 +213,39 @@
 	desc = "A headset designed to boost psychic waves. Protects ears from flashbangs."
 	icon_state = "psyker_headset"
 	worn_icon_state = "syndie_headset"
+	freerange = TRUE
 
 /obj/item/radio/headset/psyker/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/wearertargeting/earprotection)
+	set_frequency(FREQ_FUGITIVE_HUNTER)
+
+/obj/item/radio/headset/psyker/equipped(mob/user, slot, initial)
+	. = ..()
+	if(HAS_TRAIT(user, TRAIT_ECHOLOCATOR))
+		ADD_TRAIT(user, TRAIT_SIGHT_BYPASS, REF(src))
+	else
+		REMOVE_TRAIT(user, TRAIT_SIGHT_BYPASS, REF(src))
+
+/obj/item/radio/headset/psyker/dropped(mob/user, silent)
+	. = ..()
+	REMOVE_TRAIT(user, TRAIT_SIGHT_BYPASS, REF(src))
+
+/obj/item/radio/headset/psyker_seer
+	name = "psychic seer headset"
+	desc = "A psychic headset designed for the elite psyker seers."
+	icon_state = "med_headset_alt"
+	worn_icon_state = "med_headset_alt"
+	freerange = TRUE
+
+/obj/item/radio/headset/psyker_seer/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection)
+	set_frequency(FREQ_FUGITIVE_HUNTER)
+
+/obj/item/storage/belt/holster/psyker
+
+/obj/item/storage/belt/holster/psyker/Initialize(mapload)
+	. = ..()
+	atom_storage.max_slots = 5
+	atom_storage.max_total_storage = /obj/item/gun/ballistic/revolver/c38:w_class + (4 * /obj/item/ammo_box/speedloader/c38::w_class)

--- a/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
@@ -248,4 +248,4 @@
 /obj/item/storage/belt/holster/psyker/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 5
-	atom_storage.max_total_storage = /obj/item/gun/ballistic/revolver/c38:w_class + (4 * /obj/item/ammo_box/speedloader/c38::w_class)
+	atom_storage.max_total_storage = /obj/item/gun/ballistic/revolver/c38::w_class + (4 * /obj/item/ammo_box/speedloader/c38::w_class)

--- a/code/modules/antagonists/fugitive/hunters/hunter_outfits.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_outfits.dm
@@ -169,12 +169,16 @@
 
 /datum/id_trim/bounty_hunter/psykers
 	assignment = "Psyker-gang Shikari"
+	honorifics = list("Psyker-Shikari")
+	honorific_positions = HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/bounty_hunter/psykers/captain
 	assignment = "Psyker-gang Shikari Captain"
+	honorifics = list("Psyker-Shikari Captain")
 
 /datum/id_trim/bounty_hunter/psykers/seer
 	assignment = "Psyker-gang Shikari Seer"
+	honorifics = list("Psyker-Shikari Seer")
 
 /datum/outfit/psyker/captain
 	name = "Psyker-Shikari Leader"
@@ -203,6 +207,11 @@
 /datum/outfit/psyker/post_equip(mob/living/carbon/human/equipped)
 	. = ..()
 	equipped.psykerize()
+	var/obj/item/card/id/wearing = equipped.wear_id
+	wearing.registered_name = equipped.real_name
+	wearing.chosen_honorific = LAZYACCESS(wearing.trim.honorifics, 1)
+	wearing.honorific_position = (wearing.trim.honorific_positions & HONORIFIC_POSITION_FIRST_FULL)
+	wearing.update_label()
 
 /datum/outfit/psyker_seer
 	name = "Psyker-Shikari Seer"
@@ -217,6 +226,14 @@
 	id = /obj/item/card/id/advanced/bountyhunter
 
 	id_trim = /datum/id_trim/bounty_hunter/psykers/seer
+
+/datum/outfit/psyker_seer/post_equip(mob/living/carbon/human/equipped)
+	. = ..()
+	var/obj/item/card/id/wearing = equipped.wear_id
+	wearing.registered_name = equipped.real_name
+	wearing.chosen_honorific = LAZYACCESS(wearing.trim.honorifics, 1)
+	wearing.honorific_position = (wearing.trim.honorific_positions & HONORIFIC_POSITION_FIRST_FULL)
+	wearing.update_label()
 
 /datum/outfit/mi13_hunter
 	name = "\improper MI13 Fugitive Retrieval Agent"

--- a/code/modules/antagonists/fugitive/hunters/hunter_outfits.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_outfits.dm
@@ -179,6 +179,7 @@
 /datum/outfit/psyker/captain
 	name = "Psyker-Shikari Leader"
 
+	glasses = /obj/item/clothing/glasses/red
 	id_trim = /datum/id_trim/bounty_hunter/psykers/captain
 	suit = /obj/item/clothing/suit/armor/reactive/psykerboost
 	uniform = /obj/item/clothing/under/pants/camo
@@ -187,6 +188,7 @@
 	name = "Psyker-Shikari Hunter"
 	glasses = null
 	head = null
+	glasses = /obj/item/clothing/glasses/trickblindfold
 	ears = /obj/item/radio/headset/psyker
 	uniform = /obj/item/clothing/under/pants/track
 	gloves = /obj/item/clothing/gloves/fingerless
@@ -204,8 +206,8 @@
 
 /datum/outfit/psyker_seer
 	name = "Psyker-Shikari Seer"
-	glasses = /obj/item/clothing/glasses/regular/thin
-	ears = /obj/item/radio/headset
+	glasses = /obj/item/clothing/glasses/thermal/monocle
+	ears = /obj/item/radio/headset/psyker_seer
 	uniform = /obj/item/clothing/under/pants/jeans
 	suit = /obj/item/clothing/suit/hazardvest
 	gloves = /obj/item/clothing/gloves/fingerless

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -924,7 +924,7 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 /datum/reagent/drug/kronkaine/gore/on_mob_metabolize(mob/living/gored)
 	. = ..()
 	if(HAS_TRAIT(gored, TRAIT_ECHOLOCATOR))
-		to_chat(gored, span_nicegreen("OH YEAH! THAT'S THE STUFF!"))
+		to_chat(gored, span_nicegreen("OH YEAH! THAT'S THE STUFF! THAT'S GORE!"))
 
 /datum/reagent/drug/kronkaine/gore/on_mob_life(mob/living/gored, seconds_per_tick, metabolization_ratio)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -921,6 +921,17 @@ If you have at over 25u in your body you restore more than 20 stamina per cycle,
 	ph = 4
 	chemical_flags = NONE
 
+/datum/reagent/drug/kronkaine/gore/on_mob_metabolize(mob/living/gored)
+	. = ..()
+	if(HAS_TRAIT(gored, TRAIT_ECHOLOCATOR))
+		to_chat(gored, span_nicegreen("OH YEAH! THAT'S THE STUFF!"))
+
+/datum/reagent/drug/kronkaine/gore/on_mob_life(mob/living/gored, seconds_per_tick, metabolization_ratio)
+	. = ..()
+	if(HAS_TRAIT(gored, TRAIT_ECHOLOCATOR))
+		gored.adjust_brute_loss(-2 * metabolization_ratio * seconds_per_tick)
+		gored.adjust_fire_loss(-2 * metabolization_ratio * seconds_per_tick)
+
 /datum/reagent/drug/kronkaine/gore/overdose_start(mob/living/gored, metabolization_ratio)
 	. = ..()
 	gored.visible_message(


### PR DESCRIPTION
## About The Pull Request

- Psyker hunters now spawn with a bandolier and two holsters for their shotgun and revolvers, as well as some backup knives.

- All Psyker hunters now spawn with a headset set to a shared frequency. They are also freerange headsets, meaning they can be tuned to any frequency. 

- The Psyker ship now has a box of bandages and an emergency medkit.
 
- Psyker headsets now prevent their echolocation from being disabled from deafness. 

- Psyker hunters now have trick blindfolds equipped and the captain has red glasses equipped

- Psyker seer now spawns with the thermal monocle equipped (they are the only hunter without thermal vision innate)

- Gore will now heal Psykers (but not the seer) 

## Why It's Good For The Game

The Echolocation changes made Psyker itself, very playable but as it turns out Psyker Hunters still had... problems

Bandolier / Holster:
- Problem: They have no backpacks! You are given a bunch of ammo but no way to carry it. Meaning you have to go to the station, get a backpack, go back to your ship, then get your ammo.
- Solution: Give them a place to carry their ammo to the station. 
 
Headset:
- Problem: You have a communication role ( the Seer ) but no way to communicate with them, as your headset only has common. 
- Solution: Give them a channel that the crew can't easily access. (Probably should be spread to all the other hunters... maybe in a second pr)

Medkit / Gore: 
- Problem: You have no way of healing yourself if you get into a fight with the Fugitives. 
- Solution: A small medkit and some bandages will help with superficial stuff, and the Gore in emergencies. 
 
New eyewear:
- Just for fun. 

## Changelog

:cl: Melbert
balance: The Psyker hunter ship now has a bandolier and two holsters for their shotgun and revolvers, as well as some backup knives.
balance: The Psyker hunter ship now has a box of bandages and an emergency medkit.
balance: All Psyker hunters now spawn with a headset set to a shared frequency.
balance: Psyker headsets now prevent their echolocation from being disabled due to deafness. 
balance: Psyker hunters now spawn with flavorful eyewear. The Psyker Seer now spawns with the thermal monocle (which was previously on the ship).
balance: Gore will now heal Psykers.
/:cl:
