### PR TITLE
Cargo manifest stamp payment consistency

### DIFF
--- a/code/modules/cargo/exports/manifest.dm
+++ b/code/modules/cargo/exports/manifest.dm
@@ -1,47 +1,49 @@
-#define MAX_MANIFEST_PENALTY CARGO_CRATE_VALUE * 2.5
+#define MANIFEST_HANDLING_RATE 0.12
+#define MANIFEST_CORRECT_RATE MANIFEST_HANDLING_RATE * 2
+#define MANIFEST_ERRONEOUS_RATE MANIFEST_HANDLING_RATE * 4
+#define MAX_HANDLING_CHARGE CARGO_CRATE_VALUE * 0.6
+#define MAX_CORRECT_CHARGE MAX_HANDLING_CHARGE * 2
+#define MAX_ERRONEOUS_CHARGE MAX_HANDLING_CHARGE * 4
 
-// Approved manifest.
-// +80 credits flat.
+// Approved manifest. 12% handling payment, up to a maximum of the max handling charge
 /datum/export/manifest_correct
-	cost = CARGO_CRATE_VALUE * 0.4
 	k_elasticity = 0
 	unit_name = "approved manifest"
 	export_types = list(/obj/item/paper/fluff/jobs/cargo/manifest)
 	scannable = FALSE
 
-/datum/export/manifest_correct/applies_to(obj/O)
+/datum/export/manifest_correct/applies_to(obj/exported_item)
 	if(!..())
 		return FALSE
 
-	var/obj/item/paper/fluff/jobs/cargo/manifest/M = O
-	if(M.is_approved() && !M.errors)
+	var/obj/item/paper/fluff/jobs/cargo/manifest/export_manifest = exported_item
+	if(export_manifest.is_approved() && !export_manifest.errors)
 		return TRUE
 	return FALSE
 
-// Correctly denied manifest.
-// Refunds package cost minus the value of the crate.
+/datum/export/manifest_correct/get_base_cost(obj/item/paper/fluff/jobs/cargo/manifest/exported_item)
+	return min(exported_item.order_cost * MANIFEST_HANDLING_RATE, MAX_HANDLING_CHARGE)
+
+// Correctly denied manifest. Refunds package cost plus double handling payment, up to a maximum of 2x max handling charge
 /datum/export/manifest_error_denied
-	cost = -CARGO_CRATE_VALUE
 	k_elasticity = 0
 	unit_name = "correctly denied manifest"
 	export_types = list(/obj/item/paper/fluff/jobs/cargo/manifest)
 	scannable = FALSE
 
-/datum/export/manifest_error_denied/applies_to(obj/O)
+/datum/export/manifest_error_denied/applies_to(obj/exported_item)
 	if(!..())
 		return FALSE
 
-	var/obj/item/paper/fluff/jobs/cargo/manifest/M = O
-	if(M.is_denied() && M.errors)
+	var/obj/item/paper/fluff/jobs/cargo/manifest/export_manifest = exported_item
+	if(export_manifest.is_denied() && export_manifest.errors)
 		return TRUE
 	return FALSE
 
-/datum/export/manifest_error_denied/get_base_cost(obj/item/paper/fluff/jobs/cargo/manifest/M)
-	return ..() + M.order_cost
+/datum/export/manifest_error_denied/get_base_cost(obj/item/paper/fluff/jobs/cargo/manifest/exported_item)
+	return exported_item.order_cost + min(exported_item.order_cost * MANIFEST_CORRECT_RATE, MAX_CORRECT_CHARGE)
 
-
-// Erroneously approved manifest.
-// Subtracts half the package cost. (max -500 credits)
+// Erroneously approved manifest. Penalty charged quadruple handling payment, up to a maximum of 4x max handling charge
 /datum/export/manifest_error
 	unit_name = "erroneously approved manifest"
 	k_elasticity = 0
@@ -49,21 +51,19 @@
 	allow_negative_cost = TRUE
 	scannable = FALSE
 
-/datum/export/manifest_error/applies_to(obj/O)
+/datum/export/manifest_error/applies_to(obj/exported_item)
 	if(!..())
 		return FALSE
 
-	var/obj/item/paper/fluff/jobs/cargo/manifest/M = O
-	if(M.is_approved() && M.errors)
+	var/obj/item/paper/fluff/jobs/cargo/manifest/export_manifest = exported_item
+	if(export_manifest.is_approved() && export_manifest.errors)
 		return TRUE
 	return FALSE
 
-/datum/export/manifest_error/get_base_cost(obj/item/paper/fluff/jobs/cargo/manifest/M)
-	return -min(M.order_cost * 0.5, MAX_MANIFEST_PENALTY)
+/datum/export/manifest_error/get_base_cost(obj/item/paper/fluff/jobs/cargo/manifest/exported_item)
+	return -min(exported_item.order_cost * MANIFEST_ERRONEOUS_RATE, MAX_ERRONEOUS_CHARGE)
 
-
-// Erroneously denied manifest.
-// Subtracts half the package cost. (max -500 credits)
+// Erroneously denied manifest. Penalty charged quadruple handling payment, up to a maximum of 4x max handling charge
 /datum/export/manifest_correct_denied
 	k_elasticity = 0
 	unit_name = "erroneously denied manifest"
@@ -71,16 +71,21 @@
 	allow_negative_cost = TRUE
 	scannable = FALSE
 
-/datum/export/manifest_correct_denied/applies_to(obj/O)
+/datum/export/manifest_correct_denied/applies_to(obj/exported_item)
 	if(!..())
 		return FALSE
 
-	var/obj/item/paper/fluff/jobs/cargo/manifest/M = O
-	if(M.is_denied() && !M.errors)
+	var/obj/item/paper/fluff/jobs/cargo/manifest/export_manifest = exported_item
+	if(export_manifest.is_denied() && !export_manifest.errors)
 		return TRUE
 	return FALSE
 
-/datum/export/manifest_correct_denied/get_base_cost(obj/item/paper/fluff/jobs/cargo/manifest/M)
-	return -min(M.order_cost * 0.5, MAX_MANIFEST_PENALTY)
+/datum/export/manifest_correct_denied/get_base_cost(obj/item/paper/fluff/jobs/cargo/manifest/exported_item)
+	return -min(exported_item.order_cost * MANIFEST_ERRONEOUS_RATE, MAX_ERRONEOUS_CHARGE)
 
-#undef MAX_MANIFEST_PENALTY
+#undef MANIFEST_HANDLING_RATE
+#undef MANIFEST_CORRECT_RATE
+#undef MANIFEST_ERRONEOUS_RATE
+#undef MAX_HANDLING_CHARGE
+#undef MAX_CORRECT_CHARGE
+#undef MAX_ERRONEOUS_CHARGE


### PR DESCRIPTION
## About The Pull Request

Adjusts payment calculation for stamped manifests to be consistent for all three manifest types (correctly approved, correctly denied, incorrect.) The handling payment for correct manifests is changed from a flat fee to a percentage based + capped calculation like current incorrectly stamped manifests. Instead of a flat 80 credits per correct manifest, payment varies between 36-120 credits based on the order value.

It's balanced to have no large impact on total payments, however the break even threshold (correct stamps vs. errors) is set at 80%, allowing for a reasonable accuracy rate.

## Why It's Good For The Game

Fixes traps in current payment calculation which can result in a net loss of credits despite correctly stamping a manifest.
ie, Presently a manifest that is incorrect/missing items yet correctly stamped 'denied' has a 200cr loss if it was not a supply pack that arrives in a crate.

This combined with the current ~88% required accuracy rate for other manifests, makes it largely a losing proposition to bother stamping manifests at all. Getting 1 in 8 manifests stamped incorrectly results in an overall loss to the budget, and it gets worse if the denied orders didn't arrive in crates.

Having the bonus/penalties delivered more consistently should hopefully encourage more stamping of cargo manifests.

## Changelog

:cl: LT3
balance: Cargo manifest stamp payments/penalties are now consistently applied as a percentage of the order value
balance: Maximum payment for an approved cargo manifest raised to 120cr
balance: Cargo orders that arrive empty and stamped denied receive a full refund regardless of crate return
/:cl: