### PR TITLE
Fixes Icebox boulder processing room being exposed to ice wastes

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -170150,7 +170150,7 @@ cMk
 wmR
 cMk
 cMk
-uvM
+bie
 cMk
 cMk
 faL


### PR DESCRIPTION

## About The Pull Request
Fixes a window orinatation letting icewaste air into processing room.The one below the airalarm.
<img width="1297" height="1140" alt="image" src="https://github.com/user-attachments/assets/32d902de-a80c-41c5-9d58-60f79ac3dd3f" />
## Why It's Good For The Game
Station air Good,Ice air Bad. Fix Good.
<strike>closes https://github.com/tgstation/tgstation/pull/95882</strike>
closes https://github.com/tgstation/tgstation/issues/95877 ,<strike>https://github.com/tgstation/tgstation/issues/95890</strike>
## Changelog
:cl:

map: IceBox station boulder processing no longer exposed to outside.

/:cl:
