### PR TITLE
Fixes maximum time of syndicate bombs and refactors slightly

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -134,6 +134,9 @@
 /// What's the minimum duration of a syndie bomb (in seconds)
 #define SYNDIEBOMB_MIN_TIMER_SECONDS 90
 
+/// What's the maximum duration of a syndie bomb (in seconds)
+#define SYNDIEBOMB_MAX_TIMER_SECONDS 100*60 // 100 MINUTES // not using the MINUTES define because those are for deciseconds
+
 // Camera upgrade bitflags.
 #define CAMERA_UPGRADE_XRAY (1<<0)
 #define CAMERA_UPGRADE_EMP_PROOF (1<<1)

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -134,9 +134,6 @@
 /// What's the minimum duration of a syndie bomb (in seconds)
 #define SYNDIEBOMB_MIN_TIMER_SECONDS 90
 
-/// What's the maximum duration of a syndie bomb (in seconds)
-#define SYNDIEBOMB_MAX_TIMER_SECONDS 100*60 // 100 MINUTES // not using the MINUTES define because those are for deciseconds
-
 // Camera upgrade bitflags.
 #define CAMERA_UPGRADE_XRAY (1<<0)
 #define CAMERA_UPGRADE_EMP_PROOF (1<<1)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -20,7 +20,7 @@
 	/// What is the lowest amount of time we can set the timer to?
 	var/minimum_timer = SYNDIEBOMB_MIN_TIMER_SECONDS
 	/// What is the highest amount of time we can set the timer to?
-	var/maximum_timer = 100 MINUTES
+	var/maximum_timer = SYNDIEBOMB_MAX_TIMER_SECONDS
 	/// What is the default amount of time we set the timer to?
 	var/timer_set = SYNDIEBOMB_MIN_TIMER_SECONDS
 	/// Can we be unanchored?

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -20,7 +20,7 @@
 	/// What is the lowest amount of time we can set the timer to?
 	var/minimum_timer = SYNDIEBOMB_MIN_TIMER_SECONDS
 	/// What is the highest amount of time we can set the timer to?
-	var/maximum_timer = SYNDIEBOMB_MAX_TIMER_SECONDS
+	var/maximum_timer = 100*60 // 100 MINUTES // not using the MINUTES define because those are for deciseconds
 	/// What is the default amount of time we set the timer to?
 	var/timer_set = SYNDIEBOMB_MIN_TIMER_SECONDS
 	/// Can we be unanchored?


### PR DESCRIPTION

## About The Pull Request
Fixes the maximum time of syndicate bombs being 60,000 seconds (1,000 minutes) to instead be 6,000 seconds (100 minutes) as intended. The previous code used the MINUTES define, which converts to deciseconds, rather than directly converting to seconds.
## Why It's Good For The Game
Makes the game work as intended.
## Changelog
:cl:
fix: Fixed syndicate bombs having a maximum timer of 1000 minutes instead of 100 minutes.
/:cl:
