### PR TITLE
Roundstart xeno egg alert is included in the roundstart report

### DIFF
--- a/code/datums/communications.dm
+++ b/code/datums/communications.dm
@@ -120,7 +120,7 @@ GLOBAL_DATUM_INIT(communications_controller, /datum/communciations_controller, n
 
 		for(var/datum/command_footnote/footnote as anything in command_report_footnotes)
 			footnote_pile += "[footnote.message]<BR>"
-			footnote_pile += "<i>[footnote.signature]</i><BR>"
+			footnote_pile += "~ <i>[footnote.signature]</i><BR>"
 			footnote_pile += "<BR>"
 
 		. += "<hr><h4>Additional Notes: </h4>" + footnote_pile

--- a/code/game/objects/effects/spawners/random/medical.dm
+++ b/code/game/objects/effects/spawners/random/medical.dm
@@ -69,8 +69,8 @@
 	name = "2% chance xeno egg spawner"
 	icon_state = "xeno_egg"
 	loot = list(
-		/obj/effect/decal/remains/xeno = 1,
-		/obj/effect/spawner/xeno_egg_delivery = 50,
+		/obj/effect/decal/remains/xeno = 49,
+		/obj/effect/spawner/xeno_egg_delivery = 1,
 	)
 
 /obj/effect/spawner/random/medical/surgery_tool

--- a/code/game/objects/effects/spawners/random/medical.dm
+++ b/code/game/objects/effects/spawners/random/medical.dm
@@ -69,8 +69,8 @@
 	name = "2% chance xeno egg spawner"
 	icon_state = "xeno_egg"
 	loot = list(
-		/obj/effect/decal/remains/xeno = 49,
-		/obj/effect/spawner/xeno_egg_delivery = 1,
+		/obj/effect/decal/remains/xeno = 1,
+		/obj/effect/spawner/xeno_egg_delivery = 50,
 	)
 
 /obj/effect/spawner/random/medical/surgery_tool

--- a/code/game/objects/effects/spawners/xeno_egg_delivery.dm
+++ b/code/game/objects/effects/spawners/xeno_egg_delivery.dm
@@ -16,7 +16,7 @@
 	log_game("An alien egg has been delivered to [AREACOORD(spawn_turf)]")
 
 	var/datum/command_footnote/footnote = new()
-	footnote.message = "We have entrusted your crew with a research specimen in [get_area_name(spawn_turf, TRUE)]. \
+	footnote.message = "We have entrusted your crew with a research specimen in [get_area(src)]. \
 		Remember to follow all safety precautions when dealing with the specimen."
 	footnote.signature = "Central Command"
 

--- a/code/game/objects/effects/spawners/xeno_egg_delivery.dm
+++ b/code/game/objects/effects/spawners/xeno_egg_delivery.dm
@@ -2,20 +2,25 @@
 	name = "xeno egg delivery"
 	icon = 'icons/mob/nonhuman-player/alien.dmi'
 	icon_state = "egg_growing"
-	var/announcement_time = 120 SECONDS
 
 /obj/effect/spawner/xeno_egg_delivery/Initialize(mapload)
 	. = ..()
 	var/turf/spawn_turf = get_turf(src)
-
 	new /obj/structure/alien/egg/delivery(spawn_turf)
 	new /obj/effect/temp_visual/gravpush(spawn_turf)
 	playsound(spawn_turf, 'sound/items/party_horn.ogg', 50, TRUE, -1)
+	if(SSticker.HasRoundStarted())
+		return
 
 	message_admins("An alien egg has been delivered to [ADMIN_VERBOSEJMP(spawn_turf)].")
 	log_game("An alien egg has been delivered to [AREACOORD(spawn_turf)]")
-	var/message = "Attention [station_name()], we have entrusted you with a research specimen in [get_area_name(spawn_turf, TRUE)]. Remember to follow all safety precautions when dealing with the specimen."
-	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_addtimer), CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(print_command_report), message), announcement_time))
+
+	var/datum/command_footnote/footnote = new()
+	footnote.message = "We have entrusted your crew with a research specimen in [get_area_name(spawn_turf, TRUE)]. \
+		Remember to follow all safety precautions when dealing with the specimen."
+	footnote.signature = "Central Command"
+
+	GLOB.communications_controller.command_report_footnotes += footnote
 
 /obj/structure/alien/egg/delivery
 	name = "xenobiological specimen egg"


### PR DESCRIPTION
## About The Pull Request

Roundstart xeno egg no longer sends a second report if it rolls, now instead adding an addendum to the roundstart report

<img width="409" height="111" alt="image" src="https://github.com/user-attachments/assets/14a62737-4d01-4240-8d3f-975e409d1fc2" />

## Why It's Good For The Game

I never really liked how meta-game-able the second alert is, the moment you hear `Secure command report created` 2 minutes into the round you know it's an egg round. Combining the roundstart alerts give the command staff the option of trying to hide it which could be fun. 

## Changelog

:cl: Melbert
qol: Roundstart xeno egg is now mentioned in the roundstart report as an addendum, rather than as a second report (usually) following the roundstart report.
/:cl:
