### PR TITLE
Remove unsupported CSS from `client.script`

### DIFF
--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -136,21 +136,9 @@ h1.alert, h2.alert		{color: #000000;}
 .clown					{color: #FF69Bf;	font-size: 3;	font-family: "Comic Sans MS", cursive, sans-serif;	font-weight: bold;}
 .singing				{font-family: "Trebuchet MS", cursive, sans-serif; font-style: italic;}
 .his_grace				{color: #15D512;	font-family: "Courier New", cursive, sans-serif;	font-style: italic;}
-.hypnophrase			{color: #3bb5d3;	font-weight: bold;	animation: hypnocolor 1500ms infinite; animation-direction: alternate;}
-	@keyframes hypnocolor {
-		0%		{color: #0d0d0d;}
-		25%		{color: #410194;}
-		50%		{color: #7f17d8;}
-		75%		{color: #410194;}
-		100%	{color: #3bb5d3;}
-}
+.hypnophrase			{color: #3bb5d3;	font-weight: bold;}
 
-.phobia			{color: #dd0000;	font-weight: bold;	animation: phobia 750ms infinite;}
-	@keyframes phobia {
-		0%		{color: #0d0d0d;}
-		50%		{color: #dd0000;}
-		100%	{color: #0d0d0d;}
-}
+.phobia			{color: #dd0000;	font-weight: bold;}
 
 .icon					{height: 1em;	width: auto;}
 


### PR DESCRIPTION

## About The Pull Request

So it turns out that CSS validation in BYOND has been broken for some time, and it was fixed in 516.1681. This fix uncovered errors in `stylesheet.dm`, and per [this bug report](https://www.byond.com/forum/post/2986950), the `animation` style was never actually supported in DM CSS, we just didn't notice because these styles are only used in TGUI (which properly displays them) and the errors were being suppressed. 

## Why It's Good For The Game

Makes the codebase compile on the latest BYOND version

## Changelog
:cl:
fix: fixed CSS-related errors in BYOND 516.1681+
/:cl:
