### PR TITLE
Nonbinary people can respawn

### DIFF
--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -127,7 +127,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 		character_appearance = character_appearance,
 		dna_string = record_dna.unique_enzymes,
 		fingerprint = md5(record_dna.unique_identity),
-		gender = person_gender,
+		gender = person.gender,
 		initial_rank = assignment,
 		name = person.real_name,
 		rank = assignment,

--- a/code/datums/records/record.dm
+++ b/code/datums/records/record.dm
@@ -145,7 +145,7 @@
 	character_appearance,
 	dna_string = "Unknown",
 	fingerprint = "?????",
-	gender = "Other",
+	gender = "neuter",
 	initial_rank = "Unassigned",
 	name = "Unknown",
 	rank = "Unassigned",

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -285,7 +285,7 @@ ADMIN_VERB(respawn_character, R_ADMIN, "Respawn Character", "Respawn a player th
 
 	if(record_found)//If they have a record we can determine a few things.
 		new_character.real_name = record_found.name
-		new_character.gender = LOWER_TEXT(record_found.gender)
+		new_character.gender = record_found.gender
 		new_character.age = record_found.age
 		var/datum/dna/found_dna = record_found.locked_dna
 		new_character.hardset_dna(found_dna.unique_identity, found_dna.mutation_index, null, record_found.name, record_found.blood_type, new record_found.species_type, found_dna.features)


### PR DESCRIPTION

## About The Pull Request

locked records(admin-only records) now use the `gender` variable to keep the mob's actual gender, not resorting to "Other". This means that nonbinary people are once again capable of being respawned. As locked records are admin-only, and used in few other locations, the gender variable is only accessed by respawning code at the moment, and should never be accessed in a player-facing manner, so it doesn't matter that plural & neuter are in there.

## Why It's Good For The Game

fixes #95768

## Changelog
:cl:

fix: Nonbinary people can respawn

/:cl:
