### PR TITLE
Fix putting anything in a fish gene gun

### DIFF
--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -556,7 +556,7 @@
 
 /obj/item/fish_genegun/item_interaction(mob/living/user, obj/item/item, list/modifiers)
 	var/is_syringe = istype(item, /obj/item/reagent_containers/syringe)
-	if(!is_syringe && istype(item, /obj/item/fish_gene))
+	if(!is_syringe && !istype(item, /obj/item/fish_gene))
 		return NONE
 	if(loaded_injector)
 		to_chat(user, span_warning("[src] already has [loaded_injector] loaded in it."))


### PR DESCRIPTION

## About The Pull Request

Inverted condition

## Why It's Good For The Game

fixes #95575

## Changelog
:cl:
fix: You can no longer put everything other than a fish gene into a fish gene gun
/:cl:
