### PR TITLE
Optimize Github Actions CI workflow for Map Linter

### DIFF
--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -82,8 +82,16 @@ jobs:
       - name: Run OpenDream
         if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: ./DMCompiler_linux-x64/DMCompiler tgstation.dme --suppress-unimplemented --define=CIBUILDING | bash tools/ci/annotate_od.sh
+      - name: Check for Map & Maplint File Edits
+        id: map-filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            run_maps:
+              - '**.dmm'
+              - 'tools/maplint/**'
       - name: Run Map Checks
-        if: steps.linter-setup.conclusion == 'success' && !cancelled()
+        if: steps.linter-setup.conclusion == 'success' && !cancelled() && steps.map-filter.outputs.run_maps == 'true'
         run: |
           tools/bootstrap/python -m mapmerge2.dmm_test
           tools/bootstrap/python -m tools.maplint.source

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -90,6 +90,7 @@ jobs:
             run_maps:
               - '**.dmm'
               - 'tools/maplint/**'
+              - 'tools/mapmerge2/**'
       - name: Run Map Checks
         if: steps.linter-setup.conclusion == 'success' && !cancelled() && steps.map-filter.outputs.run_maps == 'true'
         run: |

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -11,7 +11,7 @@
 /area/station/commons/dorms/laundry)
 "aau" = (
 /obj/structure/railing{
-	dir = 2
+	dir = 1
 	},
 /obj/structure/showcase/machinery/implanter,
 /turf/open/floor/wood,

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -11,7 +11,7 @@
 /area/station/commons/dorms/laundry)
 "aau" = (
 /obj/structure/railing{
-	dir = 1
+	dir = 2
 	},
 /obj/structure/showcase/machinery/implanter,
 /turf/open/floor/wood,


### PR DESCRIPTION

## About The Pull Request
This PR introduces a path-filtering step to `.github/workflows/run_linters.yml`. Currently, our map linters run on every single commit, regardless of whether a map was actually touched.

I have added a check that only wakes up the Python map linter if:

1. A `.dmm` file is modified anywhere in the repository.
2. The linter tool itself (`tools/maplint/**`) is updated.
3. The mapmerge tool itself (`tools/mapmerge2/**`) is updated.

To accomplish this, we use [dorny/paths-filter@v4](https://github.com/dorny/paths-filter) since GitHub’s built-in workflow path filters cannot be applied to specific jobs or steps within a shared CI job.

To crunch some numbers here:
- Skipping the map linter saves ~30 seconds of runner time per commit
- We average about ~400 PRs a month
- Our GitHub pulse says `Excluding merges, 51 authors have pushed 482 commits to master and 776 commits to all branches.` so ~800 commits per month.
- ~10% of our PRs involve map edits (so this affects ~90% of PRs)

So this saves about ~6 hours of CI runners per month.

## Why It's Good For The Game
It stops wasting NT's electricity (and our GitHub Actions credits). Contributors no longer have to wait for the linter to verify that the maps they didn't touch are still not broken.

## Changelog
:cl:
server: Optimized CI workflow to skip map-specific linters when no maps are modified.
/:cl:
