### PR TITLE
Heretics are blocked from main tree progression if too many other heretics remain alive

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -959,6 +959,10 @@
 		stack_trace("[type] purchase_knowledge was given a path that doesn't exist in the heretic [category] knowledge list! (Got: [knowledge_type])")
 		return FALSE
 
+	if(category == HERETIC_KNOWLEDGE_TREE && is_tree_limited())
+		to_chat(owner.current, span_warning("There are too many competitors vying for the Hour's attention. Their ranks must be culled before you can gain further power."))
+		return FALSE
+
 	var/cost = knowledge_data[HKT_COST]
 	if(cost > knowledge_points)
 		return FALSE
@@ -1090,6 +1094,25 @@
 		return HERETIC_NO_LIVING_HEART
 
 	return HERETIC_HAS_LIVING_HEART
+
+/// Whether the heretic is prevented from researching more knowledge due to too many heretics remaining alive.
+/datum/antagonist/heretic/proc/is_tree_limited()
+	var/tree_knowledges = 0
+	for(var/knowledge_path in researched_knowledge)
+		if(researched_knowledge[knowledge_path][HKT_CATEGORY] == HERETIC_KNOWLEDGE_TREE)
+			tree_knowledges++
+	if(tree_knowledges > 2 || tree_knowledges > 6) // The limiting starts after armor, for no reason other than to make it easier to find and kill each other.
+		var/list/datum/mind/heretic_minds = get_antag_minds(/datum/antagonist/heretic)
+		heretic_minds.Remove(owner)
+		for(var/datum/mind/heretic_mind in heretic_minds)
+			var/mob/living/heretic_mob = heretic_mind.current
+			if(!heretic_mob || heretic_mob.stat == DEAD/* || !heretic_mob.client*/)
+				heretic_minds.Remove(heretic_mind)
+				continue
+
+		if(heretic_minds.len > -tree_knowledges + 6) // 3 or less for knowledge 4, 2 or less for knowledge 5, 1 or less for knowledge 6, and 0 for ascension.
+			return TRUE
+	return FALSE
 
 /// Heretic's minor sacrifice objective. "Minor sacrifices" includes anyone.
 /datum/objective/minor_sacrifice

--- a/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -61,6 +61,9 @@
 
 	replacement.TakeComponent(src)
 
+
+#define TRACK_TARGET_HERETIC_CHECK "Nearby heretics"
+
 /**
  * The action associated with the living heart.
  * Allows a heretic to track sacrifice targets.
@@ -109,11 +112,6 @@
 	var/datum/antagonist/heretic/heretic_datum = GET_HERETIC(owner)
 	var/datum/heretic_knowledge/sac_knowledge = heretic_datum.get_knowledge(/datum/heretic_knowledge/hunt_and_sacrifice)
 
-	if(!LAZYLEN(heretic_datum.sac_targets))
-		owner.balloon_alert(owner, "no targets, visit a rune!")
-		StartCooldown(1 SECONDS)
-		return TRUE
-
 	// Holds a list of `name = image` used to display the radial menu when you left click the living heart
 	var/list/choosable_targets = list()
 	// Holds a list of 'name = atom/thing` used to check if our thing still exists after we've made our selection
@@ -139,9 +137,17 @@
 		choosable_targets[blade.name] = image(icon = blade.icon, icon_state = blade.icon_state)
 		possible_tracked_atoms[blade.name] = blade
 
+	if(heretic_datum.is_tree_limited())
+		choosable_targets[TRACK_TARGET_HERETIC_CHECK] = image(icon = 'icons/mob/actions/actions_ecult.dmi', icon_state = "mansus_grasp") // No entry in possible_tracked_atoms, because we're pre-empting checks for it because we don't have an atom.
+
 	for(var/mob/living/carbon/human/sac_target as anything in heretic_datum.sac_targets)
 		choosable_targets[sac_target.real_name] = heretic_datum.sac_targets[sac_target]
 		possible_tracked_atoms[sac_target.real_name] = sac_target
+
+	if(!choosable_targets.len)
+		owner.balloon_alert(owner, "no targets, visit a rune!")
+		StartCooldown(1 SECONDS)
+		return TRUE
 
 	// If we don't have a last tracked name, open a radial to set one.
 	// If we DO have a last tracked name, we skip the radial if they right click the action.
@@ -161,6 +167,11 @@
 	// If our last tracked name is still null, skip the trigger
 	if(isnull(last_tracked_name))
 		return FALSE
+
+	if(last_tracked_name == TRACK_TARGET_HERETIC_CHECK)
+		owner.balloon_alert(owner, get_heretic_ping_message())
+		StartCooldown()
+		return TRUE
 
 	var/atom/tracked_thing = possible_tracked_atoms[last_tracked_name]
 	if(QDELETED(tracked_thing))
@@ -258,6 +269,35 @@
 			balloon_message = "they're dead, " + balloon_message
 
 	return balloon_message
+
+/// Gets the message for checking for the nearest heretic
+/datum/action/cooldown/track_target/proc/get_heretic_ping_message()
+	var/list/all_heretics = get_antag_minds(/datum/antagonist/heretic)
+	var/closest_dist = 500
+	for(var/datum/mind/heretic_mind in all_heretics)
+		var/mob/living/heretic = heretic_mind.current
+		if(!heretic || heretic.stat == DEAD || heretic == owner)
+			continue
+		if(heretic.z != owner.z)
+			if(!is_station_level(heretic.z) || !is_station_level(owner.z))
+				continue
+		var/dist = get_dist(heretic, owner)
+		if(dist < closest_dist)
+			closest_dist = dist
+	if(closest_dist == 500)
+		return "No other aspirants are anywhere close!"
+	closest_dist += rand(-25, 25) // Fairly unreliable as an exact check, but gives a general idea..
+	switch(closest_dist)
+		if(-25 to 15)
+			return "Another aspirant is very close!"
+		if(16 to 31)
+			return "Another aspirant is somewhere nearby!"
+		if(32 to 127)
+			return "Another aspirant is quite far!"
+		else
+			return "Another aspirant is very far away!"
+
+#undef TRACK_TARGET_HERETIC_CHECK
 
 /atom/movable/screen/navigate_arrow
 	icon = 'icons/effects/96x96.dmi'

--- a/tgui/packages/tgui/interfaces/AntagInfoHeretic.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoHeretic.tsx
@@ -228,6 +228,13 @@ const GuideSection = () => {
           harder sacrifices.
         </Stack.Item>
         <Stack.Item>
+          - There may be other aspirants to the power of the Mansus on the
+          station. You will be limited in your research by their presence, and
+          they by yours. You you will be{' '}
+          <span style={hereticRed}>unable to ascend</span> until they are all
+          dead.
+        </Stack.Item>
+        <Stack.Item>
           - Accomplish all of your objectives to be able to learn the{' '}
           <span style={hereticYellow}>final ritual</span>. Complete the ritual
           to become all powerful!


### PR DESCRIPTION

## About The Pull Request

Beginning after a heretic has purchased their armor knowledge on the tree, their further main-tree progression, including ascension, will require a decreasing amount of other heretics alive. 3 or less other heretics must be alive for knowledge 4, 2 or less for 5, 1 or less for 6, and 0 for ascension. This only applies to main-tree knowledges, and heretics are free to continue gaining knowledge from the shop.

Heretics being blocked by this(and, to be clear, only people blocked by this. The option does not appear until you are no longer able to progress on the main tree due to this) gain a new option on their living heart ability, that being the ability to gauge the general location of nearby heretics. "general" here means "very innacurate", as it provides only a vague description of distance, and even that distance has been modified + - 25, at random. No direction, either. This isn't an antag detector.

## Why It's Good For The Game

Pretty much the most dull, unimpedable, and uncounterable thing to happen on the station is not just one heretic, but two heretics, working together. They say "lemme get this rift" once, and suddenly the game is over and there is no longer anything that can be done about this pair(or, god forbid, triumvirate) of immovable rods. Even someone with the luck or planning necessary to get an upper hand on one heretic is three-tapped by the other. The only thing on par with a heretic in power is another heretic, so let's make them fight each other rather than let them curbstomp the station together every other round.

## Changelog
:cl:

add: Heretics are now blocked from further main-tree progression when too many other heretics remain alive on the station, decreasing down to requiring being the last heretic left alive in order to ascend. Heretics being impeded by this gain the ability to gauge the general distance of the nearest heretic to themselves.

/:cl:
