### PR TITLE
Deletes the misleading key request for the dragon lavaboat

### DIFF
--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -77,6 +77,7 @@
 	desc = "This boat moves where you will it, without the need for an oar."
 	icon_state = "dragon_boat"
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | FREEZE_PROOF
+	key_type = null
 
 /obj/vehicle/ridden/lavaboat/dragon/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

seems like it was asking for a key since it was a subtype of /obj/vehicle/ridden/lavaboat, so i set it s key_type to null

## Why It's Good For The Game

gbp pog. fixes #95634 

## Changelog
:cl:

fix: Deleted the misleading key request for the dragon lavaboat

/:cl:
