### PR TITLE
Fixes accidential infinite loop in multiz rendering

### DIFF
--- a/code/_onclick/hud/rendering/plane_masters/_plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_masters/_plane_master.dm
@@ -64,15 +64,18 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	/// If this plane master is outside of our visual bounds right now
 	var/is_outside_bounds = FALSE
 
+	/// Has this plane master had its offset made concrete? Avoids modifications/uses that are going to immediately break
+	var/offset_already_updated = FALSE
+
 /atom/movable/screen/plane_master/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset = 0)
 	. = ..()
 	src.offset = offset
 	true_alpha = alpha
 	real_plane = plane
+	update_offset()
 
 	if(!set_home(home))
 		return INITIALIZE_HINT_QDEL
-	update_offset()
 	if(!documentation && !(istype(src, /atom/movable/screen/plane_master) || istype(src, /atom/movable/screen/plane_master/rendering_plate)))
 		stack_trace("Plane master created without a description. Document how your thing works so people will know in future, and we can display it in the debug menu")
 	if(start_hidden)
@@ -109,6 +112,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 		render_relay_planes[i] = GET_NEW_PLANE(render_relay_planes[i], offset)
 	if(initial(render_target))
 		render_target = OFFSET_RENDER_TARGET(initial(render_target), offset)
+	offset_already_updated = TRUE
 
 /atom/movable/screen/plane_master/proc/set_alpha(new_alpha)
 	true_alpha = new_alpha

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -505,6 +505,8 @@
 /atom/movable/screen/plane_master/proc/add_relay_to(target_plane, blend_override, relay_layer, relay_color)
 	if(get_relay_to(target_plane))
 		return
+	if(!offset_already_updated)
+		CRASH("Attempted to draw a render relay before our offset has been applied, this WILL break")
 	render_relay_planes += target_plane
 	var/client/display_lad = home?.our_hud?.mymob?.canon_client
 	var/atom/movable/render_plane_relay/relay = generate_relay_to(target_plane, show_to = display_lad, blend_override = blend_override, relay_layer = relay_layer)


### PR DESCRIPTION

## About The Pull Request

Ok so on the parallax pr I moved a bunch of dumb plane group signal registration to the set home proc. Unfortunately because set_home is run BEFORE update_offset, any created relays will then be offset down X from where they should be.

For the master plate, this means #1's relay to transparent plate #0 will instead draw to transparent plate #1 (which of course renders into master plate #1)

To fix this I've moved update_offset to BEFORE set_home, so children can hook into it and do things in a sane and normal way. Near as I can tell there's no reason they're ordered as they currently are. I've also added a failsafe check to prevent relay creation before update_offset is called, and attached a CRASH() to such.

Interestingly enough this caused crashes on shift right click. That's fun I think