### PR TITLE
Stops they/them it/its gender choice from locking you into the "Female" physique

### DIFF
--- a/code/modules/client/preferences/body_type.dm
+++ b/code/modules/client/preferences/body_type.dm
@@ -10,11 +10,6 @@
 /datum/preference/choiced/body_type/init_possible_values()
 	return list(USE_GENDER, MALE, FEMALE)
 
-/datum/preference/choiced/body_type/is_valid(value, datum/preferences/preferences)
-	. = ..()
-	if(. && value == USE_GENDER)
-		return gender_has_physique(preferences.read_preference(/datum/preference/choiced/gender))
-
 /datum/preference/choiced/body_type/create_informed_default_value(datum/preferences/preferences)
 	return gender_has_physique(preferences.read_preference(/datum/preference/choiced/gender)) ? USE_GENDER : FEMALE
 

--- a/code/modules/client/preferences/gender.dm
+++ b/code/modules/client/preferences/gender.dm
@@ -16,12 +16,3 @@
 	// The only reason I'm limiting this to male or female
 	// is that hairstyle randomization handles enbies poorly
 	return pick(MALE, FEMALE)
-
-/datum/preference/choiced/gender/post_write(value, datum/preferences/preferences)
-	..()
-	if (gender_has_physique(value))
-		return
-
-	var/current_physique = preferences.read_preference(/datum/preference/choiced/body_type)
-	if(current_physique != MALE && current_physique != FEMALE)
-		preferences.update_preference(GLOB.preference_entries[/datum/preference/choiced/body_type], FEMALE)


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/95111 introduced code that threw me off a bit and felt like a bug.

If your physique is set to 'Use Gender', and you change your gender to plural, for some reason it edits your physique pref to  'Female' each time. Which leads to a disorienting user experience as you would expect the physique to change back to male when clicking the male gender icon. except it never will until you update your physique pref, which on a lot of codebases you have to scroll down far to find and likely wouldn't see changing in real time.

I don't see why it's necessary to touch the prefs when the apply_to_human code already handles everything related to defaulting to 'female' physique. 

<details><summary>before (note the Body Type setting on the right hand side)</summary>

<img width="586" height="397" alt="dreamseeker_F6LzOphJkn" src="https://github.com/user-attachments/assets/ba87bba1-b3cd-4744-82fd-24185eb4b31f" />

</details>

<details><summary>after</summary>

<img width="654" height="583" alt="9Inr4Xbh3b" src="https://github.com/user-attachments/assets/e5f78417-5886-48e9-ad56-0ce191b45095" />

</details>

## Why It's Good For The Game

Prefs which are located in separate panes shouldn't be rewriting themselves automatically like this. Better UX

## Changelog

:cl:
fix: changing your gender choice in character prefs no longer modifies your physique preference
/:cl: