### PR TITLE
Changes moon armor knowledge description to be more clear(And not lie)

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -119,8 +119,9 @@
 	research_tree_icon_frame = 9
 
 /datum/heretic_knowledge/armor/moon
-	desc = "Allows you to transmute a table (or a suit), a mask and two sheets of glass to create a Resplendant Regalia, this robe will render the user   fully immune to disabling effects and convert all forms of damage into brain damage, while also pacifying the user and render him unable to use ranged weapons (Moon blade will bypass pacifism). \
-			Acts as a focus while hooded."
+	desc = "Allows you to transmute a table (or a suit), a mask and two sheets of glass to create a Resplendant Regalia. \
+			This robe will render the user fully immune to disabling effects and convert all forms of damage into brain damage, while also pacifying the user and rendering them unable to use ranged weapons. \
+			A Moonlight Amulet will be necessary to use blades while wearing it."
 	gain_text = "Trails of light and mirth flowed from every arm of this magnificent attire. \
 				The troupe twirled in irridescent cascades, dazzling onlookers with the truth they sought. \
 				I observed, basking in the light, to find my self."


### PR DESCRIPTION

## About The Pull Request

A lie and a lie by omission, replaced with the clear truth.

## Why It's Good For The Game

closes #95993
Lying is bad

## Changelog
:cl:

spellcheck: The Moon path armor knowledge's description has been made more clear

/:cl:
