### PR TITLE
[NO GBP] Fixes passive positive virus healing.

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -148,7 +148,7 @@
 	if(!(disease_flags & CHRONIC) && disease_flags & CURABLE && bypasses_immunity != TRUE)
 		switch(severity)
 			if(DISEASE_SEVERITY_POSITIVE)
-				if(slowdown < 1 || affected_mob.satiety < 0 || affected_mob.nutrition < NUTRITION_LEVEL_STARVING)
+				if(slowdown < 1 || (!(HAS_TRAIT(affected_mob, TRAIT_NOHUNGER)) && (affected_mob.satiety < 0 || affected_mob.nutrition < NUTRITION_LEVEL_STARVING)))
 					cycles_to_beat = max(DISEASE_RECOVERY_SCALING, DISEASE_CYCLES_POSITIVE)
 				else
 					recovery_prob = 0

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -147,9 +147,11 @@
 
 	if(!(disease_flags & CHRONIC) && disease_flags & CURABLE && bypasses_immunity != TRUE)
 		switch(severity)
-			if(DISEASE_SEVERITY_POSITIVE) //good viruses don't go anywhere after hitting max stage - you can try to get rid of them by sleeping earlier
-				cycles_to_beat = max(DISEASE_RECOVERY_SCALING, DISEASE_CYCLES_POSITIVE) //because of the way we later check for recovery_prob, we need to floor this at least equal to the scaling to avoid infinitely getting less likely to cure
-				if(((HAS_TRAIT(affected_mob, TRAIT_NOHUNGER)) || ((affected_mob.nutrition > NUTRITION_LEVEL_STARVING) && (affected_mob.satiety >= 0))) && slowdown == 1) //any sort of malnourishment/immunosuppressant opens you to losing a good virus
+			if(DISEASE_SEVERITY_POSITIVE)
+				if(bad_immune != 1 || slowdown < 1 || affected_mob.satiety < 0 || affected_mob.nutrition < NUTRITION_LEVEL_STARVING)
+					cycles_to_beat = max(DISEASE_RECOVERY_SCALING, DISEASE_CYCLES_POSITIVE)
+				else
+					recovery_prob = 0
 					return TRUE
 			if(DISEASE_SEVERITY_NONTHREAT)
 				cycles_to_beat = max(DISEASE_RECOVERY_SCALING, DISEASE_CYCLES_NONTHREAT)
@@ -169,7 +171,7 @@
 		recovery_prob += DISEASE_RECOVERY_CONSTANT + (peaked_cycles / (cycles_to_beat / DISEASE_RECOVERY_SCALING)) //more severe viruses are beaten back more aggressively after the peak
 		if(stage_peaked)
 			recovery_prob *= DISEASE_PEAKED_RECOVERY_MULTIPLIER
-		if(slowdown != 1) //using spaceacillin can help get them over the finish line to kill a virus with decreasing effect over time
+		if(slowdown < 1) //using spaceacillin can help get them over the finish line to kill a virus with decreasing effect over time
 			recovery_prob += clamp((((1 - slowdown)*(DISEASE_SLOWDOWN_RECOVERY_BONUS * 2)) * ((DISEASE_SLOWDOWN_RECOVERY_BONUS_DURATION - chemical_offsets) / DISEASE_SLOWDOWN_RECOVERY_BONUS_DURATION)), 0, DISEASE_SLOWDOWN_RECOVERY_BONUS)
 			chemical_offsets = min(chemical_offsets + 1, DISEASE_SLOWDOWN_RECOVERY_BONUS_DURATION)
 		if(!HAS_TRAIT(affected_mob, TRAIT_NOHUNGER))

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -148,7 +148,7 @@
 	if(!(disease_flags & CHRONIC) && disease_flags & CURABLE && bypasses_immunity != TRUE)
 		switch(severity)
 			if(DISEASE_SEVERITY_POSITIVE)
-				if(bad_immune != 1 || slowdown < 1 || affected_mob.satiety < 0 || affected_mob.nutrition < NUTRITION_LEVEL_STARVING)
+				if(slowdown < 1 || affected_mob.satiety < 0 || affected_mob.nutrition < NUTRITION_LEVEL_STARVING)
 					cycles_to_beat = max(DISEASE_RECOVERY_SCALING, DISEASE_CYCLES_POSITIVE)
 				else
 					recovery_prob = 0


### PR DESCRIPTION
## About The Pull Request

Fixes the passive positive virus healing behavior I fucked up about two years ago in the process of reworking virology.

Basically, if you had even one single tick of time spent malnourished or at lower than 0 satiety, you started to accumulate recovery_prob. If recovery_prob was anything other than 0, you'd be rolling to get rid of your virus, eventually getting to a point where, by virtue of the scaling, it was gonna happen. 

This change just makes sure that
- if we aren't currently rocking spaceacillin,
- if we aren't eating a ton of junk food and recovering (negative satiety trends towards 0, a good binge will put you at about -150,)
- if we aren't starving (less than 150 nutrition,) 
our positive viruses are not going to have a recovery_prob and so are not going to self-cure. They will still accumulate peaked_cycles and so, if you constantly dip into and out of time spent malnourished, on antibiotics, or whatever, they're going to eventually cure faster when allowed. But if you maintain yourself, they should actually be rock solid now. 

## Why It's Good For The Game

Intended behavior that I somehow missed in the tests and tweaks and then fell out from really ever investigating why it didn't work. You weren't supposed to be fucked out of having the positive virus work from even one slightest brush with the negative circumstances. That totally undercut both the predictability and value of smart maintenance as player behavior. 

## Changelog

:cl:
fix: positive viruses no longer self-cure when not having spaceacillin or meeting the nutrition/satiety requirements. 
/:cl: