### PR TITLE
Bugsquashing

### DIFF
--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -131,8 +131,9 @@
 			SEND_SIGNAL(creator, COMSIG_LIVING_RESONATOR_BURST, creator, attacked_living)
 		to_chat(attacked_living, span_userdanger("[src] ruptured with you in it!"))
 		attacked_living.apply_damage(resonance_damage, BRUTE)
-		attacked_living.add_movespeed_modifier(/datum/movespeed_modifier/resonance)
-		addtimer(CALLBACK(attacked_living, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/resonance), 10 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		if(!QDELETED(attacked_living))
+			attacked_living.add_movespeed_modifier(/datum/movespeed_modifier/resonance)
+			addtimer(CALLBACK(attacked_living, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/resonance), 10 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 	for(var/obj/effect/temp_visual/resonance/field in orange(1, src))
 		if(field.rupturing)
 			continue

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -64,7 +64,7 @@
 
 	var/datum/bank_account/buyer = SSeconomy.get_dep_account(cargo_account)
 	var/obj/item/card/id/id_card = computer.stored_id?.GetID()
-	if(id_card?.registered_account)
+	if(id_card?.registered_account?.account_job?.paycheck_department)
 		buyer = SSeconomy.get_dep_account(id_card?.registered_account.account_job.paycheck_department)
 		if((ACCESS_BUDGET in id_card.access))
 			requestonly = FALSE

--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -426,6 +426,8 @@
 	. = ..()
 	eye_color_left = initial(eye_color_left)
 	eye_color_right = initial(eye_color_right)
+	fix_scar(LEFT_EYE_SCAR)
+	fix_scar(RIGHT_EYE_SCAR)
 
 /obj/item/organ/eyes/on_low_damage_received()
 	if(damage >= high_threshold)


### PR DESCRIPTION

## About The Pull Request
Fixes a few small, obtuse bugs/runtimes.
- Eyes would retain scarring when returned to sswardrobe, causing newly spawned characters to have a scarred eye without having the quirk
- ID cards without a connected job (eg the cargo card) would crash the cargo app
- Resonators caused timers to be created on deleted mobs, because damage applied to mobs can instantly kill and delete them. 
## Why It's Good For The Game
bug bad
## Changelog
:cl:
fix: Fix an error when trying to use the cargo app with an id card lacking a job
fix: Fix sometimes spawning with a scarred eye despite not having the quirk
/:cl:
