### PR TITLE
Fix the check_genesis.sh printing the hash for the wrong file.

### DIFF
--- a/tools/ci/check_genesis.sh
+++ b/tools/ci/check_genesis.sh
@@ -14,7 +14,7 @@ else
     echo -e "${BLUE}This is likely not intentional, please revert any changes made to it.${NC}"
     echo -e "${BLUE}On the unlikely occurance that you ARE intentionally modifying that file, replace the contents of tools/ci/genesis_call.dme.sha256sum with the following:${NC}"
 
-    sha256sum tools/ci/genesis_call.dme.sha256sum
+    sha256sum code/genesis_call.dme
 
     exit 1
 fi


### PR DESCRIPTION

## About The Pull Request
If you change the code in genesis_call.dme the tool would fail.
The error message however would print the hash of the tool file itself, not the new genesis.dme hash.
Which means you would be stuck in a permanent loop of updating the hash in the tool, which generates a new hash for the tool until you realize that it's printing the wrong hash.

lol
## Why It's Good For The Game
bugfix
## Changelog

no in-game changes at all
