### PR TITLE
Cuffing items to you now chains you to the item rather than give you nodrop (shields can be cuffed again)

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -151,6 +151,10 @@
 #define COMSIG_ITEM_STORED "item_stored"
 ///from base of datum/storage/handle_exit(): (datum/storage/storage)
 #define COMSIG_ITEM_UNSTORED "item_unstored"
+/// From datum/storage/attempt_insert()
+#define COMSIG_ITEM_PRE_STORAGE_INSERTION "item_pre_storage_insertion"
+	// return BLOCK_STORAGE_INSERT
+
 ///from base of obj/item/do_pickup_animation(): ()
 #define COMSIG_ITEM_BEFORE_PICKUP_ANIMATION "item_before_pickup_animation"
 ///from base of obj/item/do_drop_animation(): ()

--- a/code/__DEFINES/traits/sources.dm
+++ b/code/__DEFINES/traits/sources.dm
@@ -111,9 +111,6 @@
 /// Trait given to you by shapeshifting
 #define SHAPESHIFT_TRAIT "shapeshift_trait"
 
-///From the cuffed_item status effect
-#define CUFFED_ITEM_TRAIT "cuffed_item_trait"
-
 // unique trait sources, still defines
 #define EMP_TRAIT "emp_trait"
 #define STATUE_MUTE "statue"

--- a/code/datums/components/leash.dm
+++ b/code/datums/components/leash.dm
@@ -124,7 +124,7 @@
 
 	var/list/path = get_path_to(parent, owner, mintargetdist = distance)
 
-	if (last_completed_path_tick > our_path_tick)
+	if (last_completed_path_tick > our_path_tick || QDELETED(src))
 		return
 
 	last_completed_path_tick = our_path_tick
@@ -171,6 +171,7 @@
 		new force_teleport_in_effect(movable_parent.loc)
 
 	if (ismob(movable_parent))
+		SSblackbox.record_feedback("tally", "leash_force_teleport_back", 1, reason)
 		movable_parent.balloon_alert(movable_parent, "moved out of range!")
 
 	SEND_SIGNAL(parent, COMSIG_LEASH_FORCE_TELEPORT)

--- a/code/datums/components/leash.dm
+++ b/code/datums/components/leash.dm
@@ -160,8 +160,6 @@
 
 	var/atom/movable/movable_parent = parent
 
-	SSblackbox.record_feedback("tally", "leash_force_teleport_back", 1, reason)
-
 	if (force_teleport_out_effect)
 		new force_teleport_out_effect(movable_parent.loc)
 

--- a/code/datums/components/tug_towards.dm
+++ b/code/datums/components/tug_towards.dm
@@ -40,13 +40,18 @@
 /datum/component/tug_towards/Destroy(force)
 	tugging_to_targets.Cut()
 
-	animate(
-		parent,
-		pixel_x = -current_tug_offset_x,
-		pixel_y = -current_tug_offset_y,
-		time = 0.2 SECONDS,
-		flags = ANIMATION_RELATIVE
-	)
+	if(isliving(parent))
+		var/mob/living/living_parent = parent
+		living_parent.remove_offsets(REF(src))
+
+	else
+		animate(
+			parent,
+			pixel_x = -current_tug_offset_x,
+			pixel_y = -current_tug_offset_y,
+			time = 0.2 SECONDS,
+			flags = ANIMATION_RELATIVE
+		)
 
 	return ..()
 
@@ -93,6 +98,9 @@
 	SIGNAL_HANDLER
 	PRIVATE_PROC(TRUE)
 
+	if(QDELETED(src))
+		return // another movement call could have deleted us
+
 	var/atom/atom_parent = parent
 	var/mob/mob_parent = parent
 
@@ -123,13 +131,18 @@
 	if (total_tug_x == current_tug_offset_x && total_tug_y == current_tug_offset_y)
 		return
 
-	animate(
-		atom_parent,
-		pixel_x = -current_tug_offset_x + total_tug_x,
-		pixel_y = -current_tug_offset_y + total_tug_y,
-		time = 0.2 SECONDS,
-		flags = ANIMATION_RELATIVE
-	)
+	if(isliving(mob_parent))
+		var/mob/living/living_parent = mob_parent
+		living_parent.add_offsets(REF(src), x_add = total_tug_x, y_add = total_tug_y)
+
+	else
+		animate(
+			atom_parent,
+			pixel_x = -current_tug_offset_x + total_tug_x,
+			pixel_y = -current_tug_offset_y + total_tug_y,
+			time = 0.2 SECONDS,
+			flags = ANIMATION_RELATIVE
+		)
 
 	current_tug_offset_x = total_tug_x
 	current_tug_offset_y = total_tug_y

--- a/code/datums/elements/cuffable_item.dm
+++ b/code/datums/elements/cuffable_item.dm
@@ -47,10 +47,16 @@
 	if(cuffs.used || DOING_INTERACTION_WITH_TARGET(user, source))
 		return
 
+	var/num_cuffs = 0
 	for(var/datum/status_effect/cuffed_item/effect in user.status_effects)
 		if(effect.cuffed == source)
 			to_chat(user, span_warning("[source] is already cuffed to your wrist!"))
 			return
+		num_cuffs += 1
+
+	if(num_cuffs >= user.usable_hands)
+		to_chat(user, span_warning("You don't have anymore hands free to cuff [source] to!"))
+		return
 
 	if(cuffs.handcuffs_clumsiness_check(user))
 		return

--- a/code/datums/elements/cuffable_item.dm
+++ b/code/datums/elements/cuffable_item.dm
@@ -47,15 +47,16 @@
 	if(cuffs.used || DOING_INTERACTION_WITH_TARGET(user, source))
 		return
 
-	var/num_cuffs = 0
 	for(var/datum/status_effect/cuffed_item/effect in user.status_effects)
 		if(effect.cuffed == source)
 			to_chat(user, span_warning("[source] is already cuffed to your wrist!"))
 			return
-		num_cuffs += 1
+		if(effect.cuffed_to == user.get_inactive_hand())
+			to_chat(user, span_warning("You already have something cuffed to your opposite wrist!"))
+			return
 
-	if(num_cuffs >= user.usable_hands)
-		to_chat(user, span_warning("You don't have anymore hands free to cuff [source] to!"))
+	if(!user.get_inactive_hand())
+		to_chat(user, span_warning("You don't have another hand to cuff [source] to!"))
 		return
 
 	if(cuffs.handcuffs_clumsiness_check(user))

--- a/code/datums/elements/cuffable_item.dm
+++ b/code/datums/elements/cuffable_item.dm
@@ -47,9 +47,10 @@
 	if(cuffs.used || DOING_INTERACTION_WITH_TARGET(user, source))
 		return
 
-	if(HAS_TRAIT_FROM(source, TRAIT_NODROP, CUFFED_ITEM_TRAIT))
-		to_chat(user, span_warning("[source] is already cuffed to your wrist!"))
-		return
+	for(var/datum/status_effect/cuffed_item/effect in user.status_effects)
+		if(effect.cuffed == source)
+			to_chat(user, span_warning("[source] is already cuffed to your wrist!"))
+			return
 
 	if(cuffs.handcuffs_clumsiness_check(user))
 		return

--- a/code/datums/status_effects/cuffed_item.dm
+++ b/code/datums/status_effects/cuffed_item.dm
@@ -14,9 +14,9 @@
 	var/obj/item/cuffed
 	///Reference to the pair of handcuffs used to bind the item
 	var/obj/item/restraints/handcuffs/cuffs
-
+	///Reference to the bodypart we're cuffed to
 	var/obj/item/bodypart/cuffed_to
-	// Tracks the various things we apply to whatever we are cuffed to
+	//Tracks the various things we apply to whatever we are cuffed to for cleanup
 	VAR_PRIVATE/datum/component/leash/link_effect
 	VAR_PRIVATE/datum/component/tug_towards/tug_effect
 	VAR_PRIVATE/datum/beam/beam_effect

--- a/code/datums/status_effects/cuffed_item.dm
+++ b/code/datums/status_effects/cuffed_item.dm
@@ -14,10 +14,10 @@
 	var/obj/item/cuffed
 	///Reference to the pair of handcuffs used to bind the item
 	var/obj/item/restraints/handcuffs/cuffs
-
-	var/datum/component/leash/link_effect
-	var/datum/component/tug_towards/tug_effect
-	var/datum/beam/beam_effect
+	// Tracks the various things we apply to whatever we are cuffed to
+	VAR_PRIVATE/datum/component/leash/link_effect
+	VAR_PRIVATE/datum/component/tug_towards/tug_effect
+	VAR_PRIVATE/datum/beam/beam_effect
 
 /datum/status_effect/cuffed_item/on_creation(mob/living/new_owner, obj/item/cuffed, obj/item/restraints/handcuffs/cuffs)
 	src.cuffed = cuffed

--- a/code/datums/status_effects/cuffed_item.dm
+++ b/code/datums/status_effects/cuffed_item.dm
@@ -14,6 +14,8 @@
 	var/obj/item/cuffed
 	///Reference to the pair of handcuffs used to bind the item
 	var/obj/item/restraints/handcuffs/cuffs
+
+	var/obj/item/bodypart/cuffed_to
 	// Tracks the various things we apply to whatever we are cuffed to
 	VAR_PRIVATE/datum/component/leash/link_effect
 	VAR_PRIVATE/datum/component/tug_towards/tug_effect
@@ -27,7 +29,8 @@
 
 /datum/status_effect/cuffed_item/on_apply()
 	owner.temporarilyRemoveItemFromInventory(cuffs, force = TRUE)
-	if(!update_link())
+	cuffed_to = owner.get_inactive_hand()
+	if(isnull(cuffed_to) || !update_link())
 		owner.put_in_hands(cuffs)
 		qdel(src)
 		return FALSE
@@ -44,9 +47,12 @@
 	RegisterSignals(cuffs, list(COMSIG_ITEM_EQUIPPED, COMSIG_QDELETING, COMSIG_MOVABLE_MOVED), PROC_REF(cleanup_effect))
 	RegisterSignal(cuffs, COMSIG_ATOM_UPDATE_APPEARANCE, PROC_REF(on_item_update_appearance))
 
+	RegisterSignal(cuffed_to, COMSIG_QDELETING, PROC_REF(cleanup_effect))
+	RegisterSignals(cuffed_to, COMSIG_BODYPART_REMOVED, PROC_REF(cuffed_to_removed))
+
 	RegisterSignal(owner, COMSIG_ATOM_EXAMINE_MORE, PROC_REF(on_examine_more))
 
-	owner.log_message("bound [src] to themselves with restraints", LOG_GAME)
+	owner.log_message("bound [src] to [owner.p_themselves()] with restraints", LOG_GAME)
 
 	return TRUE
 
@@ -54,7 +60,8 @@
 	//Prevent possible recursions from these signals
 	UnregisterSignal(cuffed, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED, COMSIG_MOVABLE_MOVED, COMSIG_QDELETING, COMSIG_ITEM_PRE_STORAGE_INSERTION))
 	UnregisterSignal(cuffs, list(COMSIG_ITEM_EQUIPPED, COMSIG_MOVABLE_MOVED, COMSIG_QDELETING))
-
+	UnregisterSignal(cuffed_to, list(COMSIG_BODYPART_REMOVED, COMSIG_QDELETING))
+	UnregisterSignal(owner, list(COMSIG_ATOM_EXAMINE_MORE, COMSIG_CARBON_POST_ATTACH_LIMB))
 	cuffed = null
 
 	if(!QDELETED(cuffs))
@@ -63,18 +70,45 @@
 			cuffs.forceMove(owner.drop_location())
 	cuffs = null
 
+	cuffed_to = null
+
 	break_leash()
 
 ///Called when someone examines the owner twice, so they can know if someone has a cuffed item
 /datum/status_effect/cuffed_item/proc/on_examine_more(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	examine_list += span_warning("There's [cuffed.examine_title(user)] bound to [owner.p_their()] wrist by [cuffs.examine_title(user)].")
+	examine_list += span_warning("There's [cuffed.examine_title(user)] bound to [owner.p_their()] \
+		[cuffed_to.plaintext_zone] by [cuffs.examine_title(user)].")
 
 ///What happens if one of the items is moved away from the mob
 /datum/status_effect/cuffed_item/proc/on_displaced(datum/source)
 	SIGNAL_HANDLER
 	qdel(src)
+
+/// What happens if the limb we're cuffed to is removed?
+/datum/status_effect/cuffed_item/proc/cuffed_to_removed(datum/source, mob/living/carbon/owner, special)
+	SIGNAL_HANDLER
+	// if special we will just wait for the new limb
+	if(special)
+		UnregisterSignal(cuffed_to, list(COMSIG_QDELETING, COMSIG_BODYPART_REMOVED))
+		cuffed_to = null
+		RegisterSignal(owner, COMSIG_CARBON_POST_ATTACH_LIMB, PROC_REF(new_cuffed_to_attached))
+		return
+	// otherwise we wipe the effect
+	qdel(src)
+
+/// Specifically if our cuffed limb is removed "specially", change it to the newly applied arm
+/datum/status_effect/cuffed_item/proc/new_cuffed_to_attached(datum/source, obj/item/bodypart/limb, special)
+	SIGNAL_HANDLER
+
+	if(!istype(limb, /obj/item/bodypart/arm))
+		return
+
+	cuffed_to = limb
+	RegisterSignal(cuffed_to, COMSIG_QDELETING, PROC_REF(cleanup_effect))
+	RegisterSignal(cuffed_to, COMSIG_BODYPART_REMOVED, PROC_REF(cuffed_to_removed))
+	UnregisterSignal(owner, COMSIG_CARBON_POST_ATTACH_LIMB)
 
 /// Check if we need to spawn the tether effect or not
 /datum/status_effect/cuffed_item/proc/check_for_link(...)

--- a/code/datums/status_effects/cuffed_item.dm
+++ b/code/datums/status_effects/cuffed_item.dm
@@ -69,7 +69,7 @@
 /datum/status_effect/cuffed_item/proc/on_examine_more(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	examine_list += span_warning("There's [cuffed.examine_title(user)] bound to [owner.p_their()] [owner.get_held_index_name(owner.get_held_index_of_item(cuffed))] by [cuffs.examine_title(user)].")
+	examine_list += span_warning("There's [cuffed.examine_title(user)] bound to [owner.p_their()] wrist by [cuffs.examine_title(user)].")
 
 ///What happens if one of the items is moved away from the mob
 /datum/status_effect/cuffed_item/proc/on_displaced(datum/source)

--- a/code/datums/status_effects/cuffed_item.dm
+++ b/code/datums/status_effects/cuffed_item.dm
@@ -15,6 +15,10 @@
 	///Reference to the pair of handcuffs used to bind the item
 	var/obj/item/restraints/handcuffs/cuffs
 
+	var/datum/component/leash/link_effect
+	var/datum/component/tug_towards/tug_effect
+	var/datum/beam/beam_effect
+
 /datum/status_effect/cuffed_item/on_creation(mob/living/new_owner, obj/item/cuffed, obj/item/restraints/handcuffs/cuffs)
 	src.cuffed = cuffed
 	src.cuffs = cuffs
@@ -22,25 +26,22 @@
 	linked_alert.update_appearance(UPDATE_OVERLAYS)
 
 /datum/status_effect/cuffed_item/on_apply()
-	if(HAS_TRAIT_FROM(cuffed, TRAIT_NODROP, CUFFED_ITEM_TRAIT))
-		qdel(src)
-		return FALSE
 	owner.temporarilyRemoveItemFromInventory(cuffs, force = TRUE)
-	if(!owner.is_holding(cuffed) && !owner.put_in_hands(cuffed))
+	if(!owner.is_holding(cuffed) && !owner.put_in_hands(cuffed) || !update_link())
 		owner.put_in_hands(cuffs)
 		qdel(src)
 		return FALSE
 
-	ADD_TRAIT(cuffed, TRAIT_NODROP, CUFFED_ITEM_TRAIT)
-
-	RegisterSignals(cuffed, list(COMSIG_ITEM_DROPPED, COMSIG_MOVABLE_MOVED, COMSIG_QDELETING), PROC_REF(on_displaced))
+	RegisterSignals(cuffed, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED, COMSIG_MOVABLE_MOVED), PROC_REF(check_for_link))
+	RegisterSignal(cuffed, COMSIG_QDELETING, PROC_REF(cleanup_effect))
 	RegisterSignal(cuffed, COMSIG_ATOM_UPDATE_APPEARANCE, PROC_REF(on_item_update_appearance))
 	RegisterSignal(cuffed, COMSIG_ATOM_EXAMINE, PROC_REF(cuffed_reminder))
 	RegisterSignal(cuffed, COMSIG_TOPIC, PROC_REF(topic_handler))
 	RegisterSignal(cuffed, COMSIG_ITEM_GET_STRIPPABLE_ALT_ACTIONS, PROC_REF(get_strippable_action))
 	RegisterSignal(cuffed, COMSIG_ITEM_STRIPPABLE_ALT_ACTION, PROC_REF(do_strippable_action))
+	RegisterSignal(cuffed, COMSIG_ITEM_PRE_STORAGE_INSERTION, PROC_REF(block_storage_insert))
 
-	RegisterSignals(cuffs, list(COMSIG_ITEM_EQUIPPED, COMSIG_MOVABLE_MOVED, COMSIG_QDELETING), PROC_REF(on_displaced))
+	RegisterSignals(cuffs, list(COMSIG_ITEM_EQUIPPED, COMSIG_QDELETING, COMSIG_MOVABLE_MOVED), PROC_REF(cleanup_effect))
 	RegisterSignal(cuffs, COMSIG_ATOM_UPDATE_APPEARANCE, PROC_REF(on_item_update_appearance))
 
 	RegisterSignal(owner, COMSIG_ATOM_EXAMINE_MORE, PROC_REF(on_examine_more))
@@ -51,10 +52,9 @@
 
 /datum/status_effect/cuffed_item/on_remove()
 	//Prevent possible recursions from these signals
-	UnregisterSignal(cuffed, list(COMSIG_ITEM_DROPPED, COMSIG_MOVABLE_MOVED, COMSIG_QDELETING))
+	UnregisterSignal(cuffed, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED, COMSIG_MOVABLE_MOVED, COMSIG_QDELETING, COMSIG_ITEM_PRE_STORAGE_INSERTION))
 	UnregisterSignal(cuffs, list(COMSIG_ITEM_EQUIPPED, COMSIG_MOVABLE_MOVED, COMSIG_QDELETING))
 
-	REMOVE_TRAIT(cuffed, TRAIT_NODROP, CUFFED_ITEM_TRAIT)
 	cuffed = null
 
 	if(!QDELETED(cuffs))
@@ -63,14 +63,69 @@
 			cuffs.forceMove(owner.drop_location())
 	cuffs = null
 
+	break_leash()
+
 ///Called when someone examines the owner twice, so they can know if someone has a cuffed item
 /datum/status_effect/cuffed_item/proc/on_examine_more(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	examine_list += span_warning("[cuffed.examine_title(user)] is bound to [owner.p_their()] [owner.get_held_index_name(owner.get_held_index_of_item(cuffed))] by [cuffs.examine_title(user)]")
+	examine_list += span_warning("There's [cuffed.examine_title(user)] bound to [owner.p_their()] [owner.get_held_index_name(owner.get_held_index_of_item(cuffed))] by [cuffs.examine_title(user)].")
 
 ///What happens if one of the items is moved away from the mob
 /datum/status_effect/cuffed_item/proc/on_displaced(datum/source)
+	SIGNAL_HANDLER
+	qdel(src)
+
+/// Check if we need to spawn the tether effect or not
+/datum/status_effect/cuffed_item/proc/check_for_link(...)
+	SIGNAL_HANDLER
+	if(!update_link())
+		qdel(src)
+
+/// Updates our link and beam effect based on our state
+/// Returns TRUE if we are in a valid link state, FALSE otherwise
+/datum/status_effect/cuffed_item/proc/update_link()
+	// when held, we need no tether
+	if(cuffed.loc == owner)
+		break_leash()
+		return TRUE
+
+	// when on the ground, init a tether between item <-> owner
+	if(isturf(cuffed.loc))
+		init_leash(cuffed)
+		return TRUE
+
+	// when being picked up by something else, init a tether between grabber <-> owner
+	if(ismovable(cuffed.loc) && isturf(cuffed.loc.loc))
+		init_leash(cuffed.loc)
+		return TRUE
+
+	// we have no idea where it is...
+	return FALSE
+
+/// Inits the leash and beam effect to the given target, cleaning up old ones if necessary
+/datum/status_effect/cuffed_item/proc/init_leash(atom/movable/leash_to)
+	if(link_effect && link_effect.parent != leash_to)
+		break_leash()
+
+	link_effect ||= leash_to.AddComponent(/datum/component/leash, owner = src.owner, distance = 1)
+	tug_effect  ||= leash_to.AddComponent(/datum/component/tug_towards, tugging_to = src.owner, strength = 0.66)
+	beam_effect ||= leash_to.Beam(owner, "chain")
+
+/datum/status_effect/cuffed_item/proc/break_leash()
+	QDEL_NULL(link_effect)
+	QDEL_NULL(tug_effect)
+	QDEL_NULL(beam_effect)
+
+/// Stops it from being stored anywhere
+/datum/status_effect/cuffed_item/proc/block_storage_insert(obj/item/source, atom/target_storage, mob/user, force, messages)
+	SIGNAL_HANDLER
+	if(messages)
+		target_storage.balloon_alert(user, "can't store [source.name] while cuffed!")
+	return BLOCK_STORAGE_INSERT
+
+///What happens if one of the items is moved away from the mob
+/datum/status_effect/cuffed_item/proc/cleanup_effect(datum/source)
 	SIGNAL_HANDLER
 	qdel(src)
 
@@ -128,9 +183,10 @@
 	log_combat(user, owner, "removed restraints binding [cuffed] to")
 
 	var/obj/item/restraints/handcuffs/ref_cuffs = cuffs
+	var/mob/living/ref_owner = owner
 	ref_cuffs.forceMove(owner.drop_location()) //This will cause the status effect to delete itself, which unsets the 'cuffs' var
 	user.put_in_hands(ref_cuffs)
-	owner.balloon_alert(user, "cuffs removed from item")
+	ref_owner.balloon_alert(user, "cuffs removed from item")
 
 	return TRUE
 

--- a/code/datums/status_effects/cuffed_item.dm
+++ b/code/datums/status_effects/cuffed_item.dm
@@ -15,7 +15,7 @@
 	///Reference to the pair of handcuffs used to bind the item
 	var/obj/item/restraints/handcuffs/cuffs
 	///Reference to the bodypart we're cuffed to
-	var/obj/item/bodypart/cuffed_to
+	var/obj/item/bodypart/arm/cuffed_to
 	//Tracks the various things we apply to whatever we are cuffed to for cleanup
 	VAR_PRIVATE/datum/component/leash/link_effect
 	VAR_PRIVATE/datum/component/tug_towards/tug_effect
@@ -47,6 +47,7 @@
 	RegisterSignals(cuffs, list(COMSIG_ITEM_EQUIPPED, COMSIG_QDELETING, COMSIG_MOVABLE_MOVED), PROC_REF(cleanup_effect))
 	RegisterSignal(cuffs, COMSIG_ATOM_UPDATE_APPEARANCE, PROC_REF(on_item_update_appearance))
 
+	cuffed_to.set_speed_modifiers(cuffed_to.interaction_modifier + 0.5, cuffed_to.click_cd_modifier + 0.25)
 	RegisterSignal(cuffed_to, COMSIG_QDELETING, PROC_REF(cleanup_effect))
 	RegisterSignal(cuffed_to, COMSIG_BODYPART_REMOVED, PROC_REF(cuffed_to_removed))
 
@@ -70,6 +71,7 @@
 			cuffs.forceMove(owner.drop_location())
 	cuffs = null
 
+	cuffed_to.set_speed_modifiers(cuffed_to.interaction_modifier - 0.5, cuffed_to.click_cd_modifier - 0.25)
 	cuffed_to = null
 
 	break_leash()
@@ -92,6 +94,7 @@
 	// if special we will just wait for the new limb
 	if(special)
 		UnregisterSignal(cuffed_to, list(COMSIG_QDELETING, COMSIG_BODYPART_REMOVED))
+		cuffed_to.set_speed_modifiers(cuffed_to.interaction_modifier - 0.5, cuffed_to.click_cd_modifier - 0.25)
 		cuffed_to = null
 		RegisterSignal(owner, COMSIG_CARBON_POST_ATTACH_LIMB, PROC_REF(new_cuffed_to_attached))
 		return
@@ -106,6 +109,7 @@
 		return
 
 	cuffed_to = limb
+	cuffed_to.set_speed_modifiers(cuffed_to.interaction_modifier + 0.5, cuffed_to.click_cd_modifier + 0.25)
 	RegisterSignal(cuffed_to, COMSIG_QDELETING, PROC_REF(cleanup_effect))
 	RegisterSignal(cuffed_to, COMSIG_BODYPART_REMOVED, PROC_REF(cuffed_to_removed))
 	UnregisterSignal(owner, COMSIG_CARBON_POST_ATTACH_LIMB)

--- a/code/datums/status_effects/cuffed_item.dm
+++ b/code/datums/status_effects/cuffed_item.dm
@@ -47,7 +47,7 @@
 	RegisterSignals(cuffs, list(COMSIG_ITEM_EQUIPPED, COMSIG_QDELETING, COMSIG_MOVABLE_MOVED), PROC_REF(cleanup_effect))
 	RegisterSignal(cuffs, COMSIG_ATOM_UPDATE_APPEARANCE, PROC_REF(on_item_update_appearance))
 
-	cuffed_to.set_speed_modifiers(cuffed_to.interaction_modifier + 0.5, cuffed_to.click_cd_modifier + 0.25)
+	cuffed_to.set_speed_modifiers(cuffed_to.interaction_modifier + 0.25, cuffed_to.click_cd_modifier + 0.25)
 	RegisterSignal(cuffed_to, COMSIG_QDELETING, PROC_REF(cleanup_effect))
 	RegisterSignal(cuffed_to, COMSIG_BODYPART_REMOVED, PROC_REF(cuffed_to_removed))
 
@@ -71,7 +71,7 @@
 			cuffs.forceMove(owner.drop_location())
 	cuffs = null
 
-	cuffed_to.set_speed_modifiers(cuffed_to.interaction_modifier - 0.5, cuffed_to.click_cd_modifier - 0.25)
+	cuffed_to.set_speed_modifiers(cuffed_to.interaction_modifier - 0.25, cuffed_to.click_cd_modifier - 0.25)
 	cuffed_to = null
 
 	break_leash()
@@ -94,7 +94,7 @@
 	// if special we will just wait for the new limb
 	if(special)
 		UnregisterSignal(cuffed_to, list(COMSIG_QDELETING, COMSIG_BODYPART_REMOVED))
-		cuffed_to.set_speed_modifiers(cuffed_to.interaction_modifier - 0.5, cuffed_to.click_cd_modifier - 0.25)
+		cuffed_to.set_speed_modifiers(cuffed_to.interaction_modifier - 0.25, cuffed_to.click_cd_modifier - 0.25)
 		cuffed_to = null
 		RegisterSignal(owner, COMSIG_CARBON_POST_ATTACH_LIMB, PROC_REF(new_cuffed_to_attached))
 		return
@@ -109,7 +109,7 @@
 		return
 
 	cuffed_to = limb
-	cuffed_to.set_speed_modifiers(cuffed_to.interaction_modifier + 0.5, cuffed_to.click_cd_modifier + 0.25)
+	cuffed_to.set_speed_modifiers(cuffed_to.interaction_modifier + 0.25, cuffed_to.click_cd_modifier + 0.25)
 	RegisterSignal(cuffed_to, COMSIG_QDELETING, PROC_REF(cleanup_effect))
 	RegisterSignal(cuffed_to, COMSIG_BODYPART_REMOVED, PROC_REF(cuffed_to_removed))
 	UnregisterSignal(owner, COMSIG_CARBON_POST_ATTACH_LIMB)

--- a/code/datums/status_effects/cuffed_item.dm
+++ b/code/datums/status_effects/cuffed_item.dm
@@ -48,7 +48,7 @@
 	RegisterSignal(cuffs, COMSIG_ATOM_UPDATE_APPEARANCE, PROC_REF(on_item_update_appearance))
 
 	RegisterSignal(cuffed_to, COMSIG_QDELETING, PROC_REF(cleanup_effect))
-	RegisterSignals(cuffed_to, COMSIG_BODYPART_REMOVED, PROC_REF(cuffed_to_removed))
+	RegisterSignal(cuffed_to, COMSIG_BODYPART_REMOVED, PROC_REF(cuffed_to_removed))
 
 	RegisterSignal(owner, COMSIG_ATOM_EXAMINE_MORE, PROC_REF(on_examine_more))
 

--- a/code/datums/status_effects/cuffed_item.dm
+++ b/code/datums/status_effects/cuffed_item.dm
@@ -27,7 +27,7 @@
 
 /datum/status_effect/cuffed_item/on_apply()
 	owner.temporarilyRemoveItemFromInventory(cuffs, force = TRUE)
-	if(!owner.is_holding(cuffed) && !owner.put_in_hands(cuffed) || !update_link())
+	if(!update_link())
 		owner.put_in_hands(cuffs)
 		qdel(src)
 		return FALSE

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -489,6 +489,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		return FALSE
 	if(SEND_SIGNAL(parent, COMSIG_ATOM_PRE_STORED_ITEM, to_insert, user, force, messages) & BLOCK_STORAGE_INSERT)
 		return FALSE
+	if(SEND_SIGNAL(to_insert, COMSIG_ITEM_PRE_STORAGE_INSERTION, parent, user, force, messages) & BLOCK_STORAGE_INSERT)
+		return FALSE
 
 	SEND_SIGNAL(parent, COMSIG_ATOM_STORED_ITEM, to_insert, user, force)
 	SEND_SIGNAL(src, COMSIG_STORAGE_STORED_ITEM, to_insert, user, force)

--- a/code/game/objects/items/weaponry/shields.dm
+++ b/code/game/objects/items/weaponry/shields.dm
@@ -43,6 +43,7 @@
 /obj/item/shield/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/disarm_attack)
+	AddElement(/datum/element/cuffable_item)
 
 /obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
 	var/effective_block_chance = final_block_chance


### PR DESCRIPTION
## About The Pull Request

Cuffing an item to you no longer gives the item `NODROP`, ie, makes you unable to drop or be disarmed of said item

Instead, cuffed items will be tethered to you within a minimum one tile's reach at all times

https://github.com/user-attachments/assets/04d1ab39-3131-47dd-9778-7c4bae7422e1

- If you move around, the item will be dragged around with you
- If someone else grabs the item, you will drag that someone else along with you.
   - Currently, the person cannot drag you, it's a one way relationship. That might change (based on pull strength I guess)?
- If you jump through a portal or something, it'll teleport through the portal with you as you'd expect
- You can of course pick it up and carry it like normal, but it otherwise acts as a normal item
- You can only have one item handcuffed to a wrist at a time (so for the average 2 armed man, 2 items max)
- If your arm gets lopped off, the link will be severed (though in the future, moving the link to the dismembered arm would be funny...)
- Cuffed items can't be stored in any type of storage - They can still be hypothetically be worn, though, if they have slot flags. 
- Using an arm with a cuffed item has a penalty to interaction speed and click cd (1.25x) 

## Why It's Good For The Game

Cuffing items is a cool mechanic but nodrop is very oppressive mechanically, which means we have to remove it from otherwise sensible(?) itemsin the service of balance  (#95673) 

This reworking should keep its flavor aspect while making it a bit less oppressive, which in turn should let us put it on things that it'd otherwise be too potent on (like shields, and maybe more things later)

...Unless it turns out keeping something within a tile's reach is also very strong in which case we'll probably have to remove it from shields again

## Changelog

:cl: Melbert
balance: Cuffing items to yourself no longer prevents you from dropping or being disarmed of the item- instead, the item becomes "chained" to you, forcing it to stay within one tile's reach under all circumstances. 
balance: You can cuff shields to yourself again. Unless we figure out it's still oppressive in which case it'll probably be removed (again)
fix: IV drops should break your character's offsets less often
/:cl:


