### PR TITLE
Fixes a race condition with the slow shuttle station trait

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -141,6 +141,7 @@
 	var/datum/job/picked_job = pick(SSjob.get_valid_overflow_jobs())
 	chosen_job_name = LOWER_TEXT(picked_job.title) // like Chief Engineers vs like chief engineers
 	SSjob.set_overflow_role(picked_job.type)
+	UnregisterSignal(SSjob, COMSIG_SUBSYSTEM_POST_INITIALIZE)
 
 /datum/station_trait/slow_shuttle
 	name = "Slow Shuttle"
@@ -150,9 +151,14 @@
 	report_message = "Due to distance to our supply station, the cargo shuttle will have a slower flight time to your cargo department."
 	blacklist = list(/datum/station_trait/quick_shuttle)
 
-/datum/station_trait/slow_shuttle/on_round_start()
+/datum/station_trait/slow_shuttle/New()
 	. = ..()
+	RegisterSignal(SSshuttle, COMSIG_SUBSYSTEM_POST_INITIALIZE, PROC_REF(slow_the_shuttle))
+
+/datum/station_trait/slow_shuttle/proc/slow_the_shuttle(datum/source)
+	SIGNAL_HANDLER
 	SSshuttle.supply.callTime *= 1.5
+	UnregisterSignal(SSshuttle, COMSIG_SUBSYSTEM_POST_INITIALIZE)
 
 /datum/station_trait/bot_languages
 	name = "Bot Language Matrix Malfunction"


### PR DESCRIPTION
## About The Pull Request

It turns out this can actually try to modify some SSshuttle var before SSshuttle is properly initialized. This just makes it register a signal and wait until we know it's finished doing its thing.

Also adds signal unregistration for a different trait that does a similar thing.

## Why It's Good For The Game

Fixes a bug

## Changelog

:cl:
fix: fixes an issue where the 'slow shuttle' station trait can sometimes not be applied properly
/:cl: