### PR TITLE
You can purchase (lower quality) broadcast cameras as a cargo goodie

### DIFF
--- a/code/game/objects/items/devices/broadcast_camera.dm
+++ b/code/game/objects/items/devices/broadcast_camera.dm
@@ -28,6 +28,8 @@
 	var/broadcast_name = "Curator News"
 	/// The networks it broadcasts to, default is CAMERANET_NETWORK_CURATOR
 	var/list/camera_networks = list(CAMERANET_NETWORK_CURATOR)
+	/// Range of the camera
+	var/camera_range = 7
 	/// The "virtual" security camera inside of the physical camera
 	var/obj/machinery/camera/internal_camera
 	/// The "virtual" radio inside of the the physical camera, a la microphone
@@ -86,6 +88,7 @@
 	// INTERNAL CAMERA
 	internal_camera = new(wielding_carbon) // Cameras for some reason do not work inside of obj's
 	internal_camera.internal_light = FALSE
+	internal_camera.view_range = camera_range
 	internal_camera.network = camera_networks
 	internal_camera.c_tag = "LIVE: [broadcast_name]"
 	start_broadcasting_network(camera_networks, "[broadcast_name] is now LIVE!")
@@ -126,3 +129,16 @@
 
 /obj/item/broadcast_camera/proc/set_microphone_state()
 	internal_radio.set_broadcasting(active_microphone)
+
+// Orderable from cargo
+/obj/item/broadcast_camera/cargo
+	slowdown = 0.3
+	item_flags = parent_type::item_flags | SLOWS_WHILE_IN_HAND
+	broadcast_name = "Camera Broadcast"
+	camera_range = 4
+
+/obj/item/broadcast_camera/cargo/Initialize(mapload)
+	. = ..()
+	// Gives each cargo camera a unique network id
+	var/static/cargo_camera_network_id = 0
+	camera_networks = list("cargo_camera_id_[cargo_camera_network_id++]")

--- a/code/game/objects/items/devices/broadcast_camera.dm
+++ b/code/game/objects/items/devices/broadcast_camera.dm
@@ -135,7 +135,7 @@
 	slowdown = 0.3
 	item_flags = parent_type::item_flags | SLOWS_WHILE_IN_HAND
 	broadcast_name = "Camera Broadcast"
-	camera_range = 4
+	camera_range = 5
 
 /obj/item/broadcast_camera/cargo/Initialize(mapload)
 	. = ..()

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -447,5 +447,5 @@
 /datum/supply_pack/goody/camera
 	name = "Broadcast Camera"
 	desc = "A single broadcast camera which broadcasts to the station's entertainment monitors, for all your theatrical needs."
-	cost = PAYCHECK_COMMAND * 6
+	cost = PAYCHECK_COMMAND * 8
 	contains = list(/obj/item/broadcast_camera/cargo)

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -435,12 +435,17 @@
 	cost = PAYCHECK_CREW * 5
 	contains = list(/obj/item/key/golfcart)
 
-
 /datum/supply_pack/goody/handheld_crew_monitor
 	name = "Handheld Crew Monitor"
-	desc = "A crate containing a handheld crew monitor"
+	desc = "A crate containing a handheld crew monitor."
 	cost = /obj/item/sensor_device::custom_premium_price * 1.25 // 1.25X base vending machine value
 	contains = list(
 		/obj/item/sensor_device,
 	)
 	crate_name = "handheld crew monitor crate"
+
+/datum/supply_pack/goody/camera
+	name = "Broadcast Camera"
+	desc = "A single broadcast camera which broadcasts to the station's entertainment monitors, for all your theatrical needs."
+	cost = PAYCHECK_COMMAND * 6
+	contains = list(/obj/item/broadcast_camera/cargo)


### PR DESCRIPTION
## About The Pull Request

You can order a broadcast camera (the thing the curator can get which lets them livestream to entertainment screens) in cargo for 800 credits

The cargo version has a smaller view range (4 tiles instead of 7 tiles) and slows you down slightly 

## Why It's Good For The Game

There's a lot of opportunities for gimmicks in being able to broadcast to the station 

Like if you're an antag and want to prove you have a hostage, or you want to make rival news broadcasts, or you're a clown who livestreams breaking into security, etc 

Access to the ability to broadcast is very very limited (to a single curator kit). If you wanna do any of the above you have to either play curator and dedicate your entire round to it, ask the curator for *their* gimmick item, or if there's no curator and you didn't roll it you just can't do it at all. (And god forbid if someone steals the camera or you lose it)

I think it's kinda sad so I wanted to add another way to obtain the ability to broadcast and I figure cargo is a good place. It's lower quality because I'm very wary of people robbing the curator of their gimmick - The curator's camera is top of the line and that's what differentiates it from the pleb's stuff. 

## Changelog

:cl: Melbert
add: You can purchase (lower quality) broadcast cameras in cargo for 800cr
/:cl:
