### PR TITLE
Editing a tank's merge ID actually prevents it from merging with differing ID tanks

### DIFF
--- a/code/game/atom/atom_merger.dm
+++ b/code/game/atom/atom_merger.dm
@@ -3,12 +3,12 @@
 	var/list/datum/merger/mergers
 
 /// Gets a merger datum representing the connected blob of objects in the allowed_types argument
-/atom/proc/GetMergeGroup(id, list/allowed_types)
+/atom/proc/GetMergeGroup(id, list/allowed_types, can_merge_proc)
 	RETURN_TYPE(/datum/merger)
 	var/datum/merger/candidate
 	if(mergers)
 		candidate = mergers[id]
 	if(!candidate)
-		new /datum/merger(id, allowed_types, src)
+		new /datum/merger(id, allowed_types, src, can_merge_proc)
 		candidate = mergers[id]
 	return candidate

--- a/code/game/atom/atom_merger.dm
+++ b/code/game/atom/atom_merger.dm
@@ -3,7 +3,7 @@
 	var/list/datum/merger/mergers
 
 /// Gets a merger datum representing the connected blob of objects in the allowed_types argument
-/atom/proc/GetMergeGroup(id, list/allowed_types, can_merge_proc)
+/atom/proc/GetMergeGroup(id, list/allowed_types, can_merge_proc = null) 
 	RETURN_TYPE(/datum/merger)
 	var/datum/merger/candidate
 	if(mergers)

--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -22,7 +22,7 @@
 	initialize_directions = NONE
 	custom_reconcilation = TRUE
 
-	smoothing_flags = SMOOTH_BITMASK | SMOOTH_OBJ
+	smoothing_flags = SMOOTH_BITMASK | SMOOTH_OBJ | SMOOTH_PROC_FILTER
 	smoothing_groups = SMOOTH_GROUP_GAS_TANK
 	canSmoothWith = SMOOTH_GROUP_GAS_TANK
 	appearance_flags = KEEP_TOGETHER|LONG_GLIDE
@@ -113,7 +113,7 @@
 // initial gas mixes and signal registrations.
 /obj/machinery/atmospherics/components/tank/post_machine_initialize()
 	. = ..()
-	GetMergeGroup(merger_id, merger_typecache)
+	GetMergeGroup(merger_id, merger_typecache, PROC_REF(can_merge))
 
 /obj/machinery/atmospherics/components/tank/Destroy()
 	QUEUE_SMOOTH_NEIGHBORS(src)
@@ -249,9 +249,22 @@
 
 /obj/machinery/atmospherics/components/tank/return_pipenets_for_reconcilation(datum/pipeline/requester)
 	. = ..()
-	var/datum/merger/merge_group = GetMergeGroup(merger_id, merger_typecache)
+	var/datum/merger/merge_group = GetMergeGroup(merger_id, merger_typecache, PROC_REF(can_merge))
 	for(var/obj/machinery/atmospherics/components/tank/tank as anything in merge_group.members)
 		. += tank.parents
+
+/// Called by /datum/merger to stop tanks of differing IDs from merging
+/obj/machinery/atmospherics/components/tank/proc/can_merge(datum/merger/merge_group, list/found_turfs)
+	return merge_group.id == merger_id
+
+// While merger handles tank *contents* being merged we need to separately handle them being *visually* merged here
+/obj/machinery/atmospherics/components/tank/smoothing_allowed(atom/smoothing_with, direction, junction)
+	if(istype(smoothing_with, /obj/machinery/atmospherics/components/tank))
+		var/obj/machinery/atmospherics/components/tank/opposing = smoothing_with
+		if(opposing.merger_id != merger_id)
+			return NONE
+
+	return junction
 
 ///////////////////////////////////////////////////////////////////
 // Merger handling


### PR DESCRIPTION
## About The Pull Request

If you edit a pressure tank's `merger_id` in the map editor or via subtype, the tank will no longer merge with pressure tanks of differing IDs

## Why It's Good For The Game

This allows for mappers to have two adjacent pressure tanks of different gas contents without the tanks combining into one 

## Changelog

:cl: Melbert
code: Pressure tanks can now be set to not merge with adjacent tanks, so report any weirdness with pressure tanks 
/:cl:

