### PR TITLE
Fix jammer bricking headsets

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -393,7 +393,7 @@ effective or pretty fucking useless.
 	for (var/obj/item/radio/radio in target.get_all_contents() + target)
 		if(ignore_syndie && (radio.special_channels & RADIO_SPECIAL_SYNDIE))
 			continue
-		radio.set_broadcasting(FALSE)
+		radio.set_broadcasting(FALSE, actual_setting = FALSE)
 
 /obj/item/jammer/Destroy()
 	GLOB.active_jammers -= src


### PR DESCRIPTION
## About The Pull Request

`set_broadcasting(FALSE, TRUE)` = never broadcast again
`set_broadcasting(FALSE, FALSE)` = just turn off broadcast 

Fixes #95555

## Changelog

:cl: Melbert
fix: Radio jammers no longer brick headsets forever
/:cl:

