### PR TITLE
Red and black raptors no longer retaliate against their tamer's accidental attacks

### DIFF
--- a/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
+++ b/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
@@ -164,6 +164,6 @@
 	. = ..()
 	if (!.)
 		return FALSE
-	if (controller.blackboard[BB_FRIENDS_LIST] && (the_target in controller.blackboard[BB_FRIENDS_LIST]))
+	if (living_mob.ai_controller.blackboard[BB_FRIENDS_LIST] && (the_target in living_mob.ai_controller.blackboard[BB_FRIENDS_LIST]))
 		return FALSE
 	return TRUE

--- a/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
+++ b/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
@@ -157,3 +157,13 @@
 
 /datum/targeting_strategy/basic/exact_match
 	check_factions_exactly = TRUE
+
+/datum/targeting_strategy/basic/exact_match/ignore_friends
+
+/datum/targeting_strategy/basic/exact_match/ignore_friends/can_attack(mob/living/living_mob, atom/the_target, vision_range)
+	. = ..()
+	if (!.)
+		return FALSE
+	if (controller.blackboard[BB_FRIENDS_LIST] && (the_target in controller.blackboard[BB_FRIENDS_LIST]))
+		return FALSE
+	return TRUE

--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_controller.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_ai_controller.dm
@@ -43,7 +43,7 @@
 			"wags their tail against",
 			"playfully leans against"
 		),
-		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic/exact_match,
+		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic/exact_match/ignore_friends,
 		BB_HUNT_TARGETING_STRATEGY = /datum/targeting_strategy/basic,
 		BB_PET_TARGETING_STRATEGY = /datum/targeting_strategy/basic,
 		BB_BABIES_PARTNER_TYPES = list(/mob/living/basic/raptor),


### PR DESCRIPTION

## About The Pull Request

Changed aggressive raptor AI to not target their tamer

## Why It's Good For The Game

It really sucks when you accidentally punch your mount during combat or when trying to heal it, and now it permanently hates you and will attack you even after it dies and gets revived. The intent with this was to make it attack miners accidentally firing upon a wild raptor, or the crew when an antag unleashes a swarm upon the station, not to kill their owners.

## Changelog
:cl:
balance: Red and black raptors no longer retaliate against their tamer's accidental attacks
/:cl:
