### PR TITLE
Uncapitalized reagent name from scoopable element

### DIFF
--- a/code/datums/elements/reagent_scoopable_atom.dm
+++ b/code/datums/elements/reagent_scoopable_atom.dm
@@ -33,5 +33,5 @@
 		return ITEM_INTERACT_BLOCKING
 	if(!container.reagents.add_reagent(reagent_to_extract, rand(5, 10)))
 		to_chat(user, span_warning("[container] is full."))
-	user.visible_message(span_notice("[user] scoops [reagent_to_extract::name] from [source] with [container]."), span_notice("You scoop out [reagent_to_extract::name] from [source] using [container]."))
+	user.visible_message(span_notice("[user] scoops [LOWER_TEXT(reagent_to_extract::name)] from [source] with [container]."), span_notice("You scoop out [LOWER_TEXT(reagent_to_extract::name)] from [source] using [container]."))
 	return ITEM_INTERACT_SUCCESS


### PR DESCRIPTION
## About The Pull Request

uncapitalized reagent name from scoopable element because it looks ugly
<img width="330" height="38" alt="image" src="https://github.com/user-attachments/assets/3d3e61c7-32bd-466e-8ef7-7c3d0fe73d02" />

## Changelog

N/A