### PR TITLE
Prevents people crashing into their own mounts if they're thrown together

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -154,7 +154,7 @@ SUBSYSTEM_DEF(throwing)
 				continue
 			if(obstacle.pass_flags_self & LETPASSTHROW)
 				continue
-			if (obstacle == actual_target || (obstacle.density && !(obstacle.flags_1 & ON_BORDER_1) && !(obstacle in AM.buckled_mobs)))
+			if (obstacle == actual_target || (obstacle.density && !(obstacle.flags_1 & ON_BORDER_1) && !(obstacle in AM.buckled_mobs) && !(AM in obstacle.buckled_mobs)))
 				finalize(TRUE, obstacle)
 				return
 


### PR DESCRIPTION

## About The Pull Request

Throwing code checked for the obstacle being buckled to the thrown object, but not vise versa. In some cases (such as riding a mob) this could cause you to violently crash into your own mount while flying but still continue your flight.

## Changelog
:cl:
fix: Fixed people crashing into their own mounts if they're thrown together
/:cl:
