### PR TITLE
Maximum quality food is "Divine" rather than "Godlike"

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -132,7 +132,7 @@ GLOBAL_ALIST_INIT(food_quality_description, alist(
 	FOOD_QUALITY_VERYGOOD = "very good",
 	FOOD_QUALITY_FANTASTIC = "fantastic",
 	FOOD_QUALITY_AMAZING = "amazing",
-	FOOD_QUALITY_TOP = "godlike",
+	FOOD_QUALITY_TOP = "divine",
 ))
 
 /// Weighted lists of crafted food buffs randomly given according to crafting_complexity unless the food has a specific buff


### PR DESCRIPTION

## About The Pull Request

Changes the descriptor for food with maximum quality from "godlike" to "divine"

## Why It's Good For The Game

"Godlike" is not a descriptor for food. I have never heard anyone refer to food as "Godlike", and if they did, I would side-eye them.
"Divine" is a descriptor for food. I have heard people refer to food as "Divine". 

## Changelog
:cl:

spellcheck: Maximum quality food is referred to as "Divine" rather than "Godlike"

/:cl:
