### PR TITLE
Total moles optimization for compare()

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -787,7 +787,6 @@ GLOBAL_LIST_EMPTY(colored_images)
 
 	var/list/gases = canonical_mix.gases
 	var/list/gas = params2list(gas_string)
-	var/mole_sum
 	if(gas["TEMP"])
 		canonical_mix.temperature = text2num(gas["TEMP"])
 		canonical_mix.temperature_archived = canonical_mix.temperature
@@ -800,8 +799,7 @@ GLOBAL_LIST_EMPTY(colored_images)
 			path = gas_id2path(path) //a lot of these strings can't have embedded expressions (especially for mappers), so support for IDs needs to stick around
 		ADD_GAS(path, gases)
 		gases[path][MOLES] = text2num(gas[id])
-		mole_sum += text2num(gas[id])
-	canonical_mix.total_moles = mole_sum
+	canonical_mix.total_moles = values_sum(gases)
 	if(istype(canonical_mix, /datum/gas_mixture/immutable))
 		return canonical_mix
 	return canonical_mix.copy()

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -787,6 +787,7 @@ GLOBAL_LIST_EMPTY(colored_images)
 
 	var/list/gases = canonical_mix.gases
 	var/list/gas = params2list(gas_string)
+	var/mole_sum
 	if(gas["TEMP"])
 		canonical_mix.temperature = text2num(gas["TEMP"])
 		canonical_mix.temperature_archived = canonical_mix.temperature
@@ -799,7 +800,8 @@ GLOBAL_LIST_EMPTY(colored_images)
 			path = gas_id2path(path) //a lot of these strings can't have embedded expressions (especially for mappers), so support for IDs needs to stick around
 		ADD_GAS(path, gases)
 		gases[path][MOLES] = text2num(gas[id])
-
+		mole_sum += text2num(gas[id])
+	canonical_mix.total_moles = mole_sum
 	if(istype(canonical_mix, /datum/gas_mixture/immutable))
 		return canonical_mix
 	return canonical_mix.copy()

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -168,12 +168,13 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	var/list/cached_gases = gases //accessing datum vars is slower than proc vars
 	var/list/giver_gases = giver.gases
+	var/mole_taken
 	//gas transfer
 	for(var/giver_id in giver_gases)
 		ASSERT_GAS_IN_LIST(giver_id, cached_gases)
 		cached_gases[giver_id][MOLES] += giver_gases[giver_id][MOLES]
-		total_moles += giver_gases[giver_id][MOLES]
-
+		mole_taken += giver_gases[giver_id][MOLES]
+	total_moles += mole_taken
 	SEND_SIGNAL(src, COMSIG_GASMIX_MERGED)
 	return TRUE
 
@@ -183,6 +184,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/mole_diff = gases[gas_specie][MOLES] - amount
 	gases[gas_specie][MOLES] = amount
 	total_moles += mole_diff
+	garbage_collect(gas_specie)
 
 /datum/gas_mixture/proc/set_temperature(target_temp)
 	temperature = target_temp
@@ -193,7 +195,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	ASSERT_GAS(gas, src)
 	gases[gas][MOLES] += QUANTIZE(amount)
 	total_moles += QUANTIZE(amount)
-	garbage_collect()
+	garbage_collect(gas)
 
 /// Add a specific amount of moles to all the gasses present or add a new gas to the mix
 ///gases_moles is an associative list of gas species to their amount to be added
@@ -202,7 +204,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		ASSERT_GAS(gas_specie, src)
 		gases[gas_specie][MOLES] += QUANTIZE(gases_moles[gas_specie])
 		total_moles += QUANTIZE(gases_moles[gas_specie])
-	garbage_collect()
+	garbage_collect(gases_moles)
 
 
 /// Modify the gas list as to convert moles of gas species A to gas species B
@@ -400,6 +402,9 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	var/moved_moles = 0
 	var/abs_moved_moles = 0
+	//track the moles moving to and from
+	var/mole_given
+	var/mole_taken
 
 	//GAS TRANSFER
 
@@ -432,11 +437,13 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 				heat_capacity_sharer_to_self -= gas_heat_capacity //subtract here instead of adding the absolute value because we know that delta is negative.
 
 		gas[MOLES] -= delta
+		mole_given -= delta
 		sharergas[MOLES] += delta
+		mole_taken += delta
 		moved_moles += delta
 		abs_moved_moles += abs(delta)
-
-	total_moles += moved_moles
+	total_moles -= mole_given
+	sharer.total_moles += mole_taken
 	last_share = abs_moved_moles
 
 	//THERMAL ENERGY TRANSFER
@@ -501,7 +508,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/list/cached_gases = gases
 	var/moles_sum = 0
 
-	if(total_moles >= sample.total_moles)
+	if(total_moles > sample.total_moles)
 		return ""
 
 	for(var/id in cached_gases | sample_gases) // compare gases from either mixture

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -436,7 +436,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		moved_moles += delta
 		abs_moved_moles += abs(delta)
 
-	total_moles += abs(delta)
+	total_moles += moved_moles
 	last_share = abs_moved_moles
 
 	//THERMAL ENERGY TRANSFER

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	/// I am sorry
 	var/pipeline_cycle = -1
 	///track total moles for optimization
-	var/total_moles
+	var/total_moles = 0
 
 /datum/gas_mixture/New(volume)
 	gases = new

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -144,12 +144,10 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 ///Update archived versions of variables. Returns: 1 in all cases
 /datum/gas_mixture/proc/archive()
 	var/list/cached_gases = gases
-	var/moles
 	temperature_archived = temperature
 	for(var/id in cached_gases)
 		cached_gases[id][ARCHIVE] = cached_gases[id][MOLES]
-		moles += cached_gases[id][MOLES]
-	total_moles = moles
+	total_moles = values_sum(cached_gases)
 
 	return TRUE
 
@@ -168,13 +166,11 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	var/list/cached_gases = gases //accessing datum vars is slower than proc vars
 	var/list/giver_gases = giver.gases
-	var/mole_taken
 	//gas transfer
 	for(var/giver_id in giver_gases)
 		ASSERT_GAS_IN_LIST(giver_id, cached_gases)
 		cached_gases[giver_id][MOLES] += giver_gases[giver_id][MOLES]
-		mole_taken += giver_gases[giver_id][MOLES]
-	total_moles += mole_taken
+	total_moles = values_sum(giver_gases)
 	SEND_SIGNAL(src, COMSIG_GASMIX_MERGED)
 	return TRUE
 
@@ -203,7 +199,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	for(var/gas_specie in gases_moles)
 		ASSERT_GAS(gas_specie, src)
 		gases[gas_specie][MOLES] += QUANTIZE(gases_moles[gas_specie])
-		total_moles += QUANTIZE(gases_moles[gas_specie])
+	total_moles = values_sum(gases_moles)
 	garbage_collect(gases_moles)
 
 
@@ -234,7 +230,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		ADD_GAS(id, removed.gases)
 		removed_gases[id][MOLES] = QUANTIZE(cached_gases[id][MOLES] * ratio)
 		cached_gases[id][MOLES] -= removed_gases[id][MOLES]
-		total_moles -= removed_gases[id][MOLES]
+	total_moles -= values_sum(removed_gases)
 	garbage_collect()
 
 	SEND_SIGNAL(src, COMSIG_GASMIX_REMOVED)
@@ -257,7 +253,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		ADD_GAS(id, removed.gases)
 		removed_gases[id][MOLES] = QUANTIZE(cached_gases[id][MOLES] * ratio)
 		cached_gases[id][MOLES] -= removed_gases[id][MOLES]
-		total_moles -= removed_gases[id][MOLES]
+	total_moles -= values_sum(removed_gases)
 
 	garbage_collect()
 
@@ -277,6 +273,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	ADD_GAS(gas_id, removed.gases)
 	removed_gases[gas_id][MOLES] = amount
 	cached_gases[gas_id][MOLES] -= amount
+	total_moles -= amount
 
 	garbage_collect(list(gas_id))
 	return removed
@@ -294,6 +291,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	ADD_GAS(gas_id, removed.gases)
 	removed_gases[gas_id][MOLES] = QUANTIZE(cached_gases[gas_id][MOLES] * ratio)
 	cached_gases[gas_id][MOLES] -= removed_gases[gas_id][MOLES]
+	total_moles -= removed_gases[gas_id][MOLES]
 
 	garbage_collect(list(gas_id))
 
@@ -323,6 +321,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			var/total_moles = gases[gas_id][MOLES] + other.gases[gas_id][MOLES]
 			gases[gas_id][MOLES] = total_moles * (volume/total_volume)
 			other.gases[gas_id][MOLES] = total_moles * (other.volume/total_volume)
+	total_moles = values_sum(gases)
+	other.total_moles = values_sum(other.gases)
 	garbage_collect()
 	other.garbage_collect()
 
@@ -335,6 +335,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/list/copy_gases = copy.gases
 
 	copy.temperature = temperature
+	copy.total_moles = total_moles
 	for(var/id in cached_gases)
 		// Sort of a sideways way of doing ADD_GAS()
 		// Faster tho, gotta save those cpu cycles
@@ -374,6 +375,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	for(var/id in sample_gases)
 		ASSERT_GAS_IN_LIST(id, cached_gases)
 		cached_gases[id][MOLES] = sample_gases[id][MOLES] * partial
+	total_moles = values_sum(cached_gases)
 
 	return TRUE
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -501,6 +501,9 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/list/cached_gases = gases
 	var/moles_sum = 0
 
+	if(total_moles >= sample.total_moles)
+		return ""
+
 	for(var/id in cached_gases | sample_gases) // compare gases from either mixture
 		// Yes this is actually fast. I too hate it here
 		var/gas_moles = cached_gases[id]?[index] || 0

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -172,6 +172,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	for(var/giver_id in giver_gases)
 		ASSERT_GAS_IN_LIST(giver_id, cached_gases)
 		cached_gases[giver_id][MOLES] += giver_gases[giver_id][MOLES]
+		total_moles += giver_gases[giver_id][MOLES]
 
 	SEND_SIGNAL(src, COMSIG_GASMIX_MERGED)
 	return TRUE
@@ -182,8 +183,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/mole_diff = gases[gas_specie][MOLES] - amount
 	gases[gas_specie][MOLES] = amount
 	total_moles += mole_diff
-
-	garbage_collect()
 
 /datum/gas_mixture/proc/set_temperature(target_temp)
 	temperature = target_temp

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -509,7 +509,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/moles_sum = 0
 
 	if(total_moles > sample.total_moles)
-		return ""
+		return "total_moles_diff"
 
 	for(var/id in cached_gases | sample_gases) // compare gases from either mixture
 		// Yes this is actually fast. I too hate it here

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -37,6 +37,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	/// When this gas mixture was last touched by pipeline processing
 	/// I am sorry
 	var/pipeline_cycle = -1
+	///track total moles for optimization
+	var/total_moles
 
 /datum/gas_mixture/New(volume)
 	gases = new
@@ -142,10 +144,12 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 ///Update archived versions of variables. Returns: 1 in all cases
 /datum/gas_mixture/proc/archive()
 	var/list/cached_gases = gases
-
+	var/moles
 	temperature_archived = temperature
 	for(var/id in cached_gases)
 		cached_gases[id][ARCHIVE] = cached_gases[id][MOLES]
+		moles += cached_gases[id][MOLES]
+	total_moles = moles
 
 	return TRUE
 
@@ -175,7 +179,10 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 // Set the gas specie within the gas mix to a set amount, if there is none it will be created at the target temp
 /datum/gas_mixture/proc/set_gas(gas_specie, amount)
 	ASSERT_GAS(gas_specie, src)
+	var/mole_diff = gases[gas_specie][MOLES] - amount
 	gases[gas_specie][MOLES] = amount
+	total_moles += mole_diff
+
 	garbage_collect()
 
 /datum/gas_mixture/proc/set_temperature(target_temp)
@@ -186,6 +193,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 /datum/gas_mixture/proc/adjust_gas(gas, amount)
 	ASSERT_GAS(gas, src)
 	gases[gas][MOLES] += QUANTIZE(amount)
+	total_moles += QUANTIZE(amount)
 	garbage_collect()
 
 /// Add a specific amount of moles to all the gasses present or add a new gas to the mix
@@ -193,7 +201,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 /datum/gas_mixture/proc/adjust_multiple_gases(list/gases_moles)
 	for(var/gas_specie in gases_moles)
 		ASSERT_GAS(gas_specie, src)
-		gases[gas_specie][MOLES] += gases_moles[gas_specie]
+		gases[gas_specie][MOLES] += QUANTIZE(gases_moles[gas_specie])
+		total_moles += QUANTIZE(gases_moles[gas_specie])
 	garbage_collect()
 
 
@@ -224,6 +233,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		ADD_GAS(id, removed.gases)
 		removed_gases[id][MOLES] = QUANTIZE(cached_gases[id][MOLES] * ratio)
 		cached_gases[id][MOLES] -= removed_gases[id][MOLES]
+		total_moles -= removed_gases[id][MOLES]
 	garbage_collect()
 
 	SEND_SIGNAL(src, COMSIG_GASMIX_REMOVED)
@@ -246,6 +256,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		ADD_GAS(id, removed.gases)
 		removed_gases[id][MOLES] = QUANTIZE(cached_gases[id][MOLES] * ratio)
 		cached_gases[id][MOLES] -= removed_gases[id][MOLES]
+		total_moles -= removed_gases[id][MOLES]
 
 	garbage_collect()
 
@@ -426,6 +437,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		moved_moles += delta
 		abs_moved_moles += abs(delta)
 
+	total_moles += abs(delta)
 	last_share = abs_moved_moles
 
 	//THERMAL ENERGY TRANSFER

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -405,9 +405,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	var/moved_moles = 0
 	var/abs_moved_moles = 0
-	//track the moles moving to and from
-	var/mole_given
-	var/mole_taken
+
 
 	//GAS TRANSFER
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -147,7 +147,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	temperature_archived = temperature
 	for(var/id in cached_gases)
 		cached_gases[id][ARCHIVE] = cached_gases[id][MOLES]
-	total_moles = values_sum(cached_gases)
 
 	return TRUE
 
@@ -228,9 +227,10 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	removed.temperature = temperature
 	for(var/id in cached_gases)
 		ADD_GAS(id, removed.gases)
-		removed_gases[id][MOLES] = QUANTIZE(cached_gases[id][MOLES] * ratio)
+		var/removal = QUANTIZE(cached_gases[id][MOLES] * ratio)
+		removed_gases[id][MOLES] = removal
 		cached_gases[id][MOLES] -= removed_gases[id][MOLES]
-	total_moles -= values_sum(removed_gases)
+		total_moles -= removal
 	garbage_collect()
 
 	SEND_SIGNAL(src, COMSIG_GASMIX_REMOVED)
@@ -251,9 +251,10 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	removed.temperature = temperature
 	for(var/id in cached_gases)
 		ADD_GAS(id, removed.gases)
+		var/removal = QUANTIZE(cached_gases[id][MOLES] * ratio)
 		removed_gases[id][MOLES] = QUANTIZE(cached_gases[id][MOLES] * ratio)
 		cached_gases[id][MOLES] -= removed_gases[id][MOLES]
-	total_moles -= values_sum(removed_gases)
+		total_moles -= removal
 
 	garbage_collect()
 
@@ -439,13 +440,11 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 				heat_capacity_sharer_to_self -= gas_heat_capacity //subtract here instead of adding the absolute value because we know that delta is negative.
 
 		gas[MOLES] -= delta
-		mole_given -= delta
 		sharergas[MOLES] += delta
-		mole_taken += delta
 		moved_moles += delta
 		abs_moved_moles += abs(delta)
-	total_moles -= mole_given
-	sharer.total_moles += mole_taken
+	total_moles -= moved_moles
+	sharer.total_moles += moved_moles
 	last_share = abs_moved_moles
 
 	//THERMAL ENERGY TRANSFER
@@ -510,7 +509,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/list/cached_gases = gases
 	var/moles_sum = 0
 
-	if(total_moles > sample.total_moles)
+	if(QUANTIZE(total_moles - sample.total_moles) != 0)
 		return "total_moles_diff"
 
 	for(var/id in cached_gases | sample_gases) // compare gases from either mixture

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -71,6 +71,7 @@
 
 	var/list/mix = initial_gas
 	var/list/gas = params2list(gas_string)
+	var/mole_sum
 	if(gas["TEMP"])
 		initial_temperature = text2num(gas["TEMP"])
 		temperature_archived = initial_temperature
@@ -89,5 +90,7 @@
 		ADD_GAS(id, gases)
 		gases[id][MOLES] = mix[id][MOLES]
 		gases[id][ARCHIVE] = mix[id][MOLES]
+		mole_sum += mix[id][MOLES]
+	total_moles = mole_sum
 
 

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -71,7 +71,6 @@
 
 	var/list/mix = initial_gas
 	var/list/gas = params2list(gas_string)
-	var/mole_sum
 	if(gas["TEMP"])
 		initial_temperature = text2num(gas["TEMP"])
 		temperature_archived = initial_temperature
@@ -90,7 +89,6 @@
 		ADD_GAS(id, gases)
 		gases[id][MOLES] = mix[id][MOLES]
 		gases[id][ARCHIVE] = mix[id][MOLES]
-		mole_sum += mix[id][MOLES]
-	total_moles = mole_sum
+	total_moles = values_sum(gases)
 
 

--- a/code/modules/atmospherics/machinery/portable/pipe_scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/pipe_scrubber.dm
@@ -94,8 +94,8 @@
 	for(var/gas in filtering.gases & scrubbing)
 		filtered.add_gas(gas)
 
-		filtered.gases[gas][MOLES] = filtering.gases[gas][MOLES] // Shuffle the "bad" gasses to the filtered mixture.
-		filtering.gases[gas][MOLES] = 0
+		filtered.set_gas(gas, filtering.gases[gas][MOLES])  // Shuffle the "bad" gasses to the filtered mixture.
+		filtering.set_gas(gas, 0)
 	filtering.garbage_collect() // Now that the gasses are set to 0, clean up the mixture.
 
 	internal_tank.air_contents.merge(filtered) // Store filtered out gasses.

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -103,7 +103,9 @@
 		var/transferred_moles = max(QUANTIZE(env_gases[gas][MOLES] * removal_ratio * (env_gases[gas][MOLES] / total_moles_to_remove)), min(MOLAR_ACCURACY*1000, env_gases[gas][MOLES]))
 
 		filtered_out.adjust_gas(gas, transferred_moles)
+		filtered_out.total_moles += transferred_moles
 		environment.adjust_gas(gas, -transferred_moles)
+		environment.total_moles -= transferred_moles
 
 	environment.garbage_collect()
 


### PR DESCRIPTION

## About The Pull Request
Add a total moles var on gas mixture to track the total amount of moles currently present. This value should be easily tracked using the new mole setter i put in and i tried my best catching cases where moles change happen. Using this var we can now get an early return on compare() without iterating through the entire gaslist to decide if the mol difference between 2 gasmixes is enough to make it active. This should technically be free optimization but who knows might need a few weeks TM.
## Why It's Good For The Game
<img width="1418" height="83" alt="image" src="https://github.com/user-attachments/assets/cfec95d3-cbbc-4cef-ab5f-3e01ca6aab98" />

Test condition:
Air canister opened on full blast in runtime station
## Changelog
:cl:
code: optimize compare() using total_moles variable on gasmixture
/:cl:
