### PR TITLE
Quirk prefrences consistant use `::name`

### DIFF
--- a/code/modules/client/preferences/addict.dm
+++ b/code/modules/client/preferences/addict.dm
@@ -25,7 +25,7 @@
 /datum/preference/choiced/junkie/is_accessible(datum/preferences/preferences)
 	if (!..())
 		return FALSE
-	return "Junkie" in preferences.all_quirks
+	return /datum/quirk/item_quirk/addict/junkie::name in preferences.all_quirks
 
 /datum/preference/choiced/junkie/apply_to_human(mob/living/carbon/human/target, value)
 	return
@@ -45,7 +45,7 @@
 /datum/preference/choiced/smoker/is_accessible(datum/preferences/preferences)
 	if (!..())
 		return FALSE
-	return "Smoker" in preferences.all_quirks
+	return /datum/quirk/item_quirk/addict/smoker::name in preferences.all_quirks
 
 /datum/preference/choiced/smoker/apply_to_human(mob/living/carbon/human/target, value)
 	return
@@ -65,7 +65,7 @@
 /datum/preference/choiced/alcoholic/is_accessible(datum/preferences/preferences)
 	if (!..())
 		return FALSE
-	return "Alcoholic" in preferences.all_quirks
+	return /datum/quirk/item_quirk/addict/alcoholic::name in preferences.all_quirks
 
 /datum/preference/choiced/alcoholic/apply_to_human(mob/living/carbon/human/target, value)
 	return

--- a/code/modules/client/preferences/food_allergy.dm
+++ b/code/modules/client/preferences/food_allergy.dm
@@ -15,7 +15,7 @@
 	if (!..())
 		return FALSE
 
-	return "Food Allergy" in preferences.all_quirks
+	return /datum/quirk/item_quirk/food_allergic::name in preferences.all_quirks
 
 /datum/preference/choiced/food_allergy/apply_to_human(mob/living/carbon/human/target, value)
 	return

--- a/code/modules/client/preferences/glasses.dm
+++ b/code/modules/client/preferences/glasses.dm
@@ -20,7 +20,7 @@
 	if (!..(preferences))
 		return FALSE
 
-	return "Nearsighted" in preferences.all_quirks
+	return /datum/quirk/item_quirk/nearsighted::name in preferences.all_quirks
 
 /datum/preference/choiced/glasses/apply_to_human(mob/living/carbon/human/target, value)
 	return

--- a/code/modules/client/preferences/hemiplegic.dm
+++ b/code/modules/client/preferences/hemiplegic.dm
@@ -12,7 +12,7 @@
 	if (!.)
 		return FALSE
 
-	return "Hemiplegic" in preferences.all_quirks
+	return /datum/quirk/hemiplegic::name in preferences.all_quirks
 
 /datum/preference/choiced/hemiplegic/apply_to_human(mob/living/carbon/human/target, value)
 	return

--- a/code/modules/client/preferences/heterochromatic.dm
+++ b/code/modules/client/preferences/heterochromatic.dm
@@ -7,7 +7,7 @@
 	if (!..(preferences))
 		return FALSE
 
-	return "Heterochromatic" in preferences.all_quirks
+	return /datum/quirk/heterochromatic::name in preferences.all_quirks
 
 /datum/preference/color/heterochromatic/apply_to_human(mob/living/carbon/human/target, value)
 	var/datum/quirk/heterochromatic/hetero_quirk = locate() in target.quirks

--- a/code/modules/client/preferences/paint_color.dm
+++ b/code/modules/client/preferences/paint_color.dm
@@ -9,7 +9,7 @@
 	if (!..(preferences))
 		return FALSE
 
-	return "Tagger" in preferences.all_quirks
+	return /datum/quirk/item_quirk/tagger::name in preferences.all_quirks
 
 /datum/preference/color/paint_color/apply_to_human(mob/living/carbon/human/target, value)
 	return

--- a/code/modules/client/preferences/paraplegic.dm
+++ b/code/modules/client/preferences/paraplegic.dm
@@ -14,7 +14,7 @@
 	if (!.)
 		return FALSE
 
-	return "Paraplegic" in preferences.all_quirks
+	return /datum/quirk/paraplegic::name in preferences.all_quirks
 
 /datum/preference/choiced/paraplegic/apply_to_human(mob/living/carbon/human/target, value)
 	return

--- a/code/modules/client/preferences/phobia.dm
+++ b/code/modules/client/preferences/phobia.dm
@@ -11,7 +11,7 @@
 	if (!..(preferences))
 		return FALSE
 
-	return "Phobia" in preferences.all_quirks
+	return /datum/brain_trauma/mild/phobia::name in preferences.all_quirks
 
 /datum/preference/choiced/phobia/apply_to_human(mob/living/carbon/human/target, value)
 	return

--- a/code/modules/client/preferences/prosthetic_limb.dm
+++ b/code/modules/client/preferences/prosthetic_limb.dm
@@ -14,7 +14,7 @@
 	if (!.)
 		return FALSE
 
-	return "Prosthetic Limb" in preferences.all_quirks
+	return /datum/quirk/prosthetic_limb::name in preferences.all_quirks
 
 /datum/preference/choiced/prosthetic/apply_to_human(mob/living/carbon/human/target, value)
 	return

--- a/code/modules/client/preferences/prosthetic_organ.dm
+++ b/code/modules/client/preferences/prosthetic_organ.dm
@@ -15,7 +15,7 @@
 	if (!.)
 		return FALSE
 
-	return "Prosthetic Organ" in preferences.all_quirks
+	return /datum/quirk/prosthetic_organ::name in preferences.all_quirks
 
 /datum/preference/choiced/prosthetic_organ/apply_to_human(mob/living/carbon/human/target, value)
 	return

--- a/code/modules/client/preferences/scarred_eye.dm
+++ b/code/modules/client/preferences/scarred_eye.dm
@@ -14,7 +14,7 @@
 	if (!.)
 		return FALSE
 
-	return "Scarred Eye" in preferences.all_quirks
+	return /datum/quirk/item_quirk/scarred_eye::name in preferences.all_quirks
 
 /datum/preference/choiced/scarred_eye/apply_to_human(mob/living/carbon/human/target, value)
 	return

--- a/code/modules/client/preferences/trans_prosthetic.dm
+++ b/code/modules/client/preferences/trans_prosthetic.dm
@@ -14,7 +14,7 @@
 	if (!.)
 		return FALSE
 
-	return "Transhumanist" in preferences.all_quirks
+	return /datum/quirk/transhumanist::name in preferences.all_quirks
 
 /datum/preference/choiced/trans_prosthetic/apply_to_human(mob/living/carbon/human/target, value)
 	return


### PR DESCRIPTION

## About The Pull Request
Its a coin flip before wether it used the type or just a string.
<img width="428" height="770" alt="image" src="https://github.com/user-attachments/assets/ace436df-7e70-4cb1-8041-34f91bd4220f" />

all instances now use `::name`
## Why It's Good For The Game
On-top of making them easier to change/more resistant to mistake, it gives a clear link between the preference and the quirk and even means it will error if the quirk is removed so no one forgets to remove it.
## Changelog
N/A, nothing player facing.
