### PR TITLE
Fix DNA vault powers losing traits after mutation cleanup

### DIFF
--- a/code/modules/station_goals/vault_mutation.dm
+++ b/code/modules/station_goals/vault_mutation.dm
@@ -8,11 +8,11 @@
 
 /datum/mutation/breathless/on_acquiring(mob/living/carbon/human/acquirer)
 	. = ..()
-	ADD_TRAIT(acquirer, TRAIT_NOBREATH, GENETIC_MUTATION)
+	ADD_TRAIT(acquirer, TRAIT_NOBREATH, DNA_VAULT_TRAIT)
 
 /datum/mutation/breathless/on_losing(mob/living/carbon/human/owner)//this shouldnt happen under normal condition but just to be sure
 	. = ..()
-	REMOVE_TRAIT(owner, TRAIT_NOBREATH, GENETIC_MUTATION)
+	REMOVE_TRAIT(owner, TRAIT_NOBREATH, DNA_VAULT_TRAIT)
 
 /datum/mutation/quick
 	name = "Quick"
@@ -39,12 +39,12 @@
 /datum/mutation/tough/on_acquiring(mob/living/carbon/human/acquirer)
 	. = ..()
 	acquirer.physiology.brute_mod *= 0.7
-	ADD_TRAIT(acquirer, TRAIT_PIERCEIMMUNE, GENETIC_MUTATION)
+	ADD_TRAIT(acquirer, TRAIT_PIERCEIMMUNE, DNA_VAULT_TRAIT)
 
 /datum/mutation/tough/on_losing(mob/living/carbon/human/owner)
 	. = ..()
 	owner.physiology.brute_mod /= 0.7
-	REMOVE_TRAIT(owner, TRAIT_PIERCEIMMUNE, GENETIC_MUTATION)
+	REMOVE_TRAIT(owner, TRAIT_PIERCEIMMUNE, DNA_VAULT_TRAIT)
 
 /datum/mutation/dextrous
 	name = "Dextrous"
@@ -71,12 +71,12 @@
 /datum/mutation/fire_immunity/on_acquiring(mob/living/carbon/human/acquirer)
 	. = ..()
 	acquirer.physiology.burn_mod *= 0.5
-	acquirer.add_traits(list(TRAIT_RESISTHEAT, TRAIT_NOFIRE), GENETIC_MUTATION)
+	acquirer.add_traits(list(TRAIT_RESISTHEAT, TRAIT_NOFIRE), DNA_VAULT_TRAIT)
 
 /datum/mutation/fire_immunity/on_losing(mob/living/carbon/human/owner)
 	. = ..()
 	owner.physiology.burn_mod /= 0.5
-	owner.remove_traits(list(TRAIT_RESISTHEAT, TRAIT_NOFIRE), GENETIC_MUTATION)
+	owner.remove_traits(list(TRAIT_RESISTHEAT, TRAIT_NOFIRE), DNA_VAULT_TRAIT)
 
 /datum/mutation/quick_recovery
 	name = "Quick Recovery"
@@ -103,7 +103,7 @@
 /datum/mutation/plasmocile/on_acquiring(mob/living/carbon/human/acquirer)
 	. = ..()
 	var/obj/item/organ/lungs/improved_lungs = acquirer.get_organ_slot(ORGAN_SLOT_LUNGS)
-	ADD_TRAIT(owner, TRAIT_VIRUSIMMUNE, GENETIC_MUTATION)
+	ADD_TRAIT(owner, TRAIT_VIRUSIMMUNE, DNA_VAULT_TRAIT)
 	if(improved_lungs)
 		apply_buff(improved_lungs)
 	RegisterSignal(acquirer, COMSIG_CARBON_LOSE_ORGAN, PROC_REF(remove_modification))
@@ -112,7 +112,7 @@
 /datum/mutation/plasmocile/on_losing(mob/living/carbon/human/owner)
 	. = ..()
 	var/obj/item/organ/lungs/improved_lungs = owner.get_organ_slot(ORGAN_SLOT_LUNGS)
-	REMOVE_TRAIT(owner, TRAIT_VIRUSIMMUNE, GENETIC_MUTATION)
+	REMOVE_TRAIT(owner, TRAIT_VIRUSIMMUNE, DNA_VAULT_TRAIT)
 	UnregisterSignal(owner, COMSIG_CARBON_LOSE_ORGAN)
 	UnregisterSignal(owner, COMSIG_CARBON_GAIN_ORGAN)
 	if(improved_lungs)
@@ -137,4 +137,3 @@
 /datum/mutation/plasmocile/proc/remove_buff(obj/item/organ/lungs/our_lungs)
 	our_lungs.plas_breath_dam_min = initial(our_lungs.plas_breath_dam_min)
 	our_lungs.plas_breath_dam_max = initial(our_lungs.plas_breath_dam_max)
-

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -158,6 +158,7 @@
 #include "designs.dm"
 #include "dismemberment.dm"
 #include "dna_infusion.dm"
+#include "dna_vault.dm"
 #include "door_access.dm"
 #include "dragon_expiration.dm"
 #include "drink_icons.dm"

--- a/code/modules/unit_tests/dna_vault.dm
+++ b/code/modules/unit_tests/dna_vault.dm
@@ -1,0 +1,16 @@
+/datum/unit_test/dna_vault_traits_survive_dormant_activator_cleanup/Run()
+	var/mob/living/carbon/human/consistent/test_subject = allocate(/mob/living/carbon/human/consistent)
+
+	test_subject.dna.add_mutation(/datum/mutation/adaptation/heat, MUTATION_SOURCE_ACTIVATED)
+	TEST_ASSERT(HAS_TRAIT_FROM(test_subject, TRAIT_RESISTHEAT, GENETIC_MUTATION), "Heat adaptation should add heat resistance as a normal genetic mutation.")
+
+	test_subject.dna.add_mutation(/datum/mutation/fire_immunity, MUTATION_SOURCE_DNA_VAULT)
+	TEST_ASSERT(HAS_TRAIT_FROM(test_subject, TRAIT_RESISTHEAT, DNA_VAULT_TRAIT), "DNA vault fire immunity should use the DNA vault trait source.")
+	TEST_ASSERT(HAS_TRAIT_FROM(test_subject, TRAIT_NOFIRE, DNA_VAULT_TRAIT), "DNA vault fire immunity should add fire immunity with the DNA vault trait source.")
+
+	test_subject.dna.remove_all_mutations(list(MUTATION_SOURCE_GENE_SYMPTOM, MUTATION_SOURCE_ACTIVATED))
+
+	TEST_ASSERT_NULL(test_subject.dna.get_mutation(/datum/mutation/adaptation/heat), "Dormant DNA Activator cleanup should remove normally activated mutations.")
+	TEST_ASSERT_NOTNULL(test_subject.dna.get_mutation(/datum/mutation/fire_immunity), "Dormant DNA Activator cleanup should not remove DNA vault mutations.")
+	TEST_ASSERT(HAS_TRAIT_FROM(test_subject, TRAIT_RESISTHEAT, DNA_VAULT_TRAIT), "Dormant DNA Activator cleanup should not strip shared DNA vault mutation traits.")
+	TEST_ASSERT(HAS_TRAIT_FROM(test_subject, TRAIT_NOFIRE, DNA_VAULT_TRAIT), "Dormant DNA Activator cleanup should not strip DNA vault-only traits.")

--- a/code/modules/unit_tests/dna_vault.dm
+++ b/code/modules/unit_tests/dna_vault.dm
@@ -14,3 +14,5 @@
 	TEST_ASSERT_NOTNULL(test_subject.dna.get_mutation(/datum/mutation/fire_immunity), "Dormant DNA Activator cleanup should not remove DNA vault mutations.")
 	TEST_ASSERT(HAS_TRAIT_FROM(test_subject, TRAIT_RESISTHEAT, DNA_VAULT_TRAIT), "Dormant DNA Activator cleanup should not strip shared DNA vault mutation traits.")
 	TEST_ASSERT(HAS_TRAIT_FROM(test_subject, TRAIT_NOFIRE, DNA_VAULT_TRAIT), "Dormant DNA Activator cleanup should not strip DNA vault-only traits.")
+
+	test_subject.dna.remove_mutation(/datum/mutation/fire_immunity, MUTATION_SOURCE_DNA_VAULT)


### PR DESCRIPTION
## About The Pull Request

Fixes #96118

DNA vault mutations were applying their runtime traits with the generic `GENETIC_MUTATION` trait source used by normal genetic mutations. Dormant DNA Activator cleanup removes normal activated mutation sources on cure; when one of those mutations shares a trait with a DNA vault mutation, that generic trait source can be removed even though the DNA vault mutation itself remains.

This makes DNA vault mutations apply and remove their traits with `DNA_VAULT_TRAIT`, matching their own mutation source and keeping their effects isolated from ordinary mutation cleanup. It also adds a unit test for the cleanup path using a shared heat-resistance trait.

## Why It's Good For The Game

DNA vault powers are a station-goal reward, so curing an unrelated disease should not silently break their effects.

## Changelog

:cl:
fix: DNA vault mutation powers keep their effects after Dormant DNA Activator mutation cleanup.
/:cl:
