### PR TITLE
[I ded] Xenomicrobes and Nanomachines are maintenance pill only

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1527,7 +1527,7 @@
 	color = "#535E66" // rgb: 83, 94, 102
 	taste_description = "sludge"
 	penetrates_skin = NONE
-	randomized_spawns = REAGENT_SPAWN_ALL_RANDOM_SPAWNS
+	randomized_spawns = REAGENT_SPAWN_MAINTENANCE_PILL
 
 /datum/reagent/cyborg_mutation_nanomachines/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message = TRUE, touch_protection = 0)
 	. = ..()
@@ -1543,7 +1543,7 @@
 	color = "#535E66" // rgb: 83, 94, 102
 	taste_description = "sludge"
 	penetrates_skin = NONE
-	randomized_spawns = REAGENT_SPAWN_ALL_RANDOM_SPAWNS
+	randomized_spawns = REAGENT_SPAWN_MAINTENANCE_PILL
 
 /datum/reagent/xenomicrobes/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message = TRUE, touch_protection = 0)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

These reagents are far too disruptive to the round to allow to be produced in the vast quantities and with the distribution vectors that botany offers. The amounts of them that can be procured through natural maintenance pill spawns and the silver-extract-exclusive food items containing them is still acceptable.

## Changelog

:cl:
balance: You can no longer get Xenomicrobes and Nanomachines from botany mutations.
/:cl:
