### PR TITLE
Removes cloning (lab)

### DIFF
--- a/strings/locations.json
+++ b/strings/locations.json
@@ -24,7 +24,6 @@
 		"Chapel Office",
 		"Chapel",
 		"Chemistry",
-		"Cloning Lab",
 		"Command Hallway",
 		"Construction Area",
 		"Corporate Showroom",


### PR DESCRIPTION
## About The Pull Request

Removes `Cloning lab` from the traitor codewords list

(This should probably not be a json anyways? Like we can just pick from the list of station areas...)

## Changelog

:cl: Melbert
del: "Cloning Lab" is no longer a traitor codeword. 
/:cl:
