### PR TITLE
Fixes two books creation bugs: trimming and newlines.

### DIFF
--- a/code/__DEFINES/paper.dm
+++ b/code/__DEFINES/paper.dm
@@ -1,5 +1,7 @@
 /// Maximimum number of characters that we allow on paper.
 #define MAX_PAPER_LENGTH 5000
+/// Maximimum number of characters that we allow in a book, after unfolding and encoding html.
+#define MAX_BOOK_LENGTH (MAX_PAPER_LENGTH * 2)
 /// Max number of stamps that can be applied to the paper in tgui.
 #define MAX_PAPER_STAMPS 30
 /// Max number of stamp overlays that we'll add to a piece of paper's icon.

--- a/code/modules/library/book_info.dm
+++ b/code/modules/library/book_info.dm
@@ -39,15 +39,19 @@
 	if(trusted)
 		content = _content
 		return
-	content = trim(html_encode(_content), MAX_PAPER_LENGTH)
+	content = trim(html_encode(trim(_content, MAX_PAPER_LENGTH)), MAX_BOOK_LENGTH)
 
 /datum/book_info/proc/set_content_using_paper(obj/item/paper/paper)
 	// Just the paper's raw data.
 	var/raw_content = ""
 	for(var/datum/paper_input/text_input as anything in paper.raw_text_inputs)
 		raw_content += text_input.to_raw_html()
+		raw_content += (text_input.raw_text[length(text_input.raw_text)] == "\n") ? "\n" : "\n\n"
 
-	content = trim(html_encode(raw_content), MAX_PAPER_LENGTH)
+	// Paper raw inputs should already be trimmed to maximum paper length,
+	// so we don't trim here again to avoid cutting into the expanded html.
+	// We still trim to a more lenient length to avoid abuse.
+	content = trim(html_encode(raw_content), MAX_BOOK_LENGTH)
 
 /datum/book_info/proc/get_content(default="N/A")
 	return html_decode(content) || "N/A"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -850,10 +850,8 @@
 /// Returns the raw contents of the input as html, with **ZERO SANITIZATION**
 /datum/paper_input/proc/to_raw_html()
 	var/final = raw_text
-	if(font)
-		final = "<font face='[font]'>[final]</font>"
-	if(colour)
-		final = "<font color='[colour]'>[final]</font>"
+	if(font || colour)
+		final = "<font[" color='[colour]'"][" face='[font]'"]>[final]</font>"
 	if(bold)
 		final = "<b>[final]</b>"
 	return final


### PR DESCRIPTION

## About The Pull Request

### Trimming

So as per #89165, paper below 5000 characters was getting cut off despite being below the cap.
This seems to have been happening because of the following code:
https://github.com/tgstation/tgstation/blob/d8774f4c4176f09463457f04905570923b27b3de/code/modules/library/book_info.dm#L44-L50
Paper uses the raw text for its count and handles pen color/font/boldness/such tgui-side, but books first expand that html dm-side AND then encode it, significantly increasing the amount of characters before trimming occurs.
This, obviously, leads to characters getting cut off!

Buuuuuuuut not trimming it at all isn't perfect. We know paper *should* trim it, but we also know that's not gonna be all paper. There's gonna be paper where it's inexplicably past the 5000 characters cap.

So, instead we use a second more lenient book limit, right now defined as 2x the paper limit, which should stop the worst cases without breaking for the best cases.

### Newlines

Second bit! Paper stores each writing attempt as a separate thing, but turning them into books collapses these:
https://github.com/tgstation/tgstation/blob/d8774f4c4176f09463457f04905570923b27b3de/code/modules/library/book_info.dm#L46-L48
This, however, doesn't account for the part where paper tgui inserts newlines between these inputs:
https://github.com/tgstation/tgstation/blob/d8774f4c4176f09463457f04905570923b27b3de/tgui/packages/tgui/interfaces/PaperSheet/Preview.tsx#L317-L318
Which book tgui doesn't! Cause it's just one big glob of text, not separate entries.
Which in turn means paper written with multiple entries just... has all of these put on the same line, which sucks.

So we make the paper entries collapsing actually add newlines the same way, fixing our issue.

### Nitpicks

...We also change the `to_raw_html(...)` proc to re-use the same `<font>` tag. Regrettably, we can't use the exact same setup as paperwork uses on its tgui side because it uses `style` which would get sanitized out, but there's no reason for us to double the amount of characters behind the scenes by using multiple layered `<font>` tags for no reason.

***Ideally*** I feel books and paper should just use the same tgui systems, but I sure as hell wouldn't know how to do that without breaking everything including old books, with how fickle paperwork code already is.
## Why It's Good For The Game

Fixes #89165.
fix jank :+1:
It *really* sucks when you make a book below the 5000 character cap, but it somehow hits the character cap and gets trimmed anyway. I feel the books using static ui data should avoid this being horrible.
## Changelog
:cl:
fix: Books no longer get trimmed below the paper length limit.
fix: Books made using paperwork created with multiple inputs no longer put all that text on the same line.
/:cl:
