### PR TITLE
Removes /proc/type2parent, replaces it with ::parent_type

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -343,11 +343,11 @@ GLOBAL_LIST_INIT(modulo_angle_to_dir, list(NORTH,NORTHEAST,EAST,SOUTHEAST,SOUTH,
 	return rgb(the_matrix[1]*255, the_matrix[6]*255, the_matrix[11]*255, the_matrix[16]*255)
 
 //returns a string the last bit of a type, without the preceeding '/'
-/proc/type2top(the_type)
+/proc/type2top(datum/typepath)
 	//handle the builtins manually
-	if(!ispath(the_type))
+	if(!ispath(typepath))
 		return
-	switch(the_type)
+	switch(typepath)
 		if(/datum)
 			return "datum"
 		if(/atom)
@@ -361,7 +361,7 @@ GLOBAL_LIST_INIT(modulo_angle_to_dir, list(NORTH,NORTHEAST,EAST,SOUTHEAST,SOUTH,
 		if(/turf)
 			return "turf"
 		else //regex everything else (works for /proc too)
-			return LOWER_TEXT(replacetext("[the_type]", "[the_type::parent_type]/", ""))
+			return LOWER_TEXT(replacetext("[typepath]", "[typepath::parent_type]/", ""))
 
 /// Return html to load a url.
 /// for use inside of browse() calls to html assets that might be loaded on a cdn.

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -342,21 +342,6 @@ GLOBAL_LIST_INIT(modulo_angle_to_dir, list(NORTH,NORTHEAST,EAST,SOUTHEAST,SOUTH,
 		return "#ffffffff"
 	return rgb(the_matrix[1]*255, the_matrix[6]*255, the_matrix[11]*255, the_matrix[16]*255)
 
-/proc/type2parent(child)
-	var/string_type = "[child]"
-	var/last_slash = findlasttext(string_type, "/")
-	if(last_slash == 1)
-		switch(child)
-			if(/datum)
-				return null
-			if(/obj, /mob)
-				return /atom/movable
-			if(/area, /turf)
-				return /atom
-			else
-				return /datum
-	return text2path(copytext(string_type, 1, last_slash))
-
 //returns a string the last bit of a type, without the preceeding '/'
 /proc/type2top(the_type)
 	//handle the builtins manually
@@ -376,7 +361,7 @@ GLOBAL_LIST_INIT(modulo_angle_to_dir, list(NORTH,NORTHEAST,EAST,SOUTHEAST,SOUTH,
 		if(/turf)
 			return "turf"
 		else //regex everything else (works for /proc too)
-			return LOWER_TEXT(replacetext("[the_type]", "[type2parent(the_type)]/", ""))
+			return LOWER_TEXT(replacetext("[the_type]", "[the_type::parent_type]/", ""))
 
 /// Return html to load a url.
 /// for use inside of browse() calls to html assets that might be loaded on a cdn.

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -241,7 +241,7 @@
 	//and since most components are root level + 1, this won't even have to run
 	while (current_type != /datum/component)
 		. += current_type
-		current_type = type2parent(current_type)
+		current_type = current_type::parent_type
 
 // The type arg is casted so initial works, you shouldn't be passing a real instance into this
 /**

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -237,7 +237,7 @@
 /datum/component/proc/_GetInverseTypeList(our_type = type)
 	//we can do this one simple trick
 	. = list(our_type)
-	var/current_type = parent_type
+	var/datum/current_type = parent_type
 	//and since most components are root level + 1, this won't even have to run
 	while (current_type != /datum/component)
 		. += current_type

--- a/code/modules/admin/greyscale_modify_menu.dm
+++ b/code/modules/admin/greyscale_modify_menu.dm
@@ -346,7 +346,7 @@ This is highly likely to cause massive amounts of lag as every object in the gam
 		return
 	while(initial(current.greyscale_config) == initial(parent.greyscale_config))
 		current = parent
-		parent = type2parent(current)
+		parent = current::parent_type
 	config_owner_type = current
 
 /// Used for spray painting items in the gags_recolorable component

--- a/code/modules/autowiki/pages/vending.dm
+++ b/code/modules/autowiki/pages/vending.dm
@@ -11,7 +11,7 @@
 	var/obj/parent = new
 
 	for (var/obj/machinery/vending/vending_type as anything in sort_list(subtypesof(/obj/machinery/vending), GLOBAL_PROC_REF(cmp_typepaths_asc)))
-		var/obj/machinery/vending/parent_machine = type2parent(vending_type)
+		var/obj/machinery/vending/parent_machine = vending_type::parent_type
 		if(initial(parent_machine.name) == initial(vending_type.name))
 			continue //Same name, likely just a slightly touched up subtype for specific maps.
 		var/obj/machinery/vending/vending_machine = new vending_type(parent)

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -91,7 +91,7 @@
 
 			//means we have to look for subtypes
 			else if(isnull(ingredient_count))
-				ingredient_type = type2parent(ingredient_type)
+				ingredient_type = ingredient_type::parent_type
 
 			//means we have no more remaining ingredients so bail, can happen if multiple ingredients of the same type/subtype are in the pot
 			else

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -66,7 +66,7 @@
 	//number of ingredients who's requested amounts has been satisfied
 	var/completed_ingredients = 0
 	for(var/obj/item/ingredient as anything in pot.added_ingredients)
-		var/ingredient_type = ingredient.type
+		var/datum/ingredient_type = ingredient.type
 		do
 		{
 			var/ingredient_count = reqs_copy[ingredient_type]

--- a/code/modules/reagents/chemistry/holder/properties.dm
+++ b/code/modules/reagents/chemistry/holder/properties.dm
@@ -22,7 +22,7 @@
 				if(cached_reagent.type != reagent)
 					continue
 			if(REAGENT_PARENT_TYPE) //to simulate typesof() which returns the type and then child types
-				if(cached_reagent.type != reagent && type2parent(cached_reagent.type) != reagent)
+				if(cached_reagent.type != reagent && cached_reagent::parent_type != reagent)
 					continue
 			else
 				if(!istype(cached_reagent, reagent))


### PR DESCRIPTION

## About The Pull Request

I tested it, doing parent_type is practically identical to the proc and doesn't do string manipulation or have proc overhead.

The only discrepencies come from when you use it on a built-in type like /list, because the proc naively assumes that if a type doesn't have a handle before it, then it must be a subtype of datum. This caveat is never encountered in the codebase.

## Bird of Judgement

<img width="368" height="489" alt="image" src="https://github.com/user-attachments/assets/1da2dd1b-19da-444e-96ab-7ac0adb82366" />
