### PR TITLE
reworks/fixes how we do iframe vs byondstorage

### DIFF
--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -35,6 +35,7 @@ const testHubStorage = testGeneric(
 
 const STORAGE_CDN_TIMEOUT = 5000;
 const persistedStorageKeys = ['panel-settings', 'chat-state', 'chat-messages'];
+const legacyHubMigrationKeys = ['panel-settings'];
 
 class HubStorageBackend implements StorageBackend {
   public impl: StorageImplementation;
@@ -208,9 +209,11 @@ class StorageProxy implements StorageBackend {
 
             const hub = new HubStorageBackend();
 
-            // Migrate these existing settings from byondstorage to the IFrame.
+            // Migrate safe legacy settings from byondstorage to the IFrame.
+            // Chat history may contain server-specific HTML/components from
+            // other codebases that shared the old byondstorage namespace.
             await Promise.all(
-              persistedStorageKeys.map(async (setting) => {
+              legacyHubMigrationKeys.map(async (setting) => {
                 try {
                   const settings = await hub.get(setting);
                   if (settings !== undefined) {

--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -33,6 +33,7 @@ const testHubStorage = testGeneric(
   () => window.hubStorage && !!window.hubStorage.getItem,
 );
 
+const STORAGE_CDN_TIMEOUT = 5000;
 const persistedStorageKeys = ['panel-settings', 'chat-state', 'chat-messages'];
 
 class HubStorageBackend implements StorageBackend {
@@ -79,19 +80,25 @@ class IFrameIndexedDbBackend implements StorageBackend {
     iframe.src = Byond.storageCdn;
 
     const completePromise: Promise<boolean> = new Promise((resolve) => {
+      const timeout = setTimeout(() => resolve(false), STORAGE_CDN_TIMEOUT);
+      const resolveReady = (ready: boolean) => {
+        clearTimeout(timeout);
+        resolve(ready);
+      };
+
       fetch(Byond.storageCdn, { method: 'HEAD' })
         .then((response) => {
           if (response.status !== 200) {
-            resolve(false);
+            resolveReady(false);
           }
         })
         .catch(() => {
-          resolve(false);
+          resolveReady(false);
         });
 
       window.addEventListener('message', (message) => {
         if (message.data === 'ready') {
-          resolve(true);
+          resolveReady(true);
         }
       });
     });

--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -129,6 +129,7 @@ class IFrameIndexedDbBackend implements StorageBackend {
           message.data.key &&
           message.data.key === key
         ) {
+          clearTimeout(timeout);
           window.removeEventListener('message', listener);
           resolve(message.data.value);
         }

--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -80,11 +80,23 @@ class IFrameIndexedDbBackend implements StorageBackend {
     iframe.src = Byond.storageCdn;
 
     const completePromise: Promise<boolean> = new Promise((resolve) => {
-      const timeout = setTimeout(() => resolve(false), STORAGE_CDN_TIMEOUT);
+      const listener = (message: MessageEvent) => {
+        if (
+          message.source === iframe.contentWindow &&
+          message.data === 'ready'
+        ) {
+          resolveReady(true);
+        }
+      };
       const resolveReady = (ready: boolean) => {
         clearTimeout(timeout);
+        window.removeEventListener('message', listener);
         resolve(ready);
       };
+      const timeout = setTimeout(
+        () => resolveReady(false),
+        STORAGE_CDN_TIMEOUT,
+      );
 
       fetch(Byond.storageCdn, { method: 'HEAD' })
         .then((response) => {
@@ -96,11 +108,7 @@ class IFrameIndexedDbBackend implements StorageBackend {
           resolveReady(false);
         });
 
-      window.addEventListener('message', (message) => {
-        if (message.data === 'ready') {
-          resolveReady(true);
-        }
-      });
+      window.addEventListener('message', listener);
     });
 
     this.documentElement = document.body.appendChild(iframe);
@@ -115,11 +123,22 @@ class IFrameIndexedDbBackend implements StorageBackend {
 
   async get(key: string): Promise<any> {
     const promise = new Promise((resolve) => {
-      window.addEventListener('message', (message) => {
-        if (message.data.key && message.data.key === key) {
+      const listener = (message: MessageEvent) => {
+        if (
+          message.source === this.iframeWindow &&
+          message.data.key &&
+          message.data.key === key
+        ) {
+          window.removeEventListener('message', listener);
           resolve(message.data.value);
         }
-      });
+      };
+      const timeout = setTimeout(() => {
+        window.removeEventListener('message', listener);
+        resolve(undefined);
+      }, STORAGE_CDN_TIMEOUT);
+
+      window.addEventListener('message', listener);
     });
 
     this.iframeWindow.postMessage({ type: 'get', key: key }, '*');

--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -33,6 +33,8 @@ const testHubStorage = testGeneric(
   () => window.hubStorage && !!window.hubStorage.getItem,
 );
 
+const persistedStorageKeys = ['panel-settings', 'chat-state', 'chat-messages'];
+
 class HubStorageBackend implements StorageBackend {
   public impl: StorageImplementation;
 
@@ -77,20 +79,21 @@ class IFrameIndexedDbBackend implements StorageBackend {
     iframe.src = Byond.storageCdn;
 
     const completePromise: Promise<boolean> = new Promise((resolve) => {
-      fetch(Byond.storageCdn, { method: "HEAD" }).then((response) => {
-        if (response.status !== 200) {
+      fetch(Byond.storageCdn, { method: 'HEAD' })
+        .then((response) => {
+          if (response.status !== 200) {
+            resolve(false);
+          }
+        })
+        .catch(() => {
           resolve(false);
-        }
-
-      }).catch(() => {
-        resolve(false);
-      })
+        });
 
       window.addEventListener('message', (message) => {
-        if (message.data === "ready") {
+        if (message.data === 'ready') {
           resolve(true);
         }
-      })
+      });
     });
 
     this.documentElement = document.body.appendChild(iframe);
@@ -143,65 +146,87 @@ class StorageProxy implements StorageBackend {
 
   constructor() {
     this.backendPromise = (async () => {
+      // Prefer the configured iframe storage when available. hubStorage may
+      // already be enabled by another window/server, but the iframe origin is
+      // the server-configured storage boundary.
+      if (Byond.storageCdn) {
+        const iframe = new IFrameIndexedDbBackend();
 
-      // If we have not enabled byondstorage yet, we need to check
-      // if we can use the IFrame, or if we need to enable byondstorage
-      if (!testHubStorage()) {
+        if ((await iframe.ready()) === true) {
+          if (await iframe.get('byondstorage-migrated')) return iframe;
 
-        // If we have an IFrame URL we can use, and we haven't already enabled
-        // byondstorage, we should use the IFrame backend
-        if (Byond.storageCdn) {
-          const iframe = new IFrameIndexedDbBackend();
+          const iframeHasPersistedStorage = (
+            await Promise.all(
+              persistedStorageKeys.map((setting) => iframe.get(setting)),
+            )
+          ).some((settings) => settings !== undefined);
 
-          if ((await iframe.ready()) === true) {
-            if (await iframe.get('byondstorage-migrated')) return iframe;
+          if (!iframeHasPersistedStorage) {
+            const hubStorageWasEnabled = testHubStorage();
+            if (!hubStorageWasEnabled) {
+              Byond.winset(null, 'browser-options', '+byondstorage');
 
-            Byond.winset(null, 'browser-options', '+byondstorage');
-
-            await new Promise<void>((resolve) => {
-              document.addEventListener('byondstorageupdated', async () => {
-                setTimeout(() => {
-                  const hub = new HubStorageBackend();
-
-                  // Migrate these existing settings from byondstorage to the IFrame
-                  for (const setting of ['panel-settings', 'chat-state', 'chat-messages']) {
-                    hub
-                      .get(setting)
-                      .then((settings) => iframe.set(setting, settings));
-                  }
-
-                  iframe.set('byondstorage-migrated', true);
-                  Byond.winset(null, 'browser-options', '-byondstorage');
-
-                  resolve();
-                }, 1);
+              await new Promise<void>((resolve) => {
+                document.addEventListener(
+                  'byondstorageupdated',
+                  () => {
+                    // This event is emitted *before* byondstorage is actually
+                    // created, so we have to wait a little bit before using it.
+                    setTimeout(resolve, 1);
+                  },
+                  { once: true },
+                );
               });
-            });
+            }
 
-            return iframe;
+            const hub = new HubStorageBackend();
+
+            // Migrate these existing settings from byondstorage to the IFrame.
+            await Promise.all(
+              persistedStorageKeys.map(async (setting) => {
+                try {
+                  const settings = await hub.get(setting);
+                  if (settings !== undefined) {
+                    await iframe.set(setting, settings);
+                  }
+                } catch {
+                  // Ignore unreadable legacy storage entries. A bad old cache
+                  // key should not keep the client on byondstorage.
+                }
+              }),
+            );
+
+            if (!hubStorageWasEnabled) {
+              Byond.winset(null, 'browser-options', '-byondstorage');
+            }
           }
 
-          iframe.destroy();
-        };
+          await iframe.set('byondstorage-migrated', true);
 
-        // IFrame hasn't worked out for us, we'll need to enable byondstorage
-        Byond.winset(null, 'browser-options', '+byondstorage');
+          return iframe;
+        }
 
-        return new Promise((resolve) => {
-          const listener = () => {
-            document.removeEventListener('byondstorageupdated', listener);
-
-            // This event is emitted *before* byondstorage is actually created
-            // so we have to wait a little bit before we can use it
-            setTimeout(() => resolve(new HubStorageBackend()), 1);
-          };
-
-          document.addEventListener('byondstorageupdated', listener);
-        });
+        iframe.destroy();
       }
 
-      // byondstorage is already enabled, we can use it straight away
-      return new HubStorageBackend();
+      if (testHubStorage()) {
+        return new HubStorageBackend();
+      }
+
+      // IFrame hasn't worked out for us, we'll need to enable byondstorage
+      Byond.winset(null, 'browser-options', '+byondstorage');
+
+      return new Promise((resolve) => {
+        const listener = () => {
+          document.removeEventListener('byondstorageupdated', listener);
+
+          // This event is emitted *before* byondstorage is actually created
+          // so we have to wait a little bit before we can use it
+          setTimeout(() => resolve(new HubStorageBackend()), 1);
+        };
+
+        document.addEventListener('byondstorageupdated', listener);
+      });
     })();
   }
 

--- a/tgui/packages/tgui-panel/chat/renderer.tsx
+++ b/tgui/packages/tgui-panel/chat/renderer.tsx
@@ -422,10 +422,19 @@ class ChatRenderer {
             outputProps[canon_name] = working_value;
           }
           const oldHtml = { __html: childNode.innerHTML };
+          const Element = TGUI_CHAT_COMPONENTS[targetName];
+          if (!Element) {
+            logger.error(
+              `Error: unknown chat component "${targetName}" in message`,
+              message,
+            );
+            childNode.removeAttribute('data-component');
+            continue;
+          }
+
           while (childNode.firstChild) {
             childNode.removeChild(childNode.firstChild);
           }
-          const Element = TGUI_CHAT_COMPONENTS[targetName];
 
           const reactRoot = createRoot(childNode);
 


### PR DESCRIPTION

## About The Pull Request
As it says, reworks how we do chat caching slightly.
This is the culmination of me investigating issues with people having their fancy chat crash, only to find out it's due to them swapping between other servers. 

- `Byond.storageCdn` / `STORAGE_CDN_IFRAME` is tried first when configured
- reachable iframe storage is used even if `hubStorage` already exists
- legacy BYOND storage is only imported when the iframe cache appears empty
- unreadable legacy storage keys are skipped instead of blocking iframe use
## Why It's Good For The Game
Personally, I'm not a big fan of TGUI fancy chat crashing, and I doubt anyone else is either!
## Changelog
:cl: UvvU
fix: fixed improper chat caching.
/:cl:
