### PR TITLE
Fixes bots trying to blacklist items already marked for QDEL

### DIFF
--- a/code/modules/mob/living/basic/bots/bot_ai.dm
+++ b/code/modules/mob/living/basic/bots/bot_ai.dm
@@ -63,6 +63,8 @@
 	source.clear_path_hud(remove_hud = FALSE)
 
 /datum/ai_controller/basic_controller/bot/proc/add_to_blacklist(atom/target, duration)
+	if(QDELETED(target))
+		return
 	var/final_duration = duration || blackboard[BB_UNREACHABLE_LIST_COOLDOWN]
 	set_blackboard_key_assoc_lazylist(BB_TEMPORARY_IGNORE_LIST, target, TRUE)
 	addtimer(CALLBACK(src, PROC_REF(remove_from_blacklist), target), final_duration)


### PR DESCRIPTION

Was happening especially to cleanbots; they both try to clean a spot, one bot does it first, the other "fails" to clean it and tries to blacklist the object, but the object it was trying to clean was being qdel'd so it threw an error. now it checks qdeletion beforehand!

## Changelog

:cl:
fix: Fixes an issue were bots would try to blacklist qdeleted atoms
/:cl:
