### PR TITLE
Fix pda messenger splitting all words instead of putting them on new lines

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
@@ -201,7 +201,7 @@ const ContactsScreen = (props: any) => {
           <Stack vertical textAlign="center">
             <Box bold>
               <Icon name="address-card" mr={1} />
-              SpaceMessenger V6.5.3
+              SpaceMessenger V6.5.4
             </Box>
             <Box italic opacity={0.3} mt={1}>
               Bringing you spy-proof communications since 2467.

--- a/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
@@ -368,6 +368,7 @@ const SendToAllSection = (props) => {
       <Section>
         <TextArea
           height={6}
+          width="100%"
           value={message}
           placeholder="Send message to everyone..."
           onChange={setMessage}

--- a/tgui/packages/tgui/styles/interfaces/NtosMessenger.scss
+++ b/tgui/packages/tgui/styles/interfaces/NtosMessenger.scss
@@ -38,7 +38,7 @@
     min-width: 9rem;
     overflow-wrap: break-word;
     text-align: left;
-    word-break: break-all;
+    word-break: break-word;
   }
 
   &__everyone {


### PR DESCRIPTION

## About The Pull Request

back when i made #75820 i encountered an issue where word-break: break-word; would unexpectedly break the layout when the chat container switched to scroll overflow. i didn't know how that happened or how to fix it, so i assumed it was an issue with IE11 that was never gonna get fixed so i gave in and just used word-break: break-all; which resulted in overzealous word breaks but it would at least prevent that bug from happening. new web browser means that bug is likely to be fixed, and afaik it is, so back we go to intended functionality

also fixing the text field not stretching fully

## Why It's Good For The Game

easier to read

## Changelog
:cl:
fix: The PDA direct messenger will no longer overzealously break words, resulting in cleaner chat message formatting overall.
/:cl:
