### PR TITLE
Prisoner max spawns increased from 2 to 4

### DIFF
--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -3,7 +3,7 @@
 	description = "Keep yourself occupied in permabrig."
 	faction = FACTION_STATION
 	total_positions = 0
-	spawn_positions = 2
+	spawn_positions = 4
 	supervisors = "the security team"
 	exp_granted_type = EXP_TYPE_CREW
 	paycheck = PAYCHECK_LOWER


### PR DESCRIPTION

## About The Pull Request

Increases the max roundstart prisoner spawns from 2 to 4

## Why It's Good For The Game

Permabrig has so many spots for beds and prisoners, and for what?, Perma isnt packed enough and warden isnt having a hard enough time, so i figure if we have more roundstart prisoners, itd be a bit funner for sec and the prisoners

## Changelog

:cl:
add: Increased max prisoners from 2 to 4.
:cl:
