### PR TITLE
replaces cafe disposal bins in cargo

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -12983,9 +12983,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/disposal/bin{
-	name = "Jim Norton's Quebecois Coffee disposal unit"
-	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
 "ewf" = (
@@ -27916,9 +27914,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/disposal/bin{
-	name = "Jim Norton's Quebecois Coffee disposal unit"
-	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "jBu" = (


### PR DESCRIPTION

## About The Pull Request
minor map fix :)

I noticed 2 disposal bins in cargo were the quebec cafeo nes. I imagined it was a mistake someone made when they redid those areas in cargo.
## Why It's Good For The Game
mining and qm office disposal bins dont say jim nortons cafe on them anymore
## Changelog
:cl:

fix: Metastations mining and QM disposal bins are no longer Jim Norton branded.

/:cl:
