### PR TITLE
Bitrunners can't leave domains while glitches remain in them

### DIFF
--- a/code/modules/bitrunning/objects/hololadder.dm
+++ b/code/modules/bitrunning/objects/hololadder.dm
@@ -65,11 +65,12 @@
 		return
 
 	var/obj/machinery/quantum_server/our_server = server_ref.resolve()
-	for(var/datum/weakref/ghostrole_weakref as anything in our_server.spawned_threat_refs)
-		var/mob/living/ghostrole = ghostrole_weakref.resolve()
-		if(ghostrole?.stat == CONSCIOUS && ghostrole.client && ghostrole.mind.has_antag_datum(/datum/antagonist/bitrunning_glitch))
-			balloon_alert(user, "the simulation refuses to let you leave!")
-			return
+	if(!our_server.domain_complete)
+		for(var/datum/weakref/ghostrole_weakref as anything in our_server.spawned_threat_refs)
+			var/mob/living/ghostrole = ghostrole_weakref.resolve()
+			if(ghostrole?.stat == CONSCIOUS/* && ghostrole.client*/ && ghostrole.mind.has_antag_datum(/datum/antagonist/bitrunning_glitch))
+				to_chat(user, span_danger("A being in the simulation is preventing your retreat. You must either complete your mission or remove the obstacle before safe exit will be possible."))
+				return
 
 	if(!HAS_TRAIT(user, TRAIT_TEMPORARY_BODY))
 		balloon_alert(user, "no connection detected")

--- a/code/modules/bitrunning/objects/hololadder.dm
+++ b/code/modules/bitrunning/objects/hololadder.dm
@@ -64,6 +64,13 @@
 	if(isnull(user.mind))
 		return
 
+	var/obj/machinery/quantum_server/our_server = server_ref.resolve()
+	for(var/datum/weakref/ghostrole_weakref as anything in our_server.spawned_threat_refs)
+		var/mob/living/ghostrole = ghostrole_weakref.resolve()
+		if(ghostrole?.stat == CONSCIOUS && ghostrole.client && ghostrole.mind.has_antag_datum(/datum/antagonist/bitrunning_glitch))
+			balloon_alert(user, "the simulation refuses to let you leave!")
+			return
+
 	if(!HAS_TRAIT(user, TRAIT_TEMPORARY_BODY))
 		balloon_alert(user, "no connection detected")
 		return

--- a/code/modules/bitrunning/objects/hololadder.dm
+++ b/code/modules/bitrunning/objects/hololadder.dm
@@ -68,7 +68,7 @@
 	if(!our_server.domain_complete)
 		for(var/datum/weakref/ghostrole_weakref as anything in our_server.spawned_threat_refs)
 			var/mob/living/ghostrole = ghostrole_weakref.resolve()
-			if(ghostrole?.stat == CONSCIOUS/* && ghostrole.client*/ && ghostrole.mind.has_antag_datum(/datum/antagonist/bitrunning_glitch))
+			if(ghostrole?.stat == CONSCIOUS && ghostrole.client && ghostrole.mind.has_antag_datum(/datum/antagonist/bitrunning_glitch))
 				to_chat(user, span_danger("A being in the simulation is preventing your retreat. You must either complete your mission or remove the obstacle before safe exit will be possible."))
 				return
 

--- a/code/modules/bitrunning/server/_parent.dm
+++ b/code/modules/bitrunning/server/_parent.dm
@@ -16,6 +16,8 @@
 	var/datum/lazy_template/virtual_domain/generated_domain
 	/// If the current domain was a random selection
 	var/domain_randomized = FALSE
+	/// Whether the domain is finished, so the bitrunners can leave despite glitches
+	var/domain_complete = FALSE
 	/// Prevents multiple user actions. Handled by loading domains and cooldowns
 	var/is_ready = TRUE
 	/// Chance multipled by threat to spawn a glitch

--- a/code/modules/bitrunning/server/loot.dm
+++ b/code/modules/bitrunning/server/loot.dm
@@ -80,6 +80,8 @@
 		generated_domain.disk_reward_spawned = TRUE
 
 	chosen_forge.start_to_spawn(reward_cache)
+
+	domain_complete = TRUE
 	return TRUE
 
 

--- a/code/modules/bitrunning/server/map_handling.dm
+++ b/code/modules/bitrunning/server/map_handling.dm
@@ -53,12 +53,12 @@
 		scrub_vdom()
 		is_ready = TRUE
 		return FALSE
-		
-		
+
+
 	//We will want to record how the domain was selected. Either entirely randomly, with the name redacted, or with full information.
 	//Without this, it is difficult to determine what domains are selected more often intentionallly, vs unintentionally.
 	var/selection_type
-	
+
 	if(was_random_selection)
 		selection_type = "random selection"
 	else
@@ -200,6 +200,7 @@
 /// Stops the current virtual domain and disconnects all users
 /obj/machinery/quantum_server/proc/reset(fast = FALSE)
 	is_ready = FALSE
+	domain_complete = FALSE
 
 	sever_connections()
 


### PR DESCRIPTION

## About The Pull Request

When bitrunners attempt to leave their domain via the ladder, they will fail if there is an active, living bitrunning glitch antagonist within the domain. Other methods of leaving such as death or taking the red pill are unaffected.

they can also leave if the crate's delivered

sorta a sister PR to #95934

## Why It's Good For The Game

enter domain -> get alert about bitrunning glitch -> leave -> turn off domain
What a fun gameplay loop, for everyone involved.
You'll fight the glitch and you'll like it. (liking it [pending](https://github.com/tgstation/tgstation/pull/96138))

You can still leave if you REALLY, REALLY need to at the cost of a little brain damage, but otherwise the literal only obstacle that will ever be in your path should be something you have to engage with. 

## Changelog
:cl:

balance: Bitrunners can't back out of domains via the ladder while bitrunning glitches remain in them

/:cl:
