### PR TITLE
Fixes inconsistency with status_effect refresh() arguments

### DIFF
--- a/code/datums/status_effects/_status_effect_helpers.dm
+++ b/code/datums/status_effects/_status_effect_helpers.dm
@@ -13,9 +13,7 @@
 /mob/living/proc/apply_status_effect(datum/status_effect/new_effect, ...)
 	RETURN_TYPE(/datum/status_effect)
 
-	// The arguments we pass to the start effect. The 1st argument is this mob.
 	var/list/arguments = args.Copy()
-	arguments[1] = src
 
 	// If the status effect we're applying doesn't allow multiple effects, we need to handle it
 	if(initial(new_effect.status_type) != STATUS_EFFECT_MULTIPLE)
@@ -37,6 +35,9 @@
 				if(STATUS_EFFECT_REFRESH)
 					existing_effect.refresh(arglist(arguments))
 					return
+
+	// For the new effect the 1st argument is this mob
+	arguments[1] = src
 
 	// Create the status effect with our mob + our arguments
 	var/datum/status_effect/new_instance = new new_effect(arguments)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -250,9 +250,9 @@
 	return ..()
 
 /datum/status_effect/exercised/refresh(effect, bonus_time)
-	duration += workout_duration(new_owner, bonus_time)
-	new_owner.clear_mood_event("exercise") // we need to reset the old mood event in case our fitness skill changes
-	new_owner.add_mood_event("exercise", /datum/mood_event/exercise, new_owner.mind.get_skill_level(/datum/skill/athletics))
+	duration += workout_duration(owner, bonus_time)
+	owner.clear_mood_event("exercise") // we need to reset the old mood event in case our fitness skill changes
+	owner.add_mood_event("exercise", /datum/mood_event/exercise, owner.mind.get_skill_level(/datum/skill/athletics))
 
 /datum/status_effect/exercised/on_apply()
 	if(!owner.mind)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -249,7 +249,7 @@
 	duration += workout_duration(new_owner, bonus_time)
 	return ..()
 
-/datum/status_effect/exercised/refresh(mob/living/new_owner, bonus_time)
+/datum/status_effect/exercised/refresh(effect, bonus_time)
 	duration += workout_duration(new_owner, bonus_time)
 	new_owner.clear_mood_event("exercise") // we need to reset the old mood event in case our fitness skill changes
 	new_owner.add_mood_event("exercise", /datum/mood_event/exercise, new_owner.mind.get_skill_level(/datum/skill/athletics))

--- a/code/datums/status_effects/debuffs/cyborg.dm
+++ b/code/datums/status_effects/debuffs/cyborg.dm
@@ -20,7 +20,7 @@
 /datum/status_effect/borg_slow/on_remove()
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/borg_slowdown)
 
-/datum/status_effect/borg_slow/refresh(mob/living/new_owner, slowdown = 1)
+/datum/status_effect/borg_slow/refresh(effect, slowdown = 1)
 	. = ..()
 	if(src.slowdown <= slowdown)
 		return

--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -19,7 +19,7 @@
 	/// For how much firestacks does one our stack count
 	var/stack_modifier = 1
 
-/datum/status_effect/fire_handler/refresh(mob/living/new_owner, new_stacks, forced = FALSE)
+/datum/status_effect/fire_handler/refresh(effect, new_stacks, forced = FALSE)
 	if(forced)
 		set_stacks(new_stacks)
 	else

--- a/code/datums/status_effects/debuffs/genetic_damage.dm
+++ b/code/datums/status_effects/debuffs/genetic_damage.dm
@@ -27,7 +27,7 @@
 	. = ..()
 	UnregisterSignal(owner, COMSIG_LIVING_HEALTHSCAN)
 
-/datum/status_effect/genetic_damage/refresh(mob/living/owner, total_damage)
+/datum/status_effect/genetic_damage/refresh(effect, total_damage)
 	. = ..()
 	src.total_damage += total_damage
 

--- a/code/datums/status_effects/debuffs/hallucination.dm
+++ b/code/datums/status_effects/debuffs/hallucination.dm
@@ -166,7 +166,7 @@
 	strict_tier = TRUE
 	variable_tier = FALSE
 
-/datum/status_effect/hallucination/perceptomatrix/refresh(mob/living/refresh_owner, new_duration)
+/datum/status_effect/hallucination/perceptomatrix/refresh(effect, new_duration)
 	src.duration += new_duration
 
 /datum/status_effect/hallucination/perceptomatrix/on_creation(mob/living/new_owner, new_duration)


### PR DESCRIPTION

## About The Pull Request
Currently some status effects use mob as first argument in ``refresh()``, others typepath.

By default ``effect`` typepatch argument is expected:
https://github.com/tgstation/tgstation/blob/b2d8ee3fccfda9244ca3d33890b0f0ae15c623ef/code/datums/status_effects/_status_effect.dm#L187

So i changed it for ``effect`` everywhere and fixed ``apply_status_effect()``.

There is probably no point in this argument anyway, maybe for some cursed scenario with several status effects with the same ``id``. But there is no point in the mob either - we already have it set as ``owner`` in the refreshing status_effect.

I have not tested it, but should not break anything.