### PR TITLE
Partially moves the iconoclast's repeater behind a knowledge book

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -363,6 +363,7 @@ GLOBAL_LIST_INIT(rarity_loot, list(//rare: really good items
 		/obj/item/book/granter/crafting_recipe/dusting/pipegun_prime = 1,
 		/obj/item/book/granter/crafting_recipe/trash_cannon = 1,
 		/obj/item/book/granter/crafting_recipe/dusting/laser_musket_prime = 1,
+		/obj/item/book/granter/crafting_recipe/dusting/detached_ratvarian_repeater = 1,
 		/obj/item/book/granter/sign_language = 1,
 		/obj/item/disk/nuclear/fake = 1,
 		/obj/item/disk/surgery/advanced_plastic_surgery = 1,

--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -353,7 +353,7 @@
 	)
 	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
-	crafting_flags = CRAFT_CHECK_DENSITY
+	crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_MUST_BE_LEARNED
 
 
 /datum/crafting_recipe/large_ballista

--- a/code/game/objects/items/granters/crafting/pipegun.dm
+++ b/code/game/objects/items/granters/crafting/pipegun.dm
@@ -44,3 +44,17 @@
 		"10u of reactant to open the relic... Is this even real science anymore?",
 		"Making them all sleep in the cold below? This is a disabler, not a lethal weapon.",
 	)
+/obj/item/book/granter/crafting_recipe/dusting/detached_ratvarian_repeater
+	name = "memoirs of a former cultist"
+	desc = "A strange-looking book. The cover is warm to the touch."
+	crafting_recipe_types = list(
+		/datum/crafting_recipe/detached_ratvarian_repeater
+	)
+	remarks = list(
+		"It's amazing that they used to be able to mass produce these.",
+		"A welder? Well, that's surprisingly simple.",
+		"The many gears and cogs of the recharging system are making my head spin...",
+		"The tone of the author is devout, almost reverent.",
+		"The designs are all laid out in a circle, resembling a clock.",
+		"With a few modifications, this wouldn't be that heavy...",
+	)


### PR DESCRIPTION

## About The Pull Request

I considered at first moving the siege weapon variant (the thing you use to craft the repeater) behind the crafting book too, but the siege weapon version isn't strong or problematic enough to need it, and that would be basically a soft-removal since nobody would make it except to make the iconoclast's repeater.

The iconoclast's repeater (specifically making the handheld version) now requires use of a crafting book to learn how to make, which spawns in maints in the same loot pool as the other "good" improvised weapons. Without it, the welded-on version of the repeater may still be produced.

## Why It's Good For The Game

While they are fairly strong and the infinite ammo thing removes the requirement to have weapon rechargers (trivializing antagonists like blobs and xenomorphs) the main issue though is their mass availability. Specifically, you can build autocrafters to make as many as them as you want because of how trivially easy they are to produced. The current "rule" with improvised weapons is if they are on par with cargo ordered/armory stocked weapons, they have to be learned from a maintenance book. This limits how freely they can be made and distributed without nerfing them into the ground in order to make them an occasional occurrence like the heroic laser musket, which I think is probably the best way to handle it.

## Changelog
:cl:
balance: making the handheld iconoclast's repeater now requires learning its recipe, the book for which can spawn in maintenance.
/:cl:
