### PR TITLE
Changes nuclear operative reinforcement to use mid-round pref

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -139,7 +139,7 @@
 		return
 
 	to_chat(user, span_notice("You activate [src] and wait for confirmation."))
-	var/mob/chosen_one = SSpolling.poll_ghost_candidates("Do you want to play as a reinforcement [special_role_name]?", check_jobban = ROLE_OPERATIVE, role = ROLE_OPERATIVE, poll_time = 15 SECONDS, ignore_category = POLL_IGNORE_SYNDICATE, alert_pic = src, role_name_text = special_role_name, amount_to_pick = 1)
+	var/mob/chosen_one = SSpolling.poll_ghost_candidates("Do you want to play as a reinforcement [special_role_name]?", check_jobban = ROLE_OPERATIVE_MIDROUND, role = ROLE_OPERATIVE_MIDROUND, poll_time = 15 SECONDS, ignore_category = POLL_IGNORE_SYNDICATE, alert_pic = src, role_name_text = special_role_name, amount_to_pick = 1)
 	if(chosen_one)
 		if(QDELETED(src) || !check_usability(user))
 			return


### PR DESCRIPTION

## About The Pull Request
Changes the nuclear reinforcement ghost poll to use the mid-round nukie pref, rather than the round-start one.
## Why It's Good For The Game
There's no reason why this should use the round-start pref, as the only people who will be able to join the reinforcement either ghosted, or dnr'ed shortly into the round, not to mention if you roll a round-start nukie, you still can't become a reinforcement.
## Changelog
:cl:
code: Nuclear reinforcements will now poll users with the mid-round nuke op pref enabled, rather than the round-start pref.
/:cl:
