### PR TITLE
Fixes voidwalker vomit jump breaking if someone vomits far away

### DIFF
--- a/code/_onclick/hud/screen_objects/voidwalker.dm
+++ b/code/_onclick/hud/screen_objects/voidwalker.dm
@@ -56,7 +56,7 @@
 
 	for(var/atom/movable/vomit as anything in GLOB.nebula_vomits)
 		if(!is_station_level(vomit.z))
-			return
+			continue
 
 		valid_vomits += vomit
 	return valid_vomits


### PR DESCRIPTION
closes #96020

When it's making a list of valid nebula vomits, it exits and returns null the moment a nebula vomit is off the station z-level. This causes a runtime when trying to vomit jump

:cl:
fix: Fixes voidwalker being unable to vomit jump if anyone vomits on a non-station z-level
/:cl: