### PR TITLE
Replaces `action-github-app-token` with  `actions/create-github-app-token`

### DIFF
--- a/.github/workflows/discord_discussions.yml
+++ b/.github/workflows/discord_discussions.yml
@@ -51,6 +51,6 @@ jobs:
             APP_ID: ${{ secrets.APP_ID }}
 
       - name: Run Tgstation.DiscordDiscussions
-        run: dotnet discord_discussions_bins/Tgstation.DiscordDiscussions.dll ${{ steps.app-token-generation.outputs.token }} ${{ github.repository_owner }} ${{ github.event.repository.name }} ${{ github.event.pull_request.number }} ${{ github.event.pull_request.merged && 'merged' || github.event.pull_request.state }} ${{ secrets.DISCORD_DISCUSSIONS_TOKEN }} ${{ vars.DISCORD_DISCUSSIONS_CHANNEL_ID }} ${{ github.event.action == 'reopened' && 'true' || 'false' }} ${{ vars.DISCORD_JOIN_LINK }}
+        run: dotnet discord_discussions_bins/Tgstation.DiscordDiscussions.dll ${{ steps.app-token-generation.outputs.token || secrets.GITHUB_TOKEN }} ${{ github.repository_owner }} ${{ github.event.repository.name }} ${{ github.event.pull_request.number }} ${{ github.event.pull_request.merged && 'merged' || github.event.pull_request.state }} ${{ secrets.DISCORD_DISCUSSIONS_TOKEN }} ${{ vars.DISCORD_DISCUSSIONS_CHANNEL_ID }} ${{ github.event.action == 'reopened' && 'true' || 'false' }} ${{ vars.DISCORD_JOIN_LINK }}
         env:
           GITHUB_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/discord_discussions.yml
+++ b/.github/workflows/discord_discussions.yml
@@ -41,10 +41,14 @@ jobs:
 
       - name: Generate App Token
         id: app-token-generation
-        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc
+        uses: actions/create-github-app-token@v3
+        if: env.APP_PRIVATE_KEY != '' && env.APP_ID != ''
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+            app-id: ${{ secrets.APP_ID }}
+            private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          env:
+            APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+            APP_ID: ${{ secrets.APP_ID }}
 
       - name: Run Tgstation.DiscordDiscussions
         run: dotnet discord_discussions_bins/Tgstation.DiscordDiscussions.dll ${{ steps.app-token-generation.outputs.token }} ${{ github.repository_owner }} ${{ github.event.repository.name }} ${{ github.event.pull_request.number }} ${{ github.event.pull_request.merged && 'merged' || github.event.pull_request.state }} ${{ secrets.DISCORD_DISCUSSIONS_TOKEN }} ${{ vars.DISCORD_DISCUSSIONS_CHANNEL_ID }} ${{ github.event.action == 'reopened' && 'true' || 'false' }} ${{ vars.DISCORD_JOIN_LINK }}

--- a/.github/workflows/discord_discussions.yml
+++ b/.github/workflows/discord_discussions.yml
@@ -46,7 +46,7 @@ jobs:
         with:
             app-id: ${{ secrets.APP_ID }}
             private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          env:
+        env:
             APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
             APP_ID: ${{ secrets.APP_ID }}
 


### PR DESCRIPTION
## About The Pull Request
- Closes #95468.

`actions/create-github-app-token` was always the standard in this repo

## Changelog
N/A

