### PR TITLE
Fixes firebreath obj effects 3 years later

### DIFF
--- a/code/datums/mutations/fire_breath.dm
+++ b/code/datums/mutations/fire_breath.dm
@@ -91,6 +91,6 @@
 	target_mob.adjust_fire_stacks(max(2, 5 - level))
 	target_mob.ignite_mob()
 
-/datum/action/cooldown/spell/cone/staggered/firebreath/do_obj_cone_effect(obj/target_obj, atom/caster, level)
+/datum/action/cooldown/spell/cone/staggered/fire_breath/do_obj_cone_effect(obj/target_obj, atom/caster, level)
 	// Further out objects experience less exposed_temperature and exposed_volume
 	target_obj.fire_act(max(500, 900 - (100 * level)), max(50, 200 - (50 * level)))


### PR DESCRIPTION

## About The Pull Request

I cant pin it down to exactly 3 years ago, but thats when gitlens says the line was last changed, so Idk.
- https://github.com/tgstation/tgstation/pull/67083

This PR fixes the pathing of firebreath action, so that do_obj_cone_effect() correctly applies.

https://github.com/tgstation/tgstation/blob/d65ee47f6ebd0384d463a1f2a044c321ff2d912f/code/datums/mutations/fire_breath.dm#L87-L96

firebreath vs fire_breath
## Why It's Good For The Game

Fixes are cool
## Changelog
:cl:
fix: firebreath will light objects on fire more consistently
/:cl:
