### PR TITLE
fixes resource duplication bug with material floor tiles

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -475,8 +475,12 @@
 
 		if(isstack(created))
 			var/obj/item/stack/crafted_stack = created
+			if(recipe.res_amount > 0 && recipe.req_amount != recipe.res_amount)
+				var/scale = recipe.req_amount / recipe.res_amount
+				for(var/mat in result_mats)
+					result_mats[mat] *= scale
 			crafted_stack.mats_per_unit = SSmaterials.get_material_set_cache(result_mats)
-			update_custom_materials()
+			crafted_stack.update_custom_materials()
 		else
 			created.set_custom_materials(result_mats, recipe.req_amount * multiplier)
 


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/95962. Applies a scaling to the resulting items mats_per_unit of a stack so, each item in the stack has the correct material value.

Tested locally, now each material floor tile only gives 1/4 of a sheet
## Why It's Good For The Game

Bugfix.
## Changelog
:cl:
fix: fixes material floor duplication
/:cl:
