### PR TITLE
Ghostrole on revive death examine tweak

### DIFF
--- a/code/datums/components/ghostrole_on_revive.dm
+++ b/code/datums/components/ghostrole_on_revive.dm
@@ -87,11 +87,13 @@
 /datum/component/ghostrole_on_revive/proc/prepare_brain(obj/item/organ/source)
 	ADD_TRAIT(source, TRAIT_GHOSTROLE_ON_REVIVE, REF(src))
 	RegisterSignal(source, COMSIG_ORGAN_IMPLANTED, PROC_REF(prepare_mob_from_brain))
+	RegisterSignal(source, COMSIG_ATOM_EXAMINE, PROC_REF(brain_examine))
 	UnregisterSignal(source, COMSIG_ORGAN_REMOVED)
 
 /datum/component/ghostrole_on_revive/proc/unprepare_brain(obj/item/organ/source)
 	REMOVE_TRAIT(source, TRAIT_GHOSTROLE_ON_REVIVE, REF(src))
 	UnregisterSignal(source, COMSIG_ORGAN_IMPLANTED)
+	UnregisterSignal(source, COMSIG_ATOM_EXAMINE)
 	RegisterSignal(source, COMSIG_ORGAN_REMOVED, PROC_REF(prepare_brain))
 	source.owner?.med_hud_set_status()
 
@@ -101,6 +103,11 @@
 	REMOVE_TRAIT(source, TRAIT_GHOSTROLE_ON_REVIVE, REF(src))
 	UnregisterSignal(source, COMSIG_ORGAN_IMPLANTED)
 	prepare_mob(owner)
+
+/datum/component/ghostrole_on_revive/proc/brain_examine(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	examine_list += span_info("Another soul may take [source.p_their()] place if put in a body...")
 
 /datum/component/ghostrole_on_revive/proc/on_revive(mob/living/source)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -242,8 +242,6 @@
 		. += span_notice("It is a bit on the smaller side...")
 	if(brain_size > 1)
 		. += span_notice("It is bigger than average...")
-	if(GetComponent(/datum/component/ghostrole_on_revive))
-		. += span_notice("Its soul might yet come back...")
 
 /// Needed so subtypes can override examine text while still calling parent
 /obj/item/organ/brain/proc/brain_damage_examine()

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -325,7 +325,7 @@
 	//This checks to see if the body is revivable
 	var/obj/item/organ/brain = get_organ_by_type(/obj/item/organ/brain)
 	if((brain && HAS_TRAIT(brain, TRAIT_GHOSTROLE_ON_REVIVE)) || HAS_TRAIT(src, TRAIT_GHOSTROLE_ON_REVIVE))
-		return span_deadsay("[t_He] [t_is] limp and unresponsive; but [t_his] soul might yet come back...")
+		return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life, but another soul may take [t_his] place...")
 	var/client_like = client || HAS_TRAIT(src, TRAIT_MIND_TEMPORARILY_GONE)
 	var/valid_ghost = ghost?.can_reenter_corpse && ghost?.client
 	var/valid_soul = brain || !HAS_TRAIT(src, TRAIT_FAKE_SOULLESS)


### PR DESCRIPTION
## About The Pull Request

Changes message on examining recovered crew / thanatorenasia corpses: 

`He is limp and unresponsive; but his soul might yet come back...`

to

`He is limp and unresponsive; there are no signs of life, but another soul may take his place...`

This contrasts to the DNR message:

`He is limp and unresponsive; there are no signs of life and his soul has departed...`

## Why It's Good For The Game

Someone told me that dnr-ing to trigger thanatorenasia sometimes makes people think they DNR'd due to the corpse examine message and... yeah I can see that. The message kinda gives off the vibes of logged out / playing death match. 

Tweaking it slightly should give people the impression that the body isn't gone gone, and could still be taken over. 

## Changelog

:cl: Melbert
qol: Tweaks message displayed when examining recovered crew / thanatorenaisa bodies
/:cl:
