### PR TITLE
Fixes custom pizzas having broken sprites and not preserving their ingredients when sliced

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_food.dm
+++ b/code/__DEFINES/dcs/signals/signals_food.dm
@@ -20,6 +20,8 @@
 #define COMSIG_ITEM_USED_AS_INGREDIENT "item_used_as_ingredient"
 /// called when an edible ingredient is added: (datum/component/edible/ingredient)
 #define COMSIG_FOOD_INGREDIENT_ADDED "edible_ingredient_added"
+/// called when a pizza slice is picked up: (mob/user, obj/item/food/pizzaslice/slice)
+#define COMSIG_PIZZA_SLICE_TAKEN "pizza_slice_taken"
 
 /// from base of /datum/component/edible/get_recipe_complexity(): (list/extra_complexity)
 #define COMSIG_FOOD_GET_EXTRA_COMPLEXITY "food_get_extra_complexity"

--- a/code/datums/components/ingredients_holder.dm
+++ b/code/datums/components/ingredients_holder.dm
@@ -72,6 +72,7 @@
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(parent, COMSIG_ATOM_EXITED, PROC_REF(food_exited))
 	RegisterSignal(parent, COMSIG_ATOM_PROCESSED, PROC_REF(on_processed))
+	RegisterSignal(parent, COMSIG_PIZZA_SLICE_TAKEN, PROC_REF(on_slice_taken))
 	RegisterSignal(parent, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, PROC_REF(on_requesting_context_from_item))
 	ADD_TRAIT(parent, TRAIT_INGREDIENTS_HOLDER, INNATE_TRAIT)
 
@@ -81,6 +82,7 @@
 		COMSIG_ATOM_EXAMINE,
 		COMSIG_ATOM_EXITED,
 		COMSIG_ATOM_PROCESSED,
+		COMSIG_PIZZA_SLICE_TAKEN,
 		COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM,
 	))
 	REMOVE_TRAIT(parent, TRAIT_INGREDIENTS_HOLDER, INNATE_TRAIT)
@@ -286,6 +288,11 @@
 	// while custom materials are already transferred evenly between results by atom/proc/StartProcessingAtom()
 	for (var/atom/result as anything in results)
 		result.AddComponent(/datum/component/ingredients_holder, null, fill_type, ingredient_type = ingredient_type, max_ingredients = max_ingredients, processed_holder = src)
+
+/// Pizzas have unique slicing interaction so we need to do this
+/datum/component/ingredients_holder/proc/on_slice_taken(datum/source, mob/living/user, obj/item/slice)
+	SIGNAL_HANDLER
+	slice.AddComponent(/datum/component/ingredients_holder, null, fill_type, ingredient_type = ingredient_type, max_ingredients = max_ingredients, processed_holder = src)
 
 /**
  * Adds context sensitivy directly to the customizable reagent holder file for screentips

--- a/code/game/objects/items/food/dough.dm
+++ b/code/game/objects/items/food/dough.dm
@@ -46,7 +46,7 @@
 
 /obj/item/food/pizzabread/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/ingredients_holder, /obj/item/food/pizza, CUSTOM_INGREDIENT_ICON_SCATTER, max_ingredients = 12)
+	AddComponent(/datum/component/ingredients_holder, /obj/item/food/pizza/custom, CUSTOM_INGREDIENT_ICON_SCATTER, max_ingredients = 12)
 
 /obj/item/food/doughslice
 	name = "dough slice"

--- a/code/game/objects/items/food/pizza.dm
+++ b/code/game/objects/items/food/pizza.dm
@@ -106,6 +106,7 @@
 
 	slice.reagents.remove_all()
 	reagents.trans_to(slice, amount = reagents.total_volume / slices_left, no_react = TRUE)
+	SEND_SIGNAL(src, COMSIG_ATOM_PROCESSED, user, null, list(slice))
 
 	slices_left--
 	if(slices_left <= 0)
@@ -115,15 +116,6 @@
 		return
 	remove_filter("pizzaslices")
 	add_filter("pizzaslices", 1, get_slices_filter())
-
-// Raw Pizza
-/obj/item/food/pizza/raw
-	foodtypes = GRAIN | RAW
-	slice_type = null
-	crafting_complexity = FOOD_COMPLEXITY_2
-
-/obj/item/food/pizza/raw/make_bakeable()
-	AddComponent(/datum/component/bakeable, /obj/item/food/pizza, rand(70 SECONDS, 80 SECONDS), TRUE, TRUE)
 
 // Pizza Slice
 /obj/item/food/pizzaslice
@@ -139,6 +131,17 @@
 
 /obj/item/food/pizzaslice/make_processable()
 	AddElement(/datum/element/processable, TOOL_ROLLINGPIN, /obj/item/stack/sheet/pizza, 1, 1 SECONDS, table_required = TRUE, screentip_verb = "Flatten", sound_to_play = SFX_ROLLING_PIN_ROLLING)
+
+/obj/item/food/pizza/custom
+	name = "pizza"
+	desc = "A fancy custom pizza."
+	icon_state = "pizzamargherita" // Colored by the ingredient_holder component
+	slice_type = /obj/item/food/pizzaslice/custom
+
+/obj/item/food/pizzaslice/custom
+	name = "pizza slice"
+	desc = "A slice of custom fancy pizza."
+	icon_state = "pizzamargheritaslice"
 
 /obj/item/food/pizza/margherita
 	name = "pizza margherita"

--- a/code/game/objects/items/food/pizza.dm
+++ b/code/game/objects/items/food/pizza.dm
@@ -106,7 +106,7 @@
 
 	slice.reagents.remove_all()
 	reagents.trans_to(slice, amount = reagents.total_volume / slices_left, no_react = TRUE)
-	SEND_SIGNAL(src, COMSIG_ATOM_PROCESSED, user, null, list(slice))
+	SEND_SIGNAL(src, COMSIG_PIZZA_SLICE_TAKEN, user, slice)
 
 	slices_left--
 	if(slices_left <= 0)


### PR DESCRIPTION

## About The Pull Request

- Closes #95030
- Closes #96081
Removed raw pizza subtype as it is unused and does not function properly anyways

Also makes pizzas preserve their fillings when sliced

## Changelog
:cl:
fix: Fixed custom pizzas having broken sprites and not preserving their ingredients when sliced
/:cl:
