### PR TITLE
Fixes multiple objects calling examine() instead of examinate()

### DIFF
--- a/code/modules/admin/sound_emitter.dm
+++ b/code/modules/admin/sound_emitter.dm
@@ -47,7 +47,7 @@
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
 /obj/effect/sound_emitter/attack_ghost(mob/user)
 	if(!check_rights_for(user.client, R_SOUND))
-		examine(user)
+		user.examinate(src)
 		return
 	edit_emitter(user)
 

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -300,11 +300,11 @@
 	var/mob/living/interacting_living = interacting_with
 	if(user.combat_mode)
 		playsound(interacting_living, 'sound/items/weapons/throw.ogg', 30)
-		examine(interacting_living)
+		interacting_living.examinate(src)
 		to_chat(interacting_living, span_userdanger("[user] shoves the [src] up your face!"))
 		user.visible_message(span_warning("[user] have shoved a [src] into [interacting_living] face."))
 	else
 		playsound(interacting_living, 'sound/items/weapons/throwsoft.ogg', 20)
-		examine(interacting_living)
+		interacting_living.examinate(src)
 		to_chat(interacting_living, span_boldwarning("[user] shows the [src] to you."))
 		user.visible_message(span_notice("[user] shows a [src] to [interacting_living]."))

--- a/code/modules/food_and_drinks/machinery/coffeemaker.dm
+++ b/code/modules/food_and_drinks/machinery/coffeemaker.dm
@@ -353,7 +353,7 @@
 		if("Eject Cartridge")
 			eject_cartridge(user)
 		if("Examine")
-			examine(user)
+			user.examinate(src)
 		if("Take Cup")
 			take_cup(user)
 		if("Take Sugar")

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -524,7 +524,7 @@
 
 	if(!length(ingredients))
 		if(HAS_AI_ACCESS(user))
-			examine(user)
+			user.examinate(src)
 		else
 			balloon_alert(user, "it's empty!")
 		return
@@ -547,7 +547,7 @@
 			vampire_charging_enabled = TRUE
 			start_cycle(user)
 		if("examine")
-			examine(user)
+			user.examinate(src)
 
 /obj/machinery/microwave/wash(clean_types)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

``examine()`` merely returns the list of strings to display to the user, ``examinate()`` is the proc that actually displays them to the mob

## Changelog
:cl:
fix: Fixes press badges and other miscellaneous objects failing to make the user examine them.
/:cl:
