### PR TITLE
Fix argument passing in tgui_input/alert.dm

### DIFF
--- a/code/modules/tgui_input/alert.dm
+++ b/code/modules/tgui_input/alert.dm
@@ -26,7 +26,7 @@
 	// A gentle nudge - you should not be using TGUI alert for anything other than a simple message.
 	if(length(buttons) > 3)
 		log_tgui(user, "Error: TGUI Alert initiated with too many buttons. Use a list.", "TguiAlert")
-		return tgui_input_list(user, message, title, buttons, timeout, autofocus)
+		return tgui_input_list(user, message, title, buttons, timeout=timeout)
 	// Client does NOT have tgui_input on: Returns regular input
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
 		if(length(buttons) == 2)


### PR DESCRIPTION

## About The Pull Request
#67116 added a fallback to tgui_input_list if the number of args to tgui_alert is > 3
The order of arguments this fallback is being called with are wrong, though, and look essentially like this
`tgui_input_list(user=user, message=message, title=title, items=buttons, default=timeout, timeout=autofocus)`
Don't think this applies to anything on tg specifically (seemingly nothing calls alert with > 3 args), but downstreams can run into issues with their windows closing themselves instantly (timeout=0 or 1)


## Changelog

nothing changed (https://xkcd.com/1172/)