### PR TITLE
Storage opening being interrupted in on_found() now works without runtiming

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -1067,10 +1067,10 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(to_show.active_storage != src && (to_show.stat == CONSCIOUS))
 		for(var/obj/item/thing in real_location)
 			if(thing.on_found(to_show))
-				to_show.active_storage.hide_contents(to_show)
+				to_show.active_storage?.hide_contents(to_show)
+				return FALSE
 
-	if(to_show.active_storage)
-		to_show.active_storage.hide_contents(to_show)
+	to_show.active_storage?.hide_contents(to_show)
 
 	to_show.active_storage = src
 


### PR DESCRIPTION

## About The Pull Request

`active_storage` could be null

## Why It's Good For The Game

Pretty much the same functionality, without the runtime

## Changelog
:cl:

code: Things that interrupted the opening of storages are no longer reliant on a runtime, meaning they interrupt regardless of whether you had another open storage open at the time

/:cl:
