### PR TITLE
Fixes stack items not being refunded by failed heretic summon rituals

### DIFF
--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -133,7 +133,7 @@
 				var/obj/item/stack/picked_stack = nearby_atom
 				if(!stack_reqs[req_type])
 					stack_reqs[req_type] = requirements_list[req_type]
-				requirements_list[req_type] -= min(picked_stack.amount || requirements_list[req_type])
+				requirements_list[req_type] -= min(picked_stack.amount, requirements_list[req_type])
 
 			// Otherwise, just add the mark down the item as fulfilled x1
 			else
@@ -177,7 +177,7 @@
 			for(var/stack_path in stack_reqs)
 				if(!istype(nearby_stack, stack_path) && (!islist(stack_path) || !is_type_in_list(nearby_stack, stack_path)))
 					continue
-				var/amount_to_give = min(nearby_stack.amount || stack_reqs[stack_path])
+				var/amount_to_give = min(nearby_stack.amount, stack_reqs[stack_path])
 				var/obj/item/stack/our_stack = locate(nearby_stack.merge_type) in selected_atoms
 				if(!our_stack)
 					our_stack = nearby_stack.split_stack(amount = amount_to_give)
@@ -213,6 +213,10 @@
 		if(QDELETED(to_appear))
 			continue
 		to_appear.RemoveInvisibility(type)
+		// Stacks are split off into nullspace and need to be brought back
+		if (isstack(to_appear) && isnull(to_appear.loc))
+			var/obj/item/stack/as_stack = to_appear
+			as_stack.forceMove(loc)
 
 	// And finally, give some user feedback
 	// No feedback is given on failure here -


### PR DESCRIPTION

## About The Pull Request

Closes #95504

When split, new stacks are put into nullspace as to prevent them from merging with other stacks and never brought back

## Changelog
:cl:
fix: Fixed stack items not being refunded by failed heretic summon rituals
/:cl:
