### PR TITLE
Buffs the good aspects of Spacer by a little bit, so people might actually notice them

### DIFF
--- a/code/datums/quirks/positive_quirks/spacer.dm
+++ b/code/datums/quirks/positive_quirks/spacer.dm
@@ -30,6 +30,11 @@
 	/// Determines the last state we were in ([LAST_STATE_PLANET], [LAST_STATE_SPACE], or [LAST_STATE_NOGRAV])
 	VAR_FINAL/last_state
 
+	/// Modifier to damage taken from pressure/cold
+	VAR_FINAL/damage_mod = 0.66
+	/// Modifier to drift speed in zero G
+	VAR_FINAL/drift_mod = 0.75
+
 /datum/quirk/spacer_born/add(client/client_source)
 	if(isdummy(quirk_holder))
 		return
@@ -45,12 +50,12 @@
 	update_effects(quirk_holder, skip_timers = TRUE)
 
 	// drift slightly faster through zero G
-	quirk_holder.inertia_move_multiplier *= 0.8
+	quirk_holder.inertia_move_multiplier *= drift_mod
 
 	var/mob/living/carbon/human/human_quirker = quirk_holder
 	human_quirker.set_mob_height(modded_height)
-	human_quirker.physiology.pressure_mod *= 0.8
-	human_quirker.physiology.cold_mod *= 0.8
+	human_quirker.physiology.pressure_mod *= damage_mod
+	human_quirker.physiology.cold_mod *= damage_mod
 
 /datum/quirk/spacer_born/post_add()
 	var/on_a_planet = SSmapping.is_planetary()
@@ -76,15 +81,15 @@
 	if(QDELING(quirk_holder))
 		return
 
-	quirk_holder.inertia_move_multiplier /= 0.8
+	quirk_holder.inertia_move_multiplier /= drift_mod
 	quirk_holder.clear_mood_event("spacer")
 	quirk_holder.remove_movespeed_modifier(/datum/movespeed_modifier/spacer)
 	quirk_holder.remove_status_effect(/datum/status_effect/spacer)
 
 	var/mob/living/carbon/human/human_quirker = quirk_holder
 	human_quirker.set_mob_height(HUMAN_HEIGHT_MEDIUM)
-	human_quirker.physiology.pressure_mod /= 0.8
-	human_quirker.physiology.cold_mod /= 0.8
+	human_quirker.physiology.pressure_mod /= damage_mod
+	human_quirker.physiology.cold_mod /= damage_mod
 
 /// Check on Z change whether we should start or stop timers
 /datum/quirk/spacer_born/proc/spacer_moved(mob/living/source, turf/old_turf, turf/new_turf, same_z_layer)

--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -26,7 +26,7 @@
 	/// How many seconds of stuns to reduce per tick when we've been in nograv for a while
 	var/stun_heal_per_second = 2 SECONDS
 	/// How much to reduce incoming knockdown effects while in nograv for a while
-	var/knockdown_multiplier = 0.8
+	var/knockdown_multiplier = 0.75
 	/// Tracks how long we've been in no gravity
 	VAR_FINAL/seconds_in_nograv = 0 SECONDS
 	/// Tracks if we've applied knockdown modifier reduction to the mob

--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -18,15 +18,19 @@
 // The good side (being in space)
 /datum/status_effect/spacer/gravity_wellness
 	alert_type = null
-	tick_interval = 3 SECONDS
+	tick_interval = 1 SECONDS
 	/// How much disgust to heal per tick
-	var/disgust_healing_per_tick = 1.5
-	/// How much of stamina damage to heal per tick when we've been in nograv for a while
-	var/stamina_heal_per_tick = 3
+	var/disgust_healing_per_second = 1
+	/// How much of stamina damage to heal per tick when we've been in nograv for a while.
+	var/stamina_heal_per_second = 5
 	/// How many seconds of stuns to reduce per tick when we've been in nograv for a while
-	var/stun_heal_per_tick = 3 SECONDS
+	var/stun_heal_per_second = 2 SECONDS
+	/// How much to reduce incoming knockdown effects while in nograv for a while
+	var/knockdown_multiplier = 0.8
 	/// Tracks how long we've been in no gravity
 	VAR_FINAL/seconds_in_nograv = 0 SECONDS
+	/// Tracks if we've applied knockdown modifier reduction to the mob
+	VAR_FINAL/knockdown_mod_applied = FALSE
 
 /datum/status_effect/spacer/gravity_wellness/tick(seconds_between_ticks)
 	var/in_nograv = !owner.has_gravity()
@@ -35,16 +39,37 @@
 
 	if(!in_nograv)
 		seconds_in_nograv = 0 SECONDS
+		if(knockdown_mod_applied)
+			remove_knockdown_mod()
 		return
 
 	seconds_in_nograv += (seconds_between_ticks * 0.1)
 
-	if(seconds_in_nograv >= 3 MINUTES)
-		// This has some interesting side effects with gravitum or similar negating effects that may be worth nothing
-		owner.adjust_stamina_loss(-1 * stamina_heal_per_tick)
+	if(seconds_in_nograv >= 2 MINUTES)
+		// With 5 stamina healing per second you'd get out of stamcrit in 5 seconds instead of the usual 10
+		owner.adjust_stamina_loss(-1 * stamina_heal_per_tick * stamcrit_mod)
+	if(seconds_in_nograv >= 20 SECONDS)
 		owner.AdjustAllImmobility(-1 * stun_heal_per_tick)
-		// For comparison: Ephedrine heals 4 stamina per tick / 2 per second
-		// and Nicotine heals 5 seconds of stun per tick / 2.5 per second
+		if(!knockdown_mod_applied)
+			apply_knockdown_mod()
+
+/datum/status_effect/spacer/gravity_wellness/on_remove()
+	. = ..()
+	remove_knockdown_mod()
+
+/datum/status_effect/spacer/gravity_wellness/proc/apply_knockdown_mod()
+	if(knockdown_mod_applied || !ishuman(owner))
+		return
+	var/mob/living/carbon/human/the_spacer = owner
+	the_spacer.physiology.knockdown_mod *= knockdown_multiplier
+	knockdown_mod_applied = TRUE
+
+/datum/status_effect/spacer/gravity_wellness/proc/remove_knockdown_mod()
+	if(!knockdown_mod_applied || !ishuman(owner))
+		return
+	var/mob/living/carbon/human/the_spacer = owner
+	the_spacer.physiology.knockdown_mod /= knockdown_multiplier
+	knockdown_mod_applied = FALSE
 
 // The bad side (being on a planet)
 /datum/status_effect/spacer/gravity_sickness
@@ -125,7 +150,7 @@
 /datum/movespeed_modifier/spacer/in_space
 	movetypes = FLOATING
 	blacklisted_movetypes = FLYING
-	multiplicative_slowdown = -0.1
+	multiplicative_slowdown = -0.15
 
 /datum/movespeed_modifier/spacer/on_planet
 	movetypes = GROUND|FLYING
@@ -136,4 +161,4 @@
 	multiplicative_slowdown = 0.5
 
 /datum/movespeed_modifier/spacer/on_planet/nerfed
-	multiplicative_slowdown = 0.25
+	multiplicative_slowdown = 0.15

--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -34,7 +34,7 @@
 
 /datum/status_effect/spacer/gravity_wellness/tick(seconds_between_ticks)
 	var/in_nograv = !owner.has_gravity()
-	var/nograv_mod = in_nograv ? 1.5 : 0.5
+	var/nograv_mod = in_nograv ? 2 : 0.5
 	owner.adjust_disgust(-1 * nograv_mod * disgust_healing_per_second * seconds_between_ticks)
 
 	if(!in_nograv)

--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -20,7 +20,7 @@
 	alert_type = null
 	tick_interval = 1 SECONDS
 	/// How much disgust to heal per tick
-	var/disgust_healing_per_second = 1
+	var/disgust_healing_per_second = 0.5
 	/// How much of stamina damage to heal per tick when we've been in nograv for a while.
 	var/stamina_heal_per_second = 4
 	/// How many seconds of stuns to reduce per tick when we've been in nograv for a while

--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -46,7 +46,7 @@
 	seconds_in_nograv += (seconds_between_ticks * 0.1)
 
 	if(seconds_in_nograv >= 2 MINUTES)
-		// With 5 stamina healing per second you'd get out of stamcrit in 5 seconds instead of the usual 10
+		// With 4 stamina healing per second you'd get out of stamcrit in 6 seconds instead of the usual 10
 		owner.adjust_stamina_loss(-1 * stamina_heal_per_second * seconds_between_ticks)
 	if(seconds_in_nograv >= 20 SECONDS)
 		owner.AdjustAllImmobility(-1 * stun_heal_per_second * seconds_between_ticks)

--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -34,7 +34,7 @@
 
 /datum/status_effect/spacer/gravity_wellness/tick(seconds_between_ticks)
 	var/in_nograv = !owner.has_gravity()
-	var/nograv_mod = in_nograv ? 1 : 0.5
+	var/nograv_mod = in_nograv ? 1.5 : 0.5
 	owner.adjust_disgust(-1 * nograv_mod * disgust_healing_per_second * seconds_between_ticks)
 
 	if(!in_nograv)

--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -22,7 +22,7 @@
 	/// How much disgust to heal per tick
 	var/disgust_healing_per_second = 1
 	/// How much of stamina damage to heal per tick when we've been in nograv for a while.
-	var/stamina_heal_per_second = 5
+	var/stamina_heal_per_second = 4
 	/// How many seconds of stuns to reduce per tick when we've been in nograv for a while
 	var/stun_heal_per_second = 2 SECONDS
 	/// How much to reduce incoming knockdown effects while in nograv for a while

--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -35,7 +35,7 @@
 /datum/status_effect/spacer/gravity_wellness/tick(seconds_between_ticks)
 	var/in_nograv = !owner.has_gravity()
 	var/nograv_mod = in_nograv ? 1 : 0.5
-	owner.adjust_disgust(-1 * disgust_healing_per_tick * nograv_mod)
+	owner.adjust_disgust(-1 * nograv_mod * disgust_healing_per_second * seconds_between_ticks)
 
 	if(!in_nograv)
 		seconds_in_nograv = 0 SECONDS
@@ -47,9 +47,9 @@
 
 	if(seconds_in_nograv >= 2 MINUTES)
 		// With 5 stamina healing per second you'd get out of stamcrit in 5 seconds instead of the usual 10
-		owner.adjust_stamina_loss(-1 * stamina_heal_per_tick * stamcrit_mod)
+		owner.adjust_stamina_loss(-1 * stamina_heal_per_second * seconds_between_ticks)
 	if(seconds_in_nograv >= 20 SECONDS)
-		owner.AdjustAllImmobility(-1 * stun_heal_per_tick)
+		owner.AdjustAllImmobility(-1 * stun_heal_per_second * seconds_between_ticks)
 		if(!knockdown_mod_applied)
 			apply_knockdown_mod()
 

--- a/code/datums/status_effects/debuffs/spacer.dm
+++ b/code/datums/status_effects/debuffs/spacer.dm
@@ -45,10 +45,10 @@
 
 	seconds_in_nograv += (seconds_between_ticks * 0.1)
 
-	if(seconds_in_nograv >= 2 MINUTES)
+	if(seconds_in_nograv >= 1 MINUTES)
 		// With 4 stamina healing per second you'd get out of stamcrit in 6 seconds instead of the usual 10
 		owner.adjust_stamina_loss(-1 * stamina_heal_per_second * seconds_between_ticks)
-	if(seconds_in_nograv >= 20 SECONDS)
+	if(seconds_in_nograv >= 10 SECONDS)
 		owner.AdjustAllImmobility(-1 * stun_heal_per_second * seconds_between_ticks)
 		if(!knockdown_mod_applied)
 			apply_knockdown_mod()

--- a/code/modules/reagents/chemistry/holder/mob_life.dm
+++ b/code/modules/reagents/chemistry/holder/mob_life.dm
@@ -106,7 +106,7 @@
 	if(tick_return & COMSIG_MOB_STOP_REAGENT_TICK)
 		return FALSE
 
-	if(liverless && !reagent.self_consuming) //need to be metabolized
+	if(liverless && !reagent.self_consuming) //need to be6 metabolized
 		return FALSE
 
 	var/need_mob_update = FALSE


### PR DESCRIPTION
## About The Pull Request

Cold damage modifier: 0.8x -> 0.66x (less damage)
Pressure damage modifier: 0.8x -> 0.66x (less damage)
Time between zero gravity drift modifier: 0.8x -> 0.75x (faster)
Floating speed modifier: -0.1 -> -0.15 (faster)
Speed modifier when on a planet map 0.25 -> 0.15 (faster)

Passive effects: Now ticks every second, rather than every three seconds (more uptime on the effects)
Passive effects: Disgust healing boost in nograv changed from 1x to 2x 
Passive effects: Stun reduction changed from 3 seconds / 3 seconds to 2 seconds / 1 second (2x boost)
Passive effects: Stamina healing changed from 3 / 3 seconds to 4 / 1 second (4x boost)
Passive effects: Stun reduction now activates after 10 seconds in zero gravity, down from 3 minutes (18x faster)
Passive effects: Stamina healing now activates after 1 minute, down from 3 minutes (3x faster)

Passive effects: After being in zero gravity for 10 seconds, reduces the duration of incoming knockdown effects by 0.75x 

## Why It's Good For The Game

> Cold damage modifier: 0.8x -> 0.66x (less damage)
> Pressure damage modifier: 0.8x -> 0.66x (less damage)

For cold damage, the numbers are quite small - 0.25 to 1.5 to the skin, and 0.5 to 3 to the lungs. It meant a 0.8x damage modifier amounted to very small differences, like 0.2 damage. Which though it added up was hardly noticeable. Pushing it up to 0.66x puts the reduction in the 0.5 damage range which is more immediately noticeable and adds up a lot faster. 
Pressure damage is a similar story, ranging from 2 to 5. 

> Time between zero gravity drift modifier: 0.8x -> 0.75x (faster)
> Floating speed modifier: -0.1 -> -0.15 (faster)

Spacers already kinda zoomed in zero grav with the existing values, but it was pretty hard to notice since you're not often floating along side someone for comparison. The thought here is just a slight nudge is needed. 

> Speed modifier when on a planet map 0.25 -> 0.15 (faster)

Reduces the innate punishment on being a planet, since it'd stack with your sanity for a double-whammy. 

> Passive effects: Now ticks every second, rather than every three seconds (more uptime on the effects)

Makes the effects more felt since you don't need to wait three seconds. Numbers were scaled around it. 

> Passive effects: Disgust healing boost in nograv changed from 1x to 2x 

For reference, Spacers innately decay disgust 2x faster so long as they're in space (not even needing no gravity), going up to 4x decay if they are in zero gravity. This increases it to 8x ultimately which should give immediate feedback for spacers who decide to take a dip in space when feeling ill.

> Passive effects: Stun reduction changed from 3 seconds / 3 seconds to 2 seconds / 1 second (2x boost)

For reference Nicotine reduces stuns by 2.5 seconds / second, so 2 seconds / second makes it about on par with Nicotine. 

> Passive effects: Stamina healing changed from 3 / 3 seconds to 4 / 1 second (4x boost)

This was originally intended as just a flavor effect since stamina regeneration can never truly be balanced. (Either it matters or it doesn't matter, there's no "matters a little bit" with stam regen) 
So I figure let's make it matter since it only triggers in no-grav anyways. 4 / 1 second means you get out of stamcrit after 6 seconds instead of 10 seconds which is definitely notable. 

> Passive effects: Stun reduction now activates after 10 seconds in zero gravity, down from 3 minutes (18x faster)

Really big change. This'll make the effect set in during the average gravity generator outage rather than only be triggered when you purposefully go for an extended spacewalk. Given it ultimately amounts to an effect similar to nicotine which is readily available, this seemed fair. 

> Passive effects: Stamina healing now activates after 1 minute, down from 3 minutes (3x faster)

Slightly less big change, but this means the effect is liable to kick in during a standard spacewalk, rather than only during extended spacewalks. 

> Passive effects: After being in zero gravity for 10 seconds, reduces the duration of incoming knockdown effects by 0.75x 

Bonus effect because I couldn't help myself. During a gravity generator outage you are faster to correct yourself upwards - This effect stacks with the passive stun reduction per second as well. You will definitely find it harder to keep a Spacer floored when they are free floating.

## Changelog

:cl: Melbert
balance: Spacer: Reduction to cold damage increased from 20% to 33%
balance: Spacer: Reduction to pressure damage increased from 20% to 33%
balance: Spacer: Zero gravity drift speed increased from 20% to 25%
balance: Spacer: Zero gravity floating speed increased from 10% to 15%
balance: Spacer: Move speed penalty on planetary maps reduced from 25% to 15%
balance: Spacer: Passive effects now trigger every second, rather than every three seconds
balance: Spacer: Disgust healing modifier while in zero gravity increased from 1x to 2x
balance: Spacer: Passive stun reduction in zero gravity changed from 3 seconds per 3 seconds to 2 seconds per second
balance: Spacer: Passive stamina healing in zero gravity changed from 3 stamina per 3 seconds to 4 stamina per second 
balance: Spacer: Passive stun reduction in zero gravity now activates after 10 seconds in zero gravity, down from 3 minutes
balance: Spacer: Passive stamina healing in zero gravity now activates after 1 minute, down from 3 minutes 
balance: Spacer: After being in zero gravity for 10 seconds, also reduces duration of knockdown effects by 25%
/:cl:
