### PR TITLE
Blood Worms can drag themselves onto corpses to infest them

### DIFF
--- a/code/modules/antagonists/blood_worm/actions/invade_corpse.dm
+++ b/code/modules/antagonists/blood_worm/actions/invade_corpse.dm
@@ -9,10 +9,28 @@
 
 	unset_after_click = FALSE // Unsetting is handled explicitly.
 
+/datum/action/cooldown/mob_cooldown/blood_worm/invade/Grant(mob/granted_to)
+	. = ..()
+	if (!owner)
+		return
+	RegisterSignal(owner, COMSIG_MOUSEDROP_ONTO, PROC_REF(on_dragged_onto))
+
+/datum/action/cooldown/mob_cooldown/blood_worm/invade/Remove(mob/removed_from)
+	. = ..()
+	UnregisterSignal(owner, COMSIG_MOUSEDROP_ONTO)
+
 /datum/action/cooldown/mob_cooldown/blood_worm/invade/IsAvailable(feedback)
 	if (!istype(owner, /mob/living/basic/blood_worm))
 		return FALSE
 	return ..()
+
+/// If we drag ourselves onto a corpse (or a live human) then try and climb in
+/datum/action/cooldown/mob_cooldown/blood_worm/invade/proc/on_dragged_onto(atom/movable/source, atom/over, mob/user)
+	SIGNAL_HANDLER
+	if (user != owner || !ishuman(over))
+		return
+	INVOKE_ASYNC(src, PROC_REF(Activate), over)
+	return COMPONENT_CANCEL_MOUSEDROP_ONTO
 
 /datum/action/cooldown/mob_cooldown/blood_worm/invade/Activate(atom/target)
 	if (!ishuman(target))
@@ -46,6 +64,7 @@
 
 	return ..()
 
+/// See if we can invade something
 /datum/action/cooldown/mob_cooldown/blood_worm/invade/proc/invade_check(mob/living/basic/blood_worm/worm, mob/living/carbon/human/victim, feedback = FALSE)
 	if (HAS_TRAIT(victim, TRAIT_BLOOD_WORM_HOST))
 		if (feedback)

--- a/code/modules/antagonists/blood_worm/actions/invade_corpse.dm
+++ b/code/modules/antagonists/blood_worm/actions/invade_corpse.dm
@@ -17,7 +17,7 @@
 
 /datum/action/cooldown/mob_cooldown/blood_worm/invade/Remove(mob/removed_from)
 	. = ..()
-	UnregisterSignal(owner, COMSIG_MOUSEDROP_ONTO)
+	UnregisterSignal(removed_from, COMSIG_MOUSEDROP_ONTO)
 
 /datum/action/cooldown/mob_cooldown/blood_worm/invade/IsAvailable(feedback)
 	if (!istype(owner, /mob/living/basic/blood_worm))


### PR DESCRIPTION
## About The Pull Request

See title.
Blood Worms (or anyone with the blood worm corpse infest ability, but that's pretty much just blood worms because it doesn't do anything if you aren't one) can drag their sprite onto a corpse to infest it.

## Why It's Good For The Game

I played a blood worm for the first time a few weeks ago and tried to do this and it didn't work.
It just feels like an intuitive interaction to me.

## Changelog

:cl:
qol: Blood worms can drag themselves onto corpses to infest them as an alternative to pressing the action button.
/:cl:
