### PR TITLE
Fixes neurine not working in the dead

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1260,6 +1260,7 @@
 	inverse_chem_val = 0.5
 	inverse_chem = /datum/reagent/inverse/neurine
 	added_traits = list(TRAIT_ANTICONVULSANT)
+	self_consuming = TRUE
 	///brain damage level when we first started taking the chem
 	var/initial_bdamage = 200
 


### PR DESCRIPTION

## About The Pull Request

Their liver obviously isn't working when they're dead, so the chemical has to be self-consuming. 

## Why It's Good For The Game

fixes #95689

## Changelog
:cl:

fix: Neurine works in the dead again

/:cl:
