### PR TITLE
Hydroponics tray autogrow power use becomes more efficient with parts

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -191,6 +191,19 @@
 	reagents.maximum_volume = maxnutri
 	nutridrain = 1/rating
 
+	// active power draw reduction taken from stasis units in code\game\machinery\stasis.dm
+	// this really only matters if you're using the autogrow, because by default the trays don't draw power
+	var/energy_rating = 0
+	for(var/datum/stock_part/part in component_parts)
+		energy_rating += part.energy_rating()
+
+	for(var/obj/item/stock_parts/part in component_parts)
+		energy_rating += part.energy_rating
+
+	idle_power_usage = initial(idle_power_usage) / (energy_rating/3)
+	active_power_usage = initial(active_power_usage) / (energy_rating/3)
+	update_current_power_usage()
+
 /obj/machinery/hydroponics/constructable/examine(mob/user)
 	. = ..()
 	. += span_notice("Use <b>Ctrl-Click</b> to activate autogrow. <b>RMB</b> to empty the tray's nutrients.")

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -191,17 +191,19 @@
 	reagents.maximum_volume = maxnutri
 	nutridrain = 1/rating
 
-	// active power draw reduction taken from stasis units in code\game\machinery\stasis.dm
-	// this really only matters if you're using the autogrow, because by default the trays don't draw power
-	var/energy_rating = 0
+	// Active power draw reduction inspired by stasis units in code\game\machinery\stasis.dm
+	// This really only matters if you're using the autogrow, because, by default, trays don't draw power.
+	// Not using energy rating because they're nonlinear and make the power draw reduction too generous.
+	var/total_rating = 0
 	for(var/datum/stock_part/part in component_parts)
-		energy_rating += part.energy_rating()
+		total_rating += part.tier
 
-	for(var/obj/item/stock_parts/part in component_parts)
-		energy_rating += part.energy_rating
-
-	idle_power_usage = initial(idle_power_usage) / (energy_rating/3)
-	active_power_usage = initial(active_power_usage) / (energy_rating/3)
+	/**
+	 * We sum up the part tier ratings, divide by how many upgradable parts we have (in this case, 3) for a modifier,
+	 * and divide the initial power usage by the modifier. Power draw thus becomes 1 kW / 500 W / 333.3 W / 250 W at time of writing.
+	 */
+	idle_power_usage = initial(idle_power_usage) / (total_rating / 3)
+	active_power_usage = initial(active_power_usage) / (total_rating / 3)
 	update_current_power_usage()
 
 /obj/machinery/hydroponics/constructable/examine(mob/user)


### PR DESCRIPTION
## About The Pull Request

Using tgstation/tgstation#88555 as inspiration, makes it so upgrading the parts on a hydroponics tray reduces the power draw when using autogrow. Numbers now less subject to change, considering they're a bit less generous than before.

Trays don't actually have passive power draw when not using autogrow, so this only affects botanists who really like CTRL-clicking their trays.

| Parts Tier | Power Draw (With Autogrow) |
| --- | --- |
| T1 | 1 kW |
| T2 | 500 W|
| T3 | 333.33 W |
| T4 | 250 W |

## Why It's Good For The Game

Perhaps turning a handful of trays into a DIY power sink is not, in fact, the greatest of ideas. Incentivizes upgrading hydroponics trays instead of assuming the botanists are a ticking time-bomb for power issues if upgraded. (Note: botanists are probably still ticking time-bombs for other reasons.)

## Changelog

:cl:
balance: Upgraded hydroponics trays now have reduced power draw with improved parts, in the wake of complaints from both engineering and botanical staff regarding exponentially increased short circuit frequency (and associated energy waste) in affected tray basins.
/:cl:
