### PR TITLE
Fixes crafting runtime

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -180,7 +180,8 @@
 	for(var/obj/item/item in source.contents)
 		within_source += item
 		if(item.atom_storage)
-			within_source += item.contents
+			for(var/obj/item/item_stored_within in item.contents)
+				within_source += item_stored_within
 
 	for(var/obj/item/item as anything in within_source)
 		if(!item.tool_behaviour)


### PR DESCRIPTION
## About The Pull Request

<details><summary> big purple dinosaur clogging up the runtime logs </summary> 

<img width="600" height="400" alt="v7N2LciICX" src="https://github.com/user-attachments/assets/e9955159-caa2-4e86-862a-43c295bd31be" />

</details>

The issue is, the `contents` of items checked by `get_surroundings()` are assumed to be `/obj/item` which is a false assumption. So this just adds typechecking so that we don't runtime here and break crafting in the vicinity.

This is a bad spot to runtime because it will stop materials from being picked up by the crafting menu, preventing crafting from being possible.

<details><summary> before </summary> 

<img width="1786" height="162" alt="tracy-profiler_Fk2WSoYG5t" src="https://github.com/user-attachments/assets/dc8f04a5-0f68-41d3-9e90-20e075ef68b4" />

</details>

<details><summary> after </summary> 

<img width="1767" height="176" alt="tracy-profiler_gHRDdRMMqo" src="https://github.com/user-attachments/assets/a50ad290-153f-4ab6-9c6b-74fc43efaa4f" />

</details>

I profiled this both before and after these changes in the same exact spot, surrounded by 70 electrical toolboxes, and the impact is negligible (actually appears to be ~7.5% faster, interestingly).

## Why It's Good For The Game

## Changelog

:cl:
fix: fixes an issue where raptor chicks and other non-items appearing in item contents would prevent any personal crafting in the vicinity
/:cl:
