### PR TITLE
Moves lung scanning code out of `healthscan`

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -447,30 +447,6 @@
 			Possible Cure: [cure_text]</div>\
 			</span>"
 
-	// Lungs
-	var/obj/item/organ/lungs/lungs = target.get_organ_slot(ORGAN_SLOT_LUNGS)
-	if (lungs)
-		var/initial_pressure_mult = lungs::received_pressure_mult
-		if (lungs.received_pressure_mult != initial_pressure_mult)
-			var/tooltip
-			var/dilation_text
-			var/beginning_text = "Lung Dilation: "
-			if (lungs.received_pressure_mult > initial_pressure_mult) // higher than usual
-				beginning_text = span_blue("<b>[beginning_text]</b>")
-				dilation_text = span_blue("[(lungs.received_pressure_mult * 100) - 100]%")
-				tooltip = "Subject's lungs are dilated and breathing more air than usual. Increases the effectiveness of healium and other gases."
-			else
-				beginning_text = span_danger("<b>[beginning_text]</b>")
-				if (lungs.received_pressure_mult <= 0) // lethal
-					dilation_text = span_bolddanger("[lungs.received_pressure_mult * 100]%")
-					tooltip = "Subject's lungs are completely shut. Subject is unable to breathe and requires emergency surgery. If asthmatic, perform asthmatic bypass surgery and adminster albuterol inhalant. Otherwise, replace lungs."
-				else
-					dilation_text = span_danger("[lungs.received_pressure_mult * 100]%")
-					tooltip = "Subject's lungs are partially shut. If unable to breathe, administer a high-pressure internals tank or replace lungs. If asthmatic, inhaled albuterol or bypass surgery will likely help."
-
-			var/lung_message = beginning_text + conditional_tooltip(dilation_text, tooltip, TRUE)
-			render_list += lung_message
-
 	// Time of death
 	if(target.station_timestamp_timeofdeath && !target.appears_alive())
 		render_list += "<hr>"

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -876,6 +876,35 @@
 		return span_boldwarning("Your lungs feel extremely tight[HAS_TRAIT(owner, TRAIT_NOBREATH) ?  "" : ", and every breath is a struggle"].")
 	return span_boldwarning("It feels extremely tight[HAS_TRAIT(owner, TRAIT_NOBREATH) ?  "" : ", and every breath is a struggle"].")
 
+/obj/item/organ/lungs/get_status_appendix(advanced, add_tooltips)
+	var/initial_pressure_mult = initial(received_pressure_mult)
+	if (received_pressure_mult == initial_pressure_mult)
+		return
+
+	var/tooltip
+	var/dilation_text
+	var/beginning_text = "Lung Dilation: "
+	if (received_pressure_mult > initial_pressure_mult) // higher than usual
+		beginning_text = span_blue("<b>[beginning_text]</b>")
+		dilation_text = span_blue("[(received_pressure_mult * 100) - 100]%")
+		tooltip = "Subject's lungs are dilated and breathing more air than usual. \
+			Increases the effectiveness of healium and other gases."
+
+	else
+		beginning_text = span_alert("<b>[beginning_text]</b>")
+		if (received_pressure_mult <= 0) // lethal
+			dilation_text = span_alert("<b>[received_pressure_mult * 100]%</b>")
+			tooltip = "Subject's lungs are completely shut. Subject is unable to breathe and requires emergency surgery. \
+				If asthmatic, perform asthmatic bypass surgery and adminster albuterol inhalant. \
+				Otherwise, replace lungs."
+		else
+			dilation_text = span_alert("[received_pressure_mult * 100]%")
+			tooltip = "Subject's lungs are partially shut. \
+				If unable to breathe, administer a high-pressure internals tank or replace lungs. \
+				If asthmatic, inhaled albuterol or bypass surgery will likely help."
+
+	return beginning_text + conditional_tooltip(dilation_text, tooltip, add_tooltips)
+
 /// by default, returns the lungs' breath_noise var as a notice. called when stethoscope is used on chest, uses the return as a message for stethoscope user.
 /obj/item/organ/lungs/proc/hear_breath_noise(mob/living/hearer)
 	return span_notice("[owner.p_Their()] lungs emit [breath_noise].")


### PR DESCRIPTION
## About The Pull Request

Rather than have all the lung handing appended to the bottom of `healthscan`, puts it in `get_status_appendix`

## Why It's Good For The Game

Other organ maladies, like blindness and brain traumas, are in `get_status_appendix`, so this fits well for consistency's sake

## Changelog

:cl: Melbert
qol: Health analyzer lung reports are appended by the lung organs rather than at the bottom of the readout
/:cl:
