### PR TITLE
removes the pepperspray immunity and pepperspray dirtiness from sec hailer

### DIFF
--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -53,8 +53,8 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	w_class = WEIGHT_CLASS_SMALL
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	visor_flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDESNOUT
-	flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
-	visor_flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
+	flags_cover = MASKCOVERSMOUTH
+	visor_flags_cover = MASKCOVERSMOUTH
 	tint = 0
 	fishing_modifier = 0
 	unique_death = 'sound/items/sec_hailer/sec_death.ogg'


### PR DESCRIPTION

## About The Pull Request

Does what the title says, removes pepperspray immunity from the pulled up hailer, as well as the dirtiness from it (they come as a packaged deal I think)

## Why It's Good For The Game

First and foremost, a bajillion years ago (four months ago) #94155 changed sec hailers to be immune to pepperspray, making them prone to dirtiness in the process. Here's why I think that's bad:

Firstly, the obvious one:
_The mask doesn't cover your eyes._  There is an argument that could be made that it should be immune in conjunction with the sechud sunglasses, however I dont agree with this for one reason: The sunglasses dont appear to cover _around_ your eyes. The first two reasons were basically me just using logic, but for the dirtiness factor, a mask that covers your mouth and not your eyes shouldnt make you permanently blind unless you take it off/wipe it down.

Secondly, _Pepperspray is the best disarm against security that is easily obtainable by crew/antags._
In the PR that readded immunity, their argument on why it was good for the game was that security is usually immune to all of their other non-baton counterparts. Here's my question: ...why should they be? Besides uplinks/magic/batons, Security is immune to nigh everything that a crewmember could reasonably obtain other than slips/shoves/numbers. People don't actually know about how good pepperspray truly is- because it's a gearcheck way simpler than all others.  All you need is a gas mask. 

That brings me to my third reason: _It's already an incredibly easy gearcheck to pass, why make it easier?_
If an officer really wants to be immune to pepperspray, pick up one of the many gas masks on the ground. (this one is a pretty simple reason no paragraph sorry)

And last but not least, my final reason: _The mask as it stands get dirty and blinds you even if you dont have it up when you're sprayed._ Not only does it infact still disarm you when the mask is down, it also continues to get dirty, and keeps you blind. Here's why this is a bad thing: Security gets this mask _ROUNDSTART._ If Security happens to get peppersprayed earlier in the round and get blinded and take their mask off, if they dont get it fixed immediately they _will_ be blind if they need oxygen later in the round. I personally cannot think of a good reason anyone would rather not be disarmed now and blinded for a couple seconds, rather than be blind permanently if you need oxygen and dont have a cloth to wipe it down.

To sum it up for the people who "aint readin allat," Basically, if you need oxygen and you got peppersprayed and you dont have cloth, you'll be blind even though the mask doesnt cover your face, pepperspray is a good disarm against security and should stay that way, and it's already an incredibly easy gearcheck to pass.

Until we find a better way to implement a punishment for being sprayed while immune for this mask, I believe the mechanic should just be removed from it entirely.

And for the friendly fire argument, just dont pepperspray your teammates. And dont stand in the fucking cloud of pepperspray a modsuit makes. *bow
## Changelog


:cl:
balance: Security gas masks are no longer pepperspray proof. As a result of this, they don't get dirty anymore.
/:cl:


