### PR TITLE
fixes cyborg emagging not making them unconscious

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -454,6 +454,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		return TRUE
 
 	SetEmagged(TRUE)
+	Paralyze(10 SECONDS) //Make cyborgs actually unconscious. Without this they can scream for help over the radio mid-emag, which doesn't make much sense
 	SetStun(10 SECONDS) //Borgs were getting into trouble because they would attack the emagger before the new laws were shown
 	lawupdate = FALSE
 	set_connected_ai(null)


### PR DESCRIPTION

## About The Pull Request

when the cyborg flash change happened cyborg stun procs were changed in such a way that emagging a cyborg no longer made it unconscious/incapacitated. because there is a delay between when the emag is applied and the cyborg's laws are changed, it is not only totally possible to tell the AI where you are and who is emagging you, but encouraged.
## Why It's Good For The Game

we dont like bugs in this household
## Changelog
:cl:
fix: cyborgs are made properly unconscious when emagged
/:cl:
