### PR TITLE
DNA mob height doesn't instantly fall back to `HUMAN_HEIGHT_MEDIUM`

### DIFF
--- a/code/datums/dna/blocks/dna_identity_block.dm
+++ b/code/datums/dna/blocks/dna_identity_block.dm
@@ -142,7 +142,7 @@
 
 /datum/dna_block/identity/height/create_unique_block(mob/living/carbon/human/target)
 	var/max_height_index = length(dna_heights)
-	var/mob_height_index = dna_heights.Find("[target.get_base_mob_height()]") || dna_heights.Find(HUMAN_HEIGHT_MEDIUM)
+	var/mob_height_index = dna_heights.Find(target.get_base_mob_height()) || dna_heights.Find(HUMAN_HEIGHT_MEDIUM)
 	return construct_block(mob_height_index, max_height_index, block_length)
 
 /datum/dna_block/identity/height/apply_to_mob(mob/living/carbon/human/target, dna_hash)


### PR DESCRIPTION
## About The Pull Request
<img width="893" height="30" alt="image" src="https://github.com/user-attachments/assets/03d4f53e-5304-4b8f-8487-3abea829b08b" />

This tries to `Find` with a string of a mob's base height, which obviously doesn't work because this is a list of numbers and not strings of numbers, so it falls back to `Find` with the `HUMAN_HEIGHT_MEDIUM` define, a number, anyway. Why?

Might or might not be an achievable bug in game, but it being written like this doesn't seem intended.
## Changelog
:cl:
fix: DNA mob height doesn't instantly fall back to the base height for all mobs.
/:cl:
