### PR TITLE
Snow cabin fake holy wand keeps its sprite

### DIFF
--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -3361,8 +3361,8 @@
 	pixel_x = -1;
 	pixel_y = 16
 	},
-/obj/item/gun/magic/wand/fake_resurrection{
-	    pixel_y = -2    
+/obj/item/gun/magic/wand/nothing/fake_resurrection{
+	    pixel_y = -2
 	},
 /obj/effect/light_emitter{
 	set_cap = 3;

--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -3361,11 +3361,8 @@
 	pixel_x = -1;
 	pixel_y = 16
 	},
-/obj/item/gun/magic/wand{
-	desc = "It's just a fancy staff so that holy clerics and priests look cool. What? You didn't think someone would leave a REAL magic artifact with a snowman out in the cold, did you?";
-	icon_state = "revivewand";
-	name = "holy staff";
-	pixel_y = -2
+/obj/item/gun/magic/wand/fake_resurrection{
+	    pixel_y = -2    
 	},
 /obj/effect/light_emitter{
 	set_cap = 3;

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -327,12 +327,13 @@
 	return SHAME
 
 /// Also wand of doing fuck all
-/obj/item/gun/magic/wand/fake_resurrection
+/obj/item/gun/magic/wand/nothing/fake_resurrection
 	name = "holy staff"
 	desc = "It's just a fancy staff so that holy clerics and priests look cool. What? You didn't think someone would leave a REAL magic artifact with a snowman out in the cold, did you?"
 	fire_sound = 'sound/effects/magic/staff_healing.ogg'
 	icon_state = "revivewand"
 	base_icon_state = "revivewand"
+	ammo_type = /obj/item/ammo_casing/magic
 
 /// Wand of making things small
 /obj/item/gun/magic/wand/shrink

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -326,6 +326,14 @@
 	. = ..()
 	return SHAME
 
+/// Also wand of doing fuck all
+/obj/item/gun/magic/wand/fake_resurrection
+	name = "holy staff"
+	desc = "It's just a fancy staff so that holy clerics and priests look cool. What? You didn't think someone would leave a REAL magic artifact with a snowman out in the cold, did you?"
+	fire_sound = 'sound/effects/magic/staff_healing.ogg'
+	icon_state = "revivewand"
+	base_icon_state = "revivewand"
+
 /// Wand of making things small
 /obj/item/gun/magic/wand/shrink
 	name = "wand of shrinking"


### PR DESCRIPTION

## About The Pull Request

Makes the var edited fake healing wand in snow cabin a real subtype

## Why It's Good For The Game

closes #95484

## Changelog
:cl:

map: Snow Cabin fake healing wand now holds on to its sprite

/:cl:
