### PR TITLE
[NO GBP] Kitsune Mask no longer hides the user's identity while flipped

### DIFF
--- a/code/modules/clothing/masks/costume.dm
+++ b/code/modules/clothing/masks/costume.dm
@@ -75,6 +75,7 @@
 /obj/item/clothing/mask/kitsune/attack_self(mob/user)
 	adjust_visor(user)
 	alternate_worn_layer = up ? ABOVE_BODY_FRONT_HEAD_LAYER : null
+	flags_inv = up ? null : HIDEFACE|HIDEFACIALHAIR
 
 /obj/item/clothing/mask/rebellion
 	name = "rebellion mask"

--- a/code/modules/clothing/masks/costume.dm
+++ b/code/modules/clothing/masks/costume.dm
@@ -75,7 +75,7 @@
 /obj/item/clothing/mask/kitsune/attack_self(mob/user)
 	adjust_visor(user)
 	alternate_worn_layer = up ? ABOVE_BODY_FRONT_HEAD_LAYER : null
-	flags_inv = up ? null : HIDEFACE|HIDEFACIALHAIR
+	flags_inv = up ? NONE : (HIDEFACE|HIDEFACIALHAIR)
 
 /obj/item/clothing/mask/rebellion
 	name = "rebellion mask"


### PR DESCRIPTION

## About The Pull Request
I forgot to add an ``inv_flag`` for when it's used in hand to flip so it'd always keep the wearer's identity hidden even if their face were pretty much exposed

## Why It's Good For The Game
Fixes an oversight of mine, the mask pretty much reveals your face when flipped so it shouldn't keep the wearer's identity hidden

## Changelog
:cl: Hardly
fix: Kitsune mask no longer keeps the user's identity hidden while it's flipped
/:cl:
