### PR TITLE
Stops internal organs from triggering updates in prefs

### DIFF
--- a/code/modules/surgery/organs/internal/appendix/_appendix.dm
+++ b/code/modules/surgery/organs/internal/appendix/_appendix.dm
@@ -15,6 +15,7 @@
 
 	now_failing = span_warning("An explosion of pain erupts in your lower right abdomen!")
 	now_fixed = span_info("The pain in your abdomen has subsided.")
+	visual = FALSE
 
 	var/inflamation_stage = 0
 

--- a/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
@@ -5,6 +5,7 @@
 	abstract_type = /obj/item/organ/cyberimp
 	organ_flags = ORGAN_ROBOTIC
 	failing_desc = "seems to be broken."
+	visual = FALSE
 	/// icon of the bodypart overlay we're going to be applying to our owner
 	var/aug_icon = 'icons/mob/human/species/misc/bodypart_overlay_augmentations.dmi'
 	/// icon_state of the bodypart overlay we're going to be applying to our owner
@@ -17,6 +18,7 @@
 /obj/item/organ/cyberimp/Initialize(mapload)
 	. = ..()
 	if (aug_overlay)
+		visual = TRUE
 		bodypart_aug = new(src)
 
 /obj/item/organ/cyberimp/Destroy()

--- a/code/modules/surgery/organs/internal/ears/_ears.dm
+++ b/code/modules/surgery/organs/internal/ears/_ears.dm
@@ -13,6 +13,7 @@
 	now_failing = span_warning("You are unable to hear at all!")
 	now_fixed = span_info("Noise slowly begins filling your ears once more.")
 	low_threshold_cleared = span_info("The ringing in your ears has died down.")
+	visual = FALSE
 
 	/// temporary deafness, measured in seconds. While > 0, the person is unable to hear anything.
 	var/temporary_deafness = 0
@@ -140,7 +141,6 @@
 
 /obj/item/organ/ears/invincible
 	damage_multiplier = 0
-
 
 /obj/item/organ/ears/cat
 	name = "cat ears"

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -24,6 +24,7 @@
 	cell_line = CELL_LINE_ORGAN_HEART
 	cells_minimum = 1
 	cells_maximum = 2
+	visual = FALSE
 
 	// Heart attack code is in code/modules/mob/living/carbon/human/life.dm
 

--- a/code/modules/surgery/organs/internal/liver/_liver.dm
+++ b/code/modules/surgery/organs/internal/liver/_liver.dm
@@ -21,6 +21,8 @@
 	cells_minimum = 1
 	cells_maximum = 2
 
+	visual = FALSE
+
 	/// Affects how much damage the liver takes from alcohol
 	var/alcohol_tolerance = ALCOHOL_RATE
 	/// The maximum volume of toxins the liver will ignore

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -22,6 +22,8 @@
 	cells_minimum = 1
 	cells_maximum = 2
 
+	visual = FALSE
+
 	var/failed = FALSE
 	var/operated = FALSE //whether we can still have our damages fixed through surgery
 

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -28,6 +28,8 @@
 	cells_minimum = 1
 	cells_maximum = 2
 
+	visual = FALSE
+
 	///The rate that disgust decays
 	var/disgust_metabolism = 1
 

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -8,6 +8,7 @@
 	attack_verb_continuous = list("licks", "slobbers", "slaps", "frenches", "tongues")
 	attack_verb_simple = list("lick", "slobber", "slap", "french", "tongue")
 	voice_filter = ""
+	visual = FALSE
 	/**
 	 * A cached list of paths of all the languages this tongue is capable of speaking
 	 *

--- a/code/modules/surgery/organs/internal/vocal_cords/_vocal_cords.dm
+++ b/code/modules/surgery/organs/internal/vocal_cords/_vocal_cords.dm
@@ -6,6 +6,7 @@
 	gender = PLURAL
 	decay_factor = 0 //we don't want decaying vocal cords to somehow matter or appear on scanners since they don't do anything damaged
 	healing_factor = 0
+	visual = FALSE
 	var/list/spans = null
 
 /obj/item/organ/vocal_cords/proc/can_speak_with() //if there is any limitation to speaking with these cords


### PR DESCRIPTION
## About The Pull Request

<img width="840" height="102" alt="image" src="https://github.com/user-attachments/assets/80ad096b-0d84-4569-ab8c-cbd4d9c9d739" />

Seems like this got lost in the internal organ refactor maybe. Internal organs (for the most part) should have `visual` set to `FALSE` so that they can respect `visual_only` checks which are used in hot areas like char creation.

## Why It's Good For The Game

Performance. This will take a heat off SSwardrobe and make a lot fewer needless organ insertions/removals happen.

## Changelog

:cl:
fix: internal organs should not trigger needless updates in the char preview anymore
/:cl: