### PR TITLE
Replaces offstation tram consoles with indestructible variants

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
@@ -1836,9 +1836,8 @@
 /area/ruin/space)
 "QS" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
-/obj/machinery/computer/tram_controls{
+/obj/machinery/computer/tram_controls/digital{
 	dir = 8;
-	icon_state = "tram_alt_controls";
 	density = 0;
 	specific_transport_id = "hilb_1"
 	},

--- a/_maps/RandomZLevels/heretic.dmm
+++ b/_maps/RandomZLevels/heretic.dmm
@@ -1106,8 +1106,7 @@
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/structure/transport/linear/tram,
 /obj/structure/thermoplastic/light,
-/obj/machinery/computer/tram_controls/heretic_tram_computer{
-	icon_state = "tram_alt_controls";
+/obj/machinery/computer/tram_controls/digital/heretic_tram_computer{
 	dir = 8
 	},
 /turf/open/floor/engine,

--- a/code/modules/awaymissions/mission_code/heretic/heretic_gateway_tram.dm
+++ b/code/modules/awaymissions/mission_code/heretic/heretic_gateway_tram.dm
@@ -23,7 +23,7 @@
 /obj/machinery/transport/tram_controller/heretic_tram_controller
 	configured_transport_id = HERETIC_LINE_1
 
-/obj/machinery/computer/tram_controls/heretic_tram_computer
+/obj/machinery/computer/tram_controls/digital/heretic_tram_computer
 	icon = 'icons/obj/tram/heretic_tram.dmi'
 	icon_screen = HERETIC_LINE_1
 	specific_transport_id = HERETIC_LINE_1

--- a/code/modules/transport/tram/tram_controls.dm
+++ b/code/modules/transport/tram/tram_controls.dm
@@ -250,4 +250,12 @@
 				else
 					return
 
+/// Indestructible consoles for offstation use
+/obj/machinery/computer/tram_controls/digital
+	obj_flags = INDESTRUCTIBLE
+	icon_state = "tram_alt_controls"
+
+/obj/machinery/computer/tram_controls/digital/screwdriver_act()
+	return
+
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/tram_controls, 32)


### PR DESCRIPTION
/bounty

Hi! I'd like to work on this bounty. 

My Plan:

- State the requirements
- PR the solution
- Merge PR within 24-48 hours

Payment Address:

- Platform: PayPal
- Token: Quarters / Dimes
- Address: [https://www.paypal.me/zhaog100](https://www.youtube.com/watch?v=dQw4w9WgXcQ)

Let's get this done! 🚀

<details>

## About The Pull Request

Replaces offstation tram consoles in the Hilbert space ruins well as the Heretic gateway with an indestructible, undeconstructible variant.

## Why It's Good For The Game

closes #95554
These consoles were already floating buttons, there's no reason not to make them indestructible.

## Changelog
:cl:

qol: Offstation tram consoles in the Hilbert's space ruin & the Heretic gateway are no longer destructible

/:cl:
</details>