### PR TITLE
Stumps inherit (most) biostates

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -948,7 +948,7 @@
 			var/obj/item/bodypart/stump = new old_bodypart.stump_typepath()
 			stump.bodyshape = old_bodypart.bodyshape
 			stump.bodytype = old_bodypart.bodytype
-			stump.add_biostate(old_bodypart.biological_state)
+			stump.add_biostate(old_bodypart.biological_state & ~BIO_JOINTED)
 			if(!stump.try_attach_limb(src, special = TRUE))
 				// the only way this can happen is if the stump is rejected via signal
 				// not much we can do about that besides hope they know what they're doing

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -948,6 +948,7 @@
 			var/obj/item/bodypart/stump = new old_bodypart.stump_typepath()
 			stump.bodyshape = old_bodypart.bodyshape
 			stump.bodytype = old_bodypart.bodytype
+			stump.add_biostate(old_bodypart.biological_state)
 			if(!stump.try_attach_limb(src, special = TRUE))
 				// the only way this can happen is if the stump is rejected via signal
 				// not much we can do about that besides hope they know what they're doing

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1843,13 +1843,18 @@
 	if(biological_state & new_biostate)
 		return
 
-	if(!LIMB_HAS_SKIN(src) && (new_biostate & BIOSTATE_HAS_SKIN))
-		remove_surgical_state(SKINLESS_SURGERY_STATES)
-	if(!LIMB_HAS_BONES(src) && (new_biostate & BIOSTATE_HAS_BONES))
-		remove_surgical_state(BONELESS_SURGERY_STATES)
-	if(!LIMB_HAS_VESSELS(src) && (new_biostate & BIOSTATE_HAS_VESSELS))
-		remove_surgical_state(VESSELLESS_SURGERY_STATES)
+	var/had_skin = LIMB_HAS_SKIN(src)
+	var/had_bones = LIMB_HAS_BONES(src)
+	var/had_vessels = LIMB_HAS_VESSELS(src)
+
 	biological_state |= new_biostate
+
+	if(!had_skin && LIMB_HAS_SKIN(src))
+		remove_surgical_state(SKINLESS_SURGERY_STATES)
+	if(!had_bones && LIMB_HAS_BONES(src))
+		remove_surgical_state(BONELESS_SURGERY_STATES)
+	if(!had_vessels && LIMB_HAS_VESSELS(src))
+		remove_surgical_state(VESSELLESS_SURGERY_STATES)
 
 /// Removes biostate from the limb and ensures surgical states are updated accordingly
 /obj/item/bodypart/proc/remove_biostate(old_biostate)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1837,3 +1837,29 @@
 	var/old_state = surgery_state
 	. = ..()
 	update_surgical_state(old_state, surgery_state ^ old_state)
+
+/// Adds biostate to the limb and ensures surgical states are updated accordingly
+/obj/item/bodypart/proc/add_biostate(new_biostate)
+	if(biological_state & new_biostate)
+		return
+
+	if(!LIMB_HAS_SKIN(src) && (new_biostate & BIOSTATE_HAS_SKIN))
+		remove_surgical_state(SKINLESS_SURGERY_STATES)
+	if(!LIMB_HAS_BONES(src) && (new_biostate & BIOSTATE_HAS_BONES))
+		remove_surgical_state(BONELESS_SURGERY_STATES)
+	if(!LIMB_HAS_VESSELS(src) && (new_biostate & BIOSTATE_HAS_VESSELS))
+		remove_surgical_state(VESSELLESS_SURGERY_STATES)
+	biological_state |= new_biostate
+
+/// Removes biostate from the limb and ensures surgical states are updated accordingly
+/obj/item/bodypart/proc/remove_biostate(old_biostate)
+	if(!(biological_state & old_biostate))
+		return
+
+	biological_state &= ~old_biostate
+	if(!LIMB_HAS_SKIN(src))
+		add_surgical_state(SKINLESS_SURGERY_STATES)
+	if(!LIMB_HAS_BONES(src))
+		add_surgical_state(BONELESS_SURGERY_STATES)
+	if(!LIMB_HAS_VESSELS(src))
+		add_surgical_state(VESSELLESS_SURGERY_STATES)


### PR DESCRIPTION
## About The Pull Request

Stumps inherit the biological state of the bodypart it is spawned from

## Why It's Good For The Game

Right now, since they have a biostate of "nothing", they have all surgical states, which means you don't have to do any surgery on them to re-attach them. Which is obviously not intended. 

Now they're just inherit (most) biostates from their parent, meaning re-attaching limbs requires incise -> retract again. Unless the limb had no bones like skeleton limbs.

## Changelog

:cl: Melbert
fix: Re-adding limbs surgically requires you do surgery again (ie, incise -> retract -> clamp). 
/:cl:
