### PR TITLE
Fixes the slow tile in Icebox perma

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -59996,12 +59996,6 @@
 	},
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
-"qSu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/sepia,
-/area/station/security/prison/rec)
 "qSE" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
@@ -112741,7 +112735,7 @@ fps
 usS
 xhK
 mGC
-qSu
+rFN
 vIW
 nNn
 hqy


### PR DESCRIPTION

## About The Pull Request

Replaces a stray slowing tile in Icebox perma with the non-slowing version

Fixes #96198 

## Why It's Good For The Game

Mapping oversights are bad.

## Changelog
:cl:
fix: The stray slow tile in Icebox perma has been removed.
/:cl:
