### PR TITLE
Surviving heart attacks is not based on whether you recently exercised, but how fit you are.

### DIFF
--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -67,7 +67,7 @@
 	// Our fitness level can potentially block a heart attack outright.
 	var/fitness_protection_probability = winner.mind?.get_skill_modifier(/datum/skill/athletics, SKILL_RANDS_MODIFIER)
 
-	if(fitness_protection_probability && prob(fitness_protection_probability * 2)) //Stuff that should "block" a heart attack rather than just deny eligibility for one goes here.
+	if(prob(fitness_protection_probability * 2)) //Stuff that should "block" a heart attack rather than just deny eligibility for one goes here.
 		winner.visible_message(span_warning("[winner] grunts and clutches their chest for a moment, catching [winner.p_their()] breath."), span_medal("Your chest lurches in pain for a brief moment, which quickly fades. \
 								You feel like you've just avoided a serious health disaster."), span_hear("You hear someone's breathing sharpen for a moment, followed by a sigh of relief."), 4)
 		winner.playsound_local(get_turf(winner), 'sound/effects/health/slowbeat.ogg', 40, 0, channel = CHANNEL_HEARTBEAT, use_reverb = FALSE)

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -64,7 +64,10 @@
  */
 /datum/round_event/heart_attack/proc/attack_heart()
 	var/mob/living/carbon/human/winner = pick_weight(victims)
-	if(winner.has_status_effect(/datum/status_effect/exercised)) //Stuff that should "block" a heart attack rather than just deny eligibility for one goes here.
+	// Our fitness level can potentially block a heart attack outright.
+	var/fitness_protection_probability = winner.mind?.get_skill_modifier(/datum/skill/athletics, SKILL_RANDS_MODIFIER)
+
+	if(fitness_protection_probability && prob(fitness_protection_probability * 2)) //Stuff that should "block" a heart attack rather than just deny eligibility for one goes here.
 		winner.visible_message(span_warning("[winner] grunts and clutches their chest for a moment, catching [winner.p_their()] breath."), span_medal("Your chest lurches in pain for a brief moment, which quickly fades. \
 								You feel like you've just avoided a serious health disaster."), span_hear("You hear someone's breathing sharpen for a moment, followed by a sigh of relief."), 4)
 		winner.playsound_local(get_turf(winner), 'sound/effects/health/slowbeat.ogg', 40, 0, channel = CHANNEL_HEARTBEAT, use_reverb = FALSE)


### PR DESCRIPTION

## About The Pull Request

Rather than using the now extremely small exercised status effect to determine protection from heart attacks, instead we use the random probabilities from your athletics skill, multiplied by 2.

At Novice, you have a 10% chance to block a heart attack.

At Legendary, it's 100%.

## Why It's Good For The Game

It is unrealistic for this to occur naturally during the course of a round. You can spend literally your entire time lifting weights, and then die abruptly to a heart attack because the exercised status effect doesn't last a sufficient amount of time.

This achievement was made as a nod to someone who dedicated his life to physical fitness and wellbeing. It's only fitting that achieving peak physical fitness should be what saves you.

## Changelog
:cl:
qol: Your overall athletics level is what protects you from a random heart attack. If you achieve peak fitness, you are immune to random heart attacks.
/:cl:
