### PR TITLE
You can only reseal sealable biscuits once

### DIFF
--- a/code/modules/paperwork/paper_biscuit.dm
+++ b/code/modules/paperwork/paper_biscuit.dm
@@ -147,6 +147,8 @@
 	add_fingerprint(user)
 	if(!cracked)
 		return ..()
+	if(has_been_sealed)
+		return
 	if(tgui_alert(user, "Do you want to seal it? This can only be done once.", "Biscuit Sealing", list("Yes", "No")) != "Yes")
 		return
 	cracked = FALSE


### PR DESCRIPTION

## About The Pull Request

There's two other checks for `has_been_sealed` for the sake of telling people they can't seal it twice but nothing for actually preventing resealing

## Why It's Good For The Game

It is extremely clear that you are not supposed to do this

## Changelog
:cl:

fix: Sealable biscuits can only be sealed once

/:cl:
