### PR TITLE
Adds an admin secret that fixes gravity

### DIFF
--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -703,6 +703,18 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 				return
 			return
 
+		if("fix_gravity")
+			if(!is_funmin)
+				return
+			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("fix_gravity"))
+			message_admins("[key_name_admin(holder)] fixed the gravity generator.")
+
+			for(var/obj/machinery/gravity_generator/main/the_generator as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/gravity_generator/main))
+				if(!is_station_level(the_generator.z))
+					continue
+				the_generator.kickstart()
+				CHECK_TICK
+
 	if(holder)
 		log_admin("[key_name(holder)] used secret: [action].")
 #undef THUNDERDOME_TEMPLATE_FILE

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -482,6 +482,14 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	params = NONE
 	return ..()
 
+/// Admin proc that causes gravity to fully restart, via the secrets panel's fix gravity.
+/obj/machinery/gravity_generator/main/proc/kickstart()
+	charge_count = 100
+	breaker = TRUE
+	set_power()
+	enable()
+	investigate_log("was turned re-enabled by admin event.", INVESTIGATE_GRAVITY)
+
 // Misc
 
 /// Gravity generator instruction guide

--- a/tgui/packages/tgui/interfaces/Secrets.jsx
+++ b/tgui/packages/tgui/interfaces/Secrets.jsx
@@ -120,13 +120,13 @@ const HelpfulTab = (props) => {
       <Stack.Item>
         <Stack fill>
           <Stack.Item>
-            <NoticeBox
-              mb={-0.5}
+            <Button
+              icon="plane-slash"
+              lineHeight={lineHeightNormal}
               width={buttonWidthNormal}
-              height={lineHeightNormal}
-            >
-              Your admin button here, coder!
-            </NoticeBox>
+              content="Fix station gravity"
+              onClick={() => act('fix_gravity')}
+            />
           </Stack.Item>
           <Stack.Item>
             <Button


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. Secrets panel under Helpful, press it to reset and fix the gravity generator on the station.

## Why It's Good For The Game

It's very, very, very, very very annoying to have to keep reviving the gravity gen when I am hoping back and forth from the code and I imagine people also run into that so I added it as an admin secret because I'm nice like that

## Changelog

:cl:
admin: Adds a secret to restart the gravity generator.
/:cl:
