### PR TITLE
Spacer's drift speed bonus doesn't stack with jetpack speed

### DIFF
--- a/code/datums/components/jetpack.dm
+++ b/code/datums/components/jetpack.dm
@@ -109,7 +109,7 @@
 	RegisterSignal(new_user, COMSIG_MOVABLE_SPACEMOVE, PROC_REF(stabilize))
 	if (effect_type)
 		setup_trail(new_user)
-	new_user.inertia_move_multiplier /= drift_force // lower multiplier = faster drifting
+	new_user.inertia_move_multiplier_active /= drift_force // lower multiplier = faster drifting
 
 /datum/component/jetpack/proc/deactivate(datum/source, mob/old_user)
 	SIGNAL_HANDLER
@@ -126,7 +126,7 @@
 		COMSIG_MOVABLE_SPACEMOVE,
 	))
 	QDEL_NULL(trail)
-	old_user.inertia_move_multiplier *= drift_force
+	old_user.inertia_move_multiplier_active *= drift_force
 
 /datum/component/jetpack/proc/move_react(mob/source)
 	SIGNAL_HANDLER

--- a/code/datums/drift_handler.dm
+++ b/code/datums/drift_handler.dm
@@ -223,4 +223,4 @@
 	return COMSIG_MOB_CLIENT_BLOCK_PRE_MOVE
 
 /datum/drift_handler/proc/get_loop_delay(atom/movable/movable)
-	return (DEFAULT_INERTIA_SPEED / ((1 - INERTIA_SPEED_COEF) + drift_force * INERTIA_SPEED_COEF)) * movable.inertia_move_multiplier
+	return (DEFAULT_INERTIA_SPEED / ((1 - INERTIA_SPEED_COEF) + drift_force * INERTIA_SPEED_COEF)) * min(movable.inertia_move_multiplier_passive, movable.inertia_move_multiplier_active)

--- a/code/datums/quirks/positive_quirks/spacer.dm
+++ b/code/datums/quirks/positive_quirks/spacer.dm
@@ -50,7 +50,7 @@
 	update_effects(quirk_holder, skip_timers = TRUE)
 
 	// drift slightly faster through zero G
-	quirk_holder.inertia_move_multiplier *= drift_mod
+	quirk_holder.inertia_move_multiplier_passive *= drift_mod
 
 	var/mob/living/carbon/human/human_quirker = quirk_holder
 	human_quirker.set_mob_height(modded_height)
@@ -81,7 +81,7 @@
 	if(QDELING(quirk_holder))
 		return
 
-	quirk_holder.inertia_move_multiplier /= drift_mod
+	quirk_holder.inertia_move_multiplier_passive /= drift_mod
 	quirk_holder.clear_mood_event("spacer")
 	quirk_holder.remove_movespeed_modifier(/datum/movespeed_modifier/spacer)
 	quirk_holder.remove_status_effect(/datum/status_effect/spacer)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -36,9 +36,13 @@
 	var/speech_span
 	///Are we moving with inertia? Mostly used as an optimization
 	var/inertia_moving = FALSE
-	///Multiplier for inertia based movement in space
-	var/inertia_move_multiplier = 1
-	///Object "weight", higher weight reduces acceleration applied to the object
+	/// Multiplies speed the movable drifts when unaffected by gravity.
+	/// "Passive" is used for referring "base drift speed" - only the smaller of the two are used.
+	var/inertia_move_multiplier_passive = 1
+	/// Multiplies speed the movable drifts when unaffected by gravity.
+	/// "Active" is used for referring to things boosting our drift speed, like jetpacks - only the smaller of the two are used.
+	var/inertia_move_multiplier_active = 1
+	/// Object "weight", higher weight reduces acceleration applied to the object
 	var/inertia_force_weight = 1
 	///The last time we pushed off something
 	///This is a hack to get around dumb him him me scenarios


### PR DESCRIPTION
## About The Pull Request

Splits `inertia_move_multiplier` in two, `inertia_move_multiplier_passive` and `inertia_move_multiplier_active`
When calculating drift speed, only the better of the two is used.* 
Spacer now buffs the former, jetpacks now buff the latter

In short, the bonus to drift speed applied from being a spacer no longer applies multiplicatively with the bonus to drift speed from jetpacks.

**(If we want further nuance we'd probably have to look at something like movespeed modifiers. But in the meanwhile this aims to differentiate "this atom innately drifts faster" and "something is making this atom drift faster".)*

## Why It's Good For The Game

The 0.75x modifier from Spacer combined with the 0.66x modifier jetpacks apply ultimately comes out to a bonus of like 0.5x, or in other words, a 2x speed bonus which is a liiiiiiiiiiittle ridiculous. Jetpack jousting is chaotic enough as-is.

With the changes Spacers will still get mileage out of especially poor jetpacks (i.e. improvised jetpacks), but with a normal or advanced jetpack, they'll go as fast as anyone else does. 

## Changelog

:cl: Melbert
balance: Spacer: Bonus to drift speed no longer stacks with jetpack speed - only the greater of the two effects is applied. 
/:cl:
