### PR TITLE
Adds more SeCrEt ChEmS

### DIFF
--- a/code/__DEFINES/construction/material.dm
+++ b/code/__DEFINES/construction/material.dm
@@ -141,6 +141,9 @@ GLOBAL_LIST_INIT(material_flags_to_string, alist(
 /// Prevents material items from displaying their descriptors in examine_more with sci glasses
 #define MATERIAL_NO_DESCRIPTORS (1 << 8)
 
+/// Flags for metalgen imprinting
+#define MATERIAL_METALGEN MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
+
 //Special return values of [/datum/material_container/insert_item]
 /// No material was found inside them item
 #define MATERIAL_INSERT_ITEM_NO_MATS -1

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -358,7 +358,7 @@ GLOBAL_LIST_INIT(rarity_loot, list(//rare: really good items
 			/obj/item/reagent_containers/syringe/contraband/methamphetamine = 1,
 			) = 2,
 		list(
-			/obj/item/paper/secretrecipe/petrifium = 1,
+			/obj/item/paper/secretrecipe/gorgium = 1,
 			/obj/item/paper/secretrecipe/metalgen = 1,
 			) = 1,
 		) = 1,

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -351,11 +351,15 @@ GLOBAL_LIST_INIT(rarity_loot, list(//rare: really good items
 			/obj/item/storage/medkit/emergency = 1,
 			/obj/item/storage/medkit/regular = 1,
 			/obj/item/storage/box/bandages = 1,
-			) = 1,
+			) = 2,
 		list(//medical chems
 			/obj/item/reagent_containers/hypospray/medipen/oxandrolone = 1,
 			/obj/item/reagent_containers/hypospray/medipen/salacid = 1,
 			/obj/item/reagent_containers/syringe/contraband/methamphetamine = 1,
+			) = 2,
+		list(
+			/obj/item/paper/secretrecipe/petrifium = 1,
+			/obj/item/paper/secretrecipe/metalgen = 1,
 			) = 1,
 		) = 1,
 

--- a/code/datums/diseases/gbs.dm
+++ b/code/datums/diseases/gbs.dm
@@ -34,3 +34,9 @@
 				affected_mob.investigate_log("has been gibbed by GBS.", INVESTIGATE_DEATHS)
 				affected_mob.gib(DROP_ALL_REMAINS)
 				return FALSE
+
+/datum/disease/gbs/no_transmission
+	name = "Non-Transmissible GBS"
+	spread_text = "Skin contact"
+	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
+	spreading_modifier = 0

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -940,3 +940,19 @@
 	// Oops, all chainsawfish!
 	challenge.register_reward_signals(GLOB.preset_fish_sources[/datum/fish_source/portal/syndicate])
 
+/datum/material/rock
+	name = "rock"
+	desc = "Marble maybe?"
+	color = "#919191"
+	mat_flags = MATERIAL_BASIC_RECIPES | MATERIAL_CLASS_RIGID
+	mat_properties = list(
+		MATERIAL_DENSITY = 2,
+		MATERIAL_HARDNESS = 4,
+		MATERIAL_FLEXIBILITY = 0,
+		MATERIAL_REFLECTIVITY = 0,
+		MATERIAL_ELECTRICAL = 0,
+		MATERIAL_THERMAL = 1,
+		MATERIAL_CHEMICAL = 0,
+		MATERIAL_BEAUTY = 0.8,
+	)
+	texture_layer_icon_state = "sand"

--- a/code/game/objects/structures/petrified_statue.dm
+++ b/code/game/objects/structures/petrified_statue.dm
@@ -8,7 +8,7 @@
 	///Should we leave a brain behind when the statue is wrecked?
 	var/brain = TRUE
 	///Time left before the petrification ends and we let the mob free
-	var/timer = 48 SECONDS
+	var/timer = 8 MINUTES
 	///The mob that got medusa'd
 	var/mob/living/petrified_mob
 
@@ -37,7 +37,7 @@
 /obj/structure/statue/petrified/process(seconds_per_tick)
 	if(!petrified_mob)
 		STOP_PROCESSING(SSobj, src)
-	timer -= seconds_per_tick
+	timer -= seconds_per_tick SECONDS
 	petrified_mob.Stun(4 SECONDS) //So they can't do anything while petrified
 	if(timer <= 0)
 		STOP_PROCESSING(SSobj, src)

--- a/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spiders.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spiders.dm
@@ -565,7 +565,6 @@
 	unsuitable_cold_damage = 1
 	unsuitable_heat_damage = 1
 	menu_description = "Stronger assassin spider variant with an unmatched speed, high amount of health and very deadly poison, but deals very low amount of damage. It also has ability to ventcrawl."
-	apply_spider_antag = FALSE
 	innate_actions = list(
 		/datum/action/cooldown/mob_cooldown/lay_web/sticky_web,
 		/datum/action/cooldown/mob_cooldown/lay_web/web_spikes,
@@ -591,7 +590,6 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 20
 	ai_controller = /datum/ai_controller/basic_controller/giant_spider/retaliate
-	apply_spider_antag = FALSE
 
 /mob/living/basic/spider/giant/sgt_araneus/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/basic/space_fauna/spider/spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider.dm
@@ -51,8 +51,6 @@
 	var/directive = ""
 	/// Short description of what this mob is capable of, for radial menu uses
 	var/menu_description = "Tanky and strong for the defense of the nest and other spiders."
-	/// If true then you shouldn't be told that you're a spider antagonist as soon as you are placed into this mob
-	var/apply_spider_antag = TRUE
 	/// Commands you can give this spider once it is tamed
 	var/static/list/tamed_commands = list(
 		/datum/pet_command/idle,
@@ -221,7 +219,6 @@
 	response_harm_continuous = "splats"
 	response_harm_simple = "splat"
 	ai_controller = /datum/ai_controller/basic_controller/giant_spider/pest
-	apply_spider_antag = FALSE
 	///list of pet commands we follow
 	var/static/list/pet_commands = list(
 		/datum/pet_command/idle,

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -3003,10 +3003,10 @@
 	if(!metal_ref)
 		return
 
-	metal_morph(target, metal_ref)
+	metal_transmute(target, metal_ref)
 
 /// Change the material type of an object or turf, but with visuals and effects related to the material
-/proc/metal_morph(atom/target, metal_type, default_material_amount = 100, applied_material_flags = MATERIAL_METALGEN)
+/proc/metal_transmute(atom/target, metal_type, default_material_amount = 100, applied_material_flags = MATERIAL_METALGEN)
 	if(is_type_in_typecache(target, GLOB.blacklisted_metalgen_types)) //some stuff can lead to exploits if transmuted
 		return
 
@@ -3555,8 +3555,8 @@
 		affected_mob.wabbajack()
 
 /// Turns you into STONE
-/datum/reagent/metalgen/petrifium
-	name = "Petrifium"
+/datum/reagent/metalgen/gorgium
+	name = "Gorgium"
 	description = "Turns the affected... into STONE!!!"
 	color = "#929292"
 	metabolization_rate = 10 * REAGENTS_METABOLISM
@@ -3571,7 +3571,7 @@
 	/// So 1u of exposure is 5 seconds of statue time
 	var/reagent_to_time_conversion = 5 SECONDS
 
-/datum/reagent/metalgen/petrifium/expose_mob(mob/living/exposed_mob, methods, reac_volume, show_message, touch_protection)
+/datum/reagent/metalgen/gorgium/expose_mob(mob/living/exposed_mob, methods, reac_volume, show_message, touch_protection)
 	. = ..()
 
 	if(reac_volume < min_volume_to_pretrify)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -3538,7 +3538,7 @@
 /// Reagent that polymorphs you
 /datum/reagent/polyjuice
 	name = "Polyjuice"
-	description = "A bunch of magic non-sense juice that polymorphs."
+	description = "A vibrant liquid which causes sudden and irreversible changes in the body plan of living creatures."
 	color = "#ff00ea"
 	metabolization_rate = REAGENTS_METABOLISM
 	taste_description = "magic"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2980,14 +2980,10 @@
 /datum/reagent/metalgen
 	name = "Metalgen"
 	data = list("material"=null)
-	description = "A purple metal morphic liquid, said to impose its metallic properties on whatever it touches."
+	description = "A purple, metallic liquid, said to impose its metallic properties on whatever it touches."
 	color = "#b000aa"
 	taste_mult = 0 // oderless and tasteless
 	chemical_flags = REAGENT_NO_RANDOM_RECIPE
-	/// The material flags used to apply the transmuted materials
-	var/applied_material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-	/// The amount of materials to apply to the transmuted objects if they don't contain materials
-	var/default_material_amount = 100
 
 /datum/reagent/metalgen/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
 	. = ..()
@@ -3007,6 +3003,10 @@
 	if(!metal_ref)
 		return
 
+	metal_morph(target, metal_ref)
+
+/// Change the material type of an object or turf, but with visuals and effects related to the material
+/proc/metal_morph(atom/target, metal_type, default_material_amount = 100, applied_material_flags = MATERIAL_METALGEN)
 	if(is_type_in_typecache(target, GLOB.blacklisted_metalgen_types)) //some stuff can lead to exploits if transmuted
 		return
 
@@ -3021,12 +3021,12 @@
 	// Delete existing materials first before changing the material flags
 	if(length(target.custom_materials))
 		target.set_custom_materials()
-	var/list/metal_dat = list((metal_ref) = metal_amount)
+	var/list/metal_dat = list((metal_type) = metal_amount)
 	target.material_flags = applied_material_flags
 	if (target.has_material_slots())
 		var/list/new_slots = target.get_material_slots()
 		for (var/slot_type in new_slots)
-			new_slots[slot_type] = metal_ref
+			new_slots[slot_type] = metal_type
 		// Safe to call and doesn't do anything as no materials are currently present on the target
 		target.set_material_slots(new_slots)
 	target.set_custom_materials(metal_dat)
@@ -3534,3 +3534,48 @@
 /datum/reagent/luminescent_fluid/pink
 	name = "Pink Luminiscent Fluid"
 	color = LIGHT_COLOR_PINK
+
+/// Reagent that polymorphs you
+/datum/reagent/polyjuice
+	name = "Polyjuice"
+	description = "A bunch of magic non-sense juice that polymorphs."
+	color = "#ff00ea"
+	metabolization_rate = REAGENTS_METABOLISM
+	taste_description = "magic"
+	chemical_flags = REAGENT_NO_RANDOM_RECIPE
+	randomized_spawns = REAGENT_SPAWN_MAINTENANCE_PILL
+
+	/// Cycle to polymorph
+	var/polymorph_cycle = 10
+
+/datum/reagent/polyjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+	. = ..()
+
+	if(current_cycle > polymorph_cycle)
+		affected_mob.wabbajack()
+
+/// Turns you into STONE
+/datum/reagent/metalgen/petrifium
+	name = "Petrifium"
+	description = "Turns the affected... into STONE!!!"
+	color = "#929292"
+	metabolization_rate = 10 * REAGENTS_METABOLISM
+	taste_description = "rocks"
+	chemical_flags = REAGENT_NO_RANDOM_RECIPE
+	randomized_spawns = REAGENT_SPAWN_MAINTENANCE_PILL
+
+	data = list("material" = /datum/material/rock)
+
+	/// Less than this and it wont petrify
+	var/min_volume_to_pretrify = 3
+	/// So 1u of exposure is 5 seconds of statue time
+	var/reagent_to_time_conversion = 5 SECONDS
+
+/datum/reagent/metalgen/petrifium/expose_mob(mob/living/exposed_mob, methods, reac_volume, show_message, touch_protection)
+	. = ..()
+
+	if(reac_volume < min_volume_to_pretrify)
+		return
+
+	exposed_mob.Stun(4 SECONDS)
+	exposed_mob.petrify(reac_volume * reagent_to_time_conversion)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1671,3 +1671,48 @@
 	volume = round(volume/2, 0.01)
 
 #undef CRITICAL_CAPACITY
+
+/// Gibs you (lol)
+/datum/reagent/toxin/gibbium
+	name = "Gibbium"
+	description = "Guess what this does."
+	silent_toxin = TRUE
+	color = "#ff0000"
+	metabolization_rate = 4 * REAGENTS_METABOLISM
+	toxpwr = 0
+	taste_description = "regret"
+	chemical_flags = REAGENT_NO_RANDOM_RECIPE
+	randomized_spawns = REAGENT_SPAWN_MAINTENANCE_PILL
+	/// On what cycle to gib the person
+	var/gib_cycle = 5
+
+/datum/reagent/toxin/gibbium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+	. = ..()
+
+	if(current_cycle >= gib_cycle)
+		affected_mob.investigate_log("has been gibbed by the Gibbium reagent.", INVESTIGATE_DEATHS)
+		affected_mob.gib(DROP_ALL_REMAINS)
+
+/datum/reagent/toxin/spider_serum
+	name = "Spider Serum"
+	description = "A horrible mutagen that transmutes flesh into spiders."
+	color = "#000000"
+	taste_description = "unending nightmares"
+	chemical_flags = REAGENT_NO_RANDOM_RECIPE
+	randomized_spawns = REAGENT_SPAWN_MAINTENANCE_PILL
+	toxpwr = 0
+	/// The cycle for when to do the "transformation"
+	var/transformation_cycle = 30
+
+/datum/reagent/toxin/spider_serum/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+	. = ..()
+
+	if(prob(10))
+		new /mob/living/basic/spider/growing/spiderling (get_turf(affected_mob))
+		affected_mob.vomit(VOMIT_CATEGORY_BLOOD, lost_nutrition = 20)
+		to_chat(affected_mob, span_warning("You feel tiny legs climbing up your throat."))
+
+	if(current_cycle >= transformation_cycle)
+		affected_mob.mind?.add_antag_datum(/datum/antagonist/spider)
+		affected_mob.on_wabbajacked(new /mob/living/basic/spider/giant(get_turf(affected_mob)))
+

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1672,7 +1672,7 @@
 
 #undef CRITICAL_CAPACITY
 
-/// Gibs you (lol)
+/// Gibs you (lol), after an easily curable disease because WERE COWARDS
 /datum/reagent/toxin/gibbium
 	name = "Gibbium"
 	description = "Guess what this does."
@@ -1690,8 +1690,7 @@
 	. = ..()
 
 	if(current_cycle >= gib_cycle)
-		affected_mob.investigate_log("has been gibbed by the Gibbium reagent.", INVESTIGATE_DEATHS)
-		affected_mob.gib(DROP_ALL_REMAINS)
+		affected_mob.ForceContractDisease(new /datum/disease/gbs/no_transmission ())
 
 /datum/reagent/toxin/spider_serum
 	name = "Spider Serum"
@@ -1715,5 +1714,3 @@
 	if(current_cycle >= transformation_cycle)
 		affected_mob.mind?.add_antag_datum(/datum/antagonist/spider)
 		affected_mob.change_mob_type(/mob/living/basic/spider/giant, delete_old_mob = TRUE)
-		qdel(affected_mob)
-

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1715,4 +1715,5 @@
 	if(current_cycle >= transformation_cycle)
 		affected_mob.mind?.add_antag_datum(/datum/antagonist/spider)
 		affected_mob.on_wabbajacked(new /mob/living/basic/spider/giant(get_turf(affected_mob)))
+		qdel(affected_mob)
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1714,6 +1714,6 @@
 
 	if(current_cycle >= transformation_cycle)
 		affected_mob.mind?.add_antag_datum(/datum/antagonist/spider)
-		affected_mob.on_wabbajacked(new /mob/living/basic/spider/giant(get_turf(affected_mob)))
+		affected_mob.change_mob_type(/mob/living/basic/spider/giant, delete_old_mob = TRUE)
 		qdel(affected_mob)
 

--- a/code/modules/reagents/chemistry/recipes/special.dm
+++ b/code/modules/reagents/chemistry/recipes/special.dm
@@ -197,8 +197,23 @@
 		if(RNGCHEM_CATALYSTS)
 			return list(/datum/reagent/wittel)
 
+///Random recipe that turns stuff into ROCKS
+/datum/chemical_reaction/randomized/petrifium
+	persistence_period = 7
+	results = list(/datum/reagent/metalgen/petrifium = 20)
+
+/datum/chemical_reaction/randomized/petrifium/GetPossibleReagents(kind)
+	var/list/possible_ingredients = list()
+	for(var/datum/reagent/reagent as anything in valid_subtypesof(/datum/reagent))
+		var/chemical_flags = reagent::chemical_flags
+		if(VALID_RANDOM_RECIPE_REAGENT(chemical_flags))
+			possible_ingredients += reagent
+	return possible_ingredients
+
 /obj/item/paper/secretrecipe
 	name = "Old Recipe"
+	/// The recipes we can spawn with
+	var/list/possible_recipes = list(/datum/chemical_reaction/randomized/metalgen, /datum/chemical_reaction/randomized/secret_sauce)
 
 /obj/item/paper/secretrecipe/Initialize(mapload)
 	. = ..()
@@ -223,7 +238,7 @@
 /obj/item/paper/secretrecipe/proc/UpdateInfo()
 	PRIVATE_PROC(TRUE)
 
-	var/datum/chemical_reaction/recipe = GLOB.chemical_reactions_list[pick(valid_subtypesof(/datum/chemical_reaction/randomized))]
+	var/datum/chemical_reaction/recipe = GLOB.chemical_reactions_list[pick(possible_recipes)]
 	if(!recipe)
 		add_raw_text("This recipe is illegible.")
 		update_appearance()
@@ -260,6 +275,26 @@
 	dat += "."
 	add_raw_text(dat.Join(""))
 	update_appearance()
+
+/// Paper that spawns a recipe for the petrification serum
+/obj/item/paper/secretrecipe/petrifium
+	name = "paper" //gets affixed by rock
+	possible_recipes = list(/datum/chemical_reaction/randomized/petrifium)
+
+/obj/item/paper/secretrecipe/petrifium/Initialize(mapload)
+	. = ..()
+
+	metal_morph(src, /datum/material/rock)
+
+/// Recipe that always has metalgen
+/obj/item/paper/secretrecipe/metalgen
+	name = "paper" //gets affixed by uranium
+	possible_recipes = list(/datum/chemical_reaction/randomized/metalgen)
+
+/obj/item/paper/secretrecipe/metalgen/Initialize(mapload)
+	. = ..()
+
+	metal_morph(src, /datum/material/uranium)
 
 #undef RNGCHEM_INPUT
 #undef RNGCHEM_CATALYSTS

--- a/code/modules/reagents/chemistry/recipes/special.dm
+++ b/code/modules/reagents/chemistry/recipes/special.dm
@@ -284,7 +284,7 @@
 /obj/item/paper/secretrecipe/gorgium/Initialize(mapload)
 	. = ..()
 
-	metal_morph(src, /datum/material/rock)
+	metal_transmute(src, /datum/material/rock)
 
 /// Recipe that always has metalgen
 /obj/item/paper/secretrecipe/metalgen
@@ -294,7 +294,7 @@
 /obj/item/paper/secretrecipe/metalgen/Initialize(mapload)
 	. = ..()
 
-	metal_morph(src, /datum/material/uranium)
+	metal_transmute(src, /datum/material/uranium)
 
 #undef RNGCHEM_INPUT
 #undef RNGCHEM_CATALYSTS

--- a/code/modules/reagents/chemistry/recipes/special.dm
+++ b/code/modules/reagents/chemistry/recipes/special.dm
@@ -198,11 +198,11 @@
 			return list(/datum/reagent/wittel)
 
 ///Random recipe that turns stuff into ROCKS
-/datum/chemical_reaction/randomized/petrifium
+/datum/chemical_reaction/randomized/gorgium
 	persistence_period = 7
-	results = list(/datum/reagent/metalgen/petrifium = 20)
+	results = list(/datum/reagent/metalgen/gorgium = 20)
 
-/datum/chemical_reaction/randomized/petrifium/GetPossibleReagents(kind)
+/datum/chemical_reaction/randomized/gorgium/GetPossibleReagents(kind)
 	var/list/possible_ingredients = list()
 	for(var/datum/reagent/reagent as anything in valid_subtypesof(/datum/reagent))
 		var/chemical_flags = reagent::chemical_flags
@@ -277,11 +277,11 @@
 	update_appearance()
 
 /// Paper that spawns a recipe for the petrification serum
-/obj/item/paper/secretrecipe/petrifium
+/obj/item/paper/secretrecipe/gorgium
 	name = "paper" //gets affixed by rock
-	possible_recipes = list(/datum/chemical_reaction/randomized/petrifium)
+	possible_recipes = list(/datum/chemical_reaction/randomized/gorgium)
 
-/obj/item/paper/secretrecipe/petrifium/Initialize(mapload)
+/obj/item/paper/secretrecipe/gorgium/Initialize(mapload)
 	. = ..()
 
 	metal_morph(src, /datum/material/rock)


### PR DESCRIPTION

## About The Pull Request

Adds four new reagents
3 are maintpill only
1 is a new randomized chem (like secretsauce and metalgen)

<img width="228" height="88" alt="image" src="https://github.com/user-attachments/assets/c450530d-9f36-4cea-ae41-3ebf3bddffdf" />


**Gibbium**
Gibbs you when its in your system for a bit (through a non-transmissible GBS disease, so you got a bit to fix yourself)
Sources: maintpills

**Polyjuice**
Polymorphs you into a random mob (same as wizard polymorph)
Sources: maintpills

**Spider Serum**
Makes you vomit baby spiders and blood, if it's in you long enough you become spider (with antag datum!!)
Source: maintpills

**Gorgonium**
Source: When applied to a mob, petrifies them for 5 seconds per exposed unit. Minimum of 3u. Also acts as metalgen but applies a rock texture
Source: maintpills, random recipe

Metalgen now has its own recipe paper, which can rarely be found in maintenance (and is made from uranium). I didn't change anything to its spawning in the paper wizard ruin

The gorgonium recipe is only found in maintenance, written on a petrified piece of paper. 

<img width="107" height="170" alt="image" src="https://github.com/user-attachments/assets/b96d6e13-520f-4ad1-b1d3-314627657055" />


Improved metalgen code a bit by moving the metalgen code to a global proc

Also fixed a bug where the petrify timer would be 10x as long. Everyone passed seconds to the timer, but the timer only decreased by 1 decisecond per second. The only notable example is wizard Petrify spell, which was supposed to last 48 seconds but instead lasts 480 seconds. I adjusted the wizard timer so balance is not changed. Only minor stuff like forcewall book rebound is now 6 seconds instead of 60

And removed the apply_spider_antag var because it literally did nothing

## Why It's Good For The Game
Since the inception of secret chems, only metalgen has been added and nothing else. No one bothers adding them and it's laaaaame. 

The petrification juice can be ocassionally funny, and is not SUPER bad. Being petrified blocks further exposure, so it can't go too out of control. You can put it in a bottle of cleaner and annoy people a lot, and maybe use c4 to blow them up in the short time you have, but that's about it. 

The other three are just stupid maintpill chems. They only spawn in real maintenance pills, and can't be duplicated. Odds are some assistant explodes/polymorphs/spiderizes, and I think that's just funny and makes for an 'experience'. 

## Changelog
:cl:
add: Adds three new maintpill-only chems! Go eat more maintpills, and maybe you'll find out what they are :)
add: Adds a new secret chem, which can rarely be found on a petrified piece of paper somewhere in maintenance...
fix: Fixes miscellaneous sources of petrification lasting 10x as long as intended
/:cl:
i was just bored