### PR TITLE
fixes cyborg defib refunding

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -513,13 +513,11 @@
 	items_to_add = list(/obj/item/shockpaddles/cyborg)
 
 /obj/item/borg/upgrade/defib/action(mob/living/silicon/robot/borg, mob/living/user = usr)
-	. = ..()
-	if(!.)
-		return .
 	var/obj/item/borg/upgrade/defib/backpack/defib_pack = locate() in borg //If a full defib unit was used to upgrade prior, we can just pop it out now and replace
 	if(defib_pack)
 		defib_pack.deactivate(borg, user)
 		to_chat(user, span_notice("The defibrillator pops out of the chassis as the compact upgrade installs."))
+	. = ..()
 
 ///A version of the above that also acts as a holder of an actual defibrillator item used in place of the upgrade chip.
 /obj/item/borg/upgrade/defib/backpack


### PR DESCRIPTION

## About The Pull Request

this code has been in the game since cloning was removed, i dont think it's ever worked.

## Why It's Good For The Game

with defibs being cargo only now being able to get human usable ones back can be useful

## Changelog
:cl:
fix: using a dedicated cyborg defib upgrade on a mediborg with a backpack defib installed will properly eject it
/:cl:
