### PR TITLE
Making 40 parts at Adming RPED, not 10 each, and making it another, non-child, type from tier4 RPED

### DIFF
--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -421,7 +421,7 @@
 	back = /obj/item/mod/control/pre_equipped/debug
 	backpack_contents = list(
 		/obj/item/melee/energy/axe = 1,
-		/obj/item/storage/part_replacer/bluespace/tier4 = 1,
+		/obj/item/storage/part_replacer/bluespace/AdminDebug = 1,
 		/obj/item/gun/magic/wand/resurrection/debug = 1,
 		/obj/item/gun/magic/wand/death/debug = 1,
 		/obj/item/debug/human_spawner = 1,
@@ -452,7 +452,7 @@
 	back = /obj/item/mod/control/pre_equipped/administrative
 	backpack_contents = list(
 		/obj/item/melee/energy/axe = 1,
-		/obj/item/storage/part_replacer/bluespace/tier4 = 1,
+		/obj/item/storage/part_replacer/bluespace/AdminDebug = 1,
 		/obj/item/gun/magic/wand/resurrection/debug = 1,
 		/obj/item/gun/magic/wand/death/debug = 1,
 		/obj/item/debug/human_spawner = 1,

--- a/code/modules/research/part_replacer.dm
+++ b/code/modules/research/part_replacer.dm
@@ -152,6 +152,16 @@
 		new /obj/item/stock_parts/power_store/cell/bluespace(src)
 		new /obj/item/stack/cable_coil/thirty(src)
 
+/obj/item/storage/part_replacer/bluespace/AdminDebug/PopulateContents()
+	for(var/i in 1 to 40)
+		new /obj/item/stock_parts/capacitor/quadratic(src)
+		new /obj/item/stock_parts/scanning_module/triphasic(src)
+		new /obj/item/stock_parts/servo/femto(src)
+		new /obj/item/stock_parts/micro_laser/quadultra(src)
+		new /obj/item/stock_parts/matter_bin/bluespace(src)
+		new /obj/item/stock_parts/power_store/cell/bluespace(src)
+		new /obj/item/stack/cable_coil/thirty(src)
+
 //used in a cargo crate
 /obj/item/storage/part_replacer/cargo/PopulateContents()
 	for(var/i in 1 to 10)


### PR DESCRIPTION

## About The Pull Request

So now Adming Outfit and Debug Outfit using AdminDebug RPED with 40 parts of each, and its another RPED, not tier4, which is the same RPED, which has spawnpoind at lavaland base
## Why It's Good For The Game

10 not so much, so its need to regive the RPED via regive of admin outfit, so 40 is enough if, f. e., you need to fully upgrade 10 thermo freezers for sm setup, emmiters and smes and you dont need to regive yourself new admin outfit, clicking buttons like "delete old items", "give outfit" and sm will not blew up on your localhost server - all that gone, cause now your Admin RPED wont let you down
## Changelog
:cl:
qol: now Admin RPED has 40 parts each
code: now Admin outfit and Debug outfit(what is that) has AdminDebug RPED with 40 parts, and not just tier4 RPED, which is like game thing
/:cl:
