### PR TITLE
Gives a new small area for the extinguisher so it aint blocking trashcan

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -361,7 +361,6 @@
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 1
 	},
-/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "bf" = (
@@ -600,6 +599,10 @@
 /obj/machinery/light/floor,
 /turf/open/floor/mineral/titanium/blue,
 /area/ruin/powered/seedvault)
+"yq" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
 "Bb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/freezer,
@@ -691,9 +694,9 @@ aa
 aa
 aa
 ab
-ab
-aa
-aa
+ac
+ac
+ac
 aa
 aa
 aa
@@ -714,8 +717,8 @@ ac
 ac
 ac
 ac
+yq
 ac
-aa
 aa
 aa
 aa
@@ -736,7 +739,7 @@ OE
 ah
 ac
 ca
-ac
+ah
 ac
 ac
 ac

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -600,8 +600,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/ruin/powered/seedvault)
 "yq" = (
-/obj/structure/tank_holder/extinguisher,
-/turf/open/floor/iron/freezer,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/mineral/titanium/blue,
 /area/ruin/powered/seedvault)
 "Bb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -694,9 +695,9 @@ aa
 aa
 aa
 ab
-ac
-ac
-ac
+aa
+aa
+aa
 aa
 aa
 aa
@@ -717,7 +718,7 @@ ac
 ac
 ac
 ac
-yq
+ac
 ac
 aa
 aa
@@ -854,7 +855,7 @@ aT
 ac
 ac
 ac
-bb
+yq
 bb
 aN
 aN


### PR DESCRIPTION

## About The Pull Request
I was being bothered how I had first placed the fire extinguisher on the seedvault so I made a new place for it and placed it.
## Why It's Good For The Game
It makes it so the trashcan in seedvault isnt blocked but keeps the fire extinguisher
## Changelog
:cl:
fix:fixes a blocked trashcan from being blocked and moving the item that blocked it to a new area inside the ruin
/:cl:
<img width="257" height="333" alt="seed" src="https://github.com/user-attachments/assets/00e21365-ba12-41a4-93e6-e8608c7e5eb8" />
