### PR TITLE
Fixes incorrect usage of world.view or viewers() in some places

### DIFF
--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -19,6 +19,8 @@
 #define VIEWPORT_USE_PREF "use_pref"
 #define WIDESCREEN_VIEWPORT_SIZE "19x15"
 #define SQUARE_VIEWPORT_SIZE "15x15"
+/// Largest viewport possible, required for checking if someone can see an object
+#define LARGEST_VIEWPORT_SIZE WIDESCREEN_VIEWPORT_SIZE
 
 /*
 	These defines specificy screen locations.  For more information, see the byond documentation on the screen_loc var.

--- a/code/__HELPERS/view.dm
+++ b/code/__HELPERS/view.dm
@@ -11,6 +11,12 @@
 		var/list/viewrangelist = splittext(view, "x")
 		return list(text2num(viewrangelist[1]), text2num(viewrangelist[2]))
 
+// Cached for speed as its used in mirages and such
+/proc/maxviewdist(view = LARGEST_VIEWPORT_SIZE)
+	var/static/per_view = list()
+	if (!per_view[view])
+		per_view[view] = max(getviewsize(view))
+	return per_view[view]
 
 /// Takes a string or num view, and converts it to pixel width/height in a list(pixel_width, pixel_height)
 /proc/view_to_pixels(view)

--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -105,10 +105,11 @@
 	// This way, we allow for people to be able to get into hilarious situations without making the game nigh unplayable most of the time.
 
 	var/has_watchers = FALSE
-	for(var/mob/viewer in viewers(our_guy, world.view))
+	for(var/mob/viewer in viewers(our_guy, null))
 		if(viewer.client && !viewer.client.is_afk())
 			has_watchers = TRUE
 			break
+
 	if(!has_watchers)
 		effective_luck *= 0.5
 

--- a/code/datums/elements/mirage_border.dm
+++ b/code/datums/elements/mirage_border.dm
@@ -3,7 +3,7 @@
  */
 /datum/element/mirage_border
 
-/datum/element/mirage_border/Attach(datum/target, turf/target_turf, direction, range=world.view)
+/datum/element/mirage_border/Attach(datum/target, turf/target_turf, direction, range = (maxviewdist() - 1) / 2)
 	. = ..()
 	if(!isturf(target))
 		return ELEMENT_INCOMPATIBLE

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -905,7 +905,7 @@
 	REMOVE_TRAIT(src, TRAIT_NODROP, "psycho")
 	if(user.is_holding(src))
 		user.dropItemToGround(src)
-	for(var/mob/living/carbon/human/viewing_mob in viewers(user, 2))
+	for(var/mob/living/carbon/human/viewing_mob in viewers(2, user))
 		if(viewing_mob.stat || viewing_mob == user)
 			continue
 		viewing_mob.say("Is something wrong? [first_name(user.name)]... you're sweating.", forced = "psycho")

--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -175,7 +175,7 @@
 				// The crowd is pleased
 				// The delay is to make large crowds have a longer lasting applause
 				var/delay_offset = 0
-				for(var/mob/living/carbon/human/spectator in viewers(src, 7))
+				for(var/mob/living/carbon/human/spectator in viewers(7, src))
 					addtimer(CALLBACK(spectator, TYPE_PROC_REF(/mob/, emote), "clap"), delay_offset * 0.3)
 					delay_offset++
 			else

--- a/code/modules/cards/deck/deck.dm
+++ b/code/modules/cards/deck/deck.dm
@@ -124,7 +124,7 @@
 /// This checks if nearby mobs are playing a cardgame and triggers a mood and memory
 /obj/item/toy/cards/deck/proc/CardgameEvent(mob/living/dealer)
 	var/card_players = list()
-	for(var/mob/living/carbon/person in viewers(loc, COMBAT_MESSAGE_RANGE))
+	for(var/mob/living/carbon/person in viewers(COMBAT_MESSAGE_RANGE, loc))
 		var/obj/item/toy/held_card_item = person.is_holding_item_of_type(/obj/item/toy/singlecard) || person.is_holding_item_of_type(/obj/item/toy/cards/deck) || person.is_holding_item_of_type(/obj/item/toy/cards/cardhand)
 		if(held_card_item)
 			card_players[person] = held_card_item

--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -45,7 +45,7 @@
 			message_admins("Aurora Caelus event caused an oven to ignite at [ADMIN_VERBOSEJMP(ruined_roast)].")
 			log_game("Aurora Caelus event caused an oven to ignite at [loc_name(ruined_roast)].")
 			announce_to_ghosts(roast_ruiner)
-			for(var/mob/living/carbon/human/seymour in viewers(roast_ruiner, 7))
+			for(var/mob/living/carbon/human/seymour in viewers(7, roast_ruiner))
 				if (seymour in human_blacklist)
 					continue
 				human_blacklist += seymour

--- a/code/modules/mapfluff/ruins/objects_and_mobs/museum.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/museum.dm
@@ -105,7 +105,7 @@
 /turf/open/mirage/Initialize(mapload)
 	. = ..()
 	if(isnull(range))
-		range = world.view
+		range = (maxviewdist() - 1) / 2
 	var/used_z = target_turf_z || z //if target z is not defined, use ours
 	var/turf/target = locate(offset ? target_turf_x + x : target_turf_x, offset ? target_turf_y + y : target_turf_y, used_z)
 	AddElement(/datum/element/mirage_border, target, dir, range)

--- a/code/modules/mapping/space_management/space_transition.dm
+++ b/code/modules/mapping/space_management/space_transition.dm
@@ -108,7 +108,7 @@
 	var/list/y_pos_transition = list(TRANSITIONEDGE + 2, inner_max_y - 1, 1, 1) //values of y for the transition from respective blocks on the side of zlevel, 1 is being translated into turfs respective y value later in the code
 
 	// Cache the range passed to the mirage border element, to reduce world var access in the thousands
-	var/range_cached = world.view
+	var/range_cached = (maxviewdist() - 1) / 2
 
 	for(var/datum/space_level/level as anything in cached_z_list)
 		if(!level.neigbours.len)


### PR DESCRIPTION

## About The Pull Request

Our viewports are 15x19 as opposed to 15x15 set in ``world.view``, so when mirages set their range to latter it was interpreted as 7 as opposed to 9 required to fully cover the client's horizontal view radius. Also fixed some incorrect viewers() usage since my regex stumbled onto those.

## Changelog
:cl:
fix: Fixed z-transition mirages not mirroring all objects on the other z level
/:cl:
