### PR TITLE
Cytology organs can mutate again

### DIFF
--- a/code/modules/research/xenobiology/vatgrowing/samples/_micro_organism.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/_micro_organism.dm
@@ -90,11 +90,11 @@
 		ADD_TRAIT(thing, TRAIT_VATGROWN, "vatgrowing")
 		vat.visible_message(span_nicegreen("[thing] pops out of [vat]!"))
 		//We maybe add some color. the chance is static for now, but idewally we would be able to manipulate it in the future.
-		if(prob(CYTO_SHINY_CHANCE) && isbasicmob(thing))
+		if(prob(CYTO_SHINY_CHANCE))
 			var/mob/living/basic/vat_creature = thing
 			//if the mob has a special mutation interaction don't do any other mutations.
 			// Once we add more mutations that are stackable with shiny we should probably roll for each type independently.
-			if(!vat_creature.mutate())
+			if(!isbasicmob(vat_creature) || !vat_creature.mutate())
 				mutate_color(thing)
 
 		SEND_SIGNAL(vat.biological_sample, COMSIG_SAMPLE_DEPOSITED, thing)


### PR DESCRIPTION

closes #95453

Not soon after the coroner organ thing got merged, "someone" removed being able to mutate objects
I can't really be that pissed because I did merge the PR that did that

## Changelog
:cl:
fix: Coroner cytology grown organs can mutate again
/:cl:
