### PR TITLE
Wheelys dont turn you when you kick them out

### DIFF
--- a/code/modules/clothing/shoes/wheelys.dm
+++ b/code/modules/clothing/shoes/wheelys.dm
@@ -39,6 +39,7 @@
 		wheelToggle = FALSE
 		return
 	wheels.forceMove(get_turf(user))
+	wheels.setDir(user.dir)
 	wheels.buckle_mob(user)
 	wheelToggle = TRUE
 


### PR DESCRIPTION

## About The Pull Request

They kept their dir from last time you kicked em out

## Why It's Good For The Game

You should turn when you turn

## Changelog
:cl:

fix: Wheelys dont turn you when you kick them out

/:cl:
