### PR TITLE
Camera chunk updates optimisation

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
@@ -90,8 +90,6 @@
 #define COMSIG_ATOM_ORBIT_BEGIN "atom_orbit_begin"
 ///called when an atom stops orbiting another atom: (atom)
 #define COMSIG_ATOM_ORBIT_STOP "atom_orbit_stop"
-///from base of atom/set_opacity(): (new_opacity)
-#define COMSIG_ATOM_SET_OPACITY "atom_set_opacity"
 ///from base of atom/throw_impact, sent by the target hit by a thrown object. (hit_atom, thrown_atom, datum/thrownthing/throwingdatum)
 #define COMSIG_ATOM_PREHITBY "atom_pre_hitby"
 	#define COMSIG_HIT_PREVENTED (1<<0)

--- a/code/controllers/subsystem/cameras.dm
+++ b/code/controllers/subsystem/cameras.dm
@@ -119,7 +119,8 @@ SUBSYSTEM_DEF(cameras)
 /datum/controller/subsystem/cameras/proc/update_visibility(atom/relevant_atom)
 	if(!SSticker)
 		return
-	major_chunk_change(relevant_atom, IGNORE_CAMERA)
+	if(is_visible_by_cameras(relevant_atom))
+		major_chunk_change(relevant_atom, IGNORE_CAMERA)
 
 /// Removes a camera from a chunk.
 /datum/controller/subsystem/cameras/proc/remove_camera_from_chunk(obj/machinery/camera/old_cam)

--- a/code/controllers/subsystem/cameras.dm
+++ b/code/controllers/subsystem/cameras.dm
@@ -119,8 +119,7 @@ SUBSYSTEM_DEF(cameras)
 /datum/controller/subsystem/cameras/proc/update_visibility(atom/relevant_atom)
 	if(!SSticker)
 		return
-	if(is_visible_by_cameras(relevant_atom))
-		major_chunk_change(relevant_atom, IGNORE_CAMERA)
+	major_chunk_change(relevant_atom, IGNORE_CAMERA)
 
 /// Removes a camera from a chunk.
 /datum/controller/subsystem/cameras/proc/remove_camera_from_chunk(obj/machinery/camera/old_cam)

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -70,9 +70,10 @@
 /atom/proc/set_opacity(new_opacity)
 	if (new_opacity == opacity || light_flags & LIGHT_FROZEN)
 		return
-	SEND_SIGNAL(src, COMSIG_ATOM_SET_OPACITY, new_opacity)
 	. = opacity
 	opacity = new_opacity
+	// Change in opacity could change camera visibility
+	SScameras.update_visibility(src)
 	return .
 
 /atom/movable/set_opacity(new_opacity)
@@ -84,8 +85,6 @@
 		AddElement(/datum/element/light_blocking)
 	else
 		RemoveElement(/datum/element/light_blocking)
-	// Change in opacity could change camera visibility
-	SScameras.update_visibility(src)
 
 /turf/set_opacity(new_opacity)
 	. = ..()

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -1,5 +1,5 @@
 /**
- * A 16x16 grid of the map with a list of turfs that can be seen, are visible and are dimmed. \
+ * A 8x8 grid of the map with a list of turfs that can be seen, are visible and are dimmed. \
  * Allows Camera Eyes to stream these chunks and know what it can and cannot see.
  */
 


### PR DESCRIPTION

## About The Pull Request
Inspired by https://github.com/tgstation/tgstation/pull/92208
Did you know that random opacity changes update camera chunks. This means random gorilla/cockroach in icebox ruins bumpopening a random door forces camerachunk updates, disregarding presence of cameras in a chunk. Random maint critter walking over steam vent also does update camera chunks. And the worst offender is Donk Exenteration Drone. All it does is just walk around in circles opening and closing doors.


<details><summary>Just look at them. They exist to eat server CPU.</summary><img width="208" height="266" alt="image" src="https://github.com/user-attachments/assets/48544a2f-cffd-462e-8b6e-6787518e95d6" />
<img width="210" height="199" alt="image" src="https://github.com/user-attachments/assets/cfb14db6-a0be-4001-8fdc-9d3b8a0f0094" />

</details>



Opening and closing glass doors (no opacity change) will no longer update camera chunks.
This PR makes is so only opacity changes that matter (i.e. visible by cameras) trigger chunk updates.
Removes unused signal.
## Why It's Good For The Game
Performance goes up, CPU goes wzwzwzwzwz
## Changelog
:cl:

code: optimised camera chunk updates
fix: lag (maybe)

/:cl:
