### PR TITLE
Makes the casino shuttle honkbot not run away

### DIFF
--- a/_maps/shuttles/emergency_casino.dmm
+++ b/_maps/shuttles/emergency_casino.dmm
@@ -1188,7 +1188,7 @@
 /obj/item/storage/crayons,
 /obj/item/storage/crayons,
 /obj/item/storage/crayons,
-/mob/living/basic/bot/secbot/honkbot,
+/mob/living/basic/bot/secbot/honkbot/nopatrol,
 /turf/open/floor/sepia,
 /area/shuttle/escape)
 "NN" = (

--- a/code/modules/mob/living/basic/bots/honkbots/honkbot.dm
+++ b/code/modules/mob/living/basic/bots/honkbots/honkbot.dm
@@ -26,8 +26,6 @@
 	baton_type = /obj/item/bikehorn/airhorn
 	cuff_type = /obj/item/restraints/handcuffs/cable/zipties/fake
 
-
-
 /mob/living/basic/bot/secbot/honkbot/Initialize(mapload)
 	. = ..()
 	var/static/list/clown_friends = typecacheof(list(
@@ -121,3 +119,6 @@
 	honkbot_assembly.created_name = name
 	new /obj/item/assembly/prox_sensor(drop_location)
 	drop_part(baton_type, drop_location)
+
+/mob/living/basic/bot/secbot/honkbot/nopatrol
+	bot_mode_flags = BOT_MODE_ON | BOT_MODE_REMOTE_ENABLED | BOT_MODE_CAN_BE_SAPIENT | BOT_MODE_ROUNDSTART_POSSESSION

--- a/code/modules/mob/living/basic/bots/honkbots/honkbot.dm
+++ b/code/modules/mob/living/basic/bots/honkbots/honkbot.dm
@@ -121,4 +121,4 @@
 	drop_part(baton_type, drop_location)
 
 /mob/living/basic/bot/secbot/honkbot/nopatrol
-	bot_mode_flags = BOT_MODE_ON | BOT_MODE_REMOTE_ENABLED | BOT_MODE_CAN_BE_SAPIENT | BOT_MODE_ROUNDSTART_POSSESSION
+	bot_mode_flags = parent_type::bot_mode_flags & ~BOT_MODE_AUTOPATROL


### PR DESCRIPTION

## About The Pull Request

Adds a non-patrolling subtype of honkbot for the casino shuttle to use.

Fixes #96201 

## Why It's Good For The Game

He's supposed to be spreading joy to the evacuees, not running away roam the halls.

## Changelog
:cl:
fix: The honkbot on the casino emergency shuttle has been told not to abandon its post.
/:cl:
