### PR TITLE
Fix tattoo persistence version

### DIFF
--- a/code/controllers/subsystem/persistence/tattoos.dm
+++ b/code/controllers/subsystem/persistence/tattoos.dm
@@ -35,7 +35,7 @@
 
 	entries += prison_tattoos_to_save
 
-	saved_data["version"] = ENGRAVING_PERSISTENCE_VERSION
+	saved_data["version"] = TATTOO_PERSISTENCE_VERSION
 	saved_data["entries"] = entries
 
 	fdel(json_file)


### PR DESCRIPTION

## About The Pull Request

Hi, strange thing with tattoos.

https://github.com/tgstation/tgstation/blob/55366497a3f156f5553a6446edf4c0b0cbba6716/code/controllers/subsystem/persistence/tattoos.dm#L25-L42

The tattoo persistence version seems to be setting based on engravings' persistence version, ``ENGRAVING_PERSISTENCE_VERSION``

Yet, in ``load_prisoner_tattoos()``, the conditional checks the value of TATTOO_PERSISTENCE_VERSION
https://github.com/tgstation/tgstation/blob/55366497a3f156f5553a6446edf4c0b0cbba6716/code/controllers/subsystem/persistence/tattoos.dm#L10-L11

This PR just replaces the engraving version being set with the tattoo version being set.
## Why It's Good For The Game

This seems rather blatantly incorrect. 
The TATTOO_PERSISTENCE_VERSION has no setter for its value other than when defined.

Realistically? This does nothing. They are both 0 lol.