### PR TITLE
Removes butterflies from the plasma flower MOD core, reduces the amount of particles spawned

### DIFF
--- a/code/game/objects/effects/particles/plant.dm
+++ b/code/game/objects/effects/particles/plant.dm
@@ -17,6 +17,10 @@
 	rotation = 30
 	spin = generator(GEN_NUM, -20, 20)
 
+// Subtype for the lavaland flower MODcore
+/particles/pollen/modsuit
+	spawning = 1
+
 // Subtype for mushroom spores specific to mushfolk/mushroom people
 /particles/pollen/mushroom
 	icon = 'icons/effects/particles/pollen.dmi'

--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -457,18 +457,11 @@
 	// Not super sure if this should just be the same, but will see.
 	maxcharge = 15 * STANDARD_CELL_CHARGE
 	charge = 15 * STANDARD_CELL_CHARGE
-	/// The mob to be spawned by the core
-	var/mob/living/spawned_mob_type = /mob/living/basic/butterfly/lavaland/temporary
-	/// Max number of mobs it can spawn
-	var/max_spawns = 3
-	/// Mob spawner for the core
-	var/datum/component/spawner/mob_spawner
 	/// Particle holder for pollen particles
 	var/obj/effect/abstract/particle_holder/particle_effect
 
 /obj/item/mod/core/plasma/lavaland/Destroy()
 	QDEL_NULL(particle_effect)
-	QDEL_NULL(mob_spawner)
 	return ..()
 
 /obj/item/mod/core/plasma/lavaland/install(obj/item/mod/control/mod_unit)
@@ -482,28 +475,12 @@
 /obj/item/mod/core/plasma/lavaland/proc/on_toggle()
 	SIGNAL_HANDLER
 	if(mod.active)
-		particle_effect = new(mod.wearer, /particles/pollen, PARTICLE_ATTACH_MOB)
-		mob_spawner = mod.wearer.AddComponent(/datum/component/spawner, \
-			spawn_types = list(spawned_mob_type), \
-			spawn_time = 5 SECONDS, \
-			max_spawned = 3, \
-			faction = mod.wearer.get_faction(), \
-		)
-		RegisterSignal(mob_spawner, COMSIG_SPAWNER_SPAWNED, PROC_REF(new_mob))
+		particle_effect = new(mod.wearer, /particles/pollen/modsuit, PARTICLE_ATTACH_MOB)
 		RegisterSignal(mod.wearer, COMSIG_MOVABLE_MOVED, PROC_REF(spread_flowers))
 		return
 
 	QDEL_NULL(particle_effect)
-	UnregisterSignal(mob_spawner, COMSIG_SPAWNER_SPAWNED)
 	UnregisterSignal(mod.wearer, COMSIG_MOVABLE_MOVED)
-	for(var/datum/mob in mob_spawner.spawned_things)
-		qdel(mob)
-	QDEL_NULL(mob_spawner)
-
-/obj/item/mod/core/plasma/lavaland/proc/new_mob(spawner, mob/living/basic/butterfly/lavaland/temporary/spawned)
-	SIGNAL_HANDLER
-	if(spawned)
-		spawned.source = src
 
 /obj/item/mod/core/plasma/lavaland/proc/spread_flowers(atom/source, atom/oldloc, dir, forced)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request

The plasma flower MOD core from the Garden of Eden ruin no longer spawns butterflies as you run around, and the amount of pollen particles it creates on the user has been quartered.

## Why It's Good For The Game

Butterflies are incredibly annoying to deal with and can block your own swings in combat, and don't serve a purpose beyond creating a ton of visual clutter. Same applies to the pollen particles, there's so many you can barely see your own sprite underneath. Quartering them still leaves plenty there to look nice.

## Changelog
:cl:
del: Plasma flower MOD core no longer spawns butterflies around the user
qol: Plasma flower MOD core's pollen visual now spawns less particles
/:cl:
