### PR TITLE
Add human limbs to the holodeck medsim organ crate

### DIFF
--- a/_maps/templates/holodeck_medicalsim.dmm
+++ b/_maps/templates/holodeck_medicalsim.dmm
@@ -473,6 +473,10 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/freezer/organ,
+/obj/item/bodypart/leg/left,
+/obj/item/bodypart/leg/right,
+/obj/item/bodypart/arm/right,
+/obj/item/bodypart/arm/left,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},


### PR DESCRIPTION

## About The Pull Request
This adds a set of human arms and legs to the holodeck organ crate in the medsim program. I forgot to do this when I added the initial crate in #88195, and I didn't notice it until I fixed organs/limbs in:

- #95967

The code is set up so that any organs or body parts that are holograms will be deleted when the simulation is changed or turned off. (also affected by EMPs) This means any surgery you give to someone using these limbs is extremely likely to vanish at some point in the round.

## Why It's Good For The Game
Mah immersion + funny

## Changelog
:cl:
map: Add human limbs to the holodeck medsim organ crate
/:cl:
