### PR TITLE
Always update hair and eyes on coverage change, use facial hair color

### DIFF
--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -259,7 +259,12 @@
  */
 /mob/living/carbon/proc/item_coverage_changed(added_slots, removed_slots)
 	update_clothing(hidden_slots_to_inventory_slots(added_slots|removed_slots))
-	if((added_slots|removed_slots) & (HIDEJUMPSUIT|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT|HIDEMUTWINGS|HIDEANTENNAE))
+	if((added_slots|removed_slots) & (HIDEHAIR|HIDEFACIALHAIR))
+		update_hair()
+	if((added_slots|removed_slots) & HIDEEYES)
+		update_eyes()
+	// HIDEJUMPSUIT is for digitigrade legs, HIDEEARS is for lizard frills, the others should be obvious
+	if((added_slots|removed_slots) & (HIDEJUMPSUIT|HIDEEARS|HIDESNOUT|HIDEMUTWINGS|HIDEANTENNAE))
 		update_body()
 
 /// Returns the helmet if an air tank compatible helmet is equipped.

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -263,8 +263,9 @@
 		update_hair()
 	if((added_slots|removed_slots) & HIDEEYES)
 		update_eyes()
-	// HIDEJUMPSUIT is for digitigrade legs, HIDEEARS is for lizard frills, the others should be obvious
-	if((added_slots|removed_slots) & (HIDEJUMPSUIT|HIDEEARS|HIDESNOUT|HIDEMUTWINGS|HIDEANTENNAE))
+	// HIDEJUMPSUIT is for digitigrade legs, HIDEEARS is for lizard frills, HIDEHAIR is for felinid ears and lizard horns, the others should be obvious
+	// future todo; we should collect a list of all bodypart overlays and what conceals/reveals them dynamically, rather than hardcoding this
+	if((added_slots|removed_slots) & (HIDEJUMPSUIT|HIDEEARS|HIDEHAIR|HIDESNOUT|HIDEMUTWINGS|HIDEANTENNAE))
 		update_body()
 
 /// Returns the helmet if an air tank compatible helmet is equipped.

--- a/code/modules/surgery/bodyparts/head_hair_and_lips.dm
+++ b/code/modules/surgery/bodyparts/head_hair_and_lips.dm
@@ -75,7 +75,7 @@
 	// Overlay
 	var/image/facial_hair_overlay = image(sprite_accessory.icon, sprite_accessory.icon_state, -HAIR_LAYER, dir = image_dir)
 	facial_hair_overlay.alpha = facial_hair_alpha
-	set_overlay_hair_color(facial_hair_overlay)
+	set_overlay_hair_color(facial_hair_overlay, facial_hair_color)
 	// Emissive blocker
 	if(blocks_emissive != EMISSIVE_BLOCK_NONE)
 		var/mutable_appearance/em_block = emissive_blocker(facial_hair_overlay.icon, facial_hair_overlay.icon_state, location, alpha = facial_hair_alpha)
@@ -124,7 +124,7 @@
 				all_hair_overlays += image(hair_sprite_accessory.icon, icon_state = appendage_icon_state, layer = -OUTER_HAIR_LAYER, dir = image_dir)
 
 	for(var/image/hair_overlay as anything in all_hair_overlays)
-		set_overlay_hair_color(hair_overlay)
+		set_overlay_hair_color(hair_overlay, hair_color)
 		hair_overlay.alpha = hair_alpha
 		hair_overlay.pixel_z = hair_sprite_accessory.y_offset
 		// Emissive blocker
@@ -147,14 +147,14 @@
 	return .
 
 /// Helper for setting hair color of an overlay appropriately
-/obj/item/bodypart/head/proc/set_overlay_hair_color(image/hair_overlay)
+/obj/item/bodypart/head/proc/set_overlay_hair_color(image/hair_overlay, hair_color_to_use = src.hair_color)
 	PRIVATE_PROC(TRUE)
 	if(override_hair_color)
 		hair_overlay.color = override_hair_color
 	else if(fixed_hair_color)
 		hair_overlay.color = fixed_hair_color
 	else
-		hair_overlay.color = hair_color
+		hair_overlay.color = hair_color_to_use
 
 /// Returns a list of all eye related overlays, or an eyeless overlay if applicable
 /obj/item/bodypart/head/proc/get_eye_overlays(dropped)


### PR DESCRIPTION
## About The Pull Request

Fixes #95984

Objects would only obscure your hair correctly if your head needed to be updated, relying on the legacy code in `update_body_parts`. Now we can just update hair and eyes directly. 

Fixes facial hair color not being respected

I made a helper and meant to have it pass what color to use and then I just forgot I guess

## Changelog

:cl: Melbert
fix: Facial hair color can be separate from hair color again
fix: Hair covering things update when they need up
/:cl:

