### PR TITLE
Fixes conditionally added actions not appearing on player HUDs

### DIFF
--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -352,7 +352,7 @@
 	if(!our_hud || viewers[our_hud]) // There's no point in this if you have no hud in the first place
 		return
 
-	var/atom/movable/screen/movable/action_button/button = create_button()
+	var/atom/movable/screen/movable/action_button/button = create_button(viewer)
 	SetId(button, viewer)
 
 	button.our_hud = our_hud
@@ -372,8 +372,8 @@
 		qdel(button)
 
 /// Creates an action button movable for the passed mob, and returns it.
-/datum/action/proc/create_button()
-	var/atom/movable/screen/movable/action_button/button = owner.hud_used.add_screen_object(/atom/movable/screen/movable/action_button)
+/datum/action/proc/create_button(mob/viewer)
+	var/atom/movable/screen/movable/action_button/button = viewer.hud_used.add_screen_object(/atom/movable/screen/movable/action_button)
 	button.linked_action = src
 	button.allow_observer_click = allow_observer_click
 	build_button_icon(button, ALL, TRUE)

--- a/code/datums/actions/cooldown_action.dm
+++ b/code/datums/actions/cooldown_action.dm
@@ -61,7 +61,7 @@
 	if(original)
 		create_sequence_actions()
 
-/datum/action/cooldown/create_button()
+/datum/action/cooldown/create_button(mob/viewer)
 	var/atom/movable/screen/movable/action_button/button = ..()
 	button.maptext = ""
 	button.maptext_x = 4

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -78,7 +78,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	///The internal attack ID for the elite's OpenFire() proc to use
 	var/chosen_attack_num = 0
 
-/datum/action/innate/elite_attack/create_button()
+/datum/action/innate/elite_attack/create_button(mob/viewer)
 	var/atom/movable/screen/movable/action_button/button = ..()
 	button.maptext = ""
 	button.maptext_x = 6

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -211,7 +211,7 @@
 
 	START_PROCESSING(SSobj, src)
 
-/datum/action/innate/bci_charge_action/create_button()
+/datum/action/innate/bci_charge_action/create_button(mob/viewer)
 	var/atom/movable/screen/movable/action_button/button = ..()
 	button.maptext_x = 2
 	button.maptext_y = 0

--- a/code/modules/wiremod/shell/implant.dm
+++ b/code/modules/wiremod/shell/implant.dm
@@ -199,7 +199,7 @@
 
 	START_PROCESSING(SSobj, src)
 
-/datum/action/innate/implant_charge_action/create_button()
+/datum/action/innate/implant_charge_action/create_button(mob/viewer)
 	var/atom/movable/screen/movable/action_button/button = ..()
 	button.maptext_x = 2
 	button.maptext_y = 0


### PR DESCRIPTION

## About The Pull Request

Fuckup from the refactor, this should give the action to the mob not the owner of the action.
Fixes purple raptors, ninja katanas, etc

## Changelog
:cl:
fix: Fixed conditionally added actions not appearing on player HUDs
/:cl:
