### PR TITLE
Adds a boolean type to circuits

### DIFF
--- a/code/__DEFINES/wiremod.dm
+++ b/code/__DEFINES/wiremod.dm
@@ -30,6 +30,8 @@
 #define PORT_TYPE_TABLE "table"
 /// Options datatype. Derivative of string.
 #define PORT_TYPE_OPTION "option"
+/// Boolean datatype. Derivative of number.
+#define PORT_TYPE_BOOLEAN "boolean"
 
 // Composite datatypes
 #define PORT_COMPOSITE_TYPE_LIST "list"

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -670,7 +670,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/firealarm, 26)
 	alarm_trigger = add_input_port("Set", PORT_TYPE_SIGNAL)
 	reset_trigger = add_input_port("Reset", PORT_TYPE_SIGNAL)
 
-	is_on = add_output_port("Is On", PORT_TYPE_NUMBER)
+	is_on = add_output_port("Is On", PORT_TYPE_BOOLEAN)
 	triggered = add_output_port("Triggered", PORT_TYPE_SIGNAL)
 	reset = add_output_port("Reset", PORT_TYPE_SIGNAL)
 

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -135,8 +135,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 	var/obj/machinery/light_switch/attached_switch
 
 /obj/item/circuit_component/light_switch/populate_ports()
-	on_setting = add_input_port("On", PORT_TYPE_NUMBER)
-	is_on = add_output_port("Is On", PORT_TYPE_NUMBER)
+	on_setting = add_input_port("On", PORT_TYPE_BOOLEAN)
+	is_on = add_output_port("Is On", PORT_TYPE_BOOLEAN)
 
 /obj/item/circuit_component/light_switch/register_usb_parent(atom/movable/parent)
 	. = ..()

--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_circuit.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_circuit.dm
@@ -311,8 +311,8 @@
 	disable = add_input_port("Disable", PORT_TYPE_SIGNAL, trigger = PROC_REF(toggle_scrubber))
 	request_update = add_input_port("Request Data", PORT_TYPE_SIGNAL, trigger = PROC_REF(update_data))
 
-	enabled = add_output_port("Enabled", PORT_TYPE_NUMBER)
-	is_siphoning = add_output_port("Siphoning", PORT_TYPE_NUMBER)
+	enabled = add_output_port("Enabled", PORT_TYPE_BOOLEAN)
+	is_siphoning = add_output_port("Siphoning", PORT_TYPE_BOOLEAN)
 	filtering = add_output_port("Filtered Gases", PORT_TYPE_LIST(PORT_TYPE_STRING))
 	update_received = add_output_port("Update Received", PORT_TYPE_SIGNAL)
 
@@ -534,10 +534,10 @@
 	disable = add_input_port("Disable", PORT_TYPE_SIGNAL, trigger = PROC_REF(toggle_vent))
 	request_update = add_input_port("Request Data", PORT_TYPE_SIGNAL, trigger = PROC_REF(update_data))
 
-	enabled = add_output_port("Enabled", PORT_TYPE_NUMBER)
-	is_siphoning = add_output_port("Siphoning", PORT_TYPE_NUMBER)
-	external_on = add_output_port("External On", PORT_TYPE_NUMBER)
-	internal_on = add_output_port("Internal On", PORT_TYPE_NUMBER)
+	enabled = add_output_port("Enabled", PORT_TYPE_BOOLEAN)
+	is_siphoning = add_output_port("Siphoning", PORT_TYPE_BOOLEAN)
+	external_on = add_output_port("External On", PORT_TYPE_BOOLEAN)
+	internal_on = add_output_port("Internal On", PORT_TYPE_BOOLEAN)
 	current_external_pressure = add_output_port("External Pressure", PORT_TYPE_NUMBER)
 	current_internal_pressure = add_output_port("Internal Pressure", PORT_TYPE_NUMBER)
 	update_received = add_output_port("Update Received", PORT_TYPE_SIGNAL)

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -173,7 +173,7 @@
 	input_temperature = add_output_port("Input Temperature", PORT_TYPE_NUMBER)
 	output_temperature = add_output_port("Output Temperature", PORT_TYPE_NUMBER)
 
-	is_active = add_output_port("Active", PORT_TYPE_NUMBER)
+	is_active = add_output_port("Active", PORT_TYPE_BOOLEAN)
 	turned_on = add_output_port("Turned On", PORT_TYPE_SIGNAL)
 	turned_off = add_output_port("Turned Off", PORT_TYPE_SIGNAL)
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -111,7 +111,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	open = add_input_port("Open", PORT_TYPE_SIGNAL)
 	close = add_input_port("Close", PORT_TYPE_SIGNAL)
 
-	is_open = add_output_port("Is Open", PORT_TYPE_NUMBER)
+	is_open = add_output_port("Is Open", PORT_TYPE_BOOLEAN)
 	opened = add_output_port("Opened", PORT_TYPE_SIGNAL)
 	closed = add_output_port("Closed", PORT_TYPE_SIGNAL)
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -234,7 +234,7 @@
 	input_temperature = add_output_port("Input Temperature", PORT_TYPE_NUMBER)
 	output_temperature = add_output_port("Output Temperature", PORT_TYPE_NUMBER)
 
-	is_active = add_output_port("Active", PORT_TYPE_NUMBER)
+	is_active = add_output_port("Active", PORT_TYPE_BOOLEAN)
 	turned_on = add_output_port("Turned On", PORT_TYPE_SIGNAL)
 	turned_off = add_output_port("Turned Off", PORT_TYPE_SIGNAL)
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1215,10 +1215,10 @@
 	var/datum/port/output/reagents_level
 
 /obj/item/circuit_component/hydroponics/populate_ports()
-	selfsustaining_setting = add_input_port("Auto-Grow Setting", PORT_TYPE_NUMBER)
+	selfsustaining_setting = add_input_port("Auto-Grow Setting", PORT_TYPE_BOOLEAN)
 
 	plant_status = add_output_port("Plant Status", PORT_TYPE_NUMBER)
-	is_self_sustaining = add_output_port("Auto-Grow Status", PORT_TYPE_NUMBER)
+	is_self_sustaining = add_output_port("Auto-Grow Status", PORT_TYPE_BOOLEAN)
 	plant_harvested = add_output_port("Plant Harvested", PORT_TYPE_SIGNAL)
 	last_harvest = add_output_port("Last Harvest Amount", PORT_TYPE_NUMBER)
 	plant_died = add_output_port("Plant Died", PORT_TYPE_SIGNAL)

--- a/code/modules/instruments/piano_synth.dm
+++ b/code/modules/instruments/piano_synth.dm
@@ -119,7 +119,7 @@
 	sustain_value = add_input_port("Note Sustain Value", PORT_TYPE_NUMBER, trigger = PROC_REF(set_sustain_value))
 	note_decay = add_input_port("Held Note Decay", PORT_TYPE_NUMBER, trigger = PROC_REF(set_sustain_decay))
 
-	is_playing = add_output_port("Currently Playing", PORT_TYPE_NUMBER)
+	is_playing = add_output_port("Currently Playing", PORT_TYPE_BOOLEAN)
 	started_playing = add_output_port("Started Playing", PORT_TYPE_SIGNAL)
 	stopped_playing = add_output_port("Stopped Playing", PORT_TYPE_SIGNAL)
 

--- a/code/modules/modular_computers/file_system/program_circuit.dm
+++ b/code/modules/modular_computers/file_system/program_circuit.dm
@@ -57,7 +57,7 @@
 	. = ..()
 	start = add_input_port("Start", PORT_TYPE_SIGNAL, trigger = PROC_REF(start_prog))
 	kill = add_input_port("Kill", PORT_TYPE_SIGNAL, trigger = PROC_REF(kill_prog))
-	running = add_output_port("Running", PORT_TYPE_NUMBER)
+	running = add_output_port("Running", PORT_TYPE_BOOLEAN)
 
 ///For most programs, triggers only work if they're open (either active or idle).
 /obj/item/circuit_component/mod_program/should_receive_input(datum/port/input/port)

--- a/code/modules/vehicles/cars/vim.dm
+++ b/code/modules/vehicles/cars/vim.dm
@@ -129,7 +129,7 @@
 	var/datum/port/output/are_headlights_on
 
 /obj/item/circuit_component/vim/populate_ports()
-	are_headlights_on = add_output_port("Are Headlights On", PORT_TYPE_NUMBER)
+	are_headlights_on = add_output_port("Are Headlights On", PORT_TYPE_BOOLEAN)
 	chime = add_output_port("On Chime Used", PORT_TYPE_SIGNAL)
 	buzz = add_output_port("On Buzz Used", PORT_TYPE_SIGNAL)
 

--- a/code/modules/wiremod/components/abstract/compare.dm
+++ b/code/modules/wiremod/components/abstract/compare.dm
@@ -22,7 +22,7 @@
 
 	true = add_output_port("True", PORT_TYPE_SIGNAL)
 	false = add_output_port("False", PORT_TYPE_SIGNAL)
-	result = add_output_port("Result", PORT_TYPE_NUMBER)
+	result = add_output_port("Result", PORT_TYPE_BOOLEAN)
 
 /**
  * Used by derivatives to load their own ports in for custom use.

--- a/code/modules/wiremod/components/action/light.dm
+++ b/code/modules/wiremod/components/action/light.dm
@@ -33,7 +33,7 @@
 	blue = add_input_port("Blue", PORT_TYPE_NUMBER)
 	brightness = add_input_port("Brightness", PORT_TYPE_NUMBER)
 
-	on = add_input_port("On", PORT_TYPE_NUMBER)
+	on = add_input_port("On", PORT_TYPE_BOOLEAN)
 
 /obj/item/circuit_component/light/register_shell(atom/movable/shell)
 	. = ..()

--- a/code/modules/wiremod/components/action/soundemitter.dm
+++ b/code/modules/wiremod/components/action/soundemitter.dm
@@ -51,7 +51,7 @@
 /obj/item/circuit_component/soundemitter/populate_ports()
 	volume = add_input_port("Volume", PORT_TYPE_NUMBER, default = 35)
 	frequency = add_input_port("Frequency", PORT_TYPE_NUMBER, default = 0)
-	backwards = add_input_port("Play Backwards", PORT_TYPE_NUMBER, default = 0)
+	backwards = add_input_port("Play Backwards", PORT_TYPE_BOOLEAN, default = FALSE)
 
 /obj/item/circuit_component/soundemitter/populate_options()
 	var/static/component_options = list(

--- a/code/modules/wiremod/components/action/speech.dm
+++ b/code/modules/wiremod/components/action/speech.dm
@@ -23,7 +23,7 @@
 
 /obj/item/circuit_component/speech/populate_ports()
 	message = add_input_port("Message", PORT_TYPE_STRING, trigger = null)
-	quietmode = add_input_port("Quiet Mode", PORT_TYPE_NUMBER, default = 0)
+	quietmode = add_input_port("Quiet Mode", PORT_TYPE_BOOLEAN, default = FALSE)
 
 /obj/item/circuit_component/speech/input_received(datum/port/input/port)
 	if(!parent.shell)

--- a/code/modules/wiremod/components/admin/animate.dm
+++ b/code/modules/wiremod/components/admin/animate.dm
@@ -33,7 +33,7 @@
 
 /obj/item/circuit_component/begin_animation/populate_ports()
 	target = add_input_port("Target", PORT_TYPE_ATOM)
-	parallel = add_input_port("Parallel", PORT_TYPE_NUMBER, default = 1)
+	parallel = add_input_port("Parallel", PORT_TYPE_BOOLEAN, default = 1)
 	animation_loops = add_input_port("Loops", PORT_TYPE_NUMBER)
 	stop_all_animations = add_input_port("Stop All Animations", PORT_TYPE_SIGNAL, trigger = PROC_REF(stop_animations))
 	animate_event = add_output_port("Perform Animation", PORT_TYPE_INSTANT_SIGNAL)

--- a/code/modules/wiremod/components/admin/animate.dm
+++ b/code/modules/wiremod/components/admin/animate.dm
@@ -33,7 +33,7 @@
 
 /obj/item/circuit_component/begin_animation/populate_ports()
 	target = add_input_port("Target", PORT_TYPE_ATOM)
-	parallel = add_input_port("Parallel", PORT_TYPE_BOOLEAN, default = 1)
+	parallel = add_input_port("Parallel", PORT_TYPE_BOOLEAN, default = TRUE)
 	animation_loops = add_input_port("Loops", PORT_TYPE_NUMBER)
 	stop_all_animations = add_input_port("Stop All Animations", PORT_TYPE_SIGNAL, trigger = PROC_REF(stop_animations))
 	animate_event = add_output_port("Perform Animation", PORT_TYPE_INSTANT_SIGNAL)

--- a/code/modules/wiremod/components/admin/signal_handler/signal_handler.dm
+++ b/code/modules/wiremod/components/admin/signal_handler/signal_handler.dm
@@ -63,7 +63,7 @@
 	signal_map = GLOB.integrated_circuit_signal_ids
 
 /obj/item/circuit_component/signal_handler/populate_ports()
-	instant = add_input_port("Instant", PORT_TYPE_NUMBER, order = 0.5, trigger = null, default = 1)
+	instant = add_input_port("Instant", PORT_TYPE_BOOLEAN, order = 0.5, trigger = null, default = TRUE)
 	register = add_input_port("Register", PORT_TYPE_SIGNAL, order = 2, trigger = PROC_REF(register_signals))
 	unregister = add_input_port("Unregister", PORT_TYPE_SIGNAL, order = 2, trigger = PROC_REF(unregister_signals))
 	unregister_all = add_input_port("Unregister All", PORT_TYPE_SIGNAL, order = 2, trigger = PROC_REF(unregister_signals_all))

--- a/code/modules/wiremod/components/atom/hear.dm
+++ b/code/modules/wiremod/components/atom/hear.dm
@@ -23,7 +23,7 @@
 	var/datum/port/output/trigger_port
 
 /obj/item/circuit_component/hear/populate_ports()
-	on = add_input_port("On", PORT_TYPE_NUMBER, default = 1)
+	on = add_input_port("On", PORT_TYPE_BOOLEAN, default = TRUE)
 	message_port = add_output_port("Message", PORT_TYPE_STRING)
 	language_port = add_output_port("Language", PORT_TYPE_STRING)
 	speaker_port = add_output_port("Speaker", PORT_TYPE_ATOM)

--- a/code/modules/wiremod/components/atom/remotecam.dm
+++ b/code/modules/wiremod/components/atom/remotecam.dm
@@ -65,7 +65,7 @@
 	start = add_input_port("Start", PORT_TYPE_SIGNAL)
 	stop = add_input_port("Stop", PORT_TYPE_SIGNAL)
 	if(camera_range_settable)
-		camera_range = add_input_port("Camera Range", PORT_TYPE_NUMBER, default = 0)
+		camera_range = add_input_port("Far Range", PORT_TYPE_BOOLEAN, default = FALSE)
 	network = add_input_port("Network", PORT_TYPE_STRING, default = "ss13")
 
 	if(camera_range_settable)

--- a/code/modules/wiremod/components/bci/install_detector.dm
+++ b/code/modules/wiremod/components/bci/install_detector.dm
@@ -18,7 +18,7 @@
 
 /obj/item/circuit_component/install_detector/populate_ports()
 	. = ..()
-	current_state = add_output_port("Current State", PORT_TYPE_NUMBER)
+	current_state = add_output_port("Current State", PORT_TYPE_BOOLEAN)
 	implanted = add_output_port("Implanted", PORT_TYPE_SIGNAL)
 	removed = add_output_port("Removed", PORT_TYPE_SIGNAL)
 

--- a/code/modules/wiremod/components/id/access_checker.dm
+++ b/code/modules/wiremod/components/id/access_checker.dm
@@ -24,7 +24,7 @@
 /obj/item/circuit_component/compare/access/populate_custom_ports()
 	subject_accesses = add_input_port("Access To Check", PORT_TYPE_LIST(PORT_TYPE_STRING))
 	required_accesses = add_input_port("Required Access", PORT_TYPE_LIST(PORT_TYPE_STRING))
-	check_any = add_input_port("Check Any", PORT_TYPE_NUMBER)
+	check_any = add_input_port("Check Any", PORT_TYPE_BOOLEAN)
 
 /obj/item/circuit_component/compare/access/save_data_to_list(list/component_data)
 	. = ..()

--- a/code/modules/wiremod/components/id/getter.dm
+++ b/code/modules/wiremod/components/id/getter.dm
@@ -22,7 +22,7 @@
 
 /obj/item/circuit_component/id_getter/populate_ports()
 	target = add_input_port("Target", PORT_TYPE_ATOM)
-	prioritize_hands = add_input_port("Prioritize Hands", PORT_TYPE_NUMBER)
+	prioritize_hands = add_input_port("Prioritize Hands", PORT_TYPE_BOOLEAN)
 	id_port = add_output_port("ID", PORT_TYPE_ATOM)
 
 /obj/item/circuit_component/id_getter/input_received(datum/port/input/port)

--- a/code/modules/wiremod/components/math/binary_conversion.dm
+++ b/code/modules/wiremod/components/math/binary_conversion.dm
@@ -26,7 +26,7 @@
 		add_action = "add", \
 		remove_action = "remove", \
 		is_output = TRUE, \
-		port_type = PORT_TYPE_NUMBER, \
+		port_type = PORT_TYPE_BOOLEAN, \
 		prefix = "Bit", \
 		minimum_amount = 1, \
 		maximum_amount = MAX_BITFIELD_SIZE \
@@ -46,6 +46,6 @@
 	for(var/iteration in 1 to len)
 		var/datum/port/output/bit = bit_array[iteration]
 		if(iteration == 1 && is_negative)
-			bit.set_output(1)
+			bit.set_output(TRUE)
 			continue
 		bit.set_output(!!(to_convert & (1<< (len - iteration))))

--- a/code/modules/wiremod/components/math/not.dm
+++ b/code/modules/wiremod/components/math/not.dm
@@ -18,7 +18,7 @@
 /obj/item/circuit_component/not/populate_ports()
 	input_port = add_input_port("Input", PORT_TYPE_ANY)
 
-	result = add_output_port("Result", PORT_TYPE_NUMBER)
+	result = add_output_port("Result", PORT_TYPE_BOOLEAN)
 
 /obj/item/circuit_component/not/input_received(datum/port/input/port)
 

--- a/code/modules/wiremod/components/math/toggle.dm
+++ b/code/modules/wiremod/components/math/toggle.dm
@@ -16,7 +16,7 @@
 	var/toggle_state = FALSE
 
 /obj/item/circuit_component/compare/toggle/populate_custom_ports()
-	toggle_set = add_input_port("Set Toggle State", PORT_TYPE_NUMBER)
+	toggle_set = add_input_port("Set Toggle State", PORT_TYPE_BOOLEAN)
 	toggle_and_compare = add_input_port("Toggle And Compare", PORT_TYPE_SIGNAL)
 	toggle_state = FALSE
 

--- a/code/modules/wiremod/components/utility/clock.dm
+++ b/code/modules/wiremod/components/utility/clock.dm
@@ -19,7 +19,7 @@
 	. += create_ui_notice("Clock Interval: [DisplayTimeText(COMP_CLOCK_DELAY)]", "orange", "clock")
 
 /obj/item/circuit_component/clock/populate_ports()
-	on = add_input_port("On", PORT_TYPE_NUMBER)
+	on = add_input_port("On", PORT_TYPE_BOOLEAN)
 
 	signal = add_output_port("Signal", PORT_TYPE_SIGNAL)
 

--- a/code/modules/wiremod/datatypes/boolean.dm
+++ b/code/modules/wiremod/datatypes/boolean.dm
@@ -1,0 +1,10 @@
+/datum/circuit_datatype/boolean
+	datatype = PORT_TYPE_BOOLEAN
+	color = "bad" // This should be close enough to dark red.
+	datatype_flags = DATATYPE_FLAG_ALLOW_MANUAL_INPUT
+
+/datum/circuit_datatype/boolean/can_receive_from_datatype(datatype_to_check)
+	return TRUE
+
+/datum/circuit_datatype/boolean/convert_value(datum/port/port, value_to_convert, force)
+	return !!value_to_convert

--- a/code/modules/wiremod/datatypes/number.dm
+++ b/code/modules/wiremod/datatypes/number.dm
@@ -2,6 +2,7 @@
 	datatype = PORT_TYPE_NUMBER
 	color = "green"
 	datatype_flags = DATATYPE_FLAG_ALLOW_MANUAL_INPUT
+	can_receive_from = list(PORT_TYPE_BOOLEAN)
 
 /datum/circuit_datatype/number/handle_manual_input(datum/port/input/port, mob/user, user_input)
 	return text2num(user_input)

--- a/code/modules/wiremod/datatypes/signal.dm
+++ b/code/modules/wiremod/datatypes/signal.dm
@@ -7,6 +7,7 @@
 		PORT_TYPE_INSTANT_SIGNAL,
 		PORT_TYPE_RESPONSE_SIGNAL,
 		PORT_TYPE_SIGNAL,
+		PORT_TYPE_BOOLEAN,
 	)
 
 /datum/circuit_datatype/signal/handle_manual_input(datum/port/input/port, mob/user, user_input)

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -76,8 +76,8 @@
 	open = add_input_port("Open", PORT_TYPE_SIGNAL)
 	close = add_input_port("Close", PORT_TYPE_SIGNAL)
 	// States
-	is_open = add_output_port("Is Open", PORT_TYPE_NUMBER)
-	is_bolted = add_output_port("Is Bolted", PORT_TYPE_NUMBER)
+	is_open = add_output_port("Is Open", PORT_TYPE_BOOLEAN)
+	is_bolted = add_output_port("Is Bolted", PORT_TYPE_BOOLEAN)
 	// Output Signals
 	opened = add_output_port("Opened", PORT_TYPE_SIGNAL)
 	closed = add_output_port("Closed", PORT_TYPE_SIGNAL)

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -74,7 +74,7 @@
 
 	message = add_input_port("Message", PORT_TYPE_STRING, trigger = null)
 	send_message_signal = add_input_port("Send Message", PORT_TYPE_SIGNAL)
-	show_charge_meter = add_input_port("Show Charge Meter", PORT_TYPE_NUMBER, trigger = PROC_REF(update_charge_action))
+	show_charge_meter = add_input_port("Show Charge Meter", PORT_TYPE_BOOLEAN, trigger = PROC_REF(update_charge_action))
 
 	user_port = add_output_port("User", PORT_TYPE_USER)
 

--- a/code/modules/wiremod/shell/implant.dm
+++ b/code/modules/wiremod/shell/implant.dm
@@ -62,7 +62,7 @@
 
 	message = add_input_port("Message", PORT_TYPE_STRING, trigger = null)
 	send_message_signal = add_input_port("Send Message", PORT_TYPE_SIGNAL)
-	show_charge_meter = add_input_port("Show Charge Meter", PORT_TYPE_NUMBER, trigger = PROC_REF(update_charge_action))
+	show_charge_meter = add_input_port("Show Charge Meter", PORT_TYPE_BOOLEAN, trigger = PROC_REF(update_charge_action))
 
 	user_port = add_output_port("User", PORT_TYPE_USER)
 

--- a/code/modules/wiremod/shell/module.dm
+++ b/code/modules/wiremod/shell/module.dm
@@ -188,8 +188,8 @@
 	select_module = add_input_port("Select Module", PORT_TYPE_SIGNAL)
 	// States
 	wearer = add_output_port("Wearer", PORT_TYPE_USER)
-	deployed = add_output_port("Deployed", PORT_TYPE_NUMBER)
-	activated = add_output_port("Activated", PORT_TYPE_NUMBER)
+	deployed = add_output_port("Deployed", PORT_TYPE_BOOLEAN)
+	activated = add_output_port("Activated", PORT_TYPE_BOOLEAN)
 	selected_module = add_output_port("Selected Module", PORT_TYPE_STRING)
 	deployed_parts = add_output_port("Deployed Parts", PORT_TYPE_LIST(PORT_TYPE_STRING))
 	// Output Signals

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6820,6 +6820,7 @@
 #include "code\modules\wiremod\core\variable.dm"
 #include "code\modules\wiremod\datatypes\any.dm"
 #include "code\modules\wiremod\datatypes\basic.dm"
+#include "code\modules\wiremod\datatypes\boolean.dm"
 #include "code\modules\wiremod\datatypes\datum.dm"
 #include "code\modules\wiremod\datatypes\entity.dm"
 #include "code\modules\wiremod\datatypes\number.dm"

--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/FundamentalTypes.jsx
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/FundamentalTypes.jsx
@@ -129,6 +129,17 @@ export const FUNDAMENTAL_DATA_TYPES = {
       </BasicInput>
     );
   },
+  boolean: (props) => {
+    const { name, value, setValue, color } = props;
+    return (
+      <Stack>
+        <Stack.Item>{name}</Stack.Item>
+        <Stack.Item>
+          <Button.Checkbox checked={value} onClick={() => setValue(!value)} />
+        </Stack.Item>
+      </Stack>
+    );
+  },
 };
 
 export const DATATYPE_DISPLAY_HANDLERS = {


### PR DESCRIPTION
## About The Pull Request

A substantial number of number circuit ports, input and output alike, effectively act as boolean flags. That is, they are either input ports that only care about whether the value is or is not zero, or they are output ports that can only output zero or one. This PR adds a boolean datatype, and converts all these ports to booleans.

Anything can be connected to a boolean input port, effectively setting the port to the truthiness of the input. Booleans can be connected to number and signal ports, as they all use numbers as their underlying values.

## Why It's Good For The Game

Having a proper boolean datatype makes the affected ports a bit more intuitive to compute with.

## Changelog

:cl:
qol: Many circuit components have had ports that effectively act as boolean inputs or outputs converted into a new boolean datatype.
/:cl:
