### PR TITLE
a soundly sleeping disky now has a large chance to not increase the loneop weight

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -54,13 +54,13 @@
 	if(last_move < world.time - 500 SECONDS && prob((world.time - 500 SECONDS - last_move)*0.0001))
 		var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 		if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
-			loneop.weight += 1
 			if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
 				if(disk_comfort_level >= 2)
 					visible_message(span_notice("[src] sleeps soundly. Sleep tight, disky."))
 					message_admins("[src] is unsecured in [ADMIN_VERBOSEJMP(new_turf)]. The weight of Lone Operative is now [loneop.weight].")
 					if (prob(90)) // a eepy disky is a (mostly) safe disky
 						return
+			loneop.weight += 1
 			log_game("[src] was left unsecured in [loc_name(new_turf)]. Weight of the Lone Operative event increased to [loneop.weight].")
 
 /obj/item/disk/nuclear/examine(mob/user)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -57,10 +57,11 @@
 			if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
 				if(disk_comfort_level >= 2)
 					visible_message(span_notice("[src] sleeps soundly. Sleep tight, disky."))
-					message_admins("[src] is unsecured in [ADMIN_VERBOSEJMP(new_turf)]. The weight of Lone Operative is now [loneop.weight].")
-					if (prob(90)) // a eepy disky is a (mostly) safe disky
+					if (prob(90) && loneop.weight >= 10) // a eepy disky is a (mostly) safe disky
+						message_admins("[src] is unsecured in [ADMIN_VERBOSEJMP(new_turf)]. The weight of Lone Operative is still [loneop.weight].")
 						return
 			loneop.weight += 1
+			message_admins("[src] is unsecured in [ADMIN_VERBOSEJMP(new_turf)]. The weight of Lone Operative is now [loneop.weight].")
 			log_game("[src] was left unsecured in [loc_name(new_turf)]. Weight of the Lone Operative event increased to [loneop.weight].")
 
 /obj/item/disk/nuclear/examine(mob/user)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -58,7 +58,9 @@
 			if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
 				if(disk_comfort_level >= 2)
 					visible_message(span_notice("[src] sleeps soundly. Sleep tight, disky."))
-				message_admins("[src] is unsecured in [ADMIN_VERBOSEJMP(new_turf)]. The weight of Lone Operative is now [loneop.weight].")
+					message_admins("[src] is unsecured in [ADMIN_VERBOSEJMP(new_turf)]. The weight of Lone Operative is now [loneop.weight].")
+					if (prob(90)) // a eepy disky is a (mostly) safe disky
+						return
 			log_game("[src] was left unsecured in [loc_name(new_turf)]. Weight of the Lone Operative event increased to [loneop.weight].")
 
 /obj/item/disk/nuclear/examine(mob/user)


### PR DESCRIPTION

## About The Pull Request
When Disky is sleeping (tucked into a bed with a blanket), there's a 90% chance for the loneop weight increase to not happen.
## Why It's Good For The Game
Disky shouldn't be kidnapped for the crime of being tucked into bed :(
## Changelog
:cl:
balance: Disky attracts evil kidnappers less when sleeping. Sleep tight Disky!
/:cl:
