### PR TITLE
Fixes hair/ears/horns clipping at tall heights

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -839,6 +839,8 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 	"[BENEATH_HAIR_LAYER]" = UPPER_BODY,
 	// Long belts (sabre sheathe) will get cut off by filter
 	"[BELT_LAYER]" = LOWER_BODY,
+	// Hair-over-hats (ponytails, outer hair) will get cut off by filter
+	"[OUTER_HAIR_LAYER]" = UPPER_BODY,
 	// Everything below looks fine with or without a filter, so we can skip it and just offset
 	// (In practice they'd be fine if they got a filter but we can optimize a bit by not.)
 	"[NECK_LAYER]" = UPPER_BODY,

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -999,7 +999,18 @@ generate/load female uniform sprites matching all previously decided variables
 	if(isnull(offset_type))
 		if(islist(raw_applied))
 			for(var/image/applied_appearance in raw_applied)
-				apply_height_filters(applied_appearance)
+				// Bodypart overlays share a cache index but can live on different layers.
+				// Check the individual image's layer so hair/ears/horns stacked on a filtered
+				// parent don't get clipped at the top of the sprite.
+				var/sub_offset_type = GLOB.layers_to_offset[num2text(-applied_appearance.layer)]
+				if(isnull(sub_offset_type))
+					if(findtext(applied_appearance.icon_state, "horns_", 3, 9) || findtext(applied_appearance.icon_state, "ears_", 3, 8))
+						sub_offset_type = UPPER_BODY
+				if(sub_offset_type)
+					applied_appearance.pixel_z = initial(applied_appearance.pixel_z)
+					apply_height_offsets(applied_appearance, sub_offset_type)
+				else
+					apply_height_filters(applied_appearance)
 		else if(isimage(raw_applied))
 			apply_height_filters(raw_applied)
 	else


### PR DESCRIPTION

## About The Pull Request

Tall humans pass their overlays through a displacement filter that crops anything near the sprite's top or bottom edge. The apply_overlay path uses layers_to_offset to decide which layers should be shifted with a pixel offset instead of filtered but, when an overlay is actually a list of sub-images (as with stacked bodypart overlays), it previously applied the filter to every sub-image regardless of that sub-image's own layer. That meant hair, ears and horns riding on a filtered parent got clipped at the top. The fix checks each sub-image's layer against layers_to_offset individually (with a horns_/ears_ icon_state fallback for overlays whose layer isn't listed) and offsets those instead of filtering them. OUTER_HAIR_LAYER is also added to layers_to_offset so hair drawn over hats gets the same treatment.

It's been live as https://github.com/NovaSector/NovaSector/pull/7002 for some time now and it's been working fine.
## Why It's Good For The Game

Fix of a long standing bug with tall characters  https://github.com/tgstation/tgstation/issues/77440
## Changelog
:cl:
fix: Fixes tall characters getting their hair or mutant parts clipped
/:cl:
