### PR TITLE
Installing/moving windoor electronics only happens after the do-after

### DIFF
--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -226,6 +226,7 @@
 					span_notice("You start to install electronics into the airlock assembly..."))
 
 				if(do_after(user, 4 SECONDS, target = src))
+
 					if(!user.transferItemToLoc(W, src))
 						return
 					if(!src || electronics)
@@ -234,8 +235,6 @@
 					to_chat(user, span_notice("You install the airlock electronics."))
 					name = "near finished windoor assembly"
 					electronics = W
-				else
-					W.forceMove(drop_location())
 
 			//Screwdriver to remove airlock electronics. Step 6 undone.
 			else if(W.tool_behaviour == TOOL_SCREWDRIVER)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -220,13 +220,14 @@
 
 			//Adding airlock electronics for access. Step 6 complete.
 			else if(istype(W, /obj/item/electronics/airlock))
-				if(!user.transferItemToLoc(W, src))
-					return
+
 				W.play_tool_sound(src, 100)
 				user.visible_message(span_notice("[user] installs the electronics into the airlock assembly."),
 					span_notice("You start to install electronics into the airlock assembly..."))
 
 				if(do_after(user, 4 SECONDS, target = src))
+					if(!user.transferItemToLoc(W, src))
+						return
 					if(!src || electronics)
 						W.forceMove(drop_location())
 						return


### PR DESCRIPTION
## About The Pull Request

About what it says on the tin - when installing electronics in a windoor, the electronics are only moved out of your hand after the do-after. Otherwise, it just remains in your hand.

## Why It's Good For The Game

Consistency with how regular airlocks only move the electronics out of your hand after you finish installing them.

## Changelog

:cl:
qol: Installing electronics into windoors/interior doors only moves the electronics out of your hand on a successful installation.
/:cl:
