### PR TITLE
Butchering no longer moves organs to nullspace

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -642,8 +642,7 @@
 			bodypart_organ.apply_organ_damage(bodypart_organ.maxHealth * 0.5)
 
 		if(owner)
-			if(!bodypart_organ.Remove(bodypart_organ.owner))
-				continue
+			bodypart_organ.Remove(bodypart_organ.owner)
 		else if(!bodypart_organ.bodypart_remove(src))
 			continue
 


### PR DESCRIPTION

## About The Pull Request

Shockingly, what was moving the organs to nullspace was the little-known proc `MoveToNullspace()`. 
The problem was `Remove()` not having a return value, so it always stopped the loop before the organs were moved out of nullspace.

## Why It's Good For The Game

fixes #95808

## Changelog
:cl:

fix: Butchering heads no longer moves their organs to nullspace, and probably the same with any other method of mass removing organs.

/:cl:
