### PR TITLE
Restores soul by returning Rhumba Beat immunity to Cuban Pete

### DIFF
--- a/code/datums/diseases/rhumba_beat.dm
+++ b/code/datums/diseases/rhumba_beat.dm
@@ -17,7 +17,9 @@
 	. = ..()
 	if(!.)
 		return
-
+	if(affected_mob.ckey == "rosham")
+		cure()
+		return
 	switch(stage)
 		if(2)
 			if(SPT_PROB(26, seconds_per_tick))


### PR DESCRIPTION
## About The Pull Request

Restores soul by returning Rhumba Beat immunity to Cuban Pete.

## Why It's Good For The Game

I can't believe we let this piece of SS13 history die. What are we, forgetting where we come from?

## Changelog

:cl:
fix: Restores soul by returning Rhumba Beat immunity to Cuban Pete
/:cl: