### PR TITLE
Increases raptor growth speed across the board by around 50%

### DIFF
--- a/code/__DEFINES/basic_mobs.dm
+++ b/code/__DEFINES/basic_mobs.dm
@@ -60,19 +60,19 @@ GLOBAL_LIST_EMPTY(customized_pets)
 /// How much does meal complexity affect our growth?
 #define RAPTOR_MEAL_COMPLEXITY_GROWTH_FACTOR 5
 /// Base value for raptor growth from meat
-#define RAPTOR_GROWTH_BASE_MEAT 10
+#define RAPTOR_GROWTH_BASE_MEAT 15
 /// Base value for raptor growth from ash flora
-#define RAPTOR_GROWTH_BASE_PLANT 5
+#define RAPTOR_GROWTH_BASE_PLANT 8
 /// How much growth progress raptors need to accumulate to fully grow into an adult
 #define RAPTOR_GROWTH_REQUIRED 100
 /// Minimum random growth value a baby raptor can gain per second
-#define RAPTOR_BABY_GROWTH_LOWER 0.5
+#define RAPTOR_BABY_GROWTH_LOWER 0.8
 /// Maximum random growth value a baby raptor can gain per second
-#define RAPTOR_BABY_GROWTH_UPPER 0.8
+#define RAPTOR_BABY_GROWTH_UPPER 1.2
 /// How long it takes for a raptor egg to grow up, in seconds
 #define RAPTOR_EGG_GROWTH_PROGRESS 100
 /// How much happiness percentage affects our growth speed
-#define RAPTOR_GROWTH_HAPPINESS_MULTIPLIER 0.005 // Full happiness increases growth rate by 50%
+#define RAPTOR_GROWTH_HAPPINESS_MULTIPLIER 0.0075 // Full happiness increases growth rate by 75%
 
 /// Damage boost per happiness percent
 #define RAPTOR_HAPPINESS_DAMAGE_BOOST 0.05

--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_egg.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_egg.dm
@@ -11,9 +11,9 @@
 	/// Current growth progress
 	var/growth_progress = 0
 	/// Minimum growth progress per second
-	var/min_growth_rate = 0.5
+	var/min_growth_rate = 1
 	/// Maximum growth progress per second
-	var/max_growth_rate = 1
+	var/max_growth_rate = 2
 
 /obj/item/food/egg/raptor_egg/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_egg.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_egg.dm
@@ -11,9 +11,9 @@
 	/// Current growth progress
 	var/growth_progress = 0
 	/// Minimum growth progress per second
-	var/min_growth_rate = 1
+	var/min_growth_rate = 0.8
 	/// Maximum growth progress per second
-	var/max_growth_rate = 2
+	var/max_growth_rate = 1.2
 
 /obj/item/food/egg/raptor_egg/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Raptors now get around 50% more growth points from meat and plants (slightly less so from cooked meat as a portion of those came from meal complexity which was not buffed), and chick and egg passive growth has been increased by around 33%.

## Why It's Good For The Game

Currently you need to feed raptors around 20 plants or 10 slabs of meat to make them grow up, which was fine during testing with a single raptor but turns out to be unsustainable when growing multiple raptors at once or trying to breed them without having a goliath tendril nearby. This is not as much of an issue with chicks and eggs as they also have passive growth, but waiting for over 2 minutes is not ideal either. This should make roundstart raptor acquisition not take the entire first storm cycle if you have multiple people trying to grow them/a single person going for multiple raptors

## Changelog
:cl:
balance: Raptors and raptor chicks/eggs have had their growth speed increased by 50/33% respectively.
/:cl:
