### PR TITLE
Moves GBP balance from my old accounts to new one

### DIFF
--- a/.github/gbp-balances.toml
+++ b/.github/gbp-balances.toml
@@ -372,7 +372,6 @@
 20830349 = 6 # Peliex
 20852857 = 8 # RandolfTheMeh
 20977204 = 20 # NotRanged
-20987591 = 170 # AMonkeyThatCodes
 20996272 = 5 # factoryman942
 21011228 = 6 # xmikey555
 21224958 = 3 # Xsdew
@@ -1237,7 +1236,6 @@
 110273561 = 3 # ReturnToZender
 110322848 = 29 # CoiledLamb
 110352801 = 14 # LucyGrind
-110635252 = 48 # CapybaraExtravagante
 110736853 = 6 # spessmanturtle
 110812394 = 1613 # SyncIt21
 110836368 = 3 # NPC1314
@@ -1376,4 +1374,4 @@
 250045329 = 3 # BingusTheClown
 260140000 = 3 # matchalabubu67
 
-279736348 = 13 # CabinetOnFire
+279736348 = 360 # CabinetOnFire


### PR DESCRIPTION

<img width="987" height="56" alt="image" src="https://github.com/user-attachments/assets/8240d3cf-373f-4f2d-b3f0-5cf3da646b1a" />

Using the following ones as reference:

https://github.com/tgstation/tgstation/blob/1145a2171b50d9309129625679702daad771c32c/.github/gbp-balances.toml#L285C1-L285C27 129 (was removed when I deleted the acc)
https://github.com/tgstation/tgstation/blob/gbp-balances/.github/gbp-balances.toml#L1240 48
https://github.com/tgstation/tgstation/blob/gbp-balances/.github/gbp-balances.toml#L375 170
