### PR TITLE
Makes the black fedora in the detdrobe a subtype of the detective fedora

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -242,7 +242,7 @@
 	name = "detective's noir fedora"
 	desc = "There's only one man who can recklessly discharge a firearm into a crowded street while trying to stop a criminal, \
 		and he's likely wearing this hat."
-	icon_state = "fedora"
+	icon_state = /obj/item/clothing/head/fedora::icon_state
 
 ///Detectives Fedora, but like Inspector Gadget. Not a subtype to not inherit candy corn stuff
 /obj/item/clothing/head/fedora/inspector_hat

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -187,7 +187,6 @@
 	/// Cooldown for retrieving precious candy corn with rmb
 	COOLDOWN_DECLARE(candy_cooldown)
 
-
 /datum/armor/fedora_det_hat
 	melee = 25
 	bullet = 5
@@ -238,6 +237,12 @@
 
 /obj/item/clothing/head/fedora/det_hat/minor
 	flask_path = /obj/item/reagent_containers/cup/glass/flask/det/minor
+
+/obj/item/clothing/head/fedora/det_hat/noir
+	name = "detective's noir fedora"
+	desc = "There's only one man who can recklessly discharge a firearm into a crowded street while trying to stop a criminal, \
+		and he's likely wearing this hat."
+	icon_state = "fedora"
 
 ///Detectives Fedora, but like Inspector Gadget. Not a subtype to not inherit candy corn stuff
 /obj/item/clothing/head/fedora/inspector_hat

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -696,7 +696,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 		/obj/item/clothing/under/rank/security/detective/noir = 2,
 		/obj/item/clothing/under/rank/security/detective/noir/skirt = 2,
 		/obj/item/clothing/shoes/laceup = 2,
-		/obj/item/clothing/head/fedora = 2,
+		/obj/item/clothing/head/fedora/det_hat/noir = 1,
 		/obj/item/clothing/suit/toggle/jacket/det_trench/noir = 1,
 		/obj/item/clothing/suit/jacket/det_suit/noir = 1,
 		/obj/item/clothing/neck/tie/disco = 1,


### PR DESCRIPTION

## About The Pull Request

Closes https://github.com/tgstation/tgstation/issues/95198

## Why It's Good For The Game

Consistency while keeping the detective fashionably noir. I reduced it to one so it keeps in line with the other noir clothing.

## Changelog
:cl:
qol: The detective's noir fedora is actually a detective fedora, and gets all the unique qualities expected of one.
/:cl:
