### PR TITLE
Liberator pistol applies damage multipliers in process_fire() rather than fire_gun()

### DIFF
--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -268,7 +268,7 @@
 	unload_ammo(user, forced = TRUE)
 	return FALSE
 
-/obj/item/gun/ballistic/automatic/pistol/doorhickey/fire_gun(atom/target, mob/living/user, flag, params)
+/obj/item/gun/ballistic/automatic/pistol/doorhickey/process_fire(atom/target, mob/living/user, message, params, zone_override, bonus_spread)
 	var/dmg_multiplier = 1
 
 	if (get_dist(target, user) <= 1)


### PR DESCRIPTION

## About The Pull Request

The code works exactly the same, because it didn't really need to be in `fire_gun()`. The reason for this is that there are some ways that guns are shot directly through `process_fire()`, such as clowns or mail, which never end up applying multipliers. 

## Why It's Good For The Game

I'd say that the distance from your hand to your foot is probably point-blank.

## Changelog
:cl:

fix: Liberator pistol applies point-blank damage modifier no matter how it is fired

/:cl:
