### PR TITLE
SyndEye PDA app tracking successfully tracks

### DIFF
--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -174,7 +174,7 @@
 		CRASH("[src] was able to track [target] through /datum/trackable, but was not on a visible turf to cameras.")
 	for(var/obj/machinery/camera/cameras as anything in target_camerachunk.cameras["[target.z]"])
 		// We need to find a particular camera that can see this turf
-		if(length(cameras.can_see() & list(target_turf)))
+		if(!(length(cameras.can_see() & list(target_turf))))
 			continue
 		var/new_camera = WEAKREF(cameras)
 		if(camera_ref == new_camera)


### PR DESCRIPTION

## About The Pull Request

Inversion on early return, tracks only if the target isn't on cams. 

## Why It's Good For The Game

fixes #95935

## Changelog
:cl:

fix: SyndEye PDA app tracking tracks successfully

/:cl:
