### PR TITLE
Removes the minimum APC requirement for robofactories

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -646,7 +646,6 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 	name = "Robotic Factory (Removes Shunting)"
 	description = "Build a machine anywhere, using expensive nanomachines, that can convert a living human into a loyal cyborg slave when placed inside."
 	cost = 100
-	minimum_apcs = 10 // So you can't speedrun this
 	power_type = /datum/action/innate/ai/place_transformer
 	unlock_text = span_notice("You make contact with Space Amazon and request a robotics factory for delivery.")
 	unlock_sound = 'sound/machines/ping.ogg'


### PR DESCRIPTION
## About The Pull Request

Removes the minimum APC requirement for robofactories

## Why It's Good For The Game

I get why a minimum APC requirement is needed for something as impactful as the Kill Everyone™ button but I don't really see how it's needed for robofactories.
It just limits their usability and discourages their use, no one is going to place one 40 minutes into the round when they can use the points on other stuff at that point

## Changelog

:cl:
balance: Removes the minimum APC requirement for robofactories
/:cl:

