### PR TITLE
Reduces the Heretic's Codex Cicatrix transmutation rune drawing speed bonus from 75% faster to 25% faster

### DIFF
--- a/code/modules/antagonists/heretic/items/forbidden_book.dm
+++ b/code/modules/antagonists/heretic/items/forbidden_book.dm
@@ -13,7 +13,7 @@
 	/// How fast we can drain influences
 	var/drain_speed = 5 SECONDS
 	/// How fast we can draw runes
-	var/draw_speed = 8 SECONDS
+	var/draw_speed = 22.5 SECONDS
 
 /obj/item/codex_cicatrix/Initialize(mapload)
 	. = ..()

--- a/code/modules/antagonists/heretic/items/forbidden_book.dm
+++ b/code/modules/antagonists/heretic/items/forbidden_book.dm
@@ -80,7 +80,7 @@
 	base_icon_state = "book_morbus"
 	icon_state = "book_morbus"
 	drain_speed = 2.5 SECONDS
-	draw_speed = 5 SECONDS
+	draw_speed = 20 SECONDS
 	/// List of mobs we've cursed with transmutation. When the codex is destroyed all those curses become undone
 	var/list/transmuted_victims = list()
 


### PR DESCRIPTION
## About The Pull Request

Reduces the Codex Cicatrix transmutation rune drawing speed bonus from 75% faster to 25% faster

## Why It's Good For The Game

This heavy of a speed reduction turns Heretic from needing to be a stealthy sneaky killer into being aggressively brutal as fast as physically possible. A 75% reduction is insanely quick; a 25% reduction is much more in line with reasonable number adjustments and will provide a noticeable boost to speed while not enabling speedrunner tactics. Heretics shouldn't be ascending before the hour mark, let alone before the 30 minute mark, and being able to on-the-spot sacrifice your kills without needing to secure the area first makes this non-viable to prevent.

## Changelog

:cl:
balance: Reduces the Codex Cicatrix transmutation rune drawing speed bonus from 75% faster to 25% faster
balance: Reduces the Codex Morbus transmutation rune drawing speed bonus from 84% faster to 34% faster
/:cl: