### PR TITLE
Fix grenade arming not being logged

### DIFF
--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -75,8 +75,7 @@
 	if(user)
 		user.log_message(bomb_message, LOG_ATTACK) //let it go to individual logs as well as the game log
 		bomb_message = "[key_name(user)] at [AREACOORD(user)] [bomb_message]."
-	else
-		log_game(bomb_message)
+	log_game(bomb_message)
 
 	GLOB.bombers += bomb_message
 	var/area/bomb_area = get_area(bomb)

--- a/code/game/objects/items/grenades/_grenade.dm
+++ b/code/game/objects/items/grenades/_grenade.dm
@@ -145,7 +145,7 @@
 
 /obj/item/grenade/proc/log_grenade(mob/user)
 	if(!type_cluster)
-		log_bomber(user, "has primed a", src, "for detonation", message_admins = dud_flags != NONE)
+		log_bomber(user, "has primed a", src, "for detonation", message_admins = dud_flags == NONE)
 
 /**
  * arm_grenade (formerly preprime) refers to when a grenade with a standard time fuze is activated, making it go beepbeepbeep and then detonate a few seconds later.


### PR DESCRIPTION

## About The Pull Request

Issue was twofold
- `log_game` was in an `else`, meaning it only got called if the log didn't have a user, despite the comment making it clear it should be in both cases
- `message_admins = dud_flags != NONE` meant that admins were only messaged for grenades that are duds instead of the other way around

## Why It's Good For The Game

Fixes #96064

## Changelog
:cl:
fix: fixed arming grenades not being logged 
/:cl:
