### PR TITLE
Fix the division by zero error with the passive vents

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -33,6 +33,9 @@
 	var/datum/gas_mixture/external = location.return_air()
 	var/datum/gas_mixture/internal = airs[1]
 
+	if(!internal.volume || !external.volume)
+		return
+
 	if(internal.equalize(external))
 		air_update_turf(FALSE, FALSE)
 		update_parents()


### PR DESCRIPTION
## About The Pull Request

<img width="600" height="400" alt="xHRp2P1JWN" src="https://github.com/user-attachments/assets/46812be5-0405-472e-9b5f-c5b1e3e79e7e" />

<img width="600" height="400" alt="3yxQA3GkVJ" src="https://github.com/user-attachments/assets/3d5c0fb9-cfd1-4306-a7bd-01049c7caf78" />

I am really sick of seeing this spam absolutely polluting the crap out of the logs, no one else seems to be willing to touch this code so I guess I will.

This PR just adds a very minimal cost guard against this condition, which apparently occurs when you have a passive vent trying to equalize with space tiles (which, the gas mixtures force vacuum heat capacity when they have no gases), resulting in the passive vent trying to equalize with it even with its pipenet being empty.

I'm no atmos expert but I can say the cost of doing this check is basically nothing, and the cost of having runtime spam overhead is significantly worse (but more importantly it hurts log readability).

If someone can come up with a better fix then by all means but I think this is better than what we have had happening for the past year and a half now (maybe longer, that's just when I first noticed it). And it's basically all I'm able to come up with, I'm not able to rewrite vast swaths of atmos sadly

## Why It's Good For The Game

Less runtime spam plx

## Changelog

Not player-facing

