### PR TITLE
Mob height is stored in DNA

### DIFF
--- a/code/datums/dna/blocks/dna_identity_block.dm
+++ b/code/datums/dna/blocks/dna_identity_block.dm
@@ -77,7 +77,7 @@
 	return construct_block(SSaccessories.facial_hairstyles_list.Find(target.facial_hairstyle), length(SSaccessories.facial_hairstyles_list))
 
 /datum/dna_block/identity/facial_style/apply_to_mob(mob/living/carbon/human/target, dna_hash)
-	if(HAS_TRAIT(src, TRAIT_SHAVED))
+	if(HAS_TRAIT(target, TRAIT_SHAVED))
 		target.set_facial_hairstyle("Shaved", update = FALSE)
 		return
 	var/style = SSaccessories.facial_hairstyles_list[deconstruct_block(get_block(dna_hash), length(SSaccessories.facial_hairstyles_list))]
@@ -127,3 +127,25 @@
 
 /datum/dna_block/identity/facial_gradient_color/apply_to_mob(mob/living/carbon/human/target, dna_hash)
 	target.set_facial_hair_gradient_color(sanitize_hexcolor(get_block(dna_hash)), update = FALSE)
+
+/datum/dna_block/identity/height
+	/// List of all heights you can have stored in your DNA
+	/// Heights above the highest and below the lowest are locked to traits/mutations/species
+	/// Actual DNA Height is stored as "index in dna_heights list"
+	var/list/dna_heights = list(
+		HUMAN_HEIGHT_SHORTEST,
+		HUMAN_HEIGHT_SHORT,
+		HUMAN_HEIGHT_MEDIUM,
+		HUMAN_HEIGHT_TALL,
+		HUMAN_HEIGHT_TALLER,
+	)
+
+/datum/dna_block/identity/height/create_unique_block(mob/living/carbon/human/target)
+	var/max_height_index = length(dna_heights)
+	var/mob_height_index = dna_heights.Find("[target.get_base_mob_height()]") || dna_heights.Find(HUMAN_HEIGHT_MEDIUM)
+	return construct_block(mob_height_index, max_height_index, block_length)
+
+/datum/dna_block/identity/height/apply_to_mob(mob/living/carbon/human/target, dna_hash)
+	var/max_height_index = length(dna_heights)
+	var/mob_height_index = deconstruct_block(get_block(dna_hash), max_height_index, block_length)
+	target.set_mob_height(text2num(dna_heights[mob_height_index]) || HUMAN_HEIGHT_MEDIUM, update_dna = FALSE)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -265,13 +265,14 @@
 /**
  * Setter for mob height - updates the base height of the mob (which is then adjusted by traits or species)
  *
- * Exists so that the update is done immediately
- *
- * Returns TRUE if changed, FALSE otherwise
+ * * new_height - The new base height for this mob, should be one of the HUMAN_HEIGHT defines
+ * * update_dna - if TRUE (default), updates the mob's DNA with the new height value
  */
-/mob/living/carbon/human/proc/set_mob_height(new_height)
+/mob/living/carbon/human/proc/set_mob_height(new_height = HUMAN_HEIGHT_MEDIUM, update_dna = TRUE)
 	base_mob_height = new_height
 	update_mob_height()
+	if(update_dna)
+		dna?.update_ui_block(/datum/dna_block/identity/height)
 
 /**
  * Updates the mob's height
@@ -286,6 +287,13 @@
 	if(old_height != mob_height)
 		regenerate_icons()
 	SEND_SIGNAL(src, COMSIG_HUMAN_HEIGHT_UPDATED, old_height)
+
+/**
+ * Gets the mob's base height, ignoring adjustments from traits or species
+ * Necessary due to VAR_PRIVATE (it's not used in hot code anyways)
+ */
+/mob/living/carbon/human/proc/get_base_mob_height()
+	return base_mob_height
 
 /**
  * Makes a full copy of src and returns it.


### PR DESCRIPTION
## About The Pull Request

`base_mob_height` is stored in a DNA UI block, meaning it can be modified by geneticists and radstorms.

Also fixes a bug with `TRAIT_SHAVED`. Not observable in game atm. 

## Why It's Good For The Game

Copying DNA of a Spacer or Settler would not copy your height, making it a dead giveaway. 

## Changelog

:cl: Melbert
qol: Height is now an element of DNA, meaning it can be changed via genetics or radstorms and is carried between genetic copies (Changlings, etc)
/:cl:
