### PR TITLE
Renames hauntium (the reagent, not the material) to ectoplasm.

### DIFF
--- a/code/datums/materials/hauntium.dm
+++ b/code/datums/materials/hauntium.dm
@@ -17,7 +17,7 @@
 		MATERIAL_FLAMMABILITY = 6,
 	)
 	sheet_type = /obj/item/stack/sheet/hauntium
-	material_reagent = /datum/reagent/hauntium
+	material_reagent = /datum/reagent/ectoplasm
 	value_per_unit = 0.05
 
 /datum/material/hauntium/on_main_applied(atom/source, mat_amount, multiplier)

--- a/code/datums/weather/weather_types/rain_storm.dm
+++ b/code/datums/weather/weather_types/rain_storm.dm
@@ -196,7 +196,7 @@
 		/datum/reagent/aslimetoxin,
 		// misc
 		/datum/reagent/blood,
-		/datum/reagent/hauntium,
+		/datum/reagent/ectoplasm,
 		/datum/reagent/copper,
 	)
 	GLOB.wizard_rain_reagents |= allowed_exotic_reagents

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -39,7 +39,7 @@
 	)
 
 /obj/item/soulstone/grind_results()
-	return list(/datum/reagent/hauntium = 25, /datum/reagent/silicon = 10) //can be ground into hauntium
+	return list(/datum/reagent/ectoplasm = 25, /datum/reagent/silicon = 10) //can be ground into hauntium
 
 /obj/item/soulstone/update_appearance(updates)
 	. = ..()
@@ -591,7 +591,7 @@
 	icon_state = "ectoplasm"
 
 /obj/item/ectoplasm/grind_results()
-	return list(/datum/reagent/hauntium = 25)
+	return list(/datum/reagent/ectoplasm = 25)
 
 /obj/item/ectoplasm/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is inhaling [src]! It looks like [user.p_theyre()] trying to visit the astral plane!"))

--- a/code/modules/modular_computers/file_system/programs/maintenance/spectre_meter.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/spectre_meter.dm
@@ -91,7 +91,7 @@
 		var/list/materials = atom.has_material_type(/datum/material/hauntium)
 		if(materials)
 			spook_amount += materials[/datum/material/hauntium]/SHEET_MATERIAL_AMOUNT
-		spook_amount += atom.reagents?.get_reagent_amount(/datum/reagent/hauntium)/20
+		spook_amount += atom.reagents?.get_reagent_amount(/datum/reagent/ectoplasm)/20
 		if(!spook_amount)
 			continue
 		if(atom.loc == turf)

--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -15,7 +15,7 @@
 	var/scribble //Scribble on the back.
 
 /obj/item/photo/grind_results()
-	return LAZYACCESS(custom_materials, /datum/material/hauntium) ? list(/datum/reagent/hauntium = 20) : list(/datum/reagent/iodine = 4)
+	return LAZYACCESS(custom_materials, /datum/material/hauntium) ? list(/datum/reagent/ectoplasm = 20) : list(/datum/reagent/iodine = 4)
 
 /obj/item/photo/get_save_vars()
 	return ..() - NAMEOF(src, icon)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -3366,10 +3366,10 @@
 	if(SPT_PROB(10, seconds_per_tick))
 		carbon_metabolizer.set_heartattack(TRUE)
 
-/datum/reagent/hauntium
-	name = "Hauntium"
+/datum/reagent/ectoplasm
+	name = "Ectoplasm"
 	color = "#3B3B3BA3"
-	description = "An eerie liquid created by purifying the presence of ghosts. If it happens to get in your body, it starts hurting your soul." //soul as in mood and heart
+	description = "The quasi-physical matter which serves as the primary constituent of spiritual entities such as ghosts. If it happens to get in your body, it starts hurting your soul." //soul as in mood and heart
 	taste_description = "evil spirits"
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 	material = /datum/material/hauntium
@@ -3378,7 +3378,7 @@
 	randomized_spawns = REAGENT_SPAWN_ALL_RANDOM_SPAWNS
 
 //gives 20 seconds of haunting effect for every unit of it that touches an item
-/datum/reagent/hauntium/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
+/datum/reagent/ectoplasm/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
 	. = ..()
 	if(!isitem(exposed_obj))
 		return
@@ -3388,7 +3388,7 @@
 	exposed_item.make_haunted(HAUNTIUM_REAGENT_TRAIT, "#f8f8ff")
 	addtimer(CALLBACK(exposed_item, TYPE_PROC_REF(/obj/item/, remove_haunted), HAUNTIUM_REAGENT_TRAIT), reac_volume * 20 SECONDS)
 
-/datum/reagent/hauntium/on_mob_metabolize(mob/living/carbon/affected_mob, seconds_per_tick)
+/datum/reagent/ectoplasm/on_mob_metabolize(mob/living/carbon/affected_mob, seconds_per_tick)
 	. = ..()
 	to_chat(affected_mob, span_userdanger("You feel an evil presence inside you!"))
 	if(affected_mob.mob_biotypes & MOB_UNDEAD || HAS_MIND_TRAIT(affected_mob, TRAIT_MORBID))
@@ -3396,7 +3396,7 @@
 	else
 		affected_mob.add_mood_event("hauntium_spirits", /datum/mood_event/hauntium_spirits, name) //8 minutes of mood debuff
 
-/datum/reagent/hauntium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+/datum/reagent/ectoplasm/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	if(affected_mob.mob_biotypes & MOB_UNDEAD || HAS_MIND_TRAIT(affected_mob, TRAIT_MORBID)) //if morbid or undead,acts like an addiction-less drug
 		var/common = -3.34 SECONDS * metabolization_ratio * seconds_per_tick

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -1048,7 +1048,7 @@
 	..()
 
 /datum/chemical_reaction/hauntium_solidification
-	required_reagents = list(/datum/reagent/water/holywater = 10, /datum/reagent/hauntium = 20, /datum/reagent/iron = 1)
+	required_reagents = list(/datum/reagent/water/holywater = 10, /datum/reagent/ectoplasm = 20, /datum/reagent/iron = 1)
 	mob_react = FALSE
 	reaction_flags = REACTION_INSTANT
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER


### PR DESCRIPTION
## About The Pull Request

Exactly what the title says.

## Why It's Good For The Game

This reagent is obtained from grinding up ectoplasm items. It would make sense for it to be called ectoplasm. Additionally, there are several changes I've been thinking of making in the future (like giving human ghosts ectoplasm for blood) that would make more sense if this reagent is named ectoplasm rather than hauntium.

## Changelog

:cl:
spellcheck: The hauntium reagent has been renamed to ectoplasm.
/:cl:
