### PR TITLE
More accurate feedback for action button consciousness check failure

### DIFF
--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -183,7 +183,7 @@
 		if (feedback)
 			switch(owner.stat)
 				if(SOFT_CRIT)
-					owner.balloon_alert(owner, "dying!")
+					owner.balloon_alert(owner, "downed!")
 				if(DEAD)
 					owner.balloon_alert(owner, "dead!")
 				else

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -181,7 +181,13 @@
 		return FALSE
 	if((check_flags & AB_CHECK_CONSCIOUS) && owner.stat != CONSCIOUS)
 		if (feedback)
-			owner.balloon_alert(owner, "[owner.stat == DEAD ? "dead" : "unconscious"]!")
+			switch(owner.stat)
+				if(SOFT_CRIT)
+					owner.balloon_alert(owner, "dying!")
+				if(DEAD)
+					owner.balloon_alert(owner, "dead!")
+				else
+					owner.balloon_alert(owner, "unconscious!")
 		return FALSE
 	if((check_flags & AB_CHECK_HANDS_BLOCKED) && HAS_TRAIT(owner, TRAIT_HANDS_BLOCKED))
 		if (feedback)


### PR DESCRIPTION
## About The Pull Request

This PR provides a more accurate feedback message for when the consciousness check for an action button fails due to you being in softcrit.

## Why It's Good For The Game

Someone complained about an action button telling them they were unconscious while in soft crit, when they opined that they are technically conscious.

## Changelog

:cl:
spellcheck: You are told you are downed instead of unconscious if you attempt to use an action that requires you to be conscious while in softcrit.
/:cl:
