### PR TITLE
Cables without power do not produce sparks when placed

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -685,11 +685,11 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 //////////////////////////////////////////////
 
 // called when cable_coil is clicked on a turf
-/obj/item/stack/cable_coil/proc/place_turf(turf/T, mob/user, dirnew)
+/obj/item/stack/cable_coil/proc/place_turf(turf/target_turf, mob/user, dirnew)
 	if(!isturf(user.loc))
 		return
 
-	if(!isturf(T) || T.underfloor_accessibility < UNDERFLOOR_INTERACTABLE || !T.can_have_cabling())
+	if(!isturf(target_turf) || target_turf.underfloor_accessibility < UNDERFLOOR_INTERACTABLE || !target_turf.can_have_cabling())
 		to_chat(user, span_warning("You can only lay cables on catwalks and plating!"))
 		return
 
@@ -697,31 +697,31 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 		to_chat(user, span_warning("There is no cable left!"))
 		return
 
-	if(get_dist(T,user) > 1) // Too far
+	if(get_dist(target_turf,user) > 1) // Too far
 		to_chat(user, span_warning("You can't lay cable at a place that far away!"))
 		return
 
-	for(var/obj/structure/cable/C in T)
-		if(C.cable_layer & target_layer)
+	for(var/obj/structure/cable/old_cable in target_turf)
+		if(old_cable.cable_layer & target_layer)
 			to_chat(user, span_warning("There's already a cable at that position!"))
 			return
 
-	var/obj/structure/cable/C = new target_type(T)
+	var/obj/structure/cable/new_cable = new target_type(target_turf)
 
 	//create a new powernet with the cable, if needed it will be merged later
-	var/datum/powernet/PN = new()
-	PN.add_cable(C)
+	var/datum/powernet/new_powernet = new()
+	new_powernet.add_cable(new_cable)
 
 	for(var/dir_check in GLOB.cardinals)
-		C.mergeConnectedNetworks(dir_check) //merge the powernet with adjacents powernets
-	C.mergeConnectedNetworksOnTurf() //merge the powernet with on turf powernets
+		new_cable.mergeConnectedNetworks(dir_check) //merge the powernet with adjacents powernets
+	new_cable.mergeConnectedNetworksOnTurf() //merge the powernet with on turf powernets
 
 	use(1)
 
-	if(C.shock(user, 50) && prob(50)) //fail
-		C.deconstruct()
+	if(new_cable.powernet.avail && new_cable.shock(user, 50) && prob(50))
+		new_cable.deconstruct()
 
-	return C
+	return new_cable
 
 /obj/item/stack/cable_coil/five
 	amount = 5


### PR DESCRIPTION

## About The Pull Request

Cables attempted to shock, and thus produced sparks, regardless of whether they had any power in them.
Also, one letter vars.

## Why It's Good For The Game

Sparks from where

## Changelog
:cl:

fix: Cables without power no longer produce sparks when placed

/:cl:
