### PR TITLE
Removes remaining references to the flagellant robes

### DIFF
--- a/code/game/objects/items/stacks/sheets/runed_metal.dm
+++ b/code/game/objects/items/stacks/sheets/runed_metal.dm
@@ -39,8 +39,7 @@ GLOBAL_LIST_INIT(runed_metal_recipes, list( \
 		req_amount = 3, \
 		time = 4 SECONDS, \
 		crafting_flags = CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND, \
-		desc = span_cult_bold("Daemon Forge: Can make Nar'Sien Hardened Armor, Flagellant's Robes, \
-			and Eldritch Longswords. Emits Light."), \
+		desc = span_cult_bold("Daemon Forge: Can make Nar'Sien Hardened Armor and Eldritch Longswords. Emits Light."), \
 		required_noun = "runed metal sheet", \
 		category = CAT_CULT, \
 	), \

--- a/code/modules/antagonists/cult/cult_structure_forge.dm
+++ b/code/modules/antagonists/cult/cult_structure_forge.dm
@@ -1,6 +1,5 @@
 /// Some defines for items the daemon forge can create.
 #define NARSIE_ARMOR "Nar'Sien Hardened Armor"
-#define FLAGELLANT_ARMOR "Flagellant's Robe"
 #define ELDRITCH_SWORD "Eldritch Longsword"
 #define CURSED_BLADE "Cursed Ritual Blade"
 
@@ -8,7 +7,7 @@
 /obj/structure/destructible/cult/item_dispenser/forge
 	name = "daemon forge"
 	desc = "A forge used in crafting the unholy weapons used by the armies of Nar'Sie."
-	cult_examine_tip = "Can be used to create Nar'Sien hardened armor, flagellant's robes, and eldritch longswords."
+	cult_examine_tip = "Can be used to create Nar'Sien hardened armor and eldritch longswords."
 	icon_state = "forge"
 	light_range = 2
 	light_color = LIGHT_COLOR_LAVA
@@ -56,6 +55,5 @@
 	debris = list()
 
 #undef NARSIE_ARMOR
-#undef FLAGELLANT_ARMOR
 #undef ELDRITCH_SWORD
 #undef CURSED_BLADE


### PR DESCRIPTION

## About The Pull Request
None of the references to it ingame were removed in https://github.com/tgstation/tgstation/pull/92090
## Why It's Good For The Game
## Changelog
:cl:
spellcheck: Some references to the cult flagellant robes have been removed
/:cl:
