### PR TITLE
Carp mask can be used for internals again

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -449,7 +449,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	icon_state = "carp_mask"
 	inhand_icon_state = null
 	flags_cover = MASKCOVERSEYES
-	clothing_flags = CARP_STYLE_FACTOR
+	clothing_flags = MASKINTERNALS | CARP_STYLE_FACTOR
 	fishing_modifier = -4
 
 /obj/item/clothing/mask/gas/tiki_mask


### PR DESCRIPTION
## About The Pull Request

ADding the `CARP_STYLE_FACTOR` flag didn't carry over the parent flags like `MASKINTERNALS`

It also doesn't carry over `BLOCK_GAS_SMOKE_EFFECT` or `GAS_FILTERING` but I think that makes sens for a carp?

## Changelog

:cl: Melbert
fix: Carp mask can be used for internals again
/:cl:

