### PR TITLE
Implements configurable policy.json paths, so admins can better implement per server policy

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -365,12 +365,13 @@ Example config:
 */
 /datum/controller/configuration/proc/LoadPolicy()
 	policy = list()
-	var/rawpolicy = file2text("[directory]/policy.json")
+	var/json_path = CONFIG_GET(string/policy_json_path)
+	var/rawpolicy = file2text("[directory]/[json_path]")
 	if(rawpolicy)
 		var/parsed = safe_json_decode(rawpolicy)
 		if(!parsed)
-			log_config("JSON parsing failure for policy.json")
-			DelayedMessageAdmins("JSON parsing failure for policy.json")
+			log_config("JSON parsing failure for policy.json {[json_path]}")
+			DelayedMessageAdmins("JSON parsing failure for policy.json {[json_path]}")
 		else
 			policy = parsed
 

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -518,3 +518,7 @@
 
 /datum/config_entry/number/max_shuttle_size
 	default = 250
+
+/datum/config_entry/number/minimum_ascension_time
+	default = 0 // 1 minute
+	min_val = 0

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -802,8 +802,7 @@
 /datum/config_entry/flag/generate_assets_in_init
 	default = FALSE
 
-/datum/config_entry/number/minimum_ascension_time
-	default = 0 // 1 minute
-	min_val = 0
-
 /datum/config_entry/flag/fishing
+
+/datum/config_entry/string/policy_json_path
+	default = "policy.json"

--- a/config/config.txt
+++ b/config/config.txt
@@ -649,5 +649,6 @@ TGUI_MAX_CHUNK_COUNT 32
 ## It increases initialization time significantly so you'll want to disable this in live environments.
 GENERATE_ASSETS_IN_INIT
 
-## Minimum time before a heretic can ascend, in minutes
-# MINIMUM_ASCENSION_TIME 3
+## Path from the config folder to the policy json
+POLICY_JSON_PATH policy.json
+

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -593,3 +593,6 @@ SPY_EASY_REWARD_TC_THRESHOLD 5
 ## Hard bounties grant uplink rewards that cost this much TC (or higher).
 ## Also functions as the upper end for medium bounties.
 SPY_HARD_REWARD_TC_THRESHOLD 15
+
+## Minimum time before a heretic can ascend, in minutes
+# MINIMUM_ASCENSION_TIME 3


### PR DESCRIPTION

## About The Pull Request

Headmins were having trouble with per server policy (due to changes in how their config is structured), this lets them repath policy.json, so they can override it to a per server config (see the  structure seen in https://github.com/tgstation-operations/server-config)

Moved heretic ascension config into game_options, cause I think that's what it is.
## Why It's Good For The Game

Mei asked me for this, headmins should be able to headmin

## Changelog
:cl:
config: Added a config option for the path to policy.json
/:cl:
