### PR TITLE
Fixes shaft miner and assistant outfit subtypes using incorrect pda_slot

### DIFF
--- a/code/modules/jobs/job_types/assistant/gimmick_assistants.dm
+++ b/code/modules/jobs/job_types/assistant/gimmick_assistants.dm
@@ -168,6 +168,7 @@
 	head = /obj/item/clothing/head/utility/hardhat
 	uniform = /obj/item/clothing/under/color/yellow
 	l_pocket = /obj/item/modular_computer/pda/assistant
+	pda_slot = ITEM_SLOT_LPOCKET
 
 	outfit_weight = 6
 

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -96,6 +96,7 @@
 	l_pocket = /obj/item/modular_computer/pda/shaftminer
 	r_pocket = /obj/item/extinguisher/mini
 	belt = /obj/item/storage/belt/mining/healing
+	pda_slot = ITEM_SLOT_LPOCKET
 
 /datum/outfit/job/miner/equipped/combat/post_equip(mob/living/carbon/human/miner, visuals_only = FALSE)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Might want to unit test for this but I'm not sure exactly how to do so without potentially running into edge cases with weirder outfits

## Changelog
:cl:
fix: Pre-equipped shaft miners and handyman assistants now start with imprinted PDAs like the rest of the job outfits.
/:cl:
