### PR TITLE
Removes a rogue syndiedome ruin decal

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_syndidome.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_syndidome.dmm
@@ -1333,10 +1333,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/syndibiodome)
-"qJ" = (
-/obj/effect/turf_decal/trimline/tram/filled,
-/turf/closed/indestructible/syndicate,
-/area/ruin/syndibiodome)
 "qN" = (
 /turf/closed/indestructible/syndicate,
 /area/ruin/syndibiodome)
@@ -5086,7 +5082,7 @@ qN
 mW
 qN
 qN
-qJ
+qN
 qN
 xf
 oH


### PR DESCRIPTION

## About The Pull Request
<img width="478" height="331" alt="image" src="https://github.com/user-attachments/assets/e32d741a-69f3-4c01-be20-87470e039fb2" />


## Changelog
:cl:
fix: Removed a rogue syndiedome ruin decal
/:cl:
