### PR TITLE
Adds toggle for meteor mode in secrets

### DIFF
--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -703,6 +703,27 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 				return
 			return
 
+		if("meteormode")
+			if(!is_funmin)
+				return
+			if(GLOB.meteor_mode)
+				QDEL_NULL(GLOB.meteor_mode)
+				message_admins("[key_name_admin(holder)] disabled meteor mode.")
+				return TRUE
+
+			GLOB.meteor_mode = new()
+			var/start_when = tgui_input_number(usr, "Meteors will start in (this many seconds):", "Meteor Mode: Start", (5 MINUTES) / 10, (24 HOURS) / 10, 0)
+			var/ramp_speed = tgui_input_number(usr, "Meteors will worsen every (this many seconds):", "Meteor Mode: Intensity", (5 MINUTES) / 10, (24 HOURS) / 10, (30 SECONDS) / 10)
+			if(!is_funmin) // deadminnied?
+				QDEL_NULL(GLOB.meteor_mode)
+				return TRUE
+			GLOB.meteor_mode.meteordelay = world.time + (start_when * 10)
+			GLOB.meteor_mode.rampupdelta = ramp_speed / 60
+			GLOB.meteor_mode.start_meteor()
+			message_admins("[key_name_admin(holder)] enabled meteor mode. \
+				Meteors will start [start_when ? "in [DisplayTimeText(start_when * 10)]" : "immediately"], and will worsen every [DisplayTimeText(ramp_speed * 10)].")
+			return TRUE
+
 		if("fix_gravity")
 			if(!is_funmin)
 				return

--- a/code/modules/meteors/meteor_mode_controller.dm
+++ b/code/modules/meteors/meteor_mode_controller.dm
@@ -9,8 +9,6 @@ GLOBAL_DATUM(meteor_mode, /datum/meteor_mode_controller)
 	var/rampupdelta = 5
 
 /datum/meteor_mode_controller/proc/start_meteor()
-	if(datum_flags & DF_ISPROCESSING)
-		return
 	START_PROCESSING(SSprocessing, src)
 
 /datum/meteor_mode_controller/process(seconds_per_tick)

--- a/tgui/packages/tgui/interfaces/Secrets.jsx
+++ b/tgui/packages/tgui/interfaces/Secrets.jsx
@@ -580,12 +580,27 @@ const FunForYouTab = (props) => {
             <NoticeBox danger width={19.6} mb={0}>
               <Button
                 color="red"
-                icon="cat"
+                icon="explosion"
                 fluid
                 content="CASCAAADE"
                 onClick={() => act('cascade')}
               />
             </NoticeBox>
+          </Stack.Item>
+          <Stack.Item>
+            <Stack fill>
+              <Stack.Item>
+                <NoticeBox danger width={19.6} mb={0}>
+                  <Button
+                    color="red"
+                    icon="burst"
+                    fluid
+                    content="Toggle Meteor Mode"
+                    onClick={() => act('meteormode')}
+                  />
+                </NoticeBox>
+              </Stack.Item>
+            </Stack>
           </Stack.Item>
         </Stack>
       </Stack.Item>


### PR DESCRIPTION
## About The Pull Request

Admins can disable ongoing or start meteor mode in the secrets menu

## Why It's Good For The Game

Only other way is doing it mid round is manually, which is wack

## Changelog

:cl: Melbert
admin: Adds toggle for meteor mode in secrets
/:cl:
