### PR TITLE
Fixes empty message when ejecting an ID card from PDA.

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -371,6 +371,7 @@
  * * silent - Boolean, determines whether fluff text would be printed
  */
 /obj/item/modular_computer/remove_id(mob/user, silent = FALSE)
+	var/obj/item/lost_id = stored_id
 	if(!stored_id)
 		return ..()
 
@@ -381,8 +382,6 @@
 		user.put_in_hands(stored_id)
 	else
 		stored_id.forceMove(drop_location())
-
-	var/obj/item/lost_id = stored_id
 	stored_id = null
 
 	if(!silent && !isnull(user))


### PR DESCRIPTION
## About The Pull Request

this
<img width="293" height="36" alt="image" src="https://github.com/user-attachments/assets/d41e4190-ea2a-4b47-9aec-198acdaf2f4e" />

## Changelog

:cl:
fix: Fixed empty message when ejecting an ID card from PDA.
/:cl:
