### PR TITLE
Small surgery qol

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -470,9 +470,7 @@
 
 	return jointext(check_list, "<br>")
 
-/// Returns surgery self-check information for this bodypart
-/obj/item/bodypart/proc/get_surgery_self_check()
-	var/list/surgery_message = list()
+/obj/item/bodypart/proc/get_reported_surgery_state()
 	var/reported_state = surgery_state
 	if(!LIMB_HAS_SKIN(src))
 		reported_state &= ~SKINLESS_SURGERY_STATES
@@ -480,6 +478,18 @@
 		reported_state &= ~BONELESS_SURGERY_STATES
 	if(!LIMB_HAS_VESSELS(src))
 		reported_state &= ~VESSELLESS_SURGERY_STATES
+
+	// hide surgical states applied by wounds if the limb isn't being operated on, to keep it simple
+	if(!HAS_TRAIT(src, TRAIT_READY_TO_OPERATE))
+		for(var/datum/wound/wound as anything in wounds)
+			reported_state &= ~wound.surgery_states
+
+	return reported_state
+
+/// Returns surgery self-check information for this bodypart
+/obj/item/bodypart/proc/get_surgery_self_check()
+	var/list/surgery_message = list()
+	var/reported_state = get_reported_surgery_state()
 
 	if(HAS_SURGERY_STATE(reported_state, SURGERY_SKIN_CUT))
 		surgery_message += "skin has been incised"
@@ -509,7 +519,7 @@
 
 	if(length(surgery_message))
 		return span_tooltip("Your limb is undergoing surgery. If no doctors are around, \
-			you could suture or cauterize yourself to cancel it.", span_warning("Its [english_list(surgery_message)]!"))
+			you could suture or cauterize yourself to cancel it.", span_smalldanger("Its [english_list(surgery_message)]!"))
 	return ""
 
 /// Returns surgery examine information for this bodypart
@@ -518,13 +528,7 @@
 	var/capital_zone = owner ? "[owner.p_Their()] [plaintext_zone]" : capitalize("[src]")
 	var/single_message = ""
 	var/list/sub_messages = list()
-	var/reported_state = surgery_state
-	if(!LIMB_HAS_SKIN(src))
-		reported_state &= ~SKINLESS_SURGERY_STATES
-	if(!LIMB_HAS_BONES(src))
-		reported_state &= ~BONELESS_SURGERY_STATES
-	if(!LIMB_HAS_VESSELS(src))
-		reported_state &= ~VESSELLESS_SURGERY_STATES
+	var/reported_state = get_reported_surgery_state()
 
 	if(HAS_SURGERY_STATE(reported_state, SURGERY_SKIN_CUT))
 		sub_messages += "skin has been incised"
@@ -563,9 +567,9 @@
 		single_message = "[owner?.p_Their() || "The"] chest cavity is wide open!"
 
 	if(length(sub_messages) >= 2)
-		return span_danger("[capital_zone]'s [english_list(sub_messages)].")
+		return span_smalldanger("[capital_zone]'s [english_list(sub_messages)].")
 	if(single_message)
-		return span_danger(single_message)
+		return span_smalldanger(single_message)
 	return ""
 
 /obj/item/bodypart/blob_act()

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -470,6 +470,7 @@
 
 	return jointext(check_list, "<br>")
 
+/// Returns all surgical states, filtering out stuff which should not be reported
 /obj/item/bodypart/proc/get_reported_surgery_state()
 	var/reported_state = surgery_state
 	if(!LIMB_HAS_SKIN(src))

--- a/code/modules/surgery/operations/operation_generic.dm
+++ b/code/modules/surgery/operations/operation_generic.dm
@@ -396,7 +396,15 @@
 	return ..() + list("the limb must have bones")
 
 /datum/surgery_operation/limb/fix_bones/state_check(obj/item/bodypart/limb)
-	return LIMB_HAS_BONES(limb)
+	if(!LIMB_HAS_BONES(limb))
+		return FALSE
+
+	// if a wound has given us the broken bone state, don't show this surgery as an option, to prevent confusion
+	for(var/datum/wound/wound as anything in limb.wounds)
+		if(wound.surgery_states & any_surgery_states_required)
+			return FALSE
+
+	return TRUE
 
 /datum/surgery_operation/limb/fix_bones/on_preop(obj/item/bodypart/limb, mob/living/surgeon, obj/item/tool, list/operation_args)
 	display_results(


### PR DESCRIPTION
## About The Pull Request

- Surgical states applied by wounds don't appear in examine unless the mob is prepared for surgery

- Surgical state examine text is now slightly smaller

- "Fix bones" surgery operation no longer appears if the patient is suffering a bone fracture

## Why It's Good For The Game

- QoL: these can really fill up the examine block in contexts which you really don't care about it. 

- QoL: same as above, surgical states aren't that important that they need to be in big red text. 

- QoL: prevent people from thinking that "fix bones" fixes the fracture, when in reality you're just reversing the "bone sawed" state that the fracture applies. 

## Changelog

:cl: Melbert
qol: Surgical states applied by wounds don't appear in examine unless the mob is prepared for surgery
qol: Surgical state examine text is now slightly smaller
qol: "Fix bones" surgery operation no longer appears if the patient is suffering a bone fracture - you will need to "repair fracture" instead. 
/:cl:
