### PR TITLE
Quiets linters about these font glyph escapes

### DIFF
--- a/tgui/packages/tgfont/static/tgfont.css
+++ b/tgui/packages/tgfont/static/tgfont.css
@@ -14,6 +14,7 @@
 }
 
 :root {
+    /* biome-ignore-start lint/suspicious/noUselessEscapeInString: The escapes are needed */
 	--tg-air-tank-slash: "\ea01";
 	--tg-air-tank: "\ea02";
 	--tg-bad-touch: "\ea03";
@@ -26,6 +27,7 @@
 	--tg-sound-minus: "\ea0a";
 	--tg-sound-plus: "\ea0b";
 	--tg-syndicate-logo: "\ea0c";
+    /* biome-ignore-end lint/suspicious/noUselessEscapeInString: The escapes are needed */
 }
 .tg-air-tank-slash::before {
 	content: var(--tg-air-tank-slash);


### PR DESCRIPTION
## About The Pull Request

Linters is complaining about these but it's being overzealous, these do need to be escaped, so this PR just disables that rule locally so we don't have anyone accidentally auto'fix' them and break the icons again.

<details><summary> what it looks like 'fixed' </summary>

<img width="227" height="89" alt="image" src="https://github.com/user-attachments/assets/f6a40b94-1e1f-49c4-9aa7-863df6aea657" />

</details>

## Changelog

Nothing player-facing