### PR TITLE
Makes ship in a bottle smaller and allows it to be bottled back up

### DIFF
--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -160,6 +160,7 @@
 
 /datum/component/riding/vehicle/lavaboat/dragonboat
 	vehicle_move_delay = 1
+	keytype = null
 
 /datum/component/riding/vehicle/lavaboat/dragonboat/get_rider_offsets_and_layers(pass_index, mob/offsetter)
 	return list(
@@ -168,11 +169,6 @@
 		TEXT_EAST =  list(1, 2),
 		TEXT_WEST =  list(1, 2),
 	)
-
-/datum/component/riding/vehicle/lavaboat/dragonboat
-	vehicle_move_delay = 1
-	keytype = null
-
 
 /datum/component/riding/vehicle/janicart
 	keytype = /obj/item/key/janitor

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -24,9 +24,9 @@
 	  * [/datum/component/riding/var/keytype] variable because only a few specific checks are handled here with this var, and the majority of it is on the riding component
 	  * Eventually the remaining checks should be moved to the component and this var removed.
 	  */
-	var/key_type
+	var/obj/item/key_type
 	///The inserted key, needed on some vehicles to start the engine
-	var/obj/item/key/inserted_key
+	var/obj/item/inserted_key
 	/// Whether the vehicle is currently able to move
 	var/canmove = TRUE
 	var/list/autogrant_actions_passenger //plain list of typepaths

--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -1,6 +1,4 @@
-
-//Boat
-
+// Boat
 /obj/vehicle/ridden/lavaboat
 	name = "lava boat"
 	desc = "A boat used for traversing lava."
@@ -15,6 +13,26 @@
 /obj/vehicle/ridden/lavaboat/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/lavaboat)
+
+/obj/vehicle/ridden/lavaboat/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!key_type || is_key(inserted_key) || !is_key(tool))
+		return NONE
+	if(!user.transferItemToLoc(tool, src))
+		to_chat(user, span_warning("[tool] seems to be stuck to your hand!"))
+		return ITEM_INTERACT_BLOCKING
+	to_chat(user, span_notice("You attach \the [tool] to \the [src]."))
+	if(inserted_key) //just in case there's an invalid key
+		inserted_key.forceMove(drop_location())
+	inserted_key = tool
+	return ITEM_INTERACT_SUCCESS
+
+/obj/vehicle/ridden/lavaboat/examine_key_message()
+	if(!key_type)
+		return
+	if(!inserted_key)
+		return span_notice("You can attach an oar to it by clicking \the [src] with one.")
+	else
+		return span_notice("Alt-click [src] to detach \the [inserted_key].")
 
 /obj/item/oar
 	name = "oar"
@@ -57,9 +75,7 @@
 	result = /obj/vehicle/ridden/lavaboat/plasma
 	reqs = list(/obj/item/stack/sheet/animalhide/goliath_hide/polar_bear_hide = 3)
 
-//Dragon Boat
-
-
+// Dragon Boat
 /obj/item/ship_in_a_bottle
 	name = "ship in a bottle"
 	desc = "A tiny ship inside a bottle."
@@ -68,8 +84,16 @@
 
 /obj/item/ship_in_a_bottle/attack_self(mob/user)
 	to_chat(user, span_notice("You're not sure how they get the ships in these things, but you're pretty sure you know how to get it out."))
-	playsound(user.loc, 'sound/effects/glass/glassbr1.ogg', 100, TRUE)
-	new /obj/vehicle/ridden/lavaboat/dragon(get_turf(src))
+	create_boat(get_turf(src))
+
+/obj/item/ship_in_a_bottle/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	. = ..()
+	if (!.) // Shatter when not caught
+		create_boat(get_turf(src))
+
+/obj/item/ship_in_a_bottle/proc/create_boat(drop_loc)
+	playsound(drop_loc, 'sound/effects/glass/glassbr1.ogg', 100, TRUE)
+	new /obj/vehicle/ridden/lavaboat/dragon(drop_loc)
 	qdel(src)
 
 /obj/vehicle/ridden/lavaboat/dragon
@@ -82,3 +106,16 @@
 /obj/vehicle/ridden/lavaboat/dragon/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/lavaboat/dragonboat)
+
+/obj/vehicle/ridden/lavaboat/dragon/examine(mob/user)
+	. = ..()
+	. += span_notice("You can reform [src] into its bottled shape by rubbing the dragon's nose with [EXAMINE_HINT("Alt-Click")].")
+
+/obj/vehicle/ridden/lavaboat/dragon/click_alt(mob/user)
+	balloon_alert(user, "bottling the boat...")
+	if (!do_after(user, 2 SECONDS, src))
+		return CLICK_ACTION_BLOCKING
+	balloon_alert(user, "bottled the boat!")
+	var/obj/item/ship_in_a_bottle/bottled_ship = new(user.drop_location())
+	user.put_in_hands(bottled_ship)
+	return CLICK_ACTION_SUCCESS

--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -81,6 +81,7 @@
 	desc = "A tiny ship inside a bottle."
 	icon = 'icons/obj/mining_zones/artefacts.dmi'
 	icon_state = "ship_bottle"
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ship_in_a_bottle/attack_self(mob/user)
 	to_chat(user, span_notice("You're not sure how they get the ships in these things, but you're pretty sure you know how to get it out."))

--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -119,4 +119,5 @@
 	balloon_alert(user, "bottled the boat!")
 	var/obj/item/ship_in_a_bottle/bottled_ship = new(user.drop_location())
 	user.put_in_hands(bottled_ship)
+	qdel(src)
 	return CLICK_ACTION_SUCCESS

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -9,11 +9,17 @@
 
 /obj/vehicle/ridden/examine(mob/user)
 	. = ..()
-	if(key_type)
-		if(!inserted_key)
-			. += span_notice("Put a key inside it by clicking it with the key.")
-		else
-			. += span_notice("Alt-click [src] to remove the key.")
+	var/key_message = examine_key_message()
+	if (key_message)
+		. += key_message
+
+/obj/vehicle/ridden/proc/examine_key_message()
+	if(!key_type)
+		return
+	if(!inserted_key)
+		return span_notice("Put a key inside it by clicking it with the [key_type::name].")
+	else
+		return span_notice("Alt-click [src] to remove \the [inserted_key].")
 
 /obj/vehicle/ridden/generate_action_type(actiontype)
 	var/datum/action/vehicle/ridden/A = ..()
@@ -45,7 +51,7 @@
 	if(!inserted_key)
 		return CLICK_ACTION_BLOCKING
 	if(!is_occupant(user))
-		to_chat(user, span_warning("You must be riding the [src] to remove [src]'s key!"))
+		to_chat(user, span_warning("You must be riding the [src] to remove [src]'s [inserted_key]!"))
 		return CLICK_ACTION_BLOCKING
 	to_chat(user, span_notice("You remove \the [inserted_key] from \the [src]."))
 	user.put_in_hands(inserted_key)


### PR DESCRIPTION

## About The Pull Request

Makes the dragon boat dropped from lavaland tendrils capable of being bottled back up by alt clicking after a 2 second delay. This should give it a semblance of a purpose and make it not a completely dead drop. They've also been reduced in size from normal to small, allowing them to be placed in pockets and boxes.

Also, boats no longer refer to their oars as keys in examine tooltips.

## Why It's Good For The Game

Ship in a bottle is possibly the worst drop from tendrils on-par with book of babel, as its effectively a one-time use crossing tool since you rarely need to cross lava in the exact same place you've left your boat. These two changes should make it at least a bit viable if you get nasty river generation and need to cross them frequently, and don't want to use a raptor or upgrade a MODsuit.

## Changelog
:cl:
balance: Ship from a bottle can now be bottled back up by alt-clicking it
balance: Ship in a bottle can now be deployed by throwing it, and are a small item instead of normal-sized
spellcheck: Boats no longer refer to oars as keys
/:cl:
