### PR TITLE
Zombie powder fix

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -349,7 +349,7 @@
 			need_mob_update = affected_mob.adjust_stamina_loss(20 * metabolization_ratio * seconds_per_tick, updating_stamina = FALSE)
 		if(10 to INFINITY)
 			if(affected_mob.stat != DEAD)
-				affected_mob.fakedeath(type)
+				affected_mob.apply_status_effect(/datum/status_effect/reagent_effect/fakedeath, type)
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 


### PR DESCRIPTION
## About The Pull Request

Fixes #95685

The fakedeath from onlife wasn't swapped to use the reagent effect 

## Changelog

:cl: Melbert
fix: Fix zombie powder perma-coma on injection 
/:cl:
