### PR TITLE
Removing brain updates med hud

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -133,6 +133,7 @@
 		if(!(organ_owner.living_flags & STOP_OVERLAY_UPDATE_BODY_PARTS))
 			organ_owner.update_body_parts()
 		organ_owner.clear_mood_event("brain_damage")
+		organ_owner.med_hud_set_status()
 
 /obj/item/organ/brain/update_icon_state()
 	icon_state = "[initial(icon_state)][smooth_brain ? "-smooth" : ""]"


### PR DESCRIPTION
## About The Pull Request

Removing the brain updates med hud status (to indicate the body is not revivable) 

## Changelog

:cl: Melbert
fix: Removing brain updates the med hud
/:cl:
