### PR TITLE
Fixes deleted implants causing runtimes

### DIFF
--- a/code/game/objects/items/implants/implant.dm
+++ b/code/game/objects/items/implants/implant.dm
@@ -125,7 +125,7 @@
  * * silent - unused here
  * * special - Set to true if removed by admin panel, should bypass any side effects
  */
-/obj/item/implant/proc/removed(mob/living/source, silent = FALSE, special = 0)
+/obj/item/implant/proc/removed(mob/living/source, silent = FALSE, special = FALSE)
 	moveToNullspace()
 	imp_in = null
 	source.implants -= src
@@ -139,7 +139,7 @@
 	GLOB.tracked_implants -= src
 	return TRUE
 
-/obj/item/implant/Destroy()
+/obj/item/implant/Destroy(force)
 	if(imp_in)
 		removed(imp_in, silent = TRUE, special = TRUE)
 	return ..()

--- a/code/game/objects/items/implants/implant.dm
+++ b/code/game/objects/items/implants/implant.dm
@@ -141,7 +141,7 @@
 
 /obj/item/implant/Destroy()
 	if(imp_in)
-		removed(imp_in)
+		removed(imp_in, silent = TRUE, special = TRUE)
 	return ..()
 
 /**


### PR DESCRIPTION
## About The Pull Request

qdeleting an implant typically occurs in cases like mob or bodypart deletion.

Some implants have effects after they are removed, like the storage implant.

<img width="1369" height="257" alt="image" src="https://github.com/user-attachments/assets/fa58bd38-1e09-446b-acfa-5ed9845e9c81" />

Which if done on a qdeleting mob, will cause runtimes and issues. We have a `special` arg here for cases just like this so let's use it.

This PR just ensures that hard-destruction of implants is silent and free of effects like that.

## Why It's Good For The Game

Fixes an oversight

## Changelog

Not player facing really