### PR TITLE
Remove the ability to handcuff shields

### DIFF
--- a/code/game/objects/items/weaponry/shields.dm
+++ b/code/game/objects/items/weaponry/shields.dm
@@ -43,7 +43,6 @@
 /obj/item/shield/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/disarm_attack)
-	AddElement(/datum/element/cuffable_item) //I mean, it has a closed handle, right?
 
 /obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
 	var/effective_block_chance = final_block_chance


### PR DESCRIPTION
## About The Pull Request

It just removes a single line - AddElement(/datum/element/cuffable_item) 
but it does quite a lot for the game.

## Why It's Good For The Game

For quite a while now, attached shields have been a very strong meta, leaving almost no chance of losing against weapons that lack armor penetration. Since the maintainers have decided to fix their old mistakes, I thought maybe this could get merged too. Additionally, I ran a poll among my community, and almost everyone is in favor of fixing this oversight.

## Changelog

:cl: Dolphyuser
balance: Now you can't handcuff shields
/:cl:

