### PR TITLE
Fix large bulky toys from being stored in suit storage

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -210,7 +210,6 @@ GLOBAL_LIST_INIT(any_suit_storage, typecacheof(list(
 	/obj/item/lighter,
 	/obj/item/pen,
 	/obj/item/modular_computer/pda,
-	/obj/item/toy,
 	/obj/item/radio,
 	/obj/item/storage/bag/books,
 	/obj/item/storage/fancy/cigarettes,

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -210,6 +210,7 @@ GLOBAL_LIST_INIT(any_suit_storage, typecacheof(list(
 	/obj/item/lighter,
 	/obj/item/pen,
 	/obj/item/modular_computer/pda,
+	/obj/item/toy/plush,
 	/obj/item/radio,
 	/obj/item/storage/bag/books,
 	/obj/item/storage/fancy/cigarettes,


### PR DESCRIPTION

## About The Pull Request
- Fixes https://github.com/tgstation/tgstation/issues/94208

This disables large toys from being inserted into the suit storage. There really wasn't a good reason for this to bypass the item size check, since most toys are naturally small-sized and can be inserted anyway.

## Why It's Good For The Game
Removes a basketball minigame exploit. 

## Changelog
:cl:
fix: Fix large bulky toys from being stored in suit storage
/:cl:
