### PR TITLE
Fixes mushroom bowl reagent overlay

### DIFF
--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -414,12 +414,9 @@
 	name = "mushroom bowl"
 	desc = "A bowl made out of mushrooms. Not food, though it might have contained some at some point."
 	icon = 'icons/obj/mining_zones/ash_flora.dmi'
+	base_icon_state = "mushroom_bowl"
 	icon_state = "mushroom_bowl"
 	fill_icon_state = "fullbowl"
 	fill_icon = 'icons/obj/mining_zones/ash_flora.dmi'
 	custom_materials = null
 
-/obj/item/reagent_containers/cup/bowl/mushroom_bowl/update_icon_state()
-	if(!reagents.total_volume)
-		icon_state = "mushroom_bowl"
-	return ..()


### PR DESCRIPTION

## About The Pull Request
Mushroom bowl no longer turns invisible
## Why It's Good For The Game
## Changelog
:cl:
fix: The mushroom bowl no longer turns invisible when filled with a reagent.
/:cl:
