### PR TITLE
The Syndicate teleporter actually makes you lose blood now

### DIFF
--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -496,7 +496,7 @@
 
 ///Bleed and make blood splatters at tele start and end points
 /obj/item/syndicate_teleporter/proc/make_bloods(turf/old_location, turf/new_location, mob/living/user)
-	if(!user.can_bleed(BLOOD_COVER_TURFS) != BLEED_SPLATTER)
+	if(user.can_bleed(BLOOD_COVER_TURFS) != BLEED_SPLATTER)
 		return FALSE
 	user.add_splatter_floor(old_location)
 	user.add_splatter_floor(new_location)


### PR DESCRIPTION
## About The Pull Request
if(!user.can_bleed(BLOOD_COVER_TURFS) != BLEED_SPLATTER)
this was checking whether the user can bleed in that specific way and negating it would convert it into a boolean
## Why It's Good For The Game
It was broken and now it's fixed
## Changelog


:cl:
fix:The Syndicate Teleporter actually makes you lose blood now
/:cl:

