### PR TITLE
fix MMI's perspective fixed on last mob that carried it

### DIFF
--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -29,7 +29,7 @@
 	SIGNAL_HANDLER
 	if(isnull(brainmob?.client) || mecha)
 		return
-	brainmob.reset_perspective(get_turf(source))
+	brainmob.reset_perspective(source.loc || source)
 
 /obj/item/mmi/Destroy()
 	set_mecha(null)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -22,6 +22,14 @@
 	radio = new(src) //Spawns a radio inside the MMI.
 	radio.set_broadcasting(FALSE) //researching radio mmis turned the robofabs into radios because this didnt start as 0.
 	laws.set_laws_config()
+	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
+
+/// Refreshes the brainmob's camera when the MMI changes hands or is dropped.
+/obj/item/mmi/proc/on_moved(atom/movable/source, atom/old_loc, dir, forced, list/old_locs)
+	SIGNAL_HANDLER
+	if(isnull(brainmob?.client) || mecha)
+		return
+	brainmob.reset_perspective(get_turf(source))
 
 /obj/item/mmi/Destroy()
 	set_mecha(null)


### PR DESCRIPTION

## About The Pull Request
I hook a reset_perspective call on COMSIG_MOVABLE_MOVED so the MMI user always has their view set on MMI's turf. 

Fixes https://github.com/tgstation/tgstation/issues/95447
Closes #90582

## Why It's Good For The Game


Bugfix
## Changelog
:cl:
fix: MMI's view will stay on them once someone drops them
/:cl:
