### PR TITLE
[NO GBP] Makes junk food less punishing for virus cures

### DIFF
--- a/code/__DEFINES/diseases.dm
+++ b/code/__DEFINES/diseases.dm
@@ -95,6 +95,9 @@ DEFINE_BITFIELD(spread_flags, list(
 /// Satiety Recovery Multiplier - added chance to recover based on positive satiety
 //// Multiplier of satiety/max_satiety if satiety is positive or zero. Increase to make satiety more valuable, decrease for less.
 #define DISEASE_SATIETY_RECOVERY_MULTIPLIER 3
+/// Disease Satiety Threshold - how much junk food we have to eat to start curing positive viruses.
+//// About -150 is good. May need to change if satiety/junkiness var is changed up much.
+#define DISEASE_SATIETY_THRESHOLD -150
 /// Good Sleeping Recovery Bonus - additive benefits for various types of good sleep (blanket, bed, darkness, pillows.)
 //// Raise to make each factor add this much chance to recover.
 #define DISEASE_GOOD_SLEEPING_RECOVERY_BONUS 0.6

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -148,7 +148,7 @@
 	if(!(disease_flags & CHRONIC) && disease_flags & CURABLE && bypasses_immunity != TRUE)
 		switch(severity)
 			if(DISEASE_SEVERITY_POSITIVE)
-				if(slowdown < 1 || (!(HAS_TRAIT(affected_mob, TRAIT_NOHUNGER)) && (affected_mob.satiety < 0 || affected_mob.nutrition < NUTRITION_LEVEL_STARVING)))
+				if(slowdown < 1 || (!(HAS_TRAIT(affected_mob, TRAIT_NOHUNGER)) && (affected_mob.satiety < DISEASE_SATIETY_THRESHOLD || affected_mob.nutrition < NUTRITION_LEVEL_STARVING)))
 					cycles_to_beat = max(DISEASE_RECOVERY_SCALING, DISEASE_CYCLES_POSITIVE)
 				else
 					recovery_prob = 0
@@ -175,10 +175,10 @@
 			recovery_prob += clamp((((1 - slowdown)*(DISEASE_SLOWDOWN_RECOVERY_BONUS * 2)) * ((DISEASE_SLOWDOWN_RECOVERY_BONUS_DURATION - chemical_offsets) / DISEASE_SLOWDOWN_RECOVERY_BONUS_DURATION)), 0, DISEASE_SLOWDOWN_RECOVERY_BONUS)
 			chemical_offsets = min(chemical_offsets + 1, DISEASE_SLOWDOWN_RECOVERY_BONUS_DURATION)
 		if(!HAS_TRAIT(affected_mob, TRAIT_NOHUNGER))
-			if(affected_mob.satiety < 0 || affected_mob.nutrition < NUTRITION_LEVEL_STARVING) //being malnourished makes it a lot harder to defeat your illness
+			if(affected_mob.satiety < DISEASE_SATIETY_THRESHOLD || affected_mob.nutrition < NUTRITION_LEVEL_STARVING) //being malnourished makes it a lot harder to defeat your illness
 				recovery_prob -= DISEASE_MALNUTRITION_RECOVERY_PENALTY
 			else
-				if(affected_mob.satiety >= 0)
+				if(affected_mob.satiety > 0)
 					recovery_prob += round((DISEASE_SATIETY_RECOVERY_MULTIPLIER * (affected_mob.satiety/MAX_SATIETY)), 0.1)
 
 		if(affected_mob.mob_mood) // this and most other modifiers below a shameless rip from sleeping healing buffs, but feeling good helps make it go away quicker
@@ -229,7 +229,7 @@
 			var/failure_chance = (1 - get_recovery_failure_chance() / 100)
 			if(SPT_PROB(recovery_prob * failure_chance, seconds_per_tick))
 				if(stage == 1 && prob(cure_chance * DISEASE_FINAL_CURE_CHANCE_MULTIPLIER)) //if we reduce FROM stage == 1, cure the virus - after defeating its cure_chance in a final battle
-					if(!HAS_TRAIT(affected_mob, TRAIT_NOHUNGER) && (affected_mob.satiety < 0 || affected_mob.nutrition < NUTRITION_LEVEL_STARVING))
+					if(!HAS_TRAIT(affected_mob, TRAIT_NOHUNGER) && (affected_mob.satiety < DISEASE_SATIETY_THRESHOLD || affected_mob.nutrition < NUTRITION_LEVEL_STARVING))
 						if(stage_peaked == FALSE) //if you didn't ride out the virus from its peak, if you're malnourished when it cures, you don't get resistance
 							cure(add_resistance = FALSE)
 							return FALSE


### PR DESCRIPTION
## About The Pull Request

Satiety/junkiness is a weird system that still isn't behaving kindly in the view of intended behavior. -150 is about a good value to make it so that even sniffing something from a vending machine does not immediately kill a positive virus, but trying to fill up from nothing to full at one will have you getting what you paid for. 

## Why It's Good For The Game

Intended behavior good. This would probably have been better to do with another scaling sort of thing, but honestly, the way satiety works right now, a -150 threshold in testing seems like it does the job fine. It increments or decrements towards 0 every tick. A bit more grace here is fine because if you do go overboard, you will get punished for it. Don't really consider this a balance thing, more a patch for unintended fuckery that yet lingers on around this whole system and only really emerged as unintuitive annoyance. 

Edit because it needs to be said: I'm asking this to be considered a fix because on top of the fix I did last time, which corrected the basic problem of viruses continuing to self-cure even if you met the conditions to keep them, those conditions were not appropriately set with due consideration for just how the values shake out in play. Any smallest amount of negative satiety was still too punishing for what we're aiming for.

## Changelog

:cl:
fix: A single space twinkie no longer cures a virus or makes it harder to get rid of one. 
/:cl: