### PR TITLE
Add option for big manipulators to interact with dead mobs

### DIFF
--- a/code/game/machinery/big_manipulator/big_manipulator.dm
+++ b/code/game/machinery/big_manipulator/big_manipulator.dm
@@ -470,6 +470,7 @@
 			var/datum/manipulator_task/cargo/pickup/t = task
 			td["turf"] = "[t.offset_dx],[t.offset_dy]"
 			td["filters_status"] = t.should_use_filters
+			td["ignore_dead"] = t.ignore_dead
 			td["filtering_mode"] = t.filtering_mode
 			td["item_filters"] = _collect_filter_names(t.atom_filters)
 			td["settings_list"] = _collect_priorities(t.interaction_priorities)
@@ -480,6 +481,7 @@
 			var/datum/manipulator_task/cargo/dropoff_base/drop/t = task
 			td["turf"] = "[t.offset_dx],[t.offset_dy]"
 			td["filters_status"] = t.should_use_filters
+			td["ignore_dead"] = t.ignore_dead
 			td["filtering_mode"] = t.filtering_mode
 			td["item_filters"] = _collect_filter_names(t.atom_filters)
 			td["settings_list"] = _collect_priorities(t.interaction_priorities)
@@ -490,6 +492,7 @@
 			var/datum/manipulator_task/cargo/dropoff_base/throw/t = task
 			td["turf"] = "[t.offset_dx],[t.offset_dy]"
 			td["filters_status"] = t.should_use_filters
+			td["ignore_dead"] = t.ignore_dead
 			td["filtering_mode"] = t.filtering_mode
 			td["item_filters"] = _collect_filter_names(t.atom_filters)
 			td["settings_list"] = _collect_priorities(t.interaction_priorities)
@@ -500,6 +503,7 @@
 			var/datum/manipulator_task/cargo/dropoff_base/use/t = task
 			td["turf"] = "[t.offset_dx],[t.offset_dy]"
 			td["filters_status"] = t.should_use_filters
+			td["ignore_dead"] = t.ignore_dead
 			td["filtering_mode"] = t.filtering_mode
 			td["item_filters"] = _collect_filter_names(t.atom_filters)
 			td["settings_list"] = _collect_priorities(t.interaction_priorities)
@@ -513,6 +517,7 @@
 			var/datum/manipulator_task/cargo/interact/t = task
 			td["turf"] = "[t.offset_dx],[t.offset_dy]"
 			td["filters_status"] = t.should_use_filters
+			td["ignore_dead"] = t.ignore_dead
 			td["filtering_mode"] = t.filtering_mode
 			td["item_filters"] = _collect_filter_names(t.atom_filters)
 			td["settings_list"] = _collect_priorities(t.interaction_priorities)
@@ -782,6 +787,13 @@
 				return FALSE
 			var/datum/manipulator_task/cargo/ct = target_task
 			ct.should_use_filters = !ct.should_use_filters
+			return TRUE
+
+		if("toggle_ignore_dead")
+			if(!istype(target_task, /datum/manipulator_task/cargo))
+				return FALSE
+			var/datum/manipulator_task/cargo/ct = target_task
+			ct.ignore_dead = !ct.ignore_dead
 			return TRUE
 
 		if("reset_atom_filters")

--- a/code/game/machinery/big_manipulator/manipulator_tasks.dm
+++ b/code/game/machinery/big_manipulator/manipulator_tasks.dm
@@ -47,6 +47,7 @@
 	var/offset_dx
 	var/offset_dy
 	var/should_use_filters = FALSE
+	var/ignore_dead = TRUE
 	var/list/atom_filters = list()
 	var/filtering_mode = TAKE_ITEMS
 	var/list/type_filters = list(
@@ -65,6 +66,7 @@
 			interaction_turf = new_turf
 
 		should_use_filters = !!serialized_data["should_use_filters"]
+		ignore_dead = !!serialized_data["ignore_dead"]
 		atom_filters = serialized_data["atom_filters"] || list()
 		filtering_mode = serialized_data["filtering_mode"]
 		type_filters = serialized_data["type_filters"] || list()
@@ -117,7 +119,7 @@
 			if(!istype(thing, prio.atom_typepath))
 				continue
 
-			if(isliving(thing))
+			if(isliving(thing) && ignore_dead)
 				var/mob/living/living_mob = thing
 				if(living_mob.stat == DEAD)
 					continue
@@ -188,6 +190,7 @@
 		"dy" = offset_dy,
 	)
 	data["should_use_filters"] = should_use_filters
+	data["ignore_dead"] = ignore_dead
 	data["atom_filters"] = atom_filters
 	data["filtering_mode"] = filtering_mode
 	data["type_filters"] = type_filters

--- a/tgui/packages/tgui/interfaces/BigManipulator/index.tsx
+++ b/tgui/packages/tgui/interfaces/BigManipulator/index.tsx
@@ -248,6 +248,12 @@ function TaskEditModal(props: TaskEditModalProps) {
                   onClick={() => adjust('toggle_filter_skip')}
                   tooltip="Toggle filter usage"
                 />
+                <ConfigRow
+                  label="Ignore Dead"
+                  content={task.ignore_dead ? 'TRUE' : 'FALSE'}
+                  onClick={() => adjust('toggle_ignore_dead')}
+                  tooltip="Toggle whether dead mobs should be ignored"
+                />
                 {isPickup && (
                   <ConfigRow
                     label="Eagerness"

--- a/tgui/packages/tgui/interfaces/BigManipulator/types.ts
+++ b/tgui/packages/tgui/interfaces/BigManipulator/types.ts
@@ -21,6 +21,7 @@ export interface ManipulatorTask {
   turf?: string;
   item_filters?: string[];
   filters_status?: BooleanLike;
+  ignore_dead?: BooleanLike;
   filtering_mode?: number;
   settings_list?: PrioritySettings[];
   // pickup only


### PR DESCRIPTION

## About The Pull Request
Adds a toggle to ignore/interact with dead mobs
## Why It's Good For The Game
Opens up new and interesting possibilities for the manipulator
## Changelog
:cl:
balance: you can now allow big manipulators to interact with dead mobs
/:cl:
