### PR TITLE
Fixes boxing or successful blocking not preventing grabs

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -119,6 +119,11 @@ DEFINE_BITFIELD(status_flags, list(
 #define GRAB_NECK 2
 #define GRAB_KILL 3
 
+// Grab attack chain results
+#define GRAB_SKIP 0
+#define GRAB_FAILURE 1
+#define GRAB_SUCCESS 2
+
 //Grab breakout odds
 #define BASE_GRAB_RESIST_CHANCE 60 //base chance for whether or not you can escape from a grab
 

--- a/code/_onclick/click_ctrl.dm
+++ b/code/_onclick/click_ctrl.dm
@@ -38,7 +38,7 @@
 		return
 
 	. = TRUE
-	if(grab(target))
+	if(grab(target) != GRAB_SKIP)
 		changeNext_move(CLICK_CD_MELEE)
 		return
 	pulled(target)

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -181,8 +181,9 @@
 /datum/component/tackler/proc/do_grab(mob/living/carbon/tackler, mob/living/carbon/tackled, skip_to_state = GRAB_PASSIVE)
 	set waitfor = FALSE
 
-	if(!tackler.grab(tackled) || tackler.pulling != tackled)
+	if(tackler.grab(tackled) != GRAB_SUCCESS || tackler.pulling != tackled)
 		return
+
 	if(tackler.grab_state != skip_to_state)
 		tackler.setGrabState(skip_to_state)
 

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -20,6 +20,8 @@
 	help_verb = /mob/living/proc/boxing_help
 	/// Boolean on whether we are sportsmanlike in our tussling; TRUE means we have restrictions
 	var/honorable_boxer = TRUE
+	/// Can we perform grabs even if it would be dishonorable?
+	var/ignore_grab_restriction = FALSE
 	/// Default damage type for our boxing.
 	var/default_damage_type = STAMINA
 	/// List of traits applied to users of this martial art.
@@ -85,7 +87,7 @@
 	return MARTIAL_ATTACK_SUCCESS
 
 /datum/martial_art/boxing/grab_act(mob/living/attacker, mob/living/defender)
-	if(honorable_boxer)
+	if(honorable_boxer && !ignore_grab_restriction)
 		attacker.balloon_alert(attacker, "no grabbing while boxing!")
 		return MARTIAL_ATTACK_FAIL
 	return MARTIAL_ATTACK_INVALID //UNLESS YOU'RE EVIL
@@ -433,6 +435,7 @@
 	help_verb = /mob/living/proc/hunter_boxing_help
 	default_damage_type = BRUTE
 	boxing_traits = list(TRAIT_BOXING_READY)
+	ignore_grab_restriction = TRUE
 	/// The mobs we are looking for to pass the honor check
 	var/honorable_mob_biotypes = MOB_BEAST | MOB_SPECIAL | MOB_PLANT | MOB_BUG | MOB_MINING | MOB_CRUSTACEAN | MOB_REPTILE
 	/// Our crit shout words. First word is then paired with a second word to form an attack name.

--- a/code/modules/antagonists/blood_worm/actions/leech_blood.dm
+++ b/code/modules/antagonists/blood_worm/actions/leech_blood.dm
@@ -79,9 +79,10 @@
 	if (!do_after(leech, leech_grab_delay, target, extra_checks = CALLBACK(src, PROC_REF(leech_living_start_check), leech, target)))
 		return
 
-	if (leech.pulling != target && !leech.grab(target))
+	if (leech.pulling != target && leech.grab(target) != GRAB_SUCCESS)
 		target.balloon_alert(leech, "unable to grab!")
 		return
+
 	if (leech.grab_state < GRAB_AGGRESSIVE)
 		leech.setGrabState(GRAB_AGGRESSIVE)
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -330,13 +330,13 @@
  */
 /mob/living/proc/grab(mob/living/target)
 	if(!istype(target))
-		return FALSE
+		return GRAB_SKIP
 	if(SEND_SIGNAL(src, COMSIG_LIVING_GRAB, target) & (COMPONENT_CANCEL_ATTACK_CHAIN|COMPONENT_SKIP_ATTACK))
-		return FALSE
+		return GRAB_FAILURE
 	if(target.check_block(src, 0, "[src]'s grab", UNARMED_ATTACK))
-		return FALSE
+		return GRAB_FAILURE
 	target.grabbedby(src)
-	return TRUE
+	return GRAB_SUCCESS
 
 /**
  * Called when this mob is grabbed by another mob.


### PR DESCRIPTION

## About The Pull Request

Since grabs that failed due to a comsig return or the grab being blocked returned FALSE, they'd still result in the target being passively grabbed from being pulled as that was called upon the grab failing. I've added multiple return types to grabs to alleviate this. 
Per anne's recommendation, hunter boxing is exempt from the grab restriction (since it never functioned in the first place).

## Changelog
:cl:
fix: Fixed boxing or successful blocking not preventing grabs
/:cl:
