### PR TITLE
Geysers now provide some audio feedback when scanned.

### DIFF
--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -72,6 +72,7 @@
 		return
 
 	to_chat(user, span_notice("You discovered the geyser and mark it on the GPS system!"))
+	playsound(src, 'sound/machines/beep/twobeep_high.ogg', 30)
 	SEND_SIGNAL(user, COMSIG_LIVING_DISCOVERED_GEYSER, src)
 	if(discovery_message)
 		to_chat(user, discovery_message)


### PR DESCRIPTION
## About The Pull Request

Currently geysers provide a bit of chat feedback when scanned, and that's about it. I thought some quiet audio feedback would help the UX when interacting with them to better sell that the geyser as been properly scanned and completed.

## Why It's Good For The Game

Better user feedback when the action is successful is helpful in as hostile an environment as lavaland, especially when you might need to tag one fast before running away from a mob or obstacle.

## Changelog

:cl:
qol: Added a sound effect when a geyser is properly scanned.
/:cl: