### PR TITLE
fixes up some math defines to use byond builtins instead of workarounds

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -26,11 +26,8 @@
 #define REALTIMEOFDAY (world.timeofday + (MIDNIGHT_ROLLOVER * MIDNIGHT_ROLLOVER_CHECK))
 #define MIDNIGHT_ROLLOVER_CHECK ( GLOB.rollovercheck_last_timeofday != world.timeofday ? update_midnight_rollover() : GLOB.midnight_rollovers )
 
-/// Gets the sign of x, returns -1 if negative, 0 if 0, 1 if positive
-#define SIGN(x) ( ((x) > 0) - ((x) < 0) )
-
 /// Returns the integer closest to 0 from a division
-#define SIGNED_FLOOR_DIVISION(x, y) (SIGN(x) * FLOOR(abs(x) / y, 1))
+#define SIGNED_FLOOR_DIVISION(x, y) (sign(x) * floor(abs(x) / y))
 
 #define CEILING(x, y) ( -round(-(x) / (y)) * (y) )
 
@@ -56,8 +53,8 @@
 /// Helper that increments and wraps the passed in number when it hits the integer limit
 #define WRAP_UID(val) WRAP_UP(val, SHORT_REAL_LIMIT - 1)
 
-// Real modulus that handles decimals
-#define MODULUS(x, y) ( (x) - FLOOR(x, y))
+// Real modulus that handles decimals, now just a wrapper for BYOND's %% operator
+#define MODULUS(x, y) ((x) %% (y))
 
 // Cotangent
 #define COT(x) (1 / tan(x))

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -124,8 +124,8 @@
 	return A.totalResistance() - B.totalResistance()
 
 /proc/cmp_quirk_asc(datum/quirk/A, datum/quirk/B)
-	var/a_sign = SIGN(initial(A.value) * -1)
-	var/b_sign = SIGN(initial(B.value) * -1)
+	var/a_sign = sign(initial(A.value) * -1)
+	var/b_sign = sign(initial(B.value) * -1)
 
 	// Neutral traits go last.
 	if(a_sign == 0)

--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -56,8 +56,8 @@
 	var/abs_x_distance = abs(x_distance)//Absolute value of x distance
 	var/abs_y_distance = abs(y_distance)
 
-	var/x_distance_sign = SIGN(x_distance) //Sign of x distance (+ or -)
-	var/y_distance_sign = SIGN(y_distance)
+	var/x_distance_sign = sign(x_distance) //Sign of x distance (+ or -)
+	var/y_distance_sign = sign(y_distance)
 
 	var/x = abs_x_distance >> 1 //Counters for steps taken, setting to distance/2
 	var/y = abs_y_distance >> 1 //Bit-shifting makes me l33t.  It also makes get_line() unnecessarily fast.
@@ -228,7 +228,7 @@
 /// Takes a value, and a threshold it has to at least match
 /// returns the correctly signed value max'd to the threshold
 /proc/at_least(new_value, threshold)
-	var/sign = SIGN(new_value)
+	var/sign = sign(new_value)
 	// SIGN will return 0 if the value is 0, so we just go to the positive threshold
 	if(!sign)
 		return threshold

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -241,7 +241,7 @@
 		if(Y1 == Y2)
 			return TRUE //Light cannot be blocked on same tile
 		else
-			var/sign = SIGN(Y2-Y1)
+			var/sign = sign(Y2-Y1)
 			Y1 += sign
 			while(Y1 != Y2)
 				current_turf = locate(X1, Y1, Z)
@@ -257,8 +257,8 @@
 		//b = y - mx
 		var/b = (Y1 + PY1/ICON_SIZE_Y - OFFSET_Y) - m*(X1 + PX1/ICON_SIZE_X - OFFSET_X)//In tiles
 
-		var/signX = SIGN(X2-X1)
-		var/signY = SIGN(Y2-Y1)
+		var/signX = sign(X2-X1)
+		var/signY = sign(Y2-Y1)
 		if(X1 < X2)
 			b += m
 		while(X1 != X2 || Y1 != Y2)

--- a/code/__HELPERS/stoplag.dm
+++ b/code/__HELPERS/stoplag.dm
@@ -14,12 +14,12 @@
 // We don't want spurious hard deletes off this, so let's only sleep for the requested period of time here yeah?
 #ifdef UNIT_TESTS
 	sleep(initial_delay)
-	return CEILING(DS2TICKS(initial_delay), 1)
+	return ceil(DS2TICKS(initial_delay))
 #else
 	. = 0
 	var/i = DS2TICKS(initial_delay)
 	do
-		. += CEILING(i * DELTA_CALC, 1)
+		. += ceil(i * DELTA_CALC)
 		sleep(i * world.tick_lag * DELTA_CALC)
 		i *= 2
 	while (TICK_USAGE > min(TICK_LIMIT_TO_RUN, Master.current_ticklimit))

--- a/code/_onclick/hud/screen_objects/alert.dm
+++ b/code/_onclick/hud/screen_objects/alert.dm
@@ -1018,7 +1018,7 @@
 			return PROCESS_KILL
 		cut_overlay(time_left_overlay)
 		time_left_overlay = new
-		time_left_overlay.maptext = MAPTEXT("<span style='color: [(timeleft <= 10 SECONDS) ? "red" : "white"]'><b>[CEILING(timeleft / (1 SECONDS), 1)]</b></span>")
+		time_left_overlay.maptext = MAPTEXT("<span style='color: [(timeleft <= 10 SECONDS) ? "red" : "white"]'><b>[ceil(timeleft / (1 SECONDS))]</b></span>")
 		time_left_overlay.transform = time_left_overlay.transform.Translate(4, 19)
 		add_overlay(time_left_overlay)
 

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -960,8 +960,8 @@
 	angle = new_angle
 	x_rate = sin(angle)
 	y_rate = cos(angle)
-	x_sign = SIGN(x_rate)
-	y_sign = SIGN(y_rate)
+	x_sign = sign(x_rate)
+	y_sign = sign(y_rate)
 	x_rate = abs(x_rate)
 	y_rate = abs(y_rate)
 	x_ticker = 0

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -620,7 +620,7 @@ SUBSYSTEM_DEF(timer)
 			be supported and may refuse to run or run with a 0 wait")
 
 	if (flags & TIMER_CLIENT_TIME) // REALTIMEOFDAY has a resolution of 1 decisecond
-		wait = max(CEILING(wait, 1), 1) // so if we use tick_lag timers may be inserted in the "past"
+		wait = max(ceil(wait), 1) // so if we use tick_lag timers may be inserted in the "past"
 	else
 		wait = max(CEILING(wait, world.tick_lag), world.tick_lag)
 

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -166,10 +166,10 @@
 		var/final_x = segment.x
 		var/final_y = segment.y
 		if(abs(Pixel_x)>32)
-			final_x += Pixel_x > 0 ? round(Pixel_x/32) : CEILING(Pixel_x/32, 1)
+			final_x += Pixel_x > 0 ? round(Pixel_x/32) : ceil(Pixel_x/32)
 			Pixel_x %= 32
 		if(abs(Pixel_y)>32)
-			final_y += Pixel_y > 0 ? round(Pixel_y/32) : CEILING(Pixel_y/32, 1)
+			final_y += Pixel_y > 0 ? round(Pixel_y/32) : ceil(Pixel_y/32)
 			Pixel_y %= 32
 
 		segment.forceMove(locate(final_x, final_y, segment.z))

--- a/code/datums/components/cracked.dm
+++ b/code/datums/components/cracked.dm
@@ -35,7 +35,7 @@
 		return
 
 	var/current_percent = 1 - (new_value / cracked_max_integrity)
-	var/cracks = CEILING(10 * current_percent, 1) // 1 crack per 10% integrity lost
+	var/cracks = ceil(10 * current_percent) // 1 crack per 10% integrity lost
 	var/current_cracks = length(applied_cracks)
 	if(!islist(source.filters))
 		if(isnull(source.filters))

--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -396,7 +396,7 @@
 		turn_off()
 	range = clamp(CEILING(new_range, 0.5), 1, 6)
 	var/pixel_bounds = ((range - 1) * 64) + 32
-	lumcount_range = CEILING(range, 1)
+	lumcount_range = ceil(range)
 	hide_from_holder()
 
 	visible_mask.icon = light_overlays["[pixel_bounds]"]

--- a/code/datums/components/throwbonus_on_windup.dm
+++ b/code/datums/components/throwbonus_on_windup.dm
@@ -163,7 +163,7 @@
 	. = ..()
 	var/static/list/bar_positions = list(0, 2, 4, 6, 8)
 	var/current_percentage = current_count / maximum_count
-	var/bars_to_add = CEILING(length(bar_positions) * current_percentage, 1)
+	var/bars_to_add = ceil(length(bar_positions) * current_percentage)
 	for(var/curr_number in 1 to bars_to_add)
 		var/bar_color
 		switch(curr_number)

--- a/code/datums/components/tug_towards.dm
+++ b/code/datums/components/tug_towards.dm
@@ -108,8 +108,8 @@
 
 			tuggers += 1
 			var/strength = tugging_to_targets[target]
-			total_tug_x += SIGN(target.x - atom_parent.x) * strength
-			total_tug_y += SIGN(target.y - atom_parent.y) * strength
+			total_tug_x += sign(target.x - atom_parent.x) * strength
+			total_tug_y += sign(target.y - atom_parent.y) * strength
 
 		// Intentionally not trig--something at a corner with a strength of 1 should have
 		// you at the corner, rather than root(2).

--- a/code/datums/elements/volatile_gas_storage.dm
+++ b/code/datums/elements/volatile_gas_storage.dm
@@ -33,7 +33,7 @@
 	if(expelled_pressure < minimum_explosive_pressure)
 		return
 
-	var/explosive_force = CEILING((expelled_pressure / max_explosive_pressure) * max_explosive_force , 1)
+	var/explosive_force = ceil((expelled_pressure / max_explosive_pressure) * max_explosive_force )
 	// This is supposed to represent only shrapnel and no fire
 	// Maybe one day we'll get something a bit better
 	explosion(get_turf(origin), light_impact_range=explosive_force, smoke=FALSE, explosion_cause = origin)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -117,7 +117,7 @@
 		TIMER_COOLDOWN_START(user, "general_emote_audio_cooldown", general_emote_audio_cooldown)
 		var/frequency = null
 		if (affected_by_pitch && SStts.tts_enabled && SStts.pitch_enabled)
-			frequency = rand(MIN_EMOTE_PITCH, MAX_EMOTE_PITCH) * (1 + sqrt(abs(user.pitch)) * SIGN(user.pitch) * EMOTE_TTS_PITCH_MULTIPLIER)
+			frequency = rand(MIN_EMOTE_PITCH, MAX_EMOTE_PITCH) * (1 + sqrt(abs(user.pitch)) * sign(user.pitch) * EMOTE_TTS_PITCH_MULTIPLIER)
 		else if(vary)
 			frequency = rand(MIN_EMOTE_PITCH, MAX_EMOTE_PITCH)
 		playsound(source = user,soundin = tmp_sound,vol = 50, vary = FALSE, ignore_walls = sound_wall_ignore, frequency = frequency)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -1153,7 +1153,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	var/additional_row = (!(adjusted_contents % screen_max_columns) && adjusted_contents < max_slots)
 
 	var/columns = clamp(max_slots, 1, screen_max_columns)
-	var/rows = clamp(CEILING(adjusted_contents / columns, 1) + additional_row, 1, screen_max_rows)
+	var/rows = clamp(ceil(adjusted_contents / columns) + additional_row, 1, screen_max_rows)
 
 	for (var/mob/ui_user as anything in storage_interfaces)
 		if (isnull(storage_interfaces[ui_user]))

--- a/code/datums/storage/subtypes/cyborg.dm
+++ b/code/datums/storage/subtypes/cyborg.dm
@@ -32,7 +32,7 @@
 		adjusted_contents = length(numbered_contents)
 
 	var/columns = clamp(max_slots, 1, screen_max_columns)
-	var/rows = clamp(CEILING(adjusted_contents / columns, 1), 1, screen_max_rows)
+	var/rows = clamp(ceil(adjusted_contents / columns), 1, screen_max_rows)
 
 	for (var/mob/ui_user as anything in storage_interfaces)
 		if (isnull(storage_interfaces[ui_user]))

--- a/code/game/machinery/big_manipulator/big_manipulator_interactions.dm
+++ b/code/game/machinery/big_manipulator/big_manipulator_interactions.dm
@@ -220,7 +220,7 @@
 		return TRUE
 
 	// Breaking the angle up into 45 degree steps
-	var/rotation_step = 45 * SIGN(angle_diff)
+	var/rotation_step = 45 * sign(angle_diff)
 	do_step_rotation(target_point, callback, current_angle, target_angle, rotation_step, 0, total_rotation_time)
 
 	return TRUE

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -23,7 +23,7 @@
 	if(!.)
 		return
 
-	var/sweetspot_range = clamp(CEILING(flashbang_range/sweetspot_divider, 1), 0, flashbang_range)
+	var/sweetspot_range = clamp(ceil(flashbang_range/sweetspot_divider), 0, flashbang_range)
 	set_light(sweetspot_range, sweetspot_range, flashbang_light)
 
 /obj/item/grenade/flashbang/detonate(mob/living/lanced_by)
@@ -53,7 +53,7 @@
 		return
 	living_mob.show_message(span_warning("BANG"), MSG_AUDIBLE)
 	var/distance = get_dist(get_turf(src), turf)
-	var/sweetspot_range = clamp(CEILING(flashbang_range/sweetspot_divider, 1), 0, flashbang_range)
+	var/sweetspot_range = clamp(ceil(flashbang_range/sweetspot_divider), 0, flashbang_range)
 
 	//Flash
 	var/attempt_flash = living_mob.flash_act(affect_silicon = 1)

--- a/code/game/objects/items/rcd/RHD.dm
+++ b/code/game/objects/items/rcd/RHD.dm
@@ -177,7 +177,7 @@
 /obj/item/construction/update_overlays()
 	. = ..()
 	if(has_ammobar)
-		var/ratio = CEILING((matter / max_matter) * ammo_sections, 1)
+		var/ratio = ceil((matter / max_matter) * ammo_sections)
 		if(ratio > 0)
 			. += "[icon_state]_charge[ratio]"
 

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -50,7 +50,7 @@
 		. += span_notice("Use while in your hand to change what type of [src] you want.")
 	if(throwforce && !is_cyborg) //do not want to divide by zero or show the message to borgs who can't throw
 		var/damage_value
-		switch(CEILING(MAX_LIVING_HEALTH / throwforce, 1)) //throws to crit a human
+		switch(ceil(MAX_LIVING_HEALTH / throwforce)) //throws to crit a human
 			if(1 to 3)
 				damage_value = "superb"
 			if(4 to 6)

--- a/code/game/objects/items/tools/engineering/weldingtool.dm
+++ b/code/game/objects/items/tools/engineering/weldingtool.dm
@@ -86,7 +86,7 @@
 	. = ..()
 	if(change_icons)
 		var/ratio = get_fuel() / max_fuel
-		ratio = CEILING(ratio*4, 1) * 25
+		ratio = ceil(ratio*4) * 25
 		. += "[initial(icon_state)][ratio]"
 	if(welding)
 		. += "[initial(icon_state)]-on"

--- a/code/game/objects/items/tools/medical/defib.dm
+++ b/code/game/objects/items/tools/medical/defib.dm
@@ -103,7 +103,7 @@
 		. += powered_state
 		if(!QDELETED(cell) && charge_state)
 			var/ratio = cell.charge / cell.maxcharge
-			ratio = CEILING(ratio*4, 1) * 25
+			ratio = ceil(ratio*4) * 25
 			. += "[charge_state][ratio]"
 	if(!cell && nocell_state)
 		. += "[nocell_state]"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -422,7 +422,7 @@
 		QUEUE_SMOOTH(src)
 
 	var/ratio = atom_integrity / max_integrity
-	ratio = CEILING(ratio*4, 1) * 25
+	ratio = ceil(ratio*4) * 25
 	if(ratio > 75)
 		return
 	. += mutable_appearance('icons/obj/structures.dmi', "damage[ratio]", -(layer+0.1))

--- a/code/modules/antagonists/blood_worm/actions/leech_blood.dm
+++ b/code/modules/antagonists/blood_worm/actions/leech_blood.dm
@@ -118,7 +118,7 @@
 	if (synth_content >= 1)
 		target.balloon_alert(leech, "fully synthetic")
 	else if (synth_content > 0)
-		target.balloon_alert(leech, "[CEILING(synth_content * 100, 1)]% synthetic")
+		target.balloon_alert(leech, "[ceil(synth_content * 100)]% synthetic")
 
 	// Because of DO_AFTER_CHECK_NEXT_MOVE
 	leech.next_move = 0
@@ -229,7 +229,7 @@
 	if (synth_content >= 1)
 		target.balloon_alert(leech, "fully synthetic")
 	else if (synth_content > 0)
-		target.balloon_alert(leech, "[CEILING(synth_content * 100, 1)]% synthetic")
+		target.balloon_alert(leech, "[ceil(synth_content * 100)]% synthetic")
 
 /datum/action/cooldown/mob_cooldown/blood_worm/leech/proc/leech_container_start_check(mob/living/basic/blood_worm/leech, obj/item/reagent_containers/target, feedback = FALSE)
 	if (!length(get_blood_in_container(target)))

--- a/code/modules/antagonists/blood_worm/blood_worm_text_feedback.dm
+++ b/code/modules/antagonists/blood_worm/blood_worm_text_feedback.dm
@@ -35,7 +35,7 @@
 
 	var/potential_gain = total_blood_after - total_blood_now
 
-	var/rounded_volume = CEILING(cached_blood_volume, 1)
+	var/rounded_volume = ceil(cached_blood_volume)
 
 	var/growth_string = ""
 	if (HAS_TRAIT(bloodbag, TRAIT_BLOOD_WORM_HOST))
@@ -52,14 +52,14 @@
 		else
 			growth_string = ". You are already fully grown"
 
-	var/synth_string = "[CEILING(synth_content * 100, 1)]%"
+	var/synth_string = "[ceil(synth_content * 100)]%"
 	switch(synth_content)
 		if (-INFINITY to 0)
 			synth_string = "not"
 		if (1 to INFINITY)
 			synth_string = "fully"
 		if (0 to 1)
-			synth_string = "[CEILING(synth_content * 100, 1)]%"
+			synth_string = "[ceil(synth_content * 100)]%"
 
 	result += span_notice("[target.p_They()] [target.p_have()] [rounded_volume] unit[rounded_volume == 1 ? "" : "s"] of blood[growth_string]. [target.p_Their()] blood is <b>[synth_string]</b> synthetic.")
 
@@ -83,9 +83,9 @@
 	if (total_required > 0)
 		. += "Growth: [FLOOR(total / total_required * 100, 1)]%"
 	. += "Blood Consumed"
-	. += "- Normal: [CEILING(normal, 1)]u"
-	. += "- Synthetic: [CEILING(synth, 1)]u (MAX: [maximum_synth_blood]u)"
-	. += "- Total: [CEILING(total, 1)]u (REQ: [total_required]u)"
+	. += "- Normal: [ceil(normal)]u"
+	. += "- Synthetic: [ceil(synth)]u (MAX: [maximum_synth_blood]u)"
+	. += "- Total: [ceil(total)]u (REQ: [total_required]u)"
 
 /// Sends text to the blood worm, whether they are possessing a host or not.
 /mob/living/basic/blood_worm/proc/to_chat_self(text)

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -135,7 +135,7 @@
 	if((amount < 0 && has_money(-amount)) || amount > 0)
 		var/debt_collected = 0
 		if(account_debt > 0 && amount > 0)
-			debt_collected = min(CEILING(amount*DEBT_COLLECTION_COEFF, 1), account_debt)
+			debt_collected = min(ceil(amount*DEBT_COLLECTION_COEFF), account_debt)
 		account_balance += amount - debt_collected
 		if(reason)
 			add_log_to_history(amount, reason)

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -68,7 +68,7 @@
 	while(number_of_hostiles > hostiles_spawn.len)
 		hostiles_spawn += get_random_station_turf()
 
-	next_boss_spawn = start_when + CEILING(2 * number_of_hostiles / number_of_bosses, 1)
+	next_boss_spawn = start_when + ceil(2 * number_of_hostiles / number_of_bosses)
 
 /datum/round_event/portal_storm/announce(fake)
 	set waitfor = 0
@@ -124,7 +124,7 @@
 		return FALSE
 
 	if(activeFor == next_boss_spawn)
-		next_boss_spawn += CEILING(number_of_hostiles / number_of_bosses, 1)
+		next_boss_spawn += ceil(number_of_hostiles / number_of_bosses)
 		return TRUE
 	return FALSE
 

--- a/code/modules/food_and_drinks/machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/machinery/monkeyrecycler.dm
@@ -86,7 +86,7 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 	if(stored_matter >= 1)
 		to_chat(user, span_notice("The machine hisses loudly as it condenses the ground monkey meat. After a moment, it dispenses a brand new monkey cube."))
 		playsound(src.loc, 'sound/machines/hiss.ogg', 50, TRUE)
-		for(var/i in 1 to FLOOR(stored_matter, 1))
+		for(var/i in 1 to floor(stored_matter))
 			new /obj/item/food/monkeycube(src.loc)
 			stored_matter--
 		to_chat(user, span_notice("The machine's display flashes that it has [stored_matter] monkeys worth of material left."))

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -244,7 +244,7 @@ GLOBAL_LIST_EMPTY(lighting_sheets)
 	var/list/encode = list()
 	// How far away the turfs we get are, and how many there are are often not the same calculation
 	// So we need to include the visual offset, so we can ensure our sheet is large enough to accept all the distance differences
-	var/bound_range = CEILING(range, 1) + visual_offset
+	var/bound_range = ceil(range) + visual_offset
 
 	// Corners are placed at 0.5 offsets
 	// We need our coords to reflect that (though x_offsets that change the basis for how things are calculated are fine too)
@@ -447,7 +447,7 @@ GLOBAL_LIST_EMPTY(lighting_sheets)
 	if(visual_offsets[1] != offset_x || visual_offsets[2] != offset_y || source_turf != old_source_turf)
 		offset_x = visual_offsets[1]
 		offset_y = visual_offsets[2]
-		visual_offset = max(CEILING(abs(offset_x), 1), CEILING(abs(offset_y), 1))
+		visual_offset = max(ceil(abs(offset_x)), ceil(abs(offset_y)))
 		update = TRUE
 
 	// If we need to update, well, update
@@ -468,7 +468,7 @@ GLOBAL_LIST_EMPTY(lighting_sheets)
 		return list()
 
 	var/oldlum = source_turf.luminosity
-	var/working_range = CEILING(light_range + visual_offset, 1)
+	var/working_range = ceil(light_range + visual_offset)
 	source_turf.luminosity = working_range
 
 	var/uses_multiz = !!GET_LOWEST_STACK_OFFSET(source_turf.z)

--- a/code/modules/mining/lavaland/cain_and_abel/_cain_and_abel.dm
+++ b/code/modules/mining/lavaland/cain_and_abel/_cain_and_abel.dm
@@ -115,7 +115,7 @@
 	attack_speed = initial(attack_speed)
 	var/old_force = force
 	var/bonus_value = combo_count || 1
-	force = CEILING((bonus_value * damage_boost) * force, 1)
+	force = ceil((bonus_value * damage_boost) * force)
 	. = ..()
 	force = old_force
 	set_combo(new_value = combo_count + 1, user = user)

--- a/code/modules/mod/modules/modules_timeline.dm
+++ b/code/modules/mod/modules/modules_timeline.dm
@@ -362,7 +362,7 @@
 /obj/structure/chrono_field/update_overlays()
 	. = ..()
 	var/ttk_frame = 1 - (timetokill / initial(timetokill))
-	ttk_frame = clamp(CEILING(ttk_frame * CHRONO_FRAME_COUNT, 1), 1, CHRONO_FRAME_COUNT)
+	ttk_frame = clamp(ceil(ttk_frame * CHRONO_FRAME_COUNT), 1, CHRONO_FRAME_COUNT)
 	if(ttk_frame != RPpos)
 		RPpos = ttk_frame
 		underlays -= mob_underlay

--- a/code/modules/photography/camera/camera_image_capturing.dm
+++ b/code/modules/photography/camera/camera_image_capturing.dm
@@ -138,7 +138,7 @@
 					img.Scale(base_w * abs(decompose.scale_x), base_h * decompose.scale_y)
 					if(decompose.scale_x < 0)
 						img.Flip(EAST)
-					xo -= base_w * (decompose.scale_x - SIGN(decompose.scale_x)) / 2 * SIGN(decompose.scale_x)
+					xo -= base_w * (decompose.scale_x - sign(decompose.scale_x)) / 2 * sign(decompose.scale_x)
 					yo -= base_h * (decompose.scale_y - 1) / 2
 				// Rotation
 				if(decompose.rotation != 0)

--- a/code/modules/projectiles/boxes_magazines/external/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/external/shotgun.dm
@@ -10,7 +10,7 @@
 
 /obj/item/ammo_box/magazine/m12g/update_icon_state()
 	. = ..()
-	icon_state = "[base_icon_state]-[CEILING(ammo_count(FALSE)/8, 1)*8]"
+	icon_state = "[base_icon_state]-[ceil(ammo_count(FALSE)/8)*8]"
 
 /obj/item/ammo_box/magazine/m12g/stun
 	name = "shotgun magazine (12g taser slugs)"

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -19,9 +19,9 @@
 		return ..()
 
 	if(prob(33)) // 33% of the remaining 75% so another 25%
-		max_charges = CEILING(max_charges / 3, 1)
+		max_charges = ceil(max_charges / 3)
 	else
-		max_charges = CEILING(max_charges / 2, 1)
+		max_charges = ceil(max_charges / 2)
 	return ..()
 
 /obj/item/gun/magic/wand/examine(mob/user)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -817,7 +817,7 @@
 		START_PROCESSING(SSprojectiles, src)
 	// move it now to avoid potentially hitting yourself with firer-hitting projectiles
 	if (!deletion_queued && !hitscan)
-		process_movement(max(FLOOR(speed, 1), 1), tile_limit = TRUE)
+		process_movement(max(floor(speed)), tile_limit = TRUE)
 
 /// Makes projectile home onto the passed target with minor inaccuracy
 /obj/projectile/proc/set_homing_target(atom/target)
@@ -907,7 +907,7 @@
 		pixels_to_move = SSprojectiles.max_pixels_per_tick
 
 	overrun += MODULUS(pixels_to_move, 1)
-	pixels_to_move = FLOOR(pixels_to_move, 1)
+	pixels_to_move = floor(pixels_to_move)
 	SEND_SIGNAL(src, COMSIG_PROJECTILE_BEFORE_MOVE)
 
 	// Registering turf entries is done here instead of a connect_loc because else it could be called multiple times per tick and waste performance
@@ -978,8 +978,8 @@
 			distance_to_move = SSprojectiles.pixels_per_decisecond
 
 		// Figure out if we move to the next turf and if so, what its positioning relatively to us is
-		var/x_shift = distance_to_move >= x_to_border ? SIGN(movement_vector.pixel_x) : 0
-		var/y_shift = distance_to_move >= y_to_border ? SIGN(movement_vector.pixel_y) : 0
+		var/x_shift = distance_to_move >= x_to_border ? sign(movement_vector.pixel_x) : 0
+		var/y_shift = distance_to_move >= y_to_border ? sign(movement_vector.pixel_y) : 0
 		var/moving_turfs = x_shift || y_shift
 		// Calculate where in the turf we will be when we cross the edge.
 		// This is a projectile variable because its also used in hit VFX

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -86,8 +86,8 @@ Basically, we fill the time between now and 2s from now with hands based off the
 /datum/reagent/inverse/helgrasp/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	spawn_hands(affected_mob)
-	lag_remainder += seconds_per_tick - FLOOR(seconds_per_tick, 1)
-	seconds_per_tick = FLOOR(seconds_per_tick, 1)
+	lag_remainder += seconds_per_tick - floor(seconds_per_tick)
+	seconds_per_tick = floor(seconds_per_tick)
 	if(lag_remainder >= 1)
 		seconds_per_tick += 1
 		lag_remainder -= 1

--- a/code/modules/transport/tram/tram_floors.dm
+++ b/code/modules/transport/tram/tram_floors.dm
@@ -232,7 +232,7 @@
 /obj/structure/thermoplastic/update_icon_state()
 	. = ..()
 	var/ratio = atom_integrity / max_integrity
-	ratio = CEILING(ratio * 4, 1) * 25
+	ratio = ceil(ratio * 4) * 25
 	if(ratio > 75)
 		icon_state = base_icon_state
 		return
@@ -324,7 +324,7 @@
 	. = ..()
 	if(throwforce && !is_cyborg) //do not want to divide by zero or show the message to borgs who can't throw
 		var/damage_value
-		switch(CEILING(MAX_LIVING_HEALTH / throwforce, 1)) //throws to crit a human
+		switch(ceil(MAX_LIVING_HEALTH / throwforce)) //throws to crit a human
 			if(1 to 3)
 				damage_value = "superb"
 			if(4 to 6)

--- a/code/modules/transport/tram/tram_structures.dm
+++ b/code/modules/transport/tram/tram_structures.dm
@@ -103,7 +103,7 @@
 /obj/structure/tram/update_overlays(updates = ALL)
 	. = ..()
 	var/ratio = atom_integrity / max_integrity
-	ratio = CEILING(ratio * 4, 1) * 25
+	ratio = ceil(ratio * 4) * 25
 	cut_overlay(damage_overlay)
 	if(ratio > 75)
 		return


### PR DESCRIPTION

## About The Pull Request

this translates some various
- `FLOOR(x, 1)` -> `floor(x)`
- `CEILING(x, 1)` -> `ceil(x)`
- `SIGN(x)` define is gone, just uses the native BYOND `sign()` now.

Also, the `MODULUS` define is just a wrapper for the [BYOND `%%` operator](https://ref.harry.live/operator/modulomodulo) now.

would be nice if someone double checked to make sure there's no potential subtle oddities resulting from this.

## Why It's Good For The Game

These procs presumably did not exist whenever the defines were written - and they are BYOND builtins, meaning it will just be, say, one `sign` instruction, instead of two comparisons and a subtraction.

## Changelog

no player-facing changes