### PR TITLE
Fixes bubblegum suicide span, cleans up say spans

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -89,6 +89,8 @@
 #define SPAN_TAPE_RECORDER "tape_recorder"
 #define SPAN_SMALL_VOICE "small"
 #define SPAN_SOAPBOX "soapbox"
+#define SPAN_COLOSSUS "colossus"
+#define SPAN_DANGER "danger"
 //bitflag #defines for return value of the radio() proc.
 /// Makes the message use italics
 #define ITALICS (1<<0)

--- a/code/__HELPERS/hallucinations.dm
+++ b/code/__HELPERS/hallucinations.dm
@@ -293,9 +293,9 @@ ADMIN_VERB(debug_hallucination_weighted_list_per_type, R_DEBUG, "Show Hallucinat
 
 /// Lines the bubblegum hallucinatoin uses when it pops up
 #define BUBBLEGUM_HALLUCINATION_LINES list( \
-		span_colossus("I AM IMMORTAL."), \
-		span_colossus("I SHALL TAKE YOUR WORLD."), \
-		span_colossus("I SEE YOU."), \
-		span_colossus("YOU CANNOT ESCAPE ME FOREVER."), \
-		span_colossus("NOTHING CAN HOLD ME."), \
+		"I AM IMMORTAL.", \
+		"I SHALL TAKE YOUR WORLD.", \
+		"I SEE YOU.", \
+		"YOU CANNOT ESCAPE ME FOREVER.", \
+		"NOTHING CAN HOLD ME.", \
 	)

--- a/code/datums/actions/mobs/projectileattack.dm
+++ b/code/datums/actions/mobs/projectileattack.dm
@@ -331,7 +331,7 @@
 	var/mob/living/simple_animal/hostile/megafauna/colossus/colossus
 	if(istype(firer, /mob/living/simple_animal/hostile/megafauna/colossus))
 		colossus = firer
-		colossus.say("Perish.", spans = list("colossus", "yell"))
+		colossus.say("Perish.", spans = list(SPAN_COLOSSUS, SPAN_YELL))
 
 	SLEEP_CHECK_DEATH(1.5 SECONDS, firer) //gives dumbasses in melee range a slim chance to retreat
 	var/finale_counter = 10

--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -439,7 +439,7 @@
 		var/beepskys_cry = "Level 10 infraction alert!"
 		to_chat(victim, "[span_name("[name]")] exclaims, \"[span_robot("[beepskys_cry]")]")
 		if(victim.client?.prefs.read_preference(/datum/preference/toggle/enable_runechat))
-			victim.create_chat_message(src, raw_message = beepskys_cry, spans = list("robotic"))
+			victim.create_chat_message(src, raw_message = beepskys_cry, spans = list(SPAN_ROBOT))
 
 // Used by Veteran Security Advisor job.
 /datum/brain_trauma/special/ptsd

--- a/code/game/objects/items/food/sweets.dm
+++ b/code/game/objects/items/food/sweets.dm
@@ -258,7 +258,7 @@
 		to_chat(victim, span_warning("[pick("You hear faint whispers.", "You smell ash.", "You feel hot.", "You hear a roar in the distance.")]"))
 
 /obj/item/food/bubblegum/bubblegum/suicide_act(mob/living/user)
-	user.say(";[pick(BUBBLEGUM_HALLUCINATION_LINES)]")
+	user.say(";[pick(BUBBLEGUM_HALLUCINATION_LINES)]", spans = list(SPAN_COLOSSUS))
 	return ..()
 
 /obj/item/food/gumball

--- a/code/modules/hallucination/bubblegum_attack.dm
+++ b/code/modules/hallucination/bubblegum_attack.dm
@@ -49,7 +49,7 @@
 		hallucinator.playsound_local(wall_source, 'sound/effects/meteorimpact.ogg', 150, TRUE)
 
 	if(haunt_them)
-		to_chat(hallucinator, pick(hallucination_lines))
+		to_chat(hallucinator, span_collosus(pick(hallucination_lines)))
 
 	var/obj/effect/client_image_holder/hallucination/bubblegum/fake_bubbles = new(wall_source, hallucinator, src)
 	addtimer(CALLBACK(src, PROC_REF(charge_loop), fake_bubbles, target_landing_turf), 1 SECONDS)

--- a/code/modules/hallucination/bubblegum_attack.dm
+++ b/code/modules/hallucination/bubblegum_attack.dm
@@ -49,7 +49,7 @@
 		hallucinator.playsound_local(wall_source, 'sound/effects/meteorimpact.ogg', 150, TRUE)
 
 	if(haunt_them)
-		to_chat(hallucinator, span_collosus(pick(hallucination_lines)))
+		to_chat(hallucinator, span_colossus(pick(hallucination_lines)))
 
 	var/obj/effect/client_image_holder/hallucination/bubblegum/fake_bubbles = new(wall_source, hallucinator, src)
 	addtimer(CALLBACK(src, PROC_REF(charge_loop), fake_bubbles, target_landing_turf), 1 SECONDS)

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -147,7 +147,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/auxiliary_base, 32)
 				return
 			var/shuttle_error = SSshuttle.moveShuttle(shuttleId, params["shuttle_id"], 1)
 			if(launch_warning)
-				say("Launch sequence activated! Prepare for drop!!", spans = list("danger"))
+				say("Launch sequence activated! Prepare for drop!!", spans = list(SPAN_DANGER))
 				playsound(loc, 'sound/machines/warning-buzzer.ogg', 70, FALSE)
 				launch_warning = FALSE
 				blind_drop_ready = FALSE


### PR DESCRIPTION

## About The Pull Request

Closes #96085
Also went through other say spans and converted them to defines, as well as fixed beepsky smash's hallucination beepskys not having their spans due to incorrect span being passed.

## Changelog
:cl:
fix: Bubblegun suicide no longer makes the user yell out HTML
fix: Beepsky Smash beepskys now use proper text formatting
code: Cleaned up say span code in a few places
/:cl:
