### PR TITLE
Fix negative bloodloss effects being ignored by determined status

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -192,7 +192,7 @@
 	var/modified_blood_volume = get_blood_volume(apply_modifiers = TRUE)
 
 	// Some effects are halved mid-combat.
-	var/determined_mod = has_status_effect(/datum/status_effect/determined) ? 0.5 : 0
+	var/determined_mod = has_status_effect(/datum/status_effect/determined) ? 0.5 : 1
 
 	var/word = pick("dizzy","woozy","faint")
 	switch(modified_blood_volume)


### PR DESCRIPTION

## About The Pull Request
So in the original code in:
- #83874

They added a determined status effect modifier that was supposed to halve negative effects. There is even a code comment indicating so:

https://github.com/tgstation/tgstation/blob/b20c92dbb45195aea2c2459daa490fd50764da92/code/modules/mob/living/blood.dm#L194-L195

The problem is that the modifier is backwards, since without the determined status effect, you ignore negative effects. This means that having the determined status effect is a negative thing, since you will be punished more.

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: Fix negative bloodloss effects being ignored by determined status
/:cl:
