### PR TITLE
Fixes wizard, cult, nukies, revs, and malf from unable to be be rolled roundstart

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -280,7 +280,7 @@ SUBSYSTEM_DEF(dynamic)
 			log_dynamic("Roundstart: Ruleset is a solo ruleset. Cancelling other picks.")
 			QDEL_LIST(picked_rulesets)
 			rulesets_weighted -= picked_ruleset
-			picked_rulesets += picked_ruleset
+			picked_rulesets += picked_ruleset.type
 			break
 		if(current_tier.tier != DYNAMIC_TIER_HIGH && (picked_ruleset.ruleset_flags & RULESET_HIGH_IMPACT))
 			for(var/datum/dynamic_ruleset/roundstart/high_impact_ruleset as anything in rulesets_weighted)
@@ -290,7 +290,7 @@ SUBSYSTEM_DEF(dynamic)
 				rulesets_weighted -= high_impact_ruleset
 		if(!picked_ruleset.repeatable)
 			rulesets_weighted -= picked_ruleset
-			picked_rulesets += picked_ruleset
+			picked_rulesets += picked_ruleset.type
 			continue
 
 		rulesets_weighted[picked_ruleset] -= picked_ruleset.repeatable_weight_decrease


### PR DESCRIPTION
## About The Pull Request

#94899 did not fix all instances where `pick_roundstart_rulesets` added rulesets to the list

## Changelog

:cl: Melbert
fix: Fixes wizard, cult, nukies, revs, and malf being unable to be selected for roundstart antag (yes, you read that right)
/:cl:


