### PR TITLE
Gorillas can pick up kittens

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2023,7 +2023,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	real_name = name
 
 /mob/living/proc/mob_try_pickup(mob/living/user, instant=FALSE)
-	if(!ishuman(user))
+	if(!ishuman(user) && (user.mob_size <= mob_size || user.num_hands == 0))
 		return
 	if(!user.get_empty_held_indexes())
 		to_chat(user, span_warning("Your hands are full!"))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2024,7 +2024,11 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 /mob/living/proc/mob_try_pickup(mob/living/user, instant=FALSE)
 	if(!ishuman(user) && (user.mob_size <= mob_size || user.num_hands == 0))
-		return
+		if (!user.num_hands)
+			return
+		if (user.mob_size <= mob_size)
+			to_chat(user, span_warning("[src] is too big to pick up!"))
+			return
 	if(!user.get_empty_held_indexes())
 		to_chat(user, span_warning("Your hands are full!"))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

<img width="293" height="292" alt="image" src="https://github.com/user-attachments/assets/5803c1aa-1fbe-4c43-ada4-436830d7bacd" />

The proc involved with picking up other mobs had an "ishuman" check in it, barring other mobs with hands from picking up mobs.
I don't know _why_ this was here but I _suspect_ that it's because drones have hands and it is undesirable for drones to pick up other drones.

In this PR I have changed it so that any mob with hands can pick up any other mob that can be picked up, _as long as you are larger than the mob you are trying to pick up_.
This prevents drones from picking up other drones, while allowing gorillas to pick up drones (or kittens).

I think this also means that a wizard's dextrous guardian can pick up Ian and put him inside its special pocket for a perfect spectral kidnapping.

The size check is only applied to nonhuman mobs, because there aren't any pickupable mobs by default that are as large or larger than humans to exclude, and because admins would get mad at me if I removed the ability for them to make humans able to get picked up by other humans on a whim.

## Why It's Good For The Game

They can do it in real life
It's unintuitive for picking up other mobs to be exclusive to humans without explanation

## Changelog

:cl:
add: Nonhuman mobs with hands can now pick up other mobs that are smaller than them and can usually be picked up
/:cl:
