### PR TITLE
Fix holodeck organ and bodyparts behavior

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -165,8 +165,10 @@
 /// Golem's wacky rocky limbs
 #define BODYSHAPE_GOLEM (1<<4)
 
+/// List of body part flags that can not be bioscrambled
 #define BODYTYPE_BIOSCRAMBLE_INCOMPATIBLE (BODYTYPE_ROBOTIC | BODYTYPE_LARVA_PLACEHOLDER | BODYTYPE_GOLEM | BODYTYPE_PEG)
-#define BODYTYPE_CAN_BE_BIOSCRAMBLED(bodytype) (!(bodytype & BODYTYPE_BIOSCRAMBLE_INCOMPATIBLE))
+/// Check to see if a bodypart limb can be bioscrambled
+#define BODYTYPE_CAN_BE_BIOSCRAMBLED(bodypart) (!(bodypart.bodytype & BODYTYPE_BIOSCRAMBLE_INCOMPATIBLE) && !(bodypart.flags_1 & HOLOGRAM_1))
 
 // Defines for Species IDs. Used to refer to the name of a species, for things like bodypart names or species preferences.
 #define SPECIES_ABDUCTOR "abductor"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -168,7 +168,7 @@
 /// List of body part flags that can not be bioscrambled
 #define BODYTYPE_BIOSCRAMBLE_INCOMPATIBLE (BODYTYPE_ROBOTIC | BODYTYPE_LARVA_PLACEHOLDER | BODYTYPE_GOLEM | BODYTYPE_PEG)
 /// Check to see if a bodypart limb can be bioscrambled
-#define BODYTYPE_CAN_BE_BIOSCRAMBLED(bodypart) (!(bodypart.bodytype & BODYTYPE_BIOSCRAMBLE_INCOMPATIBLE) && !(bodypart.flags_1 & HOLOGRAM_1))
+#define BODYPART_CAN_BE_BIOSCRAMBLED(bodypart) (!(bodypart.bodytype & BODYTYPE_BIOSCRAMBLE_INCOMPATIBLE) && !(bodypart.flags_1 & HOLOGRAM_1))
 
 // Defines for Species IDs. Used to refer to the name of a species, for things like bodypart names or species preferences.
 #define SPECIES_ABDUCTOR "abductor"

--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -3,6 +3,11 @@
 /// Helper to figure out if an organ is robotic
 #define IS_ROBOTIC_ORGAN(organ) (organ.organ_flags & ORGAN_ROBOTIC)
 
+/// List of organ flags that can not be bioscrambled
+#define ORGAN_BIOSCRAMBLE_INCOMPATIBLE (ORGAN_ROBOTIC | ORGAN_MINERAL)
+/// Check to see if an organ can be bioscrambled
+#define ORGAN_CAN_BE_BIOSCRAMBLED(organ) (!(organ.organ_flags & ORGAN_BIOSCRAMBLE_INCOMPATIBLE) && !(organ.flags_1 & HOLOGRAM_1))
+
 // Flags for the organ_flags var on /obj/item/organ
 /// Organic organs, the default. Don't get affected by EMPs.
 #define ORGAN_ORGANIC (1<<0)

--- a/code/modules/holodeck/holo_effect.dm
+++ b/code/modules/holodeck/holo_effect.dm
@@ -55,18 +55,42 @@
 	var/mob/our_mob = null
 
 /obj/effect/holodeck_effect/mobspawner/activate(obj/machinery/computer/holodeck/HC)
+	. = list()
+
 	if(islist(mobtype))
 		mobtype = pick(mobtype)
 	our_mob = new mobtype(loc)
 	our_mob.flags_1 |= HOLOGRAM_1
+	. += our_mob
+
+	for(var/atom/holo_atom as anything in our_mob.contents)
+		holo_atom.flags_1 |= HOLOGRAM_1
+		. += holo_atom
+
+	if(iscarbon(our_mob))
+		var/mob/living/carbon/holo_carbon_mob = our_mob
+		for(var/obj/item/organ/holo_organ as anything in holo_carbon_mob.organs)
+			holo_organ.flags_1 |= HOLOGRAM_1
+			. += holo_organ
 
 	// these vars are not really standardized but all would theoretically create stuff on death
 	our_mob.add_traits(list(TRAIT_PERMANENTLY_MORTAL, TRAIT_NO_BLOOD_OVERLAY, TRAIT_NOBLOOD, TRAIT_NOHUNGER, TRAIT_SPAWNED_MOB), INNATE_TRAIT)
 	RegisterSignal(our_mob, COMSIG_QDELETING, PROC_REF(handle_mob_delete))
-	return our_mob
+
+	return .
 
 /obj/effect/holodeck_effect/mobspawner/deactivate(obj/machinery/computer/holodeck/HC)
 	if(our_mob)
+		for(var/atom/holo_atom as anything in our_mob.contents)
+			if(holo_atom.flags_1 & HOLOGRAM_1)
+				HC.derez(holo_atom)
+
+		if(iscarbon(our_mob))
+			var/mob/living/carbon/holo_carbon_mob = our_mob
+			for(var/obj/item/organ/holo_organ as anything in holo_carbon_mob.organs)
+				if(holo_organ.flags_1 & HOLOGRAM_1)
+					HC.derez(holo_organ)
+
 		HC.derez(our_mob)
 	qdel(src)
 
@@ -99,13 +123,6 @@
 
 /obj/effect/holodeck_effect/mobspawner/monkey
 	mobtype = /mob/living/carbon/human/species/monkey
-
-/obj/effect/holodeck_effect/mobspawner/monkey/activate(obj/machinery/computer/holodeck/computer)
-	var/mob/living/carbon/human/monkey = ..()
-	. = list() + monkey
-
-	for(var/atom/atom as anything in monkey.contents + monkey.organs)
-		. += atom
 
 /obj/effect/holodeck_effect/mobspawner/penguin
 	mobtype = /mob/living/basic/pet/penguin/emperor/neuter

--- a/code/modules/holodeck/holo_effect.dm
+++ b/code/modules/holodeck/holo_effect.dm
@@ -67,6 +67,12 @@
 		holo_atom.flags_1 |= HOLOGRAM_1
 		. += holo_atom
 
+	if(iscarbon(our_mob))
+		var/mob/living/carbon/holo_carbon_mob = our_mob
+		for(var/obj/item/organ/holo_organ as anything in holo_carbon_mob.organs)
+			holo_organ.flags_1 |= HOLOGRAM_1
+			. += holo_organ
+
 	// these vars are not really standardized but all would theoretically create stuff on death
 	our_mob.add_traits(list(TRAIT_PERMANENTLY_MORTAL, TRAIT_NO_BLOOD_OVERLAY, TRAIT_NOBLOOD, TRAIT_NOHUNGER, TRAIT_SPAWNED_MOB), INNATE_TRAIT)
 	RegisterSignal(our_mob, COMSIG_QDELETING, PROC_REF(handle_mob_delete))
@@ -78,6 +84,12 @@
 		for(var/atom/holo_atom as anything in our_mob.contents)
 			if(holo_atom.flags_1 & HOLOGRAM_1)
 				HC.derez(holo_atom)
+
+		if(iscarbon(our_mob))
+			var/mob/living/carbon/holo_carbon_mob = our_mob
+			for(var/obj/item/organ/holo_organ as anything in holo_carbon_mob.organs)
+				if(holo_organ.flags_1 & HOLOGRAM_1)
+					HC.derez(holo_organ)
 
 		HC.derez(our_mob)
 	qdel(src)

--- a/code/modules/holodeck/holo_effect.dm
+++ b/code/modules/holodeck/holo_effect.dm
@@ -67,12 +67,6 @@
 		holo_atom.flags_1 |= HOLOGRAM_1
 		. += holo_atom
 
-	if(iscarbon(our_mob))
-		var/mob/living/carbon/holo_carbon_mob = our_mob
-		for(var/obj/item/organ/holo_organ as anything in holo_carbon_mob.organs)
-			holo_organ.flags_1 |= HOLOGRAM_1
-			. += holo_organ
-
 	// these vars are not really standardized but all would theoretically create stuff on death
 	our_mob.add_traits(list(TRAIT_PERMANENTLY_MORTAL, TRAIT_NO_BLOOD_OVERLAY, TRAIT_NOBLOOD, TRAIT_NOHUNGER, TRAIT_SPAWNED_MOB), INNATE_TRAIT)
 	RegisterSignal(our_mob, COMSIG_QDELETING, PROC_REF(handle_mob_delete))
@@ -84,12 +78,6 @@
 		for(var/atom/holo_atom as anything in our_mob.contents)
 			if(holo_atom.flags_1 & HOLOGRAM_1)
 				HC.derez(holo_atom)
-
-		if(iscarbon(our_mob))
-			var/mob/living/carbon/holo_carbon_mob = our_mob
-			for(var/obj/item/organ/holo_organ as anything in holo_carbon_mob.organs)
-				if(holo_organ.flags_1 & HOLOGRAM_1)
-					HC.derez(holo_organ)
 
 		HC.derez(our_mob)
 	qdel(src)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -661,6 +661,9 @@
 	if (HAS_TRAIT(src, TRAIT_GENELESS))
 		return FALSE
 
+	if(flags_1 & HOLOGRAM_1)
+		return FALSE
+
 	if (run_armor_check(attack_flag = BIO, silent = TRUE) >= 100)
 		to_chat(src, span_warning("Your armor shields you from [scramble_source]!"))
 		return FALSE
@@ -671,7 +674,8 @@
 	var/changed_something = FALSE
 	var/obj/item/organ/new_organ = pick(GLOB.bioscrambler_valid_organs)
 	var/obj/item/organ/replaced = get_organ_slot(initial(new_organ.slot))
-	if (!replaced || !IS_ROBOTIC_ORGAN(replaced))
+	var/is_holo_organ = replaced && (replaced.flags_1 & HOLOGRAM_1)
+	if (!replaced || !IS_ROBOTIC_ORGAN(replaced) && !(is_holo_organ))
 		changed_something = TRUE
 		new_organ = new new_organ()
 		new_organ.replace_into(src)
@@ -680,7 +684,8 @@
 	if (!HAS_TRAIT(src, TRAIT_NODISMEMBER))
 		var/obj/item/bodypart/new_part = pick(GLOB.bioscrambler_valid_parts)
 		var/obj/item/bodypart/picked_user_part = get_bodypart(initial(new_part.body_zone))
-		if (picked_user_part && BODYTYPE_CAN_BE_BIOSCRAMBLED(picked_user_part.bodytype))
+		var/is_holo_bodypart = (picked_user_part && (picked_user_part.flags_1 & HOLOGRAM_1))
+		if (picked_user_part && BODYTYPE_CAN_BE_BIOSCRAMBLED(picked_user_part.bodytype) && !(is_holo_bodypart))
 			changed_something = TRUE
 			new_part = new new_part()
 			new_part.replace_limb(src)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -701,9 +701,9 @@
 /mob/living/carbon/proc/init_bioscrambler_lists()
 	var/list/body_parts = typesof(/obj/item/bodypart/chest) + typesof(/obj/item/bodypart/head) + subtypesof(/obj/item/bodypart/arm) + subtypesof(/obj/item/bodypart/leg)
 	for(var/obj/item/bodypart/starter_part as anything in body_parts)
-		if(!is_type_in_typecache(part, GLOB.bioscrambler_parts_blacklist) && BODYTYPE_CAN_BE_BIOSCRAMBLED(starter_part))
+		if(!is_type_in_typecache(starter_part, GLOB.bioscrambler_parts_blacklist) && BODYTYPE_CAN_BE_BIOSCRAMBLED(starter_part))
 			continue
-		body_parts -= part
+		body_parts -= starter_part
 	GLOB.bioscrambler_valid_parts = body_parts
 
 	var/list/organs = subtypesof(/obj/item/organ)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -683,7 +683,7 @@
 	if (!HAS_TRAIT(src, TRAIT_NODISMEMBER))
 		var/obj/item/bodypart/new_part = pick(GLOB.bioscrambler_valid_parts)
 		var/obj/item/bodypart/picked_user_part = get_bodypart(initial(new_part.body_zone))
-		if (picked_user_part && BODYTYPE_CAN_BE_BIOSCRAMBLED(picked_user_part))
+		if (picked_user_part && BODYPART_CAN_BE_BIOSCRAMBLED(picked_user_part))
 			changed_something = TRUE
 			new_part = new new_part()
 			new_part.replace_limb(src)
@@ -701,7 +701,7 @@
 /mob/living/carbon/proc/init_bioscrambler_lists()
 	var/list/body_parts = typesof(/obj/item/bodypart/chest) + typesof(/obj/item/bodypart/head) + subtypesof(/obj/item/bodypart/arm) + subtypesof(/obj/item/bodypart/leg)
 	for(var/obj/item/bodypart/part as anything in body_parts)
-		if(!is_type_in_typecache(part, GLOB.bioscrambler_parts_blacklist) && BODYTYPE_CAN_BE_BIOSCRAMBLED(part))
+		if(!is_type_in_typecache(part, GLOB.bioscrambler_parts_blacklist) && BODYPART_CAN_BE_BIOSCRAMBLED(part))
 			continue
 		body_parts -= part
 	GLOB.bioscrambler_valid_parts = body_parts

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -674,8 +674,7 @@
 	var/changed_something = FALSE
 	var/obj/item/organ/new_organ = pick(GLOB.bioscrambler_valid_organs)
 	var/obj/item/organ/replaced = get_organ_slot(initial(new_organ.slot))
-	var/is_holo_organ = replaced && (replaced.flags_1 & HOLOGRAM_1)
-	if (!replaced || !IS_ROBOTIC_ORGAN(replaced) && !(is_holo_organ))
+	if (!replaced || ORGAN_CAN_BE_BIOSCRAMBLED(replaced))
 		changed_something = TRUE
 		new_organ = new new_organ()
 		new_organ.replace_into(src)
@@ -684,8 +683,7 @@
 	if (!HAS_TRAIT(src, TRAIT_NODISMEMBER))
 		var/obj/item/bodypart/new_part = pick(GLOB.bioscrambler_valid_parts)
 		var/obj/item/bodypart/picked_user_part = get_bodypart(initial(new_part.body_zone))
-		var/is_holo_bodypart = (picked_user_part && (picked_user_part.flags_1 & HOLOGRAM_1))
-		if (picked_user_part && BODYTYPE_CAN_BE_BIOSCRAMBLED(picked_user_part.bodytype) && !(is_holo_bodypart))
+		if (picked_user_part && BODYTYPE_CAN_BE_BIOSCRAMBLED(picked_user_part))
 			changed_something = TRUE
 			new_part = new new_part()
 			new_part.replace_limb(src)
@@ -703,7 +701,7 @@
 /mob/living/carbon/proc/init_bioscrambler_lists()
 	var/list/body_parts = typesof(/obj/item/bodypart/chest) + typesof(/obj/item/bodypart/head) + subtypesof(/obj/item/bodypart/arm) + subtypesof(/obj/item/bodypart/leg)
 	for(var/obj/item/bodypart/part as anything in body_parts)
-		if(!is_type_in_typecache(part, GLOB.bioscrambler_parts_blacklist) && BODYTYPE_CAN_BE_BIOSCRAMBLED(initial(part.bodytype)))
+		if(!is_type_in_typecache(part, GLOB.bioscrambler_parts_blacklist) && BODYTYPE_CAN_BE_BIOSCRAMBLED(initial(part)))
 			continue
 		body_parts -= part
 	GLOB.bioscrambler_valid_parts = body_parts

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -700,8 +700,7 @@
 /// Fill in the lists of things we can bioscramble into people
 /mob/living/carbon/proc/init_bioscrambler_lists()
 	var/list/body_parts = typesof(/obj/item/bodypart/chest) + typesof(/obj/item/bodypart/head) + subtypesof(/obj/item/bodypart/arm) + subtypesof(/obj/item/bodypart/leg)
-	for(var/obj/item/bodypart/part as anything in body_parts)
-		var/obj/item/bodypart/starter_part = initial(part)
+	for(var/obj/item/bodypart/starter_part as anything in body_parts)
 		if(!is_type_in_typecache(part, GLOB.bioscrambler_parts_blacklist) && BODYTYPE_CAN_BE_BIOSCRAMBLED(starter_part))
 			continue
 		body_parts -= part

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -701,7 +701,8 @@
 /mob/living/carbon/proc/init_bioscrambler_lists()
 	var/list/body_parts = typesof(/obj/item/bodypart/chest) + typesof(/obj/item/bodypart/head) + subtypesof(/obj/item/bodypart/arm) + subtypesof(/obj/item/bodypart/leg)
 	for(var/obj/item/bodypart/part as anything in body_parts)
-		if(!is_type_in_typecache(part, GLOB.bioscrambler_parts_blacklist) && BODYTYPE_CAN_BE_BIOSCRAMBLED(initial(part)))
+		var/obj/item/bodypart/starter_part = initial(part)
+		if(!is_type_in_typecache(part, GLOB.bioscrambler_parts_blacklist) && BODYTYPE_CAN_BE_BIOSCRAMBLED(starter_part))
 			continue
 		body_parts -= part
 	GLOB.bioscrambler_valid_parts = body_parts

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -700,10 +700,10 @@
 /// Fill in the lists of things we can bioscramble into people
 /mob/living/carbon/proc/init_bioscrambler_lists()
 	var/list/body_parts = typesof(/obj/item/bodypart/chest) + typesof(/obj/item/bodypart/head) + subtypesof(/obj/item/bodypart/arm) + subtypesof(/obj/item/bodypart/leg)
-	for(var/obj/item/bodypart/starter_part as anything in body_parts)
-		if(!is_type_in_typecache(starter_part, GLOB.bioscrambler_parts_blacklist) && BODYTYPE_CAN_BE_BIOSCRAMBLED(starter_part))
+	for(var/obj/item/bodypart/part as anything in body_parts)
+		if(!is_type_in_typecache(part, GLOB.bioscrambler_parts_blacklist) && BODYTYPE_CAN_BE_BIOSCRAMBLED(part))
 			continue
-		body_parts -= starter_part
+		body_parts -= part
 	GLOB.bioscrambler_valid_parts = body_parts
 
 	var/list/organs = subtypesof(/obj/item/organ)


### PR DESCRIPTION

## About The Pull Request
- Fixes #95963

Holodeck mobs would not have their organs, body parts, and contents set as holographic objects. This means you could cut off their limbs or remove their organs, and it would be considered a "real" object. This would ignore the holodeck boundaries, changing the simulation, or turning it offline, which should have caused the object to disappear.

Also, I added some checks so that the bioscrambler activity requires the mob, organ, or body part to not be holographic. 

## Why It's Good For The Game
Holodeck should disappear and behave properly. 

## Changelog
:cl:
fix: Fix holodeck mob organs and body parts not disappearing. Any holodeck mob organs and body parts can also no longer be bioscrambled. 
/:cl:
