### PR TITLE
Fix shock immunity flag not working

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -592,7 +592,7 @@
 	shock_damage *= siemens_coeff
 	if((flags & SHOCK_TESLA) && HAS_TRAIT(src, TRAIT_TESLA_SHOCKIMMUNE))
 		return FALSE
-	if(HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
+	if(!(flags & SHOCK_IGNORE_IMMUNITY) && HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
 		return FALSE
 	if(shock_damage < 1)
 		return FALSE


### PR DESCRIPTION

## About The Pull Request
`SHOCK_IGNORE_IMMUNITY` is a flag that is supposed to bypass the `TRAIT_STUNIMMUNE`, but it doesn't and is basically ignored. To fix it, we just added a check during electrocution to see if the flag is present when checking `TRAIT-STUNIMMUNE`.

## Why It's Good For The Game
Consistent code.

## Changelog
:cl:
fix: Fix shock immunity flag not working when electrocution occurs
/:cl:
