### PR TITLE
Un-curses the bear mask in the pizzeria virtual domain

### DIFF
--- a/_maps/virtual_domains/fredingtonfastingbear.dmm
+++ b/_maps/virtual_domains/fredingtonfastingbear.dmm
@@ -250,7 +250,7 @@
 /obj/structure/closet/gmcloset,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/item/clothing/mask/animal/small/bear/cursed,
+/obj/item/clothing/mask/animal/small/bear,
 /turf/open/floor/iron/kitchen,
 /area/virtual_domain)
 "nX" = (


### PR DESCRIPTION

## About The Pull Request

This replaces the bear mask in the legally distinct bear animatronic themed pizzeria with a normal one. 

It was previously the cursed variant, so it would get stuck to your hand. You can't even put it on and get stuck with it because it's already cursed to your hand. It just takes up a hand slot, which sucks and is annoying.
## Why It's Good For The Game

Letting you equip the bear mask may mess with the animatronic's facial ID system and make you think you're one of them, which it was originally given to you, the nightguard, for.

Jokes aside I really just have no idea why this would be cursed.
## Changelog
:cl: Rhials
fix: The bear mask in the pizzeria virtual domain is now a regular, non-cursed mask.
/:cl:
