### PR TITLE
Audits and cleans up Trigger() parent calls

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -679,7 +679,10 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 	show_to_observers = FALSE
 
 /datum/action/report/Trigger(mob/clicker, trigger_flags)
-	if(owner && GLOB.common_report && SSticker.current_state == GAME_STATE_FINISHED)
+	. = ..()
+	if(!.)
+		return
+	if(GLOB.common_report && SSticker.current_state == GAME_STATE_FINISHED)
 		SSticker.show_roundend_report(owner.client)
 
 /datum/action/report/IsAvailable(feedback = FALSE)

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -163,6 +163,7 @@
 /// Actually triggers the effects of the action.
 /// Called when the on-screen button is clicked, for example.
 /datum/action/proc/Trigger(mob/clicker, trigger_flags)
+	SHOULD_CALL_PARENT(TRUE)
 	if(!(trigger_flags & TRIGGER_FORCE_AVAILABLE) && !IsAvailable(feedback = TRUE))
 		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_ACTION_TRIGGER, src) & COMPONENT_ACTION_BLOCK_TRIGGER)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -695,6 +695,9 @@ DEFINE_BITFIELD(turret_flags, list(
 	button_icon_state = "mech_cycle_equip_off"
 
 /datum/action/turret_toggle/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return
 	var/obj/machinery/porta_turret/P = target
 	if(!istype(P))
 		return
@@ -706,6 +709,9 @@ DEFINE_BITFIELD(turret_flags, list(
 	button_icon_state = "mech_eject"
 
 /datum/action/turret_quit/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return
 	var/obj/machinery/porta_turret/P = target
 	if(!istype(P))
 		return

--- a/code/modules/admin/verbs/light_debug.dm
+++ b/code/modules/admin/verbs/light_debug.dm
@@ -359,6 +359,8 @@ GLOBAL_LIST_EMPTY(light_debugged_atoms)
 
 /datum/action/spawn_light/Trigger(mob/clicker, trigger_flags)
 	. = ..()
+	if(!.)
+		return
 	ui_interact(usr)
 
 /datum/action/spawn_light/ui_state(mob/user)

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -48,6 +48,9 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 	Grant(user)//how powers are added rather than the checks in mob.dm
 
 /datum/action/changeling/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return
 	var/mob/user = owner
 	if(!user || !IS_CHANGELING(user))
 		return

--- a/code/modules/antagonists/changeling/powers/expel_worm.dm
+++ b/code/modules/antagonists/changeling/powers/expel_worm.dm
@@ -19,6 +19,9 @@
 	return TRUE
 
 /datum/action/changeling_expel_worm/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return
 	var/mob/living/basic/blood_worm/invader = locate() in owner.loc
 	to_chat(owner, span_danger("You expel \the [invader] from your body!"))
 	to_chat(invader, span_userdanger("You are forcefully expelled by the body of \the [owner.loc]!"))

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -4,6 +4,7 @@
 	category = "stings"
 
 /datum/action/changeling/sting/Trigger(mob/clicker, trigger_flags)
+	SHOULD_CALL_PARENT(FALSE) //We are snowflaked from parent
 	var/mob/user = owner
 	if(!user || !user.mind)
 		return

--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -85,6 +85,8 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 
 /datum/action/innate/ai/Trigger(mob/clicker, trigger_flags)
 	. = ..()
+	if(!.)
+		return
 	if(auto_use_uses)
 		adjust_uses(-1)
 	if(cooldown_period)

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -380,6 +380,8 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 
 /datum/action/peephole_cancel/Trigger(mob/clicker, trigger_flags)
 	. = ..()
+	if(!.)
+		return
 	to_chat(owner, span_warning("You move away from the peephole."))
 	owner.reset_perspective()
 	owner.clear_fullscreen("remote_view", 0)

--- a/code/modules/mob/living/basic/clown/clown.dm
+++ b/code/modules/mob/living/basic/clown/clown.dm
@@ -627,6 +627,8 @@
 /datum/action/cooldown/exquisite_bunch/Trigger(mob/clicker, trigger_flags, atom/target)
 	if(activating)
 		return
+	if(!IsAvailable(feedback = TRUE))
+		return
 	var/atom/bunch_turf = get_step(owner.loc, owner.dir)
 	if(!bunch_turf)
 		return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1034,6 +1034,8 @@
 	button_icon_state = "ai_shell"
 
 /datum/action/innate/deploy_shell/Trigger(mob/clicker, trigger_flags)
+	if(!..())
+		return
 	var/mob/living/silicon/ai/AI = owner
 	if(!AI)
 		return
@@ -1047,6 +1049,8 @@
 	var/mob/living/silicon/robot/last_used_shell
 
 /datum/action/innate/deploy_last_shell/Trigger(mob/clicker, trigger_flags)
+	if(!..())
+		return
 	if(!owner)
 		return
 	if(last_used_shell)

--- a/code/modules/pai/actions.dm
+++ b/code/modules/pai/actions.dm
@@ -7,6 +7,7 @@
 	if(!ispAI(owner))
 		return FALSE
 	pai_owner = owner
+	return ..()
 
 /datum/action/innate/pai/software
 	name = "Software Interface"
@@ -15,7 +16,9 @@
 	overlay_icon_state = "bg_tech_border"
 
 /datum/action/innate/pai/software/Trigger(mob/clicker, trigger_flags)
-	..()
+	. = ..()
+	if(!.)
+		return
 	pai_owner.ui_act()
 
 /datum/action/innate/pai/shell
@@ -25,7 +28,9 @@
 	overlay_icon_state = "bg_tech_border"
 
 /datum/action/innate/pai/shell/Trigger(mob/clicker, trigger_flags)
-	..()
+	. = ..()
+	if(!.)
+		return
 	if(pai_owner.holoform)
 		pai_owner.fold_in(0)
 	else
@@ -38,7 +43,9 @@
 	overlay_icon_state = "bg_tech_border"
 
 /datum/action/innate/pai/chassis/Trigger(mob/clicker, trigger_flags)
-	..()
+	. = ..()
+	if(!.)
+		return
 	pai_owner.choose_chassis()
 
 /datum/action/innate/pai/rest
@@ -48,7 +55,9 @@
 	overlay_icon_state = "bg_tech_border"
 
 /datum/action/innate/pai/rest/Trigger(mob/clicker, trigger_flags)
-	..()
+	. = ..()
+	if(!.)
+		return
 	pai_owner.toggle_resting()
 
 /datum/action/innate/pai/light
@@ -59,7 +68,9 @@
 	overlay_icon_state = "bg_tech_border"
 
 /datum/action/innate/pai/light/Trigger(mob/clicker, trigger_flags)
-	..()
+	. = ..()
+	if(!.)
+		return
 	pai_owner.toggle_integrated_light()
 
 /datum/action/innate/pai/messenger
@@ -70,6 +81,8 @@
 
 /datum/action/innate/pai/messenger/Trigger(mob/clicker, trigger_flags)
 	. = ..()
+	if(!.)
+		return
 	var/obj/item/pai_card/pai_holder = owner.loc
 	if(!istype(pai_holder.loc, /obj/item/modular_computer))
 		owner.balloon_alert(owner, "not in a pda!")

--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -141,7 +141,8 @@ Expects a turf. Returns true if the attack should be blocked, false if not.*/
 	button_icon_state = "mech_defense_mode_off"
 
 /datum/action/vehicle/sealed/mecha/mech_defense_mode/Trigger(mob/clicker, trigger_flags, forced_state = FALSE)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return

--- a/code/modules/vehicles/mecha/combat/marauder.dm
+++ b/code/modules/vehicles/mecha/combat/marauder.dm
@@ -59,7 +59,8 @@
 	button_icon_state = "mech_smoke"
 
 /datum/action/vehicle/sealed/mecha/mech_smoke/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return
@@ -73,7 +74,8 @@
 	button_icon_state = "mech_zoom_off"
 
 /datum/action/vehicle/sealed/mecha/mech_zoom/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!owner.client || !chassis || !(owner in chassis.occupants))
 		return

--- a/code/modules/vehicles/mecha/combat/phazon.dm
+++ b/code/modules/vehicles/mecha/combat/phazon.dm
@@ -42,7 +42,8 @@
 	button_icon_state = "mech_damtype_brute"
 
 /datum/action/vehicle/sealed/mecha/mech_switch_damtype/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return
@@ -67,7 +68,8 @@
 	button_icon_state = "mech_phasing_off"
 
 /datum/action/vehicle/sealed/mecha/mech_toggle_phasing/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return

--- a/code/modules/vehicles/mecha/combat/savannah_ivanov.dm
+++ b/code/modules/vehicles/mecha/combat/savannah_ivanov.dm
@@ -81,7 +81,8 @@
 	var/skyfall_charge_level = 0
 
 /datum/action/vehicle/sealed/mecha/skyfall/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!owner || !chassis || !(owner in chassis.occupants))
 		return
@@ -253,7 +254,8 @@
 	return ..()
 
 /datum/action/vehicle/sealed/mecha/ivanov_strike/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return

--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -24,7 +24,8 @@
 	button_icon_state = "mech_eject"
 
 /datum/action/vehicle/sealed/mecha/mech_eject/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return
@@ -36,7 +37,8 @@
 	desc = "Airtight cabin preserves internal air and can be pressurized with a mounted air tank."
 
 /datum/action/vehicle/sealed/mecha/mech_toggle_cabin_seal/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return
@@ -47,7 +49,8 @@
 	button_icon_state = "mech_lights_off"
 
 /datum/action/vehicle/sealed/mecha/mech_toggle_lights/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return
@@ -58,7 +61,8 @@
 	button_icon_state = "mech_view_stats"
 
 /datum/action/vehicle/sealed/mecha/mech_view_stats/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return
@@ -74,7 +78,8 @@
 	RegisterSignal(chassis, COMSIG_MECH_SAFETIES_TOGGLE, PROC_REF(update_action_icon))
 
 /datum/action/vehicle/sealed/mecha/mech_toggle_safeties/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return
@@ -94,7 +99,8 @@
 	button_icon_state = "strafe"
 
 /datum/action/vehicle/sealed/mecha/strafe/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return
@@ -124,7 +130,8 @@
 	button_icon_state = "mech_seat_swap"
 
 /datum/action/vehicle/sealed/mecha/swap_seat/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return
@@ -162,7 +169,8 @@
 	build_all_button_icons()
 
 /datum/action/vehicle/sealed/mecha/mech_overclock/Trigger(mob/clicker, trigger_flags, forced_state = null)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return
@@ -187,7 +195,8 @@
 	return ..()
 
 /datum/action/vehicle/sealed/mecha/equipment/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants) || !equipment)
 		return
@@ -214,6 +223,7 @@
 	name = "[equipment.name]"
 
 /datum/action/vehicle/sealed/mecha/equipment/cargo_module/Trigger(mob/clicker, trigger_flags)
+	SHOULD_CALL_PARENT(FALSE) //We are snowflaked from parent
 	if(!chassis || !(owner in chassis.occupants) || !equipment)
 		return
 	if(!istype(equipment, /obj/item/mecha_parts/mecha_equipment/ejector))
@@ -263,6 +273,7 @@
 	name = "[equipment.name]"
 
 /datum/action/vehicle/sealed/mecha/equipment/extinguisher_action/Trigger(mob/clicker, trigger_flags)
+	SHOULD_CALL_PARENT(FALSE) //We are snowflaked from parent
 	if(!chassis || !(owner in chassis.occupants) || !equipment)
 		return
 	if(!istype(equipment, /obj/item/mecha_parts/mecha_equipment/extinguisher))

--- a/code/modules/vehicles/mecha/working/clarke.dm
+++ b/code/modules/vehicles/mecha/working/clarke.dm
@@ -121,7 +121,8 @@
 	button_icon_state = "mecha_sleeper_miner"
 
 /datum/action/vehicle/sealed/mecha/clarke_scoop_body/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/obj/item/mecha_parts/mecha_equipment/sleeper/clarke/sleeper = locate() in chassis
 	var/mob/living/carbon/human/human_target
@@ -140,7 +141,8 @@
 	COOLDOWN_DECLARE(search_cooldown)
 
 /datum/action/vehicle/sealed/mecha/mech_search_ruins/Trigger(mob/clicker, trigger_flags)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!chassis || !(owner in chassis.occupants))
 		return

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -222,6 +222,9 @@
 	button_icon_state = "car_removekey"
 
 /datum/action/vehicle/sealed/remove_key/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return
 	vehicle_entered_target.remove_key(owner)
 
 //CLOWN CAR ACTION DATUMS
@@ -232,6 +235,9 @@
 	var/hornsound = 'sound/items/carhorn.ogg'
 
 /datum/action/vehicle/sealed/horn/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return
 	if(TIMER_COOLDOWN_RUNNING(src, COOLDOWN_CAR_HONK))
 		return
 	TIMER_COOLDOWN_START(src, COOLDOWN_CAR_HONK, 2 SECONDS)
@@ -248,6 +254,9 @@
 	button_icon_state = "car_headlights"
 
 /datum/action/vehicle/sealed/headlights/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return
 	to_chat(owner, span_notice("You flip the switch for the vehicle's headlights."))
 	vehicle_entered_target.headlights_toggle = !vehicle_entered_target.headlights_toggle
 	vehicle_entered_target.set_light_on(vehicle_entered_target.headlights_toggle)
@@ -260,6 +269,9 @@
 	button_icon_state = "car_dump"
 
 /datum/action/vehicle/sealed/dump_kidnapped_mobs/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return
 	vehicle_entered_target.visible_message(span_danger("[vehicle_entered_target] starts dumping the people inside of it."))
 	vehicle_entered_target.dump_specific_mobs(VEHICLE_CONTROL_KIDNAPPED)
 
@@ -270,6 +282,9 @@
 	button_icon_state = "car_rtd"
 
 /datum/action/vehicle/sealed/roll_the_dice/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return
 	if(!istype(vehicle_entered_target, /obj/vehicle/sealed/car/clowncar))
 		return
 	var/obj/vehicle/sealed/car/clowncar/C = vehicle_entered_target
@@ -281,6 +296,9 @@
 	button_icon_state = "car_cannon"
 
 /datum/action/vehicle/sealed/cannon/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return
 	if(!istype(vehicle_entered_target, /obj/vehicle/sealed/car/clowncar))
 		return
 	var/obj/vehicle/sealed/car/clowncar/C = vehicle_entered_target
@@ -295,6 +313,9 @@
 
 
 /datum/action/vehicle/sealed/thank/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return
 	if(!istype(vehicle_entered_target, /obj/vehicle/sealed/car/clowncar))
 		return
 	if(!COOLDOWN_FINISHED(src, thank_time_cooldown))
@@ -318,6 +339,9 @@
 	var/bell_cooldown
 
 /datum/action/vehicle/ridden/wheelchair/bell/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return
 	if(TIMER_COOLDOWN_RUNNING(src, bell_cooldown))
 		return
 	TIMER_COOLDOWN_START(src, bell_cooldown, 0.5 SECONDS)
@@ -376,6 +400,9 @@
 	check_flags = AB_CHECK_CONSCIOUS
 
 /datum/action/vehicle/ridden/scooter/skateboard/kickflip/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return
 	var/obj/vehicle/ridden/scooter/skateboard/board = vehicle_target
 	var/mob/living/rider = owner
 
@@ -426,6 +453,9 @@
 	var/sound_message = "makes a sound."
 
 /datum/action/vehicle/sealed/noise/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
 	var/obj/vehicle/sealed/car/vim/vim_mecha = vehicle_entered_target
 	if(!COOLDOWN_FINISHED(vim_mecha, sound_cooldown))
 		vim_mecha.balloon_alert(owner, "on cooldown!")
@@ -462,4 +492,6 @@
 
 /datum/action/vehicle/sealed/headlights/vim/Trigger(mob/clicker, trigger_flags)
 	. = ..()
+	if(!.)
+		return
 	SEND_SIGNAL(vehicle_entered_target, COMSIG_VIM_HEADLIGHTS_TOGGLED, vehicle_entered_target.headlights_toggle)

--- a/code/modules/wiremod/components/action/mmi.dm
+++ b/code/modules/wiremod/components/action/mmi.dm
@@ -6,7 +6,7 @@
 	button_icon = 'icons/mob/actions/actions_AI.dmi'
 	button_icon_state = "ai_core"
 
-/datum/action/innate/mmi_comp_disconnect/Trigger(trigger_flags)
+/datum/action/innate/mmi_comp_disconnect/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -226,6 +226,8 @@
 	return ..()
 
 /datum/action/innate/bci_charge_action/Trigger(mob/clicker, trigger_flags)
+	if(!..())
+		return
 	var/obj/item/stock_parts/power_store/cell/cell = circuit_component.parent.cell
 
 	if (isnull(cell))

--- a/code/modules/wiremod/shell/implant.dm
+++ b/code/modules/wiremod/shell/implant.dm
@@ -214,6 +214,8 @@
 	return ..()
 
 /datum/action/innate/implant_charge_action/Trigger(mob/clicker, trigger_flags)
+	if(!..())
+		return
 	var/obj/item/stock_parts/power_store/cell/cell = circuit_component.parent.cell
 
 	if (isnull(cell))


### PR DESCRIPTION

## About The Pull Request

``/datum/action/proc/Trigger(mob/clicker, trigger_flags)`` has a lot of children, many of which use mixed ``. = ..()`` or no parent calls at all.

https://github.com/tgstation/tgstation/blob/d65ee47f6ebd0384d463a1f2a044c321ff2d912f/code/datums/actions/action.dm#L163-L170

This PR attempts to standardize all the children procs to call parent in a uniform way, or cements that they *shouldnt* call parent for whatever reason.
## Why It's Good For The Game

Base proc calls are important, yanno?

The base proc has the action button signals and availability proc on it, so its technically possible for children procs of trigger() to have check_flags enabled, but never blocked (i.e AB_CHECK_CONSCIOUS, AB_CHECK_HANDS_BLOCKED).

Some children procs have IsAvailable on them, but its possible they can be skipped over if a coder is not paying attention. This reduces that risk.
## Changelog
:cl:
fix: audits action button triggers, more action buttons ingame should respect if the player can use the action button or not.
/:cl:
