### PR TITLE
backticks some usages of `rank` in querys

### DIFF
--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -355,7 +355,7 @@ GLOBAL_PROTECT(protected_ranks)
 			continue
 		var/flags_to_check = flags.Join(" != [R_EVERYTHING] AND ") + " != [R_EVERYTHING]"
 		var/datum/db_query/query_check_everything_ranks = SSdbcore.NewQuery(
-			"SELECT flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")] WHERE rank = :rank AND ([flags_to_check])",
+			"SELECT flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")] WHERE `rank` = :rank AND ([flags_to_check])",
 			list("rank" = R.name)
 		)
 		if(!query_check_everything_ranks.Execute())
@@ -364,7 +364,7 @@ GLOBAL_PROTECT(protected_ranks)
 		if(query_check_everything_ranks.NextRow()) //no row is returned if the rank already has the correct flag value
 			var/flags_to_update = flags.Join(" = [R_EVERYTHING], ") + " = [R_EVERYTHING]"
 			var/datum/db_query/query_update_everything_ranks = SSdbcore.NewQuery(
-				"UPDATE [format_table_name("admin_ranks")] SET [flags_to_update] WHERE rank = :rank",
+				"UPDATE [format_table_name("admin_ranks")] SET [flags_to_update] WHERE `rank` = :rank",
 				list("rank" = R.name)
 			)
 			if(!query_update_everything_ranks.Execute())

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -135,7 +135,7 @@ GLOBAL_LIST_INIT(permission_action_types, list(
 				admins_by_rank[composed_rank.name] |= list(stored_key)
 
 		// Then, pull the full list of DB ranks
-		var/datum/db_query/query_extract_ranks = SSdbcore.NewQuery("SELECT rank, flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")]")
+		var/datum/db_query/query_extract_ranks = SSdbcore.NewQuery("SELECT `rank`, flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")]")
 		if(!query_extract_ranks.warn_execute())
 			qdel(query_extract_ranks)
 			return
@@ -317,7 +317,7 @@ GLOBAL_LIST_INIT(permission_action_types, list(
 		QDEL_NULL(query_extract_admins)
 
 		// Then, pull the full list of DB ranks to purity check against
-		var/datum/db_query/query_extract_ranks = SSdbcore.NewQuery("SELECT rank, flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")]")
+		var/datum/db_query/query_extract_ranks = SSdbcore.NewQuery("SELECT `rank`, flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")]")
 		if(!query_extract_ranks.warn_execute())
 			qdel(query_extract_ranks)
 			return
@@ -1082,7 +1082,7 @@ GLOBAL_LIST_INIT(permission_action_types, list(
 	if(use_db)
 		var/datum/db_query/query_db_rank_info = SSdbcore.NewQuery({"
 			SELECT flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")]
-			WHERE rank = :rank_name
+			WHERE `rank` = :rank_name
 		"}, list("rank_name" = admin_rank))
 		if(!query_db_rank_info.warn_execute())
 			qdel(query_db_rank_info)
@@ -1169,19 +1169,19 @@ GLOBAL_LIST_INIT(permission_action_types, list(
 				query_update_rank = SSdbcore.NewQuery({"
 					UPDATE [format_table_name("admin_ranks")]
 					SET flags = :flags
-					WHERE rank = :rank_name
+					WHERE `rank` = :rank_name
 				"}, list("rank_name" = admin_rank, "flags" = new_flags))
 			if("Excluded Rights")
 				query_update_rank = SSdbcore.NewQuery({"
 					UPDATE [format_table_name("admin_ranks")]
 					SET exclude_flags = :exclude_flags
-					WHERE rank = :rank_name
+					WHERE `rank` = :rank_name
 				"}, list("rank_name" = admin_rank, "exclude_flags" = new_flags))
 			if("Editing Rights")
 				query_update_rank = SSdbcore.NewQuery({"
 					UPDATE [format_table_name("admin_ranks")]
 					SET can_edit_flags = :can_edit_flags
-					WHERE rank = :rank_name
+					WHERE `rank` = :rank_name
 				"}, list("rank_name" = admin_rank, "can_edit_flags" = new_flags))
 
 		if(!query_update_rank.warn_execute())


### PR DESCRIPTION

## About The Pull Request
See title. I looked pretty hard and only found these as having this issue.
## Why It's Good For The Game
I'm mostly working off of other peoples wisdom here but `rank` is a reserved word in sql, and as we do in MOST of our other querys. backticking it prevents that from being an issue (and therefore fixes some sql errors that CAN happen depending on version (my issues happened with mysql, but apparently dont occur with heididb))
## Changelog
~~N/A as i dont acctually think this happens in TG rn unless yalls housekeeping tab on the admin panel is broken as well.~~
:cl:
fix: A handful of permissions panel querys now work again
/:cl:
