### PR TITLE
Fixes spawn panel incorrectly spawning turfs

### DIFF
--- a/code/modules/admin/spawn_panel/spawn_handling.dm
+++ b/code/modules/admin/spawn_panel/spawn_handling.dm
@@ -96,8 +96,8 @@
 		pod = new()
 
 	for(var/i in 1 to amount)
-		if(istype(atom_to_spawn, /turf))
-			var/turf/original_turf = target
+		if(ispath(atom_to_spawn, /turf))
+			var/turf/original_turf = get_turf(target) //Get_turf is required here, because if target is not a turf we are cooked chat.
 			var/turf/created_turf = original_turf.ChangeTurf(atom_to_spawn.type)
 			if(created_turf && atom_name)
 				created_turf.name = atom_name


### PR DESCRIPTION

## About The Pull Request
The spawn panel was incorrectly spawning turfs by creating them via new, which causes a lot of issues. this issue was caused by two things:
1. It was checking if the atom_to_spawn was a turf via istype, istype uses instances
2. It was spawning it on target; god knows what happens if you try to spawn a turf in your hands.

## Why It's Good For The Game

bug fix good happy make

## Changelog

:cl:
fix: Fixes the spawn panel being unable to spawn turfs
/:cl:
