### PR TITLE
Add a "Prison Block" holodeck map

### DIFF
--- a/_maps/templates/holodeck_prison.dmm
+++ b/_maps/templates/holodeck_prison.dmm
@@ -3,6 +3,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
+/obj/item/dice/d6,
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "b" = (
@@ -64,6 +65,14 @@
 	},
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
+"j" = (
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/holofloor/dark,
+/area/template_noop)
 "k" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -110,10 +119,9 @@
 /turf/open/floor/holofloor,
 /area/template_noop)
 "s" = (
-/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
-	id = "Holodeck Cell 2";
-	name = "Cell 2";
-	dir = 1
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/north{
+	name = "Holodeck Cell 2";
+	id = "Holodeck Cell 2"
 	},
 /turf/open/floor/holofloor,
 /area/template_noop)
@@ -126,10 +134,9 @@
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
 "u" = (
-/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
-	id = "Holodeck Cell 1";
-	name = "Cell 1";
-	dir = 1
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/north{
+	name = "Holodeck Cell 1";
+	id = "Holodeck Cell 1"
 	},
 /turf/open/floor/holofloor,
 /area/template_noop)
@@ -139,7 +146,6 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/red,
-/obj/item/dice/d6,
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "w" = (
@@ -214,14 +220,6 @@
 	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
-"F" = (
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/holofloor/dark,
-/area/template_noop)
 "G" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -252,6 +250,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
+/obj/item/toy/figure/prisoner,
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "K" = (
@@ -313,7 +312,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/obj/item/toy/figure/prisoner,
 /obj/effect/turf_decal/board_number/two,
 /obj/machinery/flasher/directional/west{
 	id = "Holodeck Cell 2";
@@ -401,7 +399,7 @@ E
 "}
 (5,1,1) = {"
 B
-F
+j
 R
 K
 Z

--- a/_maps/templates/holodeck_prison.dmm
+++ b/_maps/templates/holodeck_prison.dmm
@@ -3,9 +3,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "b" = (
@@ -20,9 +17,6 @@
 	},
 /obj/structure/closet/secure_closet/brig{
 	req_one_access = null
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
@@ -77,9 +71,6 @@
 /obj/structure/closet/secure_closet/brig{
 	req_one_access = null
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "l" = (
@@ -111,13 +102,11 @@
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "q" = (
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/holofloor,
 /area/template_noop)
 "r" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/holofloor,
 /area/template_noop)
 "s" = (
@@ -154,9 +143,7 @@
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "w" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/holofloor,
 /area/template_noop)
 "x" = (
@@ -184,9 +171,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/item/instrument/harmonica,
 /turf/open/floor/holofloor/white,
 /area/template_noop)
@@ -200,6 +184,8 @@
 	pixel_x = 4;
 	pixel_y = -3
 	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
 "C" = (
@@ -226,10 +212,15 @@
 /obj/structure/closet/secure_closet/brig{
 	req_one_access = null
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/open/floor/holofloor/white,
+/area/template_noop)
+"F" = (
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/holofloor/dark,
 /area/template_noop)
 "G" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -255,17 +246,11 @@
 /obj/structure/closet/secure_closet/brig{
 	req_one_access = null
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "J" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
@@ -297,9 +282,6 @@
 "P" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
-	},
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /obj/item/coin/antagtoken,
 /turf/open/floor/holofloor/white,
@@ -352,23 +334,17 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
 "W" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/holofloor,
 /area/template_noop)
 "X" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/holofloor,
-/area/template_noop)
-"Y" = (
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/turf/open/floor/holofloor/dark,
 /area/template_noop)
 "Z" = (
 /obj/structure/chair/comfy/black,
@@ -425,7 +401,7 @@ E
 "}
 (5,1,1) = {"
 B
-Y
+F
 R
 K
 Z

--- a/_maps/templates/holodeck_prison.dmm
+++ b/_maps/templates/holodeck_prison.dmm
@@ -1,0 +1,456 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"b" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/template_noop)
+"c" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/structure/closet/secure_closet/brig{
+	req_one_access = null
+	},
+/obj/machinery/flasher/directional/west{
+	id = "Holodeck Cell 4"
+	},
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"d" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/holofloor,
+/area/template_noop)
+"e" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/board_number/four,
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"f" = (
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
+	id = "Holodeck Cell 4";
+	name = "Cell 4"
+	},
+/turf/open/floor/holofloor,
+/area/template_noop)
+"g" = (
+/obj/structure/table,
+/obj/machinery/button/flasher{
+	id = "Holodeck Cell 2";
+	name = "Cell 2";
+	pixel_y = 8
+	},
+/obj/machinery/button/flasher{
+	id = "Holodeck Cell 4";
+	name = "Cell 4";
+	pixel_y = -3
+	},
+/turf/open/floor/holofloor/dark,
+/area/template_noop)
+"h" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/turf/open/floor/holofloor/dark,
+/area/template_noop)
+"k" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/structure/closet/secure_closet/brig{
+	req_one_access = null
+	},
+/obj/machinery/flasher/directional/west{
+	id = "Holodeck Cell 2"
+	},
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"l" = (
+/obj/machinery/status_display/door_timer{
+	id = "Holodeck Cell 2";
+	req_access = null;
+	name = "Cell 2"
+	},
+/turf/closed/wall,
+/area/template_noop)
+"o" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/board_number/three,
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"p" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"q" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/holofloor,
+/area/template_noop)
+"r" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/holofloor,
+/area/template_noop)
+"s" = (
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
+	id = "Holodeck Cell 2";
+	name = "Cell 2";
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/template_noop)
+"t" = (
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_y = 13
+	},
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/holofloor/dark,
+/area/template_noop)
+"u" = (
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
+	id = "Holodeck Cell 1";
+	name = "Cell 1";
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/template_noop)
+"v" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/obj/item/dice/d6,
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"w" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/template_noop)
+"x" = (
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
+	id = "Holodeck Cell 3";
+	name = "Cell 3"
+	},
+/turf/open/floor/holofloor,
+/area/template_noop)
+"y" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"z" = (
+/obj/machinery/computer/records/security{
+	dir = 8
+	},
+/turf/open/floor/holofloor/dark,
+/area/template_noop)
+"A" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/instrument/harmonica,
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"B" = (
+/turf/closed/wall,
+/area/template_noop)
+"C" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/item/bedsheet/red,
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"D" = (
+/obj/machinery/status_display/door_timer{
+	id = "Holodeck Cell 1";
+	name = "Cell 1";
+	req_access = null
+	},
+/turf/closed/wall,
+/area/template_noop)
+"E" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/structure/closet/secure_closet/brig{
+	req_one_access = null
+	},
+/obj/machinery/flasher/directional/east{
+	id = "Holodeck Cell 3"
+	},
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"G" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/holofloor,
+/area/template_noop)
+"H" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/board_number/one,
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"I" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/brig{
+	req_one_access = null
+	},
+/obj/machinery/flasher/directional/east{
+	id = "Holodeck Cell 1"
+	},
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"J" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"K" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/holofloor,
+/area/template_noop)
+"L" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/holofloor,
+/area/template_noop)
+"M" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/template_noop)
+"N" = (
+/obj/machinery/status_display/door_timer{
+	id = "Holodeck Cell 4";
+	req_access = null;
+	name = "Cell 4"
+	},
+/turf/closed/wall,
+/area/template_noop)
+"P" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/coin/antagtoken,
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"Q" = (
+/obj/structure/table,
+/obj/machinery/button/flasher{
+	id = "Holodeck Cell 3";
+	name = "Cell 3";
+	pixel_y = -3
+	},
+/obj/machinery/button/flasher{
+	id = "Holodeck Cell 1";
+	name = "Cell 1";
+	pixel_y = 8
+	},
+/turf/open/floor/holofloor/dark,
+/area/template_noop)
+"R" = (
+/turf/open/floor/holofloor,
+/area/template_noop)
+"S" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/holofloor,
+/area/template_noop)
+"T" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/item/toy/figure/prisoner,
+/obj/effect/turf_decal/board_number/two,
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"U" = (
+/obj/machinery/status_display/door_timer{
+	id = "Holodeck Cell 3";
+	req_access = null;
+	name = "Cell 3"
+	},
+/turf/closed/wall,
+/area/template_noop)
+"V" = (
+/obj/structure/rack,
+/obj/item/restraints/handcuffs{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/restraints/handcuffs{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/turf/open/floor/holofloor/dark,
+/area/template_noop)
+"W" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/holofloor,
+/area/template_noop)
+"X" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/holofloor,
+/area/template_noop)
+"Z" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/holofloor/dark,
+/area/template_noop)
+
+(1,1,1) = {"
+R
+R
+R
+R
+R
+R
+R
+R
+R
+R
+"}
+(2,1,1) = {"
+r
+r
+R
+X
+S
+S
+G
+R
+r
+r
+"}
+(3,1,1) = {"
+C
+H
+u
+K
+D
+U
+b
+x
+o
+p
+"}
+(4,1,1) = {"
+I
+P
+w
+K
+h
+Q
+b
+q
+A
+E
+"}
+(5,1,1) = {"
+B
+V
+R
+K
+Z
+t
+b
+R
+V
+B
+"}
+(6,1,1) = {"
+k
+J
+w
+K
+z
+g
+b
+q
+a
+c
+"}
+(7,1,1) = {"
+y
+T
+s
+K
+l
+N
+b
+f
+e
+v
+"}
+(8,1,1) = {"
+W
+W
+R
+L
+d
+d
+M
+R
+W
+W
+"}
+(9,1,1) = {"
+R
+R
+R
+R
+R
+R
+R
+R
+R
+R
+"}

--- a/_maps/templates/holodeck_prison.dmm
+++ b/_maps/templates/holodeck_prison.dmm
@@ -1,11 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/obj/item/dice/d6,
-/turf/open/floor/holofloor/white,
-/area/template_noop)
 "b" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -13,13 +6,8 @@
 /turf/open/floor/holofloor,
 /area/template_noop)
 "c" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/structure/closet/secure_closet/brig{
-	req_one_access = null
-	},
-/turf/open/floor/holofloor/white,
+/obj/effect/turf_decal/caution,
+/turf/open/floor/holofloor/dark,
 /area/template_noop)
 "d" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -28,22 +16,21 @@
 /turf/open/floor/holofloor,
 /area/template_noop)
 "e" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/board_number/four,
-/obj/machinery/flasher/directional/west{
-	id = "Holodeck Cell 4";
-	pixel_x = 0
-	},
-/turf/open/floor/holofloor/white,
-/area/template_noop)
-"f" = (
-/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
-	id = "Holodeck Cell 4";
-	name = "Cell 4"
+/obj/effect/turf_decal/board_number/two{
+	pixel_y = 21
 	},
 /turf/open/floor/holofloor,
+/area/template_noop)
+"f" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/machinery/flasher/directional/east{
+	id = "Holodeck Cell 3";
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/holofloor/white,
 /area/template_noop)
 "g" = (
 /obj/structure/table,
@@ -57,6 +44,14 @@
 	name = "Cell 4";
 	pixel_y = -3
 	},
+/obj/item/restraints/handcuffs{
+	pixel_x = -17;
+	pixel_y = 9
+	},
+/obj/item/restraints/handcuffs{
+	pixel_x = -17;
+	pixel_y = -3
+	},
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
 "h" = (
@@ -66,21 +61,19 @@
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
 "j" = (
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/holofloor/dark,
-/area/template_noop)
-"k" = (
+/obj/structure/bed,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/obj/structure/closet/secure_closet/brig{
-	req_one_access = null
-	},
+/obj/item/bedsheet/red,
 /turf/open/floor/holofloor/white,
+/area/template_noop)
+"k" = (
+/obj/structure/chair/e_chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/holofloor/dark,
 /area/template_noop)
 "l" = (
 /obj/machinery/status_display/door_timer{
@@ -91,38 +84,46 @@
 /obj/structure/table,
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
-"o" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/board_number/three,
-/obj/machinery/flasher/directional/east{
-	id = "Holodeck Cell 3";
-	pixel_x = 0
-	},
-/turf/open/floor/holofloor/white,
-/area/template_noop)
-"p" = (
+"n" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/red,
+/obj/structure/closet/secure_closet/brig/holodeck{
+	id = "Holodeck Cell 4"
+	},
+/turf/open/floor/holofloor/white,
+/area/template_noop)
+"o" = (
+/obj/effect/turf_decal/board_number/four,
+/turf/open/floor/holofloor,
+/area/template_noop)
+"p" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/item/instrument/harmonica,
+/obj/machinery/door/window/brigdoor/security/holodeck/left/directional/north{
+	id = "Holodeck Cell 3";
+	name = "Cell 3"
+	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "q" = (
-/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/board_number/one{
+	pixel_y = 21
+	},
 /turf/open/floor/holofloor,
 /area/template_noop)
 "r" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/holofloor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/structure/closet/secure_closet/brig/holodeck{
+	id = "Holodeck Cell 3"
+	},
+/turf/open/floor/holofloor/white,
 /area/template_noop)
 "s" = (
-/obj/machinery/door/window/brigdoor/security/cell/left/directional/north{
-	name = "Holodeck Cell 2";
-	id = "Holodeck Cell 2"
-	},
 /turf/open/floor/holofloor,
 /area/template_noop)
 "t" = (
@@ -131,41 +132,45 @@
 	},
 /obj/structure/table,
 /obj/machinery/recharger,
+/obj/item/restraints/handcuffs{
+	pixel_x = -17;
+	pixel_y = 9
+	},
+/obj/item/restraints/handcuffs{
+	pixel_x = -17;
+	pixel_y = -3
+	},
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
 "u" = (
-/obj/machinery/door/window/brigdoor/security/cell/left/directional/north{
-	name = "Holodeck Cell 1";
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/brig/holodeck{
 	id = "Holodeck Cell 1"
 	},
-/turf/open/floor/holofloor,
+/turf/open/floor/holofloor/white,
 /area/template_noop)
 "v" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
+	dir = 9
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/red,
+/obj/structure/closet/secure_closet/brig/holodeck{
+	id = "Holodeck Cell 2"
+	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
-"w" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/holofloor,
-/area/template_noop)
 "x" = (
-/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
-	id = "Holodeck Cell 3";
-	name = "Cell 3"
-	},
-/turf/open/floor/holofloor,
-/area/template_noop)
-"y" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/red,
 /turf/open/floor/holofloor/white,
+/area/template_noop)
+"y" = (
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/holofloor/dark,
 /area/template_noop)
 "z" = (
 /obj/machinery/computer/records/security{
@@ -174,32 +179,26 @@
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
 "A" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 1
 	},
-/obj/item/instrument/harmonica,
-/turf/open/floor/holofloor/white,
+/turf/open/floor/holofloor/dark,
 /area/template_noop)
 "B" = (
-/obj/structure/rack,
-/obj/item/restraints/handcuffs{
-	pixel_x = -3;
-	pixel_y = 5
+/obj/structure/closet{
+	name = "evidence closet"
 	},
-/obj/item/restraints/handcuffs{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
 "C" = (
-/obj/structure/bed,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+	dir = 6
 	},
-/obj/item/bedsheet/red,
+/obj/item/coin/antagtoken,
+/obj/machinery/door/window/brigdoor/security/holodeck/left/directional/south{
+	id = "Holodeck Cell 1";
+	name = "Cell 1"
+	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "D" = (
@@ -211,15 +210,6 @@
 /obj/structure/table,
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
-"E" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/obj/structure/closet/secure_closet/brig{
-	req_one_access = null
-	},
-/turf/open/floor/holofloor/white,
-/area/template_noop)
 "G" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -228,30 +218,29 @@
 /area/template_noop)
 "H" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
+	dir = 6
 	},
-/obj/effect/turf_decal/board_number/one,
-/obj/machinery/flasher/directional/east{
-	id = "Holodeck Cell 1";
-	pixel_x = 0
+/obj/machinery/flasher/directional/west{
+	id = "Holodeck Cell 2";
+	pixel_x = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "I" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
+	dir = 10
 	},
-/obj/structure/closet/secure_closet/brig{
-	req_one_access = null
+/obj/machinery/flasher/directional/east{
+	id = "Holodeck Cell 1";
+	pixel_x = 0
 	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "J" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/item/toy/figure/prisoner,
-/turf/open/floor/holofloor/white,
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/turf/open/floor/holofloor/dark,
 /area/template_noop)
 "K" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -278,11 +267,26 @@
 /obj/structure/table,
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
+"O" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/machinery/flasher/directional/west{
+	id = "Holodeck Cell 4";
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/holofloor/white,
+/area/template_noop)
 "P" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
+	dir = 9
 	},
-/obj/item/coin/antagtoken,
+/obj/item/dice/d6,
+/obj/machinery/door/window/brigdoor/security/holodeck/right/directional/north{
+	name = "Cell 4";
+	id = "Holodeck Cell 4"
+	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "Q" = (
@@ -300,6 +304,7 @@
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
 "R" = (
+/obj/effect/turf_decal/board_number/three,
 /turf/open/floor/holofloor,
 /area/template_noop)
 "S" = (
@@ -312,11 +317,8 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/obj/effect/turf_decal/board_number/two,
-/obj/machinery/flasher/directional/west{
-	id = "Holodeck Cell 2";
-	pixel_x = 1
-	},
+/obj/structure/bed,
+/obj/item/bedsheet/red,
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "U" = (
@@ -329,20 +331,34 @@
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
 "V" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
 "W" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/holofloor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/item/toy/figure/prisoner,
+/obj/machinery/door/window/brigdoor/security/holodeck/right/directional/south{
+	name = "Cell 2";
+	id = "Holodeck Cell 2"
+	},
+/turf/open/floor/holofloor/white,
 /area/template_noop)
 "X" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/holofloor,
+/area/template_noop)
+"Y" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/open/floor/holofloor/white,
 /area/template_noop)
 "Z" = (
 /obj/structure/chair/comfy/black,
@@ -350,110 +366,110 @@
 /area/template_noop)
 
 (1,1,1) = {"
-R
-R
-R
-R
-R
-R
-R
-R
-R
-R
+j
+I
+s
+s
+s
+s
+s
+s
+f
+Y
 "}
 (2,1,1) = {"
-r
-r
-R
+u
+C
+q
 X
 S
 S
 G
 R
-r
+p
 r
 "}
 (3,1,1) = {"
-C
-H
-u
+y
+y
+s
 K
 D
 U
 b
-x
-o
-p
+s
+y
+y
 "}
 (4,1,1) = {"
-I
-P
-w
+B
+J
+s
 K
 h
 Q
 b
-q
+s
 A
-E
+c
 "}
 (5,1,1) = {"
 B
-j
-R
+J
+s
 K
 Z
 t
 b
-R
+s
 V
-B
+k
 "}
 (6,1,1) = {"
-k
+B
 J
-w
+s
 K
 z
 g
 b
-q
-a
+s
+A
 c
 "}
 (7,1,1) = {"
 y
-T
+y
 s
 K
 l
 N
 b
-f
-e
-v
+s
+y
+y
 "}
 (8,1,1) = {"
+v
 W
-W
-R
+e
 L
 d
 d
 M
-R
-W
-W
+o
+P
+n
 "}
 (9,1,1) = {"
-R
-R
-R
-R
-R
-R
-R
-R
-R
-R
+x
+H
+s
+s
+s
+s
+s
+s
+O
+T
 "}

--- a/_maps/templates/holodeck_prison.dmm
+++ b/_maps/templates/holodeck_prison.dmm
@@ -21,8 +21,8 @@
 /obj/structure/closet/secure_closet/brig{
 	req_one_access = null
 	},
-/obj/machinery/flasher/directional/west{
-	id = "Holodeck Cell 4"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
@@ -37,6 +37,10 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/board_number/four,
+/obj/machinery/flasher/directional/west{
+	id = "Holodeck Cell 4";
+	pixel_x = 0
+	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "f" = (
@@ -73,8 +77,8 @@
 /obj/structure/closet/secure_closet/brig{
 	req_one_access = null
 	},
-/obj/machinery/flasher/directional/west{
-	id = "Holodeck Cell 2"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
@@ -84,13 +88,18 @@
 	req_access = null;
 	name = "Cell 2"
 	},
-/turf/closed/wall,
+/obj/structure/table,
+/turf/open/floor/holofloor/dark,
 /area/template_noop)
 "o" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /obj/effect/turf_decal/board_number/three,
+/obj/machinery/flasher/directional/east{
+	id = "Holodeck Cell 3";
+	pixel_x = 0
+	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "p" = (
@@ -182,7 +191,16 @@
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "B" = (
-/turf/closed/wall,
+/obj/structure/rack,
+/obj/item/restraints/handcuffs{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/restraints/handcuffs{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/turf/open/floor/holofloor/dark,
 /area/template_noop)
 "C" = (
 /obj/structure/bed,
@@ -198,7 +216,8 @@
 	name = "Cell 1";
 	req_access = null
 	},
-/turf/closed/wall,
+/obj/structure/table,
+/turf/open/floor/holofloor/dark,
 /area/template_noop)
 "E" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -207,8 +226,8 @@
 /obj/structure/closet/secure_closet/brig{
 	req_one_access = null
 	},
-/obj/machinery/flasher/directional/east{
-	id = "Holodeck Cell 3"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
@@ -223,6 +242,10 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/board_number/one,
+/obj/machinery/flasher/directional/east{
+	id = "Holodeck Cell 1";
+	pixel_x = 0
+	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "I" = (
@@ -232,8 +255,8 @@
 /obj/structure/closet/secure_closet/brig{
 	req_one_access = null
 	},
-/obj/machinery/flasher/directional/east{
-	id = "Holodeck Cell 1"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
@@ -268,7 +291,8 @@
 	req_access = null;
 	name = "Cell 4"
 	},
-/turf/closed/wall,
+/obj/structure/table,
+/turf/open/floor/holofloor/dark,
 /area/template_noop)
 "P" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -309,6 +333,10 @@
 	},
 /obj/item/toy/figure/prisoner,
 /obj/effect/turf_decal/board_number/two,
+/obj/machinery/flasher/directional/west{
+	id = "Holodeck Cell 2";
+	pixel_x = 1
+	},
 /turf/open/floor/holofloor/white,
 /area/template_noop)
 "U" = (
@@ -317,17 +345,12 @@
 	req_access = null;
 	name = "Cell 3"
 	},
-/turf/closed/wall,
+/obj/structure/table,
+/turf/open/floor/holofloor/dark,
 /area/template_noop)
 "V" = (
-/obj/structure/rack,
-/obj/item/restraints/handcuffs{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/restraints/handcuffs{
-	pixel_x = 4;
-	pixel_y = -3
+/obj/structure/chair{
+	dir = 1
 	},
 /turf/open/floor/holofloor/dark,
 /area/template_noop)
@@ -340,6 +363,12 @@
 "X" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/holofloor,
+/area/template_noop)
+"Y" = (
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/turf/open/floor/holofloor/dark,
 /area/template_noop)
 "Z" = (
 /obj/structure/chair/comfy/black,
@@ -396,7 +425,7 @@ E
 "}
 (5,1,1) = {"
 B
-V
+Y
 R
 K
 Z

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -535,6 +535,18 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/brigdoor/security/holding
 	icon_state = "rightsecure"
 	base_state = "rightsecure"
 
+/obj/machinery/door/window/brigdoor/security/holodeck
+	name = "cell door"
+	desc = "For keeping in criminal scum."
+	req_one_access = COMMON_ACCESS
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/brigdoor/security/holodeck/left, 0)
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/door/window/brigdoor/security/holodeck/right, 0)
+
+/obj/machinery/door/window/brigdoor/security/holodeck/right
+	icon_state = "rightsecure"
+	base_state = "rightsecure"
+
 /*
  * Subtype used in unit tests to ensure instant windoor open/close
 */

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -189,6 +189,9 @@
 	req_one_access = list(ACCESS_BRIG)
 	var/id = null
 
+/obj/structure/closet/secure_closet/brig/holodeck
+	req_one_access = COMMON_ACCESS
+
 /obj/structure/closet/secure_closet/brig/genpop
 	name = "genpop storage locker"
 	desc = "Used for storing the belongings of genpop's tourists visiting the locals."

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -14,7 +14,7 @@
 	AddComponent(\
 		/datum/component/electrified_buckle,\
 		overlays_to_add = list(export_to_component),\
-		shock_flags = (SHOCK_NOGLOVES | SHOCK_IGNORE_IMMUNITY)\
+		shock_flags = (SHOCK_NOGLOVES)\
 	)
 
 /obj/structure/chair/e_chair/attackby(obj/item/W, mob/user, list/modifiers, list/attack_modifiers)

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -8,10 +8,14 @@
 
 /obj/structure/chair/e_chair/Initialize(mapload)
 	. = ..()
-	var/obj/item/assembly/shock_kit/stored_kit = new(contents)
 	var/mutable_appearance/export_to_component = mutable_appearance('icons/obj/chairs.dmi', "echair_over", OBJ_LAYER, src, appearance_flags = KEEP_APART)
 	export_to_component = color_atom_overlay(export_to_component)
-	AddComponent(/datum/component/electrified_buckle, (SHOCK_REQUIREMENT_ITEM | SHOCK_REQUIREMENT_LIVE_CABLE | SHOCK_REQUIREMENT_SIGNAL_RECEIVED_TOGGLE), stored_kit, list(export_to_component))
+
+	AddComponent(\
+		/datum/component/electrified_buckle,\
+		overlays_to_add = list(export_to_component),\
+		shock_flags = (SHOCK_NOGLOVES | SHOCK_IGNORE_IMMUNITY)\
+	)
 
 /obj/structure/chair/e_chair/attackby(obj/item/W, mob/user, list/modifiers, list/attack_modifiers)
 	if(W.tool_behaviour == TOOL_WRENCH)

--- a/code/modules/holodeck/holodeck_map_templates.dm
+++ b/code/modules/holodeck/holodeck_map_templates.dm
@@ -159,7 +159,7 @@
 	restricted = TRUE
 
 /datum/map_template/holodeck/prison
-	name = "Holodeck - Prison"
+	name = "Holodeck - Prison Block"
 	template_id = "holodeck_prison"
 	mappath = "_maps/templates/holodeck_prison.dmm"
 	restricted = TRUE

--- a/code/modules/holodeck/holodeck_map_templates.dm
+++ b/code/modules/holodeck/holodeck_map_templates.dm
@@ -157,3 +157,9 @@
 	template_id = "holodeck_refuelingstation"
 	mappath = "_maps/templates/holodeck_refuelingstation.dmm"
 	restricted = TRUE
+
+/datum/map_template/holodeck/prison
+	name = "Holodeck - Prison"
+	template_id = "holodeck_prison"
+	mappath = "_maps/templates/holodeck_prison.dmm"
+	restricted = TRUE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -592,7 +592,7 @@
 	shock_damage *= siemens_coeff
 	if((flags & SHOCK_TESLA) && HAS_TRAIT(src, TRAIT_TESLA_SHOCKIMMUNE))
 		return FALSE
-	if(HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
+	if(!(flags & SHOCK_IGNORE_IMMUNITY) && HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
 		return FALSE
 	if(shock_damage < 1)
 		return FALSE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -592,7 +592,7 @@
 	shock_damage *= siemens_coeff
 	if((flags & SHOCK_TESLA) && HAS_TRAIT(src, TRAIT_TESLA_SHOCKIMMUNE))
 		return FALSE
-	if(!(flags & SHOCK_IGNORE_IMMUNITY) && HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
+	if(HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
 		return FALSE
 	if(shock_damage < 1)
 		return FALSE


### PR DESCRIPTION

## About The Pull Request
This adds a new "Prison Block" holodeck simulation, accessible only when the holodeck safeties are disabled (or emagged). The layout features four functional jail cells with holographic flashers, a security desk, evidence lockers, an electric death chair, and camera/record consoles.

<img width="288" height="320" alt="StrongDMM-2026-05-10 20 22 24" src="https://github.com/user-attachments/assets/f32da2c6-9281-4681-b415-4eac5d9bf167" />

## Why It's Good For The Game
While many departments have dedicated holodeck programs, Security currently lacks a specialized simulation. By placing a functional brig within an emagged simulation, we create opportunities for emergent scenarios:
- Antagonists now have more non-lethal options to detain and hold personnel
- Security now has a backup brig during station emergencies
- Power cuts, EMPs, or AI intervention can trigger instant prison breaks
- With the press of a button, switching the simulation can transform it into a death trap for everyone inside

This creates high-tension gameplay for both the captors and the captives.

The electric chair was only used in the pirate shuttle (ruin?) and didn't work properly, so it needed some code updates. Also, I did not like how insulated gloves prevented electric shocks from working, so I made it bypass insulation.

I had to add holodeck versions of brig lockers and security windoors so now any ID can open windoors/lockers. People cannot open windoors/lockers without an ID, so you must strip them of their ID when imprisoning them, otherwise they can just walk out.

## Changelog
:cl:
map: Added a "Prison Block" holodeck simulation, accessible via the disabled safety/emagged menu.
code: Fixed electric chairs to work, and they now bypass insulation from gloves when executing a mob.
code: Added holodeck versions of brig lockers and windoors that allow anyone with a station ID card to access them.
/:cl:
