### PR TITLE
Recovered crew/Thanatorenasia bodies are shown as "revivable" when orbited in a morgue tray (+makes it shake)

### DIFF
--- a/code/datums/elements/orbit_twitcher.dm
+++ b/code/datums/elements/orbit_twitcher.dm
@@ -30,6 +30,11 @@
 			else
 				living.emote("twitch", forced = TRUE)
 
+			// if we're in a bodybag or morgue slab go up a level and shake that as well
+			var/obj/container = get(living, /obj/structure/bodycontainer) || get(living, /obj/structure/closet/body_bag)
+			if(!isnull(container))
+				container.Shake(2, 1, 0.3 SECONDS, 0.1 SECONDS)
+
 /datum/element/orbit_twitcher/proc/orbit_begin(atom/source, atom/orbiter)
 	SIGNAL_HANDLER
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -189,8 +189,8 @@ Medical HUD! Basic mode needs suit sensors on.
 		set_hud_image_state(STATUS_HUD, "hudxeno")
 		return FALSE
 
-	if(stat == DEAD || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))
-		if(HAS_TRAIT(src, TRAIT_MIND_TEMPORARILY_GONE) || can_defib_client())
+	if(!appears_alive())
+		if(can_defib_client())
 			set_hud_image_state(STATUS_HUD, "huddefib")
 		else if(HAS_TRAIT(src, TRAIT_GHOSTROLE_ON_REVIVE))
 			set_hud_image_state(STATUS_HUD, "hudghost")

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -322,7 +322,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 
 /obj/structure/bodycontainer/morgue/proc/occupant_revivable(mob/living/occupant)
 	if(occupant.stat != DEAD)
-		return FALSE
+		return TRUE
 	if(HAS_TRAIT(occupant, TRAIT_GHOSTROLE_ON_REVIVE) && length(occupant.get_all_orbiters()))
 		return TRUE
 	if(iscarbon(occupant))

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -315,17 +315,24 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 		return
 
 	for(var/mob/living/occupant as anything in stored_living)
-		if(occupant.stat == DEAD)
-			if(iscarbon(occupant))
-				var/mob/living/carbon/carbon_occupant = occupant
-				if(!carbon_occupant.can_defib_client())
-					continue
-			else
-				if(HAS_TRAIT(occupant, TRAIT_SUICIDED) || HAS_TRAIT(occupant, TRAIT_BADDNA) || (!occupant.key && !occupant.get_ghost(FALSE, TRUE)))
-					continue
-		morgue_state = MORGUE_HAS_REVIVABLE
-		return
+		if(occupant_revivable(occupant))
+			morgue_state = MORGUE_HAS_REVIVABLE
+			return
 	morgue_state = MORGUE_ONLY_BRAINDEAD
+
+/obj/structure/bodycontainer/morgue/proc/occupant_revivable(mob/living/occupant)
+	if(occupant.stat != DEAD)
+		return FALSE
+	if(HAS_TRAIT(occupant, TRAIT_GHOSTROLE_ON_REVIVE) && length(occupant.get_all_orbiters()))
+		return TRUE
+	if(iscarbon(occupant))
+		var/mob/living/carbon/carbon_occupant = occupant
+		return carbon_occupant.can_defib_client()
+	if(HAS_TRAIT(occupant, TRAIT_SUICIDED))
+		return FALSE
+	if(!occupant.key && !occupant.get_ghost(FALSE, TRUE))
+		return FALSE
+	return TRUE
 
 /obj/structure/bodycontainer/morgue/proc/handle_bodybag_enter(obj/structure/closet/body_bag/arrived_bag)
 	if(!arrived_bag.tag_name)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -855,7 +855,7 @@
 	return NONE
 
 /mob/living/carbon/proc/can_defib_client()
-	return (client || get_ghost(FALSE, TRUE)) && (can_defib() & DEFIB_REVIVABLE_STATES)
+	return (HAS_TRAIT(src, TRAIT_MIND_TEMPORARILY_GONE) || client || get_ghost(FALSE, TRUE)) && (can_defib() & DEFIB_REVIVABLE_STATES)
 
 /mob/living/carbon/harvest(mob/living/user)
 	if(QDELETED(src))


### PR DESCRIPTION
## About The Pull Request

If you orbit a recovered crewmember or thanatorenasia body situated in a morgue, the indicated will change from red to green, indicating the body is revivable

Additionally, orbiting a recovered crewmember or thanatorenasia body will cause morgues or bodybags to shake. This is an extension of the existing behavior where orbiting the body causes it to twitch. 

## Why It's Good For The Game

Allows doctors to store bodies in a safe place while they wait for a ghost to occupy it, also means you don't have to repeatedly defib them. 

## Changelog

:cl: Melbert
qol: Recovered crew/Thanatorenasia bodies in morgue trays change the indicator to green when a ghost is orbiting them (to allow ghosts to signal they want it to be revived) 
qol: Recovered crew/Thanatorenasia bodies now cause morgue trays / bodybags to shake when orbited, much like how the body itself shakes when orbited (to allow ghosts to signal they want it to be revived) 
/:cl:
