### PR TITLE
[NO GBP] Heretic Rework post adjustments.

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -1148,6 +1148,34 @@
 	owner.remove_filter("designated_target")
 	REMOVE_TRAIT(owner, TRAIT_DESIGNATED_TARGET, id)
 
+
+/datum/status_effect/movespeed_slowdown
+	alert_type = null
+	remove_on_fullheal = TRUE
+	status_type = STATUS_EFFECT_MULTIPLE
+	var/datum/movespeed_modifier/movespeed_modifier
+
+/datum/status_effect/movespeed_slowdown/on_creation(mob/living/new_owner, duration = 10 SECONDS, datum/movespeed_modifier/modifier, new_id)
+	if(isnull(new_id))
+		stack_trace("[src] was not provided a movespeed modifier id! Must have a UNIQUE id for the movespeed modifier to prevent conflicts with other status effects! Example: 'full_eaten_slowdown'")
+		return FALSE
+	src.duration = duration
+	movespeed_modifier = modifier
+	id = new_id
+	if(!ispath(movespeed_modifier))
+		stack_trace("[src] was provided a invalid movespeed modifier [movespeed_modifier]. Must be a typepath of a subtype of /datum/movespeed_modifier.")
+		return FALSE
+	. = ..()
+
+/datum/status_effect/movespeed_slowdown/on_apply()
+	. = ..()
+	owner.add_movespeed_modifier(movespeed_modifier, TRUE)
+
+/datum/status_effect/movespeed_slowdown/on_remove()
+	. = ..()
+	owner.remove_movespeed_modifier(movespeed_modifier)
+
+
 #undef HEALING_SLEEP_DEFAULT
 #undef HEALING_SLEEP_ORGAN_MULTIPLIER
 #undef SLEEP_QUALITY_WORKOUT_MULTIPLER

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -44,9 +44,18 @@
 	return influence_cap
 
 /// Tries to create one influence at a safe station location.
-/datum/reality_smash_tracker/proc/try_generate_influence(how_many_can_we_make = 1)
+/datum/reality_smash_tracker/proc/try_generate_influence(amount = 1)
+	var/influence_cap = get_influence_cap()
+	if(num_drained >= influence_cap)
+		return
+
+	var/amount_to_make = min(amount, influence_cap - total_influences())
+	if(amount_to_make <= 0)
+		return
+
 	var/location_sanity = 0
-	while(length(smashes) + num_drained < how_many_can_we_make && location_sanity < 100)
+	var/generated = 0
+	while(generated < amount_to_make && location_sanity < 100)
 		var/turf/chosen_location = get_safe_random_station_turf_equal_weight()
 
 		// We don't want them close to each other - at least 1 tile of separation
@@ -58,10 +67,8 @@
 			continue
 
 		new /obj/effect/heretic_influence(chosen_location)
+		generated++
 
-		return TRUE
-
-	return FALSE
 
 /// Returns true if any tracked heretic is currently eligible for influence spawning.
 /datum/reality_smash_tracker/proc/has_spawn_eligible_heretic()
@@ -71,10 +78,6 @@
 	return FALSE
 
 /datum/reality_smash_tracker/proc/handle_spawn_tick()
-	if(!length(tracked_heretics))
-		return
-	if(total_influences() >= get_influence_cap())
-		return
 	if(!has_spawn_eligible_heretic())
 		return
 	try_generate_influence(length(tracked_heretics))
@@ -88,11 +91,12 @@
  * Use this whenever you want to add someone to the list
  */
 /datum/reality_smash_tracker/proc/add_tracked_mind(datum/mind/heretic)
+	if(heretic in tracked_heretics)
+		return
 	tracked_heretics |= heretic
 	if(!spawn_timer_id)
 		spawn_timer_id = addtimer(CALLBACK(src, PROC_REF(handle_spawn_tick)), INFLUENCE_SPAWN_INTERVAL, TIMER_LOOP|TIMER_STOPPABLE)
-	if(!total_influences())
-		try_generate_influence()
+	try_generate_influence()
 
 /**
  * Removes a mind from the list of people that can see the reality smashes

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -1,8 +1,8 @@
 
 /// The number of influences spawned per heretic
-#define NUM_INFLUENCES_PER_HERETIC 5
+#define NUM_INFLUENCES_PER_HERETIC 4
 /// How often the tracker attempts to create a new influence.
-#define INFLUENCE_SPAWN_INTERVAL (5 MINUTES)
+#define INFLUENCE_SPAWN_INTERVAL (7.5 MINUTES)
 
 /**
  * #Reality smash tracker
@@ -38,12 +38,9 @@
 
 /// Calculates how many influences this tracker should support at most.
 /datum/reality_smash_tracker/proc/get_influence_cap()
-	var/influence_cap = 0
-	for(var/heretic_number in 1 to length(tracked_heretics))
-		influence_cap += max(NUM_INFLUENCES_PER_HERETIC - heretic_number + 1, 1)
-	return influence_cap
+	return length(tracked_heretics) * NUM_INFLUENCES_PER_HERETIC
 
-/// Tries to create one influence at a safe station location.
+/// Tries to create one influeSZnce at a safe station location.
 /datum/reality_smash_tracker/proc/try_generate_influence(amount = 1)
 	var/influence_cap = get_influence_cap()
 	if(num_drained >= influence_cap)

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -40,11 +40,9 @@
 /datum/reality_smash_tracker/proc/get_influence_cap()
 	return length(tracked_heretics) * NUM_INFLUENCES_PER_HERETIC
 
-/// Tries to create one influeSZnce at a safe station location.
+/// Tries to create one influence at a safe station location.
 /datum/reality_smash_tracker/proc/try_generate_influence(amount = 1)
 	var/influence_cap = get_influence_cap()
-	if(num_drained >= influence_cap)
-		return
 
 	var/amount_to_make = min(amount, influence_cap - total_influences())
 	if(amount_to_make <= 0)

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -72,11 +72,14 @@
 /datum/reality_smash_tracker/proc/handle_spawn_tick()
 	if(!length(tracked_heretics))
 		return
-	if((length(smashes) + num_drained) >= get_influence_cap())
+	if(total_influences() >= get_influence_cap())
 		return
 	if(!has_spawn_eligible_heretic())
 		return
 	try_generate_influence()
+
+/datum/reality_smash_tracker/proc/total_influences()
+	return length(smashes) + num_drained
 
 /**
  * Adds a mind to the list of people that can see the reality smashes
@@ -87,6 +90,8 @@
 	tracked_heretics |= heretic
 	if(!spawn_timer_id)
 		spawn_timer_id = addtimer(CALLBACK(src, PROC_REF(handle_spawn_tick)), INFLUENCE_SPAWN_INTERVAL, TIMER_LOOP|TIMER_STOPPABLE)
+	if(!total_influences())
+		try_generate_influence()
 
 /**
  * Removes a mind from the list of people that can see the reality smashes

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -2,7 +2,7 @@
 /// The number of influences spawned per heretic
 #define NUM_INFLUENCES_PER_HERETIC 5
 /// How often the tracker attempts to create a new influence.
-#define INFLUENCE_SPAWN_INTERVAL (10 MINUTES)
+#define INFLUENCE_SPAWN_INTERVAL (5 MINUTES)
 
 /**
  * #Reality smash tracker
@@ -44,9 +44,9 @@
 	return influence_cap
 
 /// Tries to create one influence at a safe station location.
-/datum/reality_smash_tracker/proc/try_generate_influence()
+/datum/reality_smash_tracker/proc/try_generate_influence(how_many_can_we_make = 1)
 	var/location_sanity = 0
-	while(location_sanity < 100)
+	while(length(smashes) + num_drained < how_many_can_we_make && location_sanity < 100)
 		var/turf/chosen_location = get_safe_random_station_turf_equal_weight()
 
 		// We don't want them close to each other - at least 1 tile of separation
@@ -58,6 +58,7 @@
 			continue
 
 		new /obj/effect/heretic_influence(chosen_location)
+
 		return TRUE
 
 	return FALSE
@@ -76,7 +77,7 @@
 		return
 	if(!has_spawn_eligible_heretic())
 		return
-	try_generate_influence()
+	try_generate_influence(length(tracked_heretics))
 
 /datum/reality_smash_tracker/proc/total_influences()
 	return length(smashes) + num_drained

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -1,6 +1,8 @@
 
 /// The number of influences spawned per heretic
 #define NUM_INFLUENCES_PER_HERETIC 5
+/// How often the tracker attempts to create a new influence.
+#define INFLUENCE_SPAWN_INTERVAL (10 MINUTES)
 
 /**
  * #Reality smash tracker
@@ -20,27 +22,31 @@
 	var/list/obj/effect/heretic_influence/smashes = list()
 	/// List of minds with the ability to see influences
 	var/list/datum/mind/tracked_heretics = list()
+	/// Shared timer for periodic influence spawning.
+	var/spawn_timer_id
 
 /datum/reality_smash_tracker/Destroy(force)
 	if(GLOB.reality_smash_track == src)
 		stack_trace("[type] was deleted. Heretics may no longer access any influences. Fix it, or call coder support.")
 		message_admins("The [type] was deleted. Heretics may no longer access any influences. Fix it, or call coder support.")
+	if(spawn_timer_id)
+		deltimer(spawn_timer_id)
+		spawn_timer_id = null
 	QDEL_LIST(smashes)
 	tracked_heretics.Cut()
 	return ..()
 
-/**
- * Generates a set amount of reality smashes
- * based on the number of already existing smashes
- * and the number of minds we're tracking.
- */
-/datum/reality_smash_tracker/proc/generate_new_influences()
-	var/how_many_can_we_make = 0
+/// Calculates how many influences this tracker should support at most.
+/datum/reality_smash_tracker/proc/get_influence_cap()
+	var/influence_cap = 0
 	for(var/heretic_number in 1 to length(tracked_heretics))
-		how_many_can_we_make += max(NUM_INFLUENCES_PER_HERETIC - heretic_number + 1, 1)
+		influence_cap += max(NUM_INFLUENCES_PER_HERETIC - heretic_number + 1, 1)
+	return influence_cap
 
+/// Tries to create one influence at a safe station location.
+/datum/reality_smash_tracker/proc/try_generate_influence()
 	var/location_sanity = 0
-	while((length(smashes) + num_drained) < how_many_can_we_make && location_sanity < 100)
+	while(location_sanity < 100)
 		var/turf/chosen_location = get_safe_random_station_turf_equal_weight()
 
 		// We don't want them close to each other - at least 1 tile of separation
@@ -52,6 +58,25 @@
 			continue
 
 		new /obj/effect/heretic_influence(chosen_location)
+		return TRUE
+
+	return FALSE
+
+/// Returns true if any tracked heretic is currently eligible for influence spawning.
+/datum/reality_smash_tracker/proc/has_spawn_eligible_heretic()
+	for(var/datum/mind/heretic as anything in tracked_heretics)
+		if(ishuman(heretic.current) && !is_centcom_level(heretic.current.z))
+			return TRUE
+	return FALSE
+
+/datum/reality_smash_tracker/proc/handle_spawn_tick()
+	if(!length(tracked_heretics))
+		return
+	if((length(smashes) + num_drained) >= get_influence_cap())
+		return
+	if(!has_spawn_eligible_heretic())
+		return
+	try_generate_influence()
 
 /**
  * Adds a mind to the list of people that can see the reality smashes
@@ -60,10 +85,8 @@
  */
 /datum/reality_smash_tracker/proc/add_tracked_mind(datum/mind/heretic)
 	tracked_heretics |= heretic
-
-	// If our heretic's on station, generate some new influences
-	if(ishuman(heretic.current) && !is_centcom_level(heretic.current.z))
-		generate_new_influences()
+	if(!spawn_timer_id)
+		spawn_timer_id = addtimer(CALLBACK(src, PROC_REF(handle_spawn_tick)), INFLUENCE_SPAWN_INTERVAL, TIMER_LOOP|TIMER_STOPPABLE)
 
 /**
  * Removes a mind from the list of people that can see the reality smashes
@@ -72,6 +95,9 @@
  */
 /datum/reality_smash_tracker/proc/remove_tracked_mind(datum/mind/heretic)
 	tracked_heretics -= heretic
+	if(!length(tracked_heretics) && spawn_timer_id)
+		deltimer(spawn_timer_id)
+		spawn_timer_id = null
 
 /obj/effect/visible_heretic_influence
 	name = "pierced reality"
@@ -277,6 +303,7 @@
 	name = "\improper" + pick_list(HERETIC_INFLUENCE_FILE, "prefix") + " " + pick_list(HERETIC_INFLUENCE_FILE, "postfix")
 
 #undef NUM_INFLUENCES_PER_HERETIC
+#undef INFLUENCE_SPAWN_INTERVAL
 
 /// Hud used for heretics to see influences
 /datum/atom_hud/alternate_appearance/basic/has_antagonist/heretic

--- a/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
+++ b/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
@@ -307,10 +307,15 @@ GLOBAL_LIST_INIT(heretic_path_datums, init_heretic_path_datums())
 			"parent_knowledge" = knowledge_tier4,
 			"probabilities" = list("1" = 0, "2" = 0, "3" = 0, "4" = 0, "5" = 100),
 			HKT_DEPTH = HKT_DEPTH_DRAFT_4,
+			"allowed_routes" = list(PATH_LOCK)
 		)
 	)
 	/// generate 3 drafts for each draft tier, while banning you from picking multiple drafts
 	for(var/draft in drafts)
+		var/list/allowed_routes = draft["allowed_routes"]
+		if(!isnull(allowed_routes) && !is_path_in_list(route, allowed_routes))
+			continue
+
 		var/parent_knowledge_path = draft["parent_knowledge"]
 		var/datum/heretic_knowledge/guaranteed_draft = draft["guaranteed_knowledge"]
 		var/list/probabilities = draft["probabilities"]

--- a/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
+++ b/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
@@ -358,8 +358,7 @@ GLOBAL_LIST_INIT(heretic_path_datums, init_heretic_path_datums())
 
 	// all possible drafts are added to the shop, this time with costs
 	for(var/drafting_tier in 1 to length(shop_knowledge))
-		var/list/allowed_routes = drafts[drafting_tier]["allowed_routes"]
-		if(length(allowed_routes) && !(route in allowed_routes))
+		if(drafting_tier == 5 && !is_path_in_list(PATH_LOCK, allowed_routes))
 			continue
 
 		var/unlocked_by = shop_unlock_order[drafting_tier]

--- a/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
+++ b/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
@@ -358,7 +358,7 @@ GLOBAL_LIST_INIT(heretic_path_datums, init_heretic_path_datums())
 
 	// all possible drafts are added to the shop, this time with costs
 	for(var/drafting_tier in 1 to length(shop_knowledge))
-		if(drafting_tier == 5 && !is_path_in_list(PATH_LOCK, allowed_routes))
+		if(drafting_tier == 5 && route != PATH_LOCK))
 			continue
 
 		var/unlocked_by = shop_unlock_order[drafting_tier]

--- a/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
+++ b/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
@@ -358,7 +358,7 @@ GLOBAL_LIST_INIT(heretic_path_datums, init_heretic_path_datums())
 
 	// all possible drafts are added to the shop, this time with costs
 	for(var/drafting_tier in 1 to length(shop_knowledge))
-		if(drafting_tier == 5 && route != PATH_LOCK))
+		if(drafting_tier == 5 && route != PATH_LOCK)
 			continue
 
 		var/unlocked_by = shop_unlock_order[drafting_tier]

--- a/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
+++ b/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
@@ -312,9 +312,6 @@ GLOBAL_LIST_INIT(heretic_path_datums, init_heretic_path_datums())
 	)
 	/// generate 3 drafts for each draft tier, while banning you from picking multiple drafts
 	for(var/draft in drafts)
-		var/list/allowed_routes = draft["allowed_routes"]
-		if(!isnull(allowed_routes) && !is_path_in_list(route, allowed_routes))
-			continue
 
 		var/parent_knowledge_path = draft["parent_knowledge"]
 		var/datum/heretic_knowledge/guaranteed_draft = draft["guaranteed_knowledge"]
@@ -361,6 +358,10 @@ GLOBAL_LIST_INIT(heretic_path_datums, init_heretic_path_datums())
 
 	// all possible drafts are added to the shop, this time with costs
 	for(var/drafting_tier in 1 to length(shop_knowledge))
+		var/list/allowed_routes = drafts[drafting_tier]["allowed_routes"]
+		if(length(allowed_routes) && !(route in allowed_routes))
+			continue
+
 		var/unlocked_by = shop_unlock_order[drafting_tier]
 		var/list/eligible_tier = shop_knowledge[drafting_tier]
 		for(var/knowledge_type in eligible_tier)

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -77,7 +77,7 @@
 	. = ..()
 
 	var/obj/item/clothing/under/suit = target.get_item_by_slot(ITEM_SLOT_ICLOTHING)
-	if(!suit?.can_adjust)
+	if(!istype(suit) || !suit.can_adjust)
 		return
 	if(istype(suit) && suit.adjusted == NORMAL_STYLE)
 		suit.toggle_jumpsuit_adjust()

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -77,7 +77,7 @@
 	. = ..()
 
 	var/obj/item/clothing/under/suit = target.get_item_by_slot(ITEM_SLOT_ICLOTHING)
-	if(!suit.can_adjust)
+	if(!suit?.can_adjust)
 		return
 	if(istype(suit) && suit.adjusted == NORMAL_STYLE)
 		suit.toggle_jumpsuit_adjust()

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -64,8 +64,8 @@
 		return TRUE
 
 	carbon_hit.adjust_timed_status_effect(4 SECONDS, /datum/status_effect/speech/slurring/heretic)
-	carbon_hit.AdjustKnockdown(5 SECONDS, daze_amount = 3 SECONDS)
-	carbon_hit.adjust_stamina_loss(80)
+	carbon_hit.set_timed_status_effect(10 SECONDS, /datum/status_effect/mansus_slowdown)
+	carbon_hit.AdjustKnockdown(5 SECONDS)
 
 	return TRUE
 

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -64,7 +64,12 @@
 		return TRUE
 
 	carbon_hit.adjust_timed_status_effect(4 SECONDS, /datum/status_effect/speech/slurring/heretic)
-	carbon_hit.set_timed_status_effect(10 SECONDS, /datum/status_effect/mansus_slowdown)
+	carbon_hit.apply_status_effect(
+		/datum/status_effect/movespeed_slowdown,
+		10 SECONDS,
+		/datum/movespeed_modifier/mansus_grasp_slowdown,
+		"mansus_grasp_slowdown"
+	)
 	carbon_hit.AdjustKnockdown(5 SECONDS)
 
 	return TRUE

--- a/code/modules/antagonists/heretic/status_effects/debuffs.dm
+++ b/code/modules/antagonists/heretic/status_effects/debuffs.dm
@@ -466,21 +466,5 @@
 	SIGNAL_HANDLER
 	return COMSIG_MOB_CLIENT_BLOCK_PRE_LIVING_MOVE
 
-
-/datum/status_effect/mansus_slowdown
-	id = "mansus_slowdown"
-	alert_type = null
-	remove_on_fullheal = TRUE
-	duration = 10 SECONDS
-	var/movespeed_modifier = /datum/movespeed_modifier/mansus_slowdown
-
-/datum/status_effect/mansus_slowdown/on_apply()
-	. = ..()
-	owner.add_movespeed_modifier(movespeed_modifier, TRUE)
-
-/datum/status_effect/mansus_slowdown/on_remove()
-	. = ..()
-	owner.remove_movespeed_modifier(movespeed_modifier)
-
-/datum/movespeed_modifier/mansus_slowdown
+/datum/movespeed_modifier/mansus_grasp_slowdown
 	multiplicative_slowdown = 1

--- a/code/modules/antagonists/heretic/status_effects/debuffs.dm
+++ b/code/modules/antagonists/heretic/status_effects/debuffs.dm
@@ -465,3 +465,22 @@
 /datum/status_effect/moon_parade/proc/block_move(datum/source)
 	SIGNAL_HANDLER
 	return COMSIG_MOB_CLIENT_BLOCK_PRE_LIVING_MOVE
+
+
+/datum/status_effect/mansus_slowdown
+	id = "mansus_slowdown"
+	alert_type = null
+	remove_on_fullheal = TRUE
+	duration = 10 SECONDS
+	var/movespeed_modifier = /datum/movespeed_modifier/mansus_slowdown
+
+/datum/status_effect/mansus_slowdown/on_apply()
+	. = ..()
+	owner.add_movespeed_modifier(movespeed_modifier, TRUE)
+
+/datum/status_effect/mansus_slowdown/on_remove()
+	. = ..()
+	owner.remove_movespeed_modifier(movespeed_modifier)
+
+/datum/movespeed_modifier/mansus_slowdown
+	multiplicative_slowdown = 1

--- a/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
+++ b/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
@@ -356,7 +356,10 @@
 	name = "Open Invitation"
 	id = "lock_passive"
 	passive_descriptions = list(
-		"Shock insulation, all knowledges researched from the shop are cheaper",
+		"Shock insulation, \n\
+			all knowledges researched from the shop are cheaper, \n\
+			you can unlock and purchase from the tier 5 shop knowledges and\n\
+			you do not gain a heretic aura.",
 		"X-ray vision, you can see through walls and objects.",
 		"Grasp no longer goes on cooldown when used to open a door or locker."
 	)

--- a/code/modules/antagonists/heretic/status_effects/mark_effects.dm
+++ b/code/modules/antagonists/heretic/status_effects/mark_effects.dm
@@ -83,7 +83,11 @@
 /datum/status_effect/eldritch/ash/on_effect()
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.adjust_stamina_loss(20 * repetitions) // first one = 30 stam
+		var/stamloss = 10 * repetitions
+		if(repetitions >= 5)
+			stamloss += 50
+		carbon_owner.adjust_stamina_loss(stamloss) // first one = 30 stam
+
 		carbon_owner.adjust_fire_loss(3 * repetitions) // first one = 15 burn
 		for(var/mob/living/carbon/victim in shuffle(range(1, carbon_owner)))
 			if(IS_HERETIC(victim) || victim == carbon_owner)

--- a/code/modules/antagonists/heretic/status_effects/mark_effects.dm
+++ b/code/modules/antagonists/heretic/status_effects/mark_effects.dm
@@ -83,7 +83,7 @@
 /datum/status_effect/eldritch/ash/on_effect()
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.adjust_stamina_loss(6 * repetitions) // first one = 30 stam
+		carbon_owner.adjust_stamina_loss(20 * repetitions) // first one = 30 stam
 		carbon_owner.adjust_fire_loss(3 * repetitions) // first one = 15 burn
 		for(var/mob/living/carbon/victim in shuffle(range(1, carbon_owner)))
 			if(IS_HERETIC(victim) || victim == carbon_owner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Mansus grasp no longer  makes targets eligible for a shove stun and no longer applies stamina damage.

stam damage has been replaced with a static slowdown that equals what it used to apply with the stamina slowdown.

Ash mark detonation now applies 100 stamina damage and half that amount on secondary targets, decreasing with each detonation.

The last row of the knowledge shop has been made unavailable to all paths except Lock, effectively killing sidepathing.

Eldritch Rifts are no longer immediately frontloaded at the start of the round, instead 1 rift will now spawn per Heretic  every 7 minutes and half.

Each Heretic will now generate a total of 4 rifts, you should see slightly more rifts later in the round, when more than 3 heretics are present nd less if there's only 1 or 2 of them.

Lastly Lock passive description has been updated to properly describe they don't gain the Eldritch aura and have access to the 5th row in the knowledge tree.

## Why It's Good For The Game


**Weakening Heretic early game while Killing Batontic for good**

Now that Heretics start with the grasp and mark upgrade early on, the shovestun on the mansus grasp just feels overkill.

When combined these effects can be absolutely devastating and often leave little room for counterplay.

Shove stun on grasp is a relic of a past where Heretics were considerably weaker at the start of the round.

Same thing applies to the grasp having synergy with batons, 2 click wins are boring and don't make for an interesting fight, and personally I despise how a baton is still a more useful tool than a blade.

Now this change would absolutely trivialize Ash path, as what makes the path so desirable in the insta stam crit on mark detonation, so i bumped the numbers on the Mark to mantain the same playstyle (while lessening it on spread so that it doesn't become overbearing in group fights).

Yes that effectively means that Ash will still rely on winning fights in 2 clicks, but it's something that cannot be easily addressed until I properly get to rework the entire path.

**Killing Side pathing for good**

This was originally in my plans for the rework, but I was afraid it was going to be too big of a nerf if we didn't have a handful of spells in the shop.

Turns out that even without the extra firepower a late game Heretic is still a formidable fighter, and the extra help is probably not needed.

I thought Lock could probably still retain the last row as the path has little to no combat spells of its own, and it's flavourful that the "thief path" can scrounge a few spells from the other schools.

**Making the Rift system less feast or famine**

Currently, the rift system encourages Heretics to drop everything they are doing as soon as the round commences.

Which often results in the most experienced players (and those lucky to have been blessed with more access), to sweep the station clean of tears in the first 20 minutes in the round.

This often results in a singular Heretic snowballing out of control way too early and the other poor bookworms being left in the dust.

By having them gradually spawn we prevent this scenario from occuring while avoiding putting too much pressure on our less experienced players, or really players who just want to properly plan their approach.


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Mansus grasp no longer applies stamina damage or makes targets eligible for a shove stun, instead if now applies a static slowdown.
balance: Ash Mark detonation now deal 100 stamina damage and half of that amount to secondary targets.
balance: The last row of the knowledge shop is now only accessible to Lock path
balance:  Heretic Rifts are no longer frontloaded at the start of the round, they now gradually spawn progressively as the round goes on, the total amount scales on the numbers of Heretics present.
spellcheck: Properly updated Lock passive description to specify the lack of aura and access to the 5th row of the knowledge shop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
