### PR TITLE
Right clicking with a multitool on an abandoned crate no longer puts you at risk

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/abandoned_crates/abandoned_crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates/abandoned_crates/abandoned_crates.dm
@@ -188,6 +188,12 @@
 
 	return ITEM_INTERACT_SUCCESS
 
+/obj/structure/closet/crate/secure/loot/multitool_act_secondary(mob/living/user, obj/item/tool)
+	if(!locked)
+		return
+	attack_hand(user)
+	return ITEM_INTERACT_SUCCESS
+
 /// Implements bulls and cows algorithm to compare guess against actual code
 /obj/structure/closet/crate/secure/loot/proc/bulls_and_cows(guess)
 	var/bulls = 0


### PR DESCRIPTION

## About The Pull Request

Right clicking with a multitool on an abandoned crate lets you put in a code, but interrupts the attack chain regardless of whether you actually do

## Why It's Good For The Game

fixes #96066

## Changelog
:cl:

fix: right clicking an abandoned crate with a multitool no longer can blow you up

/:cl:
