### PR TITLE
Boxcutting wrapped packages returns less wrap

### DIFF
--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -219,6 +219,9 @@
 	amount = 5
 	merge_type = /obj/item/stack/package_wrap/small
 
+/obj/item/stack/package_wrap/one
+	amount = 1
+
 /obj/item/c_tube
 	name = "cardboard tube"
 	desc = "A tube... of cardboard."

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -37,7 +37,7 @@
 		new /obj/effect/decal/cleanable/wrapping(turf_loc)
 	else
 		playsound(loc, 'sound/items/box_cut.ogg', 50, TRUE)
-		new /obj/item/stack/package_wrap(turf_loc)
+		new /obj/item/stack/package_wrap/one(turf_loc)
 	for(var/atom/movable/movable_content as anything in contents)
 		movable_content.forceMove(turf_loc)
 


### PR DESCRIPTION

## About The Pull Request

Currently, when you use boxcutters to cut open wrapped packages, you get a full stack (25) of wrapping paper back, even though it takes at most 3 wrapping paper to wrap it in the first place, meaning you can make the paper multiply infinitely. This PR changes that so you only get one wrapping paper back.
## Why It's Good For The Game
If you use one wrap to wrap something, you should not get twenty five wrap when unwrapping it
## Changelog
:cl:
fix: Fixed an oversight with package wrapping
/:cl:
