### PR TITLE
Users of a Gaseous Holoparasite no longer appear to catch on fire repeatedly

### DIFF
--- a/code/modules/mob/living/basic/guardian/guardian_types/gaseous.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/gaseous.dm
@@ -42,12 +42,6 @@
 		UnregisterSignal(summoner, COMSIG_LIVING_LIFE)
 	return ..()
 
-/// Prevent our summoner from being on fire
-/mob/living/basic/guardian/gaseous/proc/on_summoner_ignited(mob/living/source)
-	SIGNAL_HANDLER
-	source.extinguish_mob()
-	source.set_fire_stacks(0, remove_wet_stacks = FALSE)
-
 /// Maintain our summoner at a stable body temperature
 /mob/living/basic/guardian/gaseous/proc/on_summoner_life(mob/living/source, seconds_per_tick)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/basic/guardian/guardian_types/gaseous.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/gaseous.dm
@@ -33,12 +33,13 @@
 	. = ..()
 	if (QDELETED(src))
 		return
-	RegisterSignal(summoner, COMSIG_LIVING_IGNITED, PROC_REF(on_summoner_ignited))
+	ADD_TRAIT(summoner, TRAIT_NOFIRE, REF(src))
 	RegisterSignal(summoner, COMSIG_LIVING_LIFE, PROC_REF(on_summoner_life))
 
 /mob/living/basic/guardian/gaseous/cut_summoner(different_person)
 	if (!isnull(summoner))
-		UnregisterSignal(summoner, list(COMSIG_LIVING_IGNITED, COMSIG_LIVING_LIFE))
+		REMOVE_TRAIT(summoner, TRAIT_NOFIRE, REF(src))
+		UnregisterSignal(summoner, COMSIG_LIVING_LIFE)
 	return ..()
 
 /// Prevent our summoner from being on fire


### PR DESCRIPTION

## About The Pull Request

Switches from the holoparasite extinguishing their owner repeatedly whenever they caught on fire, causing a message about them catching fire to repeatedly appear, to giving them the `TRAIT_NOFIRE` trait, which does the same thing.

## Why It's Good For The Game

They're not catching fire.

## Changelog
:cl:

spellcheck: Users of a Gaseous holoparasite no longer appear to repeatedly catch fire when they are not.

/:cl:
