### PR TITLE
Animated wand of animation works and animated wand of animation animating a wand of animation works

### DIFF
--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -874,6 +874,8 @@ multiple modular subtrees with behaviors
  */
 /datum/ai_controller/proc/remove_thing_from_blackboard_key(key, thing)
 	var/associated_value = blackboard[key]
+	if(isnull(associated_value))
+		return
 	if(thing == associated_value)
 		stack_trace("remove_thing_from_blackboard_key was called un-necessarily in a situation where clear_blackboard_key would suffice. ")
 		clear_blackboard_key(key)

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -358,16 +358,12 @@
 
 // Animating a nothing wand makes it into an animating wand (and also animates it)
 /obj/item/gun/magic/wand/nothing/animate_atom_living(mob/living/owner)
-	var/obj/item/gun/magic/wand/animate/animated_wand = new()
+	var/obj/item/gun/magic/wand/animate/animated_wand = new(loc)
 	animated_wand.charges = charges
 	animated_wand.name = name + "?"
 
-	var/mob/living/basic/mimic/copy/ranged/living_wand = new(drop_location(), animated_wand, owner, TRUE) // It's already got eyes
-	QDEL_NULL(living_wand.ai_controller)
-	living_wand.ai_controller = new /datum/ai_controller/basic_controller/mimic_copy/gun/animator(living_wand)
-
 	qdel(src)
-	return living_wand
+	return animated_wand.animate_atom_living(owner)
 
 /// Also wand of doing fuck all
 /obj/item/gun/magic/wand/nothing/fake_resurrection

--- a/code/modules/projectiles/guns/magic/wands/wand_animate.dm
+++ b/code/modules/projectiles/guns/magic/wands/wand_animate.dm
@@ -50,7 +50,7 @@
 	return MANUAL_SUICIDE
 
 /obj/item/gun/magic/wand/animate/animate_atom_living(mob/living/owner)
-	var/mob/living/basic/mimic/copy/ranged/living_wand = new(drop_location(), src, owner, TRUE) // It's already got eyes
+	var/mob/living/basic/mimic/copy/ranged/living_wand = new(drop_location(), src, owner, FALSE, TRUE) // It's already got eyes
 	QDEL_NULL(living_wand.ai_controller)
 	living_wand.ai_controller = new /datum/ai_controller/basic_controller/mimic_copy/gun/animator(living_wand)
 	return living_wand


### PR DESCRIPTION

## About The Pull Request

Fix 1: argument 4 on a new mimic is delete parent, not not having googly eyes, so the issue there is clear

fix 2: `remove_thing_from_blackboard_key()` had no handling for the list not yet being up, so it crashes thinking it's been called where `clear_blackboard_key()` should've been.

fix 3: same as 1 but on wand of nothing, replaced copypaste with just calling the function

## Why It's Good For The Game

fixes #95981
fixes an animated wand of animation animating a wand of animation runtiming
Also the same problem with the wand of nothing

## Changelog
:cl:

fix: animating a wand of animation works, and that animated wand of animation animating a wand of animation does not runtime

/:cl:
