### PR TITLE
Fixes crab market crash

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -819,7 +819,7 @@
 /obj/item/card/id/click_alt(mob/living/user)
 	if(!alt_click_can_use_id(user))
 		return NONE
-	if (registered_account.being_dumped)
+	if (LAZYLEN(registered_account.being_dumped))
 		registered_account.bank_card_talk(span_warning("内部服务器错误"), TRUE)
 		return CLICK_ACTION_SUCCESS
 	if(registered_account.account_debt)

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -27,9 +27,9 @@
 		if(isliving(user))
 			L = user
 			accounts_to_rob -= L.get_bank_account()
+		var/obj/effect/dumpeet_target/dump_machine = new /obj/effect/dumpeet_target(targetturf, L)
 		for(var/datum/bank_account/B as anything in accounts_to_rob)
-			B.dumpeet()
-		new /obj/effect/dumpeet_target(targetturf, L)
+			B.dumpeet(dump_machine.dump)
 
 		to_chat(user, span_notice("You have activated Protocol CRAB-17."))
 		user.log_message("activated Protocol CRAB-17.", LOG_GAME)
@@ -67,7 +67,7 @@
  */
 /obj/structure/checkoutmachine/proc/check_if_finished()
 	for(var/datum/bank_account/B as anything in accounts_to_rob)
-		if (B.being_dumped)
+		if(LAZYFIND(B.being_dumped, src))
 			return FALSE
 	return TRUE
 
@@ -94,13 +94,13 @@
 		balloon_alert(user, "card has no registered account!")
 		return
 
-	if(!card.registered_account.being_dumped)
+	if(!LAZYFIND(card.registered_account.being_dumped, src))
 		balloon_alert(user, "funds are already safe!")
 		return
 
 	to_chat(user, span_warning("You quickly cash out your funds to a more secure banking location. Funds are safu.")) // This is a reference and not a typo
 	accounts_to_rob -= card.registered_account
-	card.registered_account.stop_dump()
+	card.registered_account.stop_dump(src)
 
 	if(check_if_finished())
 		qdel(src)
@@ -112,6 +112,8 @@
 		return
 	bogdanoff = user
 	internal_account = new /datum/bank_account/remote("CRAB-17", 0, player_account = FALSE)
+
+/obj/structure/checkoutmachine/proc/setup_siphoning()
 	add_overlay("flaps")
 	add_overlay("hatch")
 	add_overlay("legs_retracted")
@@ -232,7 +234,7 @@
  */
 /obj/structure/checkoutmachine/proc/stop_dumping()
 	for(var/datum/bank_account/B as anything in accounts_to_rob)
-		B.stop_dump()
+		B.stop_dump(src)
 
 /**
  * Splits the balance of the internal_account into several smaller piles of cash and scatters them around the area.
@@ -274,6 +276,7 @@
 /obj/effect/dumpeet_target/Initialize(mapload, user)
 	. = ..()
 	bogdanoff = user
+	dump = new /obj/structure/checkoutmachine(null, bogdanoff)
 	addtimer(CALLBACK(src, PROC_REF(startLaunch)), 10 SECONDS)
 	sound_to_playing_players('sound/items/dump_it.ogg', 20)
 	deadchat_broadcast("Protocol CRAB-17 has been activated. A space-coin market has been launched at the station!", turf_target = get_turf(src), message_type=DEADCHAT_ANNOUNCEMENT)
@@ -283,7 +286,7 @@
  */
 /obj/effect/dumpeet_target/proc/startLaunch()
 	DF = new /obj/effect/dumpeet_fall(drop_location())
-	dump = new /obj/structure/checkoutmachine(null, bogdanoff)
+	dump.setup_siphoning()
 	priority_announce("The spacecoin bubble has popped! Get to the credit deposit machine at [get_area(src)] and cash out before you lose all of your funds!", sender_override = "CRAB-17 Protocol")
 	animate(DF, pixel_z = -8, time = 5, , easing = LINEAR_EASING)
 	playsound(src,  'sound/items/weapons/mortar_whistle.ogg', 70, TRUE, 6)

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -25,8 +25,8 @@
 	var/account_id
 	///Amount of money that's been crabbed, if you lose enough from one series of CRAB-17's, you get a negative moodlet.
 	var/money_crabbed
-	///Is there a CRAB 17 on the station draining funds? Prevents manual fund transfer. pink levels are rising
-	var/being_dumped = FALSE
+	///Lazylist of CRAB 17s on the station draining funds. Prevents manual fund transfer. pink levels are rising
+	var/list/being_dumped
 	///Reference to the current civilian bounty that the account is working on.
 	var/datum/bounty/civilian_bounty
 	///If player is currently picking a civilian bounty to do, these options are held here to prevent soft-resetting through the UI.
@@ -117,15 +117,15 @@
 /**
  * Sets the bank_account to behave as though a CRAB-17 event is happening.
  */
-/datum/bank_account/proc/dumpeet()
-	being_dumped = TRUE
+/datum/bank_account/proc/dumpeet(obj/structure/checkoutmachine/dump_machine)
+	LAZYADD(being_dumped, dump_machine)
 	money_crabbed = 0
 
 /**
  * Stops the dumping of the bank account.
  */
-/datum/bank_account/proc/stop_dump()
-	being_dumped = FALSE
+/datum/bank_account/proc/stop_dump(obj/structure/checkoutmachine/dump_machine)
+	LAZYREMOVE(being_dumped, dump_machine)
 	if(money_crabbed < NO_MY_MONEY)
 		return
 	for(var/obj/card as anything in bank_cards)


### PR DESCRIPTION
## About The Pull Request

Market crashes now requires you to go to every individual market crash machine to stop the siphoning of funds.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/96096

## Changelog

:cl:
fix: Multiple crab17 crashes will now individually affect you and require you to visit each one.
/:cl: