### PR TITLE
Void cloaks do not block surgery while invisibile

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -181,6 +181,7 @@ DEFINE_BITFIELD(no_equip_flags, list(
 #define HEADCOVERSMOUTH (1<<4)
 #define PEPPERPROOF (1<<5) //protects against pepperspray
 #define EARS_COVERED (1<<6)
+#define BODY_PART_ACCESSIBLE (1<<7) //item will not obstruct body part access, such as for surgery, despite covering the body part
 
 #define TINT_MILD 1.5 //Threshold of tint level to apply mild tint overlay
 #define TINT_DARKENED 2 //Threshold of tint level to apply weld mask overlay

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -181,7 +181,7 @@ DEFINE_BITFIELD(no_equip_flags, list(
 #define HEADCOVERSMOUTH (1<<4)
 #define PEPPERPROOF (1<<5) //protects against pepperspray
 #define EARS_COVERED (1<<6)
-#define BODY_PART_ACCESSIBLE (1<<7) //item will not obstruct body part access, such as for surgery, despite covering the body part
+#define ALLOW_SURGERY_THROUGh (1<<7) //item will not obstruct body part access, such as for surgery, despite covering the body part
 
 #define TINT_MILD 1.5 //Threshold of tint level to apply mild tint overlay
 #define TINT_DARKENED 2 //Threshold of tint level to apply weld mask overlay

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -181,7 +181,7 @@ DEFINE_BITFIELD(no_equip_flags, list(
 #define HEADCOVERSMOUTH (1<<4)
 #define PEPPERPROOF (1<<5) //protects against pepperspray
 #define EARS_COVERED (1<<6)
-#define ALLOW_SURGERY_THROUGh (1<<7) //item will not obstruct body part access, such as for surgery, despite covering the body part
+#define ALLOW_SURGERY_THROUGH (1<<7) //item will not obstruct body part access, such as for surgery, despite covering the body part
 
 #define TINT_MILD 1.5 //Threshold of tint level to apply mild tint overlay
 #define TINT_DARKENED 2 //Threshold of tint level to apply weld mask overlay

--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -1233,7 +1233,7 @@
 /obj/item/clothing/suit/hooded/cultrobes/void/proc/make_visible()
 	remove_traits(list(TRAIT_NO_STRIP, TRAIT_EXAMINE_SKIP), REF(src))
 	AddElement(/datum/element/heretic_focus)
-	flags_cover &= ~ALLOW_SURGERY_THROUGh
+	flags_cover &= ~ALLOW_SURGERY_THROUGH
 
 	if(isliving(loc))
 		loc.add_traits(list(TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTCOLD), REF(src))

--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -1221,8 +1221,7 @@
 /obj/item/clothing/suit/hooded/cultrobes/void/proc/make_invisible()
 	add_traits(list(TRAIT_NO_STRIP, TRAIT_EXAMINE_SKIP), REF(src))
 	RemoveElement(/datum/element/heretic_focus)
-	if(!(flags_cover & BODY_PART_ACCESSIBLE))
-		flags_cover |= BODY_PART_ACCESSIBLE
+	flags_cover |= BODY_PART_ACCESSIBLE
 
 	if(isliving(loc))
 		loc.remove_traits(list(TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTCOLD), REF(src))

--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -1114,13 +1114,13 @@
 // Void cloak. Turns invisible with the hood up, lets you hide stuff.
 /obj/item/clothing/head/hooded/cult_hoodie/void
 	name = "void hood"
-	icon = 'icons/obj/clothing/head/helmet.dmi'
-	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	desc = "Black like tar, reflecting no light. Runic symbols line the outside. \
 		With each flash you lose comprehension of what you are seeing."
+	icon = 'icons/obj/clothing/head/helmet.dmi'
+	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	icon_state = "void_cloak"
 	flags_inv = NONE
-	flags_cover = NONE
+	flags_cover = BODY_PART_ACCESSIBLE
 	armor_type = /datum/armor/cult_hoodie_void
 
 /datum/armor/cult_hoodie_void
@@ -1221,6 +1221,8 @@
 /obj/item/clothing/suit/hooded/cultrobes/void/proc/make_invisible()
 	add_traits(list(TRAIT_NO_STRIP, TRAIT_EXAMINE_SKIP), REF(src))
 	RemoveElement(/datum/element/heretic_focus)
+	if(!(flags_cover & BODY_PART_ACCESSIBLE))
+		flags_cover |= BODY_PART_ACCESSIBLE
 
 	if(isliving(loc))
 		loc.remove_traits(list(TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTCOLD), REF(src))
@@ -1232,6 +1234,7 @@
 /obj/item/clothing/suit/hooded/cultrobes/void/proc/make_visible()
 	remove_traits(list(TRAIT_NO_STRIP, TRAIT_EXAMINE_SKIP), REF(src))
 	AddElement(/datum/element/heretic_focus)
+	flags_cover &= ~BODY_PART_ACCESSIBLE
 
 	if(isliving(loc))
 		loc.add_traits(list(TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTCOLD), REF(src))

--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -1120,7 +1120,7 @@
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	icon_state = "void_cloak"
 	flags_inv = NONE
-	flags_cover = BODY_PART_ACCESSIBLE
+	flags_cover = ALLOW_SURGERY_THROUGh
 	armor_type = /datum/armor/cult_hoodie_void
 
 /datum/armor/cult_hoodie_void
@@ -1221,7 +1221,7 @@
 /obj/item/clothing/suit/hooded/cultrobes/void/proc/make_invisible()
 	add_traits(list(TRAIT_NO_STRIP, TRAIT_EXAMINE_SKIP), REF(src))
 	RemoveElement(/datum/element/heretic_focus)
-	flags_cover |= BODY_PART_ACCESSIBLE
+	flags_cover |= ALLOW_SURGERY_THROUGh
 
 	if(isliving(loc))
 		loc.remove_traits(list(TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTCOLD), REF(src))
@@ -1233,7 +1233,7 @@
 /obj/item/clothing/suit/hooded/cultrobes/void/proc/make_visible()
 	remove_traits(list(TRAIT_NO_STRIP, TRAIT_EXAMINE_SKIP), REF(src))
 	AddElement(/datum/element/heretic_focus)
-	flags_cover &= ~BODY_PART_ACCESSIBLE
+	flags_cover &= ~ALLOW_SURGERY_THROUGh
 
 	if(isliving(loc))
 		loc.add_traits(list(TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTCOLD), REF(src))

--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -1120,7 +1120,7 @@
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	icon_state = "void_cloak"
 	flags_inv = NONE
-	flags_cover = ALLOW_SURGERY_THROUGh
+	flags_cover = ALLOW_SURGERY_THROUGH
 	armor_type = /datum/armor/cult_hoodie_void
 
 /datum/armor/cult_hoodie_void
@@ -1221,7 +1221,7 @@
 /obj/item/clothing/suit/hooded/cultrobes/void/proc/make_invisible()
 	add_traits(list(TRAIT_NO_STRIP, TRAIT_EXAMINE_SKIP), REF(src))
 	RemoveElement(/datum/element/heretic_focus)
-	flags_cover |= ALLOW_SURGERY_THROUGh
+	flags_cover |= ALLOW_SURGERY_THROUGH
 
 	if(isliving(loc))
 		loc.remove_traits(list(TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTCOLD), REF(src))

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -444,7 +444,7 @@
 	for(var/obj/item/worn_item in get_equipped_items(INCLUDE_ABSTRACT))
 		if(worn_item.slot_flags & exluded_equipment_slots)
 			continue
-		if(worn_item.flags_cover & ALLOW_SURGERY_THROUGh)
+		if(worn_item.flags_cover & ALLOW_SURGERY_THROUGH)
 			continue
 		covered_flags |= worn_item.body_parts_covered
 

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -444,7 +444,7 @@
 	for(var/obj/item/worn_item in get_equipped_items(INCLUDE_ABSTRACT))
 		if(worn_item.slot_flags & exluded_equipment_slots)
 			continue
-		if(worn_item.flags_cover & BODY_PART_ACCESSIBLE)
+		if(worn_item.flags_cover & ALLOW_SURGERY_THROUGh)
 			continue
 		covered_flags |= worn_item.body_parts_covered
 

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -444,6 +444,8 @@
 	for(var/obj/item/worn_item in get_equipped_items(INCLUDE_ABSTRACT))
 		if(worn_item.slot_flags & exluded_equipment_slots)
 			continue
+		if(worn_item.flags_cover & BODY_PART_ACCESSIBLE)
+			continue
 		covered_flags |= worn_item.body_parts_covered
 
 	// NB: we have to convert covered_flags via cover_flags2body_zones here

--- a/code/modules/unit_tests/surgeries.dm
+++ b/code/modules/unit_tests/surgeries.dm
@@ -246,8 +246,8 @@
 	TEST_ASSERT(test_mob.is_location_accessible(BODY_ZONE_CHEST), "Chest should be accessible after rolling jumpsuit down")
 	jumpsuit.adjust_to_alt()
 
-	jumpsuit.flags_cover |= BODY_PART_ACCESSIBLE
-	TEST_ASSERT(test_mob.is_location_accessible(BODY_ZONE_CHEST), "Chest should be accessible if it has the BODY_PART_ACCESSIBLE flag")
+	jumpsuit.flags_cover |= ALLOW_SURGERY_THROUGh
+	TEST_ASSERT(test_mob.is_location_accessible(BODY_ZONE_CHEST), "Chest should be accessible if it has the ALLOW_SURGERY_THROUGh flag")
 
 /// Tests surgeries which just modify basic surgical states
 /datum/unit_test/state_surgeries

--- a/code/modules/unit_tests/surgeries.dm
+++ b/code/modules/unit_tests/surgeries.dm
@@ -244,6 +244,10 @@
 	var/obj/item/clothing/under/jumpsuit = test_mob.get_item_by_slot(ITEM_SLOT_ICLOTHING)
 	jumpsuit.adjust_to_alt()
 	TEST_ASSERT(test_mob.is_location_accessible(BODY_ZONE_CHEST), "Chest should be accessible after rolling jumpsuit down")
+	jumpsuit.adjust_to_alt()
+
+	jumpsuit.flags_cover |= BODY_PART_ACCESSIBLE
+	TEST_ASSERT(test_mob.is_location_accessible(BODY_ZONE_CHEST), "Chest should be accessible if it has the BODY_PART_ACCESSIBLE flag")
 
 /// Tests surgeries which just modify basic surgical states
 /datum/unit_test/state_surgeries

--- a/code/modules/unit_tests/surgeries.dm
+++ b/code/modules/unit_tests/surgeries.dm
@@ -246,8 +246,8 @@
 	TEST_ASSERT(test_mob.is_location_accessible(BODY_ZONE_CHEST), "Chest should be accessible after rolling jumpsuit down")
 	jumpsuit.adjust_to_alt()
 
-	jumpsuit.flags_cover |= ALLOW_SURGERY_THROUGh
-	TEST_ASSERT(test_mob.is_location_accessible(BODY_ZONE_CHEST), "Chest should be accessible if it has the ALLOW_SURGERY_THROUGh flag")
+	jumpsuit.flags_cover |= ALLOW_SURGERY_THROUGH
+	TEST_ASSERT(test_mob.is_location_accessible(BODY_ZONE_CHEST), "Chest should be accessible if it has the ALLOW_SURGERY_THROUGH flag")
 
 /// Tests surgeries which just modify basic surgical states
 /datum/unit_test/state_surgeries


### PR DESCRIPTION

## About The Pull Request

fixes https://github.com/tgstation/tgstation/issues/95803

The void cloak and its hood do not obstruct body parts for things such as surgery. I guess it also lets you shave a heretic while their hood is on but that seems kind of funny.

## Why It's Good For The Game

A) This is going to result in a lot of complications due to the strip menu obscuring that the void cloak has. 

B) It also gets rid of some meta tells that you have the cloak. 

Honestly, I wonder if it would be better if this was a neck item and the 'hood' is just an abstraction, but that's kind of exiting the realm of a fix at that point.

## Changelog
:cl:
fix: Void cloaks no longer obstruct surgery while invisible.
/:cl:
