### PR TITLE
common sense powercreep for syndicate borgs

### DIFF
--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -50,6 +50,7 @@
 		/datum/reagent/medicine/morphine,\
 		/datum/reagent/medicine/potass_iodide,\
 		/datum/reagent/medicine/syndicate_nanites,\
+		/datum/reagent/medicine/atropine,\
 	)
 #define BASE_SERVICE_REAGENTS list(/datum/reagent/consumable/applejuice, /datum/reagent/consumable/banana,\
 		/datum/reagent/consumable/berryjuice, /datum/reagent/consumable/cherryjelly, /datum/reagent/consumable/coffee,\

--- a/code/game/objects/items/weaponry/melee/energy.dm
+++ b/code/game/objects/items/weaponry/melee/energy.dm
@@ -325,7 +325,7 @@
 	toolspeed = 0.7 // Faster than a normal saw.
 	hacked = FALSE
 	active_force = 30
-	block_chance = 0
+	block_chance = 0 //Unlike assault cyborgs, syndicate medical cyborgs don't get any blocking capabilities
 	sword_color_icon = null // Stops icon from breaking when turned on.
 
 /obj/item/melee/energy/sword/pirate

--- a/code/game/objects/items/weaponry/melee/energy.dm
+++ b/code/game/objects/items/weaponry/melee/energy.dm
@@ -222,48 +222,6 @@
 
 	return ..()
 
-/obj/item/melee/energy/sword/cyborg
-	name = "cyborg energy sword"
-	sword_color_icon = "red"
-	/// The cell cost of hitting something.
-	var/hitcost = 0.05 * STANDARD_CELL_CHARGE
-
-/obj/item/melee/energy/sword/cyborg/attack(mob/target, mob/living/silicon/robot/user)
-	if(!user.cell)
-		return
-
-	var/obj/item/stock_parts/power_store/our_cell = user.cell
-	if(HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE) && !(our_cell.use(hitcost)))
-		attack_self(user)
-		to_chat(user, span_notice("It's out of charge!"))
-		return
-	return ..()
-
-/obj/item/melee/energy/sword/cyborg/cyborg_unequip(mob/user)
-	if(!HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
-		return
-	attack_self(user)
-
-/obj/item/melee/energy/sword/cyborg/saw //Used by medical Syndicate cyborgs
-	name = "energy saw"
-	desc = "For heavy duty cutting. It has a carbon-fiber blade in addition to a toggleable hard-light edge to dramatically increase sharpness."
-	icon = 'icons/obj/medical/surgery_tools.dmi'
-	icon_state = "esaw"
-	hitsound = 'sound/items/weapons/circsawhit.ogg'
-	force = 18
-	hitcost = 0.075 * STANDARD_CELL_CHARGE // Costs more than a standard cyborg esword.
-	w_class = WEIGHT_CLASS_NORMAL
-	sharpness = SHARP_EDGED
-	light_color = LIGHT_COLOR_LIGHT_CYAN
-	tool_behaviour = TOOL_SAW
-	toolspeed = 0.7 // Faster than a normal saw.
-
-	active_force = 30
-	sword_color_icon = null // Stops icon from breaking when turned on.
-
-/obj/item/melee/energy/sword/cyborg/saw/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
-	return FALSE
-
 // The colored energy swords we all know and love.
 /obj/item/melee/energy/sword/saber
 	/// Assoc list of all possible saber colors to color define. If you add a new color, make sure to update /obj/item/toy/sword too!
@@ -324,6 +282,51 @@
 	sword_color_icon = "rainbow"
 	to_chat(user, span_warning("RNBW_ENGAGE"))
 	update_appearance(UPDATE_ICON_STATE)
+
+/obj/item/melee/energy/sword/saber/cyborg
+	name = "cyborg energy sword"
+	hacked = TRUE
+	sword_color_icon = "rainbow"
+	/// The cell cost of hitting something.
+	var/hitcost = 0.05 * STANDARD_CELL_CHARGE
+
+/obj/item/melee/energy/sword/saber/cyborg/Initialize(mapload)
+	. = ..()
+	set_light_range(5) //Cyborgs don't have inhand sprites, so we compensate by making it glow brightly.
+
+/obj/item/melee/energy/sword/saber/cyborg/attack(mob/target, mob/living/silicon/robot/user)
+	if(!user.cell)
+		return
+
+	var/obj/item/stock_parts/power_store/our_cell = user.cell
+	if(HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE) && !(our_cell.use(hitcost)))
+		attack_self(user)
+		to_chat(user, span_notice("It's out of charge!"))
+		return
+	return ..()
+
+/obj/item/melee/energy/sword/saber/cyborg/cyborg_unequip(mob/user)
+	if(!HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
+		return
+	attack_self(user)
+
+/obj/item/melee/energy/sword/saber/cyborg/saw //Used by medical Syndicate cyborgs
+	name = "energy saw"
+	desc = "For heavy duty cutting. It has a carbon-fiber blade in addition to a toggleable hard-light edge to dramatically increase sharpness."
+	icon = 'icons/obj/medical/surgery_tools.dmi'
+	icon_state = "esaw"
+	hitsound = 'sound/items/weapons/circsawhit.ogg'
+	force = 18
+	hitcost = 0.075 * STANDARD_CELL_CHARGE // Costs more than a standard cyborg esword.
+	w_class = WEIGHT_CLASS_NORMAL
+	sharpness = SHARP_EDGED
+	light_color = LIGHT_COLOR_LIGHT_CYAN
+	tool_behaviour = TOOL_SAW
+	toolspeed = 0.7 // Faster than a normal saw.
+	hacked = FALSE
+	active_force = 30
+	block_chance = 0
+	sword_color_icon = null // Stops icon from breaking when turned on.
 
 /obj/item/melee/energy/sword/pirate
 	name = "energy cutlass"

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -7,10 +7,6 @@
 /mob/living/silicon/robot/get_active_held_item()
 	return module_active
 
-// Returns what we have in all of our modules, not just actively selected.
-/mob/living/silicon/robot/proc/get_all_held_items()	
-	return held_items
-
 /**
  * Parent proc - triggers when an item/module is unequipped from a cyborg.
  */

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -7,6 +7,10 @@
 /mob/living/silicon/robot/get_active_held_item()
 	return module_active
 
+// Returns what we have in all of our modules, not just actively selected.
+/mob/living/silicon/robot/proc/get_all_held_items()	
+	return held_items
+
 /**
  * Parent proc - triggers when an item/module is unequipped from a cyborg.
  */

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -214,6 +214,18 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 
 	return NONE
 
+//Checks blockchance of any items in any module slots
+/mob/living/silicon/robot/check_block(atom/hit_by, damage, attack_text = "the attack", attack_type = MELEE_ATTACK, armour_penetration = 0, damage_type = BRUTE)
+	. = ..()
+	if(. == SUCCESSFUL_BLOCK)
+		return SUCCESSFUL_BLOCK
+
+	var/block_chance_modifier = round(damage / -3)
+	for(var/obj/item/module in get_all_held_items())
+		var/final_block_chance = module.block_chance - (clamp((armour_penetration - module.armour_penetration) / 2, 0, 100)) + block_chance_modifier
+		if(module.hit_reaction(src, hit_by, attack_text, final_block_chance, damage, attack_type, damage_type))
+			return SUCCESSFUL_BLOCK
+
 // This has to go at the very end of interaction so we don't block every interaction with ID-like items
 /mob/living/silicon/robot/base_item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	. = ..()
@@ -522,6 +534,8 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 	return TRUE
 
 /mob/living/silicon/robot/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit = FALSE)
+	if(check_block(hitting_projectile, hitting_projectile.damage, "\the [hitting_projectile]", PROJECTILE_ATTACK, hitting_projectile.armour_penetration, hitting_projectile.damage_type))
+		return ..(hitting_projectile, def_zone, piercing_hit, 100)
 	. = ..()
 	if(prob(25) || . != BULLET_ACT_HIT)
 		return

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -221,7 +221,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		return SUCCESSFUL_BLOCK
 
 	var/block_chance_modifier = round(damage / -3)
-	for(var/obj/item/module in get_all_held_items())
+	for(var/obj/item/module in held_items)
 		var/final_block_chance = module.block_chance - (clamp((armour_penetration - module.armour_penetration) / 2, 0, 100)) + block_chance_modifier
 		if(module.hit_reaction(src, hit_by, attack_text, final_block_chance, damage, attack_type, damage_type))
 			return SUCCESSFUL_BLOCK

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -904,7 +904,7 @@
 	name = "Syndicate Assault"
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
-		/obj/item/melee/energy/sword/cyborg,
+		/obj/item/melee/energy/sword/saber/cyborg,
 		/obj/item/gun/energy/printer,
 		/obj/item/gun/ballistic/revolver/grenadelauncher/cyborg,
 		/obj/item/card/emag,
@@ -937,7 +937,7 @@
 		/obj/item/borg/cyborg_omnitool/medical,
 		/obj/item/borg/cyborg_omnitool/medical,
 		/obj/item/blood_filter,
-		/obj/item/melee/energy/sword/cyborg/saw,
+		/obj/item/melee/energy/sword/saber/cyborg/saw,
 		/obj/item/emergency_bed/silicon,
 		/obj/item/crowbar/cyborg,
 		/obj/item/extinguisher/mini,


### PR DESCRIPTION

## About The Pull Request

I am not actually entirely sure if it's intended for syndicate cyborgs to be able to block stuff with their eswords. I feel like it might be because the energy saw for syndicate mediborgs is explicitly programmed to NOT be able to block stuff, while the assault cyborg esword isn't, cyborgs just are missing the code to block stuff in general. I ultimately decided that I'd consider it to be one and add a small buff for syndie mediborgs as well to ensure this is considered as one. This adds the framework in general for borgs to block stuff, but because only assault cyborgs feature any items with blockchance this is exclusive to them outside of badmin nans or future additions.

For syndie mediborgs, they now have atropine in their hypospray. It's pretty simple. Atropine prevents operative minibombs from going off when they're killed, allowing you to potentially drag them back to safety to pick them up. Most of the stuff in the medical syndicate module is useless because ops just blow up when they die.
## Why It's Good For The Game

Assault cyborgs are a pretty terrible buy unless they're on discount, the number one reason for this being that they are incredibly fragile. Giving them the ability to block stuff with their eswords decreases their fragility and makes sense (Normal eswords can block after all, and the borg eswords are listed as featuring blocking) as well as making them a better buy in general.

For medical cyborgs, you can now haul operatives away and use your defibrillator to revive them instead of just to troll people with a glorified one-hit stun. Op medipens have atro so the dedicated medical unit probably should too.

## Changelog
:cl:
balance: Syndicate assault cyborgs can now block attacks with their energy swords
balance: Syndicate medical cyborgs now feature atropine in their hypospray to prevent microbomb detonations.
/:cl:
