### PR TITLE
Adds a check to stop CQC disarm taking items that should be tethered to something (backtank sprayers etc)

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -342,7 +342,11 @@
 	if(prob(65) && (defender.stat == CONSCIOUS || !defender.IsParalyzed() || !restraining_mob?.resolve()))
 		var/obj/item/disarmed_item = defender.get_active_held_item()
 		if(disarmed_item && defender.temporarilyRemoveItemFromInventory(disarmed_item))
-			attacker.put_in_hands(disarmed_item)
+			defender.dropItemToGround(disarmed_item)
+			if(isturf(disarmed_item.loc)) //If it fell on the ground we can take it, otherwise assume it's attached to something.
+				attacker.put_in_hands(disarmed_item)
+			else
+				disarmed_item = null
 		else
 			disarmed_item = null
 


### PR DESCRIPTION

## About The Pull Request

Adds an extra step to CQC disarm by explicitly forcing the original owner to drop the item first, and checking if it fell on the floor. Anything that didn't go on the floor is assumed to be tethered to another item and not taken.

Fix originally proposed by Hugbug https://discord.com/channels/326822144233439242/326831214667235328/1070738859429724170

Fixes #43100 

## Why It's Good For The Game

Weird things happen when you let people steal things that should be tethered to another item, this shouldn't happen.

## Changelog
:cl: Thunder12345 and Hugbug
fix: CQC can no longer steal backtank misters and other tethered items.
/:cl:
