### PR TITLE
Fixes 2 instances of turf changing not affecting mounted objects correctly

### DIFF
--- a/code/__DEFINES/turfs.dm
+++ b/code/__DEFINES/turfs.dm
@@ -7,7 +7,7 @@
 #define CHANGETURF_TRAPDOOR_INDUCED (1<<6) // Caused by a trapdoor, for trapdoor to know that this changeturf was caused by itself
 #define CHANGETURF_GENERATE_SHUTTLE_CEILING (1<<7) // Generate a shuttle ceiling on the above turf
 #define CHANGETURF_NO_AREA_CHANGE (1<<8) // Prevents turfs like space from autoadjusting their area
-#define CHANGETURF_INHERIT_MOUNTS (1<<9) //All objects attached to the turf don't falloff after transform
+#define CHANGETURF_INHERIT_MOUNTS (1<<9) //All objects attached to the turf don't fall off after transform
 
 #define IS_OPAQUE_TURF(turf) (turf.directional_opacity == ALL_CARDINALS)
 

--- a/code/__DEFINES/turfs.dm
+++ b/code/__DEFINES/turfs.dm
@@ -7,6 +7,7 @@
 #define CHANGETURF_TRAPDOOR_INDUCED (1<<6) // Caused by a trapdoor, for trapdoor to know that this changeturf was caused by itself
 #define CHANGETURF_GENERATE_SHUTTLE_CEILING (1<<7) // Generate a shuttle ceiling on the above turf
 #define CHANGETURF_NO_AREA_CHANGE (1<<8) // Prevents turfs like space from autoadjusting their area
+#define CHANGETURF_INHERIT_MOUNTS (1<<9) //All objects attached to the turf don't falloff after transform
 
 #define IS_OPAQUE_TURF(turf) (turf.directional_opacity == ALL_CARDINALS)
 

--- a/code/datums/components/atom_mounted.dm
+++ b/code/datums/components/atom_mounted.dm
@@ -53,8 +53,8 @@
 		reload = TRUE
 	//if we transforming from open to open turf we can skip deconstruction under some conditions
 	else if(isopenturf(source) && ispath(path, /turf/open))
-		//we are transforming from plating into anything that isn't space
-		if(isplatingturf(source) && !ispath(path, /turf/open/space))
+		//we are transforming from plating into anything that isn't a groundless turf
+		if(isplatingturf(source) && !isgroundlessturf(path))
 			reload = TRUE
 		//we are transforming into plating turf
 		else if(ispath(LAZYACCESS(source.baseturfs, length(source.baseturfs)), /turf/open/floor/plating))

--- a/code/datums/components/atom_mounted.dm
+++ b/code/datums/components/atom_mounted.dm
@@ -46,10 +46,13 @@
 /datum/component/atom_mounted/proc/on_turf_changing(turf/source, path, new_baseturfs, flags, post_change_callbacks)
 	SIGNAL_HANDLER
 
-	//if we transforming from open to open turf we can skip deconstruction under some conditions
-	if(isopenturf(source) && ispath(path, /turf/open))
-		var/reload = FALSE
+	var/reload = FALSE
 
+	//For special effects where we explicitly want to preserve objects after change
+	if(flags & CHANGETURF_INHERIT_MOUNTS)
+		reload = TRUE
+	//if we transforming from open to open turf we can skip deconstruction under some conditions
+	else if(isopenturf(source) && ispath(path, /turf/open))
 		//we are transforming from plating into anything that isn't space
 		if(isplatingturf(source) && !ispath(path, /turf/open/space))
 			reload = TRUE
@@ -57,11 +60,11 @@
 		else if(ispath(LAZYACCESS(source.baseturfs, length(source.baseturfs)), /turf/open/floor/plating))
 			reload = TRUE
 
-		if(reload)
-			var/obj/target = parent
-			qdel(src)
-			post_change_callbacks += CALLBACK(target, TYPE_PROC_REF(/obj, remount))
-			return
+	if(reload)
+		var/obj/target = parent
+		qdel(src)
+		post_change_callbacks += CALLBACK(target, TYPE_PROC_REF(/obj, remount))
+		return
 
 	drop_wallmount()
 

--- a/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
+++ b/code/game/objects/effects/anomalies/anomalies_dimensional_themes.dm
@@ -117,7 +117,7 @@
 		return FALSE
 	if (isindestructiblewall(affected_turf))
 		return FALSE
-	affected_turf.ChangeTurf(replace_walls)
+	affected_turf.ChangeTurf(replace_walls, flags = CHANGETURF_INHERIT_MOUNTS)
 	return TRUE
 
 /**
@@ -131,7 +131,7 @@
 
 	if (replace_floors.len == 0)
 		return FALSE
-	affected_floor.replace_floor(pick_weight(replace_floors), flags = CHANGETURF_INHERIT_AIR)
+	affected_floor.replace_floor(pick_weight(replace_floors), flags = CHANGETURF_INHERIT_AIR | CHANGETURF_INHERIT_MOUNTS)
 	return TRUE
 
 /**

--- a/code/modules/clothing/suits/reactive_armour_dimensional_themes.dm
+++ b/code/modules/clothing/suits/reactive_armour_dimensional_themes.dm
@@ -78,9 +78,9 @@
 /datum/armour_dimensional_theme/proc/convert_turf(turf/to_convert)
 	if (isfloorturf(to_convert))
 		var/turf/open/open_turf = to_convert
-		open_turf.replace_floor(replace_floor, flags = CHANGETURF_INHERIT_AIR)
+		open_turf.replace_floor(replace_floor, flags = CHANGETURF_INHERIT_AIR | CHANGETURF_INHERIT_MOUNTS)
 	else if (iswallturf(to_convert))
-		to_convert.ChangeTurf(replace_wall)
+		to_convert.ChangeTurf(replace_wall, flags = CHANGETURF_INHERIT_MOUNTS)
 
 	if (material)
 		var/list/custom_materials = list(SSmaterials.get_material(material) = SHEET_MATERIAL_AMOUNT)


### PR DESCRIPTION
## About The Pull Request
- Fixes #95532

And the same fix applies to
- Syndicate theme bomb `/obj/item/bombcore/dimensional`
- Anomaly dimension `/obj/effect/anomaly/dimensional`
- Midas grand finale `/datum/grand_finale/midas`
- Area transmogrify `/datum/grand_side_effect/transmogrify_area`
- Dimensional anomaly core `/obj/item/assembly/signaler/anomaly/dimensional`
- Relic dimensional shift `/obj/item/relic`
- Dimensional Armor theme

Also fixes floor mounted objects not deconstructing when the plating they are attached deconstructs into something like water/lava

## Changelog
:cl:
fix: Any effect that changes the theme of the environment no longer break turf mounted objects
fix: destroying plating with lava/water etc will destroy any object mounted to it
/:cl:
