### PR TITLE
coroner's innate TRAIT_MORBID is changed to a skillchip

### DIFF
--- a/code/modules/jobs/job_types/coroner.dm
+++ b/code/modules/jobs/job_types/coroner.dm
@@ -12,7 +12,6 @@
 	outfit = /datum/outfit/job/coroner
 	plasmaman_outfit = /datum/outfit/plasmaman/coroner
 
-	mind_traits = list(TRAIT_MORBID)
 	desensitized_base = DESENSITIZED_THRESHOLD
 	liver_traits = list(TRAIT_CORONER_METABOLISM)
 
@@ -72,4 +71,7 @@
 	duffelbag = /obj/item/storage/backpack/duffelbag/coroner
 	messenger = /obj/item/storage/backpack/messenger/coroner
 
-	skillchips = list(/obj/item/skillchip/entrails_reader)
+	skillchips = list(
+		/obj/item/skillchip/entrails_reader,
+		/obj/item/skillchip/job/coroner,
+	)

--- a/code/modules/library/skill_learning/job_skillchips/coroner.dm
+++ b/code/modules/library/skill_learning/job_skillchips/coroner.dm
@@ -1,0 +1,9 @@
+/obj/item/skillchip/job/coroner
+	name = "BU1CHR Desensitization Skillchip"
+	desc = "A skillchip for Coroners to help desensitize them. May have unintended side effects."
+	auto_traits = list(TRAIT_MORBID)
+	skill_name = "Morbid Procedures"
+	skill_description = "Quicken operations on the deceased."
+	skill_icon = FA_ICON_USER_DOCTOR
+	activate_message = span_notice("Your view on life suddenly takes a dark turn.")
+	deactivate_message = span_notice("Dark thoughts clear from your mind. Your outlook on life is much less morbid.")

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -386,6 +386,8 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	premium = list(
 		/obj/item/autopsy_scanner = 1,
 		/obj/item/storage/medkit/coroner = 1,
+		/obj/item/skillchip/job/coroner = 1,
+		
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/coroner_wardrobe
 	payment_department = ACCOUNT_MED

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4860,6 +4860,7 @@
 #include "code\modules\library\skill_learning\job_skillchips\_job.dm"
 #include "code\modules\library\skill_learning\job_skillchips\chef.dm"
 #include "code\modules\library\skill_learning\job_skillchips\clown.dm"
+#include "code\modules\library\skill_learning\job_skillchips\coroner.dm"
 #include "code\modules\library\skill_learning\job_skillchips\detective.dm"
 #include "code\modules\library\skill_learning\job_skillchips\janitor.dm"
 #include "code\modules\library\skill_learning\job_skillchips\miner.dm"


### PR DESCRIPTION

## About The Pull Request

adds the "BU1CHR Desensitization Skillchip" to Coroner as a job skillchip. Coroners spawn with this, and there's additionally one for sale in the coroner vendor under the premium section. This skillchip grants TRAIT_MORBID, and consequently the innate TRAIT_MORBID has been removed from coroner.

## Why It's Good For The Game

mind traits locked to jobs really is shitty. it means, effectively, that nobody can be promoted to that job because they will be innately worse by default. (coroner's trait makes use of the morbid tools work at the same speed as advanced tools, but only on corpses, and there's some fun flavor text as well that requires TRAIT_MORBID). it also means that coroners are innately, irreparably worse at being normal doctors due to some of the debuffs associated with TRAIT_MORBID. this can't be abused as there is a 5 minute cooldown on toggling skillchips, and really all it does is make the coroner role and coroner content more flexible ~~and enable Mortuary Assistant gameplay~~

## Changelog
:cl:
add: Coroners now gain TRAIT_MORBID from a skillchip (which they spawn with) rather than being an innate property of signing up as a coroner
add: the coroner skillchip
add: the coroner's vendor sells 1 coroner skillchip at a premium price
/:cl:
