### PR TITLE
Fixes screen_shake_darken still shaking the screen

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -178,6 +178,7 @@
 
 		M.overlay_fullscreen("flash", type)
 		addtimer(CALLBACK(M, TYPE_PROC_REF(/mob, clear_fullscreen), "flash", 1 SECONDS), shake_dur)
+		return
 
 	//How much time to allot for each pixel moved
 	var/time_scalar = (1 / ICON_SIZE_ALL) * TILES_PER_SECOND
@@ -227,7 +228,7 @@
 		var/shake_dur = max(duration, 2 SECONDS)
 		recoiled_mob.overlay_fullscreen("flash", type)
 		addtimer(CALLBACK(recoiled_mob, TYPE_PROC_REF(/mob, clear_fullscreen), "flash", 1 SECONDS), shake_dur)
-
+		return
 
 	animate(client_to_shake, pixel_x = oldx+mpx, pixel_y = oldy+mpy, time = duration, flags = ANIMATION_RELATIVE)
 	animate(pixel_x = oldx, pixel_y = oldy, time = backtime_duration, easing = BACK_EASING)


### PR DESCRIPTION

## About The Pull Request
I have no idea why you'd do this, I suspect it was just an initial error? There's no reason to shake the screen if the client can't see it, all it does is create the possibility that they WILL see it shake if the overlay system fucks up for whatever reason. s silly.

## Why It's Good For The Game

s less dumb

## Changelog
:cl:
fix: the darken screen shake preference will no longer shake your screen underneath the fullscreen overlay
/:cl:
