### PR TITLE
Removes an unused variable from the plasmaman species datum

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -67,9 +67,6 @@
 		/datum/outfit/syndicate/full/loneop = /datum/outfit/syndicate/full/plasmaman/loneop,
 	)
 
-	/// If the bones themselves are burning clothes won't help you much
-	var/internal_fire = FALSE
-
 /datum/species/plasmaman/pre_equip_species_outfit(datum/job/job, mob/living/carbon/human/equipping, visuals_only = FALSE)
 	if(job?.plasmaman_outfit)
 		equipping.equipOutfit(job.plasmaman_outfit, visuals_only)


### PR DESCRIPTION

## About The Pull Request

The functionality was moved away from the species datum in the limb refactor so this isn't used by/for anything anymore

## Changelog

Not player-facing
