### PR TITLE
Exosuit drills take 1 1/2 extra seconds to start drilling into a mob

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -120,7 +120,7 @@
 		return
 
 	target.visible_message(span_warning("[chassis] starts to drill [target]."), \
-				span_userdanger("[chassis] starts to drill [target]..."), \
+				span_userdanger("[chassis] starts to drill you!"), \
 				span_hear("You hear drilling."))
 
 	log_message("Started drilling [target]", LOG_MECHA)
@@ -131,6 +131,9 @@
 		T.drill_act(src, source)
 
 		return ..()
+
+	if(isliving(target) && !do_after_mecha(target, source, 1.5 SECONDS))
+		return
 
 	// Drilling objects and mobs is a repeating procedure.
 	while(do_after_mecha(target, source, drill_delay))


### PR DESCRIPTION

## About The Pull Request

Yes, it's an Ided PR. Get it out of your system.

Adds an additional delay to the exosuit drill module of 1 1/2 seconds if the target of the drilling is a mob, before drilling begins.

## Why It's Good For The Game

0.4 seconds, that's the delay, currently. Anyone standing still for 0.4 seconds has a 1/5 chance to instantly die from loss of a vital organ. Nobody can read, interpret, and act on a message in their chat in 0.4 seconds - lag difference. I already don't like that drills are an instant kill weapon on someone that's standing still for any length of time, they really shouldn't also be an instant kill weapon on someone that's MOVING. The drill is more powerful than actual combat mech melees, and it shouldn't be.

## Changelog
:cl:

balance: Exosuit drills take longer to activate on living beings

/:cl:
