### PR TITLE
Fix silicons being unable to use operating computer from afar

### DIFF
--- a/code/game/machinery/computer/operating_computer.dm
+++ b/code/game/machinery/computer/operating_computer.dm
@@ -101,7 +101,7 @@
 
 /obj/machinery/computer/operating/ui_status(mob/user, datum/ui_state/state)
 	. = ..()
-	if(isliving(user))
+	if(isliving(user) && !issilicon(user))
 		. = min(., ui_check(user))
 
 /// Checks for special ui state conditions


### PR DESCRIPTION

## About The Pull Request

Yes they are `/mob/living` no they shouldn't be subject to this particular handling

## Why It's Good For The Game

Fixes #95557 

## Changelog
:cl:
fix: fixed silicons being unable to use operating computer from afar
/:cl:
