### PR TITLE
Bumps and removes deprecation for  `actions/create-github-app-token`

### DIFF
--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -18,10 +18,10 @@ jobs:
 
       - name: Generate App Token
         id: app-token-generation
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v3.1.1
         if: env.APP_PRIVATE_KEY != '' && env.APP_ID != ''
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
         env:
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -56,10 +56,10 @@ jobs:
 
       - name: Generate App Token
         id: app-token-generation
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v3.1.1
         if: env.APP_PRIVATE_KEY != '' && env.APP_ID != ''
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
         env:
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/discord_discussions.yml
+++ b/.github/workflows/discord_discussions.yml
@@ -41,10 +41,10 @@ jobs:
 
       - name: Generate App Token
         id: app-token-generation
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v3.1.1
         if: env.APP_PRIVATE_KEY != '' && env.APP_ID != ''
         with:
-            app-id: ${{ secrets.APP_ID }}
+            client-id: ${{ secrets.APP_ID }}
             private-key: ${{ secrets.APP_PRIVATE_KEY }}
         env:
             APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/generate_client_storage.yml
+++ b/.github/workflows/generate_client_storage.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token-generation
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v3.1.1
         if: env.APP_PRIVATE_KEY != '' && env.APP_ID != ''
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: tgstation
         env:

--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -40,10 +40,10 @@ jobs:
 
       - name: Generate App Token
         id: app-token-generation
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v3.1.1
         if: env.APP_PRIVATE_KEY != '' && env.APP_ID != ''
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
         env:
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## About The Pull Request
Fixes https://github.com/tgstation/tgstation/actions/runs/24282505958 by
  - Bumping version to 3.1.1
  - Replacing `app-id` with `client-id`

The secret should also have its name changed to `CLIENT_ID` but only a maintainer can do that

## Changelog
N/A