### PR TITLE
Soup doesn't yell at you when you drink it

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -121,16 +121,16 @@
 			if(DOING_INTERACTION_WITH_TARGET(user, user))
 				return ITEM_INTERACT_BLOCKING
 			user.visible_message(
-				span_danger("[user] attempts to drink from [src]."),
-				span_userdanger("[user] attempts to drink from [src]."),
+				span_notice("[user] attempts to drink from [src]."),
+				ignored_mobs = list(user),
 			)
+			to_chat(user, span_notice("You attempt to drink from [src]."))
 			if(!do_after(user, 1.25 SECONDS, user))
 				return ITEM_INTERACT_BLOCKING
 			if(!reagents || !reagents.total_volume)
 				return ITEM_INTERACT_BLOCKING
 			user.visible_message(
-				span_danger("[user] drinks from [src]."),
-				span_userdanger("[user] drinks from [src]."),
+				span_notice("[user] drinks from [src]."),
 				ignored_mobs = list(user),
 			)
 		to_chat(user, span_notice("You swallow a gulp of [src]."))


### PR DESCRIPTION
## About The Pull Request

Replaces userdanger spans with notice spans, so you don't get yelled at when drinking soup

## Why It's Good For The Game

IDK why I thought this was acceptable

## Changelog

:cl: Melbert
qol: Drinking soup from a bowl no longer yells at you in big text
/:cl:

