### PR TITLE
Coroners start wtih their morbid nature suppressed.

### DIFF
--- a/code/modules/jobs/job_types/coroner.dm
+++ b/code/modules/jobs/job_types/coroner.dm
@@ -12,7 +12,6 @@
 	outfit = /datum/outfit/job/coroner
 	plasmaman_outfit = /datum/outfit/plasmaman/coroner
 
-	mind_traits = list(TRAIT_MORBID)
 	desensitized_base = DESENSITIZED_THRESHOLD
 	liver_traits = list(TRAIT_CORONER_METABOLISM)
 
@@ -72,4 +71,7 @@
 	duffelbag = /obj/item/storage/backpack/duffelbag/coroner
 	messenger = /obj/item/storage/backpack/messenger/coroner
 
-	skillchips = list(/obj/item/skillchip/entrails_reader)
+	skillchips = list(
+		/obj/item/skillchip/entrails_reader,
+		/obj/item/skillchip/morbid_suppression/coroner,
+		)

--- a/code/modules/library/skill_learning/generic_skillchips/morbid_suppression.dm
+++ b/code/modules/library/skill_learning/generic_skillchips/morbid_suppression.dm
@@ -28,7 +28,7 @@
 
 	if(user.mind && removed_trait)
 		ADD_TRAIT(user.mind, TRAIT_MORBID, JOB_TRAIT)
-		to_chat(span_hypnophrase("The stillness of death. I must understand it again. I yearn observe it. I must learn the secrets kept within pallid flesh..."))
+		to_chat(user, span_hypnophrase("The stillness of death. I must understand it again. I yearn observe it. I must learn the secrets kept within pallid flesh..."))
 		removed_trait = FALSE
 
 /obj/item/skillchip/morbid_suppression/coroner

--- a/code/modules/library/skill_learning/generic_skillchips/morbid_suppression.dm
+++ b/code/modules/library/skill_learning/generic_skillchips/morbid_suppression.dm
@@ -1,0 +1,38 @@
+/obj/item/skillchip/morbid_suppression
+	name = "S0C-14L suppression chip"
+	desc = "Similar to a skillchip, but operating with the reverse logic. Once installed into the brain, the chip acts as a \
+		neural regulator, suppressing any desires or thought patterns deemed to be 'anti-social'. Some consider this a clear \
+		sign of indoctrination. But for others, this proves to be the only means to obtaining a relatively normal and stable \
+		life amongst the stars. Doesn't seem to suppress felinid feralization syndrome, much to the chagrin of medical professionals \
+		everywhere."
+	skill_name = "Mental Stability"
+	skill_description = "Helps you to keep yourself under control."
+	skill_icon = FA_ICON_USER_DOCTOR
+	activate_message = span_notice("You feel fine. Everything is fine. The chip is working. You can have a normal day at work now.")
+	deactivate_message = span_warning("You feel your mind become vulnerable to it's deepest desires...")
+	removable = FALSE
+	no_deactivation = TRUE
+	cooldown = 1 SECONDS
+	// If the chip actually removed the trait on activation, we will readd it on extraction. If you were never morbid, nothing changes.
+	var/removed_trait = FALSE
+
+/obj/item/skillchip/morbid_suppression/on_activate(mob/living/carbon/user, silent = FALSE)
+	. = ..()
+
+	if(HAS_MIND_TRAIT(user, TRAIT_MORBID) && user.mind)
+		REMOVE_TRAIT(user.mind, TRAIT_MORBID, type)
+		removed_trait = TRUE
+
+/obj/item/skillchip/morbid_suppression/on_deactivate(mob/living/carbon/user, silent = FALSE)
+	. = ..()
+
+	if(user.mind && removed_trait)
+		ADD_TRAIT(user.mind, TRAIT_MORBID, JOB_TRAIT)
+		to_chat(span_hypnophrase("The stillness of death. I must understand it again. I yearn observe it. I must learn the secrets kept within pallid flesh..."))
+		removed_trait = FALSE
+
+/obj/item/skillchip/morbid_suppression/coroner
+	// This version starts true so that it will always give the trait on removal.
+	removed_trait = TRUE
+
+

--- a/code/modules/library/skill_learning/skillchip.dm
+++ b/code/modules/library/skill_learning/skillchip.dm
@@ -29,6 +29,8 @@
 	var/deactivate_message
 	//If set to FALSE, trying to extract the chip will destroy it instead
 	var/removable
+	// If set to TRUE, the chip, once activated, cannot then be deactivated without removal.
+	var/no_deactivation = FALSE
 	/// How complex the skillchip is. Brains can only handle so much complexity at once and skillchips will start to deactivate when the brain's complexity limit is exceeded.
 	var/complexity = 1
 	/// How many slots taken up in the brain by this chip. Max brain slots are hard set and should not be changed at all.
@@ -120,6 +122,10 @@
 	if(force)
 		on_deactivate(brain_owner, silent)
 		return
+
+	// If we haven't forced this, and the chip simply cannot be deactivated, do not deactivate.
+	if(no_deactivation)
+		return "Skillchip can't be deactivated."
 
 	// Is the chip still experiencing a cooldown period?
 	if(!COOLDOWN_FINISHED(src, chip_cooldown))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4853,6 +4853,7 @@
 #include "code\modules\library\skill_learning\generic_skillchips\acrobatics.dm"
 #include "code\modules\library\skill_learning\generic_skillchips\matrix_taunt.dm"
 #include "code\modules\library\skill_learning\generic_skillchips\misc.dm"
+#include "code\modules\library\skill_learning\generic_skillchips\morbid_suppression.dm"
 #include "code\modules\library\skill_learning\generic_skillchips\musical.dm"
 #include "code\modules\library\skill_learning\generic_skillchips\point.dm"
 #include "code\modules\library\skill_learning\generic_skillchips\self_surgery.dm"


### PR DESCRIPTION

## About The Pull Request

Coroners start the shift with a new 'skillchip'. A suppression chip that keeps them normal, just like any other crew member.

If the chip is removed (it cannot be deactivated), the user turns morbid.

## Why It's Good For The Game

Kind of an alt to #96021 but mostly because it reminded me I said I would do this.

Some people expressed that they did not want to be morbid while coroner, since it kind of implied a few things about their character they didn't enjoy. Some folk really enjoy the flavour, and the benefits. For others, it doesn't work for them, and they don't care about the benefits.

As a result, I said I'd probably look at adding some kind of reverse skill chip that would turn the coroner morbid if removed.

It's more interesting than just letting it be some kind of toggle.

## Changelog
:cl:
qol: Coroners start the round with a suppression 'skill'chip, making them normal again. But if removed, they become morbid.
/:cl:
