### PR TITLE
Renamed golden data disk to syndicate data disk

### DIFF
--- a/code/modules/modular_computers/computers/item/disks/unique_disks.dm
+++ b/code/modules/modular_computers/computers/item/disks/unique_disks.dm
@@ -1,6 +1,6 @@
 /obj/item/disk/computer/syndicate
-	name = "golden data disk"
-	desc = "A data disk with some high-tech programs, probably expensive as hell."
+	name = "syndicate data disk"
+	desc = "A data disk with some high-tech programs. Rumor has it that the disk is made of gold, which probably makes it expensive as hell."
 	icon_state = "datadisk9"
 	custom_materials = list(/datum/material/gold = SMALL_MATERIAL_AMOUNT)
 


### PR DESCRIPTION
## About The Pull Request

this sprite is not gold anymore
<img width="301" height="142" alt="image" src="https://github.com/user-attachments/assets/3712b81f-d81c-419f-8545-7da6d79de571" />
(i know that its still made of gold, but you cant see the gold part anymore!!)

## Why It's Good For The Game

idk its only because of sprite, i updated description aswell to say that its made of gold. 

## Changelog

:cl:
spellcheck: Renamed golden data disk to syndicate data disk.
/:cl:
