### PR TITLE
Fixed color matrix not applying in reskinnable item preview

### DIFF
--- a/code/datums/components/reskinnable_atom.dm
+++ b/code/datums/components/reskinnable_atom.dm
@@ -258,7 +258,7 @@
 	var/list/atom_skins = get_atom_skins()
 	for(var/reskin_name, reskin_typepath in get_skins_by_name())
 		var/datum/atom_skin/reskin = atom_skins[reskin_typepath]
-		items[reskin_name] = image(icon = reskin.new_icon || atom_parent.icon, icon_state = reskin.new_icon_state || atom_parent.icon_state)
+		items[reskin_name] = reskin.get_preview_icon(atom_parent)
 
 	sort_list(items)
 


### PR DESCRIPTION
## About The Pull Request

#94466 introduced changes for reskinnable items that broke recoloring for kmaga alt style, this pr supposedly fixes it??

## Changelog

:cl:
fix: Fixed color matrix not applying in reskinnable item preview.
/:cl:
