### PR TITLE
Gives QM locker a flash

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -9,6 +9,7 @@
 	new /obj/item/radio/weather_monitor (src)
 	new /obj/item/radio/headset/heads/qm(src)
 	new /obj/item/megaphone/cargo(src)
+	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/universal_scanner(src)
 	new /obj/item/door_remote/quartermaster(src)


### PR DESCRIPTION

## About The Pull Request
Adds a flash in the QM's locker
## Why It's Good For The Game
He's one of the only heads (That isn't HoS/Cap) that doesn't get a flash. This  will make QM more consistent with other heads.
## Changelog
:cl:
add: Added a flash to the QM's locker
/:cl:
