### PR TITLE
You can be wabbajacked into a (sterile) blood worm

### DIFF
--- a/code/modules/antagonists/blood_worm/actions/cocoon.dm
+++ b/code/modules/antagonists/blood_worm/actions/cocoon.dm
@@ -407,3 +407,9 @@
 
 /obj/structure/blood_worm_cocoon/adult/examine(mob/user)
 	return ..() + span_warning("It can be broken to prevent the blood worm from reproducing, but it looks extremely tough.")
+
+/datum/action/cooldown/mob_cooldown/blood_worm/cocoon/hatchling/polymorph
+	new_worm_type = /mob/living/basic/blood_worm/juvenile/polymorph
+
+/datum/action/cooldown/mob_cooldown/blood_worm/cocoon/juvenile/polymorph
+	new_worm_type = /mob/living/basic/blood_worm/adult/polymorph

--- a/code/modules/antagonists/blood_worm/blood_worm_mob.dm
+++ b/code/modules/antagonists/blood_worm/blood_worm_mob.dm
@@ -398,3 +398,12 @@
 	transfuse_action = /datum/action/cooldown/mob_cooldown/blood_worm/inject/adult
 
 	regen_rate = 0.5 // 360 seconds to recover from 0 to 180, or exactly 6 minutes.
+
+/mob/living/basic/blood_worm/hatchling/polymorph
+	cocoon_action = /datum/action/cooldown/mob_cooldown/blood_worm/cocoon/hatchling/polymorph
+
+/mob/living/basic/blood_worm/juvenile/polymorph
+	cocoon_action = /datum/action/cooldown/mob_cooldown/blood_worm/cocoon/juvenile/polymorph
+
+/mob/living/basic/blood_worm/adult/polymorph
+	cocoon_action = null

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1589,6 +1589,7 @@
 				/mob/living/basic/bear/russian,
 				/mob/living/basic/blob_minion/blobbernaut,
 				/mob/living/basic/blob_minion/spore,
+				/mob/living/basic/blood_worm/hatchling/polymorph,
 				/mob/living/basic/butterfly,
 				/mob/living/basic/carp,
 				/mob/living/basic/carp/mega,


### PR DESCRIPTION
## About The Pull Request

Random polymorphs (like from the staff of change or the cursed spring) can turn you into a hatchling blood worm. This specific blood worm type is unable to reproduce, due to the rules headache this would result in if a non-antag bloodworm created antag bloodworms.

## Why It's Good For The Game

These types of random polymorphs can already turn people into headslugs, which can then become changelings. Why shouldn't they also be able to make blood worms?

## Changelog

:cl:
add: Random polymorphs can turn you into hatchling blood worms that can mature, but not reproduce.
/:cl:
