### PR TITLE
Dramatically reduces upgraded exoscanner power draw

### DIFF
--- a/code/modules/explorer_drone/scanner_array.dm
+++ b/code/modules/explorer_drone/scanner_array.dm
@@ -212,6 +212,19 @@ GLOBAL_LIST_INIT(scan_conditions,init_scan_conditions())
 	scan_power = power
 	GLOB.exoscanner_controller.update_scan_power()
 
+	// More generous power draw scaling. Sum the total energy ratings of all parts involved, divide by how many parts we have, use that as the multiplier.
+	// Otherwise it'd be hitting 81x power draw at T4 parts, which seems... unintended.
+	var/energy_rating = 0
+	for(var/datum/stock_part/part in component_parts)
+		energy_rating += part.energy_rating()
+
+	for(var/obj/item/stock_parts/part in component_parts)
+		energy_rating += part.energy_rating
+
+	idle_power_usage = initial(idle_power_usage) * (energy_rating/8)
+	active_power_usage = initial(active_power_usage) * (energy_rating/8)
+	update_current_power_usage()
+
 /obj/machinery/exoscanner/screwdriver_act(mob/user, obj/item/tool)
 	. = ..()
 	if(!.)


### PR DESCRIPTION
## About The Pull Request

Exoscanner power draw is now based on total energy tier of the parts divided by how many parts there are, instead of 1 + total energy tier, as this would result in excessively large power draw when fully upgraded.

## Why It's Good For The Game

A single machine hitting 81x power draw (81 kW) at tier 4 is probably not great, especially if they're meant to be built in large sets for scanning array purposes.

<img width="545" height="76" alt="suboptimal_power_draw" src="https://github.com/user-attachments/assets/7d85db4d-9713-4394-b464-94b483a7ef4b" />

## Changelog

:cl:
balance: Upgraded exoscanners no longer have skyrocketing power draw when upgraded, following an incident where a station's chief engineer declared vendetta upon their Cargo department for drawing an excessive amount of power, resulting in massive casualties.
/:cl: