### PR TITLE
Mice have a 10% chance to spawn as "clever", making it shock immune.

### DIFF
--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -1,3 +1,5 @@
+#define SMART_MOUSE_CHANCE 10
+
 /mob/living/basic/mouse
 	name = "mouse"
 	desc = "This cute little guy just loves the taste of insulated electrical cables. Isn't he adorable?"
@@ -60,6 +62,8 @@
 	if(contributes_to_ratcap)
 		SSmobs.cheeserats |= src
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
+	if(prob(SMART_MOUSE_CHANCE))
+		ADD_TRAIT(src, TRAIT_SHOCKIMMUNE, INNATE_TRAIT)
 
 	if(tame)
 		ADD_TRAIT(src, TRAIT_TAMED, INNATE_TRAIT)
@@ -272,6 +276,11 @@
 
 	playsound(cable, 'sound/effects/sparks/sparks2.ogg', 100, TRUE)
 	cable.deconstruct()
+
+/mob/living/basic/mouse/examine(mob/user)
+	. = ..()
+	if(HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
+		. += span_info("This mouse looks unusually clever.")
 
 /mob/living/basic/mouse/white
 	body_color = "white"
@@ -490,3 +499,5 @@
 		/datum/ai_planning_subtree/random_speech/mouse,
 		/datum/ai_planning_subtree/find_and_hunt_target/look_for_cables,
 	)
+
+#undef SMART_MOUSE_CHANCE


### PR DESCRIPTION
## About The Pull Request

As it says on the tin.

## Why It's Good For The Game

Mice have a bad habit of ritualistically killing themselves quickly into a shift through throwing themselves against cables, resulting in mice not really being much of a threat to the station's cabling, while also littering the ground with dead critters.

This adds a 10% chance of mice being spawned as shock immune, similar to the "tom" unique subtype, which allows it to bite cables without instantly killing themselves. This also allows for there to be a chance for mice to last more than the first 10 minutes of the shift without spawning in a room that doesn't have cables.

## Changelog

:cl:
qol: Mice have a low chance to spawn being slightly more clever, being smart enough to bite cables without shocking themselves.
/:cl: