### PR TITLE
cream-atoriums wouldnt inherit directon on maploading.

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -434,6 +434,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	. = ..()
 	if(mapload && check_holidays(ICE_CREAM_DAY) && !istype(src, /obj/structure/bodycontainer/crematorium/creamatorium))
 		var/obj/structure/bodycontainer/crematorium/creamatorium/creamy = new(loc)
+		creamy.dir = dir
 		creamy.id = id
 		return INITIALIZE_HINT_QDEL
 	GLOB.crematoriums += src


### PR DESCRIPTION

## About The Pull Request
creamatoriums wouldn't inherit dir on mapload.
## Why It's Good For The Game
PRing bugfix upstream.
## Changelog
:cl:
fix: creamatoriums now inherit the original crematorium dir
/:cl:
