### PR TITLE
Crematorium can no longer destroy indestructible objects

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -462,50 +462,55 @@ GLOBAL_LIST_EMPTY(crematoriums)
 /obj/structure/bodycontainer/crematorium/proc/cremate(mob/user)
 	if(locked)
 		return //don't let you cremate something twice or w/e
+
 	// Make sure we don't delete the actual morgue and its tray
 	var/list/conts = get_all_contents() - src - connected
-
-	if(!conts.len)
+	if(!length(conts))
 		audible_message(span_hear("You hear a hollow crackle."))
 		return
 
-	else
-		audible_message(span_hear("You hear a roar as the crematorium activates."))
+	audible_message(span_hear("You hear a roar as the crematorium activates."))
+	locked = TRUE
+	update_appearance()
 
-		locked = TRUE
-		update_appearance()
+	for(var/mob/living/victim in conts)
+		if(victim.incorporeal_move) //can't cook revenants!
+			continue
 
-		for(var/mob/living/M in conts)
-			if(M.incorporeal_move) //can't cook revenants!
-				continue
-			if (M.stat != DEAD)
-				M.emote("scream")
-			if(user)
-				log_combat(user, M, "cremated")
-			else
-				M.log_message("was cremated", LOG_ATTACK)
+		if (victim.stat != DEAD)
+			victim.emote("scream")
 
-			if(user.stat != DEAD)
-				user.investigate_log("has died from being cremated.", INVESTIGATE_DEATHS)
-			M.death(TRUE)
-			if(!QDELETED(M)) //some animals get automatically deleted on death.
-				M.ghostize()
-				qdel(M)
+		if(user)
+			log_combat(user, victim, "cremated")
+		else
+			victim.log_message("was cremated", LOG_ATTACK)
 
-		for(var/obj/O in conts) //conts defined above, ignores crematorium and tray
-			if(istype(O, /obj/effect/dummy/phased_mob)) //they're not physical, don't burn em.
-				continue
-			qdel(O)
+		if(user.stat != DEAD)
+			user.investigate_log("has died from being cremated.", INVESTIGATE_DEATHS)
 
-		if(!locate(/obj/effect/decal/cleanable/ash) in get_step(src, dir))//prevent pile-up
-			new/obj/effect/decal/cleanable/ash(src)
+		victim.death(TRUE)
+		if(!QDELETED(victim)) //some animals get automatically deleted on death.
+			victim.ghostize()
+			qdel(victim)
 
-		sleep(3 SECONDS)
+	for(var/obj/to_destroy in conts) // conts defined above, ignores crematorium and tray
+		// Indestructible atoms should not be destroyed
+		if(istype(to_destroy, /obj/effect/dummy/phased_mob) || (to_destroy.resistance_flags & INDESTRUCTIBLE))
+			continue
+		qdel(to_destroy)
 
-		if(!QDELETED(src))
-			locked = FALSE
-			update_appearance()
-			playsound(src.loc, 'sound/machines/ding.ogg', 50, TRUE) //you horrible people
+	addtimer(CALLBACK(src, PROC_REF(unlock)), 3 SECONDS)
+
+/obj/structure/bodycontainer/crematorium/proc/unlock()
+	if(QDELETED(src))
+		return
+
+	if(!locate(/obj/effect/decal/cleanable/ash) in get_step(src, dir)) // As to prevent pile-up
+		new /obj/effect/decal/cleanable/ash(src)
+
+	locked = FALSE
+	update_appearance()
+	playsound(src.loc, 'sound/machines/ding.ogg', 50, TRUE) // You horrible people
 
 /obj/structure/bodycontainer/crematorium/creamatorium
 	name = "creamatorium"
@@ -579,8 +584,8 @@ GLOBAL_LIST_EMPTY(crematoriums)
 		if(!istype(O, /obj/structure/closet/body_bag))
 			return
 	else
-		var/mob/M = O
-		if(M.buckled)
+		var/mob/victim = O
+		if(victim.buckled)
 			return
 	O.forceMove(src.loc)
 	if (user != O)


### PR DESCRIPTION

## About The Pull Request

Cleans up crematorium code, moves it to timers instead of sleeping, and stops it from deleting indestructible objects.

Closes #96091

## Why It's Good For The Game

While this does have some balance implications, we no longer have an objective to destroy the blackbox (with this being one of the few means to do so, only other common method being the supermatter) so I presume it is okay to prevent it from destroying otherwise indestructible items. I've checked with NecromancerAnne about this and she said it shouldn't have too much of a balance impact?

If I have missed any potential scenarios this breaks, please note under the PR and I will try to rethink this.

## Changelog
:cl:
fix: Crematorium can no longer destroy indestructible objects
code: Cleaned up crematorium code
/:cl:
