### PR TITLE
Style Meter: Smaller Item, Stored Multiplier

### DIFF
--- a/code/__DEFINES/mining.dm
+++ b/code/__DEFINES/mining.dm
@@ -63,3 +63,8 @@
 
 /// Maximum precision for ore spawn probabilities
 #define ORE_CHANCE_PRECISION 5
+
+/// Permanent style multiplier modifier earned from tapping vents, modified by vent size.
+#define ACTION_MULTIPLIER_PER_VENT_VALUE 0.1
+/// Permanent style multiplier modifier earned from killing a megafauna.
+#define ACTION_MULTIPLIER_MAJOR_KILL 0.1

--- a/code/datums/components/style/style.dm
+++ b/code/datums/components/style/style.dm
@@ -75,13 +75,15 @@
 	)
 
 
-/datum/component/style/Initialize(multitooled = FALSE)
+/datum/component/style/Initialize(multitooled = FALSE, stored_permanent_multiplier = 0)
 	if(!ismob(parent))
 		return COMPONENT_INCOMPATIBLE
 
 	START_PROCESSING(SSdcs, src)
 	if(multitooled)
 		src.multitooled = multitooled
+	if(stored_permanent_multiplier)
+		src.permanent_multiplier = stored_permanent_multiplier
 
 /datum/component/style/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_USER_PRE_ITEM_ATTACK, PROC_REF(hotswap))
@@ -328,6 +330,15 @@
 	else
 		source.balloon_alert(source, "unable to hotswap!")
 
+/datum/component/style/proc/adjust_permanent_multiplier(modifier)
+	permanent_multiplier += modifier
+	var/mob/living/carbon/carbon_owner = parent
+	if(!iscarbon(carbon_owner))
+		return
+	var/obj/item/style_meter/carbon_meter = locate(/obj/item/style_meter) in carbon_owner.glasses
+	if(carbon_meter)
+		carbon_meter.stored_permanent_multiplier += modifier
+
 // Point givers
 /datum/component/style/proc/on_punch(mob/living/carbon/human/punching_person, atom/attacked_atom, proximity)
 	SIGNAL_HANDLER
@@ -419,7 +430,7 @@
 
 	var/vent_value = vent.boulder_size / BOULDER_SIZE_MEDIUM
 	add_action(ACTION_VENT_TAPPED, 250 * vent_value)
-	permanent_multiplier += ACTION_MULTIPLIER_PER_VENT_VALUE * vent_value
+	adjust_permanent_multiplier(ACTION_MULTIPLIER_PER_VENT_VALUE * vent_value)
 
 // Emote-based multipliers
 /datum/component/style/proc/on_taunt()
@@ -447,7 +458,7 @@
 
 	if(ismegafauna(died))
 		add_action(ACTION_MAJOR_KILL, 350)
-		permanent_multiplier += ACTION_MULTIPLIER_MAJOR_KILL
+		adjust_permanent_multiplier(ACTION_MULTIPLIER_MAJOR_KILL)
 
 	else if(died.maxHealth >= 75) //at least legions
 		add_action(ACTION_KILL, 125)

--- a/code/datums/components/style/style.dm
+++ b/code/datums/components/style/style.dm
@@ -20,9 +20,6 @@
 #define ACTION_GEYSER_MARKED "GEYSER MARKED"
 #define ACTION_VENT_TAPPED "VENT TAPPED"
 
-#define ACTION_MULTIPLIER_PER_VENT_VALUE 0.1
-#define ACTION_MULTIPLIER_MAJOR_KILL 0.1
-
 /datum/component/style
 	/// Amount of style we have.
 	var/style_points = -1
@@ -330,14 +327,9 @@
 	else
 		source.balloon_alert(source, "unable to hotswap!")
 
+/// Increase our permanent multiplier based on the modifier.
 /datum/component/style/proc/adjust_permanent_multiplier(modifier)
 	permanent_multiplier += modifier
-	var/mob/living/carbon/carbon_owner = parent
-	if(!iscarbon(carbon_owner))
-		return
-	var/obj/item/style_meter/carbon_meter = locate(/obj/item/style_meter) in carbon_owner.glasses
-	if(carbon_meter)
-		carbon_meter.stored_permanent_multiplier += modifier
 
 // Point givers
 /datum/component/style/proc/on_punch(mob/living/carbon/human/punching_person, atom/attacked_atom, proximity)
@@ -430,7 +422,6 @@
 
 	var/vent_value = vent.boulder_size / BOULDER_SIZE_MEDIUM
 	add_action(ACTION_VENT_TAPPED, 250 * vent_value)
-	adjust_permanent_multiplier(ACTION_MULTIPLIER_PER_VENT_VALUE * vent_value)
 
 // Emote-based multipliers
 /datum/component/style/proc/on_taunt()
@@ -458,7 +449,6 @@
 
 	if(ismegafauna(died))
 		add_action(ACTION_MAJOR_KILL, 350)
-		adjust_permanent_multiplier(ACTION_MULTIPLIER_MAJOR_KILL)
 
 	else if(died.maxHealth >= 75) //at least legions
 		add_action(ACTION_KILL, 125)
@@ -487,6 +477,3 @@
 #undef ACTION_MARK_DETONATED
 #undef ACTION_GEYSER_MARKED
 #undef ACTION_VENT_TAPPED
-
-#undef ACTION_MULTIPLIER_PER_VENT_VALUE
-#undef ACTION_MULTIPLIER_MAJOR_KILL

--- a/code/datums/components/style/style_meter.dm
+++ b/code/datums/components/style/style_meter.dm
@@ -7,12 +7,15 @@
 		In addition, at high style, you are able to swap an item in your hand with one in your backpack by <b>hitting</b> one with another."
 	icon_state = "style_meter"
 	icon = 'icons/obj/clothing/glasses.dmi'
+	w_class = WEIGHT_CLASS_SMALL
 	/// The style meter component we give.
 	var/datum/component/style/style_meter
 	/// Mutable appearance added to the attached glasses
 	var/mutable_appearance/meter_appearance
 	/// If this is multitooled, which is passed onto the component on-creation, if one doesn't currently exist
 	var/multitooled = FALSE
+	/// Stored permanent multiplier from doing mining-related tasks (e.g. vents, megafauna)
+	var/stored_permanent_multiplier = 0
 
 /obj/item/style_meter/Initialize(mapload)
 	. = ..()
@@ -49,7 +52,7 @@
 	if(carbon_wearer.glasses != interacting_with)
 		return .
 
-	style_meter = carbon_wearer.AddComponent(/datum/component/style, multitooled)
+	style_meter = carbon_wearer.AddComponent(/datum/component/style, multitooled, stored_permanent_multiplier)
 	return .
 
 /obj/item/style_meter/Moved(atom/old_loc, Dir, momentum_change)
@@ -68,7 +71,7 @@
 			QDEL_NULL(style_meter)
 		return
 
-	style_meter = equipper.AddComponent(/datum/component/style, multitooled)
+	style_meter = equipper.AddComponent(/datum/component/style, multitooled, stored_permanent_multiplier)
 
 
 /// Signal proc for when the meter-holding glasses are dropped/unequipped

--- a/code/datums/components/style/style_meter.dm
+++ b/code/datums/components/style/style_meter.dm
@@ -52,7 +52,7 @@
 	if(carbon_wearer.glasses != interacting_with)
 		return .
 
-	style_meter = carbon_wearer.AddComponent(/datum/component/style, multitooled, stored_permanent_multiplier)
+	start_meter(carbon_wearer)
 	return .
 
 /obj/item/style_meter/Moved(atom/old_loc, Dir, momentum_change)
@@ -71,7 +71,7 @@
 			QDEL_NULL(style_meter)
 		return
 
-	style_meter = equipper.AddComponent(/datum/component/style, multitooled, stored_permanent_multiplier)
+	start_meter(equipper)
 
 
 /// Signal proc for when the meter-holding glasses are dropped/unequipped
@@ -125,6 +125,37 @@
 		return
 	QDEL_NULL(style_meter)
 
+/// Create the style meter component, attach it to our wearer, register other things onto the component.
+/obj/item/style_meter/proc/start_meter(mob/living/carbon/carbon_wearer)
+	style_meter = carbon_wearer.AddComponent(/datum/component/style, multitooled, stored_permanent_multiplier)
+	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, PROC_REF(on_death))
+	RegisterSignal(carbon_wearer, COMSIG_LIVING_ON_VENT_WIN, PROC_REF(on_vent_win))
+
+/// On a successful vent tap, adjust permanent multiplier, scaling with vent value.
+/obj/item/style_meter/proc/on_vent_win(datum/source, obj/structure/ore_vent/vent)
+	SIGNAL_HANDLER
+
+	var/vent_value = vent.boulder_size / BOULDER_SIZE_MEDIUM
+	adjust_permanent_multiplier(ACTION_MULTIPLIER_PER_VENT_VALUE * vent_value)
+
+/// When something dies, if it's a megafauna, adjust our permanent multiplier.
+/obj/item/style_meter/proc/on_death(datum/source, mob/living/died, gibbed)
+	SIGNAL_HANDLER
+	if(!style_meter)
+		return
+	// If we have an active style meter, we're on someone's face. Use them to check if the dead megafauna could be credited to them...
+	var/mob/mob_parent = style_meter.parent
+	if(mob_parent.faction_check_atom(died) || !died.has_faction(FACTION_MINING) || (died.z != mob_parent.z) || !(died in view(mob_parent.client?.view, get_turf(mob_parent))))
+		return
+
+	if(ismegafauna(died))
+		adjust_permanent_multiplier(ACTION_MULTIPLIER_MAJOR_KILL)
+
+/// Adjust the stored permanent multiplier. If we have an active style meter, update that style meter too.
+/obj/item/style_meter/proc/adjust_permanent_multiplier(modifier)
+	stored_permanent_multiplier += modifier
+	if(style_meter)
+		style_meter.adjust_permanent_multiplier(modifier)
 
 /atom/movable/screen/style_meter_background
 	icon_state = "style_meter_background"


### PR DESCRIPTION
## About The Pull Request

Style meters now store their permanent multiplier modifier on the item so it's not lost when unequipped or otherwise disabled. Also makes the style meter (item itself) a small item, in case you're... shoving it in your pocket or something.

## Why It's Good For The Game

I think being able to switch to NV mesons without losing my multiplier carefully obtained from kicking megafauna in the shins is a good thing, actually.

## Changelog

:cl:
qol: The style meter for miners now stores its permanent multiplier on the meter in case you're switching eyewear. The style meter item is now small, allowing for easier storage.
/:cl: