### PR TITLE
Removes testing spam about materials (??)

### DIFF
--- a/code/datums/material/material_container.dm
+++ b/code/datums/material/material_container.dm
@@ -616,7 +616,6 @@
 	for(var/x in mats) //Loop through all required materials
 		var/wanted = OPTIMAL_COST(mats[x] * coefficient) * multiplier
 		if(!has_enough_of_material(x, wanted))//Not a category, so just check the normal way
-			testing("didn't have: [x] wanted: [wanted]")
 			return FALSE
 
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
Prevents this:
<img width="481" height="188" alt="image" src="https://github.com/user-attachments/assets/f21d1af3-976d-49ff-a42b-0ac2acf67142" />
By not having `testing` output in `/datum/material_container/proc/has_materials`.

I forgot what object is processing and constantly checking for this, but oh well.
## Why It's Good For The Game
Calm down.

## Changelog
Not player-facing.