### PR TITLE
fixes cyborg omnitool upgrade doing nothing

### DIFF
--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -241,6 +241,7 @@
 	tool.item_flags |= ABSTRACT
 	ADD_TRAIT(tool, TRAIT_NODROP, INNATE_TRAIT)
 	atoms[reference] = tool
+	tool.toolspeed = initial(tool.toolspeed) - upgraded * 0.3 //and finally assign the upgraded toolspeed, if any.
 	return tool
 
 /obj/item/borg/cyborg_omnitool/attack_self(mob/user)
@@ -283,7 +284,7 @@
  * * upgrade - TRUE/FALSE for upgraded
  */
 /obj/item/borg/cyborg_omnitool/proc/set_upgraded(upgrade)
-	upgraded = upgraded
+	upgraded = upgrade
 
 	playsound(src, 'sound/items/tools/change_jaws.ogg', 50, TRUE)
 

--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -285,7 +285,9 @@
  */
 /obj/item/borg/cyborg_omnitool/proc/set_upgraded(upgrade)
 	upgraded = upgrade
-
+	for(var/obj/item/tool_path as anything in atoms)
+		var/obj/item/tool = atoms[tool_path]
+		tool.toolspeed = initial(tool.toolspeed) - upgraded * 0.3
 	playsound(src, 'sound/items/tools/change_jaws.ogg', 50, TRUE)
 
 /obj/item/borg/cyborg_omnitool/medical

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -494,7 +494,7 @@
 	for(var/obj/item/borg/cyborg_omnitool/engineering/omnitool in cyborg.model.modules)
 		omnitool.set_upgraded(TRUE)
 	for(var/obj/item/weldingtool/largetank/cyborg/welder in cyborg.model.modules)
-		welder.toolspeed = 0.7
+		welder.toolspeed = initial(welder.toolspeed) - 0.3
 
 /obj/item/borg/upgrade/engineering_omnitool/deactivate(mob/living/silicon/robot/cyborg, mob/living/user = usr)
 	. = ..()

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -493,6 +493,8 @@
 			return FALSE
 	for(var/obj/item/borg/cyborg_omnitool/engineering/omnitool in cyborg.model.modules)
 		omnitool.set_upgraded(TRUE)
+	for(var/obj/item/weldingtool/largetank/cyborg/welder in cyborg.model.modules)
+		welder.toolspeed = 0.7
 
 /obj/item/borg/upgrade/engineering_omnitool/deactivate(mob/living/silicon/robot/cyborg, mob/living/user = usr)
 	. = ..()
@@ -500,6 +502,8 @@
 		return .
 	for(var/obj/item/borg/cyborg_omnitool/omnitool in cyborg.model.modules)
 		omnitool.set_upgraded(FALSE)
+	for(var/obj/item/weldingtool/largetank/cyborg/welder in cyborg.model.modules)
+		welder.toolspeed = initial(welder.toolspeed)
 
 /obj/item/borg/upgrade/defib
 	name = "medical cyborg defibrillator"


### PR DESCRIPTION

## About The Pull Request

somehow no one has noticed this. currently all this does is give medborgs TRAIT_FASTMED and adv. health analyzer, and nothing else for it or for engiborg. 

## Why It's Good For The Game

HAHAHA I LOVE POWERCREEPING CYBORGS!!!!!

## Changelog
:cl:
fix: the cyborg omnitool upgrades properly increase tool speed
fix: the cyborg omnitool engineer upgrade properly increases the welder speed as well
/:cl:
