### PR TITLE
halves the price of grapple guns

### DIFF
--- a/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
@@ -122,4 +122,4 @@
 
 /datum/orderable_item/mining/grapple_gun
 	purchase_path = /obj/item/grapple_gun
-	cost_per_order = 3000
+	cost_per_order = 1500


### PR DESCRIPTION

## About The Pull Request
2 years ago i added this item. 2 years ago i set its price at 3000 points, i dont remember why cause this was 2 years ago.

## Why It's Good For The Game
i talked to a few (1) miner players regarding this, the feedback i got was that, for a minor QoL tool, it was a bit too expensive for what it does. Especially now that theres more viable/accessible ways of traversing lava, ive decided to knock its price down a bit hopefully to make it more worthwhile. 

## Changelog
:cl:
balance: the grapple gun's price has been reduced to 1500 points
/:cl:
