### PR TITLE
carbon_stripping.dm uses defines instead of magic numbers

### DIFF
--- a/code/modules/mob/living/carbon/carbon_stripping.dm
+++ b/code/modules/mob/living/carbon/carbon_stripping.dm
@@ -132,8 +132,8 @@
 
 /datum/strippable_item/hand/left
 	key = STRIPPABLE_ITEM_LHAND
-	hand_index = 1
+	hand_index = LEFT_HANDS
 
 /datum/strippable_item/hand/right
 	key = STRIPPABLE_ITEM_RHAND
-	hand_index = 2
+	hand_index = RIGHT_HANDS


### PR DESCRIPTION

## About The Pull Request

Tiny change suggested by vinylspiders on another PR I'm working on.
## Why It's Good For The Game

Magic numbers are a code smell.
## Changelog
:cl: Bugwasabi, vinylspiders
code: Uses defines instead of magic numbers on carbon_stripping.dm
/:cl:
