### PR TITLE
Fixes runtime/ race condition with cyberimps

### DIFF
--- a/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
@@ -20,8 +20,8 @@
 		bodypart_aug = new(src)
 
 /obj/item/organ/cyberimp/Destroy()
-	QDEL_NULL(bodypart_aug)
-	return ..()
+	. = ..()
+	QDEL_NULL(bodypart_aug) // Do this after Remove() has done its thing, otherwise on_bodypart_remove() will not properly remove the overlay
 
 /obj/item/organ/cyberimp/proc/get_overlay_state()
 	return aug_overlay


### PR DESCRIPTION
## About The Pull Request

<img width="583" height="140" alt="image" src="https://github.com/user-attachments/assets/a3d7d314-04b3-4a9a-9623-bf7c66faaa98" />

Fixes this, which is basically caused by `Destroy()` qdeleting the `bodypart_overlay` before `Remove()` is called by the parent organ `Destroy()` which you really don't want to be doing, because that results in a runtime in the `generate_cache_key()` proc...

## Why It's Good For The Game

We generally want to avoid runtiming in procs like this, + reduces log spam

## Changelog

Not really anything players would notice, though