### PR TITLE
Fixes a runtime every time you backspace out a chat message

### DIFF
--- a/code/modules/tgui_input/say_modal/speech.dm
+++ b/code/modules/tgui_input/say_modal/speech.dm
@@ -123,7 +123,7 @@
  *  boolean - success or failure
  */
 /datum/tgui_say/proc/handle_entry(type, payload)
-	if(!payload?["channel"] || !payload["entry"])
+	if(!payload?["channel"] || isnull(payload["entry"]))
 		CRASH("[usr] entered in a null payload to the chat window.")
 	if(length(payload["entry"]) > max_length)
 		CRASH("[usr] has entered more characters than allowed into a TGUI-Say")


### PR DESCRIPTION

## About The Pull Request

an empty string is falsy

## Why It's Good For The Game

fixes, like, a thousand runtimes every round
<img width="607" height="28" alt="image" src="https://github.com/user-attachments/assets/5c540d93-2367-4009-910a-4eb386e06683" />
<img width="523" height="27" alt="image" src="https://github.com/user-attachments/assets/7dedda46-d865-49b2-af62-15ee2d0f9617" />
<img width="529" height="26" alt="image" src="https://github.com/user-attachments/assets/ef04b1d1-b9b3-44ef-b8c3-41ccaa952125" />
<img width="557" height="26" alt="image" src="https://github.com/user-attachments/assets/6cdff98f-84ee-485e-a5b9-4047c4dfc1f9" />
<img width="552" height="29" alt="image" src="https://github.com/user-attachments/assets/f28f04fe-f13c-4c34-acb4-2ffa09266c74" />
<img width="489" height="27" alt="image" src="https://github.com/user-attachments/assets/11cf76e2-c615-45c7-bf83-926f2459ea97" />

I miss when namesearching in the runtime logs was useful

## Changelog
:cl:

fix: about a billion runtimes per round have been fixed, & you'll no longer repeat what you said last when you're forced to speak

/:cl:
