### PR TITLE
Bumps discord-notify workflow from v3 to main

### DIFF
--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -16,7 +16,7 @@ jobs:
           if [ -n "$ENABLER_SECRET" ]; then SECRET_EXISTS=true ; fi
           echo "SECRETS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
       - name: Send Discord notification
-        uses: tgstation/discord-notify@v3
+        uses: tgstation/discord-notify@main
         if: >
           steps.secrets_set.outputs.SECRETS_ENABLED &&
           (github.event.pull_request.merged == true || github.event.action == 'opened') &&

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -67,7 +67,7 @@ jobs:
           if [ -n "$ENABLER_SECRET" ]; then SECRET_EXISTS=true ; fi
           echo "SECRETS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
       - name: Send Discord notification
-        uses: tgstation/discord-notify@v3
+        uses: tgstation/discord-notify@main
         if: >
           steps.secrets_set.outputs.SECRETS_ENABLED
         with:


### PR DESCRIPTION
## About The Pull Request
See https://github.com/tgstation/discord-notify/pull/1#issuecomment-4286624501

Fixes all warning in https://github.com/tgstation/tgstation/actions/runs/24754317912. Either we use the `main` branch or create a new tag and I'll update it in this PR

## Changelog
N/A