### PR TITLE
When forcing an earthquake, admins can now choose its location

### DIFF
--- a/code/modules/events/earthquake.dm
+++ b/code/modules/events/earthquake.dm
@@ -45,12 +45,11 @@
 		epicenter = special_spot
 	else
 		epicenter = get_turf(pick(GLOB.generic_event_spawns))
+		// Give a bit of variance so our epicenter isn't always on the landmark.
+		epicenter = locate(epicenter.x + rand(-10, 10), epicenter.y + rand(-10, 10), epicenter.z)
 	if(!epicenter)
 		message_admins("Earthquake event failed to find a turf! generic_event_spawn landmarks may be absent or bugged. Aborting...")
 		return
-
-	// Give a bit of variance so our epicenter isn't always on the landmark.
-	epicenter = locate(epicenter.x + rand(-10, 10), epicenter.y + rand(-10, 10), epicenter.z)
 
 	message_admins("An earthquake event is about to strike the [get_area_name(epicenter)][ADMIN_JMP(epicenter)].")
 
@@ -189,7 +188,7 @@
 /datum/event_admin_setup/set_location/earthquake
 	input_text = "Have the epicenter be at the current location?"
 
-/datum/event_admin_setup/set_location/immovable_rod/apply_to_event(datum/round_event/earthquake/event)
+/datum/event_admin_setup/set_location/earthquake/apply_to_event(datum/round_event/earthquake/event)
 	event.special_spot = chosen_turf
 	var/log_message = "[key_name_admin(usr)] triggered an earthquake at [event.special_spot ? AREACOORD(event.special_spot) : "a random location"]."
 	message_admins(log_message)

--- a/code/modules/events/earthquake.dm
+++ b/code/modules/events/earthquake.dm
@@ -14,6 +14,7 @@
 	min_wizard_trigger_potency = 3
 	max_wizard_trigger_potency = 7
 	map_flags = EVENT_PLANETARY_ONLY
+	admin_setup = list(/datum/event_admin_setup/set_location/earthquake)
 
 /datum/round_event_control/earthquake/can_spawn_event(players_amt, allow_magic)
 	. = ..()
@@ -30,6 +31,8 @@
 	announce_chance = 25
 	///The chosen location and center of our earthquake.
 	var/turf/epicenter
+	///The location explicitly chosen by an admin forcing the event
+	var/turf/special_spot
 	///A list of turfs that will be damaged by this event.
 	var/list/turfs_to_shred
 	///A list of turfs directly under turfs_to_shred, for creating a proper chasm to the floor below.
@@ -38,7 +41,10 @@
 	var/list/edges = list()
 
 /datum/round_event/earthquake/setup()
-	epicenter = get_turf(pick(GLOB.generic_event_spawns))
+	if(special_spot)
+		epicenter = special_spot
+	else
+		epicenter = get_turf(pick(GLOB.generic_event_spawns))
 	if(!epicenter)
 		message_admins("Earthquake event failed to find a turf! generic_event_spawn landmarks may be absent or bugged. Aborting...")
 		return
@@ -178,3 +184,13 @@
 			SSexplosions.medturf += edge_to_damage
 		else
 			SSexplosions.lowturf += edge_to_damage
+
+/// Admins can also pick the epicenter of the earthquake
+/datum/event_admin_setup/set_location/earthquake
+	input_text = "Have the epicenter be at the current location?"
+
+/datum/event_admin_setup/set_location/immovable_rod/apply_to_event(datum/round_event/earthquake/event)
+	event.special_spot = chosen_turf
+	var/log_message = "[key_name_admin(usr)] triggered an earthquake at [event.special_spot ? AREACOORD(event.special_spot) : "a random location"]."
+	message_admins(log_message)
+	log_admin(log_message)


### PR DESCRIPTION

## About The Pull Request

Admins can now pick where an earthquake will hit the station, just like you can currently decide where an immovable rod goes through

## Why It's Good For The Game

more admin abuse

## Changelog

:cl:
admin: When forcing an earthquake, admins can now pick their precise position on the station.
/:cl:

