### PR TITLE
Fix cyborgs being unable to do surgeries that sleep in preop

### DIFF
--- a/code/modules/surgery/operations/_operation.dm
+++ b/code/modules/surgery/operations/_operation.dm
@@ -1109,8 +1109,13 @@ GLOBAL_DATUM_INIT(operations, /datum/operation_holder, new)
 	if(!pre_preop(operating_on, surgeon, tool, operation_args))
 		return FALSE
 	// if pre_preop slept, sanity check that everything is still valid
-	if(preop_time != world.time && (patient != get_patient(operating_on) || !surgeon.Adjacent(patient || operating_on) || !surgeon.is_holding(tool) || !operate_check(patient, operating_on, surgeon, tool, operation_args)))
-		return FALSE
+	if(preop_time != world.time)
+		if(patient != get_patient(operating_on))
+			return FALSE
+		if(!in_range(patient || operating_on, surgeon))
+			return FALSE
+		if(!operate_check(patient, operating_on, surgeon, tool, operation_args))
+			return FALSE
 
 	play_operation_sound(operating_on, surgeon, tool, preop_sound)
 	on_preop(operating_on, surgeon, tool, operation_args)


### PR DESCRIPTION
## About The Pull Request

`is_holding` fails for omnitools

## Changelog
:cl: Melbert
fix: Fix cyborgs being unable to do surgeries that ask for user input before it begins
/:cl:
