### PR TITLE
Restocking a Vending machine no longer creates 0 credit holochips.

### DIFF
--- a/code/modules/vending/vendor/interaction.dm
+++ b/code/modules/vending/vendor/interaction.dm
@@ -159,8 +159,9 @@
 	to_chat(user, span_notice("You loaded [restocked] items in [src][credits_contained > 0 ? ", and are rewarded [credits_contained] [MONEY_NAME]." : "."]"))
 	var/datum/bank_account/cargo_account = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	cargo_account.adjust_money(round(credits_contained * 0.5), "Vending: Restock")
-	var/obj/item/holochip/payday = new(src, credits_contained)
-	try_put_in_hand(payday, user)
+	if(credits_contained >= 1)
+		var/obj/item/holochip/payday = new(src, credits_contained)
+		try_put_in_hand(payday, user)
 	credits_contained = 0
 
 /obj/machinery/vending/exchange_parts(mob/user, obj/item/storage/part_replacer/replacer)


### PR DESCRIPTION
## About The Pull Request

The post_restock proc did not have an appropriate check to confirm that there was enough stored credits to produce a non-zero holochip. This adds a quick check for the proc, preventing their creation.

## Why It's Good For The Game

One less silly runtime on live.

## Changelog

:cl:
fix: Restocking a vending machine can no longer produce a zero credit holochip.
/:cl: