### PR TITLE
Tweaks (Fixes) formula for "internal bleeding" volume

### DIFF
--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -51,7 +51,7 @@
 
 	return ..()
 
-/datum/wound/pierce/bleed/receive_damage(wounding_type, wounding_dmg, wound_bonus)
+/datum/wound/pierce/bleed/receive_damage(wounding_type, wounding_dmg, wound_bonus, attack_direction, damage_source)
 	if(victim.stat == DEAD || wounding_dmg < 5 || !limb.can_bleed() || !victim.get_blood_volume() || !prob(internal_bleeding_chance + wounding_dmg))
 		return
 	// 20 force attack ~=  5-16 blood loss ~= 1%-3% of blood volume

--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -80,8 +80,8 @@
 				visible_message_flags = ALWAYS_SHOW_SELF_MESSAGE,
 			)
 	victim.bleed(blood_bled)
-	if(blood_bled >= 14)
-		victim.do_splatter_effect(attack_direction)
+	if(blood_bled >= 18)
+		victim.spray_blood(attack_direction)
 
 /datum/wound/pierce/bleed/get_bleed_rate_of_change()
 	//basically if a species doesn't bleed, the wound is stagnant and will not heal on its own (nor get worse)

--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -39,8 +39,8 @@
 
 	/// When hit on this bodypart, we have this chance of losing some blood + the incoming damage
 	var/internal_bleeding_chance
-	/// If we let off blood when hit, the max blood lost is this * the incoming damage
-	var/internal_bleeding_coefficient
+	/// A multiplier applied to how much blood is lost from damage to the wounded limb
+	var/internal_bleeding_coefficient = 1
 	/// If TRUE we are ready to be mended in surgery
 	VAR_FINAL/mend_state = FALSE
 
@@ -52,36 +52,36 @@
 	return ..()
 
 /datum/wound/pierce/bleed/receive_damage(wounding_type, wounding_dmg, wound_bonus)
-	if(victim.stat == DEAD || (wounding_dmg < 5) || !limb.can_bleed() || !victim.get_blood_volume() || !prob(internal_bleeding_chance + wounding_dmg))
+	if(victim.stat == DEAD || wounding_dmg < 5 || !limb.can_bleed() || !victim.get_blood_volume() || !prob(internal_bleeding_chance + wounding_dmg))
 		return
-	var/blood_bled = rand(1, limb.get_splint_factor() * internal_bleeding_coefficient) // 12 brute toolbox can cause up to 15/18/21 bloodloss on mod/sev/crit
+	// 20 force attack ~=  5-16 blood loss ~= 1%-3% of blood volume
+	// 30 force attack ~= 6-20 blood loss ~= 1%-4% of blood volume
+	var/blood_bled = sqrt(wounding_dmg) * internal_bleeding_coefficient * limb.get_splint_factor() * pick(0.75, 1, 1.25, 1.5)
 	switch(blood_bled)
-		if(1 to 6)
-			victim.bleed(blood_bled, TRUE)
-		if(7 to 13)
+		if(8 to 12)
 			victim.visible_message(
 				span_smalldanger("Blood droplets fly from the hole in [victim]'s [limb.plaintext_zone]."),
 				span_danger("You cough up a bit of blood from the blow to your [limb.plaintext_zone]."),
 				vision_distance = COMBAT_MESSAGE_RANGE,
+				visible_message_flags = ALWAYS_SHOW_SELF_MESSAGE,
 			)
-			victim.bleed(blood_bled, TRUE)
-		if(14 to 19)
+		if(12 to 18)
 			victim.visible_message(
 				span_smalldanger("A small stream of blood spurts from the hole in [victim]'s [limb.plaintext_zone]!"),
 				span_danger("You spit out a string of blood from the blow to your [limb.plaintext_zone]!"),
 				vision_distance = COMBAT_MESSAGE_RANGE,
+				visible_message_flags = ALWAYS_SHOW_SELF_MESSAGE,
 			)
-			victim.create_splatter(victim.dir)
-			victim.bleed(blood_bled)
-		if(20 to INFINITY)
+		if(18 to INFINITY)
 			victim.visible_message(
 				span_danger("A spray of blood streams from the gash in [victim]'s [limb.plaintext_zone]!"),
 				span_bolddanger("You choke up on a spray of blood from the blow to your [limb.plaintext_zone]!"),
 				vision_distance = COMBAT_MESSAGE_RANGE,
+				visible_message_flags = ALWAYS_SHOW_SELF_MESSAGE,
 			)
-			victim.bleed(blood_bled)
-			victim.create_splatter(victim.dir)
-			victim.add_splatter_floor(get_step(victim.loc, victim.dir))
+	victim.bleed(blood_bled)
+	if(blood_bled >= 14)
+		victim.do_splatter_effect(attack_direction)
 
 /datum/wound/pierce/bleed/get_bleed_rate_of_change()
 	//basically if a species doesn't bleed, the wound is stagnant and will not heal on its own (nor get worse)
@@ -206,7 +206,7 @@
 	gauzed_clot_rate = 0.75
 	clot_rate = 0.03
 	internal_bleeding_chance = 30
-	internal_bleeding_coefficient = 1.25
+	internal_bleeding_coefficient = 1.5
 	series_threshold_penalty = 20
 	status_effect_type = /datum/status_effect/wound/pierce/moderate
 	scar_keyword = "piercemoderate"
@@ -240,7 +240,6 @@
 	gauzed_clot_rate = 0.1
 	clot_rate = 0.03 // will close quickly on its own
 	internal_bleeding_chance = 0
-	internal_bleeding_coefficient = 1
 	threshold_penalty = 5
 
 /datum/wound_pregen_data/flesh_pierce/open_puncture/pinprick
@@ -285,7 +284,7 @@
 	gauzed_clot_rate = 0.5
 	clot_rate = 0.02
 	internal_bleeding_chance = 60
-	internal_bleeding_coefficient = 1.5
+	internal_bleeding_coefficient = 2
 	series_threshold_penalty = 35
 	status_effect_type = /datum/status_effect/wound/pierce/severe
 	scar_keyword = "piercesevere"
@@ -397,7 +396,7 @@
 	initial_flow = 2.5
 	gauzed_clot_rate = 0.3
 	internal_bleeding_chance = 80
-	internal_bleeding_coefficient = 1.75
+	internal_bleeding_coefficient = 2.5
 	threshold_penalty = 15
 	status_effect_type = /datum/status_effect/wound/pierce/critical
 	scar_keyword = "piercecritical"


### PR DESCRIPTION
## About The Pull Request

Before: Internal bleeding `volume = rand(1, damage * coefficient)`

Bleeding could vary between 1 to 40, causing some attacks to drain you of 0.1% of your blood, and other attacks to drain you of 7% of your blood

After: Internal bleeding `volume = sqrt(damage) * coefficient * rand(0.75, 1.5)`

Bleeding may vary between ranges like 5 to 16, amounting to 1% to 3% of your blood

Also I broke it, now it's fixed oops

## Why It's Good For The Game

The variance in "internal bleeding" roll was so large that it could practically instantly sign your death warrant or would never matter across 100 attacks

This aims to raise the low end and lower the high end to bring a more sensible range of "volume" 

## Changelog

:cl: Melbert
balance: The amount of blood loss from an attack to an already bleeding wound has been tweaked. As an example, a 20 force attack used to range 0.1% to 4% blood loss, and now ranges 1% to 3%. 
/:cl:


