### PR TITLE
Fixes ethereal revive and species change

### DIFF
--- a/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
@@ -212,10 +212,13 @@
 
 	ethereal_heart.current_crystal = null
 	COOLDOWN_START(ethereal_heart, crystalize_cooldown, CRYSTALIZE_COOLDOWN_LENGTH)
-	ethereal_heart.owner.forceMove(get_turf(src))
-	REMOVE_TRAIT(ethereal_heart.owner, TRAIT_CORPSELOCKED, SPECIES_TRAIT)
+
+	for(var/mob/living/living in contents)
+		living.forceMove(get_turf(src))
+		REMOVE_TRAIT(living, TRAIT_CORPSELOCKED, SPECIES_TRAIT)
+		visible_message(span_notice("The crystals shatters, causing [living] to fall out."))
+
 	deltimer(crystal_heal_timer)
-	visible_message(span_notice("The crystals shatters, causing [ethereal_heart.owner] to fall out."))
 	return ..()
 
 /obj/structure/ethereal_crystal/update_overlays()


### PR DESCRIPTION
closes #95542 

Old pipeline:
in crystal > species changes > heart being deleted and owner set to null > tells crystal to dump the owner > who the fuck is null????????

new pipeline: 
in crystal > species changes > heart being deleted and owner set to null > tells crystal to just dump whatever is inside > okay no problem

<img width="633" height="144" alt="image" src="https://github.com/user-attachments/assets/f39ccf34-0be1-4a69-a6bf-c2b35f0670ac" />

:cl:
fix: Ethereal crystal revive no longer breaks if you change species midway through
/:cl: