### PR TITLE
Fixes parallax runtiming horribly whenever parallax SS doesnt pick a random layer to display

### DIFF
--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -279,7 +279,9 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_home)
 
 	parallax_layers_cached = list()
 	for(var/space_layer in 1 to layers_to_draw)
-		parallax_layers_cached += generate_space_layer(space_layer)
+		var/atom/movable/screen/parallax_layer/parallax = generate_space_layer(space_layer)
+		if (parallax)
+			parallax_layers_cached += parallax
 
 	if(draw_old_space)
 		parallax_layers_cached += new /atom/movable/screen/parallax_layer/old(null, null, owner)


### PR DESCRIPTION

## About The Pull Request

There's a 30% chance that there's no random layer which leads to runtimes occuring whenever anyone with maxed out parallax tries to move

## Changelog
:cl:
fix: Fixed parallax runtiming horribly whenever parallax SS doesnt pick a random layer to display
/:cl:
