### PR TITLE
Adds an admin verb/hotkey to jump to the position of your aghost

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -13,6 +13,7 @@
 #define COMSIG_KB_ADMIN_DSAY_DOWN "keybinding_admin_dsay_down"
 #define COMSIG_KB_ADMIN_TOGGLEBUILDMODE_DOWN "keybinding_admin_togglebuildmode_down"
 #define COMSIG_KB_ADMIN_AGHOST_DOWN "keybinding_admin_aghost_down"
+#define COMSIG_KB_ADMIN_JUMPTOGHOST_DOWN "keybinding_admin_jumptoghost_down"
 #define COMSIG_KB_ADMIN_PLAYERPANELNEW_DOWN "keybinding_admin_playerpanelnew_down"
 #define COMSIG_KB_ADMIN_STEALTHMODETOGGLE_DOWN "keybinding_admin_stealthmodetoggle_down"
 #define COMSIG_KB_ADMIN_INVISIMINTOGGLE_DOWN "keybinding_admin_invisimintoggle_down"

--- a/code/datums/keybinding/admin.dm
+++ b/code/datums/keybinding/admin.dm
@@ -26,6 +26,20 @@
 	SSadmin_verbs.dynamic_invoke_verb(user, /datum/admin_verb/admin_ghost)
 	return TRUE
 
+/datum/keybinding/admin/jump_to_ghost
+	hotkey_keys = list("F4")
+	name = "jump_to_ghost"
+	full_name = "Jump to Aghost"
+	description = "Jump your body to your Aghost"
+	keybind_signal = COMSIG_KB_ADMIN_JUMPTOGHOST_DOWN
+
+/datum/keybinding/admin/jump_to_ghost/down(client/user, turf/target, mousepos_x, mousepos_y)
+	. = ..()
+	if(.)
+		return
+	SSadmin_verbs.dynamic_invoke_verb(user, /datum/admin_verb/jump_to_ghost)
+	return TRUE
+
 /datum/keybinding/admin/player_panel_new
 	hotkey_keys = list("F6")
 	name = "player_panel_new"

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -64,8 +64,8 @@ ADMIN_VERB(jump_to_ghost, R_ADMIN, "Jump To Ghost", "Jump your body to your Agho
 	if(!body)
 		to_chat(user, "No valid body to bring to ghost.", confidential = TRUE)
 		return
-	log_admin("[key_name(user)] jumped to their admin ghost")
-	message_admins("[key_name_admin(user)] jumped to their admin ghost")
+	log_admin("[key_name(user)] jumped to their Aghost at [AREACOORD(ghost.loc)]")
+	message_admins("[key_name_admin(user)] jumped to their Aghost [ADMIN_FLW(body)] at [AREACOORD(ghost.loc)]")
 	body.abstract_move(ghost.loc)
 	body.setDir(ghost.dir)
 	SSadmin_verbs.dynamic_invoke_verb(user, /datum/admin_verb/admin_ghost)

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -56,6 +56,21 @@ ADMIN_VERB(jump_to_key, R_ADMIN, "Jump To Key", "Jump to a specific player.", AD
 	user.mob.abstract_move(M.loc)
 	BLACKBOX_LOG_ADMIN_VERB("Jump To Key")
 
+ADMIN_VERB(jump_to_ghost, R_ADMIN, "Jump To Ghost", "Jump your body to your Aghost.", ADMIN_CATEGORY_GAME)
+	var/mob/dead/observer/ghost = user.mob
+	if(!isobserver(ghost))
+		return
+	var/mob/living/body = ghost?.mind?.current
+	if(!body)
+		to_chat(user, "No valid body to bring to ghost.", confidential = TRUE)
+		return
+	log_admin("[key_name(user)] jumped to their admin ghost")
+	message_admins("[key_name_admin(user)] jumped to their admin ghost")
+	body.abstract_move(ghost.loc)
+	body.setDir(ghost.dir)
+	SSadmin_verbs.dynamic_invoke_verb(user, /datum/admin_verb/admin_ghost)
+	BLACKBOX_LOG_ADMIN_VERB("Jump To Ghost")
+
 ADMIN_VERB_AND_CONTEXT_MENU(get_mob, R_ADMIN, "Get Mob", "Teleport a mob to your location.", ADMIN_CATEGORY_GAME, mob/target in world)
 	var/atom/loc = get_turf(user.mob)
 	target.admin_teleport(loc)


### PR DESCRIPTION

## About The Pull Request

Adds an admin verb "jump-to-ghost" which brings your body to the current loc of your aghost, and a hotkey for this action which defaults to F4

https://github.com/user-attachments/assets/ac28d982-452c-4bd3-b89f-d837bb5df5d9
## Why It's Good For The Game
This is something I've wanted for a while for debugging/localhost stuff, and I imagine it'd also be pretty useful for admin hijinks, like event running or fixing things during a round
It helps bridge the gap between the jump-to-turf context menu action and the somewhat slow and clunky to use jump-to-area, allowing you to teleport short off-screen distances without having to sort through a big list of areas
## Changelog
:cl:
admin: Adds the jump-to-ghost verb, which brings your body to your aghost, it has a hotkey which defaults to F4.
/:cl:
