### PR TITLE
Smartfridges become unsealed when broken, & can't be walked through by certain mobs unless broken

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -14,6 +14,7 @@
 	light_range = MINIMUM_USEFUL_LIGHT_RANGE
 	integrity_failure = 0.5
 	can_atmos_pass = ATMOS_PASS_NO
+	pass_flags_self = PASSCLOSEDTURF
 	/// Icon state part for contents display
 	var/contents_overlay_icon = "plant"
 	/// What path boards used to construct it should build into when dropped. Needed so we don't accidentally have them build variants with items preloaded in them.
@@ -131,8 +132,7 @@
 	. = ..()
 	if(!anchored && welded_down) //make sure they're keep in sync in case it was forcibly unanchored by badmins or by a megafauna.
 		welded_down = FALSE
-	can_atmos_pass = anchorvalue ? ATMOS_PASS_NO : ATMOS_PASS_YES
-	air_update_turf(TRUE, anchorvalue)
+	recheck_atmos_passing()
 
 /obj/machinery/smartfridge/wrench_act(mob/living/user, obj/item/tool)
 	if(default_unfasten_wrench(user, tool) == SUCCESSFUL_UNFASTEN)
@@ -188,6 +188,13 @@
 		. += span_notice("The status display reads: This unit can hold a maximum of <b>[max_n_of_items]</b> items.")
 
 	. += structure_examine()
+
+/obj/machinery/smartfridge/on_set_machine_stat(old_value)
+	recheck_atmos_passing()
+	if(machine_stat & BROKEN)
+		pass_flags_self = PASSMACHINE
+		return
+	pass_flags_self = PASSCLOSEDTURF
 
 /// Returns details related to the fridge structure
 /obj/machinery/smartfridge/proc/structure_examine()
@@ -421,6 +428,13 @@
 			return TRUE
 
 	return FALSE
+
+/obj/machinery/smartfridge/proc/recheck_atmos_passing()
+	if(machine_stat & BROKEN)
+		can_atmos_pass = ATMOS_PASS_YES
+	else
+		can_atmos_pass = anchored ? ATMOS_PASS_NO : ATMOS_PASS_YES
+	air_update_turf(TRUE, anchored)
 
 // ----------------------------
 //  Drying 'smartfridge'

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -190,6 +190,7 @@
 	. += structure_examine()
 
 /obj/machinery/smartfridge/on_set_machine_stat(old_value)
+	. = ..()
 	recheck_atmos_passing()
 	if(machine_stat & BROKEN)
 		pass_flags_self = PASSMACHINE


### PR DESCRIPTION

## About The Pull Request

Smartfridges update their `pass_flags_self` & `can_atmos_pass` when they're broken. Currently, they are always `PASSMACHINE` & atmos can only pass when unanchored, and with this change, they are `PASSCLOSEDTURF` until broken into `PASSMACHINE`, & they stop blocking atmos when broken.

## Why It's Good For The Game

Smartfridges are placed inline with walls, take up a wall's worth of icon size, block atmos like a wall, and yet can be flown over like they're a little computer. They also continue to block atmos when they've had their perfectly sealed glass broken open. Neither should be the case.

## Changelog
:cl:
balance: Smartfridges no longer block atmos when broken & no longer let creatures pass until broken
/:cl:
