### PR TITLE
Increases Ashen Passage's cooldown to 3 minutes, but increases it's duration to 7.5 seconds, reworking it into a more controllable emergency escape tool rather than a combat utility.

### DIFF
--- a/code/modules/antagonists/heretic/magic/ash_jaunt.dm
+++ b/code/modules/antagonists/heretic/magic/ash_jaunt.dm
@@ -8,14 +8,14 @@
 	sound = null
 
 	school = SCHOOL_FORBIDDEN
-	cooldown_time = 300 SECONDS
+	cooldown_time = 180 SECONDS
 
 	invocation = "ASH'N P'SSG'"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
 	exit_jaunt_sound = null
-	jaunt_duration = 10 SECONDS
+	jaunt_duration = 7.5 SECONDS
 	jaunt_in_time = 1.3 SECONDS
 	jaunt_type = /obj/effect/dummy/phased_mob/spell_jaunt/red
 	jaunt_in_type = /obj/effect/temp_visual/dir_setting/ash_shift
@@ -80,7 +80,7 @@
 /datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/long
 	name = "Ashen Walk"
 	desc = "A long range spell that allows you pass unimpeded through multiple walls with a reduced cooldown."
-	cooldown_time = 240 SECONDS
+	cooldown_time = 120 SECONDS
 
 /obj/effect/temp_visual/dir_setting/ash_shift
 	name = "ash_shift"

--- a/code/modules/antagonists/heretic/magic/ash_jaunt.dm
+++ b/code/modules/antagonists/heretic/magic/ash_jaunt.dm
@@ -1,6 +1,6 @@
 /datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash
 	name = "Ashen Passage"
-	desc = "A short range spell that allows you to pass unimpeded through walls, removing restraints if empowered."
+	desc = "A long range spell with a long cooldown that allows you to pass unimpeded through walls, removing restraints if empowered."
 	background_icon_state = "bg_heretic"
 	overlay_icon_state = "bg_heretic_border"
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'
@@ -8,14 +8,14 @@
 	sound = null
 
 	school = SCHOOL_FORBIDDEN
-	cooldown_time = 15 SECONDS
+	cooldown_time = 300 SECONDS
 
 	invocation = "ASH'N P'SSG'"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
 	exit_jaunt_sound = null
-	jaunt_duration = 1.1 SECONDS
+	jaunt_duration = 10 SECONDS
 	jaunt_in_time = 1.3 SECONDS
 	jaunt_type = /obj/effect/dummy/phased_mob/spell_jaunt/red
 	jaunt_in_type = /obj/effect/temp_visual/dir_setting/ash_shift
@@ -79,8 +79,8 @@
 
 /datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/long
 	name = "Ashen Walk"
-	desc = "A long range spell that allows you pass unimpeded through multiple walls."
-	jaunt_duration = 5 SECONDS
+	desc = "A long range spell that allows you pass unimpeded through multiple walls with a reduced cooldown."
+	cooldown_time = 240 SECONDS
 
 /obj/effect/temp_visual/dir_setting/ash_shift
 	name = "ash_shift"


### PR DESCRIPTION
## About The Pull Request

Increases Ashen Passage's cooldown to 5 minutes, but increases it's duration to 10 seconds, reworking it into a more controllable emergency escape tool rather than a combat utility.

## Why It's Good For The Game

Jaunting is one of the most powerful tools in our spellcaster antagonists' lineups. It lets them choose which engagements they want to fight and which ones they want to run from, and when they can constantly access it with no restrictions or consideration, it means every engagement with them has to be an immediate win or an immediate loss, which is poor gameplay. By increasing the cooldown and lengthening the escape duration to compensate, Ashen Passage/Walk becomes an emergency escape tool you can further invest in to reduce the cooldown on, instead of your bread and butter initiation tool in combo with your grasp. It is extremely unfun to die because someone just manifested next to you and one-tapped you with a stun. This removes that gameplay by making it a serious decision to burn your escape tool's cooldown.

## Changelog
:cl:
balance: Increases Ashen Passage's cooldown to 3 minutes, but increases it's duration to 7.5 seconds, reworking it into a more controllable emergency escape tool rather than a combat utility.
/:cl: