### PR TITLE
Janitors have perfect aim throwing things into disposal units

### DIFF
--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -39,7 +39,7 @@
 	uniform = /obj/item/clothing/under/rank/civilian/janitor
 	belt = /obj/item/modular_computer/pda/janitor
 	ears = /obj/item/radio/headset/headset_srv
-	skillchips = list(/obj/item/skillchip/job/janitor)
+	skillchips = list(/obj/item/skillchip/job/janitor, /obj/item/skillchip/disposals)
 	backpack_contents = list(/obj/item/access_key)
 
 /datum/outfit/job/janitor/pre_equip(mob/living/carbon/human/human_equipper, visuals_only)

--- a/code/modules/library/skill_learning/generic_skillchips/misc.dm
+++ b/code/modules/library/skill_learning/generic_skillchips/misc.dm
@@ -154,3 +154,13 @@
 /datum/action/cooldown/fishing_tip/Activate(atom/target_atom)
 	. = ..()
 	send_tip_of_the_round(owner, pick(GLOB.fishing_tips), source = "Ancient fishing wisdom")
+
+/obj/item/skillchip/disposals
+	name = "T4RG3T.bin skillchip"
+	desc = "Become a dauntless disposaler, target trash right where it belongs."
+	auto_traits = list(TRAIT_THROWINGARM)
+	skill_name = "Dauntless Disposaler"
+	skill_description = "You have an uncanny ability to perfectly land every toss into disposal units."
+	skill_icon = "trash-can"
+	activate_message = span_notice("You seem laser focused on the nearby disposal unit.")
+	deactivate_message = span_notice("The nearby disposal unit fades into the background of your vision.")


### PR DESCRIPTION
## About The Pull Request

Adds a skillchip to the janitor giving them perfect aim when throwing things into disposal units.

## Why It's Good For The Game

Much like the bartender being able to throw drinks, the janitor is the master of the trash domain and should have an uncanny ability to perfectly land every shot into the bin.

## Changelog

:cl: LT3
add: Janitors now have perfect aim when throwing things into disposal units
/:cl: