### PR TITLE
Reduction in GPU usage from atmos pipes

### DIFF
--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -14,6 +14,8 @@
 	var/gasmix_color
 	/// A named list of icon_file:overlay_object that gets automatically colored when the gasmix_color updates
 	var/list/gas_visuals
+	/// Whether the pipeline currently has visible gas (gasmix_color is not null/black). Used to avoid adding gas visuals to vis_contents when empty.
+	var/gas_visible = FALSE
 
 	///Should we equalize air amoung all our members?
 	var/update = TRUE
@@ -298,9 +300,12 @@
 //--------------------
 // GAS VISUALS STUFF
 //
-// If I could have gotten layer filters to obey the RESET_COLOR appearance flag I would have used that here
-// so that only a single overlay object needs to exist for all pipelines per icon file. It shouldn't be too
-// hard to switch over to that if it becomes possible in the future or some other equivalent feature is added.
+// Gas visuals use direct color + alpha animation on the gas_visual object rather than
+// a color filter + KEEP_APART. This avoids a separate GPU render pass and filter evaluation
+// per visible pipe, which massively reduces GPU cost for large visible pipelines.
+//
+// Gas visuals are only added to pipe vis_contents when the pipeline has visible gas
+// (gasmix_color is not null/black), eliminating all overhead for empty pipelines.
 
 /**
  * Used to create and/or get the gas visual overlay created using the given icon file.
@@ -312,13 +317,31 @@
 
 	var/obj/effect/abstract/gas_visual/new_overlay = new
 	new_overlay.icon = icon_file
-	new_overlay.ChangeColor(gasmix_color)
+	// Set initial state immediately without animation
+	if(gasmix_color && gasmix_color != COLOR_BLACK)
+		new_overlay.color = gasmix_color
+		new_overlay.alpha = 255
 
 	gas_visuals[icon_file] = new_overlay
 	return new_overlay
 
 /// Called when the gasmix color has changed and the gas visuals need to be updated.
+/// Handles adding/removing gas visuals from pipe vis_contents on visibility transitions.
 /datum/pipeline/proc/UpdateGasVisuals()
+	var/now_visible = gasmix_color && gasmix_color != COLOR_BLACK
+
+	// Handle visibility transitions - add/remove from pipes' vis_contents
+	if(now_visible != gas_visible)
+		gas_visible = now_visible
+		for(var/obj/machinery/atmospherics/pipe/member as anything in members)
+			if(!member.has_gas_visuals)
+				continue
+			if(now_visible)
+				member.vis_contents += GetGasVisual('icons/obj/pipes_n_cables/!pipe_gas_overlays.dmi')
+			else
+				member.vis_contents -= GetGasVisual('icons/obj/pipes_n_cables/!pipe_gas_overlays.dmi')
+
+	// Update colors on existing gas visuals
 	for(var/icon/source as anything in gas_visuals)
 		var/obj/effect/abstract/gas_visual/overlay = gas_visuals[source]
 		overlay.ChangeColor(gasmix_color)
@@ -353,22 +376,12 @@
 		UpdateGasVisuals()
 
 /obj/effect/abstract/gas_visual
-	appearance_flags  = RESET_COLOR | KEEP_APART
+	appearance_flags = RESET_COLOR
 	vis_flags = VIS_INHERIT_ICON_STATE | VIS_INHERIT_LAYER | VIS_INHERIT_PLANE | VIS_INHERIT_ID
-	var/current_color
-	var/color_filter
-
-/obj/effect/abstract/gas_visual/Initialize(mapload)
-	. = ..()
-	color_filter = filter(type="color", color="white")
-	filters += color_filter
-	color_filter = filters[filters.len]
-	if(current_color)
-		animate(color_filter, color=current_color, time=5)
+	alpha = 0
 
 /obj/effect/abstract/gas_visual/proc/ChangeColor(new_color)
-	current_color = new_color
-	if(isnull(color_filter))
-		// Called before init
-		return
-	animate(color_filter, time=5, color=new_color)
+	if(!new_color || new_color == COLOR_BLACK)
+		animate(src, alpha = 0, time = 0.5 SECONDS)
+	else
+		animate(src, color = new_color, alpha = 255, time = 0.5 SECONDS)

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -14,8 +14,6 @@
 	var/gasmix_color
 	/// A named list of icon_file:overlay_object that gets automatically colored when the gasmix_color updates
 	var/list/gas_visuals
-	/// Whether the pipeline currently has visible gas (gasmix_color is not null/black). Used to avoid adding gas visuals to vis_contents when empty.
-	var/gas_visible = FALSE
 
 	///Should we equalize air amoung all our members?
 	var/update = TRUE
@@ -300,12 +298,10 @@
 //--------------------
 // GAS VISUALS STUFF
 //
-// Gas visuals use direct color + alpha animation on the gas_visual object rather than
-// a color filter + KEEP_APART. This avoids a separate GPU render pass and filter evaluation
-// per visible pipe, which massively reduces GPU cost for large visible pipelines.
-//
-// Gas visuals are only added to pipe vis_contents when the pipeline has visible gas
-// (gasmix_color is not null/black), eliminating all overhead for empty pipelines.
+// Gas visuals use direct color + alpha on the gas_visual object rather than
+// a color filter + KEEP_APART.
+// Color filters are expensive.
+// KEEP_APART forces a separate render.
 
 /**
  * Used to create and/or get the gas visual overlay created using the given icon file.
@@ -317,31 +313,13 @@
 
 	var/obj/effect/abstract/gas_visual/new_overlay = new
 	new_overlay.icon = icon_file
-	// Set initial state immediately without animation
-	if(gasmix_color && gasmix_color != COLOR_BLACK)
-		new_overlay.color = gasmix_color
-		new_overlay.alpha = 255
+	new_overlay.ChangeColor(gasmix_color)
 
 	gas_visuals[icon_file] = new_overlay
 	return new_overlay
 
 /// Called when the gasmix color has changed and the gas visuals need to be updated.
-/// Handles adding/removing gas visuals from pipe vis_contents on visibility transitions.
 /datum/pipeline/proc/UpdateGasVisuals()
-	var/now_visible = gasmix_color && gasmix_color != COLOR_BLACK
-
-	// Handle visibility transitions - add/remove from pipes' vis_contents
-	if(now_visible != gas_visible)
-		gas_visible = now_visible
-		for(var/obj/machinery/atmospherics/pipe/member as anything in members)
-			if(!member.has_gas_visuals)
-				continue
-			if(now_visible)
-				member.vis_contents += GetGasVisual('icons/obj/pipes_n_cables/!pipe_gas_overlays.dmi')
-			else
-				member.vis_contents -= GetGasVisual('icons/obj/pipes_n_cables/!pipe_gas_overlays.dmi')
-
-	// Update colors on existing gas visuals
 	for(var/icon/source as anything in gas_visuals)
 		var/obj/effect/abstract/gas_visual/overlay = gas_visuals[source]
 		overlay.ChangeColor(gasmix_color)
@@ -378,10 +356,9 @@
 /obj/effect/abstract/gas_visual
 	appearance_flags = RESET_COLOR
 	vis_flags = VIS_INHERIT_ICON_STATE | VIS_INHERIT_LAYER | VIS_INHERIT_PLANE | VIS_INHERIT_ID
-	alpha = 0
+	color = COLOR_BLACK
 
 /obj/effect/abstract/gas_visual/proc/ChangeColor(new_color)
-	if(!new_color || new_color == COLOR_BLACK)
-		animate(src, alpha = 0, time = 0.5 SECONDS)
-	else
-		animate(src, color = new_color, alpha = 255, time = 0.5 SECONDS)
+	if(!new_color)
+		new_color = COLOR_BLACK
+	animate(src, color = new_color, time = 0.5 SECONDS)

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -101,12 +101,12 @@
 	return parent
 
 /obj/machinery/atmospherics/pipe/replace_pipenet(datum/pipeline/old_pipenet, datum/pipeline/new_pipenet)
-	if(parent && has_gas_visuals && parent.gas_visible)
+	if(parent && has_gas_visuals)
 		vis_contents -= parent.GetGasVisual('icons/obj/pipes_n_cables/!pipe_gas_overlays.dmi')
 
 	parent = new_pipenet
 
-	if(parent && has_gas_visuals && parent.gas_visible)
+	if(parent && has_gas_visuals) // null is a valid argument here
 		vis_contents += parent.GetGasVisual('icons/obj/pipes_n_cables/!pipe_gas_overlays.dmi')
 
 /obj/machinery/atmospherics/pipe/return_pipenets()

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -101,12 +101,12 @@
 	return parent
 
 /obj/machinery/atmospherics/pipe/replace_pipenet(datum/pipeline/old_pipenet, datum/pipeline/new_pipenet)
-	if(parent && has_gas_visuals)
+	if(parent && has_gas_visuals && parent.gas_visible)
 		vis_contents -= parent.GetGasVisual('icons/obj/pipes_n_cables/!pipe_gas_overlays.dmi')
 
 	parent = new_pipenet
 
-	if(parent && has_gas_visuals) // null is a valid argument here
+	if(parent && has_gas_visuals && parent.gas_visible)
 		vis_contents += parent.GetGasVisual('icons/obj/pipes_n_cables/!pipe_gas_overlays.dmi')
 
 /obj/machinery/atmospherics/pipe/return_pipenets()


### PR DESCRIPTION

## About The Pull Request

Came back to the game after a break, while in ghost mode I noticed my GPU usage flew up near toxins lab, Next round tested it with an admin in Thunderdrone, turns out pipes are very inefficient and GPU hungry.

Some suggestions about render relays / spatial grid were made but the performance impact is so big I'd rather put in a fix that significantly reduces the burden on player clients, anyone walking through station maints, medbay cryo, engineering/atmos/toxins is affected by this.

Removed keep_apart and colour filter.

| Before | After |
|--------|--------|
| <img width="959" height="999" alt="Screenshot 2026-03-31 042655" src="https://github.com/user-attachments/assets/6bca9cb3-5482-463a-b4e2-84e01fff9949" /> | <img width="941" height="1020" alt="Screenshot 2026-03-31 052710" src="https://github.com/user-attachments/assets/619f8591-0107-49ad-97f3-48b7197e95f6" /> |
| <img width="1009" height="1074" alt="Screenshot 2026-03-31 042738" src="https://github.com/user-attachments/assets/31b6c96c-0cf0-478d-b156-4cdc176f9dcb" /> | <img width="1005" height="1105" alt="Screenshot 2026-03-31 052832" src="https://github.com/user-attachments/assets/4fd44aff-5fe6-4ab0-b787-72d113ae215f" /> |

## Why It's Good For The Game

Takes GPU usage at Meta atmos from 58.2% to a reduction in the main pipe loop and 33.4% at air room to a reduction.

Tested in game.

## Changelog
:cl:
code: Atmos pipes GPU performance - Station areas with pipes will be less taxing on the client.
/:cl:
