### PR TITLE
Fix window spawners not being dense

### DIFF
--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -21,6 +21,7 @@ again.
 	name = "window spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/fulltile)
 	dir = SOUTH
+	density = TRUE
 
 /obj/effect/spawner/structure/window/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
This fixes a random spawner issue where objects could spawn outside windows because the pathing determined that window spawners are not considered dense.

See the code below:

```dm
/obj/effect/spawner/random/proc/has_unblocked_line(destination)
	for(var/turf/potential_blockage as anything in get_line(get_turf(src), destination))
		if(!potential_blockage.is_blocked_turf(exclude_mobs = TRUE))
			continue
		return FALSE
	return TRUE

/turf/proc/is_blocked_turf(exclude_mobs = FALSE, source_atom = null, list/ignore_atoms, type_list = FALSE)
	if(density)
		return TRUE

	for(var/atom/movable/movable_content as anything in contents)
		// We don't want to block ourselves
		if((movable_content == source_atom))
			continue
		// don't consider ignored atoms or their types
		if(length(ignore_atoms))
			if(!type_list && (movable_content in ignore_atoms))
				continue
			else if(type_list && is_type_in_list(movable_content, ignore_atoms))
				continue

		// If the thing is dense AND we're including mobs or the thing isn't a mob AND if there's a source atom and
		// it cannot pass through the thing on the turf,  we consider the turf blocked.
		if(movable_content.density && (!exclude_mobs || !ismob(movable_content)))
			if(source_atom && movable_content.CanPass(source_atom, get_dir(src, source_atom)))
				continue
			return TRUE
	return FALSE
```

## Why It's Good For The Game
Random spawners will now respect window boundaries. 

## Changelog
:cl:
fix: Fix window spawners not being dense, which affected random spawners LOS boundaries.
/:cl:
