### PR TITLE
Fixes Gene Stim missing an icon in ling UI

### DIFF
--- a/code/modules/antagonists/changeling/cellular_emporium.dm
+++ b/code/modules/antagonists/changeling/cellular_emporium.dm
@@ -42,6 +42,7 @@
 			var/list/ability_data = list(
 				"name" = initial(ability_path.name),
 				"desc" = initial(ability_path.desc),
+				"icon" = initial(ability_path.button_icon_state),
 				"helptext" = initial(ability_path.helptext),
 				"path" = ability_path,
 				"genetic_point_required" = dna_cost,

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -1,5 +1,5 @@
 /datum/action/changeling/sting//parent path, not meant for users afaik
-	name = "Tiny Prick" //cellularemporium uses `nameToIconState` to button icon state must match this, on top of matching the hud below.
+	name = "Tiny Prick"
 	desc = "Stabby stabby"
 	category = "stings"
 	button_icon_state = "sting_null" //This must be equal to the icon state for `/atom/movable/screen/ling/sting`

--- a/tgui/packages/tgui/interfaces/CellularEmporium.tsx
+++ b/tgui/packages/tgui/interfaces/CellularEmporium.tsx
@@ -24,6 +24,7 @@ type TypePath = string;
 type Ability = {
   name: string;
   desc: string;
+  icon: string;
   helptext: string;
   path: TypePath;
   genetic_point_required: number;
@@ -39,14 +40,6 @@ type CellularEmporiumContext = {
   owned_abilities: TypePath[];
   absorb_count: number;
   dna_count: number;
-};
-
-// ==========
-// Helper: convert ability name to icon_state
-// Example: "Augmented Eyesight" → "augmented_eyesight"
-// ==========
-const nameToIconState = (name: string): string => {
-  return name.toLowerCase().replace(/\s+/g, '_');
 };
 
 // ==========
@@ -252,8 +245,6 @@ const ItemList = (props: ItemListProps) => {
               ? `Cost: ${ability.dna_required} DNA`
               : `Cost: ${ability.genetic_point_required} DNA`;
 
-          const iconState = nameToIconState(ability.name);
-
           return (
             <Stack.Item key={ability.path} mt={compactMode ? 0.5 : 1}>
               <Section fitted={!!compactMode}>
@@ -281,7 +272,7 @@ const ItemList = (props: ItemListProps) => {
                           top="0"
                           left="0"
                           icon="icons/mob/actions/actions_changeling.dmi"
-                          icon_state={iconState}
+                          icon_state={ability.icon}
                           width={iconSize}
                           fallback={<Icon name="question-circle" size={3} />}
                         />


### PR DESCRIPTION

## About The Pull Request

<img width="624" height="518" alt="image" src="https://github.com/user-attachments/assets/da099c5e-d23e-4fdc-ac66-0bd6b54dc1c1" />

It was, in fact, critical

## Changelog
:cl:
fix: Fixed Gene Stim missing an icon in ling UI
/:cl:
