### PR TITLE
Support holoparasites can teleport between station Z levels

### DIFF
--- a/code/modules/mob/living/basic/guardian/guardian_types/support.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/support.dm
@@ -112,6 +112,8 @@
 
 /// Validate whether we can teleport this object
 /datum/action/cooldown/mob_cooldown/guardian_bluespace_beacon/proc/can_teleport(mob/living/source, atom/movable/target)
+	if(!istype(target)) // Turfs
+		return FALSE
 	if (isnull(beacon))
 		source.balloon_alert(source, "no beacon!")
 		return FALSE
@@ -126,7 +128,7 @@
 	if (target.anchored)
 		target.balloon_alert(source, "it won't budge!")
 		return FALSE
-	if(beacon.z != target.z)
+	if((beacon.z != target.z) && (!is_station_level(beacon.z) || !is_station_level(target.z)))
 		target.balloon_alert(source, "too far from beacon!")
 		return FALSE
 	return TRUE

--- a/code/modules/mob/living/basic/guardian/guardian_types/support.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/support.dm
@@ -128,7 +128,7 @@
 	if (target.anchored)
 		target.balloon_alert(source, "it won't budge!")
 		return FALSE
-	if((beacon.z != target.z) && (!is_station_level(beacon.z) || !is_station_level(target.z)))
+	if((beacon.z != target.z) && !(target.z in SSmapping.get_connected_levels(beacon.z)))
 		target.balloon_alert(source, "too far from beacon!")
 		return FALSE
 	return TRUE


### PR DESCRIPTION

## About The Pull Request

Changes the support holoparasite's teleporting ability's Z level check to allow teleportations between two station Z levels. Additionally, fixes a runtime when attempting to teleport a turf. 

## Why It's Good For The Game

Teleporting between floors seems quite within the realm of possibility, and not being able to do so is making people think that the ability has an extremely short range.

## Changelog
:cl:

qol: Support holoparasites can teleport things between two station Z-levels
fix: Support holoparasite teleportation no longer runtimes when attempting to teleport a turf

/:cl:
