### PR TITLE
Fixes materials market delivery crate

### DIFF
--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -221,6 +221,11 @@
 /datum/supply_order/disposable/materials/get_final_cost()
 	return (..() + CARGO_CRATE_VALUE)
 
+/// Custom material order to append cargo crate value to the final manifest cost
+/datum/supply_order/disposable/materials/generateManifest(obj/container, owner, packname, cost)
+	cost += CARGO_CRATE_VALUE
+	return ..()
+
 #undef MANIFEST_ERROR_CHANCE
 #undef MANIFEST_ERROR_NAME
 #undef MANIFEST_ERROR_CONTENTS

--- a/code/modules/cargo/packs/_packs.dm
+++ b/code/modules/cargo/packs/_packs.dm
@@ -139,7 +139,7 @@
 	name = "materials order"
 	crate_name = "galactic materials market delivery crate"
 	access = FALSE
-	crate_type = /obj/structure/closet/crate/cardboard
+	crate_type = /obj/structure/closet/crate/cargo/mining
 
 /datum/supply_pack/custom/minerals/New(purchaser, cost, list/contains)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Fixes materials orders being delivered in a box instead of a crate. The crate is billed as part of the order, subtracted from the order value, and boxes aren't eligible for the 200cr return credit. This results in a loss of 400 credits if there is an error in the order and the manifest is correctly stamped denied.

## Why It's Good For The Game

Fixes materials orders correctly stamped 'Denied' resulting in a loss of 400 credits.

## Changelog

:cl: LT3
fix: Fixed loss of credits for correctly denied minerals market cargo manifest
fix: Cargo budget materials market orders arrive in crates as expected
/:cl: