### PR TITLE
New ".policy" css style class

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -89,6 +89,7 @@
 #define span_medradio(str) ("<span class='medradio'>" + str + "</span>")
 #define span_memo(str) ("<span class='memo'>" + str + "</span>")
 #define span_memoedit(str) ("<span class='memoedit'>" + str + "</span>")
+#define span_policy(str) ("<span class='policy'>" + str + "</span>")
 #define span_message(str) ("<span class='message'>" + str + "</span>")
 #define span_mind_control(str) ("<span class='mind_control'>" + str + "</span>")
 #define span_minorannounce(str) ("<span class='minorannounce'>" + str + "</span>")

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -163,6 +163,7 @@ h1.alert, h2.alert		{color: #000000;}
 .monkey					{color: #975032;}
 .swarmer				{color: #2C75FF;}
 .resonate				{color: #298F85;}
+.policy					{color: #9730db;	font-style: italic;		text-align: center;		font-size: 2;}
 
 .upside_down			{display: inline; -moz-transform: scale(-1, -1); -webkit-transform: scale(-1, -1); -o-transform: scale(-1, -1); -ms-transform: scale(-1, -1); transform: scale(-1, -1);}
 </style>"}

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -908,6 +908,13 @@ em {
   font-size: 125%;
 }
 
+.policy {
+  text-align: center;
+  font-size: 125%;
+  color: hsl(276, 70%, 52%);
+  font-style: italic;
+}
+
 .abductor {
   color: hsl(300, 96%, 38.8%);
   font-style: italic;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -912,6 +912,13 @@ h2.alert {
   font-size: 125%;
 }
 
+.policy {
+  text-align: center;
+  font-size: 125%;
+  color: hsl(276, 70%, 52%);
+  font-style: italic;
+}
+
 .abductor {
   color: hsl(300, 100%, 25.1%);
   font-style: italic;


### PR DESCRIPTION

## About The Pull Request
Adds a new css style class to use, mainly intended for policy.json formatting that i'm tackling before term ends. Also can be used by admins for events with narrate verbs.
```css
.policy {
  text-align: center;
  font-size: 125%;
  color: hsl(276, 70%, 52%);
  font-style: italic;
}
```
Example:
<img width="639" height="321" alt="Untitled" src="https://github.com/user-attachments/assets/ebc1aa8e-6f8a-4f89-a298-376fc88e8919" />
## Why It's Good For The Game

More different styles = good, don't have to fight with manually defining the formatting anymore. Gives policy text colour unique hue (after adding to policy.json), easy to notice and read on both light and dark themes. 

Also saves me time as a headmin. /ᐠ｡ꞈ｡ᐟ\
## Changelog
:cl:Maxipat
add: New css style class for use in config. Now you can notice policy text easier
/:cl:
