### PR TITLE
Fixes cyborg guns not recharging

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -215,6 +215,7 @@
 			chambered = AC //...prepare a new shot based on the current ammo type selected
 			if(!chambered.loaded_projectile)
 				chambered.newshot()
+				return ..()
 
 /obj/item/gun/energy/handle_chamber()
 	if(chambered && !chambered.loaded_projectile) //if loaded_projectile is null, i.e the shot has been fired...

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -208,7 +208,6 @@
 				var/obj/item/ammo_casing/energy/shot = ammo_type[select] //Necessary to find cost of shot
 				if(robot.cell.use(shot.e_cost)) //Take power from the borg...
 					cell.give(shot.e_cost) //... to recharge the shot
-					return ..()
 
 	if(!chambered)
 		var/obj/item/ammo_casing/energy/AC = ammo_type[select]
@@ -216,7 +215,6 @@
 			chambered = AC //...prepare a new shot based on the current ammo type selected
 			if(!chambered.loaded_projectile)
 				chambered.newshot()
-				return ..()
 
 /obj/item/gun/energy/handle_chamber()
 	if(chambered && !chambered.loaded_projectile) //if loaded_projectile is null, i.e the shot has been fired...


### PR DESCRIPTION

## About The Pull Request
Apparently #95563 changed how energy guns recharged, and in doing so broke cyborg guns from recharging. This pr simply removes the return that is causing the problem, which fixes #96119 
## Why It's Good For The Game
Bugs bad, kill bugs
## Changelog
:cl:
fix: Fixed cyborg's recharging guns not recharging
/:cl:
