### PR TITLE
Hallucination delusions copy lighting underlays

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_lighting.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_lighting.dm
@@ -47,9 +47,12 @@
 ///Called when an atom has a light template applied to it. Frombase of [/datum/light_template/proc/mirror_onto]: ()
 #define COMSIG_ATOM_LIGHT_TEMPLATE_MIRRORED "atom_light_template_mirrored"
 
-///Called when an atom's overlay component applies visuals, from base of [/datum/component/overlay_lighting/proc/show_to_holder]: (atom/movable/light_holder)
+///Called when an atom's overlay component applies visuals, from base of [/datum/component/overlay_lighting/proc/show_to_holder]: (image/mask, image/cone, atom/movable/light_holder)
 #define COMSIG_ATOM_OVERLAY_LIGHT_APPLIED "atom_overlay_light_applied"
+///Above, but send to the holder of the light instead of the light source itself: (image/mask, image/cone, atom/movable/light_source)
+#define COMSIG_ATOM_HOLDER_OVERLAY_LIGHT_APPLIED "atom_holder_overlay_light_applied"
 
 ///Called when an atom's overlay component hides its visuals, from base of [/datum/component/overlay_lighting/proc/hide_from_holder]: (atom/movable/light_holder)
 #define COMSIG_ATOM_OVERLAY_LIGHT_REMOVED "atom_overlay_light_removed"
-
+///Above, but send to the holder of the light instead of the light source itself: (atom/movable/light_source)
+#define COMSIG_ATOM_HOLDER_OVERLAY_LIGHT_REMOVED "atom_holder_overlay_light_removed"

--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -229,6 +229,7 @@
 	var/mutable_appearance/mask_clone = new (visible_mask)
 	var/mutable_appearance/cone_clone = directional ? new /mutable_appearance(cone) : null
 	SEND_SIGNAL(parent, COMSIG_ATOM_OVERLAY_LIGHT_APPLIED, mask_clone, cone_clone, current_holder)
+	SEND_SIGNAL(current_holder, COMSIG_ATOM_HOLDER_OVERLAY_LIGHT_APPLIED, mask_clone, cone_clone, parent)
 
 /// Removes our overlay from our holder, assuming everything's setup proper
 /// MUST be called before modifying cone or visible_mask, or you will cause stuck lighting
@@ -242,6 +243,7 @@
 		current_holder.underlays -= cone
 	currently_displaying = FALSE
 	SEND_SIGNAL(parent, COMSIG_ATOM_OVERLAY_LIGHT_REMOVED, current_holder)
+	SEND_SIGNAL(current_holder, COMSIG_ATOM_HOLDER_OVERLAY_LIGHT_REMOVED, parent)
 
 ///Called to change the value of parent_attached_to.
 /datum/component/overlay_lighting/proc/set_parent_attached_to(atom/movable/new_parent_attached_to)

--- a/code/modules/hallucination/delusions.dm
+++ b/code/modules/hallucination/delusions.dm
@@ -92,8 +92,11 @@
 
 	for(var/mob/living/carbon/human/found_human as anything in funny_looking_mobs)
 		var/image/funny_image = make_delusion_image(found_human)
+		if(found_human != hallucinator)
+			RegisterSignal(found_human, COMSIG_QDELETING, PROC_REF(on_mob_delete))
 		RegisterSignal(found_human, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_z_change))
-		RegisterSignal(found_human, COMSIG_QDELETING, PROC_REF(on_mob_delete), TRUE)
+		RegisterSignal(found_human, COMSIG_ATOM_HOLDER_OVERLAY_LIGHT_APPLIED, PROC_REF(on_mob_light_add))
+		RegisterSignal(found_human, COMSIG_ATOM_HOLDER_OVERLAY_LIGHT_REMOVED, PROC_REF(on_mob_light_remove))
 		LAZYSET(delusions, found_human, funny_image)
 		hallucinator.client.images |= funny_image
 
@@ -114,14 +117,14 @@
 	funny_image.name = delusion_name
 	funny_image.override = TRUE
 	SET_PLANE_EXPLICIT(funny_image, ABOVE_GAME_PLANE, over_who)
+	// copies over lighting underlays
+	for(var/image/underlay as anything in over_who.underlays)
+		if(PLANE_TO_TRUE(underlay.plane) == O_LIGHTING_VISUAL_PLANE)
+			funny_image.underlays |= underlay
 	return funny_image
 
 /datum/hallucination/delusion/proc/on_mob_delete(mob/living/carbon/human/source)
 	SIGNAL_HANDLER
-
-	if (source == hallucinator)
-		qdel(src)
-		return
 
 	hallucinator.client.images -= delusions[source]
 	LAZYREMOVE(delusions, source)
@@ -130,6 +133,20 @@
 	SIGNAL_HANDLER
 	var/image/funny_image = delusions[source]
 	SET_PLANE_EXPLICIT(funny_image, ABOVE_GAME_PLANE, source)
+
+/datum/hallucination/delusion/proc/on_mob_light_add(mob/living/carbon/human/source, image/visible_mask, image/cone)
+	SIGNAL_HANDLER
+	var/image/funny_image = delusions[source]
+	funny_image.underlays |= visible_mask
+	if(cone)
+		funny_image.underlays |= cone
+
+/datum/hallucination/delusion/proc/on_mob_light_remove(mob/living/carbon/human/source)
+	SIGNAL_HANDLER
+	var/image/funny_image = delusions[source]
+	for(var/image/underlay as anything in funny_image.underlays)
+		if(PLANE_TO_TRUE(underlay.plane) == O_LIGHTING_VISUAL_PLANE)
+			funny_image.underlays -= underlay
 
 /datum/hallucination/delusion/proc/examine_name_override(datum/source, mob/living/examined, visible_name, list/name_override)
 	SIGNAL_HANDLER

--- a/code/modules/hallucination/delusions.dm
+++ b/code/modules/hallucination/delusions.dm
@@ -95,6 +95,7 @@
 		if(found_human != hallucinator)
 			RegisterSignal(found_human, COMSIG_QDELETING, PROC_REF(on_mob_delete))
 		RegisterSignal(found_human, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_z_change))
+		// ensures the delusion image's lighting updates if the mob's lighting changes
 		RegisterSignal(found_human, COMSIG_ATOM_HOLDER_OVERLAY_LIGHT_APPLIED, PROC_REF(on_mob_light_add))
 		RegisterSignal(found_human, COMSIG_ATOM_HOLDER_OVERLAY_LIGHT_REMOVED, PROC_REF(on_mob_light_remove))
 		LAZYSET(delusions, found_human, funny_image)
@@ -120,7 +121,7 @@
 	// copies over lighting underlays
 	for(var/image/underlay as anything in over_who.underlays)
 		if(PLANE_TO_TRUE(underlay.plane) == O_LIGHTING_VISUAL_PLANE)
-			funny_image.underlays |= new /mutable_appearance(underlay)
+			funny_image.underlays += underlay
 	return funny_image
 
 /datum/hallucination/delusion/proc/on_mob_delete(mob/living/carbon/human/source)

--- a/code/modules/hallucination/delusions.dm
+++ b/code/modules/hallucination/delusions.dm
@@ -120,7 +120,7 @@
 	// copies over lighting underlays
 	for(var/image/underlay as anything in over_who.underlays)
 		if(PLANE_TO_TRUE(underlay.plane) == O_LIGHTING_VISUAL_PLANE)
-			funny_image.underlays |= underlay
+			funny_image.underlays |= new mutable_appearance(underlay)
 	return funny_image
 
 /datum/hallucination/delusion/proc/on_mob_delete(mob/living/carbon/human/source)

--- a/code/modules/hallucination/delusions.dm
+++ b/code/modules/hallucination/delusions.dm
@@ -120,7 +120,7 @@
 	// copies over lighting underlays
 	for(var/image/underlay as anything in over_who.underlays)
 		if(PLANE_TO_TRUE(underlay.plane) == O_LIGHTING_VISUAL_PLANE)
-			funny_image.underlays |= new mutable_appearance(underlay)
+			funny_image.underlays |= new /mutable_appearance(underlay)
 	return funny_image
 
 /datum/hallucination/delusion/proc/on_mob_delete(mob/living/carbon/human/source)


### PR DESCRIPTION
## About The Pull Request

The override image generated by a hallucination delusion copies over the lighting underlays, so hallucinating yourself as a carp doesn't plunge you into darkness temporarily

## Changelog

:cl: Melbert
fix: Hallucinating yourself as another mob will no longer disable all of your light sources
/:cl:
