### PR TITLE
Medical LARP: Cause of Death field

### DIFF
--- a/code/datums/records/record.dm
+++ b/code/datums/records/record.dm
@@ -75,6 +75,8 @@
 	var/minor_disabilities_desc
 	/// Physical status of this person in medical records.
 	var/physical_status
+	/// If declared dead, this is set as the cause of death, wiped once declared alive again.
+	var/cause_of_death
 	/// Mental status of this person in medical records.
 	var/mental_status
 	/// Positive and neutral quirk strings

--- a/code/game/machinery/computer/records/medical.dm
+++ b/code/game/machinery/computer/records/medical.dm
@@ -59,6 +59,7 @@
 			major_disabilities = target.major_disabilities_desc,
 			minor_disabilities = target.minor_disabilities_desc,
 			physical_status = target.physical_status,
+			cause_of_death = target.cause_of_death,
 			mental_status = target.mental_status,
 			name = target.name,
 			notes = notes,
@@ -123,6 +124,8 @@
 				return FALSE
 
 			target.physical_status = physical_status
+			if(physical_status != PHYSICAL_DECEASED)
+				target.cause_of_death = null
 
 			return TRUE
 
@@ -133,6 +136,13 @@
 
 			target.mental_status = mental_status
 
+			return TRUE
+
+		if("set_cause_of_death")
+			var/death_text = reject_bad_name(params["cause"], allow_numbers = TRUE, max_length = MAX_DESC_LEN, strict = TRUE, cap_after_symbols = FALSE)
+			if(!death_text)
+				return FALSE
+			target.cause_of_death = death_text
 			return TRUE
 
 	return FALSE

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import {
   Box,
   Button,
+  Input,
   LabeledList,
   NoticeBox,
   RestrictedInput,
@@ -43,6 +44,7 @@ export const MedicalRecordView = (props) => {
     major_disabilities,
     minor_disabilities,
     physical_status,
+    cause_of_death,
     mental_status,
     name,
     quirk_notes,
@@ -166,6 +168,23 @@ export const MedicalRecordView = (props) => {
                 {physical_status}
               </Box>
             </LabeledList.Item>
+            {physical_status === 'Deceased' && (
+              <LabeledList.Item label="Cause of Death">
+                <Box>
+                  <Input
+                    fluid
+                    placeholder="Input Cause of Death..."
+                    value={cause_of_death}
+                    onChange={(value) =>
+                      act('set_cause_of_death', {
+                        crew_ref: crew_ref,
+                        cause: value,
+                      })
+                    }
+                  />
+                </Box>
+              </LabeledList.Item>
+            )}
             <LabeledList.Item
               buttons={mental_statuses.map((button, index) => {
                 const isSelected = button === mental_status;

--- a/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
@@ -20,6 +20,7 @@ export type MedicalRecord = {
   major_disabilities: string;
   minor_disabilities: string;
   physical_status: string;
+  cause_of_death: string;
   mental_status: string;
   name: string;
   notes: MedicalNote[];


### PR DESCRIPTION
## About The Pull Request

This was sitting on my deathwatch branch, thought I might as well add it. When pronounced dead, Medical Records will now ask for a cause of death.

<img width="749" height="551" alt="image" src="https://github.com/user-attachments/assets/a2733131-ca5a-4dd5-b768-4a82e0bccd2e" />


## Why It's Good For The Game


<img width="373" height="65" alt="image" src="https://github.com/user-attachments/assets/1f2bfc21-78f0-4c0c-bf73-56854178a030" />


## Changelog

:cl:
add: Medbay/Detectives can now add a Cause of Death to people's medical records when set as deceased.
/:cl: