### PR TITLE
Scanned wounds stay scanned when healing

### DIFF
--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -405,6 +405,8 @@
 	var/obj/item/bodypart/cached_limb = limb // remove_wound() nulls limb so we have to track it locally
 	remove_wound(replaced=TRUE)
 	new_wound.apply_wound(cached_limb, old_wound = src, smited = smited, attack_direction = attack_direction, wound_source = wound_source, replacing = TRUE)
+	if(HAS_TRAIT(src, TRAIT_WOUND_SCANNED) && severity > new_wound.severity)
+		ADD_TRAIT(new_wound, TRAIT_WOUND_SCANNED, ANALYZER_TRAIT)
 	. = new_wound
 	qdel(src)
 

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -406,7 +406,8 @@
 	remove_wound(replaced=TRUE)
 	new_wound.apply_wound(cached_limb, old_wound = src, smited = smited, attack_direction = attack_direction, wound_source = wound_source, replacing = TRUE)
 	if(HAS_TRAIT(src, TRAIT_WOUND_SCANNED) && severity > new_wound.severity)
-		ADD_TRAIT(new_wound, TRAIT_WOUND_SCANNED, ANALYZER_TRAIT)
+		for(var/trait_source in GET_TRAIT_SOURCES(src, TRAIT_WOUND_SCANNED))
+			ADD_TRAIT(new_wound, TRAIT_WOUND_SCANNED, trait_source)
 	. = new_wound
 	qdel(src)
 

--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -169,7 +169,7 @@
 
 	playsound(user, 'sound/items/handling/surgery/cautery2.ogg', 75, TRUE)
 
-	var/bleeding_wording = (!limb.can_bleed() ? "holes" : "bleeding")
+	var/bleeding_wording = (limb.can_bleed() ? "bleeding" : "holes")
 	user.visible_message(span_green("[user] cauterizes some of the [bleeding_wording] on [victim]."), span_green("You cauterize some of the [bleeding_wording] on [victim]."))
 	victim.apply_damage(2 + severity, BURN, limb, wound_bonus = CANT_WOUND)
 	if(prob(30))

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -276,7 +276,7 @@
 
 	playsound(user, 'sound/items/handling/surgery/cautery2.ogg', 75, TRUE)
 
-	var/bleeding_wording = (!limb.can_bleed() ? "cuts" : "bleeding")
+	var/bleeding_wording = (limb.can_bleed() ? "bleeding" : "cuts")
 	user.visible_message(span_green("[user] cauterizes some of the [bleeding_wording] on [victim]."), span_green("You cauterize some of the [bleeding_wording] on [victim]."))
 	victim.apply_damage(2 + severity, BURN, limb, wound_bonus = CANT_WOUND)
 	if(prob(30))


### PR DESCRIPTION

## About The Pull Request

Scanned wounds pass on `TRAIT_WOUND_SCANNED` to wounds replacing them when the new wound's severity is less than the current one's. This means that you no longer have to repeatedly scan the same wound after every step of the healing process.

also unnecessary inversion

## Why It's Good For The Game

You no longer have to repeatedly scan the same wound after every step of the healing process. 

## Changelog
:cl:

qol: Scanned wounds stay scanned while being healed

/:cl:
