### PR TITLE
Iconoclast's repeater now uses stamina instead of being crank-charged.

### DIFF
--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -347,7 +347,7 @@
 /datum/crafting_recipe/detached_ratvarian_repeater
 	name = "Iconoclast's Repeater"
 	tool_behaviors = list(TOOL_WELDER)
-	result = /obj/item/gun/energy/laser/musket/repeater
+	result = /obj/item/gun/energy/laser/repeater
 	structures = list(
 		/obj/structure/mounted_gun/ratvarian_repeater = CRAFTING_STRUCTURE_CONSUME,
 	)

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -171,6 +171,7 @@
 		/datum/material/glass = SHEET_MATERIAL_AMOUNT * 1.29
 	)
 	var/base_shots_per_stamina_bar = 8
+	var/additional_shots_per_athletics_level = 2
 
 /obj/item/gun/energy/laser/musket/repeater/Initialize(mapload)
 	. = ..()
@@ -182,7 +183,7 @@
 /obj/item/gun/energy/laser/musket/repeater/proc/get_effective_stamina_cost(mob/living/shooter)
 	var/total_shots = base_shots_per_stamina_bar
 	var/athletics_skill_modifier = (shooter.mind?.get_skill_level(/datum/skill/athletics) || 1) - 1
-	total_shots += athletics_skill_modifier * 2
+	total_shots += athletics_skill_modifier * additional_shots_per_athletics_level
 	if(HAS_TRAIT(shooter, TRAIT_STRENGTH))
 		total_shots *= 2
 	var/obj/item/organ/cyberimp/chest/spine/potential_spine = shooter.get_organ_slot(ORGAN_SLOT_SPINE)

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -157,21 +157,18 @@
 	desc = "A weapon of incredible bulk, this ratvarian repeater has been permanently severed from its stand to be carried by hand, requiring great exertion to fire. Cumbersome, Yes - but powerful."
 	icon_state = "repeater"
 	inhand_icon_state = "repeater"
-	slowdown = 1
 	fire_delay = 0.5
 	w_class = WEIGHT_CLASS_HUGE
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/musket/repeater/handheld)
 	cell_type = /obj/item/stock_parts/power_store/battery/infinite // We use stamina in place of energy, so this is done to allow other guns to use its ammo without having infinite shots.
 	spread = 20
 	charge_sections = 1
-	item_flags = SLOWS_WHILE_IN_HAND | IMMUTABLE_SLOW
 	custom_materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5.25,
 		/datum/material/bronze = SHEET_MATERIAL_AMOUNT * 5,
 		/datum/material/glass = SHEET_MATERIAL_AMOUNT * 1.29
 	)
-	var/base_shots_per_stamina_bar = 8
-	var/additional_shots_per_athletics_level = 2
+	var/stamina_cost = LASER_SHOTS(25, 100)
 
 /obj/item/gun/energy/laser/musket/repeater/Initialize(mapload)
 	. = ..()
@@ -179,17 +176,6 @@
 
 /obj/item/gun/energy/laser/musket/repeater/add_deep_lore()
 	return
-
-/obj/item/gun/energy/laser/musket/repeater/proc/get_effective_stamina_cost(mob/living/shooter)
-	var/total_shots = base_shots_per_stamina_bar
-	var/athletics_skill_modifier = (shooter.mind?.get_skill_level(/datum/skill/athletics) || 1) - 1
-	total_shots += athletics_skill_modifier * additional_shots_per_athletics_level
-	if(HAS_TRAIT(shooter, TRAIT_STRENGTH))
-		total_shots *= 2
-	var/obj/item/organ/cyberimp/chest/spine/potential_spine = shooter.get_organ_slot(ORGAN_SLOT_SPINE)
-	if (istype(potential_spine))
-		total_shots *=  1 / potential_spine.athletics_boost_multiplier
-	return round((isbasicmob(shooter) ? 100 : shooter.maxHealth) / total_shots, 0.1)
 
 /obj/item/gun/energy/laser/musket/repeater/do_autofire(datum/source, atom/target, mob/living/shooter, allow_akimbo, params)
 	var/stamcrit_immune = FALSE
@@ -203,14 +189,14 @@
 	if(stamcrit_immune)
 		var/max_health = is_basic ? 100 : shooter.maxHealth
 		var/threshold = is_basic ? 1 : shooter.crit_threshold
-		if(max_health / (shooter.staminaloss + get_effective_stamina_cost(shooter)) > threshold)
+		if(max_health / (shooter.staminaloss + stamina_cost) > threshold)
 			balloon_alert(shooter, "too tired!")
 			return NONE
 	return ..()
 
 /obj/item/gun/energy/laser/musket/repeater/do_autofire_shot(datum/source, atom/target, mob/living/shooter, allow_akimbo, params)
 	. = ..()
-	shooter.adjust_stamina_loss(get_effective_stamina_cost(shooter))
+	shooter.adjust_stamina_loss(stamina_cost)
 
 // The Deep Lore //
 

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -152,51 +152,6 @@
 	light_color = COLOR_BLUE
 	ammo_type = list(/obj/item/ammo_casing/energy/nanite/cryo)
 
-/obj/item/gun/energy/laser/musket/repeater
-	name = "iconoclast's repeater"
-	desc = "A weapon of incredible bulk, this ratvarian repeater has been permanently severed from its stand to be carried by hand, requiring great exertion to fire. Cumbersome, Yes - but powerful."
-	icon_state = "repeater"
-	inhand_icon_state = "repeater"
-	fire_delay = 0.5
-	w_class = WEIGHT_CLASS_HUGE
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/musket/repeater/handheld)
-	cell_type = /obj/item/stock_parts/power_store/battery/infinite // We use stamina in place of energy, so this is done to allow other guns to use its ammo without having infinite shots.
-	spread = 20
-	charge_sections = 1
-	custom_materials = list(
-		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5.25,
-		/datum/material/bronze = SHEET_MATERIAL_AMOUNT * 5,
-		/datum/material/glass = SHEET_MATERIAL_AMOUNT * 1.29
-	)
-	var/stamina_cost = LASER_SHOTS(25, 100)
-
-/obj/item/gun/energy/laser/musket/repeater/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.25 SECONDS)
-
-/obj/item/gun/energy/laser/musket/repeater/add_deep_lore()
-	return
-
-/obj/item/gun/energy/laser/musket/repeater/do_autofire(datum/source, atom/target, mob/living/shooter, allow_akimbo, params)
-	var/stamcrit_immune = FALSE
-	var/mob/living/basic/basic_shooter = shooter
-	var/is_basic = istype(basic_shooter)
-	if(HAS_TRAIT(shooter, TRAIT_STUNIMMUNE))
-		stamcrit_immune = TRUE
-	else if(is_basic)
-		if(basic_shooter.stamina_crit_threshold == BASIC_MOB_NO_STAMCRIT)
-			stamcrit_immune = TRUE
-	if(stamcrit_immune)
-		var/max_health = is_basic ? 100 : shooter.maxHealth
-		var/threshold = is_basic ? 1 : shooter.crit_threshold
-		if(max_health / (shooter.staminaloss + stamina_cost) > threshold)
-			balloon_alert(shooter, "too tired!")
-			return NONE
-	return ..()
-
-/obj/item/gun/energy/laser/musket/repeater/do_autofire_shot(datum/source, atom/target, mob/living/shooter, allow_akimbo, params)
-	. = ..()
-	shooter.adjust_stamina_loss(stamina_cost)
 
 // The Deep Lore //
 

--- a/code/modules/projectiles/guns/energy/crank_guns.dm
+++ b/code/modules/projectiles/guns/energy/crank_guns.dm
@@ -154,14 +154,14 @@
 
 /obj/item/gun/energy/laser/musket/repeater
 	name = "iconoclast's repeater"
-	desc = "A weapon of incredible bulk, this ratvarian repeater has been permanently severed from its stand to be carried by hand. Cumbersome, Yes - but powerful."
+	desc = "A weapon of incredible bulk, this ratvarian repeater has been permanently severed from its stand to be carried by hand, requiring great exertion to fire. Cumbersome, Yes - but powerful."
 	icon_state = "repeater"
 	inhand_icon_state = "repeater"
 	slowdown = 1
-	burst_size = 2
 	fire_delay = 0.5
 	w_class = WEIGHT_CLASS_HUGE
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/musket/repeater/handheld)
+	cell_type = /obj/item/stock_parts/power_store/battery/infinite // We use stamina in place of energy, so this is done to allow other guns to use its ammo without having infinite shots.
 	spread = 20
 	charge_sections = 1
 	item_flags = SLOWS_WHILE_IN_HAND | IMMUTABLE_SLOW
@@ -170,21 +170,46 @@
 		/datum/material/bronze = SHEET_MATERIAL_AMOUNT * 5,
 		/datum/material/glass = SHEET_MATERIAL_AMOUNT * 1.29
 	)
+	var/base_shots_per_stamina_bar = 8
 
 /obj/item/gun/energy/laser/musket/repeater/Initialize(mapload)
 	. = ..()
-	AddComponent( \
-		/datum/component/crank_recharge, \
-		charging_cell = get_cell(), \
-		charge_amount = LASER_SHOTS(6, STANDARD_CELL_CHARGE), \
-		cooldown_time = 0.4 SECONDS, \
-		charge_sound = 'sound/machines/clockcult/integration_cog_install.ogg', \
-		charge_sound_cooldown_time = 3 SECONDS, \
-	)
-	AddComponent(/datum/component/automatic_fire, 0.5 SECONDS)
+	AddComponent(/datum/component/automatic_fire, 0.25 SECONDS)
 
 /obj/item/gun/energy/laser/musket/repeater/add_deep_lore()
 	return
+
+/obj/item/gun/energy/laser/musket/repeater/proc/get_effective_stamina_cost(mob/living/shooter)
+	var/total_shots = base_shots_per_stamina_bar
+	var/athletics_skill_modifier = (shooter.mind?.get_skill_level(/datum/skill/athletics) || 1) - 1
+	total_shots += athletics_skill_modifier * 2
+	if(HAS_TRAIT(shooter, TRAIT_STRENGTH))
+		total_shots *= 2
+	var/obj/item/organ/cyberimp/chest/spine/potential_spine = shooter.get_organ_slot(ORGAN_SLOT_SPINE)
+	if (istype(potential_spine))
+		total_shots *=  1 / potential_spine.athletics_boost_multiplier
+	return round((isbasicmob(shooter) ? 100 : shooter.maxHealth) / total_shots, 0.1)
+
+/obj/item/gun/energy/laser/musket/repeater/do_autofire(datum/source, atom/target, mob/living/shooter, allow_akimbo, params)
+	var/stamcrit_immune = FALSE
+	var/mob/living/basic/basic_shooter = shooter
+	var/is_basic = istype(basic_shooter)
+	if(HAS_TRAIT(shooter, TRAIT_STUNIMMUNE))
+		stamcrit_immune = TRUE
+	else if(is_basic)
+		if(basic_shooter.stamina_crit_threshold == BASIC_MOB_NO_STAMCRIT)
+			stamcrit_immune = TRUE
+	if(stamcrit_immune)
+		var/max_health = is_basic ? 100 : shooter.maxHealth
+		var/threshold = is_basic ? 1 : shooter.crit_threshold
+		if(max_health / (shooter.staminaloss + get_effective_stamina_cost(shooter)) > threshold)
+			balloon_alert(shooter, "too tired!")
+			return NONE
+	return ..()
+
+/obj/item/gun/energy/laser/musket/repeater/do_autofire_shot(datum/source, atom/target, mob/living/shooter, allow_akimbo, params)
+	. = ..()
+	shooter.adjust_stamina_loss(get_effective_stamina_cost(shooter))
 
 // The Deep Lore //
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -301,6 +301,52 @@
 	desc = "A laser gun modified to cost 20 credits to fire. Point towards poor people."
 	pin = /obj/item/firing_pin/paywall/luxury
 
+/obj/item/gun/energy/laser/repeater
+	name = "iconoclast's repeater"
+	desc = "A weapon of incredible bulk, this ratvarian repeater has been permanently severed from its stand to be carried by hand, requiring great exertion to fire. Cumbersome, Yes - but powerful."
+	icon_state = "repeater"
+	inhand_icon_state = "repeater"
+	fire_delay = 0.5
+	w_class = WEIGHT_CLASS_HUGE
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/musket/repeater/handheld)
+	cell_type = /obj/item/stock_parts/power_store/battery/infinite // We use stamina in place of energy, so this is done to allow other guns to use its ammo without having infinite shots.
+	spread = 20
+	charge_sections = 1
+	custom_materials = list(
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5.25,
+		/datum/material/bronze = SHEET_MATERIAL_AMOUNT * 5,
+		/datum/material/glass = SHEET_MATERIAL_AMOUNT * 1.29
+	)
+	var/stamina_cost = LASER_SHOTS(25, 100)
+
+/obj/item/gun/energy/laser/repeater/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/automatic_fire, 0.25 SECONDS)
+
+/obj/item/gun/energy/laser/repeater/add_deep_lore()
+	return
+
+/obj/item/gun/energy/laser/repeater/do_autofire(datum/source, atom/target, mob/living/shooter, allow_akimbo, params)
+	var/stamcrit_immune = FALSE
+	var/mob/living/basic/basic_shooter = shooter
+	var/is_basic = istype(basic_shooter)
+	if(HAS_TRAIT(shooter, TRAIT_STUNIMMUNE))
+		stamcrit_immune = TRUE
+	else if(is_basic)
+		if(basic_shooter.stamina_crit_threshold == BASIC_MOB_NO_STAMCRIT)
+			stamcrit_immune = TRUE
+	if(stamcrit_immune)
+		var/max_health = is_basic ? 100 : shooter.maxHealth
+		var/threshold = is_basic ? 1 : shooter.crit_threshold
+		if(max_health / (shooter.staminaloss + stamina_cost) > threshold)
+			balloon_alert(shooter, "too tired!")
+			return NONE
+	return ..()
+
+/obj/item/gun/energy/laser/repeater/do_autofire_shot(datum/source, atom/target, mob/living/shooter, allow_akimbo, params)
+	. = ..()
+	shooter.adjust_stamina_loss(stamina_cost)
+
 // The Deep Lore //
 
 // Laser Gun

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -323,9 +323,6 @@
 	. = ..()
 	AddComponent(/datum/component/automatic_fire, 0.25 SECONDS)
 
-/obj/item/gun/energy/laser/repeater/add_deep_lore()
-	return
-
 /obj/item/gun/energy/laser/repeater/do_autofire(datum/source, atom/target, mob/living/shooter, allow_akimbo, params)
 	var/stamcrit_immune = FALSE
 	var/mob/living/basic/basic_shooter = shooter


### PR DESCRIPTION
## About The Pull Request

When I had originally proposed the idea for the weapon that would eventually become the iconoclast's repeater, I had imagined it to be a laser gatling gun that required stamina to fire. This was too much coding effort for the contributor who initially added it, so I have decided to do so myself.

If you are immune to stamcrit, you will stop firing the repeater at the point where you *would* enter stamcrit.

The burst fire from each shot has been removed in favor of doubling the rate of automatic fire.

Because you will incur stamina-based slowdown from firing it, the innate slowdown has been removed.

I would suggest test merging this first to determine if the stamina cost should be tweaked.

## Why It's Good For The Game

This changes the dynamics of using the repeater. You no longer have the ability to fire it endlessly while standing still, which is a clear exploit that made it overpowered in combat against npcs and blobs.

On the other hand, you can also fire it continuously for longer while moving. This, however, comes with the caveat of inching closer and closer to stamcrit, and needing to disengage and avoid stamina damage long enough for your stamina to refresh before firing more shots.

Additional design goals I have intended to aim for, as suggested by the original contributor, are as follows:
- Keep the overall dps of the weapon the same.
- Keep the same balance of sustained fire duration and required downtime.

While I can envision someone stacking stamina regen chemicals, cases where this would happen to the point of being able to fire endlessly seem like they would be few and far between, and in those cases, they are already capable of doing much more destructive things with their chemistry knowledge.

## Changelog

:cl:
balance: Instead of being crank charged, the iconoclast's repeater now costs stamina to fire
balance: The iconoclast's repeater no longer has intrinsic slowdown
/:cl:
