### PR TITLE
Fixes tape instantly falling off bleeding wounds & cleanmedical gauze

### DIFF
--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -649,7 +649,7 @@
 	var/obj/item/stack/medical/wrap/current_gauze = LAZYACCESS(limb.applied_items, LIMB_ITEM_GAUZE)
 	if ((wound_flags & ACCEPTS_GAUZE) && current_gauze)
 		var/sling_condition = get_gauze_condition()
-		desc = "[victim.p_Their()] [limb.plaintext_zone] is [sling_condition] fastened in a sling of [current_gauze.name]"
+		desc = "[victim.p_Their()] [limb.plaintext_zone] is [sling_condition]fastened in a sling of [current_gauze.name]"
 	else
 		desc = "[victim.p_Their()] [limb.plaintext_zone] [examine_desc]"
 
@@ -693,13 +693,13 @@
 
 	switch(current_gauze.absorption_capacity)
 		if(0 to 1.25)
-			return "just barely"
+			return "just barely "
 		if(1.25 to 2.75)
-			return "loosely"
+			return "loosely "
 		if(2.75 to 4)
-			return "mostly"
+			return "mostly "
 		if(4 to INFINITY)
-			return "tightly"
+			return "tightly "
 
 /// Spans [desc] based on our severity.
 /datum/wound/proc/get_desc_intensity(desc)

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -158,15 +158,15 @@
 		var/bandage_condition
 		switch(current_gauze.absorption_capacity)
 			if(0 to 1.25)
-				bandage_condition = "nearly ruined"
+				bandage_condition = "nearly ruined "
 			if(1.25 to 2.75)
-				bandage_condition = "badly worn"
+				bandage_condition = "badly worn "
 			if(2.75 to 4)
-				bandage_condition = "slightly stained"
+				bandage_condition = "slightly stained "
 			if(4 to INFINITY)
-				bandage_condition = "clean"
+				bandage_condition = "clean "
 
-		condition += " underneath a dressing of [bandage_condition] [current_gauze.name]."
+		condition += " underneath a dressing of [bandage_condition][current_gauze.name]."
 	else
 		switch(infection)
 			if(WOUND_INFECTION_MODERATE to WOUND_INFECTION_SEVERE)

--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -113,7 +113,7 @@
 
 	//gauze always reduces blood flow, even for non bleeders
 	var/obj/item/stack/medical/wrap/current_gauze = LAZYACCESS(limb.applied_items, LIMB_ITEM_GAUZE)
-	if(current_gauze)
+	if(current_gauze && current_gauze.absorption_rate)
 		var/gauze_power = current_gauze.absorption_rate
 		limb.seep_gauze(gauze_power * seconds_per_tick)
 		adjust_blood_flow((-clot_rate * seconds_per_tick) + (-gauze_power * gauzed_clot_rate * seconds_per_tick))

--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -113,7 +113,7 @@
 
 	//gauze always reduces blood flow, even for non bleeders
 	var/obj/item/stack/medical/wrap/current_gauze = LAZYACCESS(limb.applied_items, LIMB_ITEM_GAUZE)
-	if(current_gauze && current_gauze.absorption_rate)
+	if(current_gauze?.absorption_rate)
 		var/gauze_power = current_gauze.absorption_rate
 		limb.seep_gauze(gauze_power * seconds_per_tick)
 		adjust_blood_flow((-clot_rate * seconds_per_tick) + (-gauze_power * gauzed_clot_rate * seconds_per_tick))

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -102,13 +102,13 @@
 	// how much life we have left in these bandages
 	switch(current_gauze.absorption_capacity)
 		if(0 to 1.25)
-			msg += "nearly ruined"
+			msg += "nearly ruined "
 		if(1.25 to 2.75)
-			msg += "badly worn"
+			msg += "badly worn "
 		if(2.75 to 4)
-			msg += "slightly bloodied"
+			msg += "slightly bloodied "
 		if(4 to INFINITY)
-			msg += "clean"
+			msg += "clean "
 	msg += "[current_gauze.name]!"
 
 	return "<B>[msg.Join()]</B>"
@@ -158,7 +158,7 @@
 			adjust_blood_flow(0.25) // old heparin used to just add +2 bleed stacks per tick, this adds 0.5 bleed flow to all open cuts which is probably even stronger as long as you can cut them first
 
 	var/obj/item/stack/medical/wrap/current_gauze = LAZYACCESS(limb.applied_items, LIMB_ITEM_GAUZE)
-	if(current_gauze)
+	if(current_gauze && current_gauze.absorption_rate)
 		var/gauze_power = current_gauze.absorption_rate
 		limb.seep_gauze(gauze_power * seconds_per_tick)
 		adjust_blood_flow(-gauze_power * seconds_per_tick)

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -158,7 +158,7 @@
 			adjust_blood_flow(0.25) // old heparin used to just add +2 bleed stacks per tick, this adds 0.5 bleed flow to all open cuts which is probably even stronger as long as you can cut them first
 
 	var/obj/item/stack/medical/wrap/current_gauze = LAZYACCESS(limb.applied_items, LIMB_ITEM_GAUZE)
-	if(current_gauze && current_gauze.absorption_rate)
+	if(current_gauze?.absorption_rate)
 		var/gauze_power = current_gauze.absorption_rate
 		limb.seep_gauze(gauze_power * seconds_per_tick)
 		adjust_blood_flow(-gauze_power * seconds_per_tick)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1648,7 +1648,7 @@
  */
 /obj/item/bodypart/proc/seep_gauze(seep_amt = 0)
 	var/obj/item/stack/medical/wrap/current_gauze = LAZYACCESS(applied_items, LIMB_ITEM_GAUZE)
-	if(!current_gauze)
+	if(!current_gauze || !current_gauze.absorption_capacity)
 		return FALSE
 	current_gauze.absorption_capacity -= seep_amt
 	if(current_gauze.absorption_capacity <= 0)


### PR DESCRIPTION

## About The Pull Request

Tape doesn't have an `absorption_capacity,` only a `splint_factor,` but when `seep_gauze()` is called its `absorption_capacity` is operated upon, giving it a value, making it fall off.

Also changes wound description spacing to account for wounds that may or may not have gauze with `absorption_capacity`

## Why It's Good For The Game

`splint_factor` still has an effect on some bleeding wounds, so we shouldn't just make tape only applicable to bone wounds
fixes #95632

## Changelog
:cl:

fix: Gauze will stay on bleeding wounds it is applied to(but still not stop bloodflow)

/:cl:
