### PR TITLE
Pepperspray / Mask dirt tweaks

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -182,6 +182,7 @@ DEFINE_BITFIELD(no_equip_flags, list(
 #define PEPPERPROOF (1<<5) //protects against pepperspray
 #define EARS_COVERED (1<<6)
 
+#define TINT_MILD 1.5 //Threshold of tint level to apply mild tint overlay
 #define TINT_DARKENED 2 //Threshold of tint level to apply weld mask overlay
 #define TINT_BLIND 3 //Threshold of tint level to obscure vision fully
 

--- a/code/datums/components/clothing_dirt.dm
+++ b/code/datums/components/clothing_dirt.dm
@@ -7,6 +7,8 @@
 	var/dirt_state
 	/// Color of current overlay
 	var/dirt_color = COLOR_WHITE
+	/// Tracks if tint has been applied to parent
+	VAR_FINAL/tint_applied = FALSE
 
 /datum/component/clothing_dirt/Initialize(dirt_state = null)
 	if(!isclothing(parent))
@@ -21,6 +23,7 @@
 	RegisterSignal(parent, COMSIG_ATOM_EXPOSE_REAGENTS, PROC_REF(on_expose), TRUE)
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(on_overlays_updated))
 	RegisterSignal(parent, COMSIG_ITEM_GET_SEPARATE_WORN_OVERLAYS, PROC_REF(on_separate_worn_overlays))
+	RegisterSignal(parent, COMSIG_CLOTHING_VISOR_TOGGLE, PROC_REF(on_visor_move))
 
 /datum/component/clothing_dirt/UnregisterFromParent()
 	var/obj/item/clothing/clothing = parent
@@ -38,8 +41,20 @@
 		COMSIG_COMPONENT_CLEAN_ACT,
 		COMSIG_ATOM_UPDATE_OVERLAYS,
 		COMSIG_ITEM_GET_SEPARATE_WORN_OVERLAYS,
+		COMSIG_CLOTHING_VISOR_TOGGLE,
 	))
 	return ..()
+
+/datum/component/clothing_dirt/process(seconds_per_tick)
+	if(!dirtiness)
+		return PROCESS_KILL
+	if(!SPT_PROB(1, seconds_per_tick))
+		return
+	var/obj/item/clothing/clothing = parent
+	if(!iscarbon(clothing.loc) || !(clothing.flags_cover & PEPPERPROOF) || clothing.tint < dirtiness || clothing.tint < TINT_MILD)
+		return
+	var/mob/living/carbon/wearer = clothing.loc
+	to_chat(wearer, span_warning("It's hard to see with all the stuff covering your [clothing.name]..."))
 
 /datum/component/clothing_dirt/proc/on_equip(datum/source, mob/user, slot)
 	SIGNAL_HANDLER
@@ -58,8 +73,9 @@
 
 /datum/component/clothing_dirt/proc/on_examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
+	var/obj/item/clothing/clothing = parent
 	if (dirtiness > 0)
-		examine_list += span_warning("It appears to be covered in something. Won't see much while wearing it until you wash it off.")
+		examine_list += span_warning("It appears to be covered in something. [clothing.tint >= TINT_MILD ? "Won't see much while wearing it until you wash it off." : "Any more and you might struggle to see through it."]")
 
 /datum/component/clothing_dirt/proc/on_overlays_updated(obj/item/clothing/source, list/overlays)
 	SIGNAL_HANDLER
@@ -84,31 +100,62 @@
 /datum/component/clothing_dirt/proc/on_expose(atom/target, list/reagents, datum/reagents/source, methods)
 	SIGNAL_HANDLER
 
-	var/mob/living/carbon/wearer
 	var/obj/item/clothing/clothing = parent
 	if(iscarbon(target))
-		wearer = target
+		var/mob/living/carbon/wearer = target
 		if(is_protected(wearer))
 			return
 
 		if(!(wearer.get_slot_by_item(clothing) & clothing.slot_flags))
 			return
 
+	if(!(clothing.flags_cover & PEPPERPROOF))
+		return
+
 	var/datum/reagent/consumable/condensedcapsaicin/pepper = locate() in reagents
 	if(isnull(pepper) || !(methods & (TOUCH | VAPOR)))
 		return
 
+	if(!dirtiness)
+		START_PROCESSING(SSobj, src)
+
 	dirt_color = pepper.color
-	clothing.tint -= dirtiness
-	dirtiness = min(dirtiness + round(reagents[pepper] / 5), 3)
-	clothing.tint += dirtiness
-	clothing.update_appearance()
-	if(!isnull(wearer))
-		wearer.update_tint()
-		wearer.update_clothing(wearer.get_slot_by_item(clothing))
+	remove_tint(FALSE)
+	dirtiness = min(dirtiness + round(reagents[pepper] / 5, 0.75), 3)
+	apply_tint(TRUE)
 
 /datum/component/clothing_dirt/proc/is_protected(mob/living/carbon/wearer)
 	return wearer.head && wearer.head != parent && (wearer.head.flags_cover & PEPPERPROOF)
+
+/datum/component/clothing_dirt/proc/remove_tint(updates = TRUE)
+	if(!tint_applied)
+		return
+
+	tint_applied = FALSE
+	var/obj/item/clothing/clothing = parent
+	clothing.tint -= dirtiness
+	if(!updates)
+		return
+	clothing.update_appearance()
+	clothing.update_slot_icon()
+	if(iscarbon(clothing.loc))
+		var/mob/living/carbon/wearer = clothing.loc
+		wearer.update_tint()
+
+/datum/component/clothing_dirt/proc/apply_tint(updates = TRUE)
+	if(tint_applied || !dirtiness)
+		return
+
+	tint_applied = TRUE
+	var/obj/item/clothing/clothing = parent
+	clothing.tint += dirtiness
+	if(!updates)
+		return
+	clothing.update_appearance()
+	clothing.update_slot_icon()
+	if(iscarbon(clothing.loc))
+		var/mob/living/carbon/wearer = clothing.loc
+		wearer.update_tint()
 
 /datum/component/clothing_dirt/proc/on_spraypaint(mob/living/carbon/wearer, mob/user, obj/item/toy/crayon/spraycan/spraycan)
 	SIGNAL_HANDLER
@@ -120,30 +167,34 @@
 	if(!(wearer.get_slot_by_item(clothing) & clothing.slot_flags))
 		return
 
+	if(!dirtiness)
+		START_PROCESSING(SSobj, src)
+
 	dirt_color = spraycan.paint_color
-	clothing.tint -= dirtiness
+	remove_tint(FALSE)
 	dirtiness = min(3, dirtiness + rand(2, 3))
-	clothing.tint += dirtiness
-	clothing.update_appearance()
-	wearer.update_clothing(wearer.get_slot_by_item(clothing))
-	wearer.update_tint()
+	apply_tint(TRUE)
 	user.visible_message(span_danger("[user] sprays [spraycan] into the face of [wearer]!"))
 	to_chat(wearer, span_userdanger("[user] sprays [spraycan] into your face!"))
 	return COMPONENT_CANCEL_SPRAYPAINT
 
-/datum/component/clothing_dirt/proc/on_clean(datum/source, clean_types)
+/datum/component/clothing_dirt/proc/on_clean(obj/item/clothing/source, clean_types)
 	SIGNAL_HANDLER
-	. = NONE
 
-	var/obj/item/clothing/clothing = parent
-	var/mob/living/carbon/wearer
-	if(iscarbon(clothing.loc))
-		wearer = clothing.loc
+	if (!dirtiness || !(clean_types & (CLEAN_WASH|CLEAN_SCRUB)))
+		return NONE
 
-	if (clean_types & (CLEAN_WASH|CLEAN_SCRUB))
-		clothing.tint -= dirtiness
-		dirtiness = 0
-		if(!isnull(wearer))
-			wearer.update_tint()
+	remove_tint(TRUE)
+	STOP_PROCESSING(SSobj, src)
+	dirtiness = 0
+	return COMPONENT_CLEANED|COMPONENT_CLEANED_GAIN_XP
 
-		return COMPONENT_CLEANED|COMPONENT_CLEANED_GAIN_XP
+/datum/component/clothing_dirt/proc/on_visor_move(obj/item/clothing/source, up)
+	SIGNAL_HANDLER
+	if(dirtiness <= 0)
+		return
+
+	if(source.flags_cover & PEPPERPROOF)
+		apply_tint(TRUE)
+	else
+		remove_tint(TRUE)

--- a/code/datums/components/clothing_dirt.dm
+++ b/code/datums/components/clothing_dirt.dm
@@ -54,6 +54,8 @@
 	if(!iscarbon(clothing.loc) || !(clothing.flags_cover & PEPPERPROOF) || clothing.tint < dirtiness || clothing.tint < TINT_MILD)
 		return
 	var/mob/living/carbon/wearer = clothing.loc
+	if(wearer.is_blind() && !wearer.is_blind_from(EYES_COVERED))
+		return
 	to_chat(wearer, span_warning("It's hard to see with all the stuff covering your [clothing.name]..."))
 
 /datum/component/clothing_dirt/proc/on_equip(datum/source, mob/user, slot)

--- a/code/datums/components/clothing_dirt.dm
+++ b/code/datums/components/clothing_dirt.dm
@@ -121,7 +121,7 @@
 
 	dirt_color = pepper.color
 	remove_tint(FALSE)
-	dirtiness = min(dirtiness + max(0.75, round(reagents[pepper] / 5, 0.25)), 3)
+	dirtiness = min(dirtiness + round(reagents[pepper] / 5, 0.25), 3)
 	apply_tint(TRUE)
 
 /datum/component/clothing_dirt/proc/is_protected(mob/living/carbon/wearer)

--- a/code/datums/components/clothing_dirt.dm
+++ b/code/datums/components/clothing_dirt.dm
@@ -121,7 +121,7 @@
 
 	dirt_color = pepper.color
 	remove_tint(FALSE)
-	dirtiness = min(dirtiness + round(reagents[pepper] / 5, 0.75), 3)
+	dirtiness = min(dirtiness + max(0.75, round(reagents[pepper] / 5, 0.25)), 3)
 	apply_tint(TRUE)
 
 /datum/component/clothing_dirt/proc/is_protected(mob/living/carbon/wearer)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -582,7 +582,6 @@ BLIND     // can't see anything
 
 /obj/item/clothing/proc/visor_toggling() //handles all the actual toggling of flags
 	up = !up
-	SEND_SIGNAL(src, COMSIG_CLOTHING_VISOR_TOGGLE, up)
 	clothing_flags ^= visor_flags
 	flags_inv ^= visor_flags_inv
 	flags_cover ^= visor_flags_cover
@@ -590,6 +589,7 @@ BLIND     // can't see anything
 		flash_protect ^= initial(flash_protect)
 	if(visor_vars_to_toggle & VISOR_TINT)
 		tint ^= initial(tint)
+	SEND_SIGNAL(src, COMSIG_CLOTHING_VISOR_TOGGLE, up)
 	update_appearance() //most of the time the sprite changes
 
 /obj/item/clothing/proc/can_use(mob/user)

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -52,6 +52,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDESNOUT
 	w_class = WEIGHT_CLASS_SMALL
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
+	visor_vars_to_toggle = VISOR_TINT
 	visor_flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDESNOUT
 	flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
 	visor_flags_cover = MASKCOVERSMOUTH | PEPPERPROOF

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -535,6 +535,10 @@
 		cure_blind(EYES_COVERED)
 		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 2)
 
+	else if(tint >= TINT_MILD)
+		cure_blind(EYES_COVERED)
+		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 1)
+
 	else
 		cure_blind(EYES_COVERED)
 		clear_fullscreen("tint", 0 SECONDS)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -468,7 +468,7 @@
 				victim.emote("scream")
 			victim.emote("cry")
 			victim.set_eye_blur_if_lower(10 SECONDS)
-			victim.adjust_temp_blindness(6 SECONDS)
+			victim.set_temp_blindness_if_lower(6 SECONDS)
 			victim.set_confusion_if_lower(5 SECONDS)
 			victim.Knockdown(3 SECONDS)
 			victim.add_movespeed_modifier(/datum/movespeed_modifier/reagent/pepperspray)


### PR DESCRIPTION
## About The Pull Request

1. Pushing a dirty mask out of the way (such as adjusting a sec hailer down) will no longer keep the screen tint, nor will they accrue dirt

2. Applied dirt is now rounded to `0.25` rather than `1`. Before, you'd need a minimum of 2.5u to apply dirt and 2.5u-5u would all apply "1 dirt". Now, you need a minimum of 1.5u to apply dirt and it applies it piecemeal, ie 1.5u applies "0.25 dirt".

3. Adds a passive message if you are wearing a dirty mask/helmet to indicate you need to clean it.

4. A tint of 1.5 now applies tier 1 screen impairment, I don't think this will affect any existing items as tints are all defined in 1/2/3.

5. Pepper spray can no longer stack blindness infinitely, much like how it can't stack eye blur, knockdown, or confusion infinitely. 

## Why It's Good For The Game

1. While it may be illogical that a sec hailer being dirty blocks your vision, it's even MORE illogical that it blocks your vision when it's not even protecting you from pepperspray.

(Yes, the sec hailer topic is for another PR) 

2. I noticed in testing that depending on how you spray the pepper spray container, sometimes it would apply no dirt - because if you do a ranged spray it only applies 1.67u . This isn't super consistent with how the reagent works (any volume applies 100% of the downsides). 

3. Aims to make it a bit more clear how the mechanic works by reminding the player occasionally.

4. Allows for one tier of granularity between "No obscured vision" and "Majorly obscured vision". So you know that you're approaching problem territory rather than being thrust into it. 

5. This feels like an oversight to me - all effects of pepperspray are capped but the blindness, so multiple rapid exposures (which is not entirely uncommon) could quickly stack up to minutes of blindness. 

## Changelog

:cl: Melbert
fix: A dirty mask that CAN be pushed out of the way no longer obscures vision if it IS pushed out of the way. 
qol: If your mask is dirty from pepper spray, you get some passive chat messages indicating that it can be cleaned off.
balance: Pepper spray clothing dirt is applied piecemeal - smaller dosages, rather than doing nothing, now build up with repeat applications.
balance: Pepper spray clothing dirt now has a tier between "very obscured vision" and "no obscured vision", giving the wearer more of a warning before being thrust into darkness. 
balance: Pepper spray can no longer stack blindness infinitely - it is now capped to 6 seconds. This brings it in line with its other effects (confusion capped at 5 seconds, blur capped at 10 seconds, knockdown capped at 3 seconds). 
/:cl:
