### PR TITLE
Bitrunning actors no longer take double damage, their real bodies take damage

### DIFF
--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -188,7 +188,7 @@
 		INVOKE_ASYNC(old_body, TYPE_PROC_REF(/mob/living, emote), "scream")
 
 	var/zone = def_zone
-	if(istype(def_zone, /obj/item/bodypart)) // If the defined zone is a bodypart, then it is the bodypart of the domain avatar. We don't want that bodypart, we want the real body's bodypart, so we go back to zone.
+	if(isbodypart(def_zone)) // If the defined zone is a bodypart, then it is the bodypart of the domain avatar. We don't want that bodypart, we want the real body's bodypart, so we go back to zone.
 		zone = astype(def_zone, /obj/item/bodypart).body_zone
 
 	old_body.apply_damage(damage, damage_type, zone, blocked, wound_bonus = CANT_WOUND)

--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -187,6 +187,9 @@
 	if(damage > 30 && prob(30))
 		INVOKE_ASYNC(old_body, TYPE_PROC_REF(/mob/living, emote), "scream")
 
+	if(istype(def_zone, /obj/item/bodypart)) // If the defined zone is a bodypart, then it is the bodypart of the domain avatar. We don't want that bodypart, we want the real body's bodypart, so we go back to zone.
+		def_zone = astype(def_zone, /obj/item/bodypart).body_zone
+
 	old_body.apply_damage(damage, damage_type, def_zone, blocked, wound_bonus = CANT_WOUND)
 
 	if(old_body.stat > SOFT_CRIT) // KO!

--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -187,10 +187,11 @@
 	if(damage > 30 && prob(30))
 		INVOKE_ASYNC(old_body, TYPE_PROC_REF(/mob/living, emote), "scream")
 
+	var/zone = def_zone
 	if(istype(def_zone, /obj/item/bodypart)) // If the defined zone is a bodypart, then it is the bodypart of the domain avatar. We don't want that bodypart, we want the real body's bodypart, so we go back to zone.
-		def_zone = astype(def_zone, /obj/item/bodypart).body_zone
+		zone = astype(def_zone, /obj/item/bodypart).body_zone
 
-	old_body.apply_damage(damage, damage_type, def_zone, blocked, wound_bonus = CANT_WOUND)
+	old_body.apply_damage(damage, damage_type, zone, blocked, wound_bonus = CANT_WOUND)
 
 	if(old_body.stat > SOFT_CRIT) // KO!
 		full_avatar_disconnect(cause_damage = TRUE)


### PR DESCRIPTION

## About The Pull Request

`def_zone` can hold a zone or a bodypart. In the case of a simple stabbing or shooting, it sends a bodypart. That bodypart is the bodypart of the domain actor. When we call `apply_damage()` on the real-world body, we send the bodypart of the domain actor in `def_zone`, which somehow has no runtimes or checks and ends up successfully dealing damage... to the actor. Again. This doesn't always shield the original body, as `def_zone` is not guaranteed to be sent as a bodypart(or at all), so you could be killed in real life by certain attacks still, but for the grand majority of attacks this meant that the real body was invincible and the actor took double.

## Why It's Good For The Game

fixes #93081

## Changelog
:cl:

fix: Bitrunners no longer take double damage in-domain, and do take damage to their real bodies

/:cl:
