### PR TITLE
integrated circuit shells are no longer doomed to explode

### DIFF
--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -297,6 +297,8 @@
 		return
 	location.apc?.terminal?.use_energy(power_to_use, channel = AREA_USAGE_EQUIP)
 	power_used_in_minute += power_to_use
+	if(!COOLDOWN_FINISHED(src, power_used_cooldown))
+		return COMPONENT_OVERRIDE_POWER_USAGE
 	COOLDOWN_START(src, power_used_cooldown, 1 MINUTES)
 	return COMPONENT_OVERRIDE_POWER_USAGE
 

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -297,9 +297,8 @@
 		return
 	location.apc?.terminal?.use_energy(power_to_use, channel = AREA_USAGE_EQUIP)
 	power_used_in_minute += power_to_use
-	if(!COOLDOWN_FINISHED(src, power_used_cooldown))
-		return COMPONENT_OVERRIDE_POWER_USAGE
-	COOLDOWN_START(src, power_used_cooldown, 1 MINUTES)
+	if(COOLDOWN_FINISHED(src, power_used_cooldown))
+		COOLDOWN_START(src, power_used_cooldown, 1 MINUTES)
 	return COMPONENT_OVERRIDE_POWER_USAGE
 
 /**

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -284,6 +284,7 @@
 /datum/component/shell/proc/override_power_usage(datum/source, power_to_use)
 	SIGNAL_HANDLER
 	if(COOLDOWN_FINISHED(src, power_used_cooldown))
+		COOLDOWN_START(src, power_used_cooldown, 1 MINUTES)
 		power_used_in_minute = 0
 
 	var/area/location = get_area(parent)
@@ -297,8 +298,7 @@
 		return
 	location.apc?.terminal?.use_energy(power_to_use, channel = AREA_USAGE_EQUIP)
 	power_used_in_minute += power_to_use
-	if(COOLDOWN_FINISHED(src, power_used_cooldown))
-		COOLDOWN_START(src, power_used_cooldown, 1 MINUTES)
+
 	return COMPONENT_OVERRIDE_POWER_USAGE
 
 /**


### PR DESCRIPTION
## About The Pull Request

Integrated circuit shells now have an early return for setting their `power_used_cooldown` if the cooldown already exists, allowing the power usage cap to reset itself properly and not doom all circuit shells to an explosive fate, as reported by @Acer202 et al.

## Why It's Good For The Game

Perhaps we shouldn't be making our circuit shells out of explosive composite alloys like BattleTech missiles.

## Changelog

:cl:
fix: Integrated circuit shells now only explode if they draw too much power in a minute, rather than being doomed to explode if it uses too much power over its entire lifetime, following complaints from at least one guy. Nanotrasen representatives claim that this is entirely unrelated to missing shipments of explosive alloys.
/:cl: