### PR TITLE
fixes welding goggles covering your eyes when up

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -491,7 +491,7 @@
 	inhand_icon_state = "welding-g"
 	actions_types = list(/datum/action/item_action/toggle)
 	flash_protect = FLASH_PROTECTION_WELDER
-	flags_cover = GLASSESCOVERSEYES
+	visor_flags_cover = GLASSESCOVERSEYES
 	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*2.5)
 	tint = 2
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT


### PR DESCRIPTION

## About The Pull Request

hi
## Why It's Good For The Game

i use a lot of dropper to apply chems when i play MD and this is slightly annoying
## Changelog
:cl:
fix: welding goggles now only cover your eyes when covering your eyes
/:cl:
