### PR TITLE
Getting sacrificed removes you from all heretic's sacrifice list

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -26,7 +26,7 @@
 	/// A weakref to the mind of our heretic.
 	var/datum/mind/heretic_mind
 	/// Lazylist of minds that we won't pick as targets.
-	var/list/datum/mind/target_blacklist
+	var/static/list/datum/mind/target_blacklist
 	/// An assoc list of [ref] to [timers] - a list of all the timers of people in the shadow realm currently
 	var/list/return_timers
 	/// Evil organs we can put in people
@@ -42,7 +42,6 @@
 
 /datum/heretic_knowledge/hunt_and_sacrifice/Destroy(force)
 	heretic_mind = null
-	LAZYCLEARLIST(target_blacklist)
 	return ..()
 
 /datum/heretic_knowledge/hunt_and_sacrifice/on_research(mob/user, datum/antagonist/heretic/our_heretic)
@@ -202,8 +201,8 @@
 
 	if(sacrifice.mind)
 		LAZYADD(target_blacklist, sacrifice.mind)
-	heretic_datum.remove_sacrifice_target(sacrifice)
-
+	for(var/datum/antagonist/heretic/all_heretic in GLOB.antagonists)
+		all_heretic.remove_sacrifice_target(sacrifice)
 
 	var/feedback = "Your patrons accept your offer"
 	var/sac_job_flag = sacrifice.mind?.assigned_role?.job_flags | sacrifice.last_mind?.assigned_role?.job_flags


### PR DESCRIPTION
## About The Pull Request

Being successfully sacrificed by a heretic removes you from ALL heretic's sacrifice lists, as well as prevents you from being rolled as a target again

This does mean more narrow manifests (ie one head of staff) could result in all other heretics being unable to ascend, but that's fine, they should be fighting over it anyways

## Why It's Good For The Game

Being sacrificed on repeat kinda sucks and also it encourages heretics to work together to bag the same target when they should be working against each other 

## Changelog

:cl: Melbert
balance: Upon being successfully sacrificed by a heretic all other heretics lose you as a target, and you can no longer be (re)rolled as a target by other heretics. 
/:cl:

