### PR TITLE
Fixes double transforms for emissives, improves related unit test 

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -44,7 +44,6 @@
 
 /// Lighting objects that are "free floating"
 #define O_LIGHTING_VISUAL_PLANE 11
-#define O_LIGHTING_VISUAL_RENDER_TARGET "*O_LIGHT_VISUAL_PLANE"
 
 // Render plate used by overlay lighting to mask turf lights
 #define RENDER_PLANE_TURF_LIGHTING 12
@@ -70,7 +69,9 @@
 
 /// Main game plane to which everything renders, which then is multiplied by light
 /// Should not be lit directly as it is sourced for emissive bloom
-#define RENDER_PLANE_UNLIT_GAME 19
+#define RENDER_PLANE_UNLIT_GAME 18
+
+#define RENDER_PLANE_O_LIGHTING 19
 
 #define RENDER_PLANE_LIGHTING 20
 

--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -355,33 +355,13 @@
 /atom/movable/screen/plane_master/o_light_visual
 	name = "Overlight light visual"
 	documentation = "Holds overlay lighting objects, or the sort of lighting that's a well, overlay stuck to something.\
-		<br>Exists because lighting updating is really slow, and movement needs to feel smooth.\
-		<br>We draw to the game plane, and mask out space for ourselves on the lighting plane so any color we have has the chance to display."
+		<br>Exists because lighting updating is really slow, and movement needs to feel smooth (also being an overlay lets us muck with it easier)."
 	plane = O_LIGHTING_VISUAL_PLANE
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
-	render_target = O_LIGHTING_VISUAL_RENDER_TARGET
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	blend_mode = BLEND_ADD
-	render_relay_planes = list(RENDER_PLANE_LIGHTING)
+	render_relay_planes = list(RENDER_PLANE_O_LIGHTING)
 	critical = PLANE_CRITICAL_DISPLAY
-
-/atom/movable/screen/plane_master/o_light_visual/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
-	. = ..()
-	// I'd love for this to be HSL but filters don't work with blend modes
-	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_TURF_LIGHTING, offset), BLEND_MULTIPLY, relay_color = list(
-		-1, -1, -1, 0,
-		-1, -1, -1, 0,
-		-1, -1, -1, 0,
-		0, 0, 0, OVERLAY_LIGHTING_WEIGHT,
-		1, 1, 1, 0,
-	))
-	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_SPECULAR, offset), relay_color = list(
-		SPECULAR_EMISSIVE_OVERLAY_CONTRAST, 0, 0, 0,
-		0, SPECULAR_EMISSIVE_OVERLAY_CONTRAST, 0, 0,
-		0, 0, SPECULAR_EMISSIVE_OVERLAY_CONTRAST, 0,
-		0, 0, 0, 1,
-		-SPECULAR_EMISSIVE_CUTOFF, -SPECULAR_EMISSIVE_CUTOFF, -SPECULAR_EMISSIVE_CUTOFF, 0,
-	))
 
 /atom/movable/screen/plane_master/above_lighting
 	name = "Above lighting"

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -132,7 +132,7 @@
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	blend_mode = BLEND_ADD
-	render_relay_planes = list(O_LIGHTING_VISUAL_PLANE)
+	render_relay_planes = list(RENDER_PLANE_O_LIGHTING)
 	critical = PLANE_CRITICAL_DISPLAY
 
 /atom/movable/screen/plane_master/rendering_plate/emissive_bloom/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
@@ -154,6 +154,35 @@
 	render_target = SPECULAR_MASK_RENDER_TARGET
 	render_relay_planes = list()
 	critical = PLANE_CRITICAL_DISPLAY
+
+/atom/movable/screen/plane_master/rendering_plate/overlay_light
+	name = "Overlight plate"
+	documentation = "Combines overlay lights with emissives.\
+		<br>We draw to the generic lighting plate, do some funky stuff with turf lighting to sort of \"cut out\" a bit of space for ourselves there, and do some junk to speculars"
+	plane = RENDER_PLANE_O_LIGHTING
+	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	blend_mode = BLEND_ADD
+	render_relay_planes = list(RENDER_PLANE_LIGHTING)
+	critical = PLANE_CRITICAL_DISPLAY
+
+/atom/movable/screen/plane_master/rendering_plate/overlay_light/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
+	. = ..()
+	// I'd love for this to be HSL but filters don't work with blend modes
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_TURF_LIGHTING, offset), BLEND_MULTIPLY, relay_color = list(
+		-1, -1, -1, 0,
+		-1, -1, -1, 0,
+		-1, -1, -1, 0,
+		0, 0, 0, OVERLAY_LIGHTING_WEIGHT,
+		1, 1, 1, 0,
+	))
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_SPECULAR, offset), relay_color = list(
+		SPECULAR_EMISSIVE_OVERLAY_CONTRAST, 0, 0, 0,
+		0, SPECULAR_EMISSIVE_OVERLAY_CONTRAST, 0, 0,
+		0, 0, SPECULAR_EMISSIVE_OVERLAY_CONTRAST, 0,
+		0, 0, 0, 1,
+		-SPECULAR_EMISSIVE_CUTOFF, -SPECULAR_EMISSIVE_CUTOFF, -SPECULAR_EMISSIVE_CUTOFF, 0,
+	))
 
 /atom/movable/screen/plane_master/rendering_plate/specular
 	name = "Specular plate"

--- a/code/modules/unit_tests/plane_double_transform.dm
+++ b/code/modules/unit_tests/plane_double_transform.dm
@@ -13,30 +13,43 @@
 
 	// Generates a list of render target -> PM for future use
 	var/list/render_target_to_plane = list()
+	// List of all the plane masters that are being scaled by multiz. These cannot feed into each other
+	var/list/atom/movable/screen/plane_master/input_planes = list()
 	for(var/plane_key in our_group.plane_masters)
 		var/atom/movable/screen/plane_master/plane = our_group.plane_masters[plane_key]
 		if(plane.render_target)
 			render_target_to_plane[plane.render_target] = plane
+		if(plane.multiz_scaled)
+			input_planes += plane_key
 
+	// We need to walk all our input planes and see if they feed into any plane masters that are also multiz scaled
+	for(var/input_key as anything in input_planes)
+		var/list/keys_to_walk = list()
+		var/atom/movable/screen/plane_master/input_plane = our_group.plane_masters[input_key]
+		keys_to_walk[input_key] = "[input_plane.type]"
+		var/key_index = 0
+		while(key_index < length(keys_to_walk))
+			key_index += 1
+			var/next_plane_key = keys_to_walk[key_index]
+			var/atom/movable/screen/plane_master/next_plane = our_group.plane_masters[next_plane_key]
 
-	for(var/plane_key in our_group.plane_masters)
-		var/atom/movable/screen/plane_master/plane = our_group.plane_masters[plane_key]
+			for(var/target_plane in next_plane.render_relay_planes)
+				var/target_key = "[target_plane]"
+				var/atom/movable/screen/plane_master/target = our_group.plane_masters["[target_key]"]
+				if(!keys_to_walk[target_key])
+					keys_to_walk[target_key] = "[keys_to_walk[next_plane_key]]-[target.type]"
+				if(target.multiz_scaled)
+					TEST_FAIL("[input_plane.type] is eventually drawn (via render relays) onto [target.type] {[keys_to_walk[target_key]]}. Both are scaled by multiz, so this will cause strange transforms.\n\
+					consider making a new render plate that they can both draw to instead, or something of that nature.")
 
-		if(!plane.multiz_scaled)
-			continue
-
-		// Walk the relay targets
-		for(var/target_plane in plane.render_relay_planes)
-			var/atom/movable/screen/plane_master/target = our_group.plane_masters["[target_plane]"]
-			if(target.multiz_scaled)
-				TEST_FAIL("[plane.type] draws a render relay into [target.type]. Both are scaled by multiz, so this will cause strange transforms.\n\
-				consider making a new render plate that they can both draw to instead, or something of that nature.")
-
-		// Now we walk for filters that take from us
-		for(var/list/filter in plane.filter_data)
-			if(!filter["render_source"])
-				continue
-			var/atom/movable/screen/plane_master/target = render_target_to_plane[filter["render_source"]]
-			if(target.multiz_scaled)
-				TEST_FAIL("[plane.type] draws a render relay into [target.type]. Both are scaled by multiz, so this will cause strange transforms.\n\
-				consider making a new render plate that they can both draw to instead, or something of that nature.")
+			// Now we walk for filters that take from us
+			for(var/list/filter in next_plane.filter_data)
+				if(!filter["render_source"])
+					continue
+				var/atom/movable/screen/plane_master/target = render_target_to_plane[filter["render_source"]]
+				var/target_key = "[target.plane]"
+				if(!keys_to_walk[target_key])
+					keys_to_walk[target_key] = "[keys_to_walk[next_plane_key]]-[target.type]"
+				if(target.multiz_scaled)
+					TEST_FAIL("[input_plane.type] is eventually drawn (via render relays) onto [target.type] {[keys_to_walk[target_key]]}. Both are scaled by multiz, so this will cause strange transforms.\n\
+					consider making a new render plate that they can both draw to instead, or something of that nature.")

--- a/code/modules/unit_tests/plane_double_transform.dm
+++ b/code/modules/unit_tests/plane_double_transform.dm
@@ -23,7 +23,7 @@
 			input_planes += plane_key
 
 	// We need to walk all our input planes and see if they feed into any plane masters that are also multiz scaled
-	for(var/input_key as anything in input_planes)
+	for(var/input_key in input_planes)
 		var/list/keys_to_walk = list()
 		var/atom/movable/screen/plane_master/input_plane = our_group.plane_masters[input_key]
 		keys_to_walk[input_key] = "[input_plane.type]"


### PR DESCRIPTION

## About The Pull Request

[Adds an intermediary render plate for overlay lighting](https://github.com/tgstation/tgstation/commit/34cc054702140677aae94727a54ae83619cae3d7)

The emissive plate isn't allowed to draw directly onto an input plane (really almost nothing should be drawing onto input planes). This fixes that.

[Improves plane_double_transform unit test](https://github.com/tgstation/tgstation/commit/56f812da2e24bdb82966f1af1adb4e1b648b895d)

It was formerly just checking to see if any inputs were directly drawing onto other inputs. Now, we floodfill

## Why It's Good For The Game

Somewhat nebulous, I hate double transforms double transforms are evil

