### PR TITLE
Fixes clicking on compact defib

### DIFF
--- a/code/game/objects/items/tools/medical/defib.dm
+++ b/code/game/objects/items/tools/medical/defib.dm
@@ -122,12 +122,12 @@
 /obj/item/defibrillator/attack_hand(mob/user, list/modifiers)
 	if(loc == user)
 		if(user.get_slot_by_item(src) & slot_flags)
-			ui_action_click()
+			ui_action_click(user, modifiers)
 		else
 			balloon_alert(user, "equip the unit first!")
 		return
 	else if(istype(loc, /obj/machinery/defibrillator_mount))
-		ui_action_click() //checks for this are handled in defibrillator.mount.dm
+		ui_action_click(user, modifiers) //checks for this are handled in defibrillator.mount.dm
 	return ..()
 
 /obj/item/defibrillator/screwdriver_act(mob/living/user, obj/item/tool)


### PR DESCRIPTION

## About The Pull Request

You were only able to get the defib out using an action button because it runtimes if you click on it

## Why It's Good For The Game

It shouldn't do that

## Changelog
:cl:

fix: You can now get the paddles from a compact defib by clicking on it

/:cl:
