### PR TITLE
Makes easy_random_mutate mutated genes researchable

### DIFF
--- a/code/datums/dna/dna.dm
+++ b/code/datums/dna/dna.dm
@@ -619,7 +619,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 		return
 	var/datum/mutation/mutation = dna.get_mutation(mutation_path)
 	if(mutation)
-		mutation.scrambled = FALSE	//done to allow easy_random_mutate obtained genes to be saved in DNA consoles
+		mutation.scrambled = FALSE	//set to FALSE to allow easy_random_mutate obtained genes to be saved in DNA consoles
 
 /mob/living/carbon/proc/random_mutate_unique_identity()
 	if(!has_dna())

--- a/code/datums/dna/dna.dm
+++ b/code/datums/dna/dna.dm
@@ -619,7 +619,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 		return
 	var/datum/mutation/mutation = dna.get_mutation(mutation_path)
 	if(mutation)
-		mutation.scrambled = TRUE
+		mutation.scrambled = FALSE
 
 /mob/living/carbon/proc/random_mutate_unique_identity()
 	if(!has_dna())

--- a/code/datums/dna/dna.dm
+++ b/code/datums/dna/dna.dm
@@ -619,7 +619,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 		return
 	var/datum/mutation/mutation = dna.get_mutation(mutation_path)
 	if(mutation)
-		mutation.scrambled = FALSE
+		mutation.scrambled = FALSE	//done to allow easy_random_mutate obtained genes to be saved in DNA consoles
 
 /mob/living/carbon/proc/random_mutate_unique_identity()
 	if(!has_dna())


### PR DESCRIPTION

## About The Pull Request

sets the scrambled flag of easy_random_mutate to FALSE

## Why It's Good For The Game

Within my extensive geneticist playtime I have many times rushed the avalible genome in a round by myself, having a somewhat fast time of about 30 min, almost not exiting my lab in a non-stop A-T C-G frenzy. A kind of painful process for a human hand because of the amounts of clicking involved and our increasing number of avalible mutations, so i came up with what i hope is an adequate solution. In the practice what this pr does is allow for the random mutations caused by easy_random_mutate, which if im not mistaken are: 

toxin_reagents.dm | Unstable Mutagen 
body.dm | Unstable DNA mutation 
radiation_storm.dm | Radiation storm weather effects
floral.dm | Plant-mutating radiation projectiles
experimental_cloner_fuckup.dm  | Cloner malfunctions
eldritch_painting.dm | Heretic eldritch painting examines
_species.dm | Species radiation damage handling

to be saved to the dna consoles. under normal circumstances it means that unstable mutagen (and i guess cloner malf mutations) can be saved to dna consoles. IF im not mistaken and didnt miss anything, it essentially means that geneticists can now cooperate with chemistry in order to achieve a somewhat less click intensive, not necessarily much faster decoding process of the genome, at the cost of cooperating with your local chemist, and shorter lived test subjects (since it deals tox damage while metabolizing). because of how unstable mutagen works, this mostly means only unlocking negative mutations, since positives have a 2% of being unlocked and noted be mutagen only works first entering the mob, not while metabolizing.

<!--EndFragment-->
</body>
</html>
## Changelog

:cl:
balance: mutations coming from most random mutation sources can now be saved in dna consoles
/:cl:
