### PR TITLE
New foam reactions for water varients

### DIFF
--- a/code/__HELPERS/reagents.dm
+++ b/code/__HELPERS/reagents.dm
@@ -59,11 +59,11 @@
 	return TRUE
 
 //Creates foam from the reagent. Metaltype is for metal foam, notification is what to show people in textbox
-/datum/reagents/proc/create_foam(foamtype, foam_volume, result_type = null, notification = null, log = FALSE)
+/datum/reagents/proc/create_foam(foamtype, foam_volume, result_type = null, notification = null, log = FALSE, lifetime, slippery)
 	var/location = get_turf(my_atom)
 
 	var/datum/effect_system/fluid_spread/foam/foam = new foamtype(location, null, foam_volume, my_atom, carry = src, result_type = result_type)
-	foam.start(log = log)
+	foam.start(log = log, lifetime = src.lifetime, slippery = src.slippery)
 
 	clear_reagents()
 	if(!notification)

--- a/code/__HELPERS/reagents.dm
+++ b/code/__HELPERS/reagents.dm
@@ -63,7 +63,7 @@
 	var/location = get_turf(my_atom)
 
 	var/datum/effect_system/fluid_spread/foam/foam = new foamtype(location, null, foam_volume, my_atom, carry = src, result_type = result_type)
-	foam.start(log = log, lifetime = src.lifetime, slippery = src.slippery)
+	foam.start(log = log, lifetime = lifetime, slippery = slippery)
 
 	clear_reagents()
 	if(!notification)

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -31,14 +31,17 @@
 	var/allow_duplicate_results = TRUE
 	/// The amount of time this foam stick around for before it dissipates.
 	var/lifetime = 8 SECONDS
+	/// The orignal value of lifetime
+	var/oglifetime = 8 SECONDS
 	/// Whether or not this foam should be slippery.
 	var/slippery_foam = TRUE
 
 
-/obj/effect/particle_effect/fluid/foam/Initialize(mapload, lifetime, slippery)
+/obj/effect/particle_effect/fluid/foam/Initialize(mapload, fluid_group, source, lifetime, slippery)
 	. = ..()
 	src.lifetime = lifetime ? lifetime : src.lifetime
-	src.slippery_foam = slippery ? slippery : src.slippery_foam
+	src.oglifetime = src.lifetime
+	src.slippery_foam = !isnull(slippery) ? slippery : slippery_foam
 	if(slippery_foam)
 		AddComponent(/datum/component/slippery, 100, can_slip_callback = CALLBACK(src, PROC_REF(try_slip)))
 	if(HAS_TRAIT(loc, TRAIT_ELEVATED_TURF))
@@ -167,7 +170,7 @@
 				continue
 			foam_mob(foaming, seconds_per_tick)
 
-		var/obj/effect/particle_effect/fluid/foam/spread_foam = new type(spread_turf, group, src)
+		var/obj/effect/particle_effect/fluid/foam/spread_foam = new type(spread_turf, group, src, src.oglifetime, src.slippery_foam)
 		reagents.trans_to(spread_foam, reagents.total_volume, copy_only = TRUE)
 		spread_foam.add_atom_colour(color, FIXED_COLOUR_PRIORITY)
 		spread_foam.result_type = result_type
@@ -234,7 +237,7 @@
 	return ..()
 
 /datum/effect_system/fluid_spread/foam/start(log = FALSE, lifetime, slippery)
-	var/obj/effect/particle_effect/fluid/foam/foam = new effect_type(location, new /datum/fluid_group(amount), lifetime = lifetime, slippery = slippery)
+	var/obj/effect/particle_effect/fluid/foam/foam = new effect_type(location, new /datum/fluid_group(amount), null, lifetime, slippery)
 	var/foamcolor = mix_color_from_reagents(chemholder.reagent_list)
 	if(reagent_scale > 1) // Make room in case we were created by a particularly stuffed payload.
 		foam.reagents.maximum_volume *= reagent_scale

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -224,7 +224,7 @@
 	/// What type of thing the foam should leave behind when it dissipates.
 	var/atom/movable/result_type = null
 
-/datum/effect_system/fluid_spread/foam/New(turf/location, range = 1, amount = null, atom/holder = null, datum/reagents/carry = null, result_type = null, stop_reactions = FALSE, reagent_scale = FOAM_REAGENT_SCALE,)
+/datum/effect_system/fluid_spread/foam/New(turf/location, range = 1, amount = null, atom/holder = null, datum/reagents/carry = null, result_type = null, stop_reactions = FALSE, reagent_scale = FOAM_REAGENT_SCALE)
 	. = ..()
 	chemholder = new(1000, NO_REACT)
 	carry?.trans_to(chemholder, carry.total_volume, no_react = stop_reactions, copy_only = TRUE)

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -35,8 +35,10 @@
 	var/slippery_foam = TRUE
 
 
-/obj/effect/particle_effect/fluid/foam/Initialize(mapload)
+/obj/effect/particle_effect/fluid/foam/Initialize(mapload, lifetime, slippery)
 	. = ..()
+	src.lifetime = lifetime ? lifetime : src.lifetime
+	src.slippery_foam = slippery ? slippery : src.slippery_foam
 	if(slippery_foam)
 		AddComponent(/datum/component/slippery, 100, can_slip_callback = CALLBACK(src, PROC_REF(try_slip)))
 	if(HAS_TRAIT(loc, TRAIT_ELEVATED_TURF))
@@ -219,7 +221,7 @@
 	/// What type of thing the foam should leave behind when it dissipates.
 	var/atom/movable/result_type = null
 
-/datum/effect_system/fluid_spread/foam/New(turf/location, range = 1, amount = null, atom/holder = null, datum/reagents/carry = null, result_type = null, stop_reactions = FALSE, reagent_scale = FOAM_REAGENT_SCALE)
+/datum/effect_system/fluid_spread/foam/New(turf/location, range = 1, amount = null, atom/holder = null, datum/reagents/carry = null, result_type = null, stop_reactions = FALSE, reagent_scale = FOAM_REAGENT_SCALE,)
 	. = ..()
 	chemholder = new(1000, NO_REACT)
 	carry?.trans_to(chemholder, carry.total_volume, no_react = stop_reactions, copy_only = TRUE)
@@ -231,8 +233,8 @@
 	QDEL_NULL(chemholder)
 	return ..()
 
-/datum/effect_system/fluid_spread/foam/start(log = FALSE)
-	var/obj/effect/particle_effect/fluid/foam/foam = new effect_type(location, new /datum/fluid_group(amount))
+/datum/effect_system/fluid_spread/foam/start(log = FALSE, lifetime, slippery)
+	var/obj/effect/particle_effect/fluid/foam/foam = new effect_type(location, new /datum/fluid_group(amount), lifetime, slippery)
 	var/foamcolor = mix_color_from_reagents(chemholder.reagent_list)
 	if(reagent_scale > 1) // Make room in case we were created by a particularly stuffed payload.
 		foam.reagents.maximum_volume *= reagent_scale
@@ -244,42 +246,24 @@
 		help_out_the_admins(foam, holder, location)
 	SSfoam.queue_spread(foam)
 
-// Slipless foam
-/// A foam variant which you can't slip on
-/obj/effect/particle_effect/fluid/foam/slipless_life
-	slippery_foam = FALSE
-
-/datum/effect_system/fluid_spread/foam/slipless
-	effect_type = /obj/effect/particle_effect/fluid/foam/slipless_life
 
 // Short-lived foam
 /// A foam variant which dissipates quickly.
 /obj/effect/particle_effect/fluid/foam/short_life
 	lifetime = 1 SECONDS
 
-/obj/effect/particle_effect/fluid/foam/short_life/slipless_life
-	slippery_foam = FALSE
-
 /datum/effect_system/fluid_spread/foam/short
 	effect_type = /obj/effect/particle_effect/fluid/foam/short_life
-
-/datum/effect_system/fluid_spread/foam/short/slipless
-	effect_type = /obj/effect/particle_effect/fluid/foam/short_life/slipless_life
-
 
 // Long lasting foam
 /// A foam variant which lasts for an extended amount of time.
 /obj/effect/particle_effect/fluid/foam/long_life
-	lifetime = 24 SECONDS
+	lifetime = 30 SECONDS
 
-/obj/effect/particle_effect/fluid/foam/long_life/slipless_life
-	slippery_foam = FALSE
-
+/// A factory which produces foam with an extended lifespan.
 /datum/effect_system/fluid_spread/foam/long
 	effect_type = /obj/effect/particle_effect/fluid/foam/long_life
-
-/datum/effect_system/fluid_spread/foam/long/slipless
-	effect_type = /obj/effect/particle_effect/fluid/foam/long_life/slipless_life
+	reagent_scale = FOAM_REAGENT_SCALE * (30 / 8)
 
 // Firefighting foam
 /// A variant of foam which absorbs plasma in the air if there is a fire.

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -244,24 +244,42 @@
 		help_out_the_admins(foam, holder, location)
 	SSfoam.queue_spread(foam)
 
+// Slipless foam
+/// A foam variant which you can't slip on
+/obj/effect/particle_effect/fluid/foam/slipless_life
+	slippery_foam = FALSE
+
+/datum/effect_system/fluid_spread/foam/slipless
+	effect_type = /obj/effect/particle_effect/fluid/foam/slipless_life
 
 // Short-lived foam
 /// A foam variant which dissipates quickly.
 /obj/effect/particle_effect/fluid/foam/short_life
 	lifetime = 1 SECONDS
 
+/obj/effect/particle_effect/fluid/foam/short_life/slipless_life
+	slippery_foam = FALSE
+
 /datum/effect_system/fluid_spread/foam/short
 	effect_type = /obj/effect/particle_effect/fluid/foam/short_life
+
+/datum/effect_system/fluid_spread/foam/short/slipless
+	effect_type = /obj/effect/particle_effect/fluid/foam/short_life/slipless_life
+
 
 // Long lasting foam
 /// A foam variant which lasts for an extended amount of time.
 /obj/effect/particle_effect/fluid/foam/long_life
-	lifetime = 30 SECONDS
+	lifetime = 9 SECONDS
 
-/// A factory which produces foam with an extended lifespan.
+/obj/effect/particle_effect/fluid/foam/long_life/slipless_life
+	slippery_foam = FALSE
+
 /datum/effect_system/fluid_spread/foam/long
 	effect_type = /obj/effect/particle_effect/fluid/foam/long_life
-	reagent_scale = FOAM_REAGENT_SCALE * (30 / 8)
+
+/datum/effect_system/fluid_spread/foam/long/slipless
+	effect_type = /obj/effect/particle_effect/fluid/foam/long_life/slipless_life
 
 // Firefighting foam
 /// A variant of foam which absorbs plasma in the air if there is a fire.

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -234,7 +234,7 @@
 	return ..()
 
 /datum/effect_system/fluid_spread/foam/start(log = FALSE, lifetime, slippery)
-	var/obj/effect/particle_effect/fluid/foam/foam = new effect_type(location, new /datum/fluid_group(amount), lifetime, slippery)
+	var/obj/effect/particle_effect/fluid/foam/foam = new effect_type(location, new /datum/fluid_group(amount), lifetime = lifetime, slippery = slippery)
 	var/foamcolor = mix_color_from_reagents(chemholder.reagent_list)
 	if(reagent_scale > 1) // Make room in case we were created by a particularly stuffed payload.
 		foam.reagents.maximum_volume *= reagent_scale

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -32,7 +32,7 @@
 	/// The amount of time this foam stick around for before it dissipates.
 	var/lifetime = 8 SECONDS
 	/// The orignal value of lifetime
-	var/oglifetime = 8 SECONDS
+	var/original_lifetime = 8 SECONDS
 	/// Whether or not this foam should be slippery.
 	var/slippery_foam = TRUE
 
@@ -40,7 +40,7 @@
 /obj/effect/particle_effect/fluid/foam/Initialize(mapload, fluid_group, source, lifetime, slippery)
 	. = ..()
 	src.lifetime = lifetime ? lifetime : src.lifetime
-	src.oglifetime = src.lifetime
+	src.original_lifetime = src.lifetime
 	src.slippery_foam = !isnull(slippery) ? slippery : slippery_foam
 	if(slippery_foam)
 		AddComponent(/datum/component/slippery, 100, can_slip_callback = CALLBACK(src, PROC_REF(try_slip)))
@@ -170,7 +170,7 @@
 				continue
 			foam_mob(foaming, seconds_per_tick)
 
-		var/obj/effect/particle_effect/fluid/foam/spread_foam = new type(spread_turf, group, src, src.oglifetime, src.slippery_foam)
+		var/obj/effect/particle_effect/fluid/foam/spread_foam = new type(spread_turf, group, src, src.original_lifetime, src.slippery_foam)
 		reagents.trans_to(spread_foam, reagents.total_volume, copy_only = TRUE)
 		spread_foam.add_atom_colour(color, FIXED_COLOUR_PRIORITY)
 		spread_foam.result_type = result_type
@@ -224,7 +224,7 @@
 	/// What type of thing the foam should leave behind when it dissipates.
 	var/atom/movable/result_type = null
 
-/datum/effect_system/fluid_spread/foam/New(turf/location, range = 1, amount = null, atom/holder = null, datum/reagents/carry = null, result_type = null, stop_reactions = FALSE, reagent_scale = FOAM_REAGENT_SCALE)
+/datum/effect_system/fluid_spread/foam/New(turf/location, range = 1, amount = null, atom/holder = null, datum/reagents/carry = null, result_type = null, stop_reactions = FALSE, reagent_scale = FOAM_REAGENT_SCALE,)
 	. = ..()
 	chemholder = new(1000, NO_REACT)
 	carry?.trans_to(chemholder, carry.total_volume, no_react = stop_reactions, copy_only = TRUE)

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -270,7 +270,7 @@
 // Long lasting foam
 /// A foam variant which lasts for an extended amount of time.
 /obj/effect/particle_effect/fluid/foam/long_life
-	lifetime = 9 SECONDS
+	lifetime = 24 SECONDS
 
 /obj/effect/particle_effect/fluid/foam/long_life/slipless_life
 	slippery_foam = FALSE

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -344,11 +344,32 @@
 
 /datum/chemical_reaction/foam
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water = 1)
+	var/datum/effect_system/fluid_spread/foam_type = /datum/effect_system/fluid_spread/foam
 	mob_react = FALSE
 	reaction_flags = REACTION_INSTANT
 
+/datum/chemical_reaction/foam/hollow
+	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water/hollowwater = 1)
+	foam_type = /datum/effect_system/fluid_spread/foam/long
+
+/datum/chemical_reaction/foam/salt
+	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water/salt = 1)
+	foam_type = /datum/effect_system/fluid_spread/foam/short/slipless
+
+/datum/chemical_reaction/foam/ice
+	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/consumable/ice = 1)
+	foam_type = /datum/effect_system/fluid_spread/foam/slipless
+
+/datum/chemical_reaction/foam/soda
+	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/consumable/sodawater = 1)
+	foam_type = /datum/effect_system/fluid_spread/foam/short
+
+/datum/chemical_reaction/foam/holy
+	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water/holywater = 1)
+	foam_type = /datum/effect_system/fluid_spread/foam/long/slipless
+
 /datum/chemical_reaction/foam/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	holder.create_foam(/datum/effect_system/fluid_spread/foam, 2 * created_volume, notification = span_danger("The solution spews out foam!"), log = TRUE)
+	holder.create_foam(foam_type, 2 * created_volume, notification = span_danger("The solution spews out foam!"), log = TRUE)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE
 
 /datum/chemical_reaction/metalfoam

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -344,7 +344,9 @@
 
 /datum/chemical_reaction/foam
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water = 1)
+	// Does the foam slip you?
 	var/slippery = TRUE
+	// How long the foam lasts for
 	var/lifetime = 8 SECONDS
 	mob_react = FALSE
 	reaction_flags = REACTION_INSTANT

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -344,32 +344,40 @@
 
 /datum/chemical_reaction/foam
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water = 1)
-	var/datum/effect_system/fluid_spread/foam_type = /datum/effect_system/fluid_spread/foam
+	var/slippery = TRUE
+	var/lifetime = 8 SECONDS
 	mob_react = FALSE
 	reaction_flags = REACTION_INSTANT
 
 /datum/chemical_reaction/foam/hollow
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water/hollowwater = 1)
+	lifetime = 24 SECONDS
 	foam_type = /datum/effect_system/fluid_spread/foam/long
 
 /datum/chemical_reaction/foam/salt
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water/salt = 1)
+	lifetime = 1 SECONDS
+	slippery = FALSE
 	foam_type = /datum/effect_system/fluid_spread/foam/short/slipless
 
 /datum/chemical_reaction/foam/ice
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/consumable/ice = 1)
+	slippery = FALSE
 	foam_type = /datum/effect_system/fluid_spread/foam/slipless
 
 /datum/chemical_reaction/foam/soda
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/consumable/sodawater = 1)
+	lifetime = 1 SECONDS
 	foam_type = /datum/effect_system/fluid_spread/foam/short
 
 /datum/chemical_reaction/foam/holy
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water/holywater = 1)
+	lifetime = 24 SECONDS
+	slippery = FALSE
 	foam_type = /datum/effect_system/fluid_spread/foam/long/slipless
 
 /datum/chemical_reaction/foam/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	holder.create_foam(foam_type, 2 * created_volume, notification = span_danger("The solution spews out foam!"), log = TRUE)
+	holder.create_foam(datum/effect_system/fluid_spread/foam, 2 * created_volume, notification = span_danger("The solution spews out foam!"), log = TRUE, lifetime = src.lifetime, slippery = src.slippery)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE
 
 /datum/chemical_reaction/metalfoam

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -352,29 +352,24 @@
 /datum/chemical_reaction/foam/hollow
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water/hollowwater = 1)
 	lifetime = 24 SECONDS
-	foam_type = /datum/effect_system/fluid_spread/foam/long
 
 /datum/chemical_reaction/foam/salt
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water/salt = 1)
 	lifetime = 1 SECONDS
 	slippery = FALSE
-	foam_type = /datum/effect_system/fluid_spread/foam/short/slipless
 
 /datum/chemical_reaction/foam/ice
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/consumable/ice = 1)
 	slippery = FALSE
-	foam_type = /datum/effect_system/fluid_spread/foam/slipless
 
 /datum/chemical_reaction/foam/soda
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/consumable/sodawater = 1)
 	lifetime = 1 SECONDS
-	foam_type = /datum/effect_system/fluid_spread/foam/short
 
 /datum/chemical_reaction/foam/holy
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water/holywater = 1)
 	lifetime = 24 SECONDS
 	slippery = FALSE
-	foam_type = /datum/effect_system/fluid_spread/foam/long/slipless
 
 /datum/chemical_reaction/foam/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	holder.create_foam(datum/effect_system/fluid_spread/foam, 2 * created_volume, notification = span_danger("The solution spews out foam!"), log = TRUE, lifetime = src.lifetime, slippery = src.slippery)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -372,7 +372,7 @@
 	slippery = FALSE
 
 /datum/chemical_reaction/foam/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	holder.create_foam(datum/effect_system/fluid_spread/foam, 2 * created_volume, notification = span_danger("The solution spews out foam!"), log = TRUE, lifetime = src.lifetime, slippery = src.slippery)
+	holder.create_foam(/datum/effect_system/fluid_spread/foam, 2 * created_volume, notification = span_danger("The solution spews out foam!"), log = TRUE, lifetime = src.lifetime, slippery = src.slippery)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE
 
 /datum/chemical_reaction/metalfoam


### PR DESCRIPTION

## About The Pull Request
Adds slipless foam + one slipless foam for each life time + adjusted long foam's life time from 30 seconds to 24.
Adds new foam reactions, list of what they produce below.
salt water = lasts shorter + no slip
soda water = lasts shorter
ice = no slip
holy water = lasts longer + no slip
hollow water = lasts longer
## Why It's Good For The Game
Sometimes, you want to flood medbay with a colorful reagent grenade WITHOUT it slipping everyone and blocking it for a stupid amount of time.
## Changelog
:cl:
add: New reactions for water variants that make foam
code: New foam types that either slip or last longer or shorter
/:cl:
