### PR TITLE
[NO GBP] Corrects two issues with goodies and the ordering console.

### DIFF
--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -294,9 +294,10 @@
 			if(!id_card || !living_user || !access)
 				living_user = user
 				id_card = living_user.get_idcard(TRUE)
-			if(pack.access_view && !(pack.access_view in access) && personal_department)
+			if(pack.access_view && !(pack.access_view in access) && personal_department && !self_paid)
 				// We want to block cargo requests when a player is requesting a restricted pack that they don't have access to.
 				// BUT only when it's requested with non-cargo funds, as cargo had direct oversight over their own purchases with their own budget.
+				// HOWEVER, this shouldn't prevent someone from buying something using their own personal funds.
 				say("ERROR: User lacks the requisite access for this purchase request.")
 				return
 

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -294,7 +294,7 @@
 			if(!id_card || !living_user || !access)
 				living_user = user
 				id_card = living_user.get_idcard(TRUE)
-			if(pack.access_view && !(pack.access_view in access) && personal_department && !self_paid)
+			if(pack.access_view && !(pack.access_view in access) && personal_department)
 				// We want to block cargo requests when a player is requesting a restricted pack that they don't have access to.
 				// BUT only when it's requested with non-cargo funds, as cargo had direct oversight over their own purchases with their own budget.
 				// HOWEVER, this shouldn't prevent someone from buying something using their own personal funds.

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -147,7 +147,6 @@ function CatalogTabs(props: CatalogTabsProps & Props) {
                 setActiveSupplyName(supply.name);
                 setSearchText('');
               }}
-              style={supply.name === "Goodies" ? {display: 'none'} : undefined}
             >
               <Stack justify="space-between">
                 <span>{supply.name}</span>


### PR DESCRIPTION
## About The Pull Request

Whoops.

~~I missed some nuance when I made #94483, namely that while I didn't want players requesting CRATES like guns, grenades, spare SM shards with their department budgets, the logic also touches goodies and private orders meaning that players were unable to place goodie orders for things that they may not have explicit access to do so, which is part of the reason why you'd be ordering them privately in the first place. It's cargo responsibility to determine if the player should/not be receiving that item.~~
I have meditated on the issue, and I realize, nah, this is probably both a healthier design decision as well as the reason we have things like the black market in the first place. The core of the PR below however is however sound.

ALSO, I made a fairly confusing mistake with the TGUI where the goodies category just... hasn't been visible! That's on me.

## Why It's Good For The Game

Makes cargo goodies viewable. Makes cargo goodies purchasable.

Fixes #94928

🐛 💥 ‼️

## Changelog

:cl:
fix: Cargo goodies are now visible in the ordering and request consoles.
/:cl:
