### PR TITLE
heretic fixes + makes aura emissive

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -69,7 +69,13 @@
 	/// The path our heretic has chosen.
 	var/datum/heretic_knowledge_tree_column/heretic_path
 	/// Reference to the overlay heretics get when they get strong enough
-	var/static/mutable_appearance/eldritch_overlay = mutable_appearance('icons/mob/effects/heretic_aura.dmi', "heretic_aura")
+	var/static/mutable_appearance/eldritch_overlay
+	/// the accompanying emissive for the heretic overlay
+	var/static/mutable_appearance/eldritch_emissive
+	/// the icon filepath for the eldritch overlays, used for the mutable appearances
+	var/heretic_overlay_icon = 'icons/mob/effects/heretic_aura.dmi'
+	/// the icon state for the eldritch overlays, used for the mutable appearances
+	var/heretic_overlay_icon_state = "heretic_aura"
 	/// A sum of how many knowledge points this heretic CURRENTLY has. Used to research.
 	var/knowledge_points = 1
 	/// The time between gaining influence passively. The heretic gain +1 knowledge points every this duration of time.
@@ -358,6 +364,10 @@
 
 	ADD_TRAIT(owner, TRAIT_SEE_BLESSED_TILES, REF(src))
 	addtimer(CALLBACK(src, PROC_REF(passive_influence_gain)), passive_gain_timer) // Gain +1 knowledge every 20 minutes.
+
+	if(isnull(eldritch_overlay) || isnull(eldritch_emissive))
+		eldritch_overlay = mutable_appearance(heretic_overlay_icon, heretic_overlay_icon_state)
+		eldritch_emissive = emissive_appearance(heretic_overlay_icon, heretic_overlay_icon_state, owner.current)
 	return ..()
 
 /datum/antagonist/heretic/on_removal()
@@ -393,6 +403,8 @@
 		list(SIGNAL_ADDTRAIT(TRAIT_HERETIC_AURA_HIDDEN), SIGNAL_REMOVETRAIT(TRAIT_HERETIC_AURA_HIDDEN)),
 		PROC_REF(update_heretic_aura)
 	)
+	RegisterSignal(our_mob, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(add_aura_overlay))
+	our_mob.update_appearance(UPDATE_OVERLAYS)
 
 /datum/antagonist/heretic/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/our_mob = mob_override || owner.current
@@ -429,17 +441,18 @@
 	var/datum/action/cooldown/spell/shadow_cloak/cloak_spell = locate() in heretic_mob.actions
 	cloak_spell.Remove(heretic_mob)
 
+/datum/antagonist/heretic/proc/add_aura_overlay(mob/living/source, list/overlays)
+	SIGNAL_HANDLER
+	if(!should_show_aura())
+		return
+	overlays += eldritch_overlay
+	overlays += eldritch_emissive
+
 /// Adds an overlay to the heretic
 /datum/antagonist/heretic/proc/update_heretic_aura()
 	SIGNAL_HANDLER
-	var/mob/heretic_mob = owner.current
-	heretic_mob.cut_overlay(eldritch_overlay)
-
-	if(!should_show_aura())
-		return FALSE
-
-	heretic_mob.add_overlay(eldritch_overlay)
-	return TRUE
+	if(!QDELETED(owner?.current))
+		owner.current.update_appearance(UPDATE_OVERLAYS)
 
 /datum/antagonist/heretic/proc/should_show_aura()
 	if(!can_assign_self_objectives)

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -38,8 +38,6 @@
 		HERETIC_KNOWLEDGE_SHOP = list(),
 		HERETIC_KNOWLEDGE_DRAFT = list()
 	)
-	/// A static typecache of all tools we can scribe with.
-	var/static/list/scribing_tools = typecacheof(list(/obj/item/pen, /obj/item/toy/crayon))
 	/// A blacklist of turfs we cannot scribe on.
 	var/static/list/blacklisted_rune_turfs = typecacheof(list(/turf/open/space, /turf/open/openspace, /turf/open/lava, /turf/open/chasm))
 	/// A static list of all paths we can take and related info for the UI
@@ -510,7 +508,7 @@
  */
 /datum/antagonist/heretic/proc/on_item_use(mob/living/source, atom/target, obj/item/weapon, list/modifiers)
 	SIGNAL_HANDLER
-	if(!is_type_in_typecache(weapon, scribing_tools))
+	if(!IS_WRITING_UTENSIL(weapon))
 		return NONE
 	if(!isturf(target) || !isliving(source))
 		return NONE

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -69,13 +69,7 @@
 	/// The path our heretic has chosen.
 	var/datum/heretic_knowledge_tree_column/heretic_path
 	/// Reference to the overlay heretics get when they get strong enough
-	var/static/mutable_appearance/eldritch_overlay
-	/// the accompanying emissive for the heretic overlay
-	var/static/mutable_appearance/eldritch_emissive
-	/// the icon filepath for the eldritch overlays, used for the mutable appearances
-	var/heretic_overlay_icon = 'icons/mob/effects/heretic_aura.dmi'
-	/// the icon state for the eldritch overlays, used for the mutable appearances
-	var/heretic_overlay_icon_state = "heretic_aura"
+	var/static/mutable_appearance/eldritch_overlay = mutable_appearance('icons/mob/effects/heretic_aura.dmi', "heretic_aura")
 	/// A sum of how many knowledge points this heretic CURRENTLY has. Used to research.
 	var/knowledge_points = 1
 	/// The time between gaining influence passively. The heretic gain +1 knowledge points every this duration of time.
@@ -365,9 +359,6 @@
 	ADD_TRAIT(owner, TRAIT_SEE_BLESSED_TILES, REF(src))
 	addtimer(CALLBACK(src, PROC_REF(passive_influence_gain)), passive_gain_timer) // Gain +1 knowledge every 20 minutes.
 
-	if(isnull(eldritch_overlay) || isnull(eldritch_emissive))
-		eldritch_overlay = mutable_appearance(heretic_overlay_icon, heretic_overlay_icon_state)
-		eldritch_emissive = emissive_appearance(heretic_overlay_icon, heretic_overlay_icon_state, owner.current)
 	return ..()
 
 /datum/antagonist/heretic/on_removal()
@@ -446,7 +437,7 @@
 	if(!should_show_aura())
 		return
 	overlays += eldritch_overlay
-	overlays += eldritch_emissive
+	overlays += emissive_appearance(eldritch_overlay.icon, eldritch_overlay.icon_state, source)
 
 /// Adds an overlay to the heretic
 /datum/antagonist/heretic/proc/update_heretic_aura()

--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -862,6 +862,8 @@
 	var/image/object_overlay
 	/// Overlay for the hood object
 	var/image/hood_object_overlay
+	/// Turf we're currently listening to for rust trait gains
+	var/turf/listening_turf
 
 /obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/Initialize(mapload)
 	. = ..()
@@ -874,6 +876,7 @@
 /obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/on_robes_gained(mob/living/user)
 	. = ..()
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
+	register_turf_listener(user)
 	rust_overlay = new()
 	rust_overlay.icon = 'icons/mob/clothing/suits/armor.dmi'
 	rust_overlay.render_target = "*rust_overlay_[overlay_id]"
@@ -889,6 +892,9 @@
 	if(.)
 		return
 	UnregisterSignal(user, list(COMSIG_MOVABLE_MOVED))
+	if(listening_turf)
+		UnregisterSignal(listening_turf, SIGNAL_ADDTRAIT(TRAIT_RUSTY))
+		listening_turf = null
 	user.vis_contents -= rust_overlay
 	rusted = FALSE
 	set_armor(/datum/armor/eldritch_armor/rust)
@@ -921,14 +927,25 @@
 	victim.vomit(MOB_VOMIT_BLOOD | MOB_VOMIT_MESSAGE | MOB_VOMIT_HARM | MOB_VOMIT_FORCE)
 	victim.spew_organ(rand(4, 6))
 
-/*
- * Signal proc for [COMSIG_MOVABLE_MOVED].
- *
- * Checks if our armor values should be increased on the new turf
- */
-/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/proc/on_move(mob/source, atom/old_loc, dir, forced, list/old_locs)
-	SIGNAL_HANDLER
+/// Keeps our turf rust listener aligned with where the wearer currently stands.
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/proc/register_turf_listener(mob/source)
+	var/turf/new_turf = get_turf(source)
+	if(listening_turf == new_turf)
+		return
+	if(listening_turf)
+		UnregisterSignal(listening_turf, SIGNAL_ADDTRAIT(TRAIT_RUSTY))
+	listening_turf = new_turf
+	if(listening_turf)
+		RegisterSignal(listening_turf, SIGNAL_ADDTRAIT(TRAIT_RUSTY), PROC_REF(on_turf_became_rusty))
 
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/proc/on_turf_became_rusty(turf/source, rust_trait)
+	SIGNAL_HANDLER
+	var/mob/living/wearer = loc
+	if(!isliving(wearer) || !is_equipped(wearer))
+		return
+	update_rust_state(wearer)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/proc/update_rust_state(mob/source)
 	if(source.is_touching_rust())
 		set_armor(/datum/armor/eldritch_armor/rust/on_rust)
 
@@ -955,6 +972,16 @@
 		REMOVE_TRAIT(source, TRAIT_PIERCEIMMUNE, REF(src))
 		rusted = FALSE
 		update_rust()
+
+/*
+ * Signal proc for [COMSIG_MOVABLE_MOVED].
+ *
+ * Checks if our armor values should be increased on the new turf
+ */
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/proc/on_move(mob/source, atom/old_loc, dir, forced, list/old_locs)
+	SIGNAL_HANDLER
+	register_turf_listener(source)
+	update_rust_state(source)
 
 /// Updates the icon of our overlay and applies the animation
 /obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/proc/update_rust()

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -286,7 +286,7 @@
 		carbon_view.mob_mood.adjust_sanity(-20)
 
 		if(carbon_sanity >= 10)
-			return
+			continue
 		// So our sanity is dead, time to fuck em up
 		if(SPT_PROB(20, seconds_per_tick))
 			to_chat(carbon_view, span_warning("it echoes through you!"))

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -246,6 +246,8 @@
 	for(var/atom/thing_in_range as anything in range(10, source))
 		if(iscarbon(thing_in_range))
 			var/mob/living/carbon/close_carbon = thing_in_range
+			if(close_carbon.can_block_magic())
+				continue
 			if(IS_HERETIC_OR_MONSTER(close_carbon))
 				close_carbon.apply_status_effect(/datum/status_effect/void_conduit)
 				continue

--- a/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -32,18 +32,29 @@
 	UnregisterSignal(remove_from, COMSIG_MOVABLE_MOVED)
 
 /datum/action/cooldown/spell/jaunt/space_crawl/can_cast_spell(feedback = TRUE)
+	// we may loose the focus during jaunt, so you need to be always able to exit on a valid turf
+	if(is_jaunting(owner) && is_valid_turf())
+		return TRUE
 	. = ..()
 	if(!.)
 		return FALSE
-	var/turf/my_turf = get_turf(owner)
-	if(isspaceturf(my_turf))
-		return TRUE
-	var/area/my_area = get_area(owner)
-	if (isopenturf(my_turf) && my_area.outdoors && lavaland_equipment_pressure_check(my_turf))
+	if(is_valid_turf())
 		return TRUE
 	if(feedback)
 		to_chat(owner, span_warning("You must stand in space, or an outdoor area with low pressure!"))
 	return FALSE
+
+
+// do not check if we have a focus if we're already jaunting
+/datum/action/cooldown/spell/jaunt/space_crawl/before_cast(atom/cast_on)
+	if(is_jaunting(owner) && is_valid_turf())
+		return NONE
+	. = ..()
+
+/datum/action/cooldown/spell/jaunt/space_crawl/proc/is_valid_turf()
+	var/turf/my_turf = get_turf(owner)
+	var/area/my_area = get_area(owner)
+	return isspaceturf(my_turf) || (isopenturf(my_turf) && my_area.outdoors && lavaland_equipment_pressure_check(my_turf))
 
 /datum/action/cooldown/spell/jaunt/space_crawl/cast(mob/living/cast_on)
 	. = ..()
@@ -93,7 +104,6 @@
 		jaunter.put_in_hands(right_hand)
 
 	jaunter.add_traits(jaunting_traits, SPACE_PHASING)
-	RegisterSignal(jaunter, SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING), PROC_REF(on_focus_lost))
 	playsound(our_turf, 'sound/effects/magic/cosmic_energy.ogg', 50, TRUE, -1)
 	our_turf.visible_message(span_warning("[jaunter] sinks into [our_turf]!"))
 	new /obj/effect/temp_visual/space_explosion(our_turf)
@@ -118,7 +128,6 @@
 
 /datum/action/cooldown/spell/jaunt/space_crawl/on_jaunt_exited(obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
 	UnregisterSignal(jaunt, COMSIG_MOVABLE_MOVED)
-	UnregisterSignal(unjaunter, list(SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING)))
 	playsound(get_turf(unjaunter), 'sound/effects/magic/cosmic_energy.ogg', 50, TRUE, -1)
 	new /obj/effect/temp_visual/space_explosion(get_turf(unjaunter))
 	if(iscarbon(unjaunter))
@@ -127,11 +136,6 @@
 			qdel(space_hand)
 	return ..()
 
-/// Signal proc for [SIGNAL_REMOVETRAIT] via [TRAIT_ALLOW_HERETIC_CASTING], losing our focus midcast will throw us out.
-/datum/action/cooldown/spell/jaunt/space_crawl/proc/on_focus_lost(mob/living/source)
-	SIGNAL_HANDLER
-	var/turf/our_turf = get_turf(source)
-	try_exit_jaunt(our_turf, source, TRUE)
 
 /// Spacecrawl "hands", prevent the user from holding items in spacecrawl
 /obj/item/space_crawl

--- a/code/modules/antagonists/heretic/status_effects/void_chill.dm
+++ b/code/modules/antagonists/heretic/status_effects/void_chill.dm
@@ -24,6 +24,8 @@
 	owner.update_icon(UPDATE_OVERLAYS)
 
 /datum/status_effect/void_chill/on_apply()
+	if(owner.can_block_magic())
+		return FALSE
 	if(issilicon(owner))
 		return FALSE
 	if(IS_HERETIC_OR_MONSTER(owner))


### PR DESCRIPTION


## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/95493 aka rust armor not getting buffed when floor under you becomes rusty, and missing antimagic checks for void, also adds emissives for the heretic aura, it looks dope, and besides, for hiding in the dark, you can still use robes as those hide it.
also fixes a exploit where you can retract your robe hood and that would let you exit space phase anywhere not just in space, now it no longer forces you to exit phase if you loose your focus, instead it always allows dropping out of phase if you're already phasing
## Why It's Good For The Game
fixes good and emissives look really nice

https://github.com/user-attachments/assets/5b725fad-2522-498a-8514-ca4a8d48fc64

## Changelog
:cl:
fix: rust heretic robes now become buffed if the tile under you becomes rusted
balance: void ascension and the void chill status effect now respect antimagic
add: heretic aura is now emissive.
fix: a exploit where you could exit space phase anywhere by loosing your heretic focus
fix: moon ascension aura not affecting anyone else if one of the targets has more than 10 sanity
/:cl:
