### PR TITLE
Pins release downloader to actual version instead of commit hash

### DIFF
--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           dotnet-version: 9.x
       - name: Install OpenDream
-        uses: robinraju/release-downloader@93eac224fa5a1e835cc942d66c12ee373bc7fae9
+        uses: robinraju/release-downloader@v1.13
         with:
           repository: "OpenDreamProject/OpenDream"
           tag: "latest"


### PR DESCRIPTION
Closes #95833

Hopefully this will reduce dependabot spam and actually tie it to a set version that can be audited at https://github.com/robinraju/release-downloader/releases/tag/v1.13. I think this had to be on some sort of interstital version due to Node version changes but now that a proper release was made an hour ago that we should be fine.