### PR TITLE
Block two people cuffing to one item

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -685,3 +685,8 @@
 
 /// Sent from /datum/component/reflection when the reflection is updated to the mob reflecting: (atom/movable/reflecting_in, obj/effect/abstract/reflection)
 #define COMSIG_REFLECTION_UPDATED "reflection_updated"
+
+/// Send from /datum/element/cuffable_item(): (mob/cuffer, obj/item/cuffs)
+#define COMSIG_ITEM_CUFFED_TO_MOB "item_cuffed_to_mob"
+	/// Return to stop the cuffing from happening.
+	#define BLOCK_ITEM_CUFF (1<<0)

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -687,6 +687,6 @@
 #define COMSIG_REFLECTION_UPDATED "reflection_updated"
 
 /// Send from /datum/element/cuffable_item(): (mob/cuffer, obj/item/cuffs)
-#define COMSIG_ITEM_CUFFED_TO_MOB "item_cuffed_to_mob"
+#define COMSIG_ITEM_PRE_CUFFED_TO_MOB "item_cuffed_to_mob"
 	/// Return to stop the cuffing from happening.
 	#define BLOCK_ITEM_CUFF (1<<0)

--- a/code/datums/elements/cuffable_item.dm
+++ b/code/datums/elements/cuffable_item.dm
@@ -62,6 +62,9 @@
 	if(cuffs.handcuffs_clumsiness_check(user))
 		return
 
+	if(SEND_SIGNAL(source, COMSIG_ITEM_CUFFED_TO_MOB, user, cuffs) & BLOCK_ITEM_CUFF)
+		return
+
 	source.balloon_alert(user, "cuffing item...")
 	playsound(source, cuffs.cuffsound, 30, TRUE, -2)
 	if(!do_after(user, cuffs.get_handcuff_time(user), source))

--- a/code/datums/elements/cuffable_item.dm
+++ b/code/datums/elements/cuffable_item.dm
@@ -62,7 +62,7 @@
 	if(cuffs.handcuffs_clumsiness_check(user))
 		return
 
-	if(SEND_SIGNAL(source, COMSIG_ITEM_CUFFED_TO_MOB, user, cuffs) & BLOCK_ITEM_CUFF)
+	if(SEND_SIGNAL(source, COMSIG_ITEM_PRE_CUFFED_TO_MOB, user, cuffs) & BLOCK_ITEM_CUFF)
 		return
 
 	source.balloon_alert(user, "cuffing item...")

--- a/code/datums/status_effects/cuffed_item.dm
+++ b/code/datums/status_effects/cuffed_item.dm
@@ -43,6 +43,7 @@
 	RegisterSignal(cuffed, COMSIG_ITEM_GET_STRIPPABLE_ALT_ACTIONS, PROC_REF(get_strippable_action))
 	RegisterSignal(cuffed, COMSIG_ITEM_STRIPPABLE_ALT_ACTION, PROC_REF(do_strippable_action))
 	RegisterSignal(cuffed, COMSIG_ITEM_PRE_STORAGE_INSERTION, PROC_REF(block_storage_insert))
+	RegisterSignal(cuffed, COMSIG_ITEM_CUFFED_TO_MOB, PROC_REF(block_item_cuff))
 
 	RegisterSignals(cuffs, list(COMSIG_ITEM_EQUIPPED, COMSIG_QDELETING, COMSIG_MOVABLE_MOVED), PROC_REF(cleanup_effect))
 	RegisterSignal(cuffs, COMSIG_ATOM_UPDATE_APPEARANCE, PROC_REF(on_item_update_appearance))
@@ -59,10 +60,33 @@
 
 /datum/status_effect/cuffed_item/on_remove()
 	//Prevent possible recursions from these signals
-	UnregisterSignal(cuffed, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED, COMSIG_MOVABLE_MOVED, COMSIG_QDELETING, COMSIG_ITEM_PRE_STORAGE_INSERTION))
-	UnregisterSignal(cuffs, list(COMSIG_ITEM_EQUIPPED, COMSIG_MOVABLE_MOVED, COMSIG_QDELETING))
-	UnregisterSignal(cuffed_to, list(COMSIG_BODYPART_REMOVED, COMSIG_QDELETING))
-	UnregisterSignal(owner, list(COMSIG_ATOM_EXAMINE_MORE, COMSIG_CARBON_POST_ATTACH_LIMB))
+	UnregisterSignal(cuffed, list(
+		COMSIG_ATOM_EXAMINE,
+		COMSIG_ATOM_UPDATE_APPEARANCE,
+		COMSIG_ITEM_CUFFED_TO_MOB,
+		COMSIG_ITEM_DROPPED,
+		COMSIG_ITEM_EQUIPPED,
+		COMSIG_ITEM_GET_STRIPPABLE_ALT_ACTIONS,
+		COMSIG_ITEM_PRE_STORAGE_INSERTION,
+		COMSIG_ITEM_STRIPPABLE_ALT_ACTION,
+		COMSIG_MOVABLE_MOVED,
+		COMSIG_QDELETING,
+		COMSIG_TOPIC,
+	))
+	UnregisterSignal(cuffs, list(
+		COMSIG_ATOM_UPDATE_APPEARANCE,
+		COMSIG_ITEM_EQUIPPED,
+		COMSIG_MOVABLE_MOVED,
+		COMSIG_QDELETING,
+	))
+	UnregisterSignal(cuffed_to, list(
+		COMSIG_BODYPART_REMOVED,
+		COMSIG_QDELETING,
+	))
+	UnregisterSignal(owner, list(
+		COMSIG_ATOM_EXAMINE_MORE,
+		COMSIG_CARBON_POST_ATTACH_LIMB,
+	))
 	cuffed = null
 
 	if(!QDELETED(cuffs))
@@ -161,6 +185,13 @@
 	if(messages)
 		target_storage.balloon_alert(user, "can't store [source.name] while cuffed!")
 	return BLOCK_STORAGE_INSERT
+
+/// Stops double cuff
+/datum/status_effect/cuffed_item/proc/block_item_cuff(datum/source, mob/cuffer, obj/item/cuffs)
+	SIGNAL_HANDLER
+	if(messages)
+		source.balloon_alert(cuffer, "cuffed to someone else!")
+	return BLOCK_ITEM_CUFF
 
 ///What happens if one of the items is moved away from the mob
 /datum/status_effect/cuffed_item/proc/cleanup_effect(datum/source)

--- a/code/datums/status_effects/cuffed_item.dm
+++ b/code/datums/status_effects/cuffed_item.dm
@@ -43,7 +43,7 @@
 	RegisterSignal(cuffed, COMSIG_ITEM_GET_STRIPPABLE_ALT_ACTIONS, PROC_REF(get_strippable_action))
 	RegisterSignal(cuffed, COMSIG_ITEM_STRIPPABLE_ALT_ACTION, PROC_REF(do_strippable_action))
 	RegisterSignal(cuffed, COMSIG_ITEM_PRE_STORAGE_INSERTION, PROC_REF(block_storage_insert))
-	RegisterSignal(cuffed, COMSIG_ITEM_CUFFED_TO_MOB, PROC_REF(block_item_cuff))
+	RegisterSignal(cuffed, COMSIG_ITEM_PRE_CUFFED_TO_MOB, PROC_REF(block_item_cuff))
 
 	RegisterSignals(cuffs, list(COMSIG_ITEM_EQUIPPED, COMSIG_QDELETING, COMSIG_MOVABLE_MOVED), PROC_REF(cleanup_effect))
 	RegisterSignal(cuffs, COMSIG_ATOM_UPDATE_APPEARANCE, PROC_REF(on_item_update_appearance))
@@ -63,7 +63,7 @@
 	UnregisterSignal(cuffed, list(
 		COMSIG_ATOM_EXAMINE,
 		COMSIG_ATOM_UPDATE_APPEARANCE,
-		COMSIG_ITEM_CUFFED_TO_MOB,
+		COMSIG_ITEM_PRE_CUFFED_TO_MOB,
 		COMSIG_ITEM_DROPPED,
 		COMSIG_ITEM_EQUIPPED,
 		COMSIG_ITEM_GET_STRIPPABLE_ALT_ACTIONS,

--- a/code/datums/status_effects/cuffed_item.dm
+++ b/code/datums/status_effects/cuffed_item.dm
@@ -187,10 +187,9 @@
 	return BLOCK_STORAGE_INSERT
 
 /// Stops double cuff
-/datum/status_effect/cuffed_item/proc/block_item_cuff(datum/source, mob/cuffer, obj/item/cuffs)
+/datum/status_effect/cuffed_item/proc/block_item_cuff(obj/item/source, mob/cuffer, obj/item/cuffs)
 	SIGNAL_HANDLER
-	if(messages)
-		source.balloon_alert(cuffer, "cuffed to someone else!")
+	source.balloon_alert(cuffer, "cuffed to someone else!")
 	return BLOCK_ITEM_CUFF
 
 ///What happens if one of the items is moved away from the mob


### PR DESCRIPTION
## About The Pull Request

Fixes #96042
Fixes #96041

Simply stops two people from cuffing to the same item
We could add support for this behavior later, but we'd need to sort out how that behavior should work

## Changelog

:cl: Melbert
fix: Blocks two people cuffing to one item
/:cl:

