### PR TITLE
Adds an ingame holiday for Chernobyl Disaster Remembrance Day

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -44,6 +44,7 @@
 #define IAN_HOLIDAY "Ian's Birthday"
 #define HOTDOG_DAY "National Hot Dog Day"
 #define ICE_CREAM_DAY "National Ice Cream Day"
+#define CHERNOBYL_ANNIVERSARY "Chernobyl Disaster Remembrance Day"
 /*
 
 Days of the week to make it easier to reference them.

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -7,8 +7,13 @@
 	min_wizard_trigger_potency = 3
 	max_wizard_trigger_potency = 7
 
-/datum/round_event/radiation_storm
+/datum/round_event_control/radiation_storm/New()
+	. = ..()
+	if(max_occurrences > 0 && weight > 0 && check_holidays(CHERNOBYL_ANNIVERSARY))
+		weight *= 2
+		max_occurrences += 2
 
+/datum/round_event/radiation_storm
 
 /datum/round_event/radiation_storm/setup()
 	start_when = 3

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -354,6 +354,21 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/anz/getStationPrefix()
 	return pick("Australian","New Zealand","Poppy", "Southern Cross")
 
+/datum/holiday/chernobyl
+	name = CHERNOBYL_ANNIVERSARY
+	begin_day = 26
+	begin_month = APRIL
+
+/datum/holiday/chernobyl/getStationPrefix()
+	if(prob(3))
+		return "Not Great, Not Terrible"
+
+	return pick("Atomic", "Nuclear", "Radiation", "Plutonium", "Uranium", "Corium", "Zirconium", "Graphite", "Scram", "Explosion")
+
+/datum/holiday/chernobyl/greet()
+	return "On this day in 1986, the Chernobyl nuclear power plant melted down, causing one of the worst nuclear disasters in human history. \
+		Today serves as a reminder to the lives lost and to the rigorous safety standards our engineers must adhere to when providing power to the station."
+
 // MAY
 
 /datum/holiday/labor


### PR DESCRIPTION
## About The Pull Request

April 26th is Chernobyl Disaster Remembrance Day

There are no colored tiles or posters associated, but it does have station prefixes.
Also as an added effect, radiation storms are twice as likely to trigger randomly, and multiple can trigger in one round.  

## Why It's Good For The Game

Today is the 40th anniversary of the Chernobyl disaster and I feel it would be somewhat fitting as an in game holiday given our game's propensity to have reactor meltdowns

(and also the Space Soviet Union existed in the lore so I imagine they'd carry the tradition out to the Spinward Sector) 

## Changelog

:cl: Melbert
add: April 26th is Chernobyl Disaster Remembrance Day.
/:cl:
