### PR TITLE
Fix limping not switching legs when using a cane

### DIFF
--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -79,17 +79,22 @@
 	// less limping while we have determination still
 	var/determined_mod = owner.has_status_effect(/datum/status_effect/determined) ? 0.5 : 1
 
+	var/limp_chance
+	var/limp_slowdown
+	if(next_leg == left)
+		limp_chance = limp_chance_left
+		limp_slowdown = slowdown_left
+		next_leg = right
+	else
+		limp_chance = limp_chance_right
+		limp_slowdown = slowdown_right
+		next_leg = left
+
 	if(SEND_SIGNAL(owner, COMSIG_CARBON_LIMPING) & COMPONENT_CANCEL_LIMP)
 		return
 
-	if(next_leg == left)
-		if(prob(limp_chance_left * determined_mod))
-			owner.client.move_delay += slowdown_left * determined_mod
-		next_leg = right
-	else
-		if(prob(limp_chance_right * determined_mod))
-			owner.client.move_delay += slowdown_right * determined_mod
-		next_leg = left
+	if(prob(limp_chance * determined_mod))
+		owner.client.move_delay += limp_slowdown * determined_mod
 
 /// We need to make sure that we properly clear these refs if one of the owner's limbs gets deleted
 /datum/status_effect/limp/proc/on_limb_removed(datum/source, obj/item/bodypart/limb_lost, special, dismembered)


### PR DESCRIPTION

## About The Pull Request
This fixes a rare edge case involving limping. Normally, a mob switches from its left and right feet while moving, but if a crutch or cane is used, it early returns due to the signal check. This results in the feet never properly switching and effectively gets stuck on using one leg.

## Why It's Good For The Game
Consistency.

## Changelog
:cl:
fix: Fix limping not switching legs when using a cane
/:cl:
