### PR TITLE
Ninjas cannot place the spider bomb in places where it will not detonate

### DIFF
--- a/code/modules/antagonists/space_ninja/equipment/ninja_explosive.dm
+++ b/code/modules/antagonists/space_ninja/equipment/ninja_explosive.dm
@@ -51,7 +51,7 @@
 	if(!IS_SPACE_NINJA(user))
 		say("Access denied.")
 		return FALSE
-	if(!check_loc(user))
+	if(!check_loc(bomb_target, user))
 		return FALSE
 	if(!..())
 		return FALSE
@@ -59,7 +59,7 @@
 	return TRUE
 
 /obj/item/grenade/c4/ninja/detonate(mob/living/lanced_by)
-	if(!check_loc(detonator.resolve())) // if its moved, deactivate the c4
+	if(!check_loc(target, detonator.resolve())) // if its moved, deactivate the c4
 		var/obj/item/grenade/c4/ninja/new_c4 = new /obj/item/grenade/c4/ninja(target.loc)
 		new_c4.detonation_area = detonation_area
 		new_c4.say("Invalid location!")
@@ -87,11 +87,11 @@
  * Arguments
  * * mob/user - The planter of the c4
  */
-/obj/item/grenade/c4/ninja/proc/check_loc(mob/user)
+/obj/item/grenade/c4/ninja/proc/check_loc(atom/bomb_target, mob/user)
 	if(isnull(detonation_area))
 		balloon_alert(user, "no location set!")
 		return FALSE
-	if((get_area(target) != detonation_area) && (get_area(src) != detonation_area))
+	if(get_area(bomb_target) != detonation_area)
 		if (!active)
 			balloon_alert(user, "wrong location!")
 		return FALSE


### PR DESCRIPTION

## About The Pull Request

Current checks in place when attempting to place or detonate the spider bomb are:
`([bomb target's area(null until placed)] != [necessary area]) && ([bomb's area(null AFTER placed)] != [necessary area])`
The second check is utterly worthless as it doesn't matter where the bomb happens to be while it's being placed and it's in nullspace afterwards, & the first check is mostly worthless because it only checks after it's already been placed and after it's too late to get the bomb back.

The second check has been fully removed, and the first check now either checks where the bomb's being placed or where it currently is, depending on situation. This means that you can no longer place the bomb in certain locations where it would previously have failed to detonate without intervention, most notably walls of areas that do not own their walls.

## Why It's Good For The Game

If it allows you to place it, it should detonate if not moved.

## Changelog
:cl:

fix: Ninja spider bomb can no longer be placed in certain situations it would be unable to detonate

/:cl:
