### PR TITLE
Adds the "Limper" quirk

### DIFF
--- a/code/datums/quirks/negative_quirks/limper.dm
+++ b/code/datums/quirks/negative_quirks/limper.dm
@@ -1,0 +1,30 @@
+/datum/quirk/item_quirk/limper
+	name = "Limper"
+	desc = "You have a pronounced limp when you walk. This will slow you down considerably. Good thing you brought your cane."
+	icon = FA_ICON_PERSON_CANE
+	gain_text = span_danger("Your leg feels a bit weak.")
+	lose_text = span_notice("Your legs feel normal again.")
+	medical_record_text = "Patient appears to suffer from a weakness in the leg."
+	value = -6
+	hardcore_value = 3
+	quirk_flags = QUIRK_HUMAN_ONLY
+
+	mail_goodies = list(
+		/obj/item/cane,
+		/obj/item/cane/crutch,
+		/obj/item/cane/white,
+	)
+
+/datum/quirk/item_quirk/limper/add_unique(client/client_source)
+	give_item_to_holder(new /obj/item/cane(get_turf(quirk_holder)), list(
+			LOCATION_HANDS,
+			LOCATION_BACKPACK,
+		))
+	return
+
+/datum/quirk/item_quirk/limper/add(client/client_source)
+	quirk_holder.apply_status_effect(/datum/status_effect/limp/quirk)
+
+/datum/quirk/item_quirk/limper/remove(client/client_source)
+	quirk_holder.remove_status_effect(/datum/status_effect/limp/quirk)
+	

--- a/code/datums/quirks/negative_quirks/limper.dm
+++ b/code/datums/quirks/negative_quirks/limper.dm
@@ -27,4 +27,4 @@
 
 /datum/quirk/item_quirk/limper/remove(client/client_source)
 	quirk_holder.remove_status_effect(/datum/status_effect/limp/quirk)
-	
+

--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -139,6 +139,8 @@
 
 //Quirk variant of limping. Will always be applied as long as you have a leg to stand on.
 /datum/status_effect/limp/quirk
+	id = "limp_quirk"
+	alert_type = null
 
 /datum/status_effect/limp/quirk/update_limp(datum/source)
 	var/mob/living/carbon/carbon_mob = owner

--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -141,8 +141,6 @@
 /datum/status_effect/limp/quirk
 
 /datum/status_effect/limp/quirk/update_limp(datum/source)
-	SIGNAL_HANDLER
-
 	var/mob/living/carbon/carbon_mob = owner
 	left = carbon_mob.get_bodypart(BODY_ZONE_L_LEG)
 	right = carbon_mob.get_bodypart(BODY_ZONE_R_LEG)	

--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -137,6 +137,31 @@
 		carbon_mob.remove_status_effect(src)
 		return
 
+//Quirk variant of limping. Will always be applied as long as you have a leg to stand on.
+/datum/status_effect/limp/quirk
+
+/datum/status_effect/limp/quirk/update_limp(datum/source)
+	SIGNAL_HANDLER
+
+	var/mob/living/carbon/carbon_mob = owner
+	left = carbon_mob.get_bodypart(BODY_ZONE_L_LEG)
+	right = carbon_mob.get_bodypart(BODY_ZONE_R_LEG)	
+
+	slowdown_left = 0
+	slowdown_right = 0
+	limp_chance_left = 0
+	limp_chance_right = 0
+
+	
+	if(left)
+		slowdown_left = 7 //Same as compound fracture
+		limp_chance_left = 70
+
+	else if(right)
+		slowdown_right = 7
+		limp_chance_right = 70
+	
+
 /////////////////////////
 //////// WOUNDS /////////
 /////////////////////////

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1943,6 +1943,7 @@
 #include "code\datums\quirks\negative_quirks\indebted.dm"
 #include "code\datums\quirks\negative_quirks\insanity.dm"
 #include "code\datums\quirks\negative_quirks\light_drinker.dm"
+#include "code\datums\quirks\negative_quirks\limper.dm"
 #include "code\datums\quirks\negative_quirks\monophobia.dm"
 #include "code\datums\quirks\negative_quirks\mute.dm"
 #include "code\datums\quirks\negative_quirks\narcolepsy.dm"


### PR DESCRIPTION

## About The Pull Request

Adds a new negative quirk, called Limper. This quirk, as you could probably guess, will make you limp. Specifically, the limp it gives you is the same level as a compound fracture, so it's pretty significant. Luckily, you spawn with a cane, which as long as you are holding you won't be slowed down. This quirk is -6 points as it is pretty significant (have to hold an item in one of your hands at all times, losing this item makes you hella slow) but not quite as devastating as other disability quirks.

<img width="419" height="91" alt="{EC30B18D-367F-459B-8C82-2F395EE1E3EF}" src="https://github.com/user-attachments/assets/fdca07ad-5202-4945-a61b-da167d3c0541" />


## Why It's Good For The Game

<img width="341" height="337" alt="dr-house-3582986080" src="https://github.com/user-attachments/assets/e41d8a2b-bfba-4c26-83ac-aa7feea7d0b0" />

In all seriousness, it seemed pretty obvious as a negative quirk to add after canes were given the ability to negate limp slowdown. Now you can participate in improved old bastard RP without having to break your legs or be in a wheelchair!

## Changelog
:cl:
add: Added the limper quirk, which makes you limp.
/:cl:
