### PR TITLE
You can lose it all

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -98,3 +98,7 @@
 
 #define MONEY_MINING_SYMBOL "mp"
 #define MONEY_BITRUNNING_SYMBOL "np"
+
+//Mood event from minor slot events like winning/losing a few bits.
+#define SLOTS_MOOD_CATEGORY "slots"
+

--- a/code/datums/memory/general_memories.dm
+++ b/code/datums/memory/general_memories.dm
@@ -564,6 +564,25 @@
 		"[protagonist_name] [mood_verb] as they stare down [antagonist_name]'s barrel.",
 	)
 
+
+/datum/memory/won_jackpot
+	story_value = STORY_VALUE_AMAZING
+
+/datum/memory/won_jackpot/get_names()
+	return list("[protagonist_name] winning it big.")
+
+/datum/memory/won_jackpot/get_starts()
+	return list(
+		"[protagonist_name] hits [deuteragonist_name]'s lever, with money symbols in their eyes.",
+		"[deuteragonist_name] plays a jingle as [protagonist_name] pulls the lever.",
+	)
+
+/datum/memory/won_jackpot/get_moods()
+	return list(
+		"[protagonist_name] [mood_verb] as they collect the money from the [deuteragonist_name].",
+		"[protagonist_name] [mood_verb] as [deuteragonist_name] starts spitting out money with a blare.",
+	)
+
 /// Saw someone get gibbed.
 /datum/memory/witness_gib
 	story_value = STORY_VALUE_OKAY

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -619,7 +619,7 @@
 
 /datum/mood_event/slots/win/jackpot
 	description = "JACKPOT! AW YEAH!"
-	mood_change = 6
+	mood_change = 4
 
 /datum/mood_event/slots/all_gone
 	description = "NOOOOOOO! IT'S ALL GONE!!!"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -607,6 +607,8 @@
 	event_flags = MOOD_EVENT_GAMING
 
 /datum/mood_event/slots/win/be_replaced(datum/mood/home, datum/mood_event/new_event, ...)
+	if(istype(new_event, /datum/mood_event/slots/all_gone))
+		return ALLOW_NEW_MOOD
 	if(new_event.mood_change < mood_change)
 		return BLOCK_NEW_MOOD
 	return ..()
@@ -618,7 +620,17 @@
 /datum/mood_event/slots/win/jackpot
 	description = "JACKPOT! AW YEAH!"
 	mood_change = 6
-	timeout = 30 MINUTES
+
+/datum/mood_event/slots/all_gone
+	description = "NOOOOOOO! IT'S ALL GONE!!!"
+	mood_change = -2
+	timeout = 20 MINUTES
+
+/datum/mood_event/slots/all_gone/be_replaced(datum/mood/home, datum/mood_event/new_event, ...)
+	if(istype(new_event, /datum/mood_event/slots/win/jackpot))
+		return ALLOW_NEW_MOOD
+	description = "I'll never get it back..."
+	return BLOCK_NEW_MOOD
 
 /datum/mood_event/empathetic_happy
 	description = "Seeing happy people makes me happy."

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -216,7 +216,7 @@
 
 /obj/machinery/computer/slot_machine/multitool_act(mob/living/user, obj/item/tool)
 	if(balance > 0)
-		visible_message("<b>[src]</b> says, 'ERROR! Please empty the machine balance before altering paymode'") //Prevents converting coins into holocredits and vice versa
+		say("ERROR! Please empty the machine balance before altering paymode.") //Prevents converting coins into holocredits and vice versa
 		return ITEM_INTERACT_BLOCKING
 
 	if(paymode == HOLOCHIP)
@@ -394,7 +394,7 @@
 
 /// Triggers a negative effect for a slot machine if all trap icons are lined up in the middle
 /obj/machinery/computer/slot_machine/proc/activate_trap(mob/living/user)
-	visible_message("<b>[src]</b> says, 'Big Loser! Prepare for your special prize!'")
+	say("Big Loser! Prepare for your special prize!")
 
 	switch(trap_path)
 		if(/obj/item/restraints/handcuffs)
@@ -422,9 +422,10 @@
 	else if(check_middle_row_all(jackpot_path))
 		winning = WINNING_JACKPOT
 		var/prize = money + PRIZE_JACKPOT
-		visible_message("<b>[src]</b> says, 'JACKPOT! You win [prize] [MONEY_NAME]!'")
+		say("JACKPOT! You win [prize] [MONEY_NAME]!")
 		priority_announce("Congratulations to [user ? user.real_name : usrname] for winning the jackpot at the slot machine in [get_area(src)]!")
-		user.add_mood_event("slots", /datum/mood_event/slots/win/jackpot)
+		user.add_mood_event(SLOTS_MOOD_CATEGORY, /datum/mood_event/slots/win/jackpot)
+		add_memory_in_range(user, 7, /datum/memory/won_jackpot, protagonist = user, deuteragonist = src)
 		jackpots += 1
 		money = 0
 		if(paymode == HOLOCHIP)
@@ -439,19 +440,19 @@
 
 	else if(linelength == 5)
 		winning = WINNING_BIG
-		visible_message("<b>[src]</b> says, 'Big Winner! You win a thousand [MONEY_NAME]!'")
+		say("Big Winner! You win a thousand [MONEY_NAME]!")
 		give_money(PRIZE_BIG)
-		user.add_mood_event("slots", /datum/mood_event/slots/win/big)
+		user.add_mood_event(SLOTS_MOOD_CATEGORY, /datum/mood_event/slots/win/big)
 
 	else if(linelength == 4)
 		winning = WINNING_SMALL
-		visible_message("<b>[src]</b> says, 'Winner! You win four hundred [MONEY_NAME]!'")
+		say("Winner! You win four hundred [MONEY_NAME]!")
 		give_money(PRIZE_SMALL)
-		user.add_mood_event("slots", /datum/mood_event/slots/win)
+		user.add_mood_event(SLOTS_MOOD_CATEGORY, /datum/mood_event/slots/win)
 
 	else if(linelength == 3)
 		winning = WINNING_FREESPIN
-		to_chat(user, span_notice("You win three free games!"))
+		balloon_alert(user, span_notice("won 3 free games!"))
 		balance += SPIN_PRICE * 4
 		money = max(money - SPIN_PRICE * 4, money)
 
@@ -459,7 +460,7 @@
 		winning = WINNING_NOTHING
 		balloon_alert(user, "no luck!")
 		did_player_win = FALSE
-		user.add_mood_event("slots", /datum/mood_event/slots/loss)
+		user.add_mood_event(SLOTS_MOOD_CATEGORY, /datum/mood_event/slots/loss)
 
 	playsound(src, 'sound/machines/lever/lever_stop.ogg', 50)
 

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -452,7 +452,7 @@
 
 	else if(linelength == 3)
 		winning = WINNING_FREESPIN
-		balloon_alert(user, span_notice("won 3 free games!"))
+		balloon_alert(user, "won 3 free games!")
 		balance += SPIN_PRICE * 4
 		money = max(money - SPIN_PRICE * 4, money)
 

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -28,7 +28,7 @@
 			L = user
 			accounts_to_rob -= L.get_bank_account()
 		for(var/datum/bank_account/B as anything in accounts_to_rob)
-			B.being_dumped = TRUE
+			B.dumpeet()
 		new /obj/effect/dumpeet_target(targetturf, L)
 
 		to_chat(user, span_notice("You have activated Protocol CRAB-17."))
@@ -66,8 +66,7 @@
  * Returns TRUE if no accounts are being drained, FALSE otherwise
  */
 /obj/structure/checkoutmachine/proc/check_if_finished()
-	for(var/i in accounts_to_rob)
-		var/datum/bank_account/B = i
+	for(var/datum/bank_account/B as anything in accounts_to_rob)
 		if (B.being_dumped)
 			return FALSE
 	return TRUE
@@ -100,7 +99,8 @@
 		return
 
 	to_chat(user, span_warning("You quickly cash out your funds to a more secure banking location. Funds are safu.")) // This is a reference and not a typo
-	card.registered_account.being_dumped = FALSE
+	accounts_to_rob -= card.registered_account
+	card.registered_account.stop_dump()
 
 	if(check_if_finished())
 		qdel(src)
@@ -202,8 +202,6 @@
 /obj/structure/checkoutmachine/proc/start_dumping()
 	accounts_to_rob = assoc_to_values(SSeconomy.bank_accounts_by_id)
 	accounts_to_rob -= bogdanoff?.get_bank_account()
-	for(var/datum/bank_account/B as anything in accounts_to_rob)
-		B.dumpeet()
 	dump()
 
 /**
@@ -213,14 +211,14 @@
  */
 /obj/structure/checkoutmachine/proc/dump()
 	var/percentage_lost = (rand(5, 15) / 100)
-	for(var/i in accounts_to_rob)
-		var/datum/bank_account/B = i
+	for(var/datum/bank_account/B as anything in accounts_to_rob)
 		if(!(B?.being_dumped))
 			accounts_to_rob -= B
 			continue
 		var/amount = round(B.account_balance * percentage_lost) // We don't want fractions of a credit stolen. That's just agony for everyone.
 		var/datum/bank_account/account = bogdanoff?.get_bank_account() || internal_account
 		account.transfer_money(B, amount, "?VIVA¿: !LA CRABBE¡")
+		B.money_crabbed += amount
 		B.bank_card_talk("You have lost [percentage_lost * 100]% of your funds! A spacecoin credit deposit machine is located at: [get_area(src)].")
 	addtimer(CALLBACK(src, PROC_REF(dump)), 15 SECONDS) //Drain every 15 seconds
 
@@ -233,10 +231,9 @@
  * Goes through accounts_to_rob and tells every account that the drain has stopped.
  */
 /obj/structure/checkoutmachine/proc/stop_dumping()
-	for(var/i in accounts_to_rob)
-		var/datum/bank_account/B = i
+	for(var/datum/bank_account/B as anything in accounts_to_rob)
 		if(B)
-			B.being_dumped = FALSE
+			B.stop_dump()
 
 /**
  * Splits the balance of the internal_account into several smaller piles of cash and scatters them around the area.

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -232,8 +232,7 @@
  */
 /obj/structure/checkoutmachine/proc/stop_dumping()
 	for(var/datum/bank_account/B as anything in accounts_to_rob)
-		if(B)
-			B.stop_dump()
+		B.stop_dump()
 
 /**
  * Splits the balance of the internal_account into several smaller piles of cash and scatters them around the area.

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -27,8 +27,7 @@
 		if(isliving(user))
 			L = user
 			accounts_to_rob -= L.get_bank_account()
-		for(var/i in accounts_to_rob)
-			var/datum/bank_account/B = i
+		for(var/datum/bank_account/B as anything in accounts_to_rob)
 			B.being_dumped = TRUE
 		new /obj/effect/dumpeet_target(targetturf, L)
 
@@ -203,8 +202,7 @@
 /obj/structure/checkoutmachine/proc/start_dumping()
 	accounts_to_rob = assoc_to_values(SSeconomy.bank_accounts_by_id)
 	accounts_to_rob -= bogdanoff?.get_bank_account()
-	for(var/i in accounts_to_rob)
-		var/datum/bank_account/B = i
+	for(var/datum/bank_account/B as anything in accounts_to_rob)
 		B.dumpeet()
 	dump()
 

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -128,9 +128,9 @@
 	being_dumped = FALSE
 	if(money_crabbed < NO_MY_MONEY)
 		return
-	for(var/obj/card in bank_cards)
+	for(var/obj/card as anything in bank_cards)
 		var/mob/living/card_holder = recursive_loc_check(card, /mob/living)
-		if(!isliving(card_holder) || !card_holder.client) //If on a mob
+		if(!isliving(card_holder)) //If on a mob
 			continue
 		//overwrite the slots event.
 		card_holder.add_mood_event(SLOTS_MOOD_CATEGORY, /datum/mood_event/slots/all_gone)

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -1,4 +1,5 @@
 #define DUMPTIME 3000
+#define NO_MY_MONEY 10000
 
 /datum/bank_account
 	///Name listed on the account, reflected on the ID card.
@@ -115,6 +116,16 @@
  */
 /datum/bank_account/proc/dumpeet()
 	being_dumped = TRUE
+	if(!has_money(NO_MY_MONEY))
+		return
+	for(var/obj/card in bank_cards)
+		var/mob/living/card_holder = recursive_loc_check(card, /mob/living)
+		if(!isliving(card_holder)) //If on a mob
+			continue
+		if(!card_holder.client || !card_holder.mob_mood?.get_mood_event(SLOTS_MOOD_CATEGORY))
+			continue
+		//overwrite the slots event.
+		card_holder.add_mood_event(SLOTS_MOOD_CATEGORY, /datum/mood_event/slots/all_gone)
 
 /**
  * Returns TRUE if a bank account has more than or equal to the amount, amt.
@@ -352,3 +363,4 @@
 	)))
 
 #undef DUMPTIME
+#undef NO_MY_MONEY

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -1,4 +1,5 @@
 #define DUMPTIME 3000
+///Amount of money you need to lose to get the negative moodlet.
 #define NO_MY_MONEY 10000
 
 /datum/bank_account
@@ -22,6 +23,8 @@
 	var/add_to_accounts = TRUE
 	///The Unique ID number code associated with the owner's bank account, assigned at round start.
 	var/account_id
+	///Amount of money that's been crabbed, if you lose enough from one series of CRAB-17's, you get a negative moodlet.
+	var/money_crabbed
 	///Is there a CRAB 17 on the station draining funds? Prevents manual fund transfer. pink levels are rising
 	var/being_dumped = FALSE
 	///Reference to the current civilian bounty that the account is working on.
@@ -116,13 +119,18 @@
  */
 /datum/bank_account/proc/dumpeet()
 	being_dumped = TRUE
-	if(!has_money(NO_MY_MONEY))
+	money_crabbed = 0
+
+/**
+ * Stops the dumping of the bank account.
+ */
+/datum/bank_account/proc/stop_dump()
+	being_dumped = FALSE
+	if(money_crabbed < NO_MY_MONEY)
 		return
 	for(var/obj/card in bank_cards)
 		var/mob/living/card_holder = recursive_loc_check(card, /mob/living)
-		if(!isliving(card_holder)) //If on a mob
-			continue
-		if(!card_holder.client || !card_holder.mob_mood?.get_mood_event(SLOTS_MOOD_CATEGORY))
+		if(!isliving(card_holder) || !card_holder.client) //If on a mob
 			continue
 		//overwrite the slots event.
 		card_holder.add_mood_event(SLOTS_MOOD_CATEGORY, /datum/mood_event/slots/all_gone)


### PR DESCRIPTION
## About The Pull Request

Replaces visible messages with the machine talking directly

<img width="448" height="31" alt="image" src="https://github.com/user-attachments/assets/a0ea268e-67f8-4301-ae9d-1926be7d79ae" />

Winning the jackpot now gives +4 instead of +6, but is now a permanent moodlet. The only way to lose it is if you lose at least 10k from a CRAB-17 market crash, which will replace it with a 20m mood debuff of -2.

<img width="639" height="523" alt="image" src="https://github.com/user-attachments/assets/9227b931-8e72-40c9-914c-657fd50ed5d3" />


Also adds a memory for winning the jackpot.

<img width="641" height="147" alt="image" src="https://github.com/user-attachments/assets/2d34dab0-9ee8-4d1a-a7af-1ad855a51abe" />

<img width="235" height="75" alt="image" src="https://github.com/user-attachments/assets/e870ef6d-d4c8-4cd0-976b-316e8399669e" />


## Why It's Good For The Game

Winning the jackpot makes you feel great all day, not just for 30 minutes. You won life saving gamblings!
Also you aren't really glad when all your money is gone, either.

## Changelog

:cl:
add: Winning the slot machine jackpot now gives a memory.
balance: Winning the slot machine jackpot is a +4 moodlet instead of +6, but it is now a permanent moodlet.
add: Losing large amounts of money from the CRAB-17 will give you a negative moodlet, which overwrites jackpot winnings.
/:cl: