### PR TITLE
Transparence trauma is permanent

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
@@ -139,7 +139,7 @@
 /datum/spellbook_entry/perks/transparence/proc/make_stalker(mob/living/carbon/human/wizard, area/new_area)
 	SIGNAL_HANDLER
 
-	if(new_area == GLOB.areas_by_type[/area/centcom/wizard_station])
+	if(istype(new_area, /area/centcom/wizard_station))
 		return
 	wizard.gain_trauma(/datum/brain_trauma/magic/stalker, TRAUMA_RESILIENCE_ABSOLUTE)
 	UnregisterSignal(wizard, COMSIG_ENTER_AREA)

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/perks.dm
@@ -141,7 +141,7 @@
 
 	if(new_area == GLOB.areas_by_type[/area/centcom/wizard_station])
 		return
-	wizard.gain_trauma(/datum/brain_trauma/magic/stalker)
+	wizard.gain_trauma(/datum/brain_trauma/magic/stalker, TRAUMA_RESILIENCE_ABSOLUTE)
 	UnregisterSignal(wizard, COMSIG_ENTER_AREA)
 
 /datum/spellbook_entry/perks/magnetism


### PR DESCRIPTION
## About The Pull Request

I saw this comment when reading up on perk lore and no one had fixed it yet

<img width="707" height="150" alt="image" src="https://github.com/user-attachments/assets/1a10beac-534e-4cc3-9f9d-b2efa2d332f1" />

## Why It's Good For The Game

Circumventing the entire downside of the mechanic (*which is already very negligible as-is seeing you are a wizard*) is kind of wacky I would say

## Changelog

:cl: Meblert
balance: Wizard Transparence perk's curse is permanent 
/:cl:
