### PR TITLE
Changes lamarr s desc from "xenomorph facehugger" to "alien"

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -9,7 +9,7 @@
 #define MAX_ACTIVE_TIME 400
 
 /obj/item/clothing/mask/facehugger
-	name = "alien facehugger"
+	name = "alien"
 	desc = "It has some sort of a tube at the end of its tail."
 	icon = 'icons/mob/nonhuman-player/alien.dmi'
 	icon_state = "facehugger"
@@ -296,7 +296,7 @@
 
 /obj/item/clothing/mask/facehugger/lamarr
 	name = "Lamarr"
-	desc = "The Research Director's pet, a domesticated and debeaked xenomorph facehugger. Friendly, but may still try to couple with your head."
+	desc = "The Research Director's pet, a domesticated and debeaked alien. Friendly, but may still try to couple with your head."
 	sterile = TRUE
 	slowdown = 1.5 //lamarr is too fat after being fed in captivity to effectively slow people down or something
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -9,7 +9,7 @@
 #define MAX_ACTIVE_TIME 400
 
 /obj/item/clothing/mask/facehugger
-	name = "alien"
+	name = "alien facehugger"
 	desc = "It has some sort of a tube at the end of its tail."
 	icon = 'icons/mob/nonhuman-player/alien.dmi'
 	icon_state = "facehugger"


### PR DESCRIPTION

## About The Pull Request

facehuggers are referred as simply "alien(s)" throughout the game, except in lamarr s description, in which it is referred straight as "xenomorph facehugger". This pr changes lamarr s desc to be more """mysterious""""

## Why It's Good For The Game

naming consistency

## Changelog



:cl:

spellcheck: due to conflicts with the hive empress, lamarr has lost it s diplomatic facehugger title

/:cl:
