### PR TITLE
You can't dynamite fish from chest cavities

### DIFF
--- a/code/modules/fishing/sources/subtypes/surgery.dm
+++ b/code/modules/fishing/sources/subtypes/surgery.dm
@@ -10,6 +10,7 @@
 	fishing_difficulty = -10
 	//The range for waiting is also a bit narrower, so it cannot take as few as 3 seconds or as many as 25 to snatch an organ.
 	wait_time_range = list(6 SECONDS, 12 SECONDS)
+	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_NONE
 
 /datum/fish_source/surgery/spawn_reward(reward_path, atom/spawn_location, atom/fishing_spot, obj/item/fishing_rod/used_rod)
 	if(reward_path != FISHING_RANDOM_ORGAN)


### PR DESCRIPTION
## About The Pull Request

Fixes #95763

A comical intersection of sandbox elements has happened here: 
- You can fish with explosions
- You can fish from people with open cavities
- Skeletons(inc. Plasmamen) have open cavities at all times

This results in explosions blowing organs out of skeleton bodies which, while comical, is definitely not intended and overly punishing

## Changelog

:cl: Melbert
fix: Explosions won't remove organs from skeletons/plasmamen
/:cl: