### PR TITLE
Banning from ghostrole mobspawners works again

### DIFF
--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -221,7 +221,7 @@
 /obj/effect/mob_spawn/ghost_role/proc/can_ghost_take(mob/dead/observer/user)
 	if(is_banned_from(user.ckey, role_ban))
 		to_chat(user, span_warning("You are banned from this role!"))
-		return FALL_STOP_INTERCEPTING
+		return FALSE
 	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(flags_1 & ADMIN_SPAWNED_1))
 		to_chat(user, span_warning("An admin has temporarily disabled non-admin ghost roles!"))
 		return FALSE


### PR DESCRIPTION

## About The Pull Request

Six months, no ghost role mobspawner bans have worked that entire time

## Why It's Good For The Game

fixes #96053

## Changelog
:cl:

fix: Ghost role mobspawner bans work again

/:cl:
