### PR TITLE
Dont show swap hand tutorial if you only have 1 hand

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -78,7 +78,8 @@
 	// This can mean nothing happened, this can mean the target took damage, etc.
 
 	if(user.client && isitem(target))
-		if(isnull(user.get_inactive_held_item()))
+		var/mob/living/living_user = astype(user)
+		if(isnull(user.get_inactive_held_item() && living_user?.num_hands > 1))
 			SStutorials.suggest_tutorial(user, /datum/tutorial/switch_hands, modifiers)
 		else
 			SStutorials.suggest_tutorial(user, /datum/tutorial/drop, modifiers)


### PR DESCRIPTION

## About The Pull Request
Dont show swap hand tutorial if you only have 1 hand as you cannot complete it.
## Why It's Good For The Game
Someone on a downstream had an issue where it kept showing them the tutorial but they could not complete it as they play a character with only 1 arm.
Could prob extend this to a disabled limb as well.. dunno.
## Changelog
:cl:
fix: The swap hand tutorial wont be shown to someone missing a hand
/:cl:
