### PR TITLE
Adds a button to change lobby music

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -897,6 +897,10 @@ SUBSYSTEM_DEF(ticker)
 		return
 
 	login_music = new_music
+	//we just overrode the song, let's update everyone.
+	if(override)
+		for(var/mob/dead/new_player/new_player as anything in GLOB.new_player_list)
+			new_player?.client.playtitlemusic()
 
 #undef ROUND_START_MUSIC_LIST
 #undef SS_TICKER_TRAIT

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -92,6 +92,13 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 			sec_job.spawn_positions = -1
 			message_admins("[key_name_admin(holder)] has removed the cap on security officers.")
 
+		if("change_lobby_music")
+			var/new_song = input("Pick file:", "File") as null|file
+			if(isnull(new_song) || !isfile(new_song))
+				return TRUE
+			message_admins("[key_name_admin(holder)] changed the lobby music.")
+			SSticker.set_lobby_music(new_song, override = TRUE)
+
 		//Buttons for helpful stuff. This is where people land in the tgui
 		if("clear_virus")
 			var/choice = tgui_alert(usr, "Are you sure you want to cure all disease? This will also grant immunity for that disease",, list("Yes", "Cancel"))

--- a/tgui/packages/tgui/interfaces/Secrets.jsx
+++ b/tgui/packages/tgui/interfaces/Secrets.jsx
@@ -89,13 +89,13 @@ const HelpfulTab = (props) => {
       <Stack.Item>
         <Stack fill>
           <Stack.Item>
-            <NoticeBox
-              mb={-0.5}
+            <Button
+              icon="music"
+              lineHeight={lineHeightNormal}
               width={buttonWidthNormal}
-              height={lineHeightNormal}
-            >
-              Your admin button here, coder!
-            </NoticeBox>
+              content="Change Lobby Music"
+              onClick={() => act('change_lobby_music')}
+            />
           </Stack.Item>
           <Stack.Item>
             <Button


### PR DESCRIPTION
## About The Pull Request

When an admin changes the lobby music it'll now auto-update to everyone listening to it.
Also adds it as an admin secret button.

## Why It's Good For The Game

For fun?

## Changelog

:cl:
admin: Admins can now easily change the lobby music from the secrets panel.
/:cl: