### PR TITLE
Fixes incorrect var being used in sprite accessory clothing icon rendering [no gbp]

### DIFF
--- a/code/datums/sprite_accessories.dm
+++ b/code/datums/sprite_accessories.dm
@@ -1288,7 +1288,7 @@ GLOBAL_LIST_EMPTY(blended_hair_icons_cache)
 		result = mutable_appearance(icon(cached_icons[key]))
 
 	else if(greyscale_config || use_female || use_digi) // icon ops ahead
-		var/icon/created = icon(greyscale_config ? SSgreyscale.GetColoredIconByType(greyscale_config, greyscale_colors) : icon, icon_state)
+		var/icon/created = icon(greyscale_config ? SSgreyscale.GetColoredIconByType(greyscale_config, greyscale_colors) : icon, icon_state_to_use)
 		if(use_female)
 			created = wear_female_version(icon_state_to_use, icon, female_sprite_flags_to_use)
 		if(use_digi)

--- a/code/datums/sprite_accessories.dm
+++ b/code/datums/sprite_accessories.dm
@@ -1249,6 +1249,7 @@ GLOBAL_LIST_EMPTY(blended_hair_icons_cache)
 	gender = NEUTER
 
 /datum/sprite_accessory/clothing
+	abstract_type = /datum/sprite_accessory/clothing
 	/// Allows you to specify a greyscale config
 	var/greyscale_config
 	/// Icon state in the digitigrade template file to use if the wearer is digitigrade.
@@ -1315,6 +1316,7 @@ GLOBAL_LIST_EMPTY(blended_hair_icons_cache)
 	icon = 'icons/mob/clothing/underwear.dmi'
 	use_static = FALSE
 	em_block = TRUE
+	abstract_type = /datum/sprite_accessory/clothing/underwear
 
 //MALE UNDERWEAR
 /datum/sprite_accessory/clothing/underwear/nude
@@ -1509,6 +1511,7 @@ GLOBAL_LIST_EMPTY(blended_hair_icons_cache)
 /datum/sprite_accessory/clothing/undershirt
 	icon = 'icons/mob/clothing/underwear.dmi'
 	em_block = TRUE
+	abstract_type = /datum/sprite_accessory/clothing/undershirt
 
 /datum/sprite_accessory/clothing/undershirt/nude
 	name = "Nude"
@@ -1797,6 +1800,7 @@ GLOBAL_LIST_EMPTY(blended_hair_icons_cache)
 /datum/sprite_accessory/clothing/socks
 	icon = 'icons/mob/clothing/underwear.dmi'
 	em_block = TRUE
+	abstract_type = /datum/sprite_accessory/clothing/socks
 
 /datum/sprite_accessory/clothing/socks/nude
 	name = "Nude"


### PR DESCRIPTION
## About The Pull Request

This doesn't actually have any negative consequences here, but any downstreams might notice some issues if they make use of the `get_icon_state()` proc.

## Why It's Good For The Game

Fixes an oversight, I'm blind and overlooked this one.

## Changelog

Nothing placer-facing