### PR TITLE
Fixes weather forcasts randomly backtracking on themselves, and falsely announcing safety right before a storm hits

### DIFF
--- a/code/datums/components/weatherannouncer.dm
+++ b/code/datums/components/weatherannouncer.dm
@@ -122,7 +122,10 @@
 		if(WEATHER_ALERT_INCOMING)
 			light.set_light_color(LIGHT_COLOR_DIM_YELLOW)
 		if(WEATHER_ALERT_IMMINENT_OR_ACTIVE)
-			light.set_light_color(LIGHT_COLOR_INTENSE_RED)
+			if (is_weather_dangerous)
+				light.set_light_color(LIGHT_COLOR_INTENSE_RED)
+			else
+				light.set_light_color(LIGHT_COLOR_DIM_YELLOW)
 	light.update_light()
 
 /// Returns a string we should display to communicate what you should be doing
@@ -131,12 +134,10 @@
 		if(WEATHER_ALERT_CLEAR)
 			return "All clear, no weather alerts to report."
 		if(WEATHER_ALERT_INCOMING)
-			if (!is_weather_dangerous)
-				return "No risk expected from incoming weather front."
 			return "Weather front incoming, begin to seek shelter."
 		if(WEATHER_ALERT_IMMINENT_OR_ACTIVE)
 			if (!is_weather_dangerous)
-				return "No risk expected from imminent weather front."
+				return "No risk expected from incoming weather front."
 			return "Weather front imminent, find shelter immediately."
 	return "Error in meteorological calculation. Please report this deviation to a trained programmer."
 

--- a/code/datums/components/weatherannouncer.dm
+++ b/code/datums/components/weatherannouncer.dm
@@ -158,6 +158,11 @@
 
 	var/time_until_next = INFINITY
 	for(var/mining_level in mining_z_levels)
+		// About to start!
+		if (SSweather.eligible_zlevels["[mining_level]"])
+			time_until_next = 0
+			break
+
 		var/next_time = timeleft(SSweather.next_hit_by_zlevel["[mining_level]"])
 		if (!isnull(next_time) && next_time < time_until_next)
 			time_until_next = next_time

--- a/code/datums/components/weatherannouncer.dm
+++ b/code/datums/components/weatherannouncer.dm
@@ -2,6 +2,9 @@
 #define WEATHER_ALERT_INCOMING 1
 #define WEATHER_ALERT_IMMINENT_OR_ACTIVE 2
 
+#define WEATHER_CLEAR_DELAY 2 MINUTES
+#define WEATHER_INCOMING_DELAY 30 SECONDS
+
 /// Component which makes you yell about what the weather is
 /datum/component/weather_announcer
 	/// Currently displayed warning level
@@ -143,6 +146,7 @@
 	for(var/datum/weather/check_weather as anything in SSweather.processing)
 		if(!(check_weather.weather_flags & WEATHER_BAROMETER) || check_weather.stage == WIND_DOWN_STAGE || check_weather.stage == END_STAGE)
 			continue
+
 		for (var/mining_level in mining_z_levels)
 			if(mining_level in check_weather.impacted_z_levels)
 				warning_level = WEATHER_ALERT_IMMINENT_OR_ACTIVE
@@ -151,28 +155,40 @@
 
 	var/time_until_next = INFINITY
 	for(var/mining_level in mining_z_levels)
-		var/next_time = timeleft(SSweather.next_hit_by_zlevel["[mining_level ]"]) || INFINITY
-		if (next_time && next_time < time_until_next)
+		var/next_time = timeleft(SSweather.next_hit_by_zlevel["[mining_level]"]) || INFINITY
+		if (!isnull(next_time) && next_time < time_until_next)
 			time_until_next = next_time
 
-	if(!check_accuracy())
-		if(!accuracy_mod && radar_z_trait)
-			accuracy_mod = rand(-9, 9) * 5 SECONDS
+	if(check_accuracy())
+		return time_until_next
 
-		time_until_next = max(10 SECONDS, time_until_next + accuracy_mod)
+	if(!accuracy_mod && radar_z_trait)
+		accuracy_mod = rand(-9, 9) * 5 SECONDS
 
+	var/maximum_value = INFINITY
+	// Don't backtrack on weather warnings every second of process() if we're poorly calibrated
+	if (warning_level == WEATHER_ALERT_INCOMING)
+		maximum_value = WEATHER_CLEAR_DELAY - 1
+	else if (warning_level == WEATHER_ALERT_IMMINENT_OR_ACTIVE)
+		maximum_value = WEATHER_INCOMING_DELAY - 1
+
+	time_until_next = clamp(time_until_next + accuracy_mod, min(time_until_next, 10 SECONDS), maximum_value)
 	return time_until_next
 
 /// Polls existing weather for what kind of warnings we should be displaying.
 /datum/component/weather_announcer/proc/set_current_alert_level()
 	var/time_until_next = time_till_storm()
+	is_weather_dangerous = FALSE
+
 	if(isnull(time_until_next))
+		warning_level = WEATHER_ALERT_CLEAR
 		return // No problems if there are no mining z levels
-	if(time_until_next >= 2 MINUTES)
+
+	if(time_until_next >= WEATHER_CLEAR_DELAY)
 		warning_level = WEATHER_ALERT_CLEAR
 		return
 
-	if(time_until_next >= 30 SECONDS)
+	if(time_until_next >= WEATHER_INCOMING_DELAY)
 		warning_level = WEATHER_ALERT_INCOMING
 		return
 
@@ -182,10 +198,14 @@
 	for(var/datum/weather/check_weather as anything in SSweather.processing)
 		if(!(check_weather.weather_flags & WEATHER_BAROMETER) || check_weather.stage == WIND_DOWN_STAGE || check_weather.stage == END_STAGE)
 			continue
+
 		var/list/mining_z_levels = SSmapping.levels_by_trait(radar_z_trait)
 		for(var/mining_level in mining_z_levels)
-			if(mining_level in check_weather.impacted_z_levels)
-				is_weather_dangerous = (check_weather.weather_flags & FUNCTIONAL_WEATHER)
+			if(!(mining_level in check_weather.impacted_z_levels))
+				continue
+
+			if(check_weather.weather_flags & FUNCTIONAL_WEATHER)
+				is_weather_dangerous = TRUE
 				return
 
 /datum/component/weather_announcer/proc/on_examine(atom/radio, mob/examiner, list/examine_texts)
@@ -229,3 +249,6 @@
 #undef WEATHER_ALERT_CLEAR
 #undef WEATHER_ALERT_INCOMING
 #undef WEATHER_ALERT_IMMINENT_OR_ACTIVE
+
+#undef WEATHER_CLEAR_DELAY
+#undef WEATHER_INCOMING_DELAY

--- a/code/datums/components/weatherannouncer.dm
+++ b/code/datums/components/weatherannouncer.dm
@@ -171,9 +171,9 @@
 	var/maximum_value = INFINITY
 	// Don't backtrack on weather warnings every second of process() if we're poorly calibrated
 	if (warning_level == WEATHER_ALERT_INCOMING)
-		maximum_value = WEATHER_CLEAR_DELAY - 1
+		maximum_value = WEATHER_CLEAR_DELAY
 	else if (warning_level == WEATHER_ALERT_IMMINENT_OR_ACTIVE)
-		maximum_value = WEATHER_INCOMING_DELAY - 1
+		maximum_value = WEATHER_INCOMING_DELAY
 
 	time_until_next = clamp(time_until_next + accuracy_mod, min(time_until_next, 10 SECONDS), maximum_value)
 	return time_until_next
@@ -187,11 +187,11 @@
 		warning_level = WEATHER_ALERT_CLEAR
 		return // No problems if there are no mining z levels
 
-	if(time_until_next >= WEATHER_CLEAR_DELAY)
+	if(time_until_next > WEATHER_CLEAR_DELAY)
 		warning_level = WEATHER_ALERT_CLEAR
 		return
 
-	if(time_until_next >= WEATHER_INCOMING_DELAY)
+	if(time_until_next > WEATHER_INCOMING_DELAY)
 		warning_level = WEATHER_ALERT_INCOMING
 		return
 

--- a/code/datums/components/weatherannouncer.dm
+++ b/code/datums/components/weatherannouncer.dm
@@ -158,7 +158,7 @@
 
 	var/time_until_next = INFINITY
 	for(var/mining_level in mining_z_levels)
-		var/next_time = timeleft(SSweather.next_hit_by_zlevel["[mining_level]"]) || INFINITY
+		var/next_time = timeleft(SSweather.next_hit_by_zlevel["[mining_level]"])
 		if (!isnull(next_time) && next_time < time_until_next)
 			time_until_next = next_time
 

--- a/code/datums/components/weatherannouncer.dm
+++ b/code/datums/components/weatherannouncer.dm
@@ -127,14 +127,16 @@
 
 /// Returns a string we should display to communicate what you should be doing
 /datum/component/weather_announcer/proc/get_warning_message()
-	if (!is_weather_dangerous)
-		return "No risk expected from incoming weather front."
 	switch(warning_level)
 		if(WEATHER_ALERT_CLEAR)
 			return "All clear, no weather alerts to report."
 		if(WEATHER_ALERT_INCOMING)
+			if (!is_weather_dangerous)
+				return "No risk expected from incoming weather front."
 			return "Weather front incoming, begin to seek shelter."
 		if(WEATHER_ALERT_IMMINENT_OR_ACTIVE)
+			if (!is_weather_dangerous)
+				return "No risk expected from imminent weather front."
 			return "Weather front imminent, find shelter immediately."
 	return "Error in meteorological calculation. Please report this deviation to a trained programmer."
 

--- a/code/datums/components/weatherannouncer.dm
+++ b/code/datums/components/weatherannouncer.dm
@@ -175,7 +175,7 @@
 	else if (warning_level == WEATHER_ALERT_IMMINENT_OR_ACTIVE)
 		maximum_value = WEATHER_INCOMING_DELAY
 
-	time_until_next = clamp(time_until_next + accuracy_mod, min(time_until_next, 10 SECONDS), maximum_value)
+	time_until_next = clamp(time_until_next + accuracy_mod, min(time_until_next, 10 SECONDS), max(time_until_next, maximum_value))
 	return time_until_next
 
 /// Polls existing weather for what kind of warnings we should be displaying.


### PR DESCRIPTION

## About The Pull Request

Weather forecasts had some major logical flaws:
 - Uncalibrated forecasts always bottomed out at 10 seconds, even if the storm was right about to happen
 - Weather forecasts could backtrack on themselves if a tower was taken out after an incoming storm warning has given and the modifier rolled was high enough
 - ``is_weather_dangerous`` was never unset unless another weather event happened, as it was only assigned to during active weather. This means that warnings for fake/real storms would actually display previous storm's warning until it actually hit, which could cost a miner their life as it would falsely replace all incoming weather warnings with the "no danger" one until the storm hit. 

Also they exclusively checked ``SSweather``'s ``next_hit_by_zlevel`` timers which means that right before the storm hit (as the timer ran out, but before SSweather could tick) forecasters would send an all-clear announcement followed by the storm message and a second imminent weather announcement

<img width="698" height="112" alt="image" src="https://github.com/user-attachments/assets/d17d5df9-cec6-4fe9-afdb-baa798c7d13e" />

## Changelog
:cl:
fix: Fixed weather forcasts randomly backtracking on themselves, and falsely announcing safety right before a storm hits
/:cl:
