### PR TITLE
Express consoles now check that they're express when getting pack data

### DIFF
--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -137,6 +137,24 @@
 	data["supplies"] = meme_pack_data
 	return data
 
+/obj/machinery/computer/cargo/express/ui_static_data(mob/user)
+	var/list/data = list()
+	data["max_order"] = CARGO_MAX_ORDER
+	data["supplies"] = list()
+
+	for(var/pack_id in SSshuttle.supply_packs)
+		var/datum/supply_pack/pack = SSshuttle.supply_packs[pack_id]
+		if(!data["supplies"][pack.group])
+			data["supplies"][pack.group] = list(
+				"name" = pack.group,
+				"packs" = get_packs_data(pack.group, TRUE),
+			)
+
+	data["displayed_currency_full_name"] = " [MONEY_NAME]"
+	data["displayed_currency_name"] = " [MONEY_SYMBOL]"
+
+	return data
+
 /obj/machinery/computer/cargo/express/get_discount()
 	return (obj_flags & EMAGGED) ? EXPRESS_EMAG_DISCOUNT : 1
 


### PR DESCRIPTION

## About The Pull Request
Express consoles now pass "express" as TRUE to get_packs_data(). Previously, get_packs_data() had "express" always passed as FALSE.
## Why It's Good For The Game
The express console checks now work properly. Downstreams such as Nova Sector and Oculis also check "express", so now those checks should work correctly now too.
## Proof of Testing
<img width="2558" height="1381" alt="image" src="https://github.com/user-attachments/assets/7cb4e596-3f83-4d09-bbf6-0fbcf2a747d0" />
This shows that the Crab Rocket pack is now orderable through the express crate, which has the ORDER_POD_ONLY trait, making it only orderable from the express console.

## Changelog
:cl:
fix: Express consoles now properly check that they're express when getting pack data.
/:cl:
