### PR TITLE
Adds beartraps to janitor closets on wawastation and icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -32156,6 +32156,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/restraints/legcuffs/beartrap,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "jbj" = (

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -30022,6 +30022,8 @@
 /obj/structure/closet/l3closet/janitor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/autoname/directional/north,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/restraints/legcuffs/beartrap,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "kpj" = (


### PR DESCRIPTION

## About The Pull Request
Adds beartraps to stations that were missing them, specifically wawastation and icebox.
## Why It's Good For The Game
Makes janitor's starting gear more consistent across different maps.
## Changelog
:cl:
add: Added beartraps to the janitor closets of wawastation and icebox
/:cl:
