### PR TITLE
Camera blending now happens as you start the snap

### DIFF
--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -187,6 +187,7 @@
 
 /**
  * Attempts to take an image of the target and all its surrounding tiles
+ * Returns TRUE if it successfully starts taking a picture.
  * Arguments
  *
  * * atom/target - the target we are trying to take a photo of
@@ -198,15 +199,16 @@
 	if(!on)
 		if(user)
 			user.balloon_alert(user, "flash still charging!")
-		return
+		return FALSE
 
 	if(blending)
 		if(user)
 			user.balloon_alert(user, "image still blending!")
-		return
+		return FALSE
 
 	blending = TRUE
 	INVOKE_ASYNC(src, PROC_REF(capture_image), target, user)
+	return TRUE
 
 /**
  * Renders an image of the target and all its surrounding tiles

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -205,6 +205,7 @@
 			user.balloon_alert(user, "image still blending!")
 		return
 
+	blending = TRUE
 	INVOKE_ASYNC(src, PROC_REF(capture_image), target, user)
 
 /**
@@ -217,11 +218,14 @@
 	var/turf/target_turf = get_turf(target)
 	var/view_size = user?.client?.view || world.view
 	if(isnull(target_turf))
+		blending = FALSE
 		return
 	if(isAI(user))
 		if(!SScameras.is_visible_by_cameras(target_turf))
+			blending = FALSE
 			return
 	else if(!(target_turf in view(view_size, user)))
+		blending = FALSE
 		return
 
 	//These vars will be reused later on
@@ -232,11 +236,11 @@
 	var/viewer = get_turf(user?.client?.eye || user)
 	var/list/seen = get_hear_turfs(view_range, viewer)
 	if(!(target_turf in seen))
+		blending = FALSE
 		return
 
 	//taking the actual picture
 	on_flash(target, user)
-	blending = TRUE
 	var/list/mobs_spotted = list()
 	var/list/dead_spotted = list()
 	var/list/turfs = list()


### PR DESCRIPTION
## About The Pull Request

Blending is set when you start taking the image rather than when it flashes and starts the turf reservations.

This is to avoid issues where a camera is made to take a photo of several things at once, it will attempt to take a photo of each thing despite not being able to due to it being called async.

## Why It's Good For The Game

It doesn't really affect the game right now but I noticed this as an issue when I tried making a camera take several photos at once and realized it tries to take photos of everyone at once and it causes lag.

## Changelog

Nothing player-facing.