### PR TITLE
Plants no longer have pollen particles when they've died.

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -795,6 +795,7 @@
 	set_pestlevel(0, update_icon = FALSE) // Pests die
 	lastproduce = 0
 	SEND_SIGNAL(src, COMSIG_HYDROTRAY_PLANT_DEATH)
+	remove_shared_particles(/particles/pollen) //We shouldn't look like we're pollenating if we're dead.
 	if(update_icon)
 		update_appearance()
 


### PR DESCRIPTION
## About The Pull Request

Plants, after they have died, do not actively pollenate their neighbors in gameplay. However, they do still have pollen particles. This is definitely a visual oversight, and an easy fix.

Now, after a planet calls `plantdies`, we remove it's pollen particles.

## Why It's Good For The Game

Improves the visual consistency of hydroponics and better communicates when the mechanic is working as intended.

## Changelog

:cl:
fix: Hydroponics trays will no longer produce pollen particles if the plant in the tray has died.
/:cl: