### PR TITLE
Fixes blue/green cat ears being switched

### DIFF
--- a/code/modules/surgery/organs/internal/ears/_ears.dm
+++ b/code/modules/surgery/organs/internal/ears/_ears.dm
@@ -253,10 +253,10 @@
 	return all_images
 
 /datum/bodypart_overlay/mutant/cat_ears/cybernetic/green
-	inner_color = "#0079EA"
+	inner_color = "#00D844"
 
 /datum/bodypart_overlay/mutant/cat_ears/cybernetic/blue
-	inner_color = "#00D844"
+	inner_color = "#0079EA"
 
 /obj/item/organ/ears/ghost
 	name = "ghost ears"


### PR DESCRIPTION
## About The Pull Request

<img width="502" height="159" alt="Code_uPth7LpFwF" src="https://github.com/user-attachments/assets/6e0c5f19-d115-4023-a9a3-8847ff4bec07" />

## Why It's Good For The Game

Helps the cats name the colors they obviously aren't able to see very well!

## Changelog

:cl:
fix: fixes blue and green cybernetic cat ears being switched
/:cl:

