### PR TITLE
Plant nutriment is now beneficial to mobs with the `MOB_PLANT` biotype

### DIFF
--- a/code/modules/mob/living/blood_types.dm
+++ b/code/modules/mob/living/blood_types.dm
@@ -359,7 +359,7 @@
 	dna_string = "Plant DNA"
 	color = /datum/reagent/water::color
 	reagent_type = /datum/reagent/water
-	restoration_chem = /datum/reagent/plantnutriment
+	restoration_chem = /datum/reagent/plantnutriment/eznutriment
 	blood_flags = BLOOD_ADD_DNA | BLOOD_TRANSFER_VIRAL_DATA
 
 // Prevents awkward grey wounds on the mob while keeping bleed overlays looking like water leaking from a balloon

--- a/code/modules/mob/living/blood_types.dm
+++ b/code/modules/mob/living/blood_types.dm
@@ -359,7 +359,7 @@
 	dna_string = "Plant DNA"
 	color = /datum/reagent/water::color
 	reagent_type = /datum/reagent/water
-	restoration_chem = null
+	restoration_chem = /datum/reagent/plantnutriment
 	blood_flags = BLOOD_ADD_DNA | BLOOD_TRANSFER_VIRAL_DATA
 
 // Prevents awkward grey wounds on the mob while keeping bleed overlays looking like water leaking from a balloon

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1890,7 +1890,6 @@
 	tox_prob = 13
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	randomized_spawns = REAGENT_SPAWN_ALL_RANDOM_SPAWNS
-	plant_blood_regen = BLOOD_REGEN_FACTOR
 
 /datum/reagent/plantnutriment/left4zednutriment/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)
 	mytray.adjust_plant_health(round(volume * 0.1))

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1857,12 +1857,15 @@
 	color = COLOR_BLACK // RBG: 0, 0, 0
 	taste_description = "plant food"
 	ph = 3
+	/// The chance of toxin damage for a mob (heals toxins for MOB_PLANT biotype)
 	var/tox_prob = 0
 
 /datum/reagent/plantnutriment/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
+
 	if(SPT_PROB(tox_prob, seconds_per_tick))
-		if(affected_mob.adjust_tox_loss(1 * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
+		var/tox_modifier = (affected_mob.mob_biotypes & MOB_PLANT) ? -1 : 1
+		if(affected_mob.adjust_tox_loss(tox_modifier * metabolization_ratio, updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 
 /datum/reagent/plantnutriment/eznutriment
@@ -1887,9 +1890,9 @@
 	tox_prob = 13
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	randomized_spawns = REAGENT_SPAWN_ALL_RANDOM_SPAWNS
+	plant_blood_regen = BLOOD_REGEN_FACTOR
 
 /datum/reagent/plantnutriment/left4zednutriment/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)
-
 	mytray.adjust_plant_health(round(volume * 0.1))
 	mytray.myseed?.adjust_instability(round(volume * 0.2))
 


### PR DESCRIPTION

## About The Pull Request
Plant people can now have their blood restored by E-Z Nutrient, commonly found in hydroponics. This has a blood boosting effect similar to iron pills for humans. (x2 blood regeneration rate)

I noticed the code for plant nutrient chems caused toxin damage to all mobs. I went ahead and inverted it from dealing damage to healing if the mob is a `MOB_PLANT` biotype. This affects the following reagents: 
- Liquid Earthquake
- Robust Harvest
- E-Z Nutrient
- Left 4 Zed
- Enduro Grow

## Why It's Good For The Game
Mah immersion.

## Changelog
:cl:
add: Podpeople blood can now be restored by E-Z Nutrient, which functions similarly to iron pills for humans.
add: Plant nutriment (Liquid Earthsquake, Robust Harvest, E-Z Nutrient, Left 4 Zed, Enduro Grow) now heals toxin damage for mobs with the MOB_PLANT biotype.
/:cl:
