### PR TITLE
replaces reagent_explosion with dyn_explosion on heretic rift tk interaction

### DIFF
--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -147,8 +147,7 @@
 	else
 		human_user.gib(DROP_ALL_REMAINS)
 	human_user.investigate_log("has died from using telekinesis on a heretic influence.", INVESTIGATE_DEATHS)
-	var/datum/effect_system/reagents_explosion/explosion = new(get_turf(human_user), 1, 1, 1)
-	explosion.start(src)
+	dyn_explosion= new(get_turf(human_user), 1, 1, 1)
 
 /obj/effect/visible_heretic_influence/examine(mob/living/user)
 	. = ..()

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -147,7 +147,7 @@
 	else
 		human_user.gib(DROP_ALL_REMAINS)
 	human_user.investigate_log("has died from using telekinesis on a heretic influence.", INVESTIGATE_DEATHS)
-	dyn_explosion(get_turf(human_user), 1, flash_range = 1.5)
+	dyn_explosion(get_turf(human_user), 1, flash_range = 1)
 
 /obj/effect/visible_heretic_influence/examine(mob/living/user)
 	. = ..()

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -147,7 +147,7 @@
 	else
 		human_user.gib(DROP_ALL_REMAINS)
 	human_user.investigate_log("has died from using telekinesis on a heretic influence.", INVESTIGATE_DEATHS)
-	dyn_explosion(src, 1, 1, 1)
+	dyn_explosion(get_turf(human_user), 1, flash_range = 1.5)
 
 /obj/effect/visible_heretic_influence/examine(mob/living/user)
 	. = ..()

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -147,7 +147,7 @@
 	else
 		human_user.gib(DROP_ALL_REMAINS)
 	human_user.investigate_log("has died from using telekinesis on a heretic influence.", INVESTIGATE_DEATHS)
-	dyn_explosion= (get_turf(human_user), 1, 1, 1)
+	dyn_explosion(src, 1, 1, 1)
 
 /obj/effect/visible_heretic_influence/examine(mob/living/user)
 	. = ..()

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -147,7 +147,7 @@
 	else
 		human_user.gib(DROP_ALL_REMAINS)
 	human_user.investigate_log("has died from using telekinesis on a heretic influence.", INVESTIGATE_DEATHS)
-	dyn_explosion= new(get_turf(human_user), 1, 1, 1)
+	dyn_explosion= (get_turf(human_user), 1, 1, 1)
 
 /obj/effect/visible_heretic_influence/examine(mob/living/user)
 	. = ..()

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -147,7 +147,7 @@
 	else
 		human_user.gib(DROP_ALL_REMAINS)
 	human_user.investigate_log("has died from using telekinesis on a heretic influence.", INVESTIGATE_DEATHS)
-	dyn_explosion(get_turf(human_user), 1, flash_range = 1)
+	dyn_explosion(get_turf(human_user), 1, flash_range = 1, flame_range = 1)
 
 /obj/effect/visible_heretic_influence/examine(mob/living/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

fixes #94906. I think there were more instances where this had to be changed based on the issue report but i couldnt find them so please point them out if you re one of those who know 💀 

## Why It's Good For The Game

before, since it was a reagent explosion, it would generate a "the solution violently expldes!" message, which was weird

## Changelog
:cl:

fix: fixes a certain explosions message related to influences

/:cl:
