### PR TITLE
Space furnance(pyro core thing) will now also generate power

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,5 +1,5 @@
-//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
-//#define ABSOLUTE_MINIMUM //uncomment this to load a smaller centcomm and smaller runtime station, only works together with LOWMEMORYMODE
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define ABSOLUTE_MINIMUM //uncomment this to load a smaller centcomm and smaller runtime station, only works together with LOWMEMORYMODE
 
 #ifdef ABSOLUTE_MINIMUM
 #define LOWMEMORYMODE

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -1165,6 +1165,9 @@
 	active = TRUE
 	power_output = 0.2
 
+/obj/machinery/power/port_gen/space_bubble_gen/Initialize()
+	. = ..()
+
 /obj/item/flashlight/lamp/space_bubble/Initialize(mapload)
 	AddElement(/datum/element/update_icon_updates_onmob)
 	. = ..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -1240,7 +1240,7 @@
 ///Closes the bubble and cleans up after itself. Optional 'user' arg for the mob turning us off.
 /obj/item/flashlight/lamp/space_bubble/proc/close_bubble(mob/user)
 	QDEL_NULL(space_bubble)
-	QDEL_NULL(space_bubble.space_bubble_gen)
+	QDEL_NULL(space_gen)
 	if(bubble_timer)
 		deltimer(bubble_timer)
 	slowdown = initial(slowdown)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -1231,7 +1231,7 @@
 		var/obj/machinery/power/port_gen/space_bubble_gen/space_furnance_gen = new()
 		if(istype(space_bubble))
 			QDEL_NULL(space_bubble)
-			QDEL_NULL(space_gen)
+			QDEL_NULL(space_furnance_gen)
 		bubble_timer = addtimer(CALLBACK(src, PROC_REF(start_bubble_close), "dies down..."), bubble_duration, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_DELETE_ME)
 		space_bubble = new(src, 4, FALSE, src)
 		slowdown = SLOWDOWN_ON
@@ -1250,7 +1250,7 @@
 ///Closes the bubble and cleans up after itself. Optional 'user' arg for the mob turning us off.
 /obj/item/flashlight/lamp/space_bubble/proc/close_bubble(mob/user)
 	QDEL_NULL(space_bubble)
-	QDEL_NULL(space_gen)
+	QDEL_NULL(space_furnance_gen)
 	if(bubble_timer)
 		deltimer(bubble_timer)
 	slowdown = initial(slowdown)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -1250,7 +1250,7 @@
 ///Closes the bubble and cleans up after itself. Optional 'user' arg for the mob turning us off.
 /obj/item/flashlight/lamp/space_bubble/proc/close_bubble(mob/user)
 	QDEL_NULL(space_bubble)
-	QDEL_NULL(space_furnance_gen)
+	QDEL_NULL(space_bubble_gen)
 	if(bubble_timer)
 		deltimer(bubble_timer)
 	slowdown = initial(slowdown)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -1228,7 +1228,7 @@
 		return FALSE
 	. = ..()
 	if(light_on)
-		var/obj/machinery/power/port_gen/space_bubble_gen/space_furnance_gen/space_gen = new(turf_activation)
+		var/obj/machinery/power/port_gen/space_bubble_gen/space_furnance_gen = new()
 		if(istype(space_bubble))
 			QDEL_NULL(space_bubble)
 			QDEL_NULL(space_gen)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -1158,6 +1158,13 @@
 	/// The invisible, abstrat generator, which is generating unlimited(when core will die, then eneryg too) power, its low, but its something
 	var/obj/machinery/power/port_gen/space_bubble_gen/space_bubble_gen
 
+/obj/machinery/power/port_gen/space_bubble_gen
+	name = "space furnance invisible generator"
+	desc = "Structure, which generates power, when space furnance is active, also invisible, if you see this, something is wrong"
+	density = FALSE
+	active = TRUE
+	power_output = 0.2
+
 /obj/item/flashlight/lamp/space_bubble/Initialize(mapload)
 	AddElement(/datum/element/update_icon_updates_onmob)
 	. = ..()
@@ -1247,13 +1254,6 @@
 	drag_slowdown = initial(drag_slowdown)
 	if(user)
 		user.update_equipment_speed_mods()
-
-/obj/machinery/power/port_gen/space_bubble_gen
-	name = "space furnance invisible generator"
-	desc = "Structure, which generates power, when space furnance is active, also invisible, if you see this, something is wrong"
-	density = FALSE
-	active = TRUE
-	power_output = 0.2
 
 #undef SLOWDOWN_ON
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -1218,7 +1218,7 @@
 		return FALSE
 	. = ..()
 	if(light_on)
-		var/obj/machinery/power/port_gen/space_bubble/space_furnance_gen/space_gen = new(turf_activation)
+		var/obj/machinery/power/port_gen/space_bubble_gen/space_furnance_gen/space_gen = new(turf_activation)
 		if(istype(space_bubble))
 			QDEL_NULL(space_bubble)
 			QDEL_NULL(space_gen)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -1155,6 +1155,9 @@
 	///The proximity monitor & visual bubble that grants space protection to people nearby, while active.
 	var/datum/proximity_monitor/advanced/bubble/space_protection/space_bubble
 
+	/// The invisible, abstrat generator, which is generating unlimited(when core will die, then eneryg too) power, its low, but its something
+	var/obj/machinery/power/port_gen/space_bubble_gen/space_bubble_gen
+
 /obj/item/flashlight/lamp/space_bubble/Initialize(mapload)
 	AddElement(/datum/element/update_icon_updates_onmob)
 	. = ..()
@@ -1207,6 +1210,7 @@
 	if(!installed_pyro_core)
 		user.balloon_alert(user, "core missing!")
 		return FALSE
+	var/turf_activation = src.loc
 	var/datum/gas_mixture/environment = loc?.return_air()
 	var/affected_pressure = environment.return_pressure()
 	if(!light_on && (affected_pressure < ONE_ATMOSPHERE - 1))
@@ -1214,8 +1218,10 @@
 		return FALSE
 	. = ..()
 	if(light_on)
+		var/obj/machinery/power/port_gen/space_bubble/space_furnance_gen/space_gen = new(turf_activation)
 		if(istype(space_bubble))
 			QDEL_NULL(space_bubble)
+			QDEL_NULL(space_gen)
 		bubble_timer = addtimer(CALLBACK(src, PROC_REF(start_bubble_close), "dies down..."), bubble_duration, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_DELETE_ME)
 		space_bubble = new(src, 4, FALSE, src)
 		slowdown = SLOWDOWN_ON
@@ -1234,12 +1240,20 @@
 ///Closes the bubble and cleans up after itself. Optional 'user' arg for the mob turning us off.
 /obj/item/flashlight/lamp/space_bubble/proc/close_bubble(mob/user)
 	QDEL_NULL(space_bubble)
+	QDEL_NULL(space_bubble.space_bubble_gen)
 	if(bubble_timer)
 		deltimer(bubble_timer)
 	slowdown = initial(slowdown)
 	drag_slowdown = initial(drag_slowdown)
 	if(user)
 		user.update_equipment_speed_mods()
+
+/obj/machinery/power/port_gen/space_bubble_gen
+	name = "space furnance invisible generator"
+	desc = "Structure, which generates power, when space furnance is active, also invisible, if you see this, something is wrong"
+	density = FALSE
+	active = TRUE
+	power_output = 0.2
 
 #undef SLOWDOWN_ON
 


### PR DESCRIPTION

## About The Pull Request

Now space furnance also generates power, when activated, via creating abstract inifiniti fuel generator for only time, when its working, if furnance is off, generator will be deleted, but nobody can see it. So its only powering the area\room, at which you are, and its really low power, so its be capapble for barely power not really small room, but like powering enough to click on, maybe, light, and its not for sure, but its something, and its unlimited, but its only working with core inside, if its gone so no power
## Why It's Good For The Game

This space furnance will not only provide warmth to you, a group of barely alive, dirty, stinking, and blood-soaked assistants, doctors, and musicians in the freezing room of the captain who was decapitated by the cultists, but it will also give you the energy and the chance to escape by calling the shuttle from the console, which will probably be the only working and warming ray of light and hope on this cold, bloody, and sinking piece of steel.

<img width="670" height="377" alt="image" src="https://github.com/user-attachments/assets/3bad35f9-31e6-4a7a-96dd-7fabb6e1c473" />
## Changelog
:cl:
add: added functionality for space furnance, which allows to provide electro-power(very small, but infinity, while furnance is working), so you will not only not die from temp and pressure, but also will be capable power up the cap room and get out of the station
code: addes some aditions to code of space furnance, so now its also spawning generator

/:cl:
