### PR TITLE
Fixes being unable to use tape to secure limbs

### DIFF
--- a/code/__DEFINES/medical.dm
+++ b/code/__DEFINES/medical.dm
@@ -31,3 +31,9 @@
 
 ///Cooldown for being on the recently treated trait for the purposes for bounty submission
 #define RECENTLY_HEALED_COOLDOWN 5 MINUTES
+
+// Return values for the limb_applicable component's callback can_apply
+/// Block the standard application of this item
+#define LIMB_APPLICABLE_BLOCK_APPLICATION (1<<0)
+/// Block the rest of the item_interaction chain, if application is not being done.
+#define LIMB_APPLICABLE_BLOCK_ITEM_INTERACTION (1<<1)

--- a/code/datums/components/limb_applicable.dm
+++ b/code/datums/components/limb_applicable.dm
@@ -16,8 +16,10 @@
 	/// If TRUE, replaces existing items with new ones
 	/// If FALSE, application will fail if an item of the same category is already applied
 	var/override_existing
-	/// Callback to determine if parent can be applied. (Return FALSE to block application)
+	/// Callback to determine if application can be attempted. Cannot sleep. (Return FALSE to block application)
 	var/datum/callback/can_apply
+	/// Callback to attempt application, I.E. do_after()s. Can sleep.
+	var/datum/callback/do_apply
 	/// Callback invoked after application
 	var/datum/callback/on_apply
 
@@ -26,6 +28,7 @@
 	apply_category,
 	override_existing = TRUE,
 	datum/callback/can_apply,
+	datum/callback/do_apply,
 	datum/callback/on_apply,
 )
 	if(!isitem(parent))
@@ -35,6 +38,7 @@
 	src.apply_category = apply_category || REF(parent)
 	src.override_existing = override_existing
 	src.can_apply = can_apply
+	src.do_apply = do_apply
 	src.on_apply = on_apply
 
 
@@ -61,29 +65,33 @@
 	if(!isliving(interacting_with))
 		return NONE
 
-	INVOKE_ASYNC(src, PROC_REF(on_apply_async), user, interacting_with)
-	return ITEM_INTERACT_BLOCKING
-
-/datum/component/limb_applicable/proc/on_apply_async(mob/user, atom/interacting_with)
 	var/mob/living/target = interacting_with
 	var/obj/item/bodypart/applying_to = target.get_bodypart(deprecise_zone(user.zone_selected))
+
 	if(isnull(applying_to))
 		target.balloon_alert(user, "no bodypart!")
-		return
+		return NONE
 
-	if(!(applying_to.body_zone in src.valid_zones))
+	if(!(applying_to.body_zone in valid_zones))
 		target.balloon_alert(user, "can't be applied there!")
-		return
+		return NONE
 
 	if(!override_existing)
 		var/obj/item/existing = LAZYACCESS(applying_to.applied_items, apply_category)
 		if(!isnull(existing))
 			target.balloon_alert(user, "something is already there!")
-			return
+			return NONE
 
 	if(can_apply && !can_apply.Invoke(user, target, applying_to))
-		return
+		return NONE
 
+	INVOKE_ASYNC(src, PROC_REF(on_apply_async), user, interacting_with, applying_to)
+	return ITEM_INTERACT_BLOCKING
+
+/datum/component/limb_applicable/proc/on_apply_async(mob/user, atom/interacting_with, obj/item/bodypart/applying_to)
+	var/mob/living/target = interacting_with
+	if(!do_apply?.Invoke(user, target, applying_to))
+		return
 	var/obj/item/applying = parent
 	if(isstack(parent))
 		var/obj/item/stack/stack_parent = parent

--- a/code/datums/components/limb_applicable.dm
+++ b/code/datums/components/limb_applicable.dm
@@ -70,26 +70,27 @@
 
 	if(isnull(applying_to))
 		target.balloon_alert(user, "no bodypart!")
-		return NONE
+		return ITEM_INTERACT_BLOCKING
 
 	if(!(applying_to.body_zone in valid_zones))
 		target.balloon_alert(user, "can't be applied there!")
-		return NONE
+		return ITEM_INTERACT_BLOCKING
 
 	if(!override_existing)
 		var/obj/item/existing = LAZYACCESS(applying_to.applied_items, apply_category)
 		if(!isnull(existing))
 			target.balloon_alert(user, "something is already there!")
-			return NONE
+			return ITEM_INTERACT_BLOCKING
 
-	if(can_apply && !can_apply.Invoke(user, target, applying_to))
-		return NONE
+	if(can_apply)
+		var/try_apply = can_apply.Invoke(user, target, applying_to)
+		if(try_apply & LIMB_APPLICABLE_BLOCK_APPLICATION)
+			return (try_apply & LIMB_APPLICABLE_BLOCK_ITEM_INTERACTION) ? ITEM_INTERACT_BLOCKING : NONE
 
 	INVOKE_ASYNC(src, PROC_REF(on_apply_async), user, interacting_with, applying_to)
 	return ITEM_INTERACT_BLOCKING
 
-/datum/component/limb_applicable/proc/on_apply_async(mob/user, atom/interacting_with, obj/item/bodypart/applying_to)
-	var/mob/living/target = interacting_with
+/datum/component/limb_applicable/proc/on_apply_async(mob/user, mob/living/target, obj/item/bodypart/applying_to)
 	if(!do_apply?.Invoke(user, target, applying_to))
 		return
 	var/obj/item/applying = parent

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -109,7 +109,7 @@
 			msg += "slightly bloodied"
 		if(4 to INFINITY)
 			msg += "clean"
-	msg += " [current_gauze.name]!"
+	msg += "[current_gauze.name]!"
 
 	return "<B>[msg.Join()]</B>"
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -399,6 +399,7 @@
 		apply_category = LIMB_ITEM_GAUZE, \
 		override_existing = TRUE, \
 		can_apply = CALLBACK(src, PROC_REF(can_gauze_limb)), \
+		do_apply = CALLBACK(src, PROC_REF(do_gauze_limb)), \
 		on_apply = CALLBACK(src, PROC_REF(on_gauze_limb)), \
 	)
 	RegisterSignals(src, list(COMSIG_ITEM_APPLIED_TO_LIMB, COMSIG_ITEM_UNAPPLIED_FROM_LIMB), PROC_REF(update_wounds))
@@ -412,16 +413,14 @@
 
 /// Callback for limb applicability component
 /obj/item/stack/medical/wrap/proc/can_gauze_limb(mob/user, mob/living/patient, obj/item/bodypart/limb)
-	var/wound_tracker = LACKS_WOUND
-	for(var/datum/wound/woundies as anything in limb.wounds)
-		if(!(woundies.wound_flags & ACCEPTS_GAUZE))
+	var/can_gauze = FALSE
+	for(var/datum/wound/wound as anything in limb.wounds)
+		if(!(wound.wound_flags & ACCEPTS_GAUZE))
 			continue
-		if(HAS_TRAIT(woundies, TRAIT_WOUND_SCANNED))
-			wound_tracker = HAS_SCANNED_WOUND
-			break
-		wound_tracker = HAS_WOUND
+		can_gauze = TRUE
+		break
 
-	if(wound_tracker == LACKS_WOUND)
+	if(!can_gauze)
 		patient.balloon_alert(user, LAZYLEN(limb.wounds) ? "can't gauze!" : "no wounds!")
 		return FALSE
 
@@ -430,8 +429,20 @@
 		patient.balloon_alert(user, pick("already bandaged!", "bandage is clean!")) // good enough
 		return FALSE
 
+	return TRUE
+
+/// Callback for limb applicability component
+/obj/item/stack/medical/wrap/proc/do_gauze_limb(mob/user, mob/living/patient, obj/item/bodypart/limb)
+
+	var/scanned_wound = FALSE
+	for(var/datum/wound/wound as anything in limb.wounds)
+		if(!HAS_TRAIT(wound, TRAIT_WOUND_SCANNED))
+			continue
+		scanned_wound = TRUE
+		break
+
 	var/treatment_delay = (user == patient ? self_delay : other_delay)
-	if(wound_tracker == HAS_SCANNED_WOUND)
+	if(scanned_wound)
 		treatment_delay *= 0.5
 		if(user == patient)
 			user.visible_message(

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -416,22 +416,23 @@
 		can_gauze = TRUE
 		break
 
+	. = NONE
 	var/surgery_prepped = HAS_TRAIT(limb, TRAIT_READY_TO_OPERATE)
 	if(!surgery_prepped)
-		. += LIMB_APPLICABLE_BLOCK_ITEM_INTERACTION
+		. |= LIMB_APPLICABLE_BLOCK_ITEM_INTERACTION
 
 	if(!can_gauze)
 		if(!surgery_prepped)
 			patient.balloon_alert(user, LAZYLEN(limb.wounds) ? "can't gauze!" : "no wounds!")
-		. += LIMB_APPLICABLE_BLOCK_APPLICATION
-		return
+		. |= LIMB_APPLICABLE_BLOCK_APPLICATION
+		return .
 
 	var/obj/item/stack/medical/wrap/current_gauze = LAZYACCESS(limb.applied_items, LIMB_ITEM_GAUZE)
 	if(current_gauze && (current_gauze.absorption_capacity * 1.2 > absorption_capacity)) // ignore if our new wrap is < 20% better than the current one, so someone doesn't bandage it 5 times in a row
 		if(!surgery_prepped)
 			patient.balloon_alert(user, pick("already bandaged!", "bandage is clean!")) // good enough
-		. += LIMB_APPLICABLE_BLOCK_APPLICATION
-		return
+		. |= LIMB_APPLICABLE_BLOCK_APPLICATION
+		return .
 
 /// Callback for limb applicability component
 /obj/item/stack/medical/wrap/proc/do_gauze_limb(mob/user, mob/living/patient, obj/item/bodypart/limb)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -407,10 +407,6 @@
 /obj/item/stack/medical/wrap/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	return NONE // uses component
 
-#define LACKS_WOUND 0
-#define HAS_WOUND 1
-#define HAS_SCANNED_WOUND 2
-
 /// Callback for limb applicability component
 /obj/item/stack/medical/wrap/proc/can_gauze_limb(mob/user, mob/living/patient, obj/item/bodypart/limb)
 	var/can_gauze = FALSE
@@ -420,16 +416,22 @@
 		can_gauze = TRUE
 		break
 
+	var/surgery_prepped = HAS_TRAIT(limb, TRAIT_READY_TO_OPERATE)
+	if(!surgery_prepped)
+		. += LIMB_APPLICABLE_BLOCK_ITEM_INTERACTION
+
 	if(!can_gauze)
-		patient.balloon_alert(user, LAZYLEN(limb.wounds) ? "can't gauze!" : "no wounds!")
-		return FALSE
+		if(!surgery_prepped)
+			patient.balloon_alert(user, LAZYLEN(limb.wounds) ? "can't gauze!" : "no wounds!")
+		. += LIMB_APPLICABLE_BLOCK_APPLICATION
+		return
 
 	var/obj/item/stack/medical/wrap/current_gauze = LAZYACCESS(limb.applied_items, LIMB_ITEM_GAUZE)
 	if(current_gauze && (current_gauze.absorption_capacity * 1.2 > absorption_capacity)) // ignore if our new wrap is < 20% better than the current one, so someone doesn't bandage it 5 times in a row
-		patient.balloon_alert(user, pick("already bandaged!", "bandage is clean!")) // good enough
-		return FALSE
-
-	return TRUE
+		if(!surgery_prepped)
+			patient.balloon_alert(user, pick("already bandaged!", "bandage is clean!")) // good enough
+		. += LIMB_APPLICABLE_BLOCK_APPLICATION
+		return
 
 /// Callback for limb applicability component
 /obj/item/stack/medical/wrap/proc/do_gauze_limb(mob/user, mob/living/patient, obj/item/bodypart/limb)
@@ -493,10 +495,6 @@
 	SIGNAL_HANDLER
 	for(var/datum/wound/gauzed as anything in limb.wounds)
 		gauzed.update_inefficiencies()
-
-#undef LACKS_WOUND
-#undef HAS_WOUND
-#undef HAS_SCANNED_WOUND
 
 /obj/item/stack/medical/wrap/gauze
 	name = "medical gauze"

--- a/code/game/objects/items/tourniquet.dm
+++ b/code/game/objects/items/tourniquet.dm
@@ -16,7 +16,7 @@
 		/datum/component/limb_applicable, \
 		valid_zones = GLOB.limb_zones.Copy() + BODY_ZONE_HEAD, \
 		apply_category = LIMB_ITEM_TOURNIQUET, \
-		can_apply = CALLBACK(src, PROC_REF(can_apply_tourniquet)), \
+		do_apply = CALLBACK(src, PROC_REF(do_apply_tourniquet)), \
 	)
 	RegisterSignal(src, COMSIG_ITEM_APPLIED_TO_LIMB, PROC_REF(on_applied_to_limb))
 	RegisterSignal(src, COMSIG_ITEM_UNAPPLIED_FROM_LIMB, PROC_REF(on_removed_from_limb))
@@ -77,7 +77,7 @@
 		limb.owner.adjust_dizzy(4 SECONDS)
 		limb.owner.adjust_confusion(2 SECONDS)
 
-/obj/item/tourniquet/proc/can_apply_tourniquet(mob/user, mob/living/patient, obj/item/bodypart/limb)
+/obj/item/tourniquet/proc/do_apply_tourniquet(mob/user, mob/living/patient, obj/item/bodypart/limb)
 	var/speed_multiplier = 2
 	var/speed_boosted = FALSE
 	for(var/datum/wound/woundies as anything in limb.wounds)


### PR DESCRIPTION

## About The Pull Request

Gives the `limb_applicable` component a third callback, `do_apply`, for the sake of holding all the sleeping parts of the previous callback `can_apply`, so that `can_apply` can be put in the signal part of the component, fixing the mentioned issue.

## Why It's Good For The Game

fixes #95471

## Changelog
:cl:

fix: Tape can now secure prosthetic limbs again

/:cl:
