### PR TITLE
Changes megafauna kill achievement max range of acquisition to 12

### DIFF
--- a/code/datums/elements/kill_achievement.dm
+++ b/code/datums/elements/kill_achievement.dm
@@ -9,7 +9,7 @@
 	/// A memory to grant to killers, if any
 	var/kill_memory_type = null
 	/// Range in which to grant the achievement
-	var/achievement_range = 7
+	var/achievement_range = 12
 	/// Threshold for damage dealt with a crusher to count it as a crusher kill
 	/// If null, then no kill counts as a crusher kill
 	var/crusher_kill_threshold = 0.6


### PR DESCRIPTION

## About The Pull Request

i ll be honest i dont know know if the number 7 is there for a particular reason. i put it to 12 globally because of this, but it s probably best to just do hiero. Close #95799

## Why It's Good For The Game

currently obtaining the hierophant crusher kill achievement forces you to tank at least a portion of it s deathrattle attack so this makes it so that you can get the cheevo (currently of any megafauna) obtainable from 12 tiles (1 tile away from hiero final blast). would fix the underlaying issue pointed in #95799 

## Changelog
:cl:

fix: hierophant achievement can now be obtained from 1 tile away of it s final blast

/:cl:
