### PR TITLE
Spacers get pos mood for achieving nograv on planets

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -387,3 +387,6 @@
 
 /// From /mob/living/on_looking_z_level_change() : (turf/old_turf, turf/new_turf)
 #define COMSIG_LIVING_LOOK_Z_CHANGE "living_look_z_change"
+
+/// From /mob/living/proc/refresh_gravity() : (new_gravity, old_gravity)
+#define COMSIG_LIVING_GRAVITY_CHANGED "living_gravity_changed"

--- a/code/datums/quirks/positive_quirks/spacer.dm
+++ b/code/datums/quirks/positive_quirks/spacer.dm
@@ -1,5 +1,6 @@
 #define LAST_STATE_PLANET "on_planet"
 #define LAST_STATE_SPACE "in_space"
+#define LAST_STATE_NOGRAV "in_nograv"
 
 /datum/quirk/spacer_born
 	name = "Spacer"
@@ -26,7 +27,7 @@
 	var/recover_period = 1 MINUTES
 	/// TimerID for time spend in space
 	VAR_FINAL/recovering_timer
-	/// Determines the last state we were in ([LAST_STATE_PLANET] or [LAST_STATE_SPACE])
+	/// Determines the last state we were in ([LAST_STATE_PLANET], [LAST_STATE_SPACE], or [LAST_STATE_NOGRAV])
 	VAR_FINAL/last_state
 
 /datum/quirk/spacer_born/add(client/client_source)
@@ -104,8 +105,11 @@
  * * skip_timers - if TRUE, this is being done instantly / should not have feedback (such as in init)
  */
 /datum/quirk/spacer_born/proc/update_effects(mob/living/spacer, skip_timers = FALSE)
-	if(is_on_a_planet(spacer) && spacer.has_gravity())
-		on_planet(spacer, skip_timers)
+	if(is_on_a_planet(spacer))
+		if(spacer.has_gravity())
+			on_planet(spacer, skip_timers)
+		else
+			has_nograv(spacer, skip_timers)
 	else
 		in_space(spacer, skip_timers)
 
@@ -176,9 +180,10 @@
 		deltimer(planetside_timer)
 		planetside_timer = null
 
+	var/was_nograv = last_state == LAST_STATE_NOGRAV
 	last_state = LAST_STATE_SPACE
 
-	if(skip_timers)
+	if(skip_timers || was_nograv)
 		comfortably_in_space(afflicted, TRUE)
 		return
 
@@ -186,7 +191,7 @@
 	afflicted.remove_status_effect(/datum/status_effect/spacer)
 	afflicted.clear_mood_event("spacer")
 	// Does not remove the movement modifier yet, it lingers until you fully recover
-	to_chat(afflicted, span_green("You start feeling better now that you're [is_on_a_planet(afflicted) ? "in zero gravity" : "back in space"]."))
+	to_chat(afflicted, span_green("You start feeling better now that you're back in space."))
 
 /**
  * Ran when living back in space, or just no-grav in general, for a long enough period.
@@ -198,14 +203,40 @@
 	if(QDELETED(src) || QDELETED(afflicted))
 		return
 
-	var/moodlet_picked = is_on_a_planet(afflicted) ? /datum/mood_event/spacer/on_planet/low_grav : /datum/mood_event/spacer/in_space
-
 	recovering_timer = null
 	afflicted.apply_status_effect(/datum/status_effect/spacer/gravity_wellness)
-	afflicted.add_mood_event("spacer", moodlet_picked)
+	afflicted.add_mood_event("spacer", /datum/mood_event/spacer/in_space)
 	afflicted.add_movespeed_modifier(/datum/movespeed_modifier/spacer/in_space)
 	if(!skip_timers)
 		to_chat(afflicted, span_green("You feel better."))
 
+// On a planet but has no gravity
+
+/**
+ * Ran when we are on a planet while having no gravity.
+ *
+ * * afflicted - the mob arriving / same as quirk holder
+ * * skip_timers - if TRUE, this is being done instantly / should not have feedback (such as in init)
+ */
+/datum/quirk/spacer_born/proc/has_nograv(mob/living/afflicted, skip_timers = FALSE)
+	if(last_state == LAST_STATE_NOGRAV)
+		return
+	if(planetside_timer)
+		deltimer(planetside_timer)
+		planetside_timer = null
+	if(recovering_timer)
+		deltimer(recovering_timer)
+		recovering_timer = null
+
+	var/was_in_space = last_state == LAST_STATE_SPACE
+	last_state = LAST_STATE_NOGRAV
+
+	afflicted.apply_status_effect(/datum/status_effect/spacer/gravity_wellness)
+	afflicted.add_mood_event("spacer", /datum/mood_event/spacer/on_planet/low_grav)
+	afflicted.add_movespeed_modifier(/datum/movespeed_modifier/spacer/in_space)
+	if(!skip_timers && !was_in_space)
+		to_chat(afflicted, span_green("You feel like you're back in space!"))
+
 #undef LAST_STATE_PLANET
 #undef LAST_STATE_SPACE
+#undef LAST_STATE_NOGRAV

--- a/code/datums/quirks/positive_quirks/spacer.dm
+++ b/code/datums/quirks/positive_quirks/spacer.dm
@@ -38,9 +38,10 @@
 	// It won't really make sense to walk 3 feet and then suddenly gain / lose gravity sickness.
 	// If I'm proven wrong, swap this to use Moved.
 	RegisterSignal(quirk_holder, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(spacer_moved))
+	RegisterSignal(quirk_holder, COMSIG_LIVING_GRAVITY_CHANGED, PROC_REF(spacer_grav))
 
 	// Yes, it's assumed for planetary maps that you start at gravity sickness.
-	check_z(quirk_holder, skip_timers = TRUE)
+	update_effects(quirk_holder, skip_timers = TRUE)
 
 	// drift slightly faster through zero G
 	quirk_holder.inertia_move_multiplier *= 0.8
@@ -69,6 +70,7 @@
 
 /datum/quirk/spacer_born/remove()
 	UnregisterSignal(quirk_holder, COMSIG_MOVABLE_Z_CHANGED)
+	UnregisterSignal(quirk_holder, COMSIG_LIVING_GRAVITY_CHANGED)
 
 	if(QDELING(quirk_holder))
 		return
@@ -87,7 +89,13 @@
 /datum/quirk/spacer_born/proc/spacer_moved(mob/living/source, turf/old_turf, turf/new_turf, same_z_layer)
 	SIGNAL_HANDLER
 
-	check_z(source)
+	update_effects(source)
+
+/// Check on gravity change whether we should start or stop timers
+/datum/quirk/spacer_born/proc/spacer_grav(mob/living/source, new_gravity, old_gravity)
+	SIGNAL_HANDLER
+
+	update_effects(source)
 
 /**
  * Used to check if we should start or stop timers based on the quirk holder's location.
@@ -95,8 +103,8 @@
  * * afflicted - the mob arriving / same as quirk holder
  * * skip_timers - if TRUE, this is being done instantly / should not have feedback (such as in init)
  */
-/datum/quirk/spacer_born/proc/check_z(mob/living/spacer, skip_timers = FALSE)
-	if(is_on_a_planet(spacer))
+/datum/quirk/spacer_born/proc/update_effects(mob/living/spacer, skip_timers = FALSE)
+	if(is_on_a_planet(spacer) && spacer.has_gravity())
 		on_planet(spacer, skip_timers)
 	else
 		in_space(spacer, skip_timers)
@@ -178,10 +186,10 @@
 	afflicted.remove_status_effect(/datum/status_effect/spacer)
 	afflicted.clear_mood_event("spacer")
 	// Does not remove the movement modifier yet, it lingers until you fully recover
-	to_chat(afflicted, span_green("You start feeling better now that you're back in space."))
+	to_chat(afflicted, span_green("You start feeling better now that you're [is_on_a_planet(afflicted) ? "in zero gravity" : "back in space"]."))
 
 /**
- * Ran when living back in space for a long enough period.
+ * Ran when living back in space, or just no-grav in general, for a long enough period.
  *
  * * afflicted - the mob arriving / same as quirk holder
  * * skip_timers - if TRUE, this is being done instantly / should not have feedback (such as in init)
@@ -190,9 +198,11 @@
 	if(QDELETED(src) || QDELETED(afflicted))
 		return
 
+	var/moodlet_picked = is_on_a_planet(afflicted) ? /datum/mood_event/spacer/on_planet/low_grav : /datum/mood_event/spacer/in_space
+
 	recovering_timer = null
 	afflicted.apply_status_effect(/datum/status_effect/spacer/gravity_wellness)
-	afflicted.add_mood_event("spacer", /datum/mood_event/spacer/in_space)
+	afflicted.add_mood_event("spacer", moodlet_picked)
 	afflicted.add_movespeed_modifier(/datum/movespeed_modifier/spacer/in_space)
 	if(!skip_timers)
 		to_chat(afflicted, span_green("You feel better."))

--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -107,7 +107,7 @@
 
 /datum/mood_event/spacer/on_planet/low_grav
 	description = "This feels like I'm back home!"
-	mood_change = 4
+	mood_change = 3
 
 /datum/mood_event/spacer/on_planet/low_grav/add_effects(...)
 	. = ..()
@@ -116,7 +116,7 @@
 /datum/mood_event/spacer/on_planet/low_grav/proc/lower_mood_bonus()
 	mood_change -= 1
 	owner.mob_mood.update_mood()
-	if(mood_change > 0)
+	if(mood_change > 1)
 		addtimer(CALLBACK(src, PROC_REF(lower_mood_bonus)), 5 MINUTES, TIMER_DELETE_ME)
 
 /datum/movespeed_modifier/spacer

--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -107,7 +107,7 @@
 
 /datum/mood_event/spacer/on_planet/low_grav
 	description = "This feels like I'm back home!"
-	mood_change = 3
+	mood_change = 4
 
 /datum/mood_event/spacer/on_planet/low_grav/add_effects(...)
 	. = ..()

--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -109,6 +109,16 @@
 	description = "This feels like I'm back home!"
 	mood_change = 3
 
+/datum/mood_event/spacer/on_planet/low_grav/add_effects(...)
+	. = ..()
+	addtimer(CALLBACK(src, PROC_REF(lower_mood_bonus)), 5 MINUTES, TIMER_DELETE_ME)
+
+/datum/mood_event/spacer/on_planet/low_grav/proc/lower_mood_bonus()
+	mood_change -= 1
+	owner.mob_mood.update_mood()
+	if(mood_change > 0)
+		addtimer(CALLBACK(src, PROC_REF(lower_mood_bonus)), 5 MINUTES, TIMER_DELETE_ME)
+
 /datum/movespeed_modifier/spacer
 	id = "spacer"
 

--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -105,6 +105,10 @@
 	description = "I'm stationed on a planet. I'd love to be back in space."
 	mood_change = -3
 
+/datum/mood_event/spacer/on_planet/low_grav
+	description = "This feels like I'm back home!"
+	mood_change = 3
+
 /datum/movespeed_modifier/spacer
 	id = "spacer"
 

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -46,7 +46,7 @@
 		return
 
 	update_gravity(gravity_state)
-
+	SEND_SIGNAL(src, COMSIG_LIVING_GRAVITY_CHANGED, gravity_state, old_grav_state)
 	if(gravity_state > STANDARD_GRAVITY)
 		gravity_animate()
 	else if(old_grav_state > STANDARD_GRAVITY)


### PR DESCRIPTION
## About The Pull Request

Spacers who manage to get nograv on a planet are given a positive moodlet, and are considered in space for their buffs/debuffs 

## Why It's Good For The Game

I don't remember if I was opposed to this in the past or why I didn't make it work this way in the first place. 
It's sensible that, if you manage to disable your own gravity, all of the negative effects (which are tied to you feeling heavy gravity) would be lifted. 

## Changelog

:cl: Melbert
add: Spacers who manage to get nograv while on a planet are given a positive moodlet, and are considered in space for the purpose of their buffs/debuffs 
/:cl:
