### PR TITLE
Fix some signal registration issues with arm implants

### DIFF
--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -28,12 +28,14 @@
 /obj/item/organ/cyberimp/arm/proc/on_limb_attached(mob/living/carbon/source, obj/item/bodypart/limb)
 	SIGNAL_HANDLER
 	if(!limb || QDELETED(limb) || limb.body_zone != zone)
-		return FALSE
+		return
+	handle_attachment(limb)
+
+/obj/item/organ/cyberimp/arm/proc/handle_attachment(obj/item/bodypart/limb)
 	if(hand)
 		on_limb_detached(hand)
 	RegisterSignal(limb, COMSIG_BODYPART_REMOVED, PROC_REF(on_limb_detached))
 	hand = limb
-	return TRUE
 
 /obj/item/organ/cyberimp/arm/proc/on_limb_detached(obj/item/bodypart/source)
 	SIGNAL_HANDLER
@@ -93,10 +95,8 @@
 	UnregisterSignal(arm_owner, COMSIG_KB_MOB_DROPITEM_DOWN)
 	Retract()
 
-/obj/item/organ/cyberimp/arm/toolkit/on_limb_attached(mob/living/carbon/source, obj/item/bodypart/limb)
+/obj/item/organ/cyberimp/arm/toolkit/handle_attachment(obj/item/bodypart/limb)
 	. = ..()
-	if(!.)
-		return
 	RegisterSignal(limb, COMSIG_ITEM_ATTACK_SELF, PROC_REF(on_item_attack_self))
 
 /obj/item/organ/cyberimp/arm/toolkit/on_limb_detached(obj/item/bodypart/source)

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -28,11 +28,12 @@
 /obj/item/organ/cyberimp/arm/proc/on_limb_attached(mob/living/carbon/source, obj/item/bodypart/limb)
 	SIGNAL_HANDLER
 	if(!limb || QDELETED(limb) || limb.body_zone != zone)
-		return
+		return FALSE
 	if(hand)
 		on_limb_detached(hand)
 	RegisterSignal(limb, COMSIG_BODYPART_REMOVED, PROC_REF(on_limb_detached))
 	hand = limb
+	return TRUE
 
 /obj/item/organ/cyberimp/arm/proc/on_limb_detached(obj/item/bodypart/source)
 	SIGNAL_HANDLER
@@ -94,6 +95,8 @@
 
 /obj/item/organ/cyberimp/arm/toolkit/on_limb_attached(mob/living/carbon/source, obj/item/bodypart/limb)
 	. = ..()
+	if(!.)
+		return
 	RegisterSignal(limb, COMSIG_ITEM_ATTACK_SELF, PROC_REF(on_item_attack_self))
 
 /obj/item/organ/cyberimp/arm/toolkit/on_limb_detached(obj/item/bodypart/source)

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -22,6 +22,7 @@
 
 /obj/item/organ/cyberimp/arm/on_mob_remove(mob/living/carbon/arm_owner)
 	. = ..()
+	UnregisterSignal(arm_owner, COMSIG_CARBON_POST_ATTACH_LIMB)
 	on_limb_detached(hand)
 
 /obj/item/organ/cyberimp/arm/proc/on_limb_attached(mob/living/carbon/source, obj/item/bodypart/limb)
@@ -88,6 +89,7 @@
 
 /obj/item/organ/cyberimp/arm/toolkit/on_mob_remove(mob/living/carbon/arm_owner)
 	. = ..()
+	UnregisterSignal(arm_owner, COMSIG_KB_MOB_DROPITEM_DOWN)
 	Retract()
 
 /obj/item/organ/cyberimp/arm/toolkit/on_limb_attached(mob/living/carbon/source, obj/item/bodypart/limb)


### PR DESCRIPTION

## About The Pull Request

- `COMSIG_CARBON_POST_ATTACH_LIMB` and `COMSIG_KB_MOB_DROPITEM_DOWN` were not being unregistered on limb removal, leading to duplicate registration runtimes if the same limb was amputated and then reattached
- `/obj/item/organ/cyberimp/arm/on_limb_attached` early returns if the attached limb isn't in the implant's body zone i.e. it's unrelated, the child override `/obj/item/organ/cyberimp/arm/toolkit/on_limb_attached` calls the parent but doesn't early return if the parent did, leading to erroneous signal registration on unrelated limbs

## Why It's Good For The Game

Bug fixes

## Changelog
:cl:
fix: fixed a few bugs related to arm implant surgery
/:cl:
