### PR TITLE
Fix an absurdly long timer in the wraith module's start_stealth

### DIFF
--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -527,7 +527,7 @@
 
 /obj/item/mod/module/stealth/wraith/proc/start_stealth()
 	if(!COOLDOWN_FINISHED(src, recloak_timer)) // Prevents being able to bypass the cooldown by disabling and re-enabling the module
-		addtimer(CALLBACK(src, PROC_REF(start_stealth)), recloak_timer)
+		addtimer(CALLBACK(src, PROC_REF(start_stealth)), COOLDOWN_TIMELEFT(src, recloak_timer))
 		return
 	RegisterSignals(mod.wearer, list(COMSIG_LIVING_MOB_BUMP, COMSIG_ATOM_BUMPED, COMSIG_MOB_FIRED_GUN), PROC_REF(unstealth))
 	RegisterSignal(mod.wearer, COMSIG_LIVING_UNARMED_ATTACK, PROC_REF(on_unarmed_attack))


### PR DESCRIPTION

## About The Pull Request
Ensures the recloak mechanic on the wraith module respects the cooldown than it was originally given after disruption.

the original implementation, made the recloak timer equal to the server uptime + cooldown, which resulted in a massively larger cooldown than it was originally intended, the new implementation fixes that.

## Why It's Good For The Game
Makes it so the wraith module doesn't get bricked upon disruption.

## Changelog
:cl:
fix: Traitor Wraith cloaking module now reactivates after the appropriate amount of time has passed.
/:cl:
