### PR TITLE
Fixes hardcoded pod storage safe security level lock & its initial icon setup

### DIFF
--- a/code/datums/storage/subtypes/others/pod.dm
+++ b/code/datums/storage/subtypes/others/pod.dm
@@ -6,7 +6,7 @@
 	var/always_unlocked = FALSE
 
 /datum/storage/pod/open_storage(mob/to_show)
-	if(isliving(to_show) && SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED)
+	if(locked && isliving(to_show)) //Observers get to see anyway
 		to_chat(to_show, span_warning("The storage unit will only unlock during a Red or Delta security alert."))
 		return FALSE
 	return ..()

--- a/code/modules/shuttle/mobile_port/variants/emergency/pods.dm
+++ b/code/modules/shuttle/mobile_port/variants/emergency/pods.dm
@@ -140,6 +140,10 @@
 	. = ..()
 	icon_state = "wall_safe[atom_storage?.locked ? "_locked" : ""]"
 
+/obj/item/storage/pod/create_storage(max_slots, max_specific_storage, max_total_storage, list/canhold, list/canthold, storage_type)
+	. = ..()
+	update_appearance(UPDATE_ICON_STATE)
+
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/storage/pod, 32)
 
 /obj/item/storage/pod/PopulateContents()


### PR DESCRIPTION

## About The Pull Request

Pod wall storage tracks its own locked state and whatnot only to hardblock based on security state, which is confusing especially to those attempting to varedit.

Also, its initial icon is erroneously unlocked because it is updated by the storage while the storage is being created, but as the storage is still being created `atom_storage` hasn't been actually set yet.

## Why It's Good For The Game

Fixes it being locked when it shouldn't be(in varedits, but also in the scenario someone launches the pod and later the security level is lowered)

Fixes it appearing unlocked when it isn't.

## Changelog
:cl:

fix: Escape pod storage wall safes will now be unlocked when they're unlocked and appear locked when they're locked

/:cl:
