### PR TITLE
Adds something from a future PR as it was in an older commit

### DIFF
--- a/code/datums/components/crafting/melee_weapon.dm
+++ b/code/datums/components/crafting/melee_weapon.dm
@@ -28,7 +28,7 @@
 		/obj/item/restraints/handcuffs/cable = 1,
 		/obj/item/stack/rods = 1,
 		/obj/item/assembly/igniter = 1,
-		/obj/item/stack/telecrystal = 1,
+		/obj/item/stack/sheet/telecrystal = 1,
 	)
 	time = 4 SECONDS
 	category = CAT_WEAPON_MELEE

--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -272,7 +272,7 @@
 		/obj/item/stack/sheet/mineral/gold = 25,
 		/obj/item/stack/sheet/mineral/silver = 25,
 		/obj/item/food/donkpocket = 1,
-		/obj/item/stack/telecrystal = 4,
+		/obj/item/stack/sheet/telecrystal = 4,
 		/obj/item/clothing/head/costume/crown/fancy = 1, //the captain's crown
 		/obj/item/storage/toolbox/syndicate = 1,
 		/obj/item/stack/sheet/iron = 10,

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -105,7 +105,7 @@
 	purchase_log = null
 	return ..()
 
-/datum/component/uplink/proc/load_tc(mob/user, obj/item/stack/telecrystal/telecrystals, silent = FALSE)
+/datum/component/uplink/proc/load_tc(mob/user, obj/item/stack/sheet/telecrystal/telecrystals, silent = FALSE)
 	if(!silent)
 		to_chat(user, span_notice("You slot [telecrystals] into [parent] and charge its internal uplink."))
 	var/amt = telecrystals.amount
@@ -118,7 +118,7 @@
 	if(!active)
 		return //no hitting everyone/everything just to try to slot tcs in!
 
-	if(istype(item, /obj/item/stack/telecrystal))
+	if(istype(item, /obj/item/stack/sheet/telecrystal))
 		load_tc(user, item)
 
 	if(!istype(item))

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -884,3 +884,25 @@
 	if(!HAS_TRAIT(victim, TRAIT_ROCK_EATER))
 		victim.apply_damage(30, BURN, BODY_ZONE_HEAD, wound_bonus = 5)
 	return TRUE
+
+/datum/material/telecrystal
+	name = "telecrystal"
+	desc = "An ominous-looking gemstone capable of transporting objects vast distances through bluespace."
+	color = "#BD1B28"
+	alpha = 200
+	starlight_color = COLOR_SYNDIE_RED
+	mat_flags = MATERIAL_BASIC_RECIPES | MATERIAL_CLASS_CRYSTAL | MATERIAL_CLASS_RIGID
+	mat_properties = list(
+		MATERIAL_DENSITY = 1,
+		MATERIAL_HARDNESS = 4,
+		MATERIAL_FLEXIBILITY = 0,
+		MATERIAL_REFLECTIVITY = 10,
+		MATERIAL_ELECTRICAL = 10,
+		MATERIAL_THERMAL = 2,
+		MATERIAL_CHEMICAL = 8,
+		MATERIAL_BEAUTY = -0.5, // very evil bad no good
+	)
+	sheet_type = /obj/item/stack/sheet/telecrystal
+	material_reagent = list(/datum/reagent/bluespace = 1, /datum/reagent/medicine/stimulants = 1) // We don't have liquid telecrystals and I don't wanna risk it
+	value_per_unit = 1200 / SHEET_MATERIAL_AMOUNT
+	texture_layer_icon_state = "shine"

--- a/code/datums/storage/subtypes/bags.dm
+++ b/code/datums/storage/subtypes/bags.dm
@@ -355,7 +355,7 @@
 		/obj/item/stack/sheet/mineral/gold, // This is money, the only real money actually, if you ask a Ron Paul-style guy.
 		/obj/item/stack/sheet/mineral/silver,
 		/obj/item/stack/sheet/mineral/mythril,
-		/obj/item/stack/telecrystal,
+		/obj/item/stack/sheet/telecrystal,
 	))
 
 

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -1,4 +1,4 @@
-/obj/item/stack/telecrystal
+/obj/item/stack/sheet/telecrystal
 	name = "telecrystal"
 	desc = "It seems to be pulsing with suspiciously enticing energies."
 	singular_name = "telecrystal"
@@ -8,10 +8,11 @@
 	w_class = WEIGHT_CLASS_TINY
 	max_amount = 50
 	item_flags = NOBLUDGEON
-	merge_type = /obj/item/stack/telecrystal
+	merge_type = /obj/item/stack/sheet/telecrystal
 	novariants = FALSE
+	material_type = /datum/material/telecrystal
 
-/obj/item/stack/telecrystal/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+/obj/item/stack/sheet/telecrystal/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(interacting_with != user) //You can't go around smacking people with crystals to find out if they have an uplink or not.
 		return NONE
 
@@ -26,8 +27,8 @@
 			to_chat(user, span_notice("You press [src] onto yourself and charge your hidden uplink."))
 	return ITEM_INTERACT_SUCCESS
 
-/obj/item/stack/telecrystal/five
+/obj/item/stack/sheet/telecrystal/five
 	amount = 5
 
-/obj/item/stack/telecrystal/twenty
+/obj/item/stack/sheet/telecrystal/twenty
 	amount = 20

--- a/code/game/objects/items/storage/toolboxes/mechanical.dm
+++ b/code/game/objects/items/storage/toolboxes/mechanical.dm
@@ -47,7 +47,7 @@
 
 /obj/item/storage/toolbox/mechanical/old/clean/proc/calc_damage()
 	var/power = 0
-	for (var/obj/item/stack/telecrystal/stored_crystals in get_all_contents())
+	for (var/obj/item/stack/sheet/telecrystal/stored_crystals in get_all_contents())
 		power += stored_crystals.amount
 	force = initial(force) + power
 	throwforce = initial(throwforce) + power

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -322,7 +322,7 @@
 	new /obj/item/chameleon(src) //its not the original cloaking device, but it will do. 8 tc
 	new /obj/item/gun/ballistic/revolver(src) // 13 tc old one stays in the old box
 	new /obj/item/implanter/freedom(src) // 5 tc
-	new /obj/item/stack/telecrystal(src) //The failsafe/self destruct isn't an item we can physically include in the kit, but 1 TC is technically enough to buy the equivalent.
+	new /obj/item/stack/sheet/telecrystal(src) //The failsafe/self destruct isn't an item we can physically include in the kit, but 1 TC is technically enough to buy the equivalent.
 
 /obj/item/storage/belt/military/assault/fisher
 

--- a/code/game/objects/items/weaponry/melee/baton.dm
+++ b/code/game/objects/items/weaponry/melee/baton.dm
@@ -855,8 +855,8 @@
 		our_crystal.use(1)
 		our_prod = /obj/item/melee/baton/security/cattleprod/teleprod
 
-	else if(istype(item, /obj/item/stack/telecrystal))
-		var/obj/item/stack/telecrystal/our_crystal = item
+	else if(istype(item, /obj/item/stack/sheet/telecrystal))
+		var/obj/item/stack/sheet/telecrystal/our_crystal = item
 		our_crystal.use(1)
 		our_prod = /obj/item/melee/baton/security/cattleprod/telecrystalprod
 	else

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -130,14 +130,14 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		tc_to_distribute -= tc_per_nukie
 
 	for (var/mob/living/L in orphans)
-		var/TC = new /obj/item/stack/telecrystal(L.drop_location(), tc_per_nukie)
+		var/TC = new /obj/item/stack/sheet/telecrystal(L.drop_location(), tc_per_nukie)
 		to_chat(L, span_warning("Your uplink could not be found so your share of the team's bonus telecrystals has been bluespaced to your [L.put_in_hands(TC) ? "hands" : "feet"]."))
 		tc_to_distribute -= tc_per_nukie
 
 	if (tc_to_distribute > 0) // What shall we do with the remainder...
 		for (var/mob/living/basic/carp/pet/cayenne/C in GLOB.mob_living_list)
 			if (C.stat != DEAD)
-				var/obj/item/stack/telecrystal/TC = new(C.drop_location(), tc_to_distribute)
+				var/obj/item/stack/sheet/telecrystal/TC = new(C.drop_location(), tc_to_distribute)
 				TC.throw_at(get_step(C, C.dir), 3, 3)
 				C.visible_message(span_notice("[C] coughs up a half-digested telecrystal"),span_notice("You cough up a half-digested telecrystal!"))
 				break

--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -121,7 +121,7 @@
 		return FALSE
 
 	telecrystals -= amount
-	var/tcs = new /obj/item/stack/telecrystal(get_turf(user), amount)
+	var/tcs = new /obj/item/stack/sheet/telecrystal(get_turf(user), amount)
 	user.put_in_hands(tcs)
 
 	log_uplink("[key_name(user)] purchased [amount] raw telecrystals from [source]'s uplink")

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -327,7 +327,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/survival_pod/left, 0)
 		/obj/item/gun/magic/staff/spellblade,
 		/obj/item/gun/magic/wand/death,
 		/obj/item/gun/magic/wand/fireball,
-		/obj/item/stack/telecrystal/twenty,
+		/obj/item/stack/sheet/telecrystal/twenty,
 		/obj/item/nuke_core,
 		/obj/item/banhammer,
 	)

--- a/code/modules/modular_computers/computers/item/disks/virus_disk.dm
+++ b/code/modules/modular_computers/computers/item/disks/virus_disk.dm
@@ -111,12 +111,12 @@
 
 /obj/item/disk/computer/virus/frame/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	. = ..()
-	if(!istype(attacking_item, /obj/item/stack/telecrystal))
+	if(!istype(attacking_item, /obj/item/stack/sheet/telecrystal))
 		return
 	if(!charges)
 		to_chat(user, span_notice("[src] is out of charges, it's refusing to accept [attacking_item]."))
 		return
-	var/obj/item/stack/telecrystal/telecrystal_stack = attacking_item
+	var/obj/item/stack/sheet/telecrystal/telecrystal_stack = attacking_item
 	telecrystals += telecrystal_stack.amount
 	to_chat(user, span_notice("You slot [telecrystal_stack] into [src]. The next time it's used, it will also give telecrystals."))
 	telecrystal_stack.use(telecrystal_stack.amount)

--- a/code/modules/modular_computers/file_system/programs/antagonist/contractor_program.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contractor_program.dm
@@ -84,7 +84,7 @@
 			return TRUE
 		if("PRG_redeem_TC")
 			if (traitor_data.uplink_handler.contractor_hub.contract_TC_to_redeem)
-				var/obj/item/stack/telecrystal/crystals = new /obj/item/stack/telecrystal(get_turf(user), traitor_data.uplink_handler.contractor_hub.contract_TC_to_redeem)
+				var/obj/item/stack/sheet/telecrystal/crystals = new /obj/item/stack/sheet/telecrystal(get_turf(user), traitor_data.uplink_handler.contractor_hub.contract_TC_to_redeem)
 				if(ishuman(user))
 					var/mob/living/carbon/human/H = user
 					if(H.put_in_hands(crystals))

--- a/code/modules/uplink/uplink_items/bundle.dm
+++ b/code/modules/uplink/uplink_items/bundle.dm
@@ -35,7 +35,7 @@
 /datum/uplink_item/bundles_tc/telecrystal
 	name = "1 Raw Telecrystal"
 	desc = "A telecrystal in its rawest and purest form; can be utilized on active uplinks to increase their telecrystal count."
-	item = /obj/item/stack/telecrystal
+	item = /obj/item/stack/sheet/telecrystal
 	cost = 1
 	// Don't add telecrystals to the purchase_log since
 	// it's just used to buy more items (including itself!)


### PR DESCRIPTION
## About The Pull Request

Part 2 of Smartkar's material refactor PR makes telecrystals into a material that can be used in autolathes. I decided you guys deserve a sneak preview of this. Sure, it doesn't have the teleportation and armor penetration properties because they aren't currently implemented, but that's outside the scope of this PR. Don't worry about the consequences of telecrystals being a material.

## Why It's Good For The Game

Provides a nice bright red material for people to make things out of. Surely people won't find ways to produce infinite TC using fish.

## Changelog

:cl:
add: Telecrystal is now a material, and telecrystals can be put into the autolathe.
/:cl: