### PR TITLE
Takes the donk-co cameras off of the main station network

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/hauntedtradingpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hauntedtradingpost.dmm
@@ -147,7 +147,8 @@
 /obj/effect/mapping_helpers/broken_machine,
 /obj/machinery/camera/autoname/directional/east{
 	camera_construction_state = 1;
-	camera_enabled = 0
+	camera_enabled = 0;
+	network = list("donk")
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/hauntedtradingpost/public/corridor)
@@ -1692,7 +1693,8 @@
 	},
 /obj/machinery/camera/autoname/directional/west{
 	camera_construction_state = 1;
-	camera_enabled = 0
+	camera_enabled = 0;
+	network = list("donk")
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/hauntedtradingpost/employees)
@@ -3083,7 +3085,8 @@
 	},
 /obj/machinery/camera/autoname/directional/south{
 	camera_construction_state = 1;
-	camera_enabled = 0
+	camera_enabled = 0;
+	network = list("donk")
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/hauntedtradingpost/public/corridor)
@@ -4089,7 +4092,8 @@
 /obj/item/shard,
 /obj/machinery/camera/autoname/directional/east{
 	camera_construction_state = 1;
-	camera_enabled = 0
+	camera_enabled = 0;
+	network = list("donk")
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/hauntedtradingpost/public/corridor)
@@ -4183,7 +4187,8 @@
 /obj/machinery/duct,
 /obj/machinery/camera/autoname/directional/west{
 	camera_construction_state = 1;
-	camera_enabled = 0
+	camera_enabled = 0;
+	network = list("donk")
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/hauntedtradingpost/public/corridor)
@@ -4435,7 +4440,8 @@
 "Mr" = (
 /obj/machinery/camera/autoname/directional/west{
 	camera_construction_state = 1;
-	camera_enabled = 0
+	camera_enabled = 0;
+	network = list("donk")
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hauntedtradingpost/public)
@@ -6015,7 +6021,8 @@
 "ZZ" = (
 /obj/machinery/camera/autoname/directional/east{
 	camera_construction_state = 1;
-	camera_enabled = 0
+	camera_enabled = 0;
+	network = list("donk")
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hauntedtradingpost/public)

--- a/code/__DEFINES/cameranets.dm
+++ b/code/__DEFINES/cameranets.dm
@@ -36,6 +36,7 @@
 #define CAMERANET_NETWORK_CURATOR "curator"
 #define CAMERANET_NETWORK_FILMSTUDIO "filmstudio"
 #define CAMERANET_NETWORK_MONASTERY "monastery"
+#define CAMERANET_NETWORK_TRADINGPOST "donk"
 
 // Ruins/Away missiosn/Misc camera nets
 #define CAMERANET_NETWORK_MOON19_XENO "mo19x"


### PR DESCRIPTION

## About The Pull Request

This moves the donk co trading post cameras to a currently unused "donk" network.

This means they no longer show up on the "ss13" station network.
## Why It's Good For The Game

These cameras aren't even active, and they shouldn't be on the main station network anyways.

Closes #95633.

## Changelog
:cl: Rhials
fix: Donk Trading Post cameras no longer show up on the station cameranet
/:cl:
