### PR TITLE
Fixes pet commands that required pointing (by fixing pointing) and fixes pets being unable to attack

### DIFF
--- a/code/datums/ai/dog/dog_behaviors.dm
+++ b/code/datums/ai/dog/dog_behaviors.dm
@@ -27,16 +27,8 @@
 		paw_harmlessly(living_pawn, target, seconds_per_tick)
 		return AI_BEHAVIOR_INSTANT
 
-	// Give Ian some teeth
-	var/old_melee_lower = living_pawn.melee_damage_lower
-	var/old_melee_upper = living_pawn.melee_damage_upper
-	living_pawn.melee_damage_lower = max(5, old_melee_lower)
-	living_pawn.melee_damage_upper = max(10, old_melee_upper)
-
 	. = ..() // Bite time
 
-	living_pawn.melee_damage_lower = old_melee_lower
-	living_pawn.melee_damage_upper = old_melee_upper
 	return AI_BEHAVIOR_DELAY
 
 /// Swat at someone we don't like but won't hurt

--- a/code/modules/mob/living/basic/pets/dog/_dog.dm
+++ b/code/modules/mob/living/basic/pets/dog/_dog.dm
@@ -35,6 +35,8 @@
 	attack_sound = 'sound/items/weapons/bite.ogg'
 	attack_vis_effect = ATTACK_EFFECT_BITE
 	melee_attack_cooldown = 0.8 SECONDS
+	melee_damage_lower = 5
+	melee_damage_upper = 10
 	/// Instructions you can give to dogs
 	var/static/list/pet_commands = list(
 		/datum/pet_command/idle,

--- a/code/modules/mob/living/basic/pets/pet.dm
+++ b/code/modules/mob/living/basic/pets/pet.dm
@@ -5,5 +5,7 @@
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	default_blood_volume = BLOOD_VOLUME_NORMAL
 	basic_mob_flags = SENDS_DEATH_MOODLETS
+	melee_damage_lower = 5
+	melee_damage_upper = 5
 	/// if the mob is protected from being renamed by collars.
 	var/unique_pet = FALSE

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -110,12 +110,13 @@
 /// either called immediately or in the tick after pointed() was called, as per the [DEFAULT_QUEUE_OR_CALL_VERB()] macro
 /mob/proc/_pointed(atom/pointing_at)
 	if(client) //Clientless mobs can just go ahead and point
+		var/atom/atom_to_view_verify = pointing_at
 		if(ismovable(pointing_at))
 			var/atom/movable/pointed_movable = pointing_at
 			if(HAS_TRAIT(pointed_movable, TRAIT_SKIP_BASIC_REACH_CHECK) || pointing_at.loc.IsContainedAtomAccessible(pointing_at, src))
-				pointing_at = pointed_movable.loc
+				atom_to_view_verify = pointed_movable.loc
 
-		if(!(pointing_at in view(client.view, src)))
+		if(!(atom_to_view_verify in view(client.view, src)))
 			return FALSE
 	if(iscarbon(src)) // special interactions for carbons
 		var/mob/living/carbon/our_carbon = src


### PR DESCRIPTION

## About The Pull Request

This is a two-parter but they are part of the same journey; I was fixing #95715 and noticed the commands didnt work, so I also fixed that #94689

The issue for #95715 was that pets did not have their damage set at all, so they could not attack on combat mode. Dogs specifically circumvented this by setting and reverting the damage during behavior, which is not what ai behavior should do. Now those values are the same. I set it up as 5 lower and upper by default on pets, but if I need to tweak that let me know.

For #94689 the issue is that if pointed_at's loc is a turf, it would override pointed_at to be the turf, so that it could pass the view() check below. But by setting pointed_at everything after now uses that for the logic, including the signals. Which means the logic often just thought you were pointing at the floor. I've fixed this by assigning the loc to a temp var and not changing pointed_at

## Why It's Good For The Game

Dog-mauling is back, this is a good thing.

## Changelog
:cl: dresseronfire
fix: You can now sic pets onto targets again
fix: Pointing at things no longer sometimes points at the wrong thing
/:cl:

