### PR TITLE
Janiborg cleans its own brushes when auto washing

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -651,6 +651,9 @@
 
 	if(reagents.has_reagent(amount = 1, chemical_flags = REAGENT_CLEANS))
 		our_turf.wash(CLEAN_SCRUB)
+		var/datum/component/bloodysoles/bot/trackfilth = robot_owner.GetComponent(/datum/component/bloodysoles/bot)
+		if(trackfilth)
+			trackfilth.change_blood_amount(-trackfilth.total_bloodiness)
 
 	reagents.expose(our_turf, TOUCH, min(1, 10 / reagents.total_volume))
 	// We use more water doing this then mopping


### PR DESCRIPTION

## About The Pull Request

empties the blood out of the `bloodysoles` component when janiborg moves with autowash. This means they will no longer make foot(?)prints on diagonal movements.

## Why It's Good For The Game

fixes #95785

## Changelog
:cl:

fix: Janiborgs will no longer track blood while autowashing

/:cl:
