### PR TITLE
Restores keybindings to their original defaults, moves the new per-hand bind options to Unbound by default.

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -6,7 +6,7 @@
 	return ishuman(user.mob)
 
 /datum/keybinding/human/quick_equip
-	hotkey_keys = list("R")
+	hotkey_keys = list("E")
 	name = "quick_equip"
 	full_name = "Quick equip"
 	description = "Quickly puts an item in the best slot available"
@@ -21,7 +21,7 @@
 	return TRUE
 
 /datum/keybinding/human/quick_equip_belt
-	hotkey_keys = list("ShiftR")
+	hotkey_keys = list("ShiftE")
 	name = "quick_equip_belt"
 	full_name = "Quick equip belt"
 	description = "Put held thing in belt or take out most recent thing from belt"

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -167,7 +167,7 @@
 	return TRUE
 
 /datum/keybinding/living/toggle_throw_mode
-	hotkey_keys = list("Southwest") // END
+	hotkey_keys = list("R", "Southwest") // END
 	name = "toggle_throw_mode"
 	full_name = "Toggle throw mode"
 	description = "Toggle throwing the current item or not."

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -21,7 +21,7 @@
 	return TRUE
 
 /datum/keybinding/mob/swap_hands
-	hotkey_keys = list(UNBOUND_KEY)
+	hotkey_keys = list("X")
 	name = "swap_hands"
 	full_name = "Swap hands"
 	description = ""
@@ -39,14 +39,14 @@
 	var/hand_index = NONE
 
 /datum/keybinding/mob/select_hand/right
-	hotkey_keys = list("Q")
+	hotkey_keys = list(UNBOUND_KEY)
 	name = "select_right_hand"
 	full_name = "Swap to Right Hand"
 	keybind_signal = COMSIG_KB_MOB_SELECTRIGHTHAND_DOWN
 	hand_index = RIGHT_HANDS
 
 /datum/keybinding/mob/select_hand/left
-	hotkey_keys = list("E")
+	hotkey_keys = list(UNBOUND_KEY)
 	name = "select_left_hand"
 	full_name = "Swap to Left Hand"
 	keybind_signal = COMSIG_KB_MOB_SELECTLEFTHAND_DOWN
@@ -81,7 +81,7 @@
 	return TRUE
 
 /datum/keybinding/mob/drop_item
-	hotkey_keys = list("X")
+	hotkey_keys = list("Q")
 	name = "drop_item"
 	full_name = "Drop Item"
 	description = "Drops the item in your active hand to the ground."

--- a/code/modules/tutorials/tutorials/switch_hands.dm
+++ b/code/modules/tutorials/tutorials/switch_hands.dm
@@ -50,17 +50,9 @@
 
 	switch (stage)
 		if (STAGE_SHOULD_SWAP_HAND)
-			var/datum/keybinding/mob/select_hand/hand_keybinding
-			var/hand_name
-			if (IS_RIGHT_INDEX(hand_to_watch))
-				hand_keybinding = /datum/keybinding/mob/select_hand/right
-				hand_name = "right"
-			else
-				hand_keybinding = /datum/keybinding/mob/select_hand/left
-				hand_name = "left"
-
+			var/hand_name = IS_RIGHT_INDEX(hand_to_watch) ? "right" : "left"
 			show_instruction(keybinding_message(
-				hand_keybinding,
+				/datum/keybinding/mob/swap_hands,
 				"Press '%KEY%' to use your [hand_name] hand",
 				"Click '<b>SWAP</b>' to use your [hand_name] hand",
 			))


### PR DESCRIPTION
## About The Pull Request

Restores keybindings to their original defaults, moves the new per-hand bind options to Unbound by default. Partially reverts #92659

## Why It's Good For The Game

I've seen approximately zero players say the new binds are better, and quite a lot of older players report the new bindings are confusing or harder to use. I'm also not convinced that burning 2 buttons on hand swapping is better than having one button to swap between hands. 

I understand having roguetown bindings as an option given that it's currently eating all of SS13's pop right now, which is why I've left in the bindings set as Unbound for now, but we should really just add buttons for players to pick binding defaults, so that we can go "coming over from Goon/Roguetown/Whatever flavor of the month you're from? Click here for those bindings" and sidestep this issue entirely.

If someone can provide some data proving this is actually better for new players, I'll close this PR, but until I see some hard data or testimony from newer players that they find this new control scheme easier to understand, I'm not convinced.

## Changelog

:cl:
qol: Restores keybindings to their original pre-August 2025 defaults, moves the new per-hand bind options to Unbound by default.
/:cl:
