### PR TITLE
Drying rack wont process or accept dried items

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -506,7 +506,7 @@
 		use_energy(active_power_usage)
 
 /obj/machinery/smartfridge/drying/accept_check(obj/item/O)
-	return HAS_TRAIT(O, TRAIT_DRYABLE)
+	return HAS_TRAIT(O, TRAIT_DRYABLE) && !HAS_TRAIT(O, TRAIT_DRIED)
 
 /**
  * Toggles drying on or off


### PR DESCRIPTION

## About The Pull Request
All items im aware of only care amout the dried signal once, in which it applies dried, then it does nothing new.
This changes it so it wont accept, process, or otherwise consider valid "completed"/dried items

I considered just removing the element in whole, but i realized that would have an effect on the ciggie rolling recipes which check for specificly `TRAIT_DRYABLE` which is added and removed by whether it has said element. Im also not sure how weird the practice or `RemoveElement` yourself inside an element is.
But this would be my alternative if anyone has any thoughts.
<img width="853" height="239" alt="image" src="https://github.com/user-attachments/assets/4d3803ff-2248-48d8-8c60-f8abac8647e6" />
<img width="747" height="85" alt="image" src="https://github.com/user-attachments/assets/396b06cb-d8a8-4318-853f-fe9d90050346" />
## Why It's Good For The Game
prob dont need to waste effort or allow someone to reinsert a dried item.

It also means we can have logic for if the drying rack has processed all of its contents. ([evil downstream pr](https://github.com/DarkPack13/SecondCity/pull/1028) where i added a filled-dried icon state)
## Changelog
:cl:
fix: Drying rack no longer accepts or processes dried items
/:cl:
