### PR TITLE
Observers can move again

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -381,7 +381,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	client.view_size.resetToDefault()//Let's reset so people can't become allseeing gods
 	SStgui.on_transfer(src, mind.current) // Transfer NanoUIs.
 	if(mind.current.stat == DEAD && SSlag_switch.measures[DISABLE_DEAD_KEYLOOP] && !client.holder)
-		to_chat(src, span_warning("To leave your body again use the Ghost verb."))
+		to_chat(src, span_warning("To leave your body again use the Ghost verb (in the command bar)."))
 	mind.current.PossessByPlayer(key)
 	mind.current.client.init_verbs()
 	return TRUE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -381,7 +381,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	client.view_size.resetToDefault()//Let's reset so people can't become allseeing gods
 	SStgui.on_transfer(src, mind.current) // Transfer NanoUIs.
 	if(mind.current.stat == DEAD && SSlag_switch.measures[DISABLE_DEAD_KEYLOOP] && !client.holder)
-		to_chat(src, span_warning("To leave your body again use the Ghost verb (in the command bar)."))
+		to_chat(src, span_warning("To leave your body again use the 'Ghost verb' (in the command bar)."))
 	mind.current.PossessByPlayer(key)
 	mind.current.client.init_verbs()
 	return TRUE

--- a/code/modules/mob/mob_lists.dm
+++ b/code/modules/mob/mob_lists.dm
@@ -66,7 +66,9 @@
 ///Adds the cliented mob reference to either the list of dead player-mobs or to the list of observers, depending on how they joined the game.
 /mob/proc/add_to_current_dead_players()
 	GLOB.dead_player_list |= src
-	if(SSlag_switch.measures[DISABLE_DEAD_KEYLOOP] && !client.holder)
+	if(!SSlag_switch.measures[DISABLE_DEAD_KEYLOOP] || client.holder)
+		GLOB.keyloop_list |= src
+	else
 		GLOB.keyloop_list -= src
 
 /mob/dead/observer/add_to_current_dead_players()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -27,7 +27,7 @@
  * in the parent proc with istype checks right?):
  * * having incorporeal_move set (calls Process_Incorpmove() instead)
  * * being grabbed
- * * being buckled  (relaymove() is called to the buckled atom instead)
+ * * being buckled (relaymove() is called to the buckled atom instead)
  * * having your loc be some other mob (relaymove() is called on that mob instead)
  * * Not having MOBILITY_MOVE
  * * Failing Process_Spacemove() call


### PR DESCRIPTION
## About The Pull Request

Issue that came out of https://github.com/tgstation/tgstation/pull/95976 - We never actually add the dead player to the list of keyloops, so they can't move out of their body.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/96094

## Changelog

:cl:
fix: People who re-enter their body can now exit again by moving.
/:cl: