### PR TITLE
Fixes three cult runtimes

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -116,6 +116,9 @@
 
 /obj/structure/emergency_shield/cult/barrier/Destroy()
 	if(parent_rune)
+		if(QDELING(parent_rune))
+			parent_rune = null
+			return ..()
 		parent_rune.visible_message(span_danger("The [parent_rune] fades away as [src] is destroyed!"))
 		QDEL_NULL(parent_rune)
 	return ..()

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -403,11 +403,13 @@
 	if(isliving(interacting_with))
 		return ITEM_INTERACT_SKIP_TO_ATTACK
 
+	var/spell_name = source.name // Spell action is deleted in cast_spell() if we're out of charges
+
 	if(!cast_spell(interacting_with, user))
 		return ITEM_INTERACT_BLOCKING
 
 	user.do_attack_animation(interacting_with)
-	log_combat(user, interacting_with, "used a cult spell on", source.name, "")
+	log_combat(user, interacting_with, "used a cult spell on", spell_name)
 	SSblackbox.record_feedback("tally", "cult_spell_invoke", 1, "[name]")
 	return ITEM_INTERACT_SUCCESS
 

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -399,7 +399,7 @@
 
 		var/turf/throwee_turf = get_turf(throwee)
 
-		playsound(throwee_turf, 'sound/effects/magic/exit_blood.ogg')
+		playsound(throwee_turf, 'sound/effects/magic/exit_blood.ogg', 50)
 		new /obj/effect/temp_visual/cult/sparks(throwee_turf, clicker.dir)
 		throwee.visible_message(
 			span_warning("A pulse of magic whisks [throwee] away!"),

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -799,7 +799,9 @@ GLOBAL_VAR_INIT(narsie_summon_count, 0)
 
 /obj/effect/rune/wall/Destroy()
 	if(barrier)
-		QDEL_NULL(barrier)
+		if(!QDELING(barrier))
+			qdel(barrier)
+		barrier = null
 	return ..()
 
 /obj/effect/rune/wall/invoke(list/invokers)


### PR DESCRIPTION

## About The Pull Request

The cult barrier rune runtimes when destroyed because both the barrier and the rune try to qdel each other in `Destroy()`
Spells runtime when using their last charge because they attempt to log their action's name, which is deleted in `cast_spell()`
The cult master spell that moves your underlings around runtimes because they pass no volume into `play_sound()`

## Why It's Good For The Game

Fixes runtimes

## Changelog
:cl:

fix: Three cult abilities no longer runtime

/:cl:
