### PR TITLE
Smoke applies to people once per tick

### DIFF
--- a/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
@@ -82,8 +82,6 @@
 			break
 		if(locate(type) in spread_turf)
 			continue // Don't spread smoke where there's already smoke!
-		for(var/mob/living/smoker in spread_turf)
-			smoke_mob(smoker, seconds_per_tick)
 
 		var/obj/effect/particle_effect/fluid/smoke/spread_smoke = new type(spread_turf, group, src)
 		reagents.trans_to(spread_smoke, reagents.total_volume, copy_only = TRUE)
@@ -379,6 +377,8 @@
 			continue
 		if(HAS_TRAIT(thing, TRAIT_UNDERFLOOR))
 			continue
+		if(isliving(thing))
+			continue
 		reagents.expose(thing, SMOKE_MACHINE, fraction)
 
 	reagents.expose(location, SMOKE_MACHINE, fraction)
@@ -394,7 +394,6 @@
 
 	var/fraction = (seconds_per_tick SECONDS) / initial(lifetime)
 	reagents.trans_to(smoker, reagents.total_volume, fraction, methods = SMOKE_MACHINE, copy_only = TRUE)
-	reagents.expose(smoker, SMOKE_MACHINE, fraction)
 	return TRUE
 
 /// Helper to quickly create a cloud of reagent smoke


### PR DESCRIPTION

## About The Pull Request

Chem smoke no longer applies smoke during `spread()`, waiting for `process()` instead. 
Chem smoke no longer gives reagents to mobs during its override of `process()`, letting its parent do it instead. 
Smoke no longer calls both `trans_to()` & `expose()`, letting `trans_to()` call `expose()` instead. 
All in all, it triggers on mobs once per tick, instead of 3 or 5. Hooray for eyes everywhere.

(Stuff like tear gas still goes kind of crazy with it, being volume-agnostic, but it's one third as bad)

## Why It's Good For The Game

fixes #95539

## Changelog
:cl:

fix: Smoke no longer exposes mobs to reagents multiple times per tick, significantly lowering the duration of effects applied by chemical smoke

/:cl:
