### PR TITLE
[WIP] Adding Metro to Ice Box: lowest z-level, maint loot, some mobs and input into station budget

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1273,6 +1273,9 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/virology)
+"arF" = (
+/turf/open/indestructible/tram,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "arG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1584,6 +1587,11 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
+"avm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/south_tunnel)
 "avs" = (
 /obj/structure/railing{
 	dir = 8
@@ -1738,6 +1746,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"awP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "awR" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -4051,7 +4068,7 @@
 /obj/structure/chair/sofa/bench/tram/left,
 /obj/structure/thermoplastic/light,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/south_tunnel)
 "ben" = (
 /obj/machinery/bluespace_beacon,
@@ -9335,6 +9352,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/south_tunnel)
 "cyr" = (
@@ -10862,6 +10882,12 @@
 /obj/structure/platform/iron,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/range)
+"cTz" = (
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "cTD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -11143,6 +11169,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/south_tunnel)
 "cYC" = (
@@ -13258,7 +13287,7 @@
 "dzI" = (
 /obj/structure/thermoplastic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/south_tunnel)
 "dzJ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -14227,6 +14256,7 @@
 "dOm" = (
 /obj/structure/tram/alt/titanium,
 /obj/machinery/transport/tram_controller,
+/obj/structure/fluff/tram_rail/electric,
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/south_tunnel)
 "dOp" = (
@@ -20623,6 +20653,9 @@
 /obj/structure/chair/sofa/bench/tram/right{
 	dir = 1
 	},
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/south_tunnel)
 "fHV" = (
@@ -21175,6 +21208,9 @@
 /obj/structure/thermoplastic/light,
 /obj/structure/thermoplastic,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/south_tunnel)
 "fPv" = (
@@ -24824,7 +24860,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/south_tunnel)
 "gQD" = (
 /obj/structure/table,
@@ -24921,7 +24957,7 @@
 /area/station/maintenance/disposal/incinerator)
 "gRS" = (
 /obj/structure/thermoplastic,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/south_tunnel)
 "gSd" = (
 /obj/structure/fence/door{
@@ -26719,6 +26755,14 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
+"hrw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "hrN" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/laser/carbine/practice{
@@ -32623,6 +32667,12 @@
 	dir = 8
 	},
 /area/station/medical/chem_storage)
+"jaM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "jaO" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Turbine Access"
@@ -32960,6 +33010,9 @@
 /obj/structure/chair/sofa/bench/tram/left{
 	dir = 1
 	},
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/south_tunnel)
 "jfb" = (
@@ -33123,6 +33176,9 @@
 "jhY" = (
 /obj/structure/thermoplastic/light,
 /obj/structure/thermoplastic,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/south_tunnel)
 "jim" = (
@@ -33700,6 +33756,9 @@
 "jre" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/lesser)
+"jrt" = (
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/south_tunnel)
 "jrv" = (
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating/snowed/icemoon,
@@ -42602,7 +42661,7 @@
 /obj/structure/thermoplastic/light,
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/south_tunnel)
 "lMx" = (
 /obj/structure/rack,
@@ -43114,6 +43173,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
+"lSn" = (
+/obj/structure/fluff/tram_rail/electric,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "lSu" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
@@ -44041,6 +44105,13 @@
 /obj/structure/flora/grass/both/style_random,
 /turf/open/misc/asteroid/snow/standard_air,
 /area/station/hallway/secondary/exit/departure_lounge)
+"mim" = (
+/obj/structure/thermoplastic,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "miw" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -48043,7 +48114,7 @@
 /obj/structure/thermoplastic,
 /obj/structure/thermoplastic/light,
 /obj/structure/chair/sofa/bench/tram/solo,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/south_tunnel)
 "noC" = (
 /obj/structure/railing{
@@ -48752,6 +48823,10 @@
 "nyC" = (
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/service/chapel)
+"nyD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/south_tunnel)
 "nyH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59426,6 +59501,10 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/genturf/blue,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
+"qmy" = (
+/obj/structure/tram/alt/titanium,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/south_tunnel)
 "qmK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -67813,7 +67892,7 @@
 /obj/structure/thermoplastic,
 /obj/structure/thermoplastic/light,
 /obj/structure/chair/sofa/bench/tram/right,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/south_tunnel)
 "sAt" = (
 /obj/structure/table/wood,
@@ -68710,6 +68789,7 @@
 /obj/structure/tram/spoiler{
 	dir = 1
 	},
+/obj/structure/fluff/tram_rail/electric,
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/south_tunnel)
 "sNA" = (
@@ -68950,6 +69030,10 @@
 	dir = 8
 	},
 /area/station/service/kitchen/coldroom)
+"sRD" = (
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "sRI" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
@@ -70630,6 +70714,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/metro/center_station)
+"toA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "toG" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -73545,6 +73636,11 @@
 /obj/structure/sign/departments/holy/directional/east,
 /turf/open/openspace,
 /area/station/service/chapel)
+"ueN" = (
+/obj/structure/tram/alt/titanium,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "ueP" = (
 /obj/structure/table,
 /obj/structure/reagent_dispensers/servingdish,
@@ -74090,6 +74186,7 @@
 "umI" = (
 /obj/structure/thermoplastic/light,
 /obj/machinery/door/airlock/titanium,
+/obj/structure/fluff/tram_rail/electric,
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/south_tunnel)
 "umM" = (
@@ -74825,6 +74922,14 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
+"uxZ" = (
+/obj/structure/thermoplastic,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "uyi" = (
 /obj/item/chair/stool{
 	pixel_y = 0;
@@ -74991,6 +75096,15 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
+"uzX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "uAi" = (
 /obj/structure/table/reinforced,
 /obj/item/hfr_box/corner,
@@ -75685,6 +75799,14 @@
 /obj/effect/turf_decal/tile/red/half,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig/upper)
+"uKb" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/titanium,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "uKc" = (
 /turf/open/misc/dirt{
 	initial_gas_mix = "ICEMOON_ATMOS"
@@ -79310,6 +79432,11 @@
 /obj/machinery/brm,
 /turf/open/floor/iron,
 /area/mine/production)
+"vLE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/tram,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "vLM" = (
 /obj/structure/railing{
 	dir = 1
@@ -79487,9 +79614,11 @@
 /area/station/service/janitor)
 "vPp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
+/area/station/metro/train_tunnels/south_tunnel)
 "vPx" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/workout)
@@ -80108,6 +80237,10 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"vYk" = (
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "vYm" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -82468,6 +82601,11 @@
 	dir = 8
 	},
 /area/mine/laborcamp/security)
+"wJF" = (
+/obj/structure/tram,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "wJM" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -84346,6 +84484,11 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
+"xhf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "xhk" = (
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
@@ -84423,6 +84566,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
+"xin" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/tram,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "xit" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/structure/table/wood,
@@ -86736,6 +86883,12 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/service/theater)
+"xNx" = (
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "xNC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -86933,7 +87086,7 @@
 "xQV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/south_tunnel)
 "xQX" = (
 /obj/machinery/camera/directional/west{
@@ -87409,6 +87562,13 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"xXu" = (
+/obj/structure/tram,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "xXv" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -109013,10 +109173,10 @@ ghx
 ghx
 ghx
 ghx
-gkM
+lSn
 igP
 uwB
-pGD
+gpH
 ghx
 ghx
 ghx
@@ -109530,7 +109690,7 @@ ghx
 gkM
 igP
 uwB
-pGD
+gpH
 ghx
 ghx
 ghx
@@ -110815,7 +110975,7 @@ ghx
 gkM
 igP
 uwB
-pGD
+gpH
 thA
 xuo
 xuo
@@ -111583,10 +111743,10 @@ ghx
 ghx
 ghx
 ghx
-gkM
+lSn
 igP
 uwB
-pGD
+gpH
 thA
 thA
 thA
@@ -113129,7 +113289,7 @@ gkM
 igP
 uwB
 pGD
-pGD
+gpH
 pXV
 oSU
 oSU
@@ -113637,7 +113797,7 @@ thA
 ghx
 ghx
 pXV
-pGD
+gpH
 pGD
 gkM
 igP
@@ -114928,7 +115088,7 @@ gkM
 igP
 nkX
 gpH
-pGD
+gpH
 pXV
 oSU
 oSU
@@ -115180,7 +115340,7 @@ thA
 thA
 pXV
 pGD
-pGD
+gpH
 gkM
 ltJ
 duG
@@ -115693,7 +115853,7 @@ thA
 thA
 thA
 pXV
-pGD
+gpH
 pGD
 gkM
 ltJ
@@ -115956,7 +116116,7 @@ gkM
 igP
 aYR
 pGD
-pGD
+gpH
 pXV
 oSU
 oSU
@@ -116207,7 +116367,7 @@ thA
 thA
 thA
 pXV
-pGD
+gpH
 pGD
 gkM
 igP
@@ -116984,7 +117144,7 @@ gkM
 ltJ
 duG
 pGD
-pGD
+gpH
 pXV
 oSU
 oSU
@@ -117240,7 +117400,7 @@ pGD
 nzD
 lsu
 uwB
-pGD
+gpH
 pGD
 pXV
 oSU
@@ -117492,8 +117652,8 @@ thA
 thA
 thA
 pXV
-pGD
-pGD
+gpH
+gpH
 nzD
 ltJ
 uwB
@@ -117754,7 +117914,7 @@ gpH
 gkM
 ltJ
 uwB
-pGD
+gpH
 pGD
 pXV
 oSU
@@ -118012,7 +118172,7 @@ gkM
 ltJ
 uwB
 pGD
-pGD
+gpH
 pXV
 oSU
 oSU
@@ -119554,7 +119714,7 @@ nzD
 igP
 uwB
 pGD
-pGD
+gpH
 pXV
 oSU
 oSU
@@ -119805,7 +119965,7 @@ oSU
 oSU
 oSU
 pXV
-pGD
+gpH
 pGD
 gkM
 ltJ
@@ -121369,7 +121529,7 @@ aeV
 lLs
 flr
 nKc
-vXL
+ueN
 dzI
 jfa
 wuN
@@ -121883,9 +122043,9 @@ gPk
 bTI
 vWR
 iva
-vXL
+ueN
 gRS
-dzI
+uxZ
 vXL
 neA
 neA
@@ -122140,7 +122300,7 @@ gPk
 rtV
 flr
 iva
-wuN
+wJF
 sAf
 fPq
 wuN
@@ -122397,7 +122557,7 @@ xpI
 gYI
 sWR
 nKc
-vXL
+ueN
 bed
 jhY
 wuN
@@ -122654,9 +122814,9 @@ gzt
 gzt
 rCM
 dbl
-vXL
-vXL
-umI
+ueN
+qmy
+uKb
 vXL
 cGX
 oSU
@@ -122890,7 +123050,7 @@ oSU
 oSU
 pXV
 pGD
-pGD
+gpH
 gkM
 igP
 uwB
@@ -122913,7 +123073,7 @@ upJ
 glg
 dOm
 lMv
-gRS
+mim
 wuN
 cGX
 oSU
@@ -123168,9 +123328,9 @@ bIf
 bTI
 wMB
 nVV
-wuN
+wJF
 nov
-dzI
+uxZ
 vXL
 cGX
 oSU
@@ -123403,7 +123563,7 @@ oSU
 oSU
 oSU
 pXV
-pGD
+gpH
 pGD
 gkM
 igP
@@ -123425,9 +123585,9 @@ dIF
 bTI
 tow
 hLW
-vXL
+ueN
 dzI
-dzI
+uxZ
 wuN
 cGX
 oSU
@@ -123662,9 +123822,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-pGD
-gpH
+gkM
+igP
+duG
 pGD
 pvX
 bTI
@@ -123682,7 +123842,7 @@ pRu
 bTI
 nfx
 wGy
-vXL
+ueN
 dzI
 jfa
 wuN
@@ -123919,9 +124079,9 @@ oSU
 pXV
 xrd
 pGD
-pGD
-pGD
-vPp
+gkM
+igP
+nkX
 pGD
 pGD
 pXV
@@ -124176,9 +124336,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-pGD
-gpH
+gkM
+igP
+duG
 gpH
 ufA
 pXV
@@ -124197,8 +124357,8 @@ oSU
 cGX
 nHU
 sNw
-vXL
-wuN
+qmy
+xXu
 wDh
 cGX
 oSU
@@ -124433,11 +124593,11 @@ oSU
 euu
 aFD
 aFD
-aFD
-aFD
-aFD
+sRD
+arF
+cTz
 vOF
-vOF
+pxg
 euu
 oSU
 oSU
@@ -124453,9 +124613,9 @@ oSU
 oSU
 cGX
 nib
-nib
-nib
-nib
+vYk
+jrt
+xNx
 nib
 cGX
 oSU
@@ -124688,11 +124848,11 @@ oSU
 oSU
 oSU
 euu
+vOF
 aFD
-aFD
-aFD
-aFD
-aFD
+sRD
+arF
+cTz
 vOF
 aFD
 euu
@@ -124710,9 +124870,9 @@ oSU
 oSU
 cGX
 aeZ
-aeZ
-nib
-nib
+xhf
+jrt
+xNx
 nib
 cGX
 oSU
@@ -124947,9 +125107,9 @@ oSU
 euu
 aFD
 aFD
-aFD
-aFD
-aFD
+sRD
+xin
+cTz
 vOF
 cFH
 euu
@@ -124967,9 +125127,9 @@ oSU
 oSU
 cGX
 aeZ
-nib
-nib
-nib
+vYk
+jrt
+xNx
 nib
 cGX
 oSU
@@ -125203,10 +125363,10 @@ oSU
 oSU
 euu
 aFD
-aFD
-aFD
-aFD
-aFD
+vOF
+sRD
+arF
+cTz
 vOF
 aFD
 euu
@@ -125224,9 +125384,9 @@ oSU
 oSU
 cGX
 aeZ
-nib
-nib
-nib
+vYk
+jrt
+xNx
 nib
 cGX
 oSU
@@ -125461,11 +125621,11 @@ oSU
 euu
 aFD
 aFD
-aFD
-aFD
-aFD
+sRD
+arF
+cTz
 vOF
-aFD
+vOF
 euu
 oSU
 oSU
@@ -125481,9 +125641,9 @@ oSU
 oSU
 cGX
 aeZ
-aeZ
-nib
-nib
+xhf
+jrt
+xNx
 nib
 cGX
 oSU
@@ -125718,9 +125878,9 @@ oSU
 euu
 aFD
 aFD
-aFD
-aFD
-aFD
+sRD
+arF
+cTz
 pxg
 aFD
 euu
@@ -125738,9 +125898,9 @@ oSU
 oSU
 cGX
 nib
-kHD
-aeZ
-nib
+jaM
+nyD
+xNx
 nib
 cGX
 oSU
@@ -125975,9 +126135,9 @@ oSU
 euu
 ohG
 aFD
-aFD
-aFD
-vOF
+sRD
+arF
+toA
 vOF
 wkq
 euu
@@ -125995,9 +126155,9 @@ oSU
 oSU
 cGX
 nib
-aeZ
-aeZ
-nib
+xhf
+nyD
+xNx
 nib
 cGX
 oSU
@@ -126230,11 +126390,11 @@ oSU
 oSU
 oSU
 euu
-aFD
-aFD
-aFD
-aFD
 vOF
+aFD
+sRD
+arF
+toA
 aFD
 aFD
 euu
@@ -126252,9 +126412,9 @@ oSU
 oSU
 cGX
 nib
-nib
-kHD
-nib
+vYk
+avm
+xNx
 nib
 cGX
 oSU
@@ -126489,9 +126649,9 @@ oSU
 euu
 aFD
 aFD
-aFD
-aFD
-vOF
+sRD
+arF
+toA
 vOF
 aFD
 euu
@@ -126509,9 +126669,9 @@ oSU
 oSU
 cGX
 nib
-nib
-kHD
-nib
+vYk
+avm
+xNx
 nib
 cGX
 oSU
@@ -126745,10 +126905,10 @@ oSU
 oSU
 euu
 aFD
-aFD
-aFD
-aFD
-aFD
+vOF
+sRD
+arF
+cTz
 aFD
 aFD
 euu
@@ -126766,9 +126926,9 @@ oSU
 oSU
 cGX
 nib
-nib
-aeZ
-aeZ
+vYk
+nyD
+vPp
 nib
 cGX
 oSU
@@ -127003,9 +127163,9 @@ oSU
 euu
 aFD
 aFD
-aFD
-pxg
-gWs
+sRD
+vLE
+awP
 oWa
 aFD
 euu
@@ -127023,9 +127183,9 @@ oSU
 oSU
 cGX
 nib
-nib
-aeZ
-aeZ
+vYk
+nyD
+vPp
 nib
 cGX
 oSU
@@ -127280,9 +127440,9 @@ oSU
 oSU
 cGX
 nib
-nib
-nib
-aeZ
+vYk
+jrt
+vPp
 nib
 cGX
 oSU
@@ -127537,9 +127697,9 @@ oSU
 oSU
 cGX
 nib
-nib
-nib
-nib
+vYk
+jrt
+xNx
 nib
 cGX
 oSU
@@ -127794,9 +127954,9 @@ oSU
 oSU
 cGX
 nib
-nib
-nib
-aeZ
+vYk
+jrt
+vPp
 nib
 cGX
 oSU
@@ -128051,9 +128211,9 @@ oSU
 oSU
 cGX
 aeZ
-aeZ
-aeZ
-aeZ
+xhf
+nyD
+vPp
 nib
 cGX
 oSU
@@ -128308,9 +128468,9 @@ sMX
 sMX
 cGX
 aeZ
-aeZ
-aeZ
-aeZ
+xhf
+nyD
+vPp
 nib
 cGX
 oSU
@@ -128565,9 +128725,9 @@ sMX
 sMX
 nib
 aeZ
-aeZ
-aeZ
-kHD
+xhf
+nyD
+hrw
 nib
 cGX
 oSU
@@ -128822,9 +128982,9 @@ sMX
 cqM
 nib
 aeZ
-aeZ
-aeZ
-gQB
+xhf
+nyD
+uzX
 nib
 cGX
 oSU
@@ -129079,9 +129239,9 @@ sMX
 sMX
 lUe
 aeZ
-aeZ
-aeZ
-gQB
+xhf
+nyD
+uzX
 aeZ
 cGX
 oSU
@@ -129336,9 +129496,9 @@ sMX
 sMX
 cGX
 aeZ
-aeZ
-aeZ
-kHD
+xhf
+nyD
+hrw
 aeZ
 cGX
 oSU
@@ -129593,9 +129753,9 @@ oSU
 oSU
 cGX
 aeZ
-aeZ
-aeZ
-gQB
+xhf
+nyD
+uzX
 aeZ
 cGX
 oSU
@@ -129850,9 +130010,9 @@ oSU
 oSU
 cGX
 aeZ
-aeZ
-aeZ
-gQB
+xhf
+nyD
+uzX
 aeZ
 cGX
 oSU
@@ -130107,9 +130267,9 @@ oSU
 oSU
 cGX
 aeZ
-aeZ
-aeZ
-kHD
+xhf
+nyD
+hrw
 nib
 cGX
 oSU
@@ -130364,9 +130524,9 @@ oSU
 oSU
 cGX
 aeZ
-aeZ
-aeZ
-kHD
+xhf
+nyD
+hrw
 nib
 cGX
 oSU
@@ -130621,9 +130781,9 @@ oSU
 oSU
 cGX
 aeZ
-aeZ
-kHD
-gQB
+xhf
+avm
+uzX
 nib
 cGX
 oSU
@@ -130878,9 +131038,9 @@ oSU
 oSU
 cGX
 aeZ
-aeZ
-kHD
-kHD
+xhf
+avm
+hrw
 nib
 cGX
 oSU
@@ -131135,9 +131295,9 @@ oSU
 oSU
 cGX
 nib
-nib
-nib
-nib
+vYk
+jrt
+xNx
 nib
 cGX
 oSU
@@ -131392,9 +131552,9 @@ oSU
 oSU
 cGX
 nib
-nib
-aeZ
-gQB
+vYk
+nyD
+uzX
 aeZ
 cGX
 oSU
@@ -131649,9 +131809,9 @@ oSU
 oSU
 cGX
 nib
-nib
-aeZ
-kHD
+vYk
+nyD
+hrw
 nib
 cGX
 oSU
@@ -131906,9 +132066,9 @@ oSU
 oSU
 cGX
 nib
-nib
-aeZ
-gQB
+vYk
+nyD
+uzX
 aeZ
 cGX
 oSU
@@ -132163,9 +132323,9 @@ oSU
 oSU
 cGX
 uBk
-nib
-aeZ
-kHD
+vYk
+nyD
+hrw
 nib
 cGX
 oSU
@@ -132420,8 +132580,8 @@ oSU
 oSU
 cGX
 nib
-nib
-aeZ
+vYk
+nyD
 cYv
 nib
 cGX
@@ -132677,9 +132837,9 @@ oSU
 oSU
 cGX
 nib
-nib
-kHD
-kHD
+vYk
+avm
+hrw
 aeZ
 cGX
 oSU
@@ -132934,9 +133094,9 @@ oSU
 oSU
 cGX
 nib
-nib
-kHD
-kHD
+vYk
+avm
+hrw
 nib
 cGX
 oSU
@@ -133191,9 +133351,9 @@ oSU
 oSU
 cGX
 nib
-nib
-kHD
-kHD
+vYk
+avm
+hrw
 aeZ
 cGX
 oSU
@@ -133448,9 +133608,9 @@ oSU
 oSU
 cGX
 nib
-nib
-nib
-nib
+vYk
+jrt
+xNx
 aeZ
 cGX
 oSU
@@ -133705,9 +133865,9 @@ oSU
 oSU
 cGX
 nib
-aeZ
-aeZ
-nib
+xhf
+nyD
+xNx
 aeZ
 cGX
 oSU
@@ -133962,9 +134122,9 @@ oSU
 oSU
 cGX
 nib
-aeZ
-nib
-nib
+xhf
+jrt
+xNx
 aeZ
 cGX
 oSU
@@ -134219,9 +134379,9 @@ oSU
 oSU
 cGX
 aeZ
-aeZ
-aeZ
-aeZ
+xhf
+nyD
+vPp
 aeZ
 cGX
 oSU
@@ -134476,9 +134636,9 @@ oSU
 oSU
 cGX
 aeZ
-aeZ
+xhf
 xQV
-aeZ
+vPp
 aeZ
 cGX
 oSU
@@ -134733,9 +134893,9 @@ oSU
 oSU
 cGX
 aeZ
-aeZ
-aeZ
-aeZ
+xhf
+nyD
+vPp
 kHD
 cGX
 oSU
@@ -134990,9 +135150,9 @@ oSU
 oSU
 cGX
 aeZ
-aeZ
-aeZ
-aeZ
+xhf
+nyD
+vPp
 aeZ
 cGX
 oSU
@@ -135247,9 +135407,9 @@ oSU
 oSU
 cGX
 nib
-aeZ
-kHD
-aeZ
+xhf
+avm
+vPp
 aeZ
 cGX
 iDt
@@ -135504,9 +135664,9 @@ oSU
 oSU
 cGX
 nib
-aeZ
+xhf
 gQB
-aeZ
+vPp
 aeZ
 cGX
 iDt
@@ -135761,9 +135921,9 @@ oSU
 oSU
 cGX
 nib
-nib
-aeZ
-aeZ
+vYk
+nyD
+vPp
 nib
 fhx
 fhx
@@ -136018,9 +136178,9 @@ oSU
 cGX
 cGX
 nib
-nib
-nib
-nib
+vYk
+jrt
+xNx
 aeZ
 fhx
 eUd
@@ -136275,9 +136435,9 @@ oSU
 fhx
 umB
 jfP
-nib
-nib
-nib
+vYk
+jrt
+xNx
 aeZ
 bus
 tar
@@ -136532,9 +136692,9 @@ oSU
 fhx
 mHb
 jmn
-nib
-aeZ
-nib
+vYk
+nyD
+xNx
 nib
 vkk
 eHt
@@ -136789,9 +136949,9 @@ oSU
 fhx
 csZ
 sWm
-nib
-nib
-nib
+vYk
+jrt
+xNx
 aeZ
 sPb
 eHt
@@ -137046,9 +137206,9 @@ fhx
 fhx
 uCZ
 inW
-nib
-aeZ
-nib
+vYk
+nyD
+xNx
 nib
 iod
 kdm
@@ -137303,9 +137463,9 @@ pAj
 tgU
 gLx
 deB
-nib
-aeZ
-aeZ
+vYk
+nyD
+vPp
 aeZ
 sPb
 eHt
@@ -137560,9 +137720,9 @@ cLf
 fhx
 cvr
 jZR
-nib
-aeZ
-aeZ
+vYk
+nyD
+vPp
 nib
 vkk
 uDR
@@ -137817,9 +137977,9 @@ cLf
 gVx
 xPX
 hHm
-nib
-aeZ
-aeZ
+vYk
+nyD
+vPp
 nib
 sPb
 usr
@@ -138074,9 +138234,9 @@ cLf
 gVx
 kdm
 hHm
-nib
-nib
-aeZ
+vYk
+jrt
+vPp
 nHU
 fhx
 tgU
@@ -138331,9 +138491,9 @@ kdm
 qnn
 eHt
 hHm
-nib
-nib
-aeZ
+vYk
+jrt
+vPp
 nib
 fhx
 rsO
@@ -138588,9 +138748,9 @@ eHt
 gVx
 gDI
 jZR
-nib
-aeZ
-nib
+vYk
+nyD
+xNx
 nib
 fhx
 usr
@@ -138845,9 +139005,9 @@ eHt
 fhx
 rsj
 hjK
-nib
-aeZ
-nib
+vYk
+nyD
+xNx
 nib
 fhx
 kdm
@@ -139102,9 +139262,9 @@ eHt
 fhx
 cvr
 cmA
-nib
-nib
-nib
+vYk
+jrt
+xNx
 nib
 fhx
 tgU
@@ -139359,9 +139519,9 @@ eHt
 uDR
 cvr
 cmA
-nib
-aeZ
-nib
+vYk
+nyD
+xNx
 nib
 fhx
 kdm
@@ -139616,9 +139776,9 @@ cLf
 cLf
 scr
 cDr
-aeZ
-nib
-nib
+xhf
+jrt
+xNx
 nib
 fhx
 usr

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -319,6 +319,13 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"afI" = (
+/obj/structure/transport/linear/public,
+/obj/structure/barricade/wooden{
+	name = "wooden barricade (CLOSED)"
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "afR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
@@ -2033,6 +2040,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"aBY" = (
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "aCb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3060,16 +3071,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
-"aRv" = (
-/obj/machinery/door/window/elevator/left/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "aRx" = (
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/plating,
@@ -3437,13 +3438,8 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aVL" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/button/elevator/directional/east,
-/obj/machinery/lift_indicator/directional/east,
-/obj/machinery/door/window/elevator/right/directional/north,
-/obj/effect/turf_decal/caution/stand_clear/white,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics/garden)
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers/deep)
 "aVM" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -3582,6 +3578,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
+"aYD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/report_crimes/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "aYJ" = (
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -3662,10 +3663,13 @@
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "aZL" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/chapel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "aZU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4524,11 +4528,6 @@
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/security/prison/mess)
-"blK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/report_crimes/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "blM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -7215,9 +7214,15 @@
 /turf/closed/wall/r_wall,
 /area/station/command/eva)
 "bWp" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/iron/dark,
-/area/station/service/chapel)
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "bWv" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -7678,10 +7683,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
 "ccx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/enlist/directional/west,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/elevator/directional/east,
+/obj/machinery/lift_indicator/directional/east,
+/obj/machinery/door/window/elevator/right/directional/north,
+/obj/effect/turf_decal/caution/stand_clear/white,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/garden)
 "ccz" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -7995,13 +8003,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
-"cgH" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "cgR" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -8174,6 +8175,12 @@
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"cjE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "cjI" = (
 /obj/structure/tram/spoiler{
 	dir = 8
@@ -8308,6 +8315,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"cmt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "cmu" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/sign/warning/electric_shock/directional/north,
@@ -8345,7 +8358,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "cmJ" = (
 /obj/item/radio/intercom/directional/north,
@@ -9002,7 +9015,8 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
 "cvr" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/decal/cleanable/fuel_pool,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "cvB" = (
@@ -10410,13 +10424,14 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "cOS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
-"cPc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/obj/machinery/button/elevator/directional/south{
+	id = "tram_perma_lift"
+	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "tram_perma_lift"
+	},
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "cPd" = (
 /obj/structure/cable,
@@ -10552,6 +10567,13 @@
 	dir = 8
 	},
 /area/station/command/eva)
+"cQG" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "cQL" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -10760,10 +10782,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "cUB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence{
-	dir = 8
-	},
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "cUG" = (
@@ -10832,11 +10852,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
-"cWB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "cWC" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -11635,13 +11650,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"dgo" = (
-/obj/structure/fence{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "dgp" = (
 /obj/machinery/modular_computer/preset/engineering,
 /obj/structure/cable,
@@ -11836,6 +11844,10 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/textured,
 /area/mine/mechbay)
+"diK" = (
+/obj/machinery/door/window/elevator/right/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "diL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -12000,12 +12012,6 @@
 "dky" = (
 /obj/structure/sign/nanotrasen/directional/east,
 /turf/open/openspace/icemoon/keep_below,
-/area/icemoon/underground/explored)
-"dkB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/crayon,
-/obj/effect/spawner/random/trash/deluxe_garbage,
-/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "dkM" = (
 /obj/structure/table/glass,
@@ -12587,6 +12593,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"dsx" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "dsR" = (
 /obj/machinery/conveyor/inverted{
 	dir = 10;
@@ -12891,6 +12901,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"dxl" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "dxm" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/toggle/labcoat,
@@ -13112,6 +13130,12 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
+"dAg" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "dAh" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/preopen{
@@ -13249,9 +13273,6 @@
 "dBZ" = (
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"dCr" = (
-/turf/open/openspace,
-/area/station/hallway/primary/central)
 "dCy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -13968,6 +13989,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"dNg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "dNw" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -14426,6 +14453,11 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/checker,
 /area/station/science/lab)
+"dVC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "dVF" = (
 /obj/structure/sign/warning/secure_area/directional/north,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -14848,6 +14880,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/medical/morgue)
+"ebS" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/iron/dark,
+/area/icemoon/underground/explored)
 "ebW" = (
 /obj/structure/fence/cut/medium{
 	dir = 8
@@ -15003,6 +15039,10 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/interrogation)
+"efa" = (
+/obj/item/pickaxe,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "eff" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/white/line{
@@ -15156,10 +15196,8 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
 "eha" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
 "ehc" = (
 /turf/open/floor/plating,
@@ -15211,11 +15249,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
-"ehK" = (
-/obj/structure/thermoplastic,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "ehL" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -15367,6 +15400,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
+"eju" = (
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "ejK" = (
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 4
@@ -15865,20 +15904,10 @@
 /turf/open/floor/iron,
 /area/station/construction)
 "erI" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_y = 3
-	},
-/obj/item/tank/internals/emergency_oxygen,
-/obj/structure/sign/warning/cold_temp/directional/west,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/white,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "erK" = (
 /obj/effect/spawner/structure/window,
@@ -17168,6 +17197,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"eLe" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "eLl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -17929,11 +17966,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"eWi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "eWj" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/engine/plasma,
@@ -17964,6 +17996,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"eWU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/spawner/random/maintenance/dumpster,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "eWV" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -18096,11 +18134,6 @@
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/iron/textured,
 /area/station/hallway/secondary/entry)
-"eYP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "eYR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -18729,6 +18762,11 @@
 "fhL" = (
 /obj/structure/sign/warning/directional/north,
 /turf/open/openspace/icemoon/keep_below,
+/area/icemoon/underground/explored)
+"fhR" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "fhW" = (
 /obj/structure/disposalpipe/segment{
@@ -19395,11 +19433,6 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern/on,
 /turf/open/misc/hay/icemoon,
-/area/icemoon/underground/explored)
-"fsC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "fsF" = (
 /obj/effect/spawner/structure/window,
@@ -20828,6 +20861,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
+"fOt" = (
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "fOH" = (
 /obj/structure/fence/post{
 	dir = 1
@@ -21726,6 +21762,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
+"gce" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "gcu" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/cable,
@@ -21977,11 +22018,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"ggx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing/corner,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "ggz" = (
 /obj/effect/turf_decal/tile/green/opposingcorners{
 	dir = 1
@@ -22025,9 +22061,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ghe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/spawner/random/maintenance/dumpster,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "ghl" = (
@@ -22448,15 +22485,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"gmr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "gmJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Infiltrate/Filter"
@@ -23876,16 +23904,9 @@
 /area/station/science/genetics)
 "gGE" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/hooded/wintercoat{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
 /obj/item/clothing/shoes/winterboots,
 /obj/machinery/firealarm/directional/south,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/white,
+/turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gGF" = (
 /obj/effect/spawner/random/trash/mess,
@@ -24857,11 +24878,9 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "gVx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "gVB" = (
 /obj/structure/chair/stool/directional/west,
 /obj/structure/disposalpipe/segment{
@@ -25737,14 +25756,10 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "hjh" = (
-/obj/machinery/computer/records/security{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/closed/wall/r_wall,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hjl" = (
 /obj/effect/turf_decal/siding/wood{
@@ -26706,14 +26721,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "hwe" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plastic,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "hwm" = (
@@ -26864,14 +26873,6 @@
 /obj/structure/sign/xenobio_guide/directional/north,
 /turf/open/openspace,
 /area/station/science/xenobiology)
-"hzi" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "hzo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27115,9 +27116,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "hBG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron/smooth,
+/obj/effect/mapping_helpers/no_atoms_ontop,
+/turf/closed/wall,
 /area/icemoon/underground/explored)
 "hBZ" = (
 /obj/structure/table/wood,
@@ -28406,13 +28406,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/mine/eva)
-"hVQ" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/structure/sign/poster/contraband/kudzu/directional/north,
-/obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "hVR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -29566,11 +29559,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "ilw" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "ily" = (
 /turf/open/openspace,
 /area/station/science/xenobiology)
@@ -30310,10 +30301,8 @@
 /area/station/command/teleporter)
 "ixv" = (
 /obj/machinery/status_display/evac/directional/south,
-/obj/structure/chair/office{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ixG" = (
@@ -30461,6 +30450,11 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
+"izN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/enlist/directional/west,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "izT" = (
 /obj/structure/closet/crate{
 	name = "Firing Range Supplies Set"
@@ -30699,6 +30693,14 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
+"iED" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "iEN" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -31004,6 +31006,12 @@
 	},
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
+"iJG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/left/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "iJK" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -32575,6 +32583,10 @@
 "jfc" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/hop)
+"jfp" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "jfF" = (
 /obj/structure/rack,
 /obj/item/shovel,
@@ -33294,6 +33306,13 @@
 /obj/structure/railing/corner/end/flip,
 /turf/open/floor/iron,
 /area/mine/production)
+"jrV" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "jrX" = (
 /obj/item/cigbutt,
 /obj/structure/sign/warning/cold_temp/directional/north,
@@ -33450,18 +33469,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "jtG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/item/stack/sheet/iron/twenty,
 /obj/structure/table,
-/obj/item/stack/sheet/glass{
-	amount = 20;
-	pixel_x = -3;
-	pixel_y = 6
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_y = 3
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "jtH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35152,13 +35164,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"jQF" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "jQS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -36853,16 +36858,6 @@
 	},
 /turf/closed/wall,
 /area/station/hallway/primary/central)
-"krx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/glass,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "krJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -38278,8 +38273,8 @@
 /area/station/maintenance/port/greater)
 "kJS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/west,
-/obj/machinery/lift_indicator/directional/west,
+/obj/effect/decal/cleanable/crayon,
+/obj/effect/spawner/random/trash/deluxe_garbage,
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "kJU" = (
@@ -38838,22 +38833,6 @@
 "kRP" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/central)
-"kRT" = (
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/green/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/duct,
-/obj/structure/table/glass,
-/obj/item/watertank{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/item/plant_analyzer,
-/obj/item/book/manual/hydroponics_pod_people,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "kRU" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -39376,6 +39355,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
+"kYD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/spawner/random/junk_shell,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "kYF" = (
 /mob/living/basic/goose/vomit,
 /turf/open/floor/wood,
@@ -40018,7 +40003,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "liM" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -40657,12 +40641,6 @@
 /obj/structure/curtain,
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/captain)
-"lrL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/status_display/ai/directional/north,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "lrM" = (
 /obj/effect/turf_decal/siding/wideplating_new/light{
 	dir = 4
@@ -40726,6 +40704,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/morgue)
+"lsu" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "lsA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -41546,10 +41528,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "lDH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "lDM" = (
 /obj/effect/spawner/structure/window,
@@ -42071,9 +42052,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/armory/upper)
 "lMG" = (
-/obj/structure/thermoplastic,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "lMK" = (
 /obj/structure/table,
@@ -42709,6 +42691,12 @@
 	dir = 4
 	},
 /area/station/engineering/storage_shared)
+"lVn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "lVr" = (
 /obj/structure/fence/cut/medium{
 	dir = 1
@@ -43470,6 +43458,11 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/office)
+"mhD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "mhG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -44197,6 +44190,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"msH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "msM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/corner/end/flip{
@@ -44883,13 +44883,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
 "mCP" = (
-/obj/machinery/light/small/red/directional/south,
-/obj/structure/chair{
-	dir = 1
+/obj/effect/turf_decal/siding/green{
+	dir = 4
 	},
-/obj/item/radio/intercom/chapel/directional/east,
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "mCT" = (
 /turf/open/water/no_planet_atmos/deep,
 /area/station/service/hydroponics/garden)
@@ -45323,6 +45322,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"mJp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "mJq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -45339,14 +45343,6 @@
 "mJE" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
-"mJF" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "mJM" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -45435,10 +45431,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mLd" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/garbage,
-/obj/effect/spawner/random/junk_shell,
-/turf/open/floor/iron,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "mLf" = (
 /turf/open/openspace/icemoon/keep_below,
@@ -45506,6 +45506,11 @@
 /obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"mMs" = (
+/obj/structure/thermoplastic,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "mMy" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Security - Permabrig Upper Hallway South";
@@ -46496,6 +46501,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Departure Lounge Holding Area"
 	},
+/obj/machinery/computer/records/security,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "nbM" = (
@@ -47377,6 +47383,11 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
+"nnZ" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "nof" = (
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/stone,
@@ -47448,6 +47459,17 @@
 	dir = 1
 	},
 /area/mine/laborcamp/security)
+"noF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "noJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47615,6 +47637,16 @@
 /obj/machinery/vitals_reader/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"nqf" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "nqh" = (
 /obj/effect/decal/cleanable/blood/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
@@ -47627,12 +47659,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"nqv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "nqx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -47659,6 +47685,13 @@
 /obj/structure/fluff/minepost,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
+"nrt" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "nrz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
@@ -48691,12 +48724,6 @@
 	dir = 8
 	},
 /area/station/security/brig)
-"nEL" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "nEV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -48874,6 +48901,10 @@
 /obj/effect/spawner/random/armory/barrier_grenades,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/armory/upper)
+"nGU" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "nGY" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -49389,11 +49420,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"nNN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/west,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "nNZ" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -49842,6 +49868,11 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
+"nTg" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "nTp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50274,10 +50305,6 @@
 /obj/machinery/light/small/red/directional/west,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"oam" = (
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "oaG" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 9
@@ -50766,6 +50793,7 @@
 "ohF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/left/directional/west,
 /turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "ohI" = (
@@ -51894,6 +51922,15 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
+"owq" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "owr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -53287,14 +53324,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/aft/greater)
-"oMG" = (
-/obj/structure/toiletbong,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/left,
-/obj/structure/thermoplastic/light,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "oMP" = (
 /obj/effect/spawner/random/entertainment/slot_machine,
 /turf/open/floor/wood,
@@ -53411,10 +53440,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
 "oOD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oOP" = (
 /obj/effect/turf_decal/siding/thinplating_new/corner,
@@ -53992,10 +54020,6 @@
 /obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology)
-"oXt" = (
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "oXx" = (
 /obj/machinery/mass_driver/trash{
 	dir = 1
@@ -54772,17 +54796,6 @@
 /obj/item/pillow/random,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
-"piK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "piL" = (
 /obj/machinery/door/window/brigdoor/security/cell/left/directional/west{
 	id = "Cell 2";
@@ -54989,6 +55002,11 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"plK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "plN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -55153,6 +55171,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/execution/transfer)
+"poh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/window/elevator/left/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "pos" = (
 /obj/structure/table,
 /obj/effect/spawner/round_default_module,
@@ -55348,6 +55371,13 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"prD" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/sign/poster/contraband/kudzu/directional/north,
+/obj/structure/sink/kitchen/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "prE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -55476,8 +55506,21 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/aft/greater)
 "ptt" = (
-/turf/open/openspace,
-/area/icemoon/underground/explored)
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/structure/table/glass,
+/obj/item/watertank{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/plant_analyzer,
+/obj/item/book/manual/hydroponics_pod_people,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "ptQ" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
 /obj/effect/turf_decal/stripes/line,
@@ -56192,11 +56235,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"pDz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "pDA" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/stripes/line{
@@ -57311,6 +57349,16 @@
 "pUa" = (
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"pUf" = (
+/obj/machinery/door/window/elevator/left/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "pUi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57418,15 +57466,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
-"pVP" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "pVQ" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -58291,6 +58330,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
+"qfQ" = (
+/obj/structure/fence/door{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "qfS" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -58349,6 +58395,10 @@
 /obj/effect/spawner/random/trash/mopbucket,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"qhp" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "qhy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58418,18 +58468,9 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "qiL" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
 /obj/item/shovel,
 /obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/radio/off,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Departure Lounge Emergency EVA"
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qiN" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -58535,9 +58576,8 @@
 /turf/open/misc/asteroid/snow/standard_air,
 /area/station/science/cytology)
 "qkn" = (
-/obj/effect/spawner/random/trash/bin,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "qku" = (
 /obj/structure/chair/comfy/beige{
@@ -58606,6 +58646,12 @@
 /obj/item/wirecutters,
 /turf/open/floor/plating,
 /area/station/construction)
+"qlu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "qlw" = (
 /obj/machinery/disposal/bin,
 /obj/item/radio/intercom/prison/directional/north,
@@ -58697,6 +58743,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"qmQ" = (
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "qmU" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -59332,6 +59382,17 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"qwI" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "qwN" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Research Division North";
@@ -59396,6 +59457,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"qxr" = (
+/obj/structure/transport/linear/public,
+/turf/open/space/basic,
+/area/icemoon/underground/explored)
 "qxu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59596,6 +59661,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
+"qBD" = (
+/obj/effect/spawner/random/trash/bin,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "qBU" = (
 /obj/structure/sign/warning/directional/east,
 /obj/machinery/light/small/directional/east,
@@ -59641,11 +59711,9 @@
 /turf/open/floor/plating,
 /area/station/security/prison/mess)
 "qCx" = (
-/obj/structure/fence/door{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
+/obj/structure/thermoplastic,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "qCA" = (
 /obj/structure/table/wood,
@@ -60050,6 +60118,14 @@
 	dir = 1
 	},
 /area/station/medical/virology)
+"qHM" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "qHO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench/right{
@@ -60180,8 +60256,8 @@
 /turf/open/floor/wood/large,
 /area/mine/eva/lower)
 "qJB" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
+/obj/machinery/door/window/elevator/right/directional/north,
+/obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "qJT" = (
@@ -61157,6 +61233,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"qWE" = (
+/obj/structure/transport/linear/public,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "qWI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
@@ -61955,11 +62036,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"rhE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "rhF" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Security - Permabrig Observation North";
@@ -62821,9 +62897,8 @@
 	},
 /area/station/security/prison/safe)
 "rsO" = (
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "rsR" = (
 /obj/structure/table/optable,
@@ -63917,6 +63992,12 @@
 /obj/structure/sign/poster/official/work_for_a_future/directional/west,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
+"rIK" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "rIU" = (
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
@@ -64715,10 +64796,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rVr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/work_for_a_future/directional/north,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "rVB" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
@@ -64820,9 +64900,10 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rWJ" = (
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/genturf/blue,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/door,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "rWO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -65210,10 +65291,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "scr" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers)
 "sct" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -65335,8 +65414,7 @@
 /turf/open/floor/iron/dark,
 /area/station/command/eva)
 "seb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/lava/plasma/ice_moon,
+/turf/open/openspace,
 /area/icemoon/underground/explored)
 "sen" = (
 /obj/structure/cable,
@@ -65595,11 +65673,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
-"shQ" = (
-/obj/structure/thermoplastic/light,
-/obj/machinery/door/airlock/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "shR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -65732,12 +65805,10 @@
 /turf/closed/wall,
 /area/station/maintenance/fore)
 "skm" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "skn" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -66596,6 +66667,10 @@
 	dir = 1
 	},
 /area/station/commons/lounge)
+"suK" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "suL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67564,6 +67639,14 @@
 "sIt" = (
 /turf/closed/wall,
 /area/station/maintenance/central/lesser)
+"sIy" = (
+/obj/structure/toiletbong,
+/obj/structure/thermoplastic,
+/obj/structure/chair/sofa/bench/tram/left,
+/obj/structure/thermoplastic/light,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "sIA" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -67643,11 +67726,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
-"sJX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "sKf" = (
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
@@ -68519,17 +68597,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix)
-"sYa" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "sYe" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/suit/red,
@@ -68697,6 +68764,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"tbc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "tbh" = (
 /turf/open/floor/iron/half{
 	dir = 1
@@ -68998,6 +69070,10 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"tfL" = (
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/genturf/blue,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "tfM" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -69112,12 +69188,11 @@
 /turf/open/genturf/blue,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "thB" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
+/obj/structure/fence{
+	dir = 2
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "thC" = (
 /obj/structure/closet/crate,
@@ -69501,12 +69576,6 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/security/brig)
-"tly" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "tlA" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -69726,6 +69795,12 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
+"toD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "toG" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -71572,11 +71647,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
-"tOO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/wood,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "tOX" = (
 /obj/machinery/light/small/broken/directional/south,
 /obj/item/trash/energybar,
@@ -71670,6 +71740,10 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage/tech)
+"tQk" = (
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "tQx" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 10
@@ -72698,14 +72772,7 @@
 /turf/open/floor/iron/textured,
 /area/mine/laborcamp/security)
 "ugO" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/door/airlock/command/glass{
-	name = "Emergency EVA Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/eva,
-/obj/effect/mapping_helpers/airlock/red_alert_access,
-/turf/open/floor/iron/textured,
+/turf/open/openspace,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ugP" = (
 /obj/effect/turf_decal/siding/red{
@@ -72971,16 +73038,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/command/eva)
-"ukK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "ukN" = (
 /obj/structure/table,
 /obj/machinery/door/poddoor/shutters{
@@ -73596,6 +73653,12 @@
 "utC" = (
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"utK" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "utR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -74865,11 +74928,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
-"uNK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence/door,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "uNN" = (
 /obj/effect/spawner/random/trash/bin,
 /obj/effect/spawner/random/maintenance,
@@ -75208,6 +75266,14 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
+"uSC" = (
+/obj/machinery/light/small/red/directional/south,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/item/radio/intercom/chapel/directional/east,
+/turf/open/floor/wood/large,
+/area/icemoon/underground/explored)
 "uTk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -75911,10 +75977,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/work)
-"vea" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "veh" = (
 /obj/structure/chair{
 	dir = 4
@@ -76273,9 +76335,8 @@
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "vkk" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/turf/closed/mineral/random/snow,
+/area/station/service/chapel)
 "vkz" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/stripes/line{
@@ -76505,6 +76566,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "vnv" = (
@@ -76552,6 +76614,17 @@
 	dir = 8
 	},
 /area/station/science/explab)
+"vnS" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "vnU" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -77606,6 +77679,16 @@
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"vCp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "vCy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78319,11 +78402,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"vNt" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "vND" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -78994,13 +79072,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
-"vXQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "vXU" = (
 /obj/item/toy/snowball,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -79345,6 +79416,11 @@
 	},
 /turf/open/floor/plating,
 /area/mine/eva)
+"wcR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "wdg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -81292,9 +81368,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"wIo" = (
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers)
 "wIz" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/table/wood,
@@ -82048,10 +82121,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
-"wSM" = (
-/obj/effect/mapping_helpers/no_atoms_ontop,
-/turf/closed/wall,
-/area/icemoon/underground/explored)
 "wSU" = (
 /obj/structure/chair{
 	dir = 1
@@ -82400,6 +82469,15 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/openspace,
 /area/station/service/bar/atrium)
+"wXd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/west,
+/obj/machinery/lift_indicator/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "wXh" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
 	dir = 8
@@ -83340,8 +83418,9 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "xiL" = (
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/corner,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "xiO" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -84668,12 +84747,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"xBA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/left/directional/west,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "xBL" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Solar Maintenance - North East Access"
@@ -85213,11 +85286,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/iron/textured,
 /area/station/command/eva)
-"xIl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/work_for_a_future/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "xIF" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
@@ -85503,6 +85571,11 @@
 /obj/item/gun/syringe,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/storage)
+"xLY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "xMf" = (
 /obj/structure/railing{
 	dir = 1
@@ -86283,16 +86356,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"xXM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/south{
-	id = "tram_perma_lift"
-	},
-/obj/machinery/lift_indicator/directional/south{
-	linked_elevator_id = "tram_perma_lift"
-	},
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "xXR" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/security/glass{
@@ -86535,6 +86598,11 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
+"ybp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/west,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ybq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -86727,8 +86795,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "ydH" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/smooth,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "ydI" = (
 /turf/closed/wall/r_wall,
@@ -101944,9 +102017,9 @@ oSU
 oSU
 oSU
 gFX
-ghe
-ccx
-dkB
+eWU
+izN
+kJS
 gFX
 gFX
 gFX
@@ -102201,10 +102274,10 @@ oSU
 oSU
 oSU
 gFX
-nqv
-tly
+cmt
+lVn
 eHt
-aRv
+pUf
 nTH
 nTH
 gFX
@@ -102459,9 +102532,9 @@ oSU
 oSU
 gFX
 pEs
-rhE
+hwe
 kdm
-piK
+noF
 nTH
 nTH
 gFX
@@ -102715,9 +102788,9 @@ oSU
 oSU
 oSU
 gFX
-lrL
-scr
-xXM
+qlu
+nTg
+cOS
 gFX
 gFX
 gFX
@@ -102973,10 +103046,10 @@ oSU
 gFX
 gFX
 wMB
-qCx
-dgo
+qfQ
+thB
 wMB
-mLd
+kYD
 gFX
 ghx
 ghx
@@ -103228,13 +103301,13 @@ thA
 thA
 thA
 gFX
-qkn
+qBD
 eHt
 bJv
 aCI
 cLf
-krx
-cOS
+mLd
+qkn
 ghx
 ghx
 thA
@@ -103486,10 +103559,10 @@ thA
 thA
 gFX
 kdm
-ggx
-eha
-vXQ
-eha
+xiL
+rIK
+msH
+rIK
 gFX
 gFX
 ghx
@@ -103742,13 +103815,13 @@ thA
 thA
 thA
 gFX
-blK
-eWi
+aYD
+dVC
 cjI
 aMC
 wuN
 nLK
-cOS
+qkn
 ghx
 ghx
 thA
@@ -104005,7 +104078,7 @@ aMC
 uWq
 bKQ
 wuN
-cOS
+qkn
 ghx
 ghx
 thA
@@ -104257,12 +104330,12 @@ thA
 thA
 gFX
 cLf
-hwe
+vnS
 eiQ
 uWq
 fHU
 wuN
-cOS
+qkn
 ghx
 ghx
 thA
@@ -104512,11 +104585,11 @@ thA
 thA
 ghx
 ghx
-cOS
+qkn
 cLf
-thB
+eLe
 aMC
-ehK
+mMs
 uWq
 aMC
 gFX
@@ -104769,14 +104842,14 @@ ghx
 ghx
 ghx
 ghx
-cOS
-fsC
-thB
+qkn
+xLY
+eLe
 wuN
 rOU
 qFF
-shQ
-cOS
+nnZ
+qkn
 ghx
 ghx
 ijY
@@ -105026,14 +105099,14 @@ ghx
 ghx
 ghx
 ghx
-cOS
+qkn
 cLf
-pVP
+owq
 aMC
-oMG
+sIy
 qFF
 cqV
-cOS
+qkn
 ghx
 ghx
 ghx
@@ -105283,14 +105356,14 @@ ghx
 ghx
 ghx
 ghx
-cOS
+qkn
 eHt
 gFX
 aMC
 aMC
 oge
 aMC
-cOS
+qkn
 ghx
 ghx
 ghx
@@ -105542,7 +105615,7 @@ ghx
 ghx
 gFX
 eHt
-mJF
+qHM
 txh
 cqV
 uWq
@@ -105798,13 +105871,13 @@ thA
 thA
 ghx
 gFX
-xIl
-gmr
+rVr
+ydH
 wuN
 nov
 dzI
 aMC
-cOS
+qkn
 ghx
 ghx
 iDt
@@ -106054,14 +106127,14 @@ ghx
 thA
 thA
 ghx
-cOS
+qkn
 eHt
-hzi
+dxl
 aMC
-ehK
+mMs
 dzI
 eiQ
-cOS
+qkn
 ghx
 ghx
 iDt
@@ -106311,14 +106384,14 @@ ghx
 ghx
 thA
 ghx
-cOS
+qkn
 eHt
 gFX
 aMC
-lMG
+qCx
 vrk
 aMC
-cOS
+qkn
 ghx
 ghx
 iDt
@@ -106568,9 +106641,9 @@ ghx
 ghx
 thA
 ghx
-cOS
+qkn
 cLf
-sYa
+qwI
 eiQ
 uWq
 kdq
@@ -106825,14 +106898,14 @@ ghx
 ghx
 ghx
 ghx
-cOS
-tOO
-jQF
+qkn
+tbc
+jrV
 kJN
 aMC
 sAc
 iOk
-seb
+eha
 ghx
 iDt
 iDt
@@ -107083,13 +107156,13 @@ ghx
 ghx
 ghx
 gFX
-qJB
-nEL
+cUB
+lMG
 vBN
 vBN
 lhB
 vBN
-seb
+eha
 ghx
 ghx
 iDt
@@ -107342,10 +107415,10 @@ ghx
 gFX
 gFX
 gFX
-xiL
-xiL
-pDz
-xiL
+gVx
+gVx
+wcR
+gVx
 gFX
 ghx
 ghx
@@ -112739,10 +112812,10 @@ ghx
 gFX
 vBN
 vBN
-xiL
-xiL
-pDz
-xiL
+gVx
+gVx
+wcR
+gVx
 vBN
 gFX
 oSU
@@ -119945,7 +120018,7 @@ nqh
 tgU
 gFX
 gFX
-rVr
+cjE
 usr
 usr
 hgg
@@ -120202,11 +120275,11 @@ kdm
 bJv
 gFX
 nTH
-ohF
+iJG
 msM
 cBz
 cBz
-cWB
+gce
 bJv
 aeV
 lLs
@@ -120459,7 +120532,7 @@ kdm
 bJv
 gFX
 nTH
-cBz
+skm
 eHt
 kdm
 eHt
@@ -121483,7 +121556,7 @@ lhB
 vBN
 thL
 tgU
-eYP
+mhD
 jRP
 usr
 usr
@@ -133320,7 +133393,7 @@ oSU
 gFX
 lhB
 lhB
-cPc
+mJp
 lhB
 lhB
 gFX
@@ -134869,8 +134942,8 @@ gFX
 nTH
 nTH
 gFX
-ydH
-wSM
+dsx
+hBG
 aKb
 iDt
 iDt
@@ -135122,12 +135195,12 @@ vBN
 vBN
 vBN
 lhB
-kJS
-nNN
-xBA
+wXd
+ybp
+ohF
 efl
 eHt
-vkk
+tQk
 chg
 iDt
 iDt
@@ -135379,12 +135452,12 @@ vBN
 lhB
 vBN
 vBN
-usr
+aZL
 eHt
 cBz
-uNK
+rWJ
 eHt
-wSM
+hBG
 pJm
 iDt
 iDt
@@ -135636,10 +135709,10 @@ vBN
 vBN
 vBN
 lhB
-usr
+gBp
 eHt
 cBz
-cUB
+ghe
 eHt
 gFX
 xMq
@@ -135881,7 +135954,7 @@ xMq
 oSU
 oSU
 oSU
-oSU
+aVL
 gFX
 gFX
 gFX
@@ -135893,11 +135966,11 @@ vBN
 lhB
 vBN
 vBN
-sJX
+iED
 kdm
 cBz
-cUB
-oXt
+ghe
+aBY
 gFX
 iDt
 xMq
@@ -136138,9 +136211,9 @@ xMq
 oSU
 oSU
 oSU
-oSU
-gFX
-cnF
+aVL
+qxr
+poh
 luS
 pAj
 tgU
@@ -136150,7 +136223,7 @@ vBN
 lhB
 lhB
 lhB
-usr
+gBp
 eHt
 cXw
 gFX
@@ -136395,9 +136468,9 @@ xMq
 oSU
 oSU
 oSU
-oSU
-gFX
-eHt
+aVL
+qxr
+diK
 eHt
 cLf
 gFX
@@ -136407,7 +136480,7 @@ vBN
 lhB
 lhB
 vBN
-usr
+aZL
 bJv
 cBz
 gFX
@@ -136652,9 +136725,9 @@ iDt
 oSU
 oSU
 oSU
-oSU
+aVL
 gFX
-cnF
+dNg
 aCI
 cLf
 bJv
@@ -136664,7 +136737,7 @@ vBN
 lhB
 lhB
 vBN
-usr
+gBp
 usr
 usr
 gFX
@@ -137179,7 +137252,7 @@ vBN
 lhB
 vBN
 gFX
-vNt
+fhR
 bJv
 gFX
 oSU
@@ -138196,7 +138269,7 @@ oSU
 oSU
 oSU
 gFX
-tgU
+qhp
 bJv
 eHt
 bJv
@@ -138453,18 +138526,18 @@ oSU
 gFX
 gFX
 gFX
-rsO
+eju
 eHt
-eHt
-eHt
-ydH
-cmA
+cLf
+cLf
+dsx
+nqf
 lhB
 vBN
 vBN
 vBN
 gFX
-tgU
+usr
 eHt
 gFX
 oSU
@@ -138708,21 +138781,21 @@ oSU
 oSU
 oSU
 gFX
-vBN
-nTH
+rsO
+afI
 usr
 bJv
-eHt
+lsu
 bJv
 eHt
-cvr
+cQG
 lhB
 vBN
 vBN
 vBN
 gFX
-eHt
-vea
+kdm
+ilw
 gFX
 oSU
 oSU
@@ -138965,21 +139038,21 @@ oSU
 oSU
 oSU
 gFX
-vBN
-nTH
-pAj
+cvr
+afI
+toD
 bJv
 cLf
 bJv
-eHt
-eHt
+kdm
+bWp
 gFX
 gFX
 gFX
 gFX
 gFX
 tgU
-vea
+ilw
 gFX
 oSU
 oSU
@@ -139222,21 +139295,21 @@ oSU
 oSU
 oSU
 gFX
-vBN
-nTH
-tgU
+suK
+qWE
+qJB
 eHt
-eHt
+lsu
 gFX
 cLf
-eHt
-tgU
+xLY
+usr
 eHt
 usr
 kdm
-oam
-hBG
-eHt
+qmQ
+plK
+kdm
 gFX
 oSU
 oSU
@@ -139481,7 +139554,7 @@ oSU
 gFX
 gFX
 gFX
-eHt
+mJE
 cLf
 cnF
 eHt
@@ -167483,7 +167556,7 @@ tjo
 tjo
 tjo
 tjo
-wIo
+scr
 gFX
 wlK
 wlK
@@ -167740,9 +167813,9 @@ tjo
 tjo
 tjo
 tjo
-wIo
-ptt
-ptt
+scr
+seb
+seb
 wlK
 lhB
 lhB
@@ -167997,9 +168070,9 @@ tjo
 tjo
 tjo
 tjo
-wIo
-ptt
-ptt
+scr
+seb
+seb
 wlK
 lhB
 lhB
@@ -168254,7 +168327,7 @@ tjo
 tjo
 tjo
 tjo
-wIo
+scr
 gFX
 gFX
 gFX
@@ -169287,7 +169360,7 @@ tjo
 thA
 thA
 thA
-rWJ
+tfL
 iLh
 pwg
 peG
@@ -185742,7 +185815,7 @@ caA
 mty
 urQ
 sQI
-hVQ
+prD
 pme
 pme
 aon
@@ -186254,13 +186327,13 @@ gFX
 uVb
 exw
 mqd
-kRT
+ptt
 wDb
 oZG
 oZG
 rZY
 oZG
-ukK
+vCp
 exw
 exw
 exw
@@ -201164,8 +201237,8 @@ oTA
 xeJ
 oTA
 kub
-aZL
-wrX
+oTA
+nGU
 wrX
 wrX
 wrX
@@ -201417,13 +201490,13 @@ wrX
 wrX
 wrX
 wrX
+wrX
+wrX
+wrX
 nfS
 wrX
 eoS
-wrX
-wrX
-wrX
-xMq
+gFX
 xMq
 xMq
 xMq
@@ -201673,14 +201746,14 @@ lvt
 lvt
 xMq
 xMq
+vkk
+wrX
+gEE
 wrX
 wee
-bWp
-mCP
-wrX
-xMq
-xMq
-xMq
+ebS
+uSC
+gFX
 xMq
 xMq
 xMq
@@ -201930,14 +202003,14 @@ lvt
 lvt
 xMq
 xMq
+vkk
+wrX
+gEE
 wrX
 wrX
-wrX
-wrX
-wrX
-xMq
-xMq
-xMq
+gFX
+gFX
+gFX
 thA
 thA
 thA
@@ -202188,9 +202261,9 @@ lvt
 xMq
 xMq
 xMq
-xMq
-xMq
-xMq
+gFX
+gFX
+gFX
 xMq
 thA
 thA
@@ -233536,7 +233609,7 @@ aPM
 oCO
 qTm
 qTm
-aVL
+ccx
 tmL
 arG
 cIa
@@ -234045,9 +234118,9 @@ lJO
 lJO
 lJO
 lJO
-ilw
-skm
-cgH
+dAg
+mCP
+nrt
 tNd
 nor
 sst
@@ -251530,7 +251603,7 @@ oUO
 kHO
 mQi
 uja
-dCr
+fOt
 hNU
 kyL
 kyL
@@ -266950,11 +267023,11 @@ nui
 kDs
 kDs
 kDs
-tpd
+jfp
 oOD
 lDH
-gVx
-tpd
+qPL
+qPL
 qWO
 pCI
 gVt
@@ -267207,10 +267280,10 @@ pUa
 pUa
 pUa
 kDs
-tpd
+jZM
 jtG
-myJ
-myJ
+efa
+qPL
 ugO
 wLS
 myJ
@@ -267468,7 +267541,7 @@ qPL
 qPL
 qPL
 qPL
-qPL
+ugO
 liM
 myJ
 nMw
@@ -267980,7 +268053,7 @@ pUa
 kDs
 qPL
 nbK
-vXy
+utK
 ixv
 qPL
 gHD

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -164,12 +164,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
-"acM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/status_display/ai/directional/north,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "acN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -316,7 +310,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/icemoon/underground/explored)
 "afp" = (
 /obj/machinery/air_sensor/nitrogen_tank,
 /turf/open/floor/engine/n2,
@@ -1833,17 +1827,6 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
-"ayj" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "ayq" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "atmos-entrance"
@@ -1885,12 +1868,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
-"ayQ" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "ayS" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - Permabrig Lower Hallway Stairwell";
@@ -2412,11 +2389,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
-"aHv" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "aHz" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -3455,8 +3427,9 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aVL" = (
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers/deep)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "aVM" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -5356,6 +5329,10 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/brig/upper)
+"bwb" = (
+/obj/structure/transport/linear/public,
+/turf/closed/wall,
+/area/icemoon/underground/explored)
 "bwh" = (
 /turf/closed/wall/mineral/iron,
 /area/icemoon/underground/explored)
@@ -5497,6 +5474,12 @@
 	dir = 5
 	},
 /area/station/maintenance/port/aft)
+"byc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "byl" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -5863,12 +5846,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"bCU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/random/directional/north,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "bDi" = (
 /obj/machinery/door/window/left/directional/west,
 /obj/structure/cable,
@@ -6237,6 +6214,11 @@
 /obj/machinery/smartfridge,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"bHK" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "bHO" = (
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 6;
@@ -7693,11 +7675,7 @@
 /area/station/ai/satellite/atmos)
 "ccx" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "ccz" = (
 /obj/item/radio/intercom/directional/east,
@@ -7974,6 +7952,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"cfM" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "cfR" = (
 /obj/structure/chair{
 	dir = 1
@@ -8111,7 +8095,7 @@
 "chT" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/icemoon/underground/explored)
 "chZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9012,8 +8996,10 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
 "cvr" = (
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "cvB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/west,
@@ -9069,12 +9055,6 @@
 "cvS" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical/central)
-"cvX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "cwa" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -9527,6 +9507,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"cBQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/spawner/random/maintenance/dumpster,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "cBT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -9762,6 +9748,11 @@
 	},
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/security/evidence)
+"cEX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/corner,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "cFp" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9876,10 +9867,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"cHr" = (
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "cHs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -10132,10 +10119,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
-"cLg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/icemoon/underground/unexplored/rivers/deep)
 "cLo" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
@@ -10433,12 +10416,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "cOS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/unexplored/rivers/deep)
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "cPd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10766,7 +10746,7 @@
 "cUg" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/icemoon/underground/explored)
 "cUq" = (
 /obj/structure/rack,
 /obj/item/stack/ducts{
@@ -10781,9 +10761,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "cUB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "cUG" = (
 /obj/effect/turf_decal/stripes/red/corner,
@@ -10814,10 +10793,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
-"cVl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/unexplored/rivers/deep)
 "cVz" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -11046,7 +11021,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/trash/soap,
 /turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/icemoon/underground/explored)
 "cYT" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
@@ -11939,14 +11914,6 @@
 	dir = 8
 	},
 /area/station/science/ordnance/office)
-"djN" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "djO" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer"
@@ -12067,11 +12034,6 @@
 /obj/effect/landmark/start/cook,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
-"dlr" = (
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "dlt" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
@@ -12158,6 +12120,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
+"dmP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "dmV" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -13902,6 +13869,9 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"dLR" = (
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers)
 "dLT" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -15171,9 +15141,11 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
 "eha" = (
-/obj/effect/decal/cleanable/blood/trail,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/spawner/random/junk_shell,
 /turf/open/floor/iron,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/icemoon/underground/explored)
 "ehc" = (
 /turf/open/floor/plating,
 /area/station/security/prison)
@@ -15454,6 +15426,12 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"ekz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/west,
+/obj/machinery/lift_indicator/directional/west,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "ekE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16739,6 +16717,11 @@
 	dir = 1
 	},
 /area/station/maintenance/department/cargo)
+"eEJ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "eEO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17292,12 +17275,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"eNg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/west,
-/obj/machinery/lift_indicator/directional/west,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "eNh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17740,11 +17717,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hos)
-"eUt" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "eUx" = (
 /obj/machinery/light_switch/directional/east,
 /obj/structure/table,
@@ -18141,6 +18113,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
+"eYV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "eYX" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -19002,11 +18980,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"flk" = (
-/obj/structure/thermoplastic,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "flx" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=HOP";
@@ -19230,6 +19203,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"fqg" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "fqj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19538,11 +19519,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"fuu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/enlist/directional/west,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "fuD" = (
 /obj/structure/tank_holder/extinguisher,
 /obj/structure/sign/poster/random/directional/north,
@@ -20353,17 +20329,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
-"fHX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "fHZ" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -21524,16 +21489,6 @@
 /obj/structure/sign/clock/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
-"fZP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/south{
-	id = "tram_perma_lift"
-	},
-/obj/machinery/lift_indicator/directional/south{
-	linked_elevator_id = "tram_perma_lift"
-	},
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "fZV" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -22012,6 +21967,11 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"ggu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/enlist/directional/west,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ggz" = (
 /obj/effect/turf_decal/tile/green/opposingcorners{
 	dir = 1
@@ -22055,14 +22015,21 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ghe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
 	},
-/obj/structure/railing,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/obj/machinery/duct,
+/obj/structure/table/glass,
+/obj/item/watertank{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/plant_analyzer,
+/obj/item/book/manual/hydroponics_pod_people,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "ghl" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -23034,6 +23001,14 @@
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"gtO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "gtP" = (
 /obj/structure/table,
 /obj/item/assembly/timer,
@@ -23160,13 +23135,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"gvJ" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/structure/sign/poster/contraband/kudzu/directional/north,
-/obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "gvK" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
@@ -23309,7 +23277,7 @@
 	name = "wooden barricade (CLOSED)"
 	},
 /turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/area/icemoon/underground/explored)
 "gxO" = (
 /obj/structure/table/reinforced,
 /obj/item/hand_labeler{
@@ -23668,11 +23636,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/textured,
 /area/station/security/brig)
-"gCS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "gCV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -23888,10 +23851,6 @@
 "gFX" = (
 /turf/closed/wall,
 /area/icemoon/underground/explored)
-"gGo" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "gGs" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/machinery/newscaster/directional/west,
@@ -24064,6 +24023,9 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/mine/mechbay)
+"gIy" = (
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "gIF" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/showroomfloor,
@@ -24136,13 +24098,6 @@
 "gKd" = (
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/cargo/warehouse)
-"gKf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "gKl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25327,13 +25282,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/security/brig)
-"hak" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "hap" = (
 /turf/open/floor/vault,
 /area/station/security/prison/rec)
@@ -25776,6 +25724,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/textured,
 /area/station/maintenance/fore)
+"hiY" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "hjc" = (
 /obj/structure/closet/emcloset,
 /obj/item/pickaxe,
@@ -26182,6 +26137,10 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"hoC" = (
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/genturf/blue,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "hoD" = (
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -26760,11 +26719,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "hwe" = (
-/obj/structure/barricade/wooden{
-	name = "wooden barricade (CLOSED)"
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/door,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "hwm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -27156,7 +27114,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "hBG" = (
-/turf/open/openspace,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "hBZ" = (
 /obj/structure/table/wood,
@@ -29598,9 +29564,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "ilw" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/obj/effect/spawner/random/trash/bin,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ily" = (
 /turf/open/openspace,
 /area/station/science/xenobiology)
@@ -30552,16 +30519,6 @@
 	dir = 4
 	},
 /area/station/service/chapel)
-"iBb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/glass,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "iBe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -30800,10 +30757,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"iFq" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/unexplored/rivers/deep)
 "iFs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -33849,13 +33802,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/engineering)
-"jzj" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "jzk" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/wood,
@@ -34774,6 +34720,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"jLD" = (
+/obj/structure/thermoplastic,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "jLK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35509,6 +35460,11 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
+"jVV" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "jWb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -35787,6 +35743,17 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"kao" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "kaw" = (
 /obj/machinery/photocopier/prebuilt,
 /obj/item/radio/intercom/directional/north,
@@ -36236,11 +36203,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/ai/satellite/atmos)
-"khI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/report_crimes/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "khR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
@@ -36286,12 +36248,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
-"kiN" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "kiO" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -36576,11 +36532,6 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
-"klQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence/door,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "klW" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron,
@@ -37612,6 +37563,10 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
+"kAw" = (
+/obj/effect/mapping_helpers/no_atoms_ontop,
+/turf/closed/wall,
+/area/icemoon/underground/explored)
 "kAC" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -37895,6 +37850,13 @@
 	dir = 4
 	},
 /area/mine/eva)
+"kDL" = (
+/obj/structure/fence/door{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "kDO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -38206,7 +38168,7 @@
 "kIu" = (
 /obj/machinery/power/smes/engineering,
 /turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/icemoon/underground/explored)
 "kIy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -38328,11 +38290,10 @@
 /area/station/maintenance/port/greater)
 "kJS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/fence{
-	dir = 2
-	},
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/unexplored/rivers/deep)
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "kJU" = (
 /obj/structure/girder,
 /turf/open/floor/iron/dark,
@@ -38830,6 +38791,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
+"kQX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/crayon,
+/obj/effect/spawner/random/trash/deluxe_garbage,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "kQY" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 4;
@@ -39621,22 +39588,6 @@
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"lbP" = (
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/green/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/duct,
-/obj/structure/table/glass,
-/obj/item/watertank{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/item/plant_analyzer,
-/obj/item/book/manual/hydroponics_pod_people,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "lch" = (
 /obj/machinery/computer/monitor{
 	dir = 1;
@@ -41359,6 +41310,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
+"lAI" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "lAL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41596,11 +41556,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"lDJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "lDM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -41947,6 +41902,16 @@
 /obj/effect/spawner/random/food_or_drink/cups,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"lJB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "lJO" = (
 /turf/closed/wall,
 /area/station/maintenance/port/fore)
@@ -42122,12 +42087,9 @@
 /area/station/security/armory/upper)
 "lMG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/railing,
-/obj/structure/fence/door{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "lMK" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -42970,6 +42932,10 @@
 	name = "hyper-reinforced wall"
 	},
 /area/station/science/ordnance/bomb/planet)
+"lZu" = (
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "lZP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45345,11 +45311,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
-"mIy" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/work_for_a_future/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "mIE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -45485,9 +45446,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mLd" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/iron/smooth,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "mLf" = (
 /turf/open/openspace/icemoon/keep_below,
@@ -47019,12 +46984,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"nhG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/spawner/random/maintenance/dumpster,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "nhI" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Research Division Genetics Monkey Pen";
@@ -47814,9 +47773,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"nsK" = (
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/unexplored/rivers/deep)
 "nsM" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/warning/directional/west,
@@ -48048,13 +48004,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
-"nwm" = (
-/obj/structure/fence{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "nwn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -48126,6 +48075,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"nxF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "nxM" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical/morgue)
@@ -48670,11 +48624,6 @@
 "nDE" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/garden)
-"nDH" = (
-/obj/effect/spawner/random/trash/bin,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "nDJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49013,6 +48962,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
+"nIM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "nIN" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -49204,6 +49158,11 @@
 /obj/structure/mirror/broken/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
+"nKY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "nLb" = (
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/iron/dark/telecomms,
@@ -49600,13 +49559,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"nPw" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "nPI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50760,11 +50712,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
-"ogj" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/unexplored/rivers/deep)
 "ogl" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -50799,16 +50746,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/chamber)
-"ogG" = (
-/obj/machinery/door/window/elevator/left/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "oha" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -51685,10 +51622,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"osc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/unexplored/rivers/deep)
 "osd" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -52013,6 +51946,13 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"oxt" = (
+/obj/structure/fence{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "oxB" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -52207,11 +52147,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/textured,
 /area/station/commons/toilet)
-"ozm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/unexplored/rivers/deep)
 "ozo" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -52423,15 +52358,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"oBt" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "oBz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -53312,12 +53238,6 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/mine/living_quarters)
-"oLy" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "oLz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -53491,10 +53411,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"oOA" = (
-/obj/structure/transport/linear/public,
-/turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "oOB" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -54029,6 +53945,13 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"oWZ" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/sign/poster/contraband/kudzu/directional/north,
+/obj/structure/sink/kitchen/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "oXb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -54642,13 +54565,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"pgj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "pgk" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable,
@@ -55559,9 +55475,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/aft/greater)
 "ptt" = (
-/obj/machinery/door/poddoor/shutters,
-/turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "ptQ" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
 /obj/effect/turf_decal/stripes/line,
@@ -55661,11 +55577,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/breakroom)
-"puU" = (
-/obj/structure/thermoplastic/light,
-/obj/machinery/door/airlock/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "puX" = (
 /obj/structure/table,
 /obj/item/stock_parts/scanning_module{
@@ -56354,8 +56265,11 @@
 /turf/open/floor/iron/large,
 /area/station/medical/break_room)
 "pEs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "pEE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -56569,12 +56483,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"pIs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "pIu" = (
 /obj/structure/table,
 /obj/item/binoculars,
@@ -57079,6 +56987,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"pPW" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "pPY" = (
 /obj/machinery/light/small/dim/directional/west,
 /obj/effect/mapping_helpers/broken_floor,
@@ -58614,8 +58526,13 @@
 /turf/open/misc/asteroid/snow/standard_air,
 /area/station/science/cytology)
 "qkn" = (
+/obj/structure/toiletbong,
+/obj/structure/thermoplastic,
+/obj/structure/chair/sofa/bench/tram/left,
+/obj/structure/thermoplastic/light,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/area/icemoon/underground/explored)
 "qku" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
@@ -59718,9 +59635,9 @@
 /turf/open/floor/plating,
 /area/station/security/prison/mess)
 "qCx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/underground/explored)
 "qCA" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -60124,11 +60041,6 @@
 	dir = 1
 	},
 /area/station/medical/virology)
-"qHG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "qHO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench/right{
@@ -60253,17 +60165,15 @@
 /obj/structure/sign/warning/radiation/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"qJk" = (
-/turf/open/openspace,
-/area/station/hallway/primary/central)
 "qJv" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/cigbutt,
 /turf/open/floor/wood/large,
 /area/mine/eva/lower)
 "qJB" = (
-/obj/effect/mapping_helpers/no_atoms_ontop,
-/turf/closed/wall,
+/obj/structure/thermoplastic,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "qJT" = (
 /obj/machinery/light/small/directional/south,
@@ -60285,6 +60195,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
+"qKl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "qKn" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -61678,11 +61593,6 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/icemoon/underground/explored)
-"rcf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "rcj" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Lockers";
@@ -62062,6 +61972,12 @@
 /obj/structure/marker_beacon/burgundy,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"rhO" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "rhQ" = (
 /obj/structure/sign/warning/gas_mask/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -62524,11 +62440,6 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"rog" = (
-/obj/structure/thermoplastic,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "roj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62907,8 +62818,15 @@
 	},
 /area/station/security/prison/safe)
 "rsO" = (
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "rsR" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue/full,
@@ -64014,6 +63932,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"rJb" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "rJc" = (
 /obj/structure/minecart_rail{
 	dir = 4
@@ -64059,6 +63982,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/fore/lesser)
+"rKn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "rKv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 1
@@ -64789,6 +64723,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"rVk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "rVq" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -64799,10 +64738,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rVr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/crayon,
-/obj/effect/spawner/random/trash/deluxe_garbage,
-/turf/open/floor/iron,
+/turf/open/openspace,
 /area/icemoon/underground/explored)
 "rVB" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
@@ -64904,10 +64840,13 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rWJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/unexplored/rivers/deep)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/elevator/directional/east,
+/obj/machinery/lift_indicator/directional/east,
+/obj/machinery/door/window/elevator/right/directional/north,
+/obj/effect/turf_decal/caution/stand_clear/white,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/garden)
 "rWO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -65134,13 +65073,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
-"saa" = (
-/obj/structure/fence/door{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "sab" = (
 /turf/open/floor/iron/chapel{
 	dir = 4
@@ -65303,8 +65235,9 @@
 /area/station/medical/medbay/central)
 "scr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/garbage,
-/obj/effect/spawner/random/junk_shell,
+/obj/structure/fence{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "sct" = (
@@ -65428,8 +65361,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/eva)
 "seb" = (
-/turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "sen" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -65819,9 +65755,10 @@
 /turf/closed/wall,
 /area/station/maintenance/fore)
 "skm" = (
-/obj/structure/barricade/security,
-/turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "skn" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -67859,16 +67796,6 @@
 /obj/structure/flora/grass/both/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
-"sMB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "sML" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68700,10 +68627,6 @@
 "sZU" = (
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
-"tac" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "taf" = (
 /obj/effect/landmark/start/quartermaster,
 /obj/structure/chair/office{
@@ -69190,13 +69113,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
+"thy" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "thA" = (
 /turf/open/genturf/blue,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "thB" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep)
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "thC" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/iron/fifty,
@@ -71318,10 +71251,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
-"tKT" = (
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "tKV" = (
 /obj/structure/table_frame,
 /obj/effect/decal/cleanable/glass,
@@ -72185,14 +72114,6 @@
 /obj/machinery/light/small/red/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/greater)
-"tXx" = (
-/obj/structure/toiletbong,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/left,
-/obj/structure/thermoplastic/light,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "tXB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72471,11 +72392,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
-"ubb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "ubc" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -72507,6 +72423,11 @@
 	},
 /turf/open/floor/iron/stairs/medium,
 /area/mine/eva/lower)
+"ubH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/report_crimes/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ubZ" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Security - Permabrig Chapel";
@@ -72720,14 +72641,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"ufA" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "ufF" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner{
@@ -73241,6 +73154,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"unp" = (
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "unq" = (
 /obj/structure/light_construct/directional/north,
 /obj/effect/spawner/random/structure/closet_private,
@@ -74393,6 +74310,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"uDY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "uEf" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
@@ -75903,7 +75825,7 @@
 "vcG" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/icemoon/underground/explored)
 "vcO" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/dark,
@@ -76101,10 +76023,6 @@
 /obj/structure/flora/grass/brown/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
-"vfC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/lava/plasma/ice_moon,
-/area/icemoon/underground/explored)
 "vfH" = (
 /obj/structure/closet/crate{
 	name = "Le Caisee D'abeille"
@@ -76350,10 +76268,15 @@
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "vkk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/obj/machinery/door/window/elevator/left/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "vkz" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/stripes/line{
@@ -77148,6 +77071,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
+"vvp" = (
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "vvu" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/trimline/neutral/warning{
@@ -77775,7 +77703,7 @@
 /obj/item/flashlight/lamp,
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/icemoon/underground/explored)
 "vEJ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -78525,7 +78453,7 @@
 "vQb" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/icemoon/underground/explored)
 "vQj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -78545,13 +78473,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/mine/production)
-"vQF" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
+"vQJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/south{
+	id = "tram_perma_lift"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "tram_perma_lift"
+	},
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "vQN" = (
@@ -78660,6 +78589,13 @@
 "vSi" = (
 /turf/closed/wall,
 /area/mine/eva)
+"vSu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "vSE" = (
 /obj/machinery/door/window/right/directional/east{
 	name = "Bar Access"
@@ -78678,6 +78614,13 @@
 /obj/item/reagent_containers/syringe,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"vSV" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "vSY" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -78892,7 +78835,7 @@
 	name = "service reservoir"
 	},
 /turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/icemoon/underground/explored)
 "vVt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79280,7 +79223,7 @@
 "waK" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/icemoon/underground/explored)
 "waL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -79829,11 +79772,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"wjO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/wood,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "wjP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/rack,
@@ -80533,11 +80471,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
-"wvQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "wvV" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/pumproom)
@@ -80708,12 +80641,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"wyt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "wyB" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -83305,10 +83232,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
-"xgV" = (
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/genturf/blue,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "xhk" = (
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
@@ -83428,7 +83351,9 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "xiL" = (
-/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "xiO" = (
@@ -83556,14 +83481,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
-"xkS" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/button/elevator/directional/east,
-/obj/machinery/lift_indicator/directional/east,
-/obj/machinery/door/window/elevator/right/directional/north,
-/obj/effect/turf_decal/caution/stand_clear/white,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics/garden)
 "xkW" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
@@ -84529,17 +84446,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"xyq" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "xyr" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -86814,8 +86720,8 @@
 /area/station/maintenance/department/chapel)
 "ydH" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing/corner,
-/turf/open/floor/iron,
+/obj/structure/sign/poster/official/work_for_a_future/directional/north,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "ydI" = (
 /turf/closed/wall/r_wall,
@@ -87259,9 +87165,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"ymd" = (
-/turf/open/floor/iron,
-/area/icemoon/underground/unexplored/rivers/deep)
 "ymf" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
@@ -102034,9 +101937,9 @@ oSU
 oSU
 oSU
 gFX
-nhG
-fuu
-rVr
+cBQ
+ggu
+kQX
 gFX
 gFX
 gFX
@@ -102291,10 +102194,10 @@ oSU
 oSU
 oSU
 gFX
-pIs
-wyt
+xiL
+byc
 eHt
-ogG
+vkk
 nTH
 nTH
 gFX
@@ -102548,12 +102451,12 @@ oSU
 oSU
 oSU
 gFX
-bCU
-mLd
+seb
+skm
 kdm
-fHX
+rKn
 nTH
-oOA
+nTH
 gFX
 ghx
 ghx
@@ -102805,12 +102708,12 @@ oSU
 oSU
 oSU
 gFX
-acM
-aHv
-fZP
+eYV
+eEJ
+vQJ
 gFX
+bwb
 gFX
-rsO
 gFX
 ghx
 ghx
@@ -103063,10 +102966,10 @@ oSU
 gFX
 gFX
 wMB
-saa
-nwm
+kDL
+oxt
 wMB
-scr
+eha
 gFX
 ghx
 ghx
@@ -103318,13 +103221,13 @@ thA
 thA
 thA
 gFX
-nDH
+ilw
 eHt
 bJv
 aCI
 cLf
-iBb
-pEs
+lJB
+aVL
 ghx
 ghx
 thA
@@ -103576,10 +103479,10 @@ thA
 thA
 gFX
 kdm
-ydH
-kiN
-pgj
-kiN
+cEX
+thB
+vSu
+thB
 gFX
 gFX
 ghx
@@ -103832,13 +103735,13 @@ thA
 thA
 thA
 gFX
-khI
-ubb
+ubH
+qKl
 cjI
 aMC
 wuN
 nLK
-pEs
+aVL
 ghx
 ghx
 thA
@@ -104095,7 +103998,7 @@ aMC
 uWq
 bKQ
 wuN
-pEs
+aVL
 ghx
 ghx
 thA
@@ -104347,12 +104250,12 @@ thA
 thA
 gFX
 cLf
-xyq
+hBG
 eiQ
 uWq
 fHU
 wuN
-pEs
+aVL
 ghx
 ghx
 thA
@@ -104602,11 +104505,11 @@ thA
 thA
 ghx
 ghx
-pEs
+aVL
 cLf
-ccx
+gtO
 aMC
-rog
+jLD
 uWq
 aMC
 gFX
@@ -104859,14 +104762,14 @@ ghx
 ghx
 ghx
 ghx
-pEs
-wvQ
-ccx
+aVL
+nKY
+gtO
 wuN
 rOU
 qFF
-puU
-pEs
+jVV
+aVL
 ghx
 ghx
 ijY
@@ -105116,14 +105019,14 @@ ghx
 ghx
 ghx
 ghx
-pEs
+aVL
 cLf
-vQF
+lAI
 aMC
-tXx
+qkn
 qFF
 cqV
-pEs
+aVL
 ghx
 ghx
 ghx
@@ -105373,14 +105276,14 @@ ghx
 ghx
 ghx
 ghx
-pEs
+aVL
 eHt
 gFX
 aMC
 aMC
 oge
 aMC
-pEs
+aVL
 ghx
 ghx
 ghx
@@ -105632,7 +105535,7 @@ ghx
 ghx
 gFX
 eHt
-ufA
+thy
 txh
 cqV
 uWq
@@ -105888,13 +105791,13 @@ thA
 thA
 ghx
 gFX
-mIy
-oBt
+ydH
+mLd
 wuN
 nov
 dzI
 aMC
-pEs
+aVL
 ghx
 ghx
 iDt
@@ -106144,14 +106047,14 @@ ghx
 thA
 thA
 ghx
-pEs
+aVL
 eHt
-djN
+fqg
 aMC
-rog
+jLD
 dzI
 eiQ
-pEs
+aVL
 ghx
 ghx
 iDt
@@ -106401,14 +106304,14 @@ ghx
 ghx
 thA
 ghx
-pEs
+aVL
 eHt
 gFX
 aMC
-flk
+qJB
 vrk
 aMC
-pEs
+aVL
 ghx
 ghx
 iDt
@@ -106658,9 +106561,9 @@ ghx
 ghx
 thA
 ghx
-pEs
+aVL
 cLf
-ayj
+kao
 eiQ
 uWq
 kdq
@@ -106915,14 +106818,14 @@ ghx
 ghx
 ghx
 ghx
+aVL
+dmP
 pEs
-wjO
-hak
 kJN
 aMC
 sAc
 iOk
-vfC
+qCx
 ghx
 iDt
 iDt
@@ -107173,13 +107076,13 @@ ghx
 ghx
 ghx
 gFX
-eUt
-oLy
+bHK
+rhO
 vBN
 vBN
 lhB
 vBN
-vfC
+qCx
 ghx
 ghx
 iDt
@@ -107432,10 +107335,10 @@ ghx
 gFX
 gFX
 gFX
-tKT
-tKT
-cUB
-tKT
+cOS
+cOS
+rVk
+cOS
 gFX
 ghx
 ghx
@@ -112829,10 +112732,10 @@ ghx
 gFX
 vBN
 vBN
-tKT
-tKT
-cUB
-tKT
+cOS
+cOS
+rVk
+cOS
 vBN
 gFX
 oSU
@@ -118491,11 +118394,11 @@ vBN
 gFX
 oSU
 oSU
-aVL
-aVL
-aVL
-aVL
-aVL
+gFX
+gFX
+gFX
+gFX
+gFX
 oSU
 oSU
 thA
@@ -118748,18 +118651,18 @@ vBN
 gFX
 oSU
 oSU
-aVL
+gFX
 vEH
 afk
 kIu
-aVL
+gFX
 oSU
 oSU
 oSU
 thA
 thA
 thA
-rsO
+gFX
 gFX
 gFX
 gFX
@@ -119003,21 +118906,21 @@ vBN
 vBN
 mGh
 gFX
-aVL
-aVL
-aVL
+gFX
+gFX
+gFX
 vcG
-seb
-aVL
-aVL
-aVL
+vBN
+gFX
+gFX
+gFX
 oSU
 oSU
 oSU
-aVL
-aVL
+gFX
+gFX
 gxu
-ptt
+msP
 msP
 msP
 msP
@@ -119260,22 +119163,22 @@ vBN
 vBN
 aFY
 eHt
-aVL
-seb
-aVL
+gFX
+vBN
+gFX
 cUg
-juV
+eHt
 vVn
 cYS
-aVL
+gFX
 oSU
 oSU
 oSU
-aVL
-rWJ
-vkk
-skm
-hwe
+gFX
+ruu
+lDp
+bdn
+ygI
 qcJ
 bdn
 gFX
@@ -119517,21 +119420,21 @@ vBN
 vBN
 vKn
 wMB
-aVL
-seb
-aVL
+gFX
+vBN
+gFX
 vQb
 waK
-juV
-juV
-aVL
+eHt
+eHt
+gFX
 oSU
 oSU
 oSU
-aVL
-kJS
-lMG
-qCx
+gFX
+csZ
+rxZ
+lhB
 lhB
 lhB
 lhB
@@ -119774,29 +119677,29 @@ vBN
 vBN
 kxF
 eHt
-aVL
-aVL
-aVL
-aVL
-aVL
-aVL
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
 chT
-aVL
-aVL
-aVL
-aVL
-aVL
-cOS
-ghe
-ilw
-qkn
-qCx
-qkn
-rsO
-rsO
-rsO
-aVL
-aVL
+gFX
+gFX
+gFX
+gFX
+gFX
+rAE
+lnK
+nHU
+vBN
+lhB
+vBN
+gFX
+gFX
+gFX
+gFX
+gFX
 oSU
 oSU
 oSU
@@ -120035,7 +119938,7 @@ nqh
 tgU
 gFX
 gFX
-cvX
+kJS
 usr
 usr
 hgg
@@ -120053,7 +119956,7 @@ mKr
 deW
 vBN
 vBN
-aVL
+gFX
 oSU
 oSU
 oSU
@@ -120296,7 +120199,7 @@ ohF
 msM
 cBz
 cBz
-rcf
+uDY
 bJv
 aeV
 lLs
@@ -120310,7 +120213,7 @@ vfg
 lhB
 udj
 vBN
-aVL
+gFX
 oSU
 oSU
 oSU
@@ -120567,7 +120470,7 @@ vfg
 nHU
 vBN
 uBk
-aVL
+gFX
 oSU
 oSU
 oSU
@@ -120821,10 +120724,10 @@ uWq
 dzI
 aMC
 gFX
-aVL
-aVL
-aVL
-aVL
+gFX
+gFX
+gFX
+gFX
 oSU
 oSU
 oSU
@@ -121573,7 +121476,7 @@ lhB
 vBN
 thL
 tgU
-lDJ
+nIM
 jRP
 usr
 usr
@@ -133410,7 +133313,7 @@ oSU
 gFX
 lhB
 lhB
-qHG
+lMG
 lhB
 lhB
 gFX
@@ -134959,8 +134862,8 @@ gFX
 nTH
 nTH
 gFX
-xiL
-qJB
+pPW
+kAw
 aKb
 iDt
 iDt
@@ -135212,12 +135115,12 @@ vBN
 vBN
 vBN
 lhB
-eNg
+ekz
 kdm
 ohF
 efl
 eHt
-tac
+lZu
 chg
 iDt
 iDt
@@ -135472,9 +135375,9 @@ vBN
 usr
 eHt
 cBz
-klQ
+hwe
 eHt
-qJB
+kAw
 pJm
 iDt
 iDt
@@ -135729,7 +135632,7 @@ lhB
 usr
 eHt
 cBz
-gKf
+scr
 eHt
 gFX
 xMq
@@ -135983,11 +135886,11 @@ vBN
 lhB
 vBN
 vBN
-gCS
+cvr
 kdm
 cBz
-gKf
-cHr
+scr
+unp
 gFX
 iDt
 xMq
@@ -137269,9 +137172,9 @@ vBN
 lhB
 vBN
 gFX
-ogj
-nsK
-aVL
+rJb
+bJv
+gFX
 oSU
 oSU
 oSU
@@ -137526,9 +137429,9 @@ lhB
 vBN
 vBN
 gFX
-cLg
-osc
-aVL
+usr
+cBz
+gFX
 oSU
 oSU
 oSU
@@ -137783,9 +137686,9 @@ lhB
 vBN
 vBN
 gFX
-cVl
-cVl
-aVL
+kdm
+kdm
+gFX
 oSU
 oSU
 oSU
@@ -138035,14 +137938,14 @@ eHt
 gFX
 eHt
 cmA
-seb
-seb
-seb
-seb
+vBN
+vBN
+vBN
+vBN
 gFX
-ymd
-osc
-aVL
+tgU
+cBz
+gFX
 oSU
 oSU
 oSU
@@ -138292,14 +138195,14 @@ eHt
 bJv
 eHt
 cmA
-seb
-thB
-seb
-seb
-aVL
-cVl
-osc
-aVL
+vBN
+lhB
+vBN
+vBN
+gFX
+kdm
+cBz
+gFX
 oSU
 oSU
 oSU
@@ -138543,20 +138446,20 @@ oSU
 gFX
 gFX
 gFX
-dlr
+vvp
 eHt
 eHt
 eHt
-xiL
+pPW
 cmA
-thB
-seb
-seb
-seb
-aVL
-ymd
-juV
-aVL
+lhB
+vBN
+vBN
+vBN
+gFX
+tgU
+eHt
+gFX
 oSU
 oSU
 oSU
@@ -138805,15 +138708,15 @@ bJv
 eHt
 bJv
 eHt
-gGo
-thB
-seb
-seb
-seb
-aVL
-juV
-iFq
-aVL
+ccx
+lhB
+vBN
+vBN
+vBN
+gFX
+eHt
+ptt
+gFX
 oSU
 oSU
 oSU
@@ -139062,15 +138965,15 @@ bJv
 cLf
 bJv
 eHt
-juV
-aVL
-aVL
-aVL
-aVL
-aVL
-ymd
-iFq
-aVL
+eHt
+gFX
+gFX
+gFX
+gFX
+gFX
+tgU
+ptt
+gFX
 oSU
 oSU
 oSU
@@ -139319,15 +139222,15 @@ eHt
 eHt
 gFX
 cLf
-juV
-ymd
-juV
-cLg
-cVl
-eha
-ozm
-juV
-aVL
+eHt
+tgU
+eHt
+usr
+kdm
+cUB
+nxF
+eHt
+gFX
 oSU
 oSU
 oSU
@@ -139576,15 +139479,15 @@ cLf
 cnF
 eHt
 cLf
-juV
-nsK
-nsK
-cVl
-osc
-nsK
-juV
-cLg
-aVL
+eHt
+bJv
+bJv
+kdm
+cBz
+bJv
+eHt
+usr
+gFX
 oSU
 oSU
 oSU
@@ -139827,21 +139730,21 @@ oSU
 oSU
 oSU
 oSU
-aVL
-aVL
-aVL
-aVL
-aVL
-aVL
-aVL
-aVL
-aVL
-aVL
-aVL
-aVL
-aVL
-aVL
-aVL
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
 oSU
 oSU
 oSU
@@ -167573,7 +167476,7 @@ tjo
 tjo
 tjo
 tjo
-cvr
+dLR
 gFX
 wlK
 wlK
@@ -167830,9 +167733,9 @@ tjo
 tjo
 tjo
 tjo
-cvr
-hBG
-hBG
+dLR
+rVr
+rVr
 wlK
 lhB
 lhB
@@ -168087,9 +167990,9 @@ tjo
 tjo
 tjo
 tjo
-cvr
-hBG
-hBG
+dLR
+rVr
+rVr
 wlK
 lhB
 lhB
@@ -168344,7 +168247,7 @@ tjo
 tjo
 tjo
 tjo
-cvr
+dLR
 gFX
 gFX
 gFX
@@ -169377,7 +169280,7 @@ tjo
 thA
 thA
 thA
-xgV
+hoC
 iLh
 pwg
 peG
@@ -185832,7 +185735,7 @@ caA
 mty
 urQ
 sQI
-gvJ
+oWZ
 pme
 pme
 aon
@@ -186344,13 +186247,13 @@ gFX
 uVb
 exw
 mqd
-lbP
+ghe
 wDb
 oZG
 oZG
 rZY
 oZG
-sMB
+rsO
 exw
 exw
 exw
@@ -233626,7 +233529,7 @@ aPM
 oCO
 qTm
 qTm
-xkS
+rWJ
 tmL
 arG
 cIa
@@ -234135,9 +234038,9 @@ lJO
 lJO
 lJO
 lJO
-ayQ
-jzj
-nPw
+cfM
+vSV
+hiY
 tNd
 nor
 sst
@@ -251620,7 +251523,7 @@ oUO
 kHO
 mQi
 uja
-qJk
+gIy
 hNU
 kyL
 kyL

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -4160,6 +4160,10 @@
 	},
 /turf/open/floor/circuit,
 /area/station/ai/satellite/chamber)
+"bgI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/ice/smooth,
+/area/icemoon/underground/unexplored/rivers/deep)
 "bgJ" = (
 /obj/structure/closet,
 /turf/open/floor/iron/dark/textured,
@@ -4982,12 +4986,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"brE" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "brJ" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/landmark/event_spawn,
@@ -6426,6 +6424,10 @@
 "bJv" = (
 /turf/open/floor/catwalk_floor,
 /area/station/metro/center_station)
+"bJw" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers/deep)
 "bJD" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 4
@@ -6643,6 +6645,17 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"bNB" = (
+/obj/effect/decal/cleanable/chem_pile,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "bNC" = (
 /obj/structure/fence{
 	dir = 8
@@ -7004,6 +7017,17 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
+"bSg" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "bSi" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/railing/corner{
@@ -9012,6 +9036,16 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
+"cuN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/asphalt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "cvb" = (
 /obj/structure/sign/warning/directional/east,
 /turf/open/floor/iron/smooth,
@@ -10215,6 +10249,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth,
 /area/station/metro/outrivals_station)
+"cLl" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/asphalt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "cLo" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
@@ -11793,6 +11831,13 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"dgP" = (
+/obj/structure/fluff/minepost,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "dgQ" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/siding/dark_blue/inner_corner{
@@ -12430,6 +12475,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"doY" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers/deep)
 "dpb" = (
 /obj/structure/table/wood,
 /obj/item/food/pie/cream,
@@ -14590,6 +14638,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"dVG" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/sandy_dirt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "dWl" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -16576,6 +16628,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"ezO" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/misc/sandy_dirt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "eAb" = (
 /obj/structure/chair{
 	dir = 1
@@ -16583,6 +16639,10 @@
 /obj/item/toy/sword,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/port/fore)
+"eAg" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers/deep)
 "eAh" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -17356,6 +17416,12 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/cmo)
+"eLp" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "eLr" = (
 /turf/open/floor/iron/white/side{
 	dir = 5
@@ -19335,6 +19401,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
+"foC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "foI" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -25204,6 +25282,10 @@
 /obj/structure/plasticflaps/kitchen,
 /turf/open/floor/plating,
 /area/station/service/kitchen/coldroom)
+"gWl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/sandy_dirt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "gWn" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
 	dir = 4;
@@ -25381,6 +25463,10 @@
 	},
 /turf/open/misc/asteroid/snow/coldroom,
 /area/station/service/kitchen/coldroom)
+"gYs" = (
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers/deep)
 "gYt" = (
 /obj/machinery/door/window/left/directional/west{
 	name = "Research Division Delivery";
@@ -26521,6 +26607,13 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/metro/abandoned/abandoned_north_east_tunnel)
+"hpS" = (
+/obj/effect/decal/cleanable/plastic,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/asphalt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "hpU" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -27042,6 +27135,10 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"hxR" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "hyc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -28725,6 +28822,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
+"hWE" = (
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "hWI" = (
 /obj/effect/turf_decal/box,
 /obj/effect/spawner/random/structure/closet_empty/crate/with_loot,
@@ -30620,6 +30720,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"iyk" = (
+/obj/effect/decal/fakelattice,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "iym" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark/side{
@@ -31130,13 +31238,6 @@
 "iHp" = (
 /turf/closed/wall/r_wall,
 /area/station/ai/satellite/chamber)
-"iHF" = (
-/obj/structure/fluff/minepost,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "iHG" = (
 /obj/machinery/shower/directional/south,
 /obj/item/soap/nanotrasen,
@@ -31450,6 +31551,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"iLG" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers/deep)
 "iLK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33334,6 +33439,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"jnO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "jnR" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
@@ -36841,6 +36950,13 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
+"klA" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "klW" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron,
@@ -36946,6 +37062,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"knM" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "knX" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -39753,6 +39875,13 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
+"kZr" = (
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "kZt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -40650,6 +40779,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"lmX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/corpse/human/charredskeleton,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers/deep)
 "lnc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -42233,6 +42368,11 @@
 "lIW" = (
 /turf/open/floor/plating,
 /area/station/ai/satellite/interior)
+"lIX" = (
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/asphalt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "lJc" = (
 /obj/machinery/hydroponics/soil/rich,
 /turf/open/floor/grass,
@@ -42812,6 +42952,10 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/space_hut/cabin)
+"lQR" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "lRc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -43186,6 +43330,12 @@
 	},
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
+"lWJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "lXd" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -46529,6 +46679,12 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"mXH" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "mXK" = (
 /obj/structure/table,
 /obj/structure/reagent_dispensers/servingdish,
@@ -48264,6 +48420,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
+"nuS" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "nuX" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/bush/snow/style_random,
@@ -48480,6 +48640,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
+"nye" = (
+/turf/open/floor/asphalt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "nyh" = (
 /obj/structure/sign/departments/maint/directional/north,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -49275,6 +49438,9 @@
 	dir = 4
 	},
 /area/mine/eva)
+"nHl" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "nHQ" = (
 /obj/structure/closet/firecloset,
 /obj/effect/mapping_helpers/broken_floor,
@@ -55011,6 +55177,9 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/entry)
+"pgB" = (
+/turf/open/misc/sandy_dirt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "pgE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -58471,6 +58640,10 @@
 /obj/machinery/plumbing/sender,
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
+"qde" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers/deep)
 "qdq" = (
 /obj/structure/railing,
 /obj/structure/disposalpipe/segment{
@@ -59413,6 +59586,13 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
+"qqr" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "qqs" = (
 /obj/structure/table/wood,
 /obj/item/rag,
@@ -59594,6 +59774,9 @@
 /mob/living/basic/sloth/paperwork,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"qtB" = (
+/turf/open/misc/beach/sand,
+/area/station/metro/abandoned/abandoned_collector)
 "qtD" = (
 /obj/structure/sign/warning/directional/south,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -65739,6 +65922,17 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
+"scG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "scV" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Security - Detective's Office"
@@ -66152,6 +66346,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/mine/eva)
+"siZ" = (
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers/deep)
 "sjb" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/drone_bay)
@@ -66365,6 +66562,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/security/prison)
+"slC" = (
+/obj/structure/barricade/wooden/snowed,
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers/deep)
 "slD" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -66855,6 +67056,10 @@
 	dir = 8
 	},
 /area/station/medical/morgue)
+"srN" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/asphalt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "srP" = (
 /turf/closed/wall,
 /area/station/science/breakroom)
@@ -68961,6 +69166,10 @@
 /obj/structure/sign/nanotrasen/directional/north,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
+"sWM" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers/deep)
 "sWN" = (
 /obj/structure/chair{
 	dir = 1;
@@ -70345,6 +70554,15 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"tpy" = (
+/obj/item/storage/medkit/fire,
+/obj/effect/mob_spawn/corpse/human/charredskeleton,
+/obj/item/ammo_casing/shotgun/buckshot,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "tpF" = (
 /obj/structure/closet/bombcloset/security,
 /obj/effect/turf_decal/bot,
@@ -70610,6 +70828,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"tui" = (
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "tuk" = (
 /obj/structure/closet/crate/grave,
 /turf/open/misc/dirt/dark{
@@ -71170,6 +71393,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/mine/production)
+"tDb" = (
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
+"tDe" = (
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "tDg" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
@@ -74314,6 +74545,10 @@
 /obj/item/chair/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
+"uwh" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers/deep)
 "uwp" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /turf/open/floor/iron/dark,
@@ -74398,6 +74633,12 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"uxv" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "uxx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/air_output{
 	dir = 1
@@ -74779,6 +75020,17 @@
 /obj/structure/grille/broken,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"uCU" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "uCZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -74952,6 +75204,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/bridge)
+"uFe" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/asphalt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "uFh" = (
 /turf/open/floor/plating,
 /area/station/construction)
@@ -76332,6 +76588,9 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
+"vbv" = (
+/turf/open/misc/beach/sand,
+/area/icemoon/underground/unexplored/rivers/deep)
 "vbC" = (
 /obj/structure/chair{
 	dir = 4
@@ -77680,7 +77939,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "vuT" = (
-/turf/open/genturf,
+/turf/closed/wall,
 /area/station/metro/abandoned/abandoned_collector)
 "vuW" = (
 /obj/structure/closet/boxinggloves,
@@ -78243,6 +78502,13 @@
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"vCs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/rubble,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored/rivers/deep)
 "vCy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80534,6 +80800,11 @@
 	dir = 6
 	},
 /area/station/command/heads_quarters/rd)
+"wlZ" = (
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/barricade/wooden/snowed,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "wme" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -80867,6 +81138,15 @@
 /obj/machinery/keycard_auth/wall_mounted/directional/north,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
+"wrQ" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/misc/sandy_dirt,
+/area/icemoon/underground/unexplored/rivers/deep)
+"wrT" = (
+/obj/effect/decal/cleanable/greenglow/waste,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/asphalt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "wrV" = (
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -81578,6 +81858,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"wCC" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "wCI" = (
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/openspace,
@@ -82345,6 +82636,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/security/holding_cell)
+"wOm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/asphalt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "wOn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -82734,6 +83029,12 @@
 	},
 /turf/open/openspace,
 /area/station/security/prison)
+"wTa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "wTg" = (
 /turf/closed/wall,
 /area/station/engineering/main)
@@ -83976,6 +84277,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
+"xik" = (
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/icemoon/underground/unexplored/rivers/deep)
 "xit" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/structure/table/wood,
@@ -84149,6 +84456,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
+"xkN" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/misc/beach/sand,
+/area/icemoon/underground/unexplored/rivers/deep)
 "xkW" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
@@ -87685,6 +87996,10 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/toilet)
+"yif" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/floor/asphalt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "yiv" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -87719,6 +88034,10 @@
 /obj/structure/sign/warning/cold_temp/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"yjf" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/asphalt,
+/area/icemoon/underground/unexplored/rivers/deep)
 "yjh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -112421,7 +112740,7 @@ pGD
 pGD
 gpH
 pGD
-brE
+uxv
 pXV
 oSU
 oSU
@@ -112672,7 +112991,7 @@ thA
 ghx
 ghx
 ghx
-brE
+uxv
 gpH
 pGD
 pGD
@@ -112929,7 +113248,7 @@ thA
 ghx
 ghx
 ghx
-iHF
+dgP
 gpH
 pGD
 pGD
@@ -126818,11 +127137,11 @@ euu
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+siZ
+siZ
+siZ
+siZ
 oSU
 oSU
 oSU
@@ -127073,14 +127392,14 @@ vOF
 vOF
 euu
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+siZ
+siZ
+vCs
+wrQ
+qde
+siZ
+siZ
 oSU
 oSU
 oSU
@@ -127330,15 +127649,15 @@ aFD
 aFD
 euu
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+qde
+nye
+xkN
+nye
+pgB
+doY
+siZ
+siZ
 oSU
 oSU
 cGX
@@ -127587,15 +127906,15 @@ qiu
 aFD
 euu
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+gWl
+nye
+nye
+nye
+klA
+knM
+qde
+siZ
 oSU
 oSU
 cGX
@@ -127845,16 +128164,16 @@ euu
 euu
 vuT
 vuT
+nuS
 vuT
-vuT
-vuT
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+hWE
+wOm
+vbv
+siZ
+lWJ
+siZ
+siZ
+siZ
 cGX
 aeZ
 aeZ
@@ -128100,19 +128419,19 @@ pxg
 aFD
 euu
 euu
-vuT
-vuT
-vuT
-vuT
-vuT
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-cGX
+nHl
+tui
+qqr
+tui
+hWE
+yif
+pgB
+vbv
+nye
+tDb
+siZ
+siZ
+nib
 aeZ
 aeZ
 aeZ
@@ -128355,21 +128674,21 @@ pxg
 vOF
 gWs
 aFD
-euu
-euu
-vuT
-vuT
-vuT
-vuT
-vuT
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-cGX
+wlZ
+lQR
+tui
+wTa
+jnO
+tui
+tui
+pgB
+yjf
+nye
+nye
+xik
+siZ
+slC
+nib
 aeZ
 aeZ
 aeZ
@@ -128614,19 +128933,19 @@ pxg
 aFD
 euu
 euu
-vuT
-vuT
-vuT
-vuT
-vuT
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-cGX
+nHl
+tDe
+qtB
+hWE
+hWE
+wrT
+srN
+nye
+nye
+nye
+siZ
+siZ
+hxR
 aeZ
 aeZ
 aeZ
@@ -128871,18 +129190,18 @@ cQQ
 aFD
 euu
 euu
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+siZ
+nye
+siZ
+pgB
+klA
+vbv
+siZ
+ezO
+siZ
+siZ
+siZ
 cGX
 aeZ
 aeZ
@@ -129129,15 +129448,15 @@ oWa
 euu
 euu
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+nye
+nye
+mXH
+tDb
+pgB
+pgB
+qde
+siZ
 oSU
 oSU
 cGX
@@ -129386,15 +129705,15 @@ aFD
 euu
 euu
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+dVG
+tDb
+tDb
+lWJ
+nye
+bgI
+siZ
+siZ
 oSU
 oSU
 cGX
@@ -129643,15 +129962,15 @@ aFD
 euu
 euu
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+lmX
+eLp
+pgB
+pgB
+pgB
+qde
+qde
+siZ
 oSU
 oSU
 cGX
@@ -129900,15 +130219,15 @@ aFD
 oSU
 euu
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+siZ
+siZ
+siZ
+tDb
+tDb
+siZ
+siZ
+siZ
 oSU
 oSU
 cGX
@@ -130158,14 +130477,14 @@ oSU
 euu
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+doY
+iyk
+tDb
+nye
+bNB
+eAg
+siZ
 oSU
 oSU
 cGX
@@ -130415,14 +130734,14 @@ oSU
 euu
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+nye
+hpS
+wOm
+nye
+scG
+wOm
+siZ
 oSU
 oSU
 cGX
@@ -130672,14 +130991,14 @@ oSU
 euu
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+kZr
+doY
+knM
+uFe
+mXH
+iLG
+siZ
 oSU
 oSU
 cGX
@@ -130926,17 +131245,17 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+siZ
+siZ
+siZ
+siZ
+siZ
+nye
+klA
+siZ
+siZ
+siZ
 oSU
 oSU
 cGX
@@ -131183,17 +131502,17 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+tpy
+sWM
+cuN
+wCC
+knM
+tDb
+bJw
+nye
+uwh
+siZ
 oSU
 oSU
 cGX
@@ -131440,17 +131759,17 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+gYs
+tDb
+tDb
+wOm
+nye
+srN
+nye
+nye
+nye
+siZ
 oSU
 oSU
 cGX
@@ -131697,17 +132016,17 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+tDb
+lWJ
+knM
+tDb
+uCU
+foC
+bSg
+cLl
+lIX
+siZ
 oSU
 oSU
 cGX
@@ -131954,17 +132273,17 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+siZ
+siZ
+siZ
+siZ
+siZ
+siZ
+siZ
+siZ
+siZ
+siZ
+siZ
 oSU
 oSU
 cGX

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -319,13 +319,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"afI" = (
-/obj/structure/transport/linear/public,
-/obj/structure/barricade/wooden{
-	name = "wooden barricade (CLOSED)"
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "afR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
@@ -875,6 +868,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
+"anx" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/sign/poster/contraband/kudzu/directional/north,
+/obj/structure/sink/kitchen/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "anz" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
@@ -2040,10 +2040,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"aBY" = (
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "aCb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3259,6 +3255,11 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
+"aTX" = (
+/obj/machinery/door/window/elevator/right/directional/north,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "aTZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -3313,6 +3314,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/security/courtroom)
+"aUp" = (
+/obj/item/pickaxe,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "aUt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3438,8 +3443,12 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aVL" = (
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers/deep)
+/obj/structure/transport/linear/public,
+/obj/structure/barricade/wooden{
+	name = "wooden barricade (CLOSED)"
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "aVM" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -3569,6 +3578,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"aYs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "aYu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/disposalpipe/segment{
@@ -3578,11 +3593,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
-"aYD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/report_crimes/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "aYJ" = (
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -3663,13 +3673,8 @@
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "aZL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers)
 "aZU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4409,6 +4414,11 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/work)
+"bkj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/corner,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "bkq" = (
 /obj/machinery/door/window/left/directional/west{
 	name = "Graveyard Access";
@@ -4422,6 +4432,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/service)
+"bkA" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "bkC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5522,6 +5540,11 @@
 /obj/item/trash/semki,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"byx" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "byA" = (
 /obj/structure/table,
 /obj/machinery/firealarm/directional/west,
@@ -5656,6 +5679,12 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/qm)
+"bAk" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "bAo" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -5854,6 +5883,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"bCU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
+"bCZ" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "bDi" = (
 /obj/machinery/door/window/left/directional/west,
 /obj/structure/cable,
@@ -7214,14 +7253,15 @@
 /turf/closed/wall/r_wall,
 /area/station/command/eva)
 "bWp" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/obj/machinery/door/window/elevator/right/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "bWv" = (
 /obj/item/radio/intercom/directional/south,
@@ -7683,12 +7723,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
 "ccx" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/button/elevator/directional/east,
-/obj/machinery/lift_indicator/directional/east,
-/obj/machinery/door/window/elevator/right/directional/north,
-/obj/effect/turf_decal/caution/stand_clear/white,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "ccz" = (
 /obj/item/radio/intercom/directional/east,
@@ -8175,12 +8214,6 @@
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
-"cjE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "cjI" = (
 /obj/structure/tram/spoiler{
 	dir = 8
@@ -8315,12 +8348,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
-"cmt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "cmu" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/sign/warning/electric_shock/directional/north,
@@ -9015,8 +9042,8 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
 "cvr" = (
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/decal/cleanable/fuel_pool,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/holosign/barrier/atmos/tram,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "cvB" = (
@@ -10424,14 +10451,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "cOS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/south{
-	id = "tram_perma_lift"
-	},
-/obj/machinery/lift_indicator/directional/south{
-	linked_elevator_id = "tram_perma_lift"
-	},
-/turf/open/floor/iron/smooth,
+/obj/structure/toiletbong,
+/obj/structure/thermoplastic,
+/obj/structure/chair/sofa/bench/tram/left,
+/obj/structure/thermoplastic/light,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "cPd" = (
 /obj/structure/cable,
@@ -10567,13 +10592,6 @@
 	dir = 8
 	},
 /area/station/command/eva)
-"cQG" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "cQL" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -10782,10 +10800,12 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "cUB" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/service/hydroponics/garden)
 "cUG" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /obj/effect/turf_decal/stripes/red/corner{
@@ -11844,10 +11864,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/textured,
 /area/mine/mechbay)
-"diK" = (
-/obj/machinery/door/window/elevator/right/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "diL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -12593,10 +12609,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"dsx" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "dsR" = (
 /obj/machinery/conveyor/inverted{
 	dir = 10;
@@ -12901,14 +12913,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
-"dxl" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "dxm" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/toggle/labcoat,
@@ -13130,12 +13134,6 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
-"dAg" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "dAh" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/preopen{
@@ -13273,6 +13271,10 @@
 "dBZ" = (
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"dCh" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "dCy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -13989,12 +13991,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"dNg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "dNw" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -14453,11 +14449,6 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/checker,
 /area/station/science/lab)
-"dVC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "dVF" = (
 /obj/structure/sign/warning/secure_area/directional/north,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -14880,10 +14871,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/medical/morgue)
-"ebS" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/iron/dark,
-/area/icemoon/underground/explored)
 "ebW" = (
 /obj/structure/fence/cut/medium{
 	dir = 8
@@ -15039,10 +15026,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/interrogation)
-"efa" = (
-/obj/item/pickaxe,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit/departure_lounge)
 "eff" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/white/line{
@@ -15196,8 +15179,8 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
 "eha" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/lava/plasma/ice_moon,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "ehc" = (
 /turf/open/floor/plating,
@@ -15400,12 +15383,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
-"eju" = (
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "ejK" = (
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 4
@@ -16729,6 +16706,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth_large,
 /area/station/command/heads_quarters/hos)
+"eDR" = (
+/turf/open/openspace,
+/area/icemoon/underground/explored)
 "eEl" = (
 /obj/structure/railing{
 	dir = 8
@@ -17197,14 +17177,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"eLe" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "eLl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -17605,6 +17577,16 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/security/brig/upper)
+"eSk" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "eSn" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/assistant,
@@ -17996,18 +17978,18 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"eWU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/spawner/random/maintenance/dumpster,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "eWV" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"eWY" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "eXa" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4
@@ -18762,11 +18744,6 @@
 "fhL" = (
 /obj/structure/sign/warning/directional/north,
 /turf/open/openspace/icemoon/keep_below,
-/area/icemoon/underground/explored)
-"fhR" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "fhW" = (
 /obj/structure/disposalpipe/segment{
@@ -20861,9 +20838,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
-"fOt" = (
-/turf/open/openspace,
-/area/station/hallway/primary/central)
 "fOH" = (
 /obj/structure/fence/post{
 	dir = 1
@@ -21762,11 +21736,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
-"gce" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "gcu" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/cable,
@@ -22061,16 +22030,20 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ghe" = (
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/genturf/blue,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+"ghl" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
+"ght" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fence{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
-"ghl" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "ghx" = (
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
@@ -23052,6 +23025,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
+"gul" = (
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "guz" = (
 /obj/structure/rack,
 /obj/item/lighter,
@@ -24317,6 +24294,14 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/lab)
+"gNs" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "gNC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/sign/warning/secure_area/directional/north,
@@ -24415,6 +24400,16 @@
 	},
 /turf/open/openspace,
 /area/station/cargo/storage)
+"gOK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/south{
+	id = "tram_perma_lift"
+	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "tram_perma_lift"
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "gOP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -24825,6 +24820,10 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/stone,
 /area/station/service/bar/atrium)
+"gUw" = (
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "gUx" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -24878,8 +24877,8 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "gVx" = (
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "gVB" = (
 /obj/structure/chair/stool/directional/west,
@@ -25016,6 +25015,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"gXd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "gXf" = (
 /obj/machinery/duct,
 /obj/machinery/door/poddoor/preopen{
@@ -26721,9 +26725,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "hwe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/iron/smooth,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "hwm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -27116,8 +27121,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "hBG" = (
-/obj/effect/mapping_helpers/no_atoms_ontop,
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "hBZ" = (
 /obj/structure/table/wood,
@@ -29559,9 +29564,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "ilw" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/turf/closed/mineral/random/snow,
+/area/station/service/chapel)
 "ily" = (
 /turf/open/openspace,
 /area/station/science/xenobiology)
@@ -30450,11 +30454,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
-"izN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/enlist/directional/west,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "izT" = (
 /obj/structure/closet/crate{
 	name = "Firing Range Supplies Set"
@@ -30693,14 +30692,6 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
-"iED" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "iEN" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -31006,12 +30997,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
-"iJG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/left/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "iJK" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -32583,10 +32568,6 @@
 "jfc" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/hop)
-"jfp" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit/departure_lounge)
 "jfF" = (
 /obj/structure/rack,
 /obj/item/shovel,
@@ -32759,6 +32740,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"jix" = (
+/obj/structure/fence{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "jiU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -32953,6 +32941,11 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
+"jlz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/west,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "jlF" = (
 /obj/machinery/computer/arcade/amputation{
 	dir = 4
@@ -33225,6 +33218,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"jqd" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/iron/dark,
+/area/icemoon/underground/explored)
 "jqj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33306,13 +33303,6 @@
 /obj/structure/railing/corner/end/flip,
 /turf/open/floor/iron,
 /area/mine/production)
-"jrV" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "jrX" = (
 /obj/item/cigbutt,
 /obj/structure/sign/warning/cold_temp/directional/north,
@@ -34167,6 +34157,12 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
+"jDL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/crayon,
+/obj/effect/spawner/random/trash/deluxe_garbage,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "jDM" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/flora/bush/sunny/style_random,
@@ -35214,6 +35210,11 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/science/cytology)
+"jRy" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "jRA" = (
 /turf/open/openspace,
 /area/station/service/bar/atrium)
@@ -35703,6 +35704,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"jZz" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "jZD" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -37255,6 +37260,13 @@
 /obj/structure/mirror/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/mine/laborcamp)
+"kwT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "kwX" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -37881,6 +37893,12 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"kEF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/left/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "kEM" = (
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
@@ -38272,10 +38290,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "kJS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/crayon,
-/obj/effect/spawner/random/trash/deluxe_garbage,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "kJU" = (
 /obj/structure/girder,
@@ -38377,6 +38395,11 @@
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"kLk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "kLr" = (
 /obj/structure/table/wood,
@@ -39355,12 +39378,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
-"kYD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/garbage,
-/obj/effect/spawner/random/junk_shell,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "kYF" = (
 /mob/living/basic/goose/vomit,
 /turf/open/floor/wood,
@@ -40704,10 +40721,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/morgue)
-"lsu" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "lsA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -41059,6 +41072,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/interior)
+"lxl" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/decal/cleanable/fuel_pool,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "lxu" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -42052,10 +42070,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/armory/upper)
 "lMG" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "lMK" = (
 /obj/structure/table,
@@ -42107,6 +42124,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"lNA" = (
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "lNC" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -42329,6 +42350,12 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
+"lPN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "lPW" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -42437,6 +42464,14 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/space_hut/cabin)
+"lRa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "lRc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -42691,12 +42726,6 @@
 	dir = 4
 	},
 /area/station/engineering/storage_shared)
-"lVn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "lVr" = (
 /obj/structure/fence/cut/medium{
 	dir = 1
@@ -43452,17 +43481,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/eva)
+"mhq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "mhx" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/office)
-"mhD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "mhG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -44190,13 +44219,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"msH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "msM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/corner/end/flip{
@@ -44232,6 +44254,10 @@
 	dir = 1
 	},
 /area/mine/eva/lower)
+"mto" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "mtq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood,
@@ -44467,6 +44493,22 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/fore)
+"mxG" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/structure/table/glass,
+/obj/item/watertank{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/plant_analyzer,
+/obj/item/book/manual/hydroponics_pod_people,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "mxK" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -44883,12 +44925,14 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
 "mCP" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "mCT" = (
 /turf/open/water/no_planet_atmos/deep,
 /area/station/service/hydroponics/garden)
@@ -45322,11 +45366,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"mJp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "mJq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -45431,15 +45470,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mLd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/glass,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "mLf" = (
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
@@ -45506,11 +45538,6 @@
 /obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"mMs" = (
-/obj/structure/thermoplastic,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "mMy" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Security - Permabrig Upper Hallway South";
@@ -47039,6 +47066,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"niz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/door,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "niE" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -47194,6 +47226,10 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/commons/storage/mining)
+"nlG" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "nlJ" = (
 /obj/structure/railing{
 	dir = 5
@@ -47383,11 +47419,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
-"nnZ" = (
-/obj/structure/thermoplastic/light,
-/obj/machinery/door/airlock/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "nof" = (
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/stone,
@@ -47459,17 +47490,6 @@
 	dir = 1
 	},
 /area/mine/laborcamp/security)
-"noF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "noJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47493,6 +47513,11 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
+"noO" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "noT" = (
 /obj/effect/spawner/random/trash/bin,
 /obj/effect/decal/cleanable/dirt,
@@ -47637,16 +47662,6 @@
 /obj/machinery/vitals_reader/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
-"nqf" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "nqh" = (
 /obj/effect/decal/cleanable/blood/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
@@ -47685,13 +47700,6 @@
 /obj/structure/fluff/minepost,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
-"nrt" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "nrz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
@@ -47926,6 +47934,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
+"nuV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/underground/explored)
 "nuX" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/bush/snow/style_random,
@@ -48871,6 +48883,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"nGw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/window/elevator/left/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "nGA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -48901,10 +48918,6 @@
 /obj/effect/spawner/random/armory/barrier_grenades,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/armory/upper)
-"nGU" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/chapel)
 "nGY" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -49868,11 +49881,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
-"nTg" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "nTp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49955,6 +49963,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
+"nUn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "nUr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51922,15 +51938,6 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
-"owq" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "owr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -53804,6 +53811,12 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/disposal/incinerator)
+"oTY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/spawner/random/junk_shell,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "oUb" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/weather/snow/corner{
@@ -55002,11 +55015,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"plK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "plN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -55171,11 +55179,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/execution/transfer)
-"poh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/window/elevator/left/directional/north,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "pos" = (
 /obj/structure/table,
 /obj/effect/spawner/round_default_module,
@@ -55371,13 +55374,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"prD" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/structure/sign/poster/contraband/kudzu/directional/north,
-/obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "prE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -55506,21 +55502,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/aft/greater)
 "ptt" = (
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/green/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/duct,
-/obj/structure/table/glass,
-/obj/item/watertank{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/item/plant_analyzer,
-/obj/item/book/manual/hydroponics_pod_people,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/enlist/directional/west,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ptQ" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
 /obj/effect/turf_decal/stripes/line,
@@ -55803,6 +55788,17 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"pxe" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "pxg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -56308,10 +56304,9 @@
 /turf/open/floor/iron/large,
 /area/station/medical/break_room)
 "pEs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/random/directional/north,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/smooth,
+/obj/structure/thermoplastic,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "pEE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -56782,6 +56777,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
+"pLX" = (
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "pLZ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -56957,6 +56956,14 @@
 "pOL" = (
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"pON" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "pOV" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -57349,16 +57356,6 @@
 "pUa" = (
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
-"pUf" = (
-/obj/machinery/door/window/elevator/left/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "pUi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57683,6 +57680,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/commons/storage/mining)
+"pYO" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "pYT" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
@@ -57751,6 +57752,11 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"pZK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "pZM" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
@@ -58330,13 +58336,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
-"qfQ" = (
-/obj/structure/fence/door{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "qfS" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -58395,10 +58394,6 @@
 /obj/effect/spawner/random/trash/mopbucket,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"qhp" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "qhy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58576,8 +58571,12 @@
 /turf/open/misc/asteroid/snow/standard_air,
 /area/station/science/cytology)
 "qkn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/light/small/red/directional/south,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/item/radio/intercom/chapel/directional/east,
+/turf/open/floor/wood/large,
 /area/icemoon/underground/explored)
 "qku" = (
 /obj/structure/chair/comfy/beige{
@@ -58646,12 +58645,6 @@
 /obj/item/wirecutters,
 /turf/open/floor/plating,
 /area/station/construction)
-"qlu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/status_display/ai/directional/north,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "qlw" = (
 /obj/machinery/disposal/bin,
 /obj/item/radio/intercom/prison/directional/north,
@@ -58743,16 +58736,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
-"qmQ" = (
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "qmU" = (
 /obj/machinery/duct,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/plating,
 /area/station/medical/virology)
+"qmV" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "qnj" = (
 /turf/closed/wall,
 /area/station/commons/locker)
@@ -59059,6 +59055,11 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/large,
 /area/station/engineering/storage/tech)
+"qqY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "qrb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59382,17 +59383,6 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
-"qwI" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "qwN" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Research Division North";
@@ -59457,10 +59447,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"qxr" = (
-/obj/structure/transport/linear/public,
-/turf/open/space/basic,
-/area/icemoon/underground/explored)
 "qxu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59492,6 +59478,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"qxU" = (
+/obj/machinery/door/window/elevator/right/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "qxY" = (
 /obj/item/chair/plastic,
 /obj/effect/decal/cleanable/dirt,
@@ -59661,11 +59651,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
-"qBD" = (
-/obj/effect/spawner/random/trash/bin,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "qBU" = (
 /obj/structure/sign/warning/directional/east,
 /obj/machinery/light/small/directional/east,
@@ -59711,9 +59696,9 @@
 /turf/open/floor/plating,
 /area/station/security/prison/mess)
 "qCx" = (
-/obj/structure/thermoplastic,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/work_for_a_future/directional/north,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "qCA" = (
 /obj/structure/table/wood,
@@ -59882,6 +59867,11 @@
 /obj/structure/weightmachine,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"qEG" = (
+/obj/effect/spawner/random/trash/bin,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "qEJ" = (
 /turf/closed/wall,
 /area/station/service/chapel/office)
@@ -60118,14 +60108,6 @@
 	dir = 1
 	},
 /area/station/medical/virology)
-"qHM" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "qHO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench/right{
@@ -60256,8 +60238,10 @@
 /turf/open/floor/wood/large,
 /area/mine/eva/lower)
 "qJB" = (
-/obj/machinery/door/window/elevator/right/directional/north,
-/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "qJT" = (
@@ -61233,11 +61217,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"qWE" = (
-/obj/structure/transport/linear/public,
-/obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "qWI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
@@ -62839,6 +62818,11 @@
 /obj/structure/sign/poster/contraband/the_big_gas_giant_truth/directional/north,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"rsp" = (
+/obj/structure/thermoplastic,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "rsw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -62897,7 +62881,8 @@
 	},
 /area/station/security/prison/safe)
 "rsO" = (
-/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/transport/linear/public,
+/obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "rsR" = (
@@ -63992,12 +63977,6 @@
 /obj/structure/sign/poster/official/work_for_a_future/directional/west,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
-"rIK" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "rIU" = (
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
@@ -64088,6 +64067,17 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"rLg" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "rLl" = (
 /obj/structure/sign/nanotrasen/directional/north,
 /turf/open/floor/iron,
@@ -64796,8 +64786,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rVr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/work_for_a_future/directional/north,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "rVB" = (
@@ -64900,9 +64890,8 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rWJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence/door,
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/no_atoms_ontop,
+/turf/closed/wall,
 /area/icemoon/underground/explored)
 "rWO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65291,8 +65280,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "scr" = (
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/west,
+/obj/machinery/lift_indicator/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "sct" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -65414,7 +65409,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/eva)
 "seb" = (
-/turf/open/openspace,
+/obj/structure/fence/door{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "sen" = (
 /obj/structure/cable,
@@ -65805,10 +65804,11 @@
 /turf/closed/wall,
 /area/station/maintenance/fore)
 "skm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "skn" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -66402,6 +66402,15 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/aft)
+"srv" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "srw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -66667,10 +66676,6 @@
 	dir = 1
 	},
 /area/station/commons/lounge)
-"suK" = (
-/obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "suL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67639,14 +67644,6 @@
 "sIt" = (
 /turf/closed/wall,
 /area/station/maintenance/central/lesser)
-"sIy" = (
-/obj/structure/toiletbong,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/left,
-/obj/structure/thermoplastic/light,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "sIA" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -68764,11 +68761,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"tbc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/wood,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "tbh" = (
 /turf/open/floor/iron/half{
 	dir = 1
@@ -69070,10 +69062,6 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"tfL" = (
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/genturf/blue,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "tfM" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -69188,11 +69176,9 @@
 /turf/open/genturf/blue,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "thB" = (
-/obj/structure/fence{
-	dir = 2
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "thC" = (
 /obj/structure/closet/crate,
@@ -69796,12 +69782,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
-"toD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "toG" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -69927,6 +69907,14 @@
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/plating,
 /area/station/medical/morgue)
+"tqB" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/elevator/directional/east,
+/obj/machinery/lift_indicator/directional/east,
+/obj/machinery/door/window/elevator/right/directional/north,
+/obj/effect/turf_decal/caution/stand_clear/white,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/garden)
 "tqJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -69989,6 +69977,16 @@
 /obj/structure/sign/poster/official/obey/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/execution/transfer)
+"trG" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "trK" = (
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron/dark,
@@ -70083,6 +70081,12 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"tti" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ttw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/smooth_large,
@@ -70386,6 +70390,12 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"txG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "txI" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating,
@@ -71733,6 +71743,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/storage)
+"tQd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "tQg" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -71740,10 +71756,6 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage/tech)
-"tQk" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "tQx" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 10
@@ -72188,6 +72200,12 @@
 /obj/machinery/light/small/red/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/greater)
+"tXz" = (
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "tXB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73653,12 +73671,6 @@
 "utC" = (
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
-"utK" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "utR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -75266,14 +75278,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
-"uSC" = (
-/obj/machinery/light/small/red/directional/south,
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/item/radio/intercom/chapel/directional/east,
-/turf/open/floor/wood/large,
-/area/icemoon/underground/explored)
 "uTk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -76212,6 +76216,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"vhK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "vhT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
@@ -76285,6 +76294,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"vjs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "vjA" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Service - Kitchen"
@@ -76335,8 +76354,9 @@
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "vkk" = (
-/turf/closed/mineral/random/snow,
-/area/station/service/chapel)
+/obj/structure/transport/linear/public,
+/turf/open/space/basic,
+/area/icemoon/underground/explored)
 "vkz" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/stripes/line{
@@ -76614,17 +76634,6 @@
 	dir = 8
 	},
 /area/station/science/explab)
-"vnS" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "vnU" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -77679,16 +77688,6 @@
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"vCp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "vCy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79416,11 +79415,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/eva)
-"wcR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "wdg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79495,6 +79489,16 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"weH" = (
+/obj/machinery/door/window/elevator/left/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "weI" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -82469,15 +82473,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/openspace,
 /area/station/service/bar/atrium)
-"wXd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/west,
-/obj/machinery/lift_indicator/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "wXh" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
 	dir = 8
@@ -83376,6 +83371,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
+"xin" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/report_crimes/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "xit" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/structure/table/wood,
@@ -83418,9 +83418,9 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "xiL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing/corner,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/north,
+/turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "xiO" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -85571,11 +85571,6 @@
 /obj/item/gun/syringe,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/storage)
-"xLY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "xMf" = (
 /obj/structure/railing{
 	dir = 1
@@ -86598,11 +86593,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
-"ybp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/west,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "ybq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -86795,13 +86785,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "ydH" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "ydI" = (
 /turf/closed/wall/r_wall,
@@ -87031,6 +87022,12 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/grimy,
 /area/station/ai/satellite/interior)
+"yhK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/spawner/random/maintenance/dumpster,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "yhM" = (
 /obj/structure/rack,
 /obj/machinery/light/cold/directional/north,
@@ -102017,9 +102014,9 @@ oSU
 oSU
 oSU
 gFX
-eWU
-izN
-kJS
+yhK
+ptt
+jDL
 gFX
 gFX
 gFX
@@ -102274,10 +102271,10 @@ oSU
 oSU
 oSU
 gFX
-cmt
-lVn
+aYs
+tQd
 eHt
-pUf
+weH
 nTH
 nTH
 gFX
@@ -102531,10 +102528,10 @@ oSU
 oSU
 oSU
 gFX
-pEs
-hwe
+tti
+pZK
 kdm
-noF
+bWp
 nTH
 nTH
 gFX
@@ -102788,9 +102785,9 @@ oSU
 oSU
 oSU
 gFX
-qlu
-nTg
-cOS
+kJS
+byx
+gOK
 gFX
 gFX
 gFX
@@ -103046,10 +103043,10 @@ oSU
 gFX
 gFX
 wMB
-qfQ
-thB
+seb
+jix
 wMB
-kYD
+oTY
 gFX
 ghx
 ghx
@@ -103301,13 +103298,13 @@ thA
 thA
 thA
 gFX
-qBD
+qEG
 eHt
 bJv
 aCI
 cLf
-mLd
-qkn
+ydH
+hBG
 ghx
 ghx
 thA
@@ -103559,10 +103556,10 @@ thA
 thA
 gFX
 kdm
-xiL
-rIK
-msH
-rIK
+bkj
+hwe
+kwT
+hwe
 gFX
 gFX
 ghx
@@ -103815,13 +103812,13 @@ thA
 thA
 thA
 gFX
-aYD
-dVC
+xin
+mhq
 cjI
 aMC
 wuN
 nLK
-qkn
+hBG
 ghx
 ghx
 thA
@@ -104078,7 +104075,7 @@ aMC
 uWq
 bKQ
 wuN
-qkn
+hBG
 ghx
 ghx
 thA
@@ -104330,12 +104327,12 @@ thA
 thA
 gFX
 cLf
-vnS
+rLg
 eiQ
 uWq
 fHU
 wuN
-qkn
+hBG
 ghx
 ghx
 thA
@@ -104585,11 +104582,11 @@ thA
 thA
 ghx
 ghx
-qkn
+hBG
 cLf
-eLe
+pON
 aMC
-mMs
+rsp
 uWq
 aMC
 gFX
@@ -104842,14 +104839,14 @@ ghx
 ghx
 ghx
 ghx
-qkn
-xLY
-eLe
+hBG
+vhK
+pON
 wuN
 rOU
 qFF
-nnZ
-qkn
+jRy
+hBG
 ghx
 ghx
 ijY
@@ -105099,14 +105096,14 @@ ghx
 ghx
 ghx
 ghx
-qkn
+hBG
 cLf
-owq
+srv
 aMC
-sIy
+cOS
 qFF
 cqV
-qkn
+hBG
 ghx
 ghx
 ghx
@@ -105356,14 +105353,14 @@ ghx
 ghx
 ghx
 ghx
-qkn
+hBG
 eHt
 gFX
 aMC
 aMC
 oge
 aMC
-qkn
+hBG
 ghx
 ghx
 ghx
@@ -105615,7 +105612,7 @@ ghx
 ghx
 gFX
 eHt
-qHM
+gNs
 txh
 cqV
 uWq
@@ -105871,13 +105868,13 @@ thA
 thA
 ghx
 gFX
-rVr
-ydH
+qCx
+mCP
 wuN
 nov
 dzI
 aMC
-qkn
+hBG
 ghx
 ghx
 iDt
@@ -106127,14 +106124,14 @@ ghx
 thA
 thA
 ghx
-qkn
+hBG
 eHt
-dxl
+bkA
 aMC
-mMs
+rsp
 dzI
 eiQ
-qkn
+hBG
 ghx
 ghx
 iDt
@@ -106384,14 +106381,14 @@ ghx
 ghx
 thA
 ghx
-qkn
+hBG
 eHt
 gFX
 aMC
-qCx
+pEs
 vrk
 aMC
-qkn
+hBG
 ghx
 ghx
 iDt
@@ -106641,9 +106638,9 @@ ghx
 ghx
 thA
 ghx
-qkn
+hBG
 cLf
-qwI
+pxe
 eiQ
 uWq
 kdq
@@ -106898,14 +106895,14 @@ ghx
 ghx
 ghx
 ghx
-qkn
-tbc
-jrV
+hBG
+qqY
+qmV
 kJN
 aMC
 sAc
 iOk
-eha
+nuV
 ghx
 iDt
 iDt
@@ -107156,13 +107153,13 @@ ghx
 ghx
 ghx
 gFX
-cUB
-lMG
+noO
+eWY
 vBN
 vBN
 lhB
 vBN
-eha
+nuV
 ghx
 ghx
 iDt
@@ -107415,10 +107412,10 @@ ghx
 gFX
 gFX
 gFX
-gVx
-gVx
-wcR
-gVx
+pLX
+pLX
+cvr
+pLX
 gFX
 ghx
 ghx
@@ -112812,10 +112809,10 @@ ghx
 gFX
 vBN
 vBN
-gVx
-gVx
-wcR
-gVx
+pLX
+pLX
+cvr
+pLX
 vBN
 gFX
 oSU
@@ -120018,7 +120015,7 @@ nqh
 tgU
 gFX
 gFX
-cjE
+lPN
 usr
 usr
 hgg
@@ -120275,11 +120272,11 @@ kdm
 bJv
 gFX
 nTH
-iJG
+kEF
 msM
 cBz
 cBz
-gce
+lMG
 bJv
 aeV
 lLs
@@ -120532,7 +120529,7 @@ kdm
 bJv
 gFX
 nTH
-skm
+xiL
 eHt
 kdm
 eHt
@@ -121556,7 +121553,7 @@ lhB
 vBN
 thL
 tgU
-mhD
+thB
 jRP
 usr
 usr
@@ -133393,7 +133390,7 @@ oSU
 gFX
 lhB
 lhB
-mJp
+kLk
 lhB
 lhB
 gFX
@@ -134942,8 +134939,8 @@ gFX
 nTH
 nTH
 gFX
-dsx
-hBG
+nlG
+rWJ
 aKb
 iDt
 iDt
@@ -135195,12 +135192,12 @@ vBN
 vBN
 vBN
 lhB
-wXd
-ybp
+scr
+jlz
 ohF
 efl
 eHt
-tQk
+lNA
 chg
 iDt
 iDt
@@ -135452,12 +135449,12 @@ vBN
 lhB
 vBN
 vBN
-aZL
+nUn
 eHt
 cBz
-rWJ
+niz
 eHt
-hBG
+rWJ
 pJm
 iDt
 iDt
@@ -135712,7 +135709,7 @@ lhB
 gBp
 eHt
 cBz
-ghe
+ght
 eHt
 gFX
 xMq
@@ -135954,7 +135951,7 @@ xMq
 oSU
 oSU
 oSU
-aVL
+gFX
 gFX
 gFX
 gFX
@@ -135966,11 +135963,11 @@ vBN
 lhB
 vBN
 vBN
-iED
+lRa
 kdm
 cBz
-ghe
-aBY
+ght
+gul
 gFX
 iDt
 xMq
@@ -136211,9 +136208,9 @@ xMq
 oSU
 oSU
 oSU
-aVL
-qxr
-poh
+gFX
+vkk
+nGw
 luS
 pAj
 tgU
@@ -136468,9 +136465,9 @@ xMq
 oSU
 oSU
 oSU
-aVL
-qxr
-diK
+gFX
+vkk
+qxU
 eHt
 cLf
 gFX
@@ -136480,7 +136477,7 @@ vBN
 lhB
 lhB
 vBN
-aZL
+nUn
 bJv
 cBz
 gFX
@@ -136725,9 +136722,9 @@ iDt
 oSU
 oSU
 oSU
-aVL
 gFX
-dNg
+gFX
+bCU
 aCI
 cLf
 bJv
@@ -137252,7 +137249,7 @@ vBN
 lhB
 vBN
 gFX
-fhR
+rVr
 bJv
 gFX
 oSU
@@ -138269,7 +138266,7 @@ oSU
 oSU
 oSU
 gFX
-qhp
+gVx
 bJv
 eHt
 bJv
@@ -138526,12 +138523,12 @@ oSU
 gFX
 gFX
 gFX
-eju
+tXz
 eHt
 cLf
 cLf
-dsx
-nqf
+nlG
+eSk
 lhB
 vBN
 vBN
@@ -138781,21 +138778,21 @@ oSU
 oSU
 oSU
 gFX
-rsO
-afI
+dCh
+aVL
 usr
 bJv
-lsu
+eha
 bJv
 eHt
-cQG
+qJB
 lhB
 vBN
 vBN
 vBN
 gFX
 kdm
-ilw
+jZz
 gFX
 oSU
 oSU
@@ -139038,21 +139035,21 @@ oSU
 oSU
 oSU
 gFX
-cvr
-afI
-toD
+lxl
+aVL
+txG
 bJv
 cLf
 bJv
 kdm
-bWp
+trG
 gFX
 gFX
 gFX
 gFX
 gFX
 tgU
-ilw
+jZz
 gFX
 oSU
 oSU
@@ -139295,20 +139292,20 @@ oSU
 oSU
 oSU
 gFX
-suK
-qWE
-qJB
+mto
+rsO
+aTX
 eHt
-lsu
+eha
 gFX
 cLf
-xLY
+vhK
 usr
 eHt
 usr
 kdm
-qmQ
-plK
+gUw
+gXd
 kdm
 gFX
 oSU
@@ -167556,7 +167553,7 @@ tjo
 tjo
 tjo
 tjo
-scr
+aZL
 gFX
 wlK
 wlK
@@ -167813,9 +167810,9 @@ tjo
 tjo
 tjo
 tjo
-scr
-seb
-seb
+aZL
+eDR
+eDR
 wlK
 lhB
 lhB
@@ -168070,9 +168067,9 @@ tjo
 tjo
 tjo
 tjo
-scr
-seb
-seb
+aZL
+eDR
+eDR
 wlK
 lhB
 lhB
@@ -168327,7 +168324,7 @@ tjo
 tjo
 tjo
 tjo
-scr
+aZL
 gFX
 gFX
 gFX
@@ -169360,7 +169357,7 @@ tjo
 thA
 thA
 thA
-tfL
+ghe
 iLh
 pwg
 peG
@@ -185815,7 +185812,7 @@ caA
 mty
 urQ
 sQI
-prD
+anx
 pme
 pme
 aon
@@ -186327,13 +186324,13 @@ gFX
 uVb
 exw
 mqd
-ptt
+mxG
 wDb
 oZG
 oZG
 rZY
 oZG
-vCp
+vjs
 exw
 exw
 exw
@@ -201238,7 +201235,7 @@ xeJ
 oTA
 kub
 oTA
-nGU
+bCZ
 wrX
 wrX
 wrX
@@ -201746,13 +201743,13 @@ lvt
 lvt
 xMq
 xMq
-vkk
+ilw
 wrX
 gEE
 wrX
 wee
-ebS
-uSC
+jqd
+qkn
 gFX
 xMq
 xMq
@@ -202003,7 +202000,7 @@ lvt
 lvt
 xMq
 xMq
-vkk
+ilw
 wrX
 gEE
 wrX
@@ -233609,7 +233606,7 @@ aPM
 oCO
 qTm
 qTm
-ccx
+tqB
 tmL
 arG
 cIa
@@ -234118,9 +234115,9 @@ lJO
 lJO
 lJO
 lJO
-dAg
-mCP
-nrt
+bAk
+ccx
+cUB
 tNd
 nor
 sst
@@ -251603,7 +251600,7 @@ oUO
 kHO
 mQi
 uja
-fOt
+mLd
 hNU
 kyL
 kyL
@@ -267023,7 +267020,7 @@ nui
 kDs
 kDs
 kDs
-jfp
+pYO
 oOD
 lDH
 qPL
@@ -267282,7 +267279,7 @@ pUa
 kDs
 jZM
 jtG
-efa
+aUp
 qPL
 ugO
 wLS
@@ -268053,7 +268050,7 @@ pUa
 kDs
 qPL
 nbK
-utK
+skm
 ixv
 qPL
 gHD

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1625,6 +1625,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/stone,
 /area/station/service/bar/atrium)
+"awj" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "awm" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/textured,
@@ -1987,6 +1998,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"aBe" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "aBf" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/engine{
@@ -3373,6 +3388,10 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
+"aUE" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "aUK" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering Equipment Storage"
@@ -3834,6 +3853,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"bby" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "bbM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -4160,10 +4189,6 @@
 	},
 /turf/open/floor/circuit,
 /area/station/ai/satellite/chamber)
-"bgI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/misc/ice/smooth,
-/area/icemoon/underground/unexplored/rivers/deep)
 "bgJ" = (
 /obj/structure/closet,
 /turf/open/floor/iron/dark/textured,
@@ -5008,6 +5033,12 @@
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
+"brX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "brY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -5496,6 +5527,10 @@
 	},
 /turf/open/floor/iron,
 /area/mine/production)
+"bxE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "bxJ" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -6424,10 +6459,6 @@
 "bJv" = (
 /turf/open/floor/catwalk_floor,
 /area/station/metro/center_station)
-"bJw" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored/rivers/deep)
 "bJD" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 4
@@ -6645,17 +6676,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"bNB" = (
-/obj/effect/decal/cleanable/chem_pile,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "bNC" = (
 /obj/structure/fence{
 	dir = 8
@@ -7017,17 +7037,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
-"bSg" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "bSi" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/railing/corner{
@@ -7561,6 +7570,12 @@
 /obj/structure/sign/poster/official/report_crimes/directional/north,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/explored)
+"bZF" = (
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "bZI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9036,16 +9051,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
-"cuN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/asphalt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "cvb" = (
 /obj/structure/sign/warning/directional/east,
 /turf/open/floor/iron/smooth,
@@ -10249,10 +10254,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth,
 /area/station/metro/outrivals_station)
-"cLl" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/asphalt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "cLo" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
@@ -11831,13 +11832,6 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"dgP" = (
-/obj/structure/fluff/minepost,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "dgQ" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/siding/dark_blue/inner_corner{
@@ -12475,9 +12469,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"doY" = (
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored/rivers/deep)
 "dpb" = (
 /obj/structure/table/wood,
 /obj/item/food/pie/cream,
@@ -12854,6 +12845,10 @@
 "duh" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/transit_tube)
+"duo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "duE" = (
 /obj/machinery/atmospherics/components/binary/tank_compressor{
 	dir = 4
@@ -14360,6 +14355,10 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/security/prison/toilet)
+"dQW" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "dQZ" = (
 /obj/machinery/door/window/right/directional/west{
 	name = "Containment Pen 9";
@@ -14638,10 +14637,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"dVG" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/sandy_dirt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "dWl" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -16628,10 +16623,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"ezO" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/misc/sandy_dirt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "eAb" = (
 /obj/structure/chair{
 	dir = 1
@@ -16639,10 +16630,6 @@
 /obj/item/toy/sword,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/port/fore)
-"eAg" = (
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored/rivers/deep)
 "eAh" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -17175,6 +17162,15 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"eHE" = (
+/obj/item/storage/medkit/fire,
+/obj/effect/mob_spawn/corpse/human/charredskeleton,
+/obj/item/ammo_casing/shotgun/buckshot,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "eHT" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -17416,12 +17412,6 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/cmo)
-"eLp" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "eLr" = (
 /turf/open/floor/iron/white/side{
 	dir = 5
@@ -17777,6 +17767,17 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
+"eRl" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "eRw" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -19401,18 +19402,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
-"foC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/fakelattice,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "foI" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -19476,6 +19465,17 @@
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
+"fpY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "fqd" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -20745,6 +20745,13 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"fJU" = (
+/obj/structure/fluff/minepost,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "fJZ" = (
 /obj/effect/turf_decal/tile/red,
 /obj/structure/railing/corner,
@@ -20878,6 +20885,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
+"fLs" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "fLu" = (
 /obj/effect/turf_decal/tile/green/opposingcorners{
 	dir = 1
@@ -21159,6 +21170,10 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"fPk" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "fPq" = (
 /obj/structure/thermoplastic/light,
 /obj/structure/thermoplastic,
@@ -22076,6 +22091,10 @@
 /obj/structure/sign/warning/directional/north,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"gdq" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "gdv" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
@@ -23300,6 +23319,10 @@
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"gtH" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "gtP" = (
 /obj/structure/table,
 /obj/item/assembly/timer,
@@ -23872,6 +23895,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/prison/work)
+"gBY" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "gCf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -23914,6 +23941,10 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"gCw" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "gCK" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -25282,10 +25313,6 @@
 /obj/structure/plasticflaps/kitchen,
 /turf/open/floor/plating,
 /area/station/service/kitchen/coldroom)
-"gWl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/misc/sandy_dirt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "gWn" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
 	dir = 4;
@@ -25463,10 +25490,6 @@
 	},
 /turf/open/misc/asteroid/snow/coldroom,
 /area/station/service/kitchen/coldroom)
-"gYs" = (
-/obj/item/ammo_casing/shotgun/buckshot,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored/rivers/deep)
 "gYt" = (
 /obj/machinery/door/window/left/directional/west{
 	name = "Research Division Delivery";
@@ -26607,13 +26630,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/metro/abandoned/abandoned_north_east_tunnel)
-"hpS" = (
-/obj/effect/decal/cleanable/plastic,
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/asphalt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "hpU" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -27135,10 +27151,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"hxR" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "hyc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -27869,6 +27881,13 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"hIF" = (
+/obj/effect/decal/cleanable/plastic,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "hIH" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -28822,9 +28841,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
-"hWE" = (
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "hWI" = (
 /obj/effect/turf_decal/box,
 /obj/effect/spawner/random/structure/closet_empty/crate/with_loot,
@@ -30720,14 +30736,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
-"iyk" = (
-/obj/effect/decal/fakelattice,
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "iym" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark/side{
@@ -31054,6 +31062,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"iEy" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "iEA" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/gloves{
@@ -31551,10 +31563,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"iLG" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored/rivers/deep)
 "iLK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32663,6 +32671,9 @@
 /obj/item/restraints/legcuffs/beartrap,
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"jbi" = (
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "jbj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33439,10 +33450,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"jnO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "jnR" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
@@ -35988,6 +35995,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"jXO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/corpse/human/charredskeleton,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "jYc" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -36950,13 +36963,6 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
-"klA" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "klW" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron,
@@ -37062,12 +37068,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
-"knM" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "knX" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -39875,13 +39875,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
-"kZr" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "kZt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -40779,12 +40772,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"lmX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/mob_spawn/corpse/human/charredskeleton,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored/rivers/deep)
 "lnc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -42368,11 +42355,6 @@
 "lIW" = (
 /turf/open/floor/plating,
 /area/station/ai/satellite/interior)
-"lIX" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/asphalt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "lJc" = (
 /obj/machinery/hydroponics/soil/rich,
 /turf/open/floor/grass,
@@ -42952,10 +42934,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/space_hut/cabin)
-"lQR" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "lRc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -43001,6 +42979,10 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/chamber)
+"lRA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/ice/smooth,
+/area/station/metro/abandoned/abandoned_collector)
 "lRD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -43330,12 +43312,6 @@
 	},
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
-"lWJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "lXd" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -45068,6 +45044,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"myV" = (
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "myX" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46291,6 +46272,11 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/central)
+"mQQ" = (
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "mQW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -46679,12 +46665,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"mXH" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "mXK" = (
 /obj/structure/table,
 /obj/structure/reagent_dispensers/servingdish,
@@ -46892,6 +46872,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"naL" = (
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "naP" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -47531,6 +47514,13 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"nin" = (
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "nit" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -47821,6 +47811,9 @@
 /obj/structure/sign/departments/holy/directional/west,
 /turf/open/openspace,
 /area/station/service/chapel)
+"nmF" = (
+/turf/closed/wall,
+/area/station/metro/abandoned/abandoned_collector)
 "nmH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48420,10 +48413,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
-"nuS" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "nuX" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/bush/snow/style_random,
@@ -48640,9 +48629,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
-"nye" = (
-/turf/open/floor/asphalt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "nyh" = (
 /obj/structure/sign/departments/maint/directional/north,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -48745,6 +48731,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/transfer)
+"nzk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/rubble,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "nzl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/item/radio/intercom/directional/east,
@@ -48913,6 +48906,10 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
+"nAY" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "nBe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -49438,9 +49435,6 @@
 	dir = 4
 	},
 /area/mine/eva)
-"nHl" = (
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "nHQ" = (
 /obj/structure/closet/firecloset,
 /obj/effect/mapping_helpers/broken_floor,
@@ -51281,6 +51275,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"oho" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "ohp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -54358,6 +54356,10 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"oUo" = (
+/obj/structure/barricade/wooden,
+/turf/open/genturf,
+/area/icemoon/underground/unexplored/rivers/deep)
 "oUp" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54502,6 +54504,10 @@
 "oWy" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/circuit_workshop)
+"oWJ" = (
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "oWN" = (
 /obj/machinery/requests_console/auto_name/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -54620,6 +54626,11 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"oXY" = (
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/barricade/wooden/snowed,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "oYa" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
@@ -55177,9 +55188,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/entry)
-"pgB" = (
-/turf/open/misc/sandy_dirt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "pgE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -58640,10 +58648,6 @@
 /obj/machinery/plumbing/sender,
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
-"qde" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored/rivers/deep)
 "qdq" = (
 /obj/structure/railing,
 /obj/structure/disposalpipe/segment{
@@ -59049,6 +59053,10 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
+"qiU" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/misc/beach/sand,
+/area/station/metro/abandoned/abandoned_collector)
 "qjb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -59586,13 +59594,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
-"qqr" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "qqs" = (
 /obj/structure/table/wood,
 /obj/item/rag,
@@ -59774,9 +59775,6 @@
 /mob/living/basic/sloth/paperwork,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"qtB" = (
-/turf/open/misc/beach/sand,
-/area/station/metro/abandoned/abandoned_collector)
 "qtD" = (
 /obj/structure/sign/warning/directional/south,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -60068,6 +60066,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"qyr" = (
+/obj/effect/decal/cleanable/greenglow/waste,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "qyG" = (
 /turf/open/floor/wood/large,
 /area/station/security/prison/rec)
@@ -62969,6 +62972,10 @@
 	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
+"rmy" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "rmA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -63800,6 +63807,10 @@
 /obj/structure/girder,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
+"rxB" = (
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "rxG" = (
 /obj/structure/ore_vent/starter_resources{
 	icon_state = "ore_vent_ice_active";
@@ -64585,6 +64596,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
+"rIv" = (
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "rIz" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -65922,17 +65937,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
-"scG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "scV" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Security - Detective's Office"
@@ -66346,9 +66350,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/mine/eva)
-"siZ" = (
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers/deep)
 "sjb" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/drone_bay)
@@ -66562,10 +66563,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/security/prison)
-"slC" = (
-/obj/structure/barricade/wooden/snowed,
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers/deep)
 "slD" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -67056,10 +67053,6 @@
 	dir = 8
 	},
 /area/station/medical/morgue)
-"srN" = (
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/asphalt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "srP" = (
 /turf/closed/wall,
 /area/station/science/breakroom)
@@ -69166,10 +69159,6 @@
 /obj/structure/sign/nanotrasen/directional/north,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
-"sWM" = (
-/obj/effect/decal/cleanable/ash/large,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored/rivers/deep)
 "sWN" = (
 /obj/structure/chair{
 	dir = 1;
@@ -69786,6 +69775,12 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
+"tfY" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "tgd" = (
 /obj/machinery/door/airlock{
 	name = "Garden"
@@ -69819,6 +69814,12 @@
 /obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"tgm" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "tgn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -69999,6 +70000,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
+"tiE" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "tiI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70427,6 +70434,10 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"tnD" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "tnI" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 10
@@ -70554,15 +70565,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"tpy" = (
-/obj/item/storage/medkit/fire,
-/obj/effect/mob_spawn/corpse/human/charredskeleton,
-/obj/item/ammo_casing/shotgun/buckshot,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "tpF" = (
 /obj/structure/closet/bombcloset/security,
 /obj/effect/turf_decal/bot,
@@ -70828,11 +70830,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"tui" = (
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "tuk" = (
 /obj/structure/closet/crate/grave,
 /turf/open/misc/dirt/dark{
@@ -71393,14 +71390,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/mine/production)
-"tDb" = (
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
-"tDe" = (
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "tDg" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
@@ -72284,6 +72273,17 @@
 /obj/effect/turf_decal/tile/dark/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"tNm" = (
+/obj/effect/decal/cleanable/chem_pile,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "tNx" = (
 /obj/structure/cable,
 /obj/machinery/light/floor,
@@ -73605,6 +73605,14 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"uia" = (
+/obj/effect/decal/fakelattice,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "uif" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74369,6 +74377,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"utk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "utr" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -74545,10 +74565,6 @@
 /obj/item/chair/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
-"uwh" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored/rivers/deep)
 "uwp" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /turf/open/floor/iron/dark,
@@ -74633,12 +74649,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"uxv" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "uxx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/air_output{
 	dir = 1
@@ -75020,17 +75030,6 @@
 /obj/structure/grille/broken,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"uCU" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "uCZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -75204,10 +75203,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/bridge)
-"uFe" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/asphalt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "uFh" = (
 /turf/open/floor/plating,
 /area/station/construction)
@@ -75942,6 +75937,10 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/metro/outrivals_station)
+"uQL" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "uQR" = (
 /obj/machinery/light_switch/directional/east,
 /obj/structure/sign/warning/biohazard/directional/north,
@@ -76588,9 +76587,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
-"vbv" = (
-/turf/open/misc/beach/sand,
-/area/icemoon/underground/unexplored/rivers/deep)
 "vbC" = (
 /obj/structure/chair{
 	dir = 4
@@ -77939,7 +77935,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "vuT" = (
-/turf/closed/wall,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/sandy_dirt,
 /area/station/metro/abandoned/abandoned_collector)
 "vuW" = (
 /obj/structure/closet/boxinggloves,
@@ -78502,13 +78499,6 @@
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"vCs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/rubble,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored/rivers/deep)
 "vCy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78559,6 +78549,9 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"vDs" = (
+/turf/open/misc/beach/sand,
+/area/station/metro/abandoned/abandoned_collector)
 "vDx" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -80236,6 +80229,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/large,
 /area/station/command/heads_quarters/ce)
+"wcz" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "wcD" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -80316,6 +80320,10 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
+"wen" = (
+/obj/structure/barricade/wooden/snowed,
+/turf/closed/wall,
+/area/station/metro/abandoned/abandoned_collector)
 "wes" = (
 /obj/effect/turf_decal/siding/wideplating_new/light,
 /obj/item/trash/bee,
@@ -80800,11 +80808,6 @@
 	dir = 6
 	},
 /area/station/command/heads_quarters/rd)
-"wlZ" = (
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/barricade/wooden/snowed,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "wme" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -81138,15 +81141,6 @@
 /obj/machinery/keycard_auth/wall_mounted/directional/north,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
-"wrQ" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/misc/sandy_dirt,
-/area/icemoon/underground/unexplored/rivers/deep)
-"wrT" = (
-/obj/effect/decal/cleanable/greenglow/waste,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/asphalt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "wrV" = (
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -81541,6 +81535,12 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"wyc" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "wyi" = (
 /obj/structure/fence/door,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -81646,6 +81646,12 @@
 	},
 /turf/open/floor/plating/snowed/coldroom,
 /area/icemoon/underground/explored)
+"wzJ" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "wzK" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Camp Supplies"
@@ -81858,17 +81864,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
-"wCC" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "wCI" = (
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/openspace,
@@ -82636,10 +82631,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/security/holding_cell)
-"wOm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/asphalt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "wOn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -83029,12 +83020,6 @@
 	},
 /turf/open/openspace,
 /area/station/security/prison)
-"wTa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "wTg" = (
 /turf/closed/wall,
 /area/station/engineering/main)
@@ -84277,12 +84262,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
-"xik" = (
-/obj/effect/decal/cleanable/insectguts,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/icemoon/underground/unexplored/rivers/deep)
 "xit" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/structure/table/wood,
@@ -84456,10 +84435,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
-"xkN" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/misc/beach/sand,
-/area/icemoon/underground/unexplored/rivers/deep)
 "xkW" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
@@ -84694,6 +84669,13 @@
 	},
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
+"xol" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "xoo" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/snowed/icemoon,
@@ -84739,6 +84721,9 @@
 /obj/item/stack/sheet/leather,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"xpG" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "xpI" = (
 /obj/effect/decal/cleanable/blood/oil/slippery,
 /turf/open/floor/catwalk_floor,
@@ -84838,6 +84823,10 @@
 /obj/structure/railing,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix)
+"xqx" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "xqy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -85224,6 +85213,12 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"xwb" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "xwc" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/decal/cleanable/dirt,
@@ -87996,10 +87991,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/toilet)
-"yif" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/floor/asphalt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "yiv" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -88034,10 +88025,6 @@
 /obj/structure/sign/warning/cold_temp/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"yjf" = (
-/obj/effect/decal/cleanable/shreds,
-/turf/open/floor/asphalt,
-/area/icemoon/underground/unexplored/rivers/deep)
 "yjh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -112740,7 +112727,7 @@ pGD
 pGD
 gpH
 pGD
-uxv
+tfY
 pXV
 oSU
 oSU
@@ -112991,7 +112978,7 @@ thA
 ghx
 ghx
 ghx
-uxv
+tfY
 gpH
 pGD
 pGD
@@ -113248,7 +113235,7 @@ thA
 ghx
 ghx
 ghx
-dgP
+fJU
 gpH
 pGD
 pGD
@@ -114533,13 +114520,13 @@ thA
 thA
 thA
 pXV
-pGD
+rxB
 pGD
 gpH
 pGD
 vPp
 pGD
-pGD
+xwb
 pXV
 oSU
 oSU
@@ -116332,13 +116319,13 @@ thA
 thA
 thA
 pXV
-pGD
+rxB
 pGD
 pGD
 pGD
 pGD
 gpH
-pGD
+xwb
 pXV
 oSU
 oSU
@@ -118388,13 +118375,13 @@ thA
 thA
 thA
 pXV
-pGD
+rxB
 gpH
 pGD
 gpH
 pGD
 pGD
-pGD
+xwb
 pXV
 oSU
 oSU
@@ -120187,7 +120174,7 @@ oSU
 oSU
 oSU
 pXV
-pGD
+rxB
 pGD
 pGD
 pGD
@@ -121986,7 +121973,7 @@ oSU
 oSU
 oSU
 pXV
-pGD
+rxB
 dPN
 pGD
 gpH
@@ -123785,7 +123772,7 @@ oSU
 oSU
 oSU
 pXV
-pGD
+rxB
 pGD
 pGD
 pGD
@@ -125841,13 +125828,13 @@ oSU
 oSU
 oSU
 euu
-aFD
+oWJ
 aFD
 aFD
 aFD
 vOF
 vOF
-aFD
+tiE
 euu
 oSU
 oSU
@@ -127137,11 +127124,11 @@ euu
 oSU
 oSU
 oSU
-siZ
-siZ
-siZ
-siZ
-siZ
+nmF
+nmF
+nmF
+nmF
+nmF
 oSU
 oSU
 oSU
@@ -127392,14 +127379,14 @@ vOF
 vOF
 euu
 oSU
-siZ
-siZ
-siZ
-vCs
-wrQ
-qde
-siZ
-siZ
+nmF
+nmF
+nmF
+nzk
+xqx
+bxE
+nmF
+nmF
 oSU
 oSU
 oSU
@@ -127640,24 +127627,24 @@ oSU
 oSU
 oSU
 euu
-aFD
+oWJ
 oWa
 vOF
 vOF
 vOF
 aFD
-aFD
+tiE
 euu
 oSU
-siZ
-qde
-nye
-xkN
-nye
-pgB
-doY
-siZ
-siZ
+nmF
+bxE
+naL
+qiU
+naL
+jbi
+xpG
+nmF
+nmF
 oSU
 oSU
 cGX
@@ -127903,18 +127890,18 @@ vOF
 aFD
 vOF
 qiu
-aFD
+gtH
 euu
 oSU
-siZ
-gWl
-nye
-nye
-nye
-klA
-knM
-qde
-siZ
+nmF
+vuT
+naL
+naL
+naL
+xol
+wyc
+bxE
+nmF
 oSU
 oSU
 cGX
@@ -128162,18 +128149,18 @@ pxg
 aFD
 euu
 euu
-vuT
-vuT
-nuS
-vuT
-hWE
-wOm
-vbv
-siZ
-lWJ
-siZ
-siZ
-siZ
+nmF
+nmF
+gCw
+nmF
+naL
+duo
+vDs
+nmF
+brX
+nmF
+nmF
+nmF
 cGX
 aeZ
 aeZ
@@ -128419,18 +128406,18 @@ pxg
 aFD
 euu
 euu
-nHl
-tui
-qqr
-tui
-hWE
-yif
-pgB
-vbv
-nye
-tDb
-siZ
-siZ
+xpG
+myV
+xol
+myV
+naL
+fPk
+jbi
+vDs
+naL
+myV
+nmF
+nmF
 nib
 aeZ
 aeZ
@@ -128674,20 +128661,20 @@ pxg
 vOF
 gWs
 aFD
-wlZ
-lQR
-tui
-wTa
-jnO
-tui
-tui
-pgB
-yjf
-nye
-nye
-xik
-siZ
-slC
+oXY
+uQL
+myV
+brX
+vuT
+myV
+myV
+jbi
+fLs
+naL
+naL
+bZF
+nmF
+wen
 nib
 aeZ
 aeZ
@@ -128933,19 +128920,19 @@ pxg
 aFD
 euu
 euu
-nHl
-tDe
-qtB
-hWE
-hWE
-wrT
-srN
-nye
-nye
-nye
-siZ
-siZ
-hxR
+xpG
+jbi
+vDs
+naL
+naL
+qyr
+aUE
+naL
+naL
+naL
+nmF
+nmF
+gBY
 aeZ
 aeZ
 aeZ
@@ -129190,18 +129177,18 @@ cQQ
 aFD
 euu
 euu
-siZ
-siZ
-nye
-siZ
-pgB
-klA
-vbv
-siZ
-ezO
-siZ
-siZ
-siZ
+nmF
+nmF
+naL
+nmF
+jbi
+xol
+vDs
+nmF
+gCw
+nmF
+nmF
+nmF
 cGX
 aeZ
 aeZ
@@ -129448,15 +129435,15 @@ oWa
 euu
 euu
 oSU
-siZ
-nye
-nye
-mXH
-tDb
-pgB
-pgB
-qde
-siZ
+nmF
+naL
+naL
+wzJ
+myV
+jbi
+jbi
+bxE
+nmF
 oSU
 oSU
 cGX
@@ -129705,15 +129692,15 @@ aFD
 euu
 euu
 oSU
-siZ
-dVG
-tDb
-tDb
-lWJ
-nye
-bgI
-siZ
-siZ
+nmF
+gdq
+myV
+myV
+brX
+naL
+lRA
+nmF
+nmF
 oSU
 oSU
 cGX
@@ -129962,15 +129949,15 @@ aFD
 euu
 euu
 oSU
-siZ
-lmX
-eLp
-pgB
-pgB
-pgB
-qde
-qde
-siZ
+nmF
+jXO
+tgm
+jbi
+jbi
+jbi
+bxE
+bxE
+nmF
 oSU
 oSU
 cGX
@@ -130219,15 +130206,15 @@ aFD
 oSU
 euu
 oSU
-siZ
-siZ
-siZ
-siZ
-tDb
-tDb
-siZ
-siZ
-siZ
+nmF
+nmF
+nmF
+nmF
+myV
+myV
+nmF
+nmF
+nmF
 oSU
 oSU
 cGX
@@ -130477,14 +130464,14 @@ oSU
 euu
 oSU
 oSU
-siZ
-doY
-iyk
-tDb
-nye
-bNB
-eAg
-siZ
+nmF
+xpG
+uia
+myV
+naL
+tNm
+iEy
+nmF
 oSU
 oSU
 cGX
@@ -130734,14 +130721,14 @@ oSU
 euu
 oSU
 oSU
-siZ
-nye
-hpS
-wOm
-nye
-scG
-wOm
-siZ
+nmF
+naL
+hIF
+duo
+naL
+fpY
+duo
+nmF
 oSU
 oSU
 cGX
@@ -130991,14 +130978,14 @@ oSU
 euu
 oSU
 oSU
-siZ
-kZr
-doY
-knM
-uFe
-mXH
-iLG
-siZ
+nmF
+nin
+xpG
+wyc
+oho
+wzJ
+aBe
+nmF
 oSU
 oSU
 cGX
@@ -131239,23 +131226,23 @@ oSU
 oSU
 oSU
 oSU
+oUo
 oSU
+oUo
 oSU
+oUo
 oSU
-oSU
-oSU
-oSU
-siZ
-siZ
-siZ
-siZ
-siZ
-siZ
-nye
-klA
-siZ
-siZ
-siZ
+nmF
+nmF
+nmF
+nmF
+nmF
+nmF
+naL
+xol
+nmF
+nmF
+nmF
 oSU
 oSU
 cGX
@@ -131502,17 +131489,17 @@ oSU
 oSU
 oSU
 oSU
-siZ
-tpy
-sWM
-cuN
-wCC
-knM
-tDb
-bJw
-nye
-uwh
-siZ
+nmF
+eHE
+tnD
+bby
+eRl
+wyc
+myV
+dQW
+naL
+nAY
+nmF
 oSU
 oSU
 cGX
@@ -131759,17 +131746,17 @@ oSU
 oSU
 oSU
 oSU
-siZ
-gYs
-tDb
-tDb
-wOm
-nye
-srN
-nye
-nye
-nye
-siZ
+nmF
+rIv
+myV
+myV
+duo
+naL
+aUE
+naL
+naL
+naL
+nmF
 oSU
 oSU
 cGX
@@ -132016,17 +132003,17 @@ oSU
 oSU
 oSU
 oSU
-siZ
-tDb
-lWJ
-knM
-tDb
-uCU
-foC
-bSg
-cLl
-lIX
-siZ
+nmF
+myV
+brX
+wyc
+myV
+wcz
+utk
+awj
+rmy
+mQQ
+nmF
 oSU
 oSU
 cGX
@@ -132273,17 +132260,17 @@ oSU
 oSU
 oSU
 oSU
-siZ
-siZ
-siZ
-siZ
-siZ
-siZ
-siZ
-siZ
-siZ
-siZ
-siZ
+nmF
+nmF
+nmF
+nmF
+nmF
+nmF
+nmF
+nmF
+nmF
+nmF
+nmF
 oSU
 oSU
 cGX

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -379,6 +379,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"agt" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "agF" = (
 /obj/structure/rack,
 /obj/item/storage/box/teargas{
@@ -7471,6 +7477,13 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/treatment_center)
+"bZM" = (
+/obj/machinery/door/window/elevator/left/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "bZQ" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/starboard)
@@ -7677,11 +7690,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
 "ccx" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/elevator/directional/east,
+/obj/machinery/lift_indicator/directional/east,
+/obj/machinery/door/window/elevator/right/directional/north,
+/turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
 "ccz" = (
 /obj/item/radio/intercom/directional/east,
@@ -20041,6 +20054,13 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"fDL" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "fDP" = (
 /obj/structure/cable,
 /obj/item/radio/intercom/prison/directional/north,
@@ -22080,6 +22100,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/mine/eva/lower)
+"giW" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "gjc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22400,6 +22427,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
+"gmU" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "gmW" = (
 /turf/closed/wall,
 /area/station/commons/fitness)
@@ -27024,14 +27056,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "hBG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/south{
-	id = "tram_perma_lift"
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
 	},
-/obj/machinery/lift_indicator/directional/south{
-	linked_elevator_id = "tram_perma_lift"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "hBZ" = (
 /obj/structure/table/wood,
@@ -27556,6 +27585,14 @@
 "hJH" = (
 /turf/open/openspace,
 /area/station/science/research)
+"hJO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "hKi" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
@@ -27564,6 +27601,16 @@
 	dir = 8
 	},
 /area/station/engineering/lobby)
+"hKr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/south{
+	id = "tram_perma_lift"
+	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "tram_perma_lift"
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "hKu" = (
 /obj/structure/sign/poster/official/cleanliness/directional/east,
 /obj/structure/closet/secure_closet/medical2,
@@ -41490,6 +41537,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"lEQ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "lET" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/briefcase/secure{
@@ -43342,6 +43393,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
+"mhL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "mhQ" = (
 /turf/closed/wall/r_wall,
 /area/station/command/teleporter)
@@ -45294,11 +45350,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mLd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "mLf" = (
@@ -55036,13 +55088,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/fore/lesser)
-"ppj" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/button/elevator/directional/east,
-/obj/machinery/lift_indicator/directional/east,
-/obj/machinery/door/window/elevator/right/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics/garden)
 "ppl" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -55402,6 +55447,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/breakroom)
+"puT" = (
+/obj/structure/transport/linear/public,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "puX" = (
 /obj/structure/table,
 /obj/item/stock_parts/scanning_module{
@@ -56090,9 +56139,8 @@
 /turf/open/floor/iron/large,
 /area/station/medical/break_room)
 "pEs" = (
-/obj/structure/transport/linear/public,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers)
 "pEE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -64531,11 +64579,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rVr" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "rVB" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
@@ -65027,11 +65073,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "scr" = (
-/obj/machinery/door/window/elevator/left/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/railing/corner/end{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "sct" = (
 /obj/structure/disposalpipe/segment,
@@ -67585,11 +67635,6 @@
 /obj/structure/flora/grass/both/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
-"sMK" = (
-/obj/structure/thermoplastic/light,
-/obj/machinery/door/airlock/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "sML" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68366,6 +68411,10 @@
 	},
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
+"sYH" = (
+/obj/structure/transport/linear/public,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "sYS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -72276,6 +72325,10 @@
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
+"udf" = (
+/obj/structure/railing,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "udj" = (
 /obj/structure/toiletbong,
 /obj/effect/decal/cleanable/dirt,
@@ -73342,13 +73395,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
-"utn" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "utr" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -74984,6 +75030,13 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
+"uTe" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "uTk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80545,10 +80598,6 @@
 /obj/machinery/griddle,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
-"wAK" = (
-/obj/structure/transport/linear/public,
-/turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "wAN" = (
 /obj/structure/sign/warning/directional/east,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -81353,6 +81402,10 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
+"wMR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/underground/explored)
 "wMT" = (
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron,
@@ -81826,6 +81879,13 @@
 "wTg" = (
 /turf/closed/wall,
 /area/station/engineering/main)
+"wTl" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "wTA" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/iron/dark/telecomms,
@@ -86468,8 +86528,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "ydH" = (
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers)
+/obj/structure/fence/door{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ydI" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/entry)
@@ -101683,9 +101746,9 @@ oSU
 oSU
 oSU
 gFX
-vBN
-vBN
-vBN
+tgU
+eHt
+tgU
 gFX
 gFX
 gFX
@@ -101940,12 +102003,12 @@ oSU
 oSU
 oSU
 gFX
-vBN
-vBN
-vBN
-scr
-pEs
-pEs
+eHt
+eHt
+eHt
+bZM
+puT
+puT
 gFX
 ghx
 ghx
@@ -102196,13 +102259,13 @@ oSU
 oSU
 oSU
 oSU
-vBN
-vBN
-vBN
-vBN
-mLd
-pEs
-wAK
+gFX
+eHt
+eHt
+eHt
+hJO
+puT
+sYH
 gFX
 ghx
 ghx
@@ -102453,10 +102516,10 @@ oSU
 oSU
 oSU
 oSU
-vBN
-vBN
-nHU
-hBG
+gFX
+eHt
+lEQ
+hKr
 gFX
 gFX
 rsO
@@ -102709,14 +102772,14 @@ oSU
 oSU
 oSU
 oSU
-oSU
-vBN
-vBN
-vBN
-vBN
-vBN
-vBN
-iDt
+aVL
+gFX
+wMB
+ydH
+wMB
+wMB
+tgU
+gFX
 ghx
 ghx
 ghx
@@ -102966,14 +103029,14 @@ thA
 thA
 thA
 thA
-thA
-vBN
-vBN
-vBN
-vBN
-vBN
-vBN
-iDt
+rsO
+eHt
+eHt
+bJv
+bJv
+eHt
+eHt
+mLd
 ghx
 ghx
 thA
@@ -103223,14 +103286,14 @@ thA
 thA
 thA
 thA
-thA
-vBN
-vBN
-vBN
-vBN
-vBN
-vBN
-ghx
+rsO
+eHt
+tgU
+tgU
+tgU
+tgU
+gFX
+gFX
 ghx
 ghx
 thA
@@ -103480,14 +103543,14 @@ thA
 thA
 thA
 thA
-thA
-vBN
-vBN
+rsO
+eHt
+tgU
 cjI
 aMC
 wuN
 nLK
-ghx
+mLd
 ghx
 ghx
 thA
@@ -103737,14 +103800,14 @@ thA
 thA
 thA
 thA
-thA
-vBN
-vBN
+rsO
+eHt
+gFX
 aMC
 uWq
 bKQ
 wuN
-ghx
+mLd
 ghx
 ghx
 thA
@@ -103994,14 +104057,14 @@ thA
 thA
 thA
 thA
-thA
-vBN
-vBN
+rsO
+eHt
+hBG
 eiQ
 uWq
 fHU
 wuN
-ghx
+mLd
 ghx
 ghx
 thA
@@ -104251,14 +104314,14 @@ thA
 thA
 ghx
 ghx
-ghx
-vBN
-vBN
+mLd
+eHt
+wTl
 aMC
 uWq
 uWq
 aMC
-ghx
+gFX
 ghx
 ghx
 thA
@@ -104508,14 +104571,14 @@ ghx
 ghx
 ghx
 ghx
-ghx
-vBN
-vBN
+mLd
+eHt
+wTl
 wuN
 rOU
 qFF
-sMK
-ghx
+gmU
+mLd
 ghx
 ghx
 ijY
@@ -104765,14 +104828,14 @@ ghx
 ghx
 ghx
 ghx
-ghx
-vBN
-vBN
+mLd
+eHt
+hBG
 aMC
 bed
 qFF
 cqV
-iDt
+mLd
 ghx
 ghx
 ghx
@@ -105022,14 +105085,14 @@ ghx
 ghx
 ghx
 ghx
-ghx
-vBN
-vBN
+mLd
+eHt
+gFX
 aMC
 aMC
 oge
 aMC
-iDt
+mLd
 ghx
 ghx
 ghx
@@ -105279,14 +105342,14 @@ thA
 thA
 ghx
 ghx
-ghx
-vBN
-vBN
+gFX
+eHt
+wTl
 txh
 cqV
 uWq
 wuN
-iDt
+gFX
 ghx
 ghx
 iDt
@@ -105536,14 +105599,14 @@ thA
 thA
 thA
 ghx
-ghx
-vBN
-vBN
+gFX
+eHt
+wTl
 wuN
 nov
 dzI
 aMC
-iDt
+mLd
 ghx
 ghx
 iDt
@@ -105793,14 +105856,14 @@ ghx
 thA
 thA
 ghx
-ghx
-vBN
-vBN
+mLd
+eHt
+hBG
 aMC
 uWq
 dzI
 eiQ
-ghx
+mLd
 ghx
 ghx
 iDt
@@ -106050,14 +106113,14 @@ ghx
 ghx
 thA
 ghx
-ghx
-vBN
-vBN
+mLd
+eHt
+gFX
 aMC
 uWq
 vrk
 aMC
-ghx
+mLd
 ghx
 ghx
 iDt
@@ -106307,14 +106370,14 @@ ghx
 ghx
 thA
 ghx
-ghx
-vBN
-nHU
+mLd
+eHt
+scr
 eiQ
 uWq
 kdq
 wuN
-ghx
+gFX
 ghx
 ghx
 iDt
@@ -106564,14 +106627,14 @@ ghx
 ghx
 ghx
 ghx
-ghx
-vBN
-vBN
+mLd
+eHt
+fDL
 kJN
 aMC
 sAc
 iOk
-ghx
+wMR
 ghx
 iDt
 iDt
@@ -106821,14 +106884,14 @@ ghx
 ghx
 ghx
 ghx
-ghx
-vBN
-vBN
+gFX
+tgU
+udf
 vBN
 vBN
 lhB
 vBN
-ghx
+wMR
 ghx
 ghx
 iDt
@@ -107078,14 +107141,14 @@ ghx
 ghx
 ghx
 ghx
-ghx
-vBN
-vBN
-vBN
-vBN
-lhB
-vBN
-ghx
+gFX
+gFX
+gFX
+rVr
+rVr
+mhL
+rVr
+gFX
 ghx
 ghx
 iDt
@@ -107336,8 +107399,8 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 lhB
@@ -107593,8 +107656,8 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 vBN
@@ -107850,8 +107913,8 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 vBN
@@ -108107,8 +108170,8 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 vBN
@@ -108364,8 +108427,8 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 nHU
@@ -108621,8 +108684,8 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 vBN
@@ -108878,8 +108941,8 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 vBN
@@ -109135,8 +109198,8 @@ thA
 thA
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 vBN
@@ -109392,8 +109455,8 @@ thA
 thA
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 vBN
@@ -109649,8 +109712,8 @@ thA
 thA
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 vBN
@@ -109906,8 +109969,8 @@ thA
 thA
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 vBN
@@ -110163,8 +110226,8 @@ thA
 thA
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 vBN
@@ -110420,8 +110483,8 @@ thA
 thA
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 vBN
@@ -110677,8 +110740,8 @@ thA
 thA
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 lhB
 vBN
@@ -110934,8 +110997,8 @@ thA
 thA
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 nHU
 lhB
 vBN
@@ -111191,8 +111254,8 @@ thA
 thA
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 lhB
 lhB
@@ -111448,8 +111511,8 @@ thA
 thA
 ghx
 ghx
-vBN
-vBN
+ghx
+ghx
 vBN
 vBN
 lhB
@@ -111967,8 +112030,8 @@ lhB
 vBN
 vBN
 vBN
-nrp
 vBN
+nrp
 gFX
 oSU
 oSU
@@ -112478,10 +112541,10 @@ ghx
 gFX
 vBN
 vBN
-vBN
-vBN
-lhB
-vBN
+rVr
+rVr
+mhL
+rVr
 vBN
 gFX
 oSU
@@ -167222,7 +167285,7 @@ tjo
 tjo
 tjo
 tjo
-ydH
+pEs
 gFX
 wlK
 wlK
@@ -167479,7 +167542,7 @@ tjo
 tjo
 tjo
 tjo
-ydH
+pEs
 vBN
 lhB
 wlK
@@ -167736,7 +167799,7 @@ tjo
 tjo
 tjo
 tjo
-ydH
+pEs
 vBN
 lhB
 wlK
@@ -167993,7 +168056,7 @@ tjo
 tjo
 tjo
 tjo
-ydH
+pEs
 gFX
 gFX
 gFX
@@ -233275,7 +233338,7 @@ aPM
 oCO
 qTm
 qTm
-ppj
+ccx
 tmL
 arG
 cIa
@@ -233784,9 +233847,9 @@ lJO
 lJO
 lJO
 lJO
-rVr
-utn
-ccx
+agt
+uTe
+giW
 tNd
 nor
 sst

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -320,6 +320,11 @@
 /obj/machinery/air_sensor/nitrogen_tank,
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
+"afr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "afz" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -475,6 +480,10 @@
 /obj/structure/platform/iron,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/range)
+"aif" = (
+/obj/structure/tram/alt/titanium,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/south_tunnel)
 "ain" = (
 /obj/structure/railing{
 	dir = 4
@@ -1232,6 +1241,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/service/bar/backroom)
+"aqW" = (
+/obj/effect/spawner/random/trash/deluxe_garbage,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "arg" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -1273,9 +1286,6 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/virology)
-"arF" = (
-/turf/open/indestructible/tram,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "arG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1587,11 +1597,6 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
-"avm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/tram,
-/area/station/metro/train_tunnels/south_tunnel)
 "avs" = (
 /obj/structure/railing{
 	dir = 8
@@ -1746,15 +1751,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
-"awP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "awR" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -1979,6 +1975,10 @@
 /obj/effect/decal/cleanable/plastic,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/station/metro/abandoned/abandoned_collector)
+"azU" = (
+/obj/effect/spawner/random/trash/ghetto_containers,
+/turf/open/floor/plating,
+/area/station/metro/center_station)
 "aAe" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2917,6 +2917,11 @@
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/station/metro/abandoned/abandoned_collector)
+"aOq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "aOx" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/vending/clothing,
@@ -3447,6 +3452,10 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"aUU" = (
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "aVb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -6409,6 +6418,12 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"bIN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/catwalk_floor,
+/area/station/metro/outrivals_station)
 "bIQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -6717,6 +6732,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/side,
 /area/station/security/range)
+"bNN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/south_tunnel)
 "bOh" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -8001,6 +8020,11 @@
 /obj/effect/turf_decal/stripes/red/box,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"cfd" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/deluxe_garbage,
+/turf/open/floor/iron/smooth,
+/area/station/metro/outrivals_station)
 "cfe" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
@@ -9075,6 +9099,7 @@
 /area/station/medical/virology)
 "cvb" = (
 /obj/structure/sign/warning/directional/east,
+/obj/effect/spawner/random/maintenance/dumpster,
 /turf/open/floor/iron/smooth,
 /area/station/metro/center_station)
 "cvg" = (
@@ -10882,12 +10907,6 @@
 /obj/structure/platform/iron,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/range)
-"cTz" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "cTD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -12553,6 +12572,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
+"dpE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass/titanium,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "dpH" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -12571,6 +12595,10 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"dqg" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "dqw" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -13403,6 +13431,10 @@
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"dBn" = (
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "dBp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14651,6 +14683,11 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage/tech)
+"dUQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "dUR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/poster/random/directional/north,
@@ -14689,6 +14726,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"dVS" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "dWl" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -14999,6 +15040,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"eao" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "eaq" = (
 /obj/structure/table,
 /obj/item/paper_bin/carbon,
@@ -15787,6 +15834,11 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"emB" = (
+/obj/structure/tram/alt/titanium,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "emG" = (
 /obj/structure/sign/nanotrasen/directional/south,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -19445,6 +19497,9 @@
 /obj/effect/spawner/random/entertainment/cigar,
 /turf/open/floor/iron,
 /area/station/service/bar)
+"foJ" = (
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/south_tunnel)
 "foO" = (
 /turf/open/floor/carpet,
 /area/station/security/prison/rec)
@@ -20563,6 +20618,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
+"fGa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "fGm" = (
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
@@ -21294,6 +21358,12 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/grimy,
 /area/station/ai/satellite/interior)
+"fQy" = (
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "fQz" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
@@ -21390,6 +21460,11 @@
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/plating/snowed/coldroom,
 /area/icemoon/underground/explored)
+"fSF" = (
+/obj/structure/fluff/minepost,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "fSP" = (
 /obj/structure/railing{
 	dir = 1
@@ -22424,6 +22499,10 @@
 	},
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"ghT" = (
+/obj/effect/spawner/random/trash/bacteria,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "ghY" = (
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
@@ -24860,7 +24939,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/tram,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/station/metro/train_tunnels/south_tunnel)
 "gQD" = (
 /obj/structure/table,
@@ -25201,6 +25283,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"gVb" = (
+/obj/effect/spawner/random/trash/moisture_trap,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "gVe" = (
 /obj/structure/table,
 /obj/effect/spawner/random/trash/food_packaging,
@@ -25867,6 +25953,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"hdG" = (
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "hdH" = (
 /obj/structure/railing{
 	dir = 1
@@ -26755,14 +26848,6 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
-"hrw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "hrN" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/laser/carbine/practice{
@@ -27528,6 +27613,13 @@
 /obj/structure/barricade/wooden,
 /turf/open/genturf/blue,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
+"hCu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "hCC" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -31554,6 +31646,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"iLg" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/titanium,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "iLh" = (
 /turf/closed/wall,
 /area/station/maintenance/port/lesser)
@@ -31852,6 +31952,11 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"iPF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "iPI" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
@@ -32667,12 +32772,6 @@
 	dir = 8
 	},
 /area/station/medical/chem_storage)
-"jaM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "jaO" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Turbine Access"
@@ -33756,9 +33855,6 @@
 "jre" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/lesser)
-"jrt" = (
-/turf/open/indestructible/tram,
-/area/station/metro/train_tunnels/south_tunnel)
 "jrv" = (
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating/snowed/icemoon,
@@ -34124,6 +34220,14 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"jwg" = (
+/obj/structure/thermoplastic,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "jwj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -38216,6 +38320,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"kBD" = (
+/obj/structure/fluff/paper/stack,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "kBL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -43173,11 +43281,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
-"lSn" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "lSu" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
@@ -43237,6 +43340,7 @@
 /area/station/medical/medbay/lobby)
 "lUe" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/sign/warning/directional/north,
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/south_tunnel)
 "lUf" = (
@@ -43584,6 +43688,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"maG" = (
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "maO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -44105,13 +44213,6 @@
 /obj/structure/flora/grass/both/style_random,
 /turf/open/misc/asteroid/snow/standard_air,
 /area/station/hallway/secondary/exit/departure_lounge)
-"mim" = (
-/obj/structure/thermoplastic,
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "miw" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -44273,6 +44374,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"mlg" = (
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "mln" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/amplifier,
@@ -45748,6 +45853,11 @@
 	dir = 8
 	},
 /area/station/metro/center_station)
+"mGm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/tram,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "mGs" = (
 /obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
 /obj/structure/cable,
@@ -46259,6 +46369,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"mOr" = (
+/obj/effect/spawner/random/trash/bacteria,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "mOx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -46362,6 +46476,11 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/storage)
+"mPE" = (
+/obj/structure/fluff/tram_rail/electric,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "mPH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46782,6 +46901,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"mWX" = (
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "mWY" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -48823,10 +48946,6 @@
 "nyC" = (
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/service/chapel)
-"nyD" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/tram,
-/area/station/metro/train_tunnels/south_tunnel)
 "nyH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51435,6 +51554,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/command/eva)
+"ogE" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "ogF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51744,6 +51867,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /turf/open/floor/iron/large,
 /area/mine/mechbay)
+"okt" = (
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "okx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/left/directional/south{
@@ -52401,6 +52528,11 @@
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/range)
+"osW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "otd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -55158,6 +55290,13 @@
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
+"pdb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron,
+/area/station/metro/outrivals_station)
 "pdd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56041,6 +56180,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"ppO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "ppQ" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/latex,
@@ -56264,6 +56409,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"ptV" = (
+/obj/effect/decal/cleanable/fuel_pool,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "ptY" = (
 /turf/closed/wall/r_wall,
 /area/station/ai/satellite/maintenance)
@@ -57284,6 +57433,11 @@
 	},
 /turf/open/floor/engine/cult,
 /area/station/service/library)
+"pIx" = (
+/obj/structure/tram,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "pIy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -57937,6 +58091,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"pSs" = (
+/obj/structure/tram,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "pSt" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -58848,6 +59009,10 @@
 /obj/machinery/plumbing/sender,
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
+"qcZ" = (
+/obj/effect/spawner/random/trash/bacteria,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "qdq" = (
 /obj/structure/railing,
 /obj/structure/disposalpipe/segment{
@@ -59415,6 +59580,11 @@
 /obj/item/wirecutters,
 /turf/open/floor/plating,
 /area/station/construction)
+"qls" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "qlw" = (
 /obj/machinery/disposal/bin,
 /obj/item/radio/intercom/prison/directional/north,
@@ -59501,10 +59671,6 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/genturf/blue,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
-"qmy" = (
-/obj/structure/tram/alt/titanium,
-/turf/open/indestructible/tram,
-/area/station/metro/train_tunnels/south_tunnel)
 "qmK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -59630,6 +59796,7 @@
 "qoS" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/glitter,
+/obj/effect/spawner/random/maintenance/dumpster,
 /turf/open/floor/plating,
 /area/station/metro/abandoned/garbage_corner)
 "qpb" = (
@@ -60821,6 +60988,10 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"qGH" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "qGJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62159,6 +62330,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/auxiliary)
+"qYE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/south_tunnel)
 "qYF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -63280,6 +63457,11 @@
 	dir = 8
 	},
 /area/station/medical/chem_storage)
+"rnJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "rnQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -63859,6 +64041,7 @@
 "ruu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/garbage,
+/obj/effect/spawner/random/trash/crushed_can,
 /turf/open/floor/iron/smooth,
 /area/station/metro/center_station)
 "ruw" = (
@@ -63914,6 +64097,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"rvQ" = (
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "rvS" = (
 /obj/structure/rack,
 /obj/item/poster/random_contraband,
@@ -64650,6 +64839,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/eva/lower)
+"rFH" = (
+/obj/structure/thermoplastic,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "rFI" = (
 /obj/structure/cable,
 /obj/machinery/button/door/directional/north{
@@ -64949,6 +65145,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"rLF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/botanical_waste,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "rLL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65214,6 +65416,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"rOQ" = (
+/obj/effect/spawner/random/trash/botanical_waste,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "rOT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -65449,6 +65655,11 @@
 "rSC" = (
 /turf/open/floor/glass/reinforced,
 /area/station/engineering/lobby)
+"rSH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/south_tunnel)
 "rSN" = (
 /obj/machinery/computer/upload/borg{
 	dir = 1
@@ -65952,6 +66163,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"rZG" = (
+/obj/effect/spawner/random/trash/botanical_waste,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "rZR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/landmark/start/chief_medical_officer,
@@ -68007,6 +68222,10 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
+"sCa" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "sCb" = (
 /obj/structure/minecart_rail{
 	dir = 6
@@ -69030,10 +69249,6 @@
 	dir = 8
 	},
 /area/station/service/kitchen/coldroom)
-"sRD" = (
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "sRI" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
@@ -70714,13 +70929,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/metro/center_station)
-"toA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "toG" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -71153,6 +71361,10 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
+"tvs" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/tram,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "tvt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -71306,6 +71518,10 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
+"txy" = (
+/obj/effect/spawner/random/trash/bacteria,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "txE" = (
 /obj/item/cigbutt,
 /obj/effect/decal/cleanable/dirt,
@@ -72504,6 +72720,11 @@
 /obj/effect/turf_decal/tile/dark/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"tNu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "tNx" = (
 /obj/structure/cable,
 /obj/machinery/light/floor,
@@ -72861,6 +73082,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/textured,
 /area/station/service/kitchen/coldroom)
+"tTb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "tTC" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
@@ -73181,6 +73408,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"tYj" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "tYk" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -73591,6 +73822,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"udO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "uei" = (
 /obj/machinery/power/solar{
 	id = "auxsolareast";
@@ -73636,11 +73872,6 @@
 /obj/structure/sign/departments/holy/directional/east,
 /turf/open/openspace,
 /area/station/service/chapel)
-"ueN" = (
-/obj/structure/tram/alt/titanium,
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "ueP" = (
 /obj/structure/table,
 /obj/structure/reagent_dispensers/servingdish,
@@ -73850,6 +74081,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"uia" = (
+/obj/structure/fluff/tram_rail/electric,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "uif" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74922,14 +75158,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
-"uxZ" = (
-/obj/structure/thermoplastic,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "uyi" = (
 /obj/item/chair/stool{
 	pixel_y = 0;
@@ -75096,15 +75324,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
-"uzX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "uAi" = (
 /obj/structure/table/reinforced,
 /obj/item/hfr_box/corner,
@@ -75148,6 +75367,12 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"uAN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "uAP" = (
 /turf/open/floor/iron/stairs/medium{
 	dir = 4
@@ -75799,14 +76024,6 @@
 /obj/effect/turf_decal/tile/red/half,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig/upper)
-"uKb" = (
-/obj/structure/thermoplastic/light,
-/obj/machinery/door/airlock/titanium,
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "uKc" = (
 /turf/open/misc/dirt{
 	initial_gas_mix = "ICEMOON_ATMOS"
@@ -78997,6 +79214,10 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"vGl" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "vGw" = (
 /obj/structure/transit_tube/station/reverse,
 /obj/structure/sign/warning/secure_area/directional/north,
@@ -79108,6 +79329,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"vHQ" = (
+/turf/open/indestructible/tram,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "vHR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -79432,11 +79656,6 @@
 /obj/machinery/brm,
 /turf/open/floor/iron,
 /area/mine/production)
-"vLE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/tram,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "vLM" = (
 /obj/structure/railing{
 	dir = 1
@@ -79613,6 +79832,7 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "vPp" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/tram_rail/electric{
 	dir = 1
@@ -80237,10 +80457,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"vYk" = (
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "vYm" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -82011,6 +82227,13 @@
 /obj/machinery/griddle,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
+"wAM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "wAN" = (
 /obj/structure/sign/warning/directional/east,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -82146,6 +82369,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"wCv" = (
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/catwalk_floor,
+/area/station/metro/outrivals_station)
 "wCI" = (
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/openspace,
@@ -82601,11 +82828,6 @@
 	dir = 8
 	},
 /area/mine/laborcamp/security)
-"wJF" = (
-/obj/structure/tram,
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "wJM" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -82870,6 +83092,11 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/fore)
+"wNe" = (
+/obj/effect/spawner/random/trash/graffiti,
+/obj/structure/sign/warning/directional/south,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "wNj" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 5
@@ -83929,6 +84156,11 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
+"xba" = (
+/obj/structure/fluff/tram_rail/electric,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "xbg" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/light/floor,
@@ -84484,11 +84716,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
-"xhf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "xhk" = (
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
@@ -84566,10 +84793,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
-"xin" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/tram,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "xit" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/structure/table/wood,
@@ -84919,6 +85142,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"xmV" = (
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "xni" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -86883,12 +87110,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/service/theater)
-"xNx" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "xNC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -87562,13 +87783,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
-"xXu" = (
-/obj/structure/tram,
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "xXv" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -108915,7 +109129,7 @@ ghx
 ghx
 ghx
 ghx
-rzh
+fSF
 gkM
 igP
 duG
@@ -109173,7 +109387,7 @@ ghx
 ghx
 ghx
 ghx
-lSn
+mPE
 igP
 uwB
 gpH
@@ -111743,7 +111957,7 @@ ghx
 ghx
 ghx
 ghx
-lSn
+mPE
 igP
 uwB
 gpH
@@ -113797,7 +114011,7 @@ thA
 ghx
 ghx
 pXV
-gpH
+dUQ
 pGD
 gkM
 igP
@@ -114317,7 +114531,7 @@ gkM
 igP
 nkX
 pGD
-pGD
+dqg
 pXV
 oSU
 oSU
@@ -115345,7 +115559,7 @@ gkM
 ltJ
 duG
 gpH
-pGD
+sCa
 pXV
 oSU
 oSU
@@ -116110,7 +116324,7 @@ thA
 thA
 thA
 pXV
-pGD
+rZG
 pGD
 gkM
 igP
@@ -117395,7 +117609,7 @@ thA
 thA
 thA
 pXV
-pGD
+dqg
 pGD
 nzD
 lsu
@@ -117658,7 +117872,7 @@ nzD
 ltJ
 uwB
 pGD
-pGD
+ghT
 pXV
 oSU
 oSU
@@ -119714,7 +119928,7 @@ nzD
 igP
 uwB
 pGD
-gpH
+tNu
 pXV
 oSU
 oSU
@@ -120222,7 +120436,7 @@ oSU
 oSU
 oSU
 pXV
-pGD
+dqg
 pGD
 gkM
 igP
@@ -120488,7 +120702,7 @@ pGD
 aFY
 gYI
 bTI
-ida
+azU
 bBl
 cUg
 wth
@@ -121250,7 +121464,7 @@ oSU
 oSU
 oSU
 pXV
-pGD
+sCa
 pGD
 gkM
 ltJ
@@ -121529,7 +121743,7 @@ aeV
 lLs
 flr
 nKc
-ueN
+emB
 dzI
 jfa
 wuN
@@ -122043,9 +122257,9 @@ gPk
 bTI
 vWR
 iva
-ueN
+emB
 gRS
-uxZ
+jwg
 vXL
 neA
 neA
@@ -122300,7 +122514,7 @@ gPk
 rtV
 flr
 iva
-wJF
+pIx
 sAf
 fPq
 wuN
@@ -122557,7 +122771,7 @@ xpI
 gYI
 sWR
 nKc
-ueN
+emB
 bed
 jhY
 wuN
@@ -122814,9 +123028,9 @@ gzt
 gzt
 rCM
 dbl
-ueN
-qmy
-uKb
+emB
+aif
+iLg
 vXL
 cGX
 oSU
@@ -123073,7 +123287,7 @@ upJ
 glg
 dOm
 lMv
-mim
+rFH
 wuN
 cGX
 oSU
@@ -123328,9 +123542,9 @@ bIf
 bTI
 wMB
 nVV
-wJF
+pIx
 nov
-uxZ
+jwg
 vXL
 cGX
 oSU
@@ -123565,7 +123779,7 @@ oSU
 pXV
 gpH
 pGD
-gkM
+mPE
 igP
 duG
 pGD
@@ -123585,9 +123799,9 @@ dIF
 bTI
 tow
 hLW
-ueN
+emB
 dzI
-uxZ
+jwg
 wuN
 cGX
 oSU
@@ -123842,7 +124056,7 @@ pRu
 bTI
 nfx
 wGy
-ueN
+emB
 dzI
 jfa
 wuN
@@ -124357,8 +124571,8 @@ oSU
 cGX
 nHU
 sNw
-qmy
-xXu
+aif
+pSs
 wDh
 cGX
 oSU
@@ -124591,13 +124805,13 @@ oSU
 oSU
 oSU
 euu
-aFD
-aFD
-sRD
-arF
-cTz
+qGH
 vOF
-pxg
+mlg
+vHQ
+rvQ
+vOF
+tTb
 euu
 oSU
 oSU
@@ -124612,10 +124826,10 @@ oSU
 oSU
 oSU
 cGX
-nib
-vYk
-jrt
-xNx
+kBD
+okt
+foJ
+fQy
 nib
 cGX
 oSU
@@ -124850,9 +125064,9 @@ oSU
 euu
 vOF
 aFD
-sRD
-arF
-cTz
+mlg
+vHQ
+rvQ
 vOF
 aFD
 euu
@@ -124870,9 +125084,9 @@ oSU
 oSU
 cGX
 aeZ
-xhf
-jrt
-xNx
+rnJ
+foJ
+fQy
 nib
 cGX
 oSU
@@ -125107,9 +125321,9 @@ oSU
 euu
 aFD
 aFD
-sRD
-xin
-cTz
+mlg
+tvs
+rvQ
 vOF
 cFH
 euu
@@ -125127,9 +125341,9 @@ oSU
 oSU
 cGX
 aeZ
-vYk
-jrt
-xNx
+okt
+foJ
+fQy
 nib
 cGX
 oSU
@@ -125364,9 +125578,9 @@ oSU
 euu
 aFD
 vOF
-sRD
-arF
-cTz
+mlg
+vHQ
+rvQ
 vOF
 aFD
 euu
@@ -125383,10 +125597,10 @@ oSU
 oSU
 oSU
 cGX
-aeZ
-vYk
-jrt
-xNx
+aOq
+okt
+foJ
+fQy
 nib
 cGX
 oSU
@@ -125621,9 +125835,9 @@ oSU
 euu
 aFD
 aFD
-sRD
-arF
-cTz
+mlg
+vHQ
+rvQ
 vOF
 vOF
 euu
@@ -125641,9 +125855,9 @@ oSU
 oSU
 cGX
 aeZ
-xhf
-jrt
-xNx
+rnJ
+foJ
+fQy
 nib
 cGX
 oSU
@@ -125878,11 +126092,11 @@ oSU
 euu
 aFD
 aFD
-sRD
-arF
-cTz
+mlg
+vHQ
+rvQ
 pxg
-aFD
+qGH
 euu
 oSU
 oSU
@@ -125898,9 +126112,9 @@ oSU
 oSU
 cGX
 nib
-jaM
-nyD
-xNx
+uAN
+bNN
+fQy
 nib
 cGX
 oSU
@@ -126135,9 +126349,9 @@ oSU
 euu
 ohG
 aFD
-sRD
-arF
-toA
+mlg
+vHQ
+hCu
 vOF
 wkq
 euu
@@ -126155,10 +126369,10 @@ oSU
 oSU
 cGX
 nib
-xhf
-nyD
-xNx
-nib
+rnJ
+bNN
+fQy
+aeZ
 cGX
 oSU
 oSU
@@ -126392,11 +126606,11 @@ oSU
 euu
 vOF
 aFD
-sRD
-arF
-toA
+xba
+vHQ
+hCu
 aFD
-aFD
+afr
 euu
 oSU
 oSU
@@ -126411,10 +126625,10 @@ oSU
 oSU
 oSU
 cGX
-nib
-vYk
-avm
-xNx
+txy
+okt
+rSH
+fQy
 nib
 cGX
 oSU
@@ -126647,12 +126861,12 @@ oSU
 oSU
 oSU
 euu
+maG
 aFD
-aFD
-sRD
-arF
-toA
-vOF
+mlg
+vHQ
+hCu
+qls
 aFD
 euu
 oSU
@@ -126669,9 +126883,9 @@ oSU
 oSU
 cGX
 nib
-vYk
-avm
-xNx
+okt
+rSH
+fQy
 nib
 cGX
 oSU
@@ -126906,11 +127120,11 @@ oSU
 euu
 aFD
 vOF
-sRD
-arF
-cTz
+mlg
+vHQ
+rvQ
 aFD
-aFD
+rOQ
 euu
 oSU
 oSU
@@ -126926,9 +127140,9 @@ oSU
 oSU
 cGX
 nib
-vYk
-nyD
-vPp
+okt
+bNN
+wAM
 nib
 cGX
 oSU
@@ -127161,11 +127375,11 @@ oSU
 oSU
 oSU
 euu
+jHx
 aFD
-aFD
-sRD
-vLE
-awP
+mlg
+mGm
+fGa
 oWa
 aFD
 euu
@@ -127182,10 +127396,10 @@ oSU
 oSU
 oSU
 cGX
-nib
-vYk
-nyD
-vPp
+dVS
+uia
+bNN
+wAM
 nib
 cGX
 oSU
@@ -127419,12 +127633,12 @@ oSU
 oSU
 euu
 aFD
-aFD
+ogE
 vOF
 aFD
 gWs
 vOF
-vOF
+osW
 euu
 oSU
 oSU
@@ -127440,9 +127654,9 @@ oSU
 oSU
 cGX
 nib
-vYk
-jrt
-vPp
+okt
+foJ
+wAM
 nib
 cGX
 oSU
@@ -127678,10 +127892,10 @@ euu
 aFD
 aFD
 vOF
+udO
 vOF
 vOF
-vOF
-vOF
+qls
 euu
 oSU
 sMX
@@ -127696,10 +127910,10 @@ oSU
 oSU
 oSU
 cGX
-nib
-vYk
-jrt
-xNx
+xmV
+okt
+foJ
+fQy
 nib
 cGX
 oSU
@@ -127936,8 +128150,8 @@ ohG
 oWa
 vOF
 vOF
-vOF
-aFD
+afr
+tYj
 wkq
 euu
 oSU
@@ -127954,9 +128168,9 @@ oSU
 oSU
 cGX
 nib
-vYk
-jrt
-vPp
+okt
+foJ
+wAM
 nib
 cGX
 oSU
@@ -128190,7 +128404,7 @@ oSU
 oSU
 euu
 aFD
-aFD
+ptV
 vOF
 aFD
 vOF
@@ -128211,9 +128425,9 @@ oSU
 oSU
 cGX
 aeZ
-xhf
-nyD
-vPp
+rnJ
+bNN
+wAM
 nib
 cGX
 oSU
@@ -128446,12 +128660,12 @@ oSU
 oSU
 oSU
 euu
-aFD
-aFD
+jHx
+qcZ
 vOF
 vpe
-pxg
-aFD
+ppO
+ptV
 euu
 euu
 sMX
@@ -128468,9 +128682,9 @@ sMX
 sMX
 cGX
 aeZ
-xhf
-nyD
-vPp
+rnJ
+bNN
+wAM
 nib
 cGX
 oSU
@@ -128703,12 +128917,12 @@ oSU
 oSU
 oSU
 euu
-aFD
+qGH
 aFD
 vOF
 pxg
-pxg
-aFD
+rLF
+wNe
 euu
 euu
 hdu
@@ -128723,11 +128937,11 @@ vuT
 qzp
 sMX
 sMX
-nib
+mWX
 aeZ
-xhf
-nyD
-hrw
+rnJ
+bNN
+vPp
 nib
 cGX
 oSU
@@ -128960,9 +129174,9 @@ oSU
 oSU
 oSU
 euu
+rOQ
 aFD
-aFD
-pxg
+rLF
 vOF
 gWs
 aFD
@@ -128980,11 +129194,11 @@ vuT
 jwo
 sMX
 cqM
-nib
+gVb
 aeZ
-xhf
-nyD
-uzX
+rnJ
+bNN
+gQB
 nib
 cGX
 oSU
@@ -129218,11 +129432,11 @@ oSU
 oSU
 euu
 aFD
-aFD
+qcZ
 pxg
 vOF
-pxg
-aFD
+eao
+maG
 euu
 euu
 hdu
@@ -129233,15 +129447,15 @@ vuT
 lWk
 pSj
 vuT
-vuT
+mOr
 vuT
 sMX
 sMX
 lUe
 aeZ
-xhf
-nyD
-uzX
+rnJ
+bNN
+gQB
 aeZ
 cGX
 oSU
@@ -129474,8 +129688,8 @@ oSU
 oSU
 oSU
 euu
-aFD
-aFD
+rOQ
+ptV
 vOF
 kyd
 cQQ
@@ -129496,9 +129710,9 @@ sMX
 sMX
 cGX
 aeZ
-xhf
-nyD
-hrw
+rnJ
+bNN
+vPp
 aeZ
 cGX
 oSU
@@ -129731,8 +129945,8 @@ oSU
 oSU
 oSU
 euu
-aFD
-aFD
+vGl
+jHx
 pxg
 veH
 kyd
@@ -129753,9 +129967,9 @@ oSU
 oSU
 cGX
 aeZ
-xhf
-nyD
-uzX
+rnJ
+bNN
+gQB
 aeZ
 cGX
 oSU
@@ -129990,9 +130204,9 @@ oSU
 euu
 aFD
 aFD
-aFD
+maG
 pxg
-aFD
+aUU
 aFD
 euu
 euu
@@ -130002,7 +130216,7 @@ ftB
 qzp
 qzp
 fqI
-vuT
+mOr
 crs
 sMX
 sMX
@@ -130010,9 +130224,9 @@ oSU
 oSU
 cGX
 aeZ
-xhf
-nyD
-uzX
+rnJ
+bNN
+gQB
 aeZ
 cGX
 oSU
@@ -130245,12 +130459,12 @@ oSU
 oSU
 oSU
 euu
-aFD
+aUU
 aFD
 vOF
-vOF
+dpE
 aFD
-aFD
+rOQ
 euu
 euu
 oSU
@@ -130266,10 +130480,10 @@ sMX
 oSU
 oSU
 cGX
-aeZ
-xhf
-nyD
-hrw
+aOq
+rnJ
+bNN
+vPp
 nib
 cGX
 oSU
@@ -130502,12 +130716,12 @@ oSU
 oSU
 oSU
 euu
-aFD
+dBn
 hpO
 vOF
-aFD
-aFD
-aFD
+rOQ
+jHx
+qGH
 oSU
 euu
 oSU
@@ -130524,9 +130738,9 @@ oSU
 oSU
 cGX
 aeZ
-xhf
-nyD
-hrw
+rnJ
+bNN
+vPp
 nib
 cGX
 oSU
@@ -130781,9 +130995,9 @@ oSU
 oSU
 cGX
 aeZ
-xhf
-avm
-uzX
+rnJ
+rSH
+gQB
 nib
 cGX
 oSU
@@ -131016,12 +131230,12 @@ oSU
 oSU
 oSU
 euu
+rOQ
+tYj
 aFD
-aFD
-aFD
-vOF
-aFD
-aFD
+afr
+qcZ
+dBn
 oSU
 euu
 oSU
@@ -131038,9 +131252,9 @@ oSU
 oSU
 cGX
 aeZ
-xhf
-avm
-hrw
+rnJ
+rSH
+vPp
 nib
 cGX
 oSU
@@ -131273,12 +131487,12 @@ oSU
 oSU
 oSU
 euu
+aqW
+dBn
 aFD
+dBn
 aFD
-aFD
-aFD
-aFD
-aFD
+tYj
 oSU
 euu
 oSU
@@ -131295,9 +131509,9 @@ oSU
 oSU
 cGX
 nib
-vYk
-jrt
-xNx
+okt
+foJ
+fQy
 nib
 cGX
 oSU
@@ -131552,9 +131766,9 @@ oSU
 oSU
 cGX
 nib
-vYk
-nyD
-uzX
+okt
+bNN
+gQB
 aeZ
 cGX
 oSU
@@ -131808,10 +132022,10 @@ sMX
 oSU
 oSU
 cGX
-nib
-vYk
-nyD
-hrw
+dVS
+okt
+bNN
+vPp
 nib
 cGX
 oSU
@@ -132066,9 +132280,9 @@ oSU
 oSU
 cGX
 nib
-vYk
-nyD
-uzX
+okt
+bNN
+gQB
 aeZ
 cGX
 oSU
@@ -132323,10 +132537,10 @@ oSU
 oSU
 cGX
 uBk
-vYk
-nyD
-hrw
-nib
+okt
+bNN
+vPp
+aeZ
 cGX
 oSU
 oSU
@@ -132580,8 +132794,8 @@ oSU
 oSU
 cGX
 nib
-vYk
-nyD
+okt
+bNN
 cYv
 nib
 cGX
@@ -132836,10 +133050,10 @@ oSU
 oSU
 oSU
 cGX
-nib
-vYk
-avm
-hrw
+xmV
+uia
+rSH
+vPp
 aeZ
 cGX
 oSU
@@ -133094,9 +133308,9 @@ oSU
 oSU
 cGX
 nib
-vYk
-avm
-hrw
+okt
+rSH
+vPp
 nib
 cGX
 oSU
@@ -133351,9 +133565,9 @@ oSU
 oSU
 cGX
 nib
-vYk
-avm
-hrw
+okt
+rSH
+vPp
 aeZ
 cGX
 oSU
@@ -133608,9 +133822,9 @@ oSU
 oSU
 cGX
 nib
-vYk
-jrt
-xNx
+okt
+foJ
+fQy
 aeZ
 cGX
 oSU
@@ -133865,9 +134079,9 @@ oSU
 oSU
 cGX
 nib
-xhf
-nyD
-xNx
+rnJ
+bNN
+fQy
 aeZ
 cGX
 oSU
@@ -134122,9 +134336,9 @@ oSU
 oSU
 cGX
 nib
-xhf
-jrt
-xNx
+rnJ
+foJ
+fQy
 aeZ
 cGX
 oSU
@@ -134379,9 +134593,9 @@ oSU
 oSU
 cGX
 aeZ
-xhf
-nyD
-vPp
+rnJ
+bNN
+wAM
 aeZ
 cGX
 oSU
@@ -134635,10 +134849,10 @@ oSU
 oSU
 oSU
 cGX
-aeZ
-xhf
+aOq
+rnJ
 xQV
-vPp
+wAM
 aeZ
 cGX
 oSU
@@ -134892,10 +135106,10 @@ oSU
 oSU
 oSU
 cGX
-aeZ
-xhf
-nyD
-vPp
+iPF
+rnJ
+bNN
+wAM
 kHD
 cGX
 oSU
@@ -135150,9 +135364,9 @@ oSU
 oSU
 cGX
 aeZ
-xhf
-nyD
-vPp
+rnJ
+bNN
+wAM
 aeZ
 cGX
 oSU
@@ -135407,9 +135621,9 @@ oSU
 oSU
 cGX
 nib
-xhf
-avm
-vPp
+rnJ
+rSH
+wAM
 aeZ
 cGX
 iDt
@@ -135664,9 +135878,9 @@ oSU
 oSU
 cGX
 nib
-xhf
-gQB
-vPp
+rnJ
+qYE
+wAM
 aeZ
 cGX
 iDt
@@ -135921,9 +136135,9 @@ oSU
 oSU
 cGX
 nib
-vYk
-nyD
-vPp
+okt
+bNN
+wAM
 nib
 fhx
 fhx
@@ -136178,9 +136392,9 @@ oSU
 cGX
 cGX
 nib
-vYk
-jrt
-xNx
+okt
+foJ
+fQy
 aeZ
 fhx
 eUd
@@ -136435,9 +136649,9 @@ oSU
 fhx
 umB
 jfP
-vYk
-jrt
-xNx
+okt
+foJ
+fQy
 aeZ
 bus
 tar
@@ -136692,12 +136906,12 @@ oSU
 fhx
 mHb
 jmn
-vYk
-nyD
-xNx
+okt
+bNN
+fQy
 nib
 vkk
-eHt
+mJE
 pzJ
 tpb
 cvr
@@ -136949,9 +137163,9 @@ oSU
 fhx
 csZ
 sWm
-vYk
-jrt
-xNx
+okt
+foJ
+fQy
 aeZ
 sPb
 eHt
@@ -137206,9 +137420,9 @@ fhx
 fhx
 uCZ
 inW
-vYk
-nyD
-xNx
+okt
+bNN
+fQy
 nib
 iod
 kdm
@@ -137463,9 +137677,9 @@ pAj
 tgU
 gLx
 deB
-vYk
-nyD
-vPp
+okt
+bNN
+wAM
 aeZ
 sPb
 eHt
@@ -137720,12 +137934,12 @@ cLf
 fhx
 cvr
 jZR
-vYk
-nyD
-vPp
+okt
+bNN
+wAM
 nib
 vkk
-uDR
+wCv
 uQJ
 fhx
 oSU
@@ -137977,9 +138191,9 @@ cLf
 gVx
 xPX
 hHm
-vYk
-nyD
-vPp
+okt
+bNN
+wAM
 nib
 sPb
 usr
@@ -138234,9 +138448,9 @@ cLf
 gVx
 kdm
 hHm
-vYk
-jrt
-vPp
+okt
+foJ
+wAM
 nHU
 fhx
 tgU
@@ -138491,9 +138705,9 @@ kdm
 qnn
 eHt
 hHm
-vYk
-jrt
-vPp
+okt
+foJ
+wAM
 nib
 fhx
 rsO
@@ -138748,9 +138962,9 @@ eHt
 gVx
 gDI
 jZR
-vYk
-nyD
-xNx
+okt
+bNN
+fQy
 nib
 fhx
 usr
@@ -139005,9 +139219,9 @@ eHt
 fhx
 rsj
 hjK
-vYk
-nyD
-xNx
+okt
+bNN
+fQy
 nib
 fhx
 kdm
@@ -139262,9 +139476,9 @@ eHt
 fhx
 cvr
 cmA
-vYk
-jrt
-xNx
+okt
+foJ
+fQy
 nib
 fhx
 tgU
@@ -139519,13 +139733,13 @@ eHt
 uDR
 cvr
 cmA
-vYk
-nyD
-xNx
+okt
+bNN
+hdG
 nib
 fhx
 kdm
-uQJ
+bIN
 fhx
 oSU
 oSU
@@ -139776,9 +139990,9 @@ cLf
 cLf
 scr
 cDr
-xhf
-jrt
-xNx
+rnJ
+foJ
+fQy
 nib
 fhx
 usr
@@ -140809,8 +141023,8 @@ gVx
 qnn
 uQJ
 gVx
-cvr
-pEs
+cfd
+pdb
 fhx
 oSU
 oSU

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -4982,6 +4982,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"brE" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "brJ" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/landmark/event_spawn,
@@ -31124,6 +31130,13 @@
 "iHp" = (
 /turf/closed/wall/r_wall,
 /area/station/ai/satellite/chamber)
+"iHF" = (
+/obj/structure/fluff/minepost,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "iHG" = (
 /obj/machinery/shower/directional/south,
 /obj/item/soap/nanotrasen,
@@ -112408,7 +112421,7 @@ pGD
 pGD
 gpH
 pGD
-pGD
+brE
 pXV
 oSU
 oSU
@@ -112659,7 +112672,7 @@ thA
 ghx
 ghx
 ghx
-pGD
+brE
 gpH
 pGD
 pGD
@@ -112916,7 +112929,7 @@ thA
 ghx
 ghx
 ghx
-rzh
+iHF
 gpH
 pGD
 pGD
@@ -113430,13 +113443,13 @@ ghx
 thA
 ghx
 pXV
-pGD
-pGD
+sJx
+sJx
 sJx
 sJx
 hwe
 sJx
-pGD
+sJx
 pXV
 oSU
 oSU

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -475,6 +475,13 @@
 /obj/structure/platform/iron,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/range)
+"ain" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/static_signal/southwest,
+/turf/open/floor/iron,
+/area/station/metro/arrivals_station)
 "ait" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -526,6 +533,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/interior)
+"ajd" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "ajr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -712,10 +723,6 @@
 /obj/item/clothing/suit/hooded/wintercoat/science,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"alC" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "alD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -1951,6 +1958,10 @@
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
+"azQ" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "aAe" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2188,6 +2199,11 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"aDA" = (
+/obj/structure/tram,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "aDG" = (
 /obj/structure/fence{
 	dir = 8
@@ -2880,6 +2896,10 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/iron/dark,
 /area/icemoon/underground/explored)
+"aOp" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "aOx" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/vending/clothing,
@@ -3196,13 +3216,6 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/hallway/secondary/service)
-"aSQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/rubble,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "aSS" = (
 /obj/effect/turf_decal/trimline/dark_red/end,
 /obj/machinery/meter,
@@ -4068,6 +4081,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
+"beK" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/titanium,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "beO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -6616,11 +6635,6 @@
 /obj/structure/sign/warning/secure_area/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
-"bMD" = (
-/obj/structure/holosign/barrier/atmos/tram,
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "bMF" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -7924,6 +7938,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"ceC" = (
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/barricade/wooden/snowed,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "ceO" = (
 /obj/machinery/button/crematorium{
 	id = "crematoriumChapel";
@@ -8006,10 +8025,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"cfm" = (
-/obj/structure/barricade/wooden/snowed,
-/turf/closed/wall,
-/area/station/metro/abandoned/abandoned_collector)
 "cfr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8424,10 +8439,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/metro/outrivals_station)
-"cmE" = (
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "cmJ" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
@@ -8738,6 +8749,10 @@
 /obj/structure/sign/warning/electric_shock/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"cqM" = (
+/obj/structure/barricade/wooden/snowed,
+/turf/closed/wall,
+/area/station/metro/abandoned/abandoned_collector)
 "cqN" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -8788,6 +8803,10 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"crs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/ice/smooth,
+/area/station/metro/abandoned/abandoned_collector)
 "crv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10731,9 +10750,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"cRz" = (
-/turf/closed/wall,
-/area/station/metro/abandoned/abandoned_collector)
 "cRC" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
@@ -11832,12 +11848,6 @@
 /obj/machinery/smartfridge,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
-"dgV" = (
-/obj/effect/decal/cleanable/insectguts,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "dgZ" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
@@ -12136,6 +12146,10 @@
 /obj/effect/mapping_helpers/requests_console/announcement,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/cmo)
+"dki" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "dkn" = (
 /obj/machinery/space_heater,
 /turf/open/floor/wood,
@@ -12840,12 +12854,6 @@
 "duh" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/transit_tube)
-"duu" = (
-/obj/structure/thermoplastic/light,
-/obj/machinery/door/airlock/titanium,
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "duE" = (
 /obj/machinery/atmospherics/components/binary/tank_compressor{
 	dir = 4
@@ -12853,6 +12861,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
+"duG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "duT" = (
 /obj/item/chair/stool/bar{
 	pixel_y = -2
@@ -13062,6 +13077,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"dxi" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "dxm" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/toggle/labcoat,
@@ -13151,15 +13170,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/sepia,
 /area/station/security/prison/rec)
-"dxX" = (
-/obj/item/storage/medkit/fire,
-/obj/effect/mob_spawn/corpse/human/charredskeleton,
-/obj/item/ammo_casing/shotgun/buckshot,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "dyf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13172,10 +13182,6 @@
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
-"dyr" = (
-/obj/effect/decal/cleanable/ash/large,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "dyA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/effect/turf_decal/stripes/line,
@@ -13598,10 +13604,6 @@
 	dir = 8
 	},
 /area/station/security/brig/entrance)
-"dEu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "dEv" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
@@ -13851,6 +13853,16 @@
 /obj/structure/flora/grass/green/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"dHH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "dHJ" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/line,
@@ -14164,10 +14176,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"dNd" = (
-/obj/item/ammo_casing/shotgun/buckshot,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "dNw" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -14887,12 +14895,6 @@
 	dir = 8
 	},
 /area/mine/eva)
-"dZs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/mob_spawn/corpse/human/charredskeleton,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "dZN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -17445,16 +17447,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/brig)
-"eLx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "eLB" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Service - Gambling Lounge"
@@ -17839,6 +17831,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/library)
+"eSo" = (
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "eSq" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/layer2{
 	dir = 1
@@ -18045,10 +18041,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/chem_storage)
-"eUJ" = (
-/obj/structure/tram/alt/titanium,
-/turf/open/indestructible/tram,
-/area/station/metro/train_tunnels/north_tunnel)
 "eUK" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty{
@@ -19514,6 +19506,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"fqI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "fqJ" = (
 /obj/effect/turf_decal/trimline/white/filled/warning,
 /turf/open/genturf,
@@ -19740,6 +19738,10 @@
 /obj/structure/sign/flag/nanotrasen/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"ftB" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "ftD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -20199,6 +20201,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"fAp" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "fAF" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/boxing/green,
@@ -22577,12 +22583,10 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
-"gkA" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
+"gkM" = (
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "gkN" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/iron/dark/textured,
@@ -22823,12 +22827,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/engineering/lobby)
-"gnE" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "gnJ" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -23518,13 +23516,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
-"gwB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "gwJ" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 5
@@ -25371,13 +25362,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/evidence)
-"gXj" = (
-/obj/structure/fluff/minepost,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "gXk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25592,13 +25576,6 @@
 /obj/effect/gibspawner/human,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"gZx" = (
-/obj/structure/thermoplastic,
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "gZP" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -25845,6 +25822,9 @@
 	dir = 1
 	},
 /area/mine/living_quarters)
+"hdu" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "hdw" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25864,10 +25844,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/interrogation)
-"hdX" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "heg" = (
 /obj/effect/spawner/random/engineering/canister,
 /turf/open/floor/plating,
@@ -25938,11 +25914,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/textured,
 /area/station/maintenance/starboard/fore)
-"hfq" = (
-/obj/effect/decal/cleanable/greenglow/waste,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "hfs" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -25984,10 +25955,6 @@
 "hgr" = (
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/secondary/entry)
-"hgz" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "hgK" = (
 /obj/structure/ladder,
 /obj/effect/landmark/blobstart,
@@ -26670,12 +26637,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
-"hqf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "hqm" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -26928,10 +26889,6 @@
 "htB" = (
 /turf/open/floor/carpet/red,
 /area/station/security/prison/work)
-"htD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/misc/ice/smooth,
-/area/station/metro/abandoned/abandoned_collector)
 "htH" = (
 /obj/structure/table/wood,
 /obj/machinery/fax{
@@ -27164,10 +27121,6 @@
 /obj/effect/mapping_helpers/airlock/unres/delayed,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"hxb" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "hxs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27527,6 +27480,10 @@
 	dir = 4
 	},
 /area/mine/eva)
+"hCr" = (
+/obj/structure/barricade/wooden,
+/turf/open/genturf/blue,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "hCC" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -27758,10 +27715,6 @@
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
-"hGb" = (
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "hGh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27945,6 +27898,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
+"hIR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "hIT" = (
 /obj/machinery/door/airlock{
 	id_tag = "Toilet1";
@@ -29581,6 +29538,9 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"igP" = (
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/north_tunnel)
 "igQ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -30252,17 +30212,6 @@
 "ipE" = (
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
-"ipH" = (
-/obj/effect/decal/cleanable/chem_pile,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "ipM" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -30672,6 +30621,12 @@
 "iwf" = (
 /turf/closed/wall/r_wall,
 /area/mine/mechbay)
+"iwg" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "iwz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31379,17 +31334,6 @@
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
-"iJc" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "iJh" = (
 /obj/structure/sign/warning/gas_mask/directional/west,
 /turf/open/floor/plating,
@@ -32279,6 +32223,14 @@
 /obj/structure/flora/rock/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/labor_camp)
+"iVx" = (
+/obj/effect/decal/fakelattice,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "iVA" = (
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
@@ -33077,13 +33029,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
-"jgM" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "jgV" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
@@ -33288,6 +33233,13 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /turf/open/floor/iron,
 /area/mine/living_quarters)
+"jkE" = (
+/obj/structure/tram,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "jkH" = (
 /obj/structure/training_machine,
 /obj/effect/landmark/blobstart,
@@ -34020,6 +33972,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"juD" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "juH" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -34127,6 +34085,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"jwo" = (
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "jwt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34611,10 +34575,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/treatment_center)
-"jDo" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "jDz" = (
 /obj/machinery/light/small/directional/east,
 /obj/item/pickaxe,
@@ -34715,10 +34675,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
-"jER" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/misc/beach/sand,
-/area/station/metro/abandoned/abandoned_collector)
 "jEU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -34807,6 +34763,10 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
+"jHx" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "jHF" = (
 /obj/item/trash/boritos/red,
 /obj/structure/cable,
@@ -35829,6 +35789,13 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
+"jTX" = (
+/obj/structure/fluff/minepost,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "jTZ" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Server Room"
@@ -36241,10 +36208,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/security/eva)
-"kaV" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "kaW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36261,10 +36224,6 @@
 /obj/item/clothing/shoes/workboots,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"kbk" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "kbn" = (
 /obj/effect/decal/cleanable/food/pie_smudge,
 /turf/open/floor/iron,
@@ -36302,10 +36261,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
-"kca" = (
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "kcc" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - Infirmary"
@@ -36567,6 +36522,17 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"kfp" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "kfr" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -36708,10 +36674,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/ai/satellite/atmos)
-"khH" = (
-/obj/structure/railing,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "khR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
@@ -37175,6 +37137,10 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/entry)
+"kop" = (
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/north_tunnel)
 "koH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -38548,10 +38514,6 @@
 	dir = 1
 	},
 /area/station/commons/storage/art)
-"kGN" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "kGQ" = (
 /obj/structure/table,
 /obj/item/stamp/head/qm,
@@ -38608,10 +38570,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"kHJ" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "kHN" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/openspace,
@@ -39227,10 +39185,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
-"kPC" = (
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/indestructible/tram,
-/area/station/metro/train_tunnels/north_tunnel)
 "kPH" = (
 /obj/structure/stairs/south{
 	dir = 8
@@ -40278,15 +40232,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/science/research)
-"leq" = (
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/barricade/wooden/snowed,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
-"leD" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
+"lez" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "leM" = (
 /obj/structure/railing{
 	dir = 8
@@ -41119,13 +41068,6 @@
 /obj/item/rcl/pre_loaded,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
-"lqv" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "lqz" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -41297,6 +41239,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/morgue)
+"lsu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/north_tunnel)
 "lsA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -41349,12 +41296,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/medical/chem_storage)
-"ltG" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
+"ltJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/north_tunnel)
 "ltP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -42132,6 +42077,13 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"lDG" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "lDH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate,
@@ -42786,9 +42738,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"lOq" = (
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "lOr" = (
 /obj/structure/railing,
 /obj/structure/stairs/east,
@@ -43025,10 +42974,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/station/service/library)
-"lQD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "lQE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
@@ -43226,6 +43171,10 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/large,
 /area/station/medical/medbay/lobby)
+"lUe" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "lUf" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
@@ -43418,6 +43367,11 @@
 	},
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig/upper)
+"lWk" = (
+/obj/effect/decal/cleanable/greenglow/waste,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "lWG" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/fore)
@@ -43557,6 +43511,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
+"mat" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "maB" = (
 /obj/structure/chair/stool/directional/north,
 /obj/effect/turf_decal/tile/neutral,
@@ -44440,6 +44398,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
+"mne" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "mnm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -45302,6 +45264,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"mAC" = (
+/obj/effect/decal/cleanable/plastic,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "mAM" = (
 /obj/structure/ladder,
 /obj/machinery/light/small/red/directional/west,
@@ -45496,17 +45465,6 @@
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"mDl" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "mDq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/east,
@@ -45992,6 +45950,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"mKn" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "mKq" = (
 /obj/structure/closet/secure_closet/evidence,
 /obj/machinery/light/small/directional/north,
@@ -46705,6 +46667,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"mWG" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "mWK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -46751,6 +46720,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"mXc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/corpse/human/charredskeleton,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "mXe" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -47774,6 +47749,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"nkX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "nli" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -48828,12 +48811,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
-"nze" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "nzj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48898,6 +48875,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/eva)
+"nzD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "nzG" = (
 /obj/structure/railing{
 	dir = 10
@@ -49302,9 +49284,6 @@
 /obj/effect/spawner/random/trash/caution_sign,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"nEt" = (
-/turf/open/indestructible/tram,
-/area/station/metro/train_tunnels/north_tunnel)
 "nEA" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50238,6 +50217,11 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/commons/storage/art)
+"nQG" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "nQH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -50312,6 +50296,12 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/armory)
+"nRk" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "nRm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50663,6 +50653,10 @@
 /obj/item/plate,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/port/fore)
+"nWh" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/misc/beach/sand,
+/area/station/metro/abandoned/abandoned_collector)
 "nWj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50850,9 +50844,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
-"nZC" = (
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "nZH" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
@@ -51405,6 +51396,10 @@
 /obj/machinery/door/window/elevator/left/directional/west,
 /turf/open/floor/catwalk_floor,
 /area/station/metro/outrivals_station)
+"ohG" = (
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "ohI" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
@@ -52112,6 +52107,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"oqi" = (
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "oqz" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -52634,6 +52636,10 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"oxS" = (
+/obj/structure/barricade/wooden,
+/turf/open/genturf,
+/area/icemoon/underground/unexplored/rivers/deep)
 "oxU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53341,6 +53347,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"oEY" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "oFc" = (
 /obj/structure/sign/warning/directional/north,
 /turf/open/openspace/icemoon,
@@ -53658,9 +53670,6 @@
 /obj/structure/sign/departments/cargo/directional/west,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
-"oIu" = (
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "oIv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/drip,
@@ -54013,6 +54022,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/aft/lesser)
+"oNV" = (
+/obj/structure/tram/alt/titanium,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/north_tunnel)
 "oNX" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
@@ -55198,11 +55211,6 @@
 /obj/structure/grille/broken,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/explored)
-"pfi" = (
-/obj/structure/tram/alt/titanium,
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "pfw" = (
 /obj/structure/flora/grass/green/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -55456,6 +55464,13 @@
 /obj/item/pillow/random,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
+"piK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/rubble,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "piL" = (
 /obj/machinery/door/window/brigdoor/security/cell/left/directional/west{
 	id = "Cell 2";
@@ -56048,17 +56063,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/metro/center_station)
-"prS" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "prX" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -56072,17 +56076,6 @@
 "psb" = (
 /turf/closed/wall/ice,
 /area/icemoon/underground/explored)
-"pse" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "psm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -56991,11 +56984,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
-"pEF" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "pER" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon{
@@ -57647,10 +57635,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
-"pPb" = (
-/obj/structure/barricade/wooden,
-/turf/open/genturf/blue,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "pPg" = (
 /obj/structure/stairs/west,
 /turf/open/floor/iron/stairs/medium{
@@ -57841,11 +57825,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/storage/art)
-"pRT" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "pRX" = (
 /obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -57853,6 +57832,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/commissary)
+"pSj" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "pSk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58083,6 +58066,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"pUC" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "pUD" = (
 /obj/machinery/door/airlock/security{
 	name = "Permanent Cell 2"
@@ -58439,11 +58426,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
-"pZv" = (
-/obj/structure/tram,
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "pZB" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Chemistry Access"
@@ -58734,12 +58716,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
-"qcb" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "qch" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/disposalpipe/segment,
@@ -59715,6 +59691,10 @@
 /obj/structure/sign/nanotrasen/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/storage/mining)
+"qpX" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "qpZ" = (
 /obj/structure/table,
 /obj/item/folder/blue{
@@ -60168,6 +60148,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"qxt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "qxu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60254,6 +60238,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/metro/outrivals_station)
+"qzp" = (
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "qzs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63484,6 +63473,17 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/primary/starboard)
+"rry" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "rrB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -64067,6 +64067,10 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"rzu" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "rzz" = (
 /obj/machinery/door/airlock/command{
 	name = "Server Room"
@@ -64423,14 +64427,6 @@
 	dir = 10
 	},
 /area/mine/eva)
-"rDI" = (
-/obj/effect/decal/fakelattice,
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "rDJ" = (
 /obj/structure/ladder{
 	name = "upper dispenser access"
@@ -64889,6 +64885,9 @@
 /obj/machinery/computer/security/telescreen/med_sec/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
+"rMb" = (
+/turf/open/misc/beach/sand,
+/area/station/metro/abandoned/abandoned_collector)
 "rMd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66287,10 +66286,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"sfB" = (
-/obj/structure/railing,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "sfF" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Security - Lower Hallway North";
@@ -66369,6 +66364,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"sgU" = (
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "sgV" = (
 /obj/effect/turf_decal/siding/brown/corner,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -67522,11 +67522,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/station/science/explab)
-"swq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/tram,
-/area/station/metro/train_tunnels/north_tunnel)
 "sws" = (
 /obj/machinery/door/airlock/security{
 	name = "Permabrig Library"
@@ -68147,6 +68142,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"sEG" = (
+/obj/structure/holosign/barrier/atmos/tram,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "sEN" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 8
@@ -68652,6 +68652,9 @@
 /obj/structure/sign/nanotrasen/directional/west,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"sMX" = (
+/turf/closed/wall,
+/area/station/metro/abandoned/abandoned_collector)
 "sNj" = (
 /obj/machinery/light_switch/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69108,6 +69111,10 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/sepia,
 /area/station/service/library)
+"sTF" = (
+/obj/structure/thermoplastic/light,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/north_tunnel)
 "sTH" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -70634,10 +70641,6 @@
 /obj/machinery/shower/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"toL" = (
-/obj/structure/thermoplastic/light,
-/turf/open/indestructible/tram,
-/area/station/metro/train_tunnels/north_tunnel)
 "toT" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/railing/corner{
@@ -70915,10 +70918,6 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"ttd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/tram,
-/area/station/metro/train_tunnels/north_tunnel)
 "ttw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/smooth_large,
@@ -72169,6 +72168,9 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
+"tKU" = (
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "tKV" = (
 /obj/structure/table_frame,
 /obj/effect/decal/cleanable/glass,
@@ -72437,6 +72439,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"tNN" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "tOb" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/light/directional/south,
@@ -72507,6 +72520,15 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"tPD" = (
+/obj/item/storage/medkit/fire,
+/obj/effect/mob_spawn/corpse/human/charredskeleton,
+/obj/item/ammo_casing/shotgun/buckshot,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "tPG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 4
@@ -72973,10 +72995,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/service/bar/backroom)
-"tWt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "tWy" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -73694,9 +73712,6 @@
 /obj/effect/landmark/navigate_destination/dockaux,
 /turf/open/floor/iron/large,
 /area/station/hallway/secondary/entry)
-"uhD" = (
-/turf/open/misc/beach/sand,
-/area/station/metro/abandoned/abandoned_collector)
 "uhE" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 9
@@ -74503,6 +74518,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"uth" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "utr" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -74623,10 +74649,6 @@
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"uvl" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "uvt" = (
 /turf/closed/wall,
 /area/station/science/robotics/mechbay)
@@ -74687,6 +74709,12 @@
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
+"uwB" = (
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "uwE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74797,11 +74825,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
-"uyf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "uyi" = (
 /obj/item/chair/stool{
 	pixel_y = 0;
@@ -75759,12 +75782,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
-"uMn" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "uMp" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -76204,13 +76221,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
-"uSB" = (
-/obj/structure/tram,
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "uTk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -76906,18 +76916,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
-"vdO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/fakelattice,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "vdW" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -77106,6 +77104,17 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"vgv" = (
+/obj/effect/decal/cleanable/chem_pile,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "vgw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
@@ -78064,6 +78073,13 @@
 /obj/structure/fireaxecabinet/mechremoval/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"vur" = (
+/obj/structure/thermoplastic,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "vuu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold/dark,
@@ -78082,9 +78098,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "vuT" = (
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
+/turf/open/floor/asphalt,
 /area/station/metro/abandoned/abandoned_collector)
 "vuW" = (
 /obj/structure/closet/boxinggloves,
@@ -78861,14 +78875,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
-"vGp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "vGw" = (
 /obj/structure/transit_tube/station/reverse,
 /obj/structure/sign/warning/secure_area/directional/north,
@@ -79289,6 +79295,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured,
 /area/station/commons/storage/mining)
+"vLy" = (
+/obj/structure/tram/alt/titanium,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "vLB" = (
 /obj/machinery/conveyor{
 	dir = 6;
@@ -79299,6 +79310,12 @@
 /obj/machinery/brm,
 /turf/open/floor/iron,
 /area/mine/production)
+"vLM" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "vLY" = (
 /obj/structure/railing{
 	dir = 8
@@ -79765,10 +79782,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"vUa" = (
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "vUr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -80393,13 +80406,6 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/mine/living_quarters)
-"wcG" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "wcL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -80866,6 +80872,12 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"wkq" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "wkr" = (
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
@@ -82259,10 +82271,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
-"wFY" = (
-/obj/effect/decal/cleanable/shreds,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "wGa" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
@@ -82638,6 +82646,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
+"wMa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "wMc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -83116,10 +83136,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
-"wSI" = (
-/obj/structure/barricade/wooden,
-/turf/open/genturf,
-/area/icemoon/underground/unexplored/rivers/deep)
 "wSL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -83507,13 +83523,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
-"wXA" = (
-/obj/effect/decal/cleanable/plastic,
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "wXW" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -85013,10 +85022,8 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"xrc" = (
-/obj/structure/railing{
-	dir = 1
-	},
+"xrd" = (
+/obj/structure/railing,
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "xrf" = (
@@ -104637,7 +104644,7 @@ thA
 mlt
 tcV
 laq
-thB
+ain
 rWJ
 thB
 mlt
@@ -104895,8 +104902,8 @@ mlt
 kJS
 uJW
 boY
-eUJ
-uSB
+oNV
+jkE
 sdC
 rVr
 ghx
@@ -105151,7 +105158,7 @@ thA
 mlt
 qGA
 mlt
-pfi
+vLy
 uWq
 bKQ
 gcH
@@ -105408,7 +105415,7 @@ thA
 mlt
 qJB
 cpd
-duu
+beK
 uWq
 fyO
 gcH
@@ -105665,9 +105672,9 @@ ghx
 rVr
 jiY
 qGk
-pfi
+vLy
 wjW
-gZx
+vur
 aMC
 mlt
 ghx
@@ -105922,7 +105929,7 @@ ghx
 rVr
 lFA
 qGk
-pZv
+aDA
 rOU
 qFF
 gTE
@@ -106179,7 +106186,7 @@ ghx
 rVr
 qJB
 jlq
-pfi
+vLy
 cOS
 qFF
 cqV
@@ -106436,8 +106443,8 @@ ghx
 rVr
 qGA
 mlt
-pfi
-eUJ
+vLy
+oNV
 oge
 aMC
 rVr
@@ -106694,8 +106701,8 @@ mlt
 qGA
 xfV
 txh
-toL
-gZx
+sTF
+vur
 gcH
 mlt
 ghx
@@ -106950,7 +106957,7 @@ ghx
 mlt
 dLW
 oWp
-pZv
+aDA
 xMP
 pFD
 aMC
@@ -107207,7 +107214,7 @@ ghx
 rVr
 qGA
 otE
-pfi
+vLy
 wjW
 pFD
 eiQ
@@ -107459,12 +107466,12 @@ ghx
 ghx
 ghx
 ghx
-pPb
+hCr
 ghx
 rVr
 qGA
 mlt
-pfi
+vLy
 duW
 vrk
 aMC
@@ -107721,7 +107728,7 @@ ghx
 rVr
 qJB
 tbc
-duu
+beK
 uWq
 kdq
 gcH
@@ -107979,7 +107986,7 @@ rVr
 oti
 lde
 kJN
-eUJ
+oNV
 sAc
 iOk
 ccx
@@ -108235,9 +108242,9 @@ ghx
 mlt
 eha
 uOd
-cmE
-nEt
-gwB
+gkM
+igP
+duG
 pGD
 ccx
 ghx
@@ -108492,8 +108499,8 @@ ghx
 mlt
 mlt
 mlt
-bMD
-kPC
+sEG
+kop
 hwe
 sJx
 mlt
@@ -108749,9 +108756,9 @@ ghx
 ghx
 ghx
 rzh
-cmE
-nEt
-gwB
+gkM
+igP
+duG
 pGD
 rzh
 ghx
@@ -109006,9 +109013,9 @@ ghx
 ghx
 ghx
 ghx
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 ghx
 ghx
@@ -109263,9 +109270,9 @@ ghx
 ghx
 ghx
 ghx
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 ghx
 ghx
@@ -109520,9 +109527,9 @@ ghx
 ghx
 ghx
 ghx
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 ghx
 ghx
@@ -109777,9 +109784,9 @@ ghx
 ghx
 ghx
 ghx
-cmE
-nEt
-wcG
+gkM
+igP
+lDG
 pGD
 ghx
 ghx
@@ -110034,9 +110041,9 @@ ghx
 ghx
 ghx
 ghx
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 ghx
 ghx
@@ -110291,9 +110298,9 @@ ghx
 ghx
 ghx
 ghx
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 ghx
 ghx
@@ -110548,9 +110555,9 @@ ghx
 ghx
 ghx
 ghx
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 thA
 xuo
@@ -110805,9 +110812,9 @@ ghx
 ghx
 ghx
 ghx
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 thA
 xuo
@@ -111062,9 +111069,9 @@ ghx
 ghx
 ghx
 rzh
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 rzh
 thA
@@ -111319,9 +111326,9 @@ ghx
 ghx
 ghx
 ghx
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 thA
 thA
@@ -111576,9 +111583,9 @@ ghx
 ghx
 ghx
 ghx
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 thA
 thA
@@ -111833,9 +111840,9 @@ ghx
 ghx
 ghx
 ghx
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 thA
 thA
@@ -112090,9 +112097,9 @@ ghx
 ghx
 ghx
 ghx
-cmE
-ttd
-nze
+gkM
+ltJ
+uwB
 pGD
 thA
 thA
@@ -112347,9 +112354,9 @@ ghx
 ghx
 ghx
 ghx
-pRT
-ttd
-nze
+nQG
+ltJ
+uwB
 pGD
 thA
 thA
@@ -112604,9 +112611,9 @@ ghx
 ghx
 ghx
 ghx
-cmE
-ttd
-gwB
+gkM
+ltJ
+duG
 pGD
 thA
 oSU
@@ -112861,11 +112868,11 @@ ghx
 ghx
 ghx
 ghx
-cmE
-nEt
-gwB
+gkM
+igP
+duG
 pGD
-qcb
+iwg
 pXV
 oSU
 oSU
@@ -113116,11 +113123,11 @@ thA
 ghx
 ghx
 ghx
-qcb
+iwg
 gpH
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 pGD
 pXV
@@ -113373,11 +113380,11 @@ thA
 ghx
 ghx
 ghx
-gXj
+jTX
 gpH
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 rzh
 pXV
@@ -113632,9 +113639,9 @@ ghx
 pXV
 pGD
 pGD
-cmE
-nEt
-gwB
+gkM
+igP
+duG
 pGD
 pGD
 pXV
@@ -113889,8 +113896,8 @@ ghx
 pXV
 sJx
 sJx
-bMD
-kPC
+sEG
+kop
 hwe
 sJx
 sJx
@@ -114146,9 +114153,9 @@ thA
 pXV
 pGD
 pGD
-cmE
-nEt
-vGp
+gkM
+igP
+nkX
 pGD
 pGD
 pXV
@@ -114403,9 +114410,9 @@ thA
 pXV
 pGD
 pGD
-cmE
-nEt
-gwB
+gkM
+igP
+duG
 pGD
 pGD
 pXV
@@ -114658,13 +114665,13 @@ thA
 thA
 thA
 pXV
-khH
+xrd
 pGD
-uyf
-nEt
-vGp
+nzD
+igP
+nkX
 pGD
-xrc
+vLM
 pXV
 oSU
 oSU
@@ -114917,9 +114924,9 @@ thA
 pXV
 pGD
 pGD
-cmE
-nEt
-vGp
+gkM
+igP
+nkX
 gpH
 pGD
 pXV
@@ -115174,9 +115181,9 @@ thA
 pXV
 pGD
 pGD
-cmE
-ttd
-gwB
+gkM
+ltJ
+duG
 gpH
 pGD
 pXV
@@ -115431,9 +115438,9 @@ thA
 pXV
 pGD
 pGD
-cmE
-ttd
-gwB
+gkM
+ltJ
+duG
 gpH
 pGD
 pXV
@@ -115688,9 +115695,9 @@ thA
 pXV
 pGD
 pGD
-cmE
-ttd
-gwB
+gkM
+ltJ
+duG
 pGD
 pGD
 pXV
@@ -115945,8 +115952,8 @@ thA
 pXV
 pGD
 pGD
-cmE
-nEt
+gkM
+igP
 aYR
 pGD
 pGD
@@ -116202,9 +116209,9 @@ thA
 pXV
 pGD
 pGD
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 gpH
 pGD
 pXV
@@ -116457,13 +116464,13 @@ thA
 thA
 thA
 pXV
-khH
+xrd
 pGD
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 gpH
-xrc
+vLM
 pXV
 oSU
 oSU
@@ -116716,9 +116723,9 @@ thA
 pXV
 pGD
 pGD
-cmE
-nEt
-wcG
+gkM
+igP
+lDG
 pGD
 pGD
 pXV
@@ -116973,9 +116980,9 @@ thA
 pXV
 pGD
 pGD
-cmE
-ttd
-gwB
+gkM
+ltJ
+duG
 pGD
 pGD
 pXV
@@ -117230,9 +117237,9 @@ thA
 pXV
 pGD
 pGD
-uyf
-swq
-nze
+nzD
+lsu
+uwB
 pGD
 pGD
 pXV
@@ -117487,9 +117494,9 @@ thA
 pXV
 pGD
 pGD
-uyf
-ttd
-nze
+nzD
+ltJ
+uwB
 pGD
 pGD
 pXV
@@ -117744,9 +117751,9 @@ thA
 pXV
 pGD
 gpH
-cmE
-ttd
-nze
+gkM
+ltJ
+uwB
 pGD
 pGD
 pXV
@@ -118001,9 +118008,9 @@ thA
 pXV
 pGD
 gpH
-cmE
-ttd
-nze
+gkM
+ltJ
+uwB
 pGD
 pGD
 pXV
@@ -118258,9 +118265,9 @@ thA
 pXV
 pGD
 gpH
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 pGD
 pXV
@@ -118513,13 +118520,13 @@ thA
 thA
 thA
 pXV
-khH
+xrd
 gpH
-cmE
-ttd
-nze
+gkM
+ltJ
+uwB
 pGD
-xrc
+vLM
 pXV
 oSU
 oSU
@@ -118772,9 +118779,9 @@ thA
 pXV
 pGD
 gpH
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 pGD
 pXV
@@ -119029,9 +119036,9 @@ thA
 pXV
 pGD
 gpH
-cmE
-nEt
-wcG
+gkM
+igP
+lDG
 pGD
 pGD
 pXV
@@ -119286,9 +119293,9 @@ thA
 pXV
 pGD
 pGD
-cmE
-ttd
-nze
+gkM
+ltJ
+uwB
 pGD
 wAm
 pXV
@@ -119543,9 +119550,9 @@ thA
 pXV
 pGD
 pGD
-uyf
-nEt
-nze
+nzD
+igP
+uwB
 pGD
 pGD
 pXV
@@ -119800,9 +119807,9 @@ oSU
 pXV
 pGD
 pGD
-cmE
-ttd
-nze
+gkM
+ltJ
+uwB
 pGD
 pGD
 pXV
@@ -120057,9 +120064,9 @@ oSU
 pXV
 pGD
 pGD
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 mGh
 bTI
@@ -120312,11 +120319,11 @@ oSU
 oSU
 oSU
 pXV
-khH
+xrd
 pGD
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 aFY
 gYI
@@ -120571,9 +120578,9 @@ oSU
 pXV
 pGD
 pGD
-cmE
-swq
-nze
+gkM
+lsu
+uwB
 pGD
 vKn
 wMB
@@ -120828,9 +120835,9 @@ oSU
 pXV
 pGD
 pGD
-cmE
-swq
-nze
+gkM
+lsu
+uwB
 pGD
 kxF
 gYI
@@ -121085,9 +121092,9 @@ oSU
 pXV
 pGD
 pGD
-cmE
-ttd
-nze
+gkM
+ltJ
+uwB
 pGD
 kku
 gzt
@@ -121342,9 +121349,9 @@ oSU
 pXV
 pGD
 pGD
-cmE
-nEt
-gwB
+gkM
+igP
+duG
 pGD
 djd
 cBz
@@ -121599,9 +121606,9 @@ oSU
 pXV
 pGD
 pGD
-cmE
-ttd
-gwB
+gkM
+ltJ
+duG
 pGD
 prM
 hYC
@@ -121856,9 +121863,9 @@ oSU
 pXV
 pGD
 pGD
-cmE
-ttd
-nze
+gkM
+ltJ
+uwB
 pGD
 ykU
 bTI
@@ -122111,11 +122118,11 @@ oSU
 oSU
 oSU
 pXV
-khH
+xrd
 dPN
-cmE
-ttd
-gwB
+gkM
+ltJ
+duG
 pGD
 prM
 cBz
@@ -122370,9 +122377,9 @@ oSU
 pXV
 pGD
 pGD
-cmE
-nEt
-vGp
+gkM
+igP
+nkX
 pGD
 gBp
 rls
@@ -122627,9 +122634,9 @@ oSU
 pXV
 pGD
 pGD
-cmE
-nEt
-gwB
+gkM
+igP
+duG
 pGD
 thL
 ert
@@ -122884,9 +122891,9 @@ oSU
 pXV
 pGD
 pGD
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 xMf
 iVP
@@ -123141,9 +123148,9 @@ oSU
 pXV
 pGD
 pGD
-cmE
-nEt
-nze
+gkM
+igP
+uwB
 pGD
 rBl
 hrV
@@ -123398,9 +123405,9 @@ oSU
 pXV
 pGD
 pGD
-cmE
-nEt
-gwB
+gkM
+igP
+duG
 pGD
 aFY
 cvb
@@ -123910,7 +123917,7 @@ oSU
 oSU
 oSU
 pXV
-khH
+xrd
 pGD
 pGD
 pGD
@@ -125966,13 +125973,13 @@ oSU
 oSU
 oSU
 euu
-sfB
+ohG
 aFD
 aFD
 aFD
 vOF
 vOF
-gnE
+wkq
 euu
 oSU
 oSU
@@ -127262,11 +127269,11 @@ euu
 oSU
 oSU
 oSU
-cRz
-cRz
-cRz
-cRz
-cRz
+sMX
+sMX
+sMX
+sMX
+sMX
 oSU
 oSU
 oSU
@@ -127517,14 +127524,14 @@ vOF
 vOF
 euu
 oSU
-cRz
-cRz
-cRz
-aSQ
-kHJ
-dEu
-cRz
-cRz
+sMX
+sMX
+sMX
+piK
+pUC
+hIR
+sMX
+sMX
 oSU
 oSU
 oSU
@@ -127765,24 +127772,24 @@ oSU
 oSU
 oSU
 euu
-sfB
+ohG
 oWa
 vOF
 vOF
 vOF
 aFD
-gnE
+wkq
 euu
 oSU
-cRz
-dEu
-nZC
-jER
-nZC
-lOq
-oIu
-cRz
-cRz
+sMX
+hIR
+vuT
+nWh
+vuT
+tKU
+hdu
+sMX
+sMX
 oSU
 oSU
 cGX
@@ -128028,18 +128035,18 @@ vOF
 aFD
 vOF
 qiu
-hGb
+jHx
 euu
 oSU
-cRz
-lQD
-nZC
-nZC
-nZC
-jgM
-gkA
-dEu
-cRz
+sMX
+qxt
+vuT
+vuT
+vuT
+mWG
+juD
+hIR
+sMX
 oSU
 oSU
 cGX
@@ -128287,18 +128294,18 @@ pxg
 aFD
 euu
 euu
-cRz
-cRz
-hgz
-cRz
-nZC
-tWt
-uhD
-cRz
-hqf
-cRz
-cRz
-cRz
+sMX
+sMX
+fAp
+sMX
+vuT
+mne
+rMb
+sMX
+fqI
+sMX
+sMX
+sMX
 cGX
 aeZ
 aeZ
@@ -128544,18 +128551,18 @@ pxg
 aFD
 euu
 euu
-oIu
+hdu
+qzp
+mWG
+qzp
 vuT
-jgM
+qpX
+tKU
+rMb
 vuT
-nZC
-hxb
-lOq
-uhD
-nZC
-vuT
-cRz
-cRz
+qzp
+sMX
+sMX
 nib
 aeZ
 aeZ
@@ -128799,20 +128806,20 @@ pxg
 vOF
 gWs
 aFD
-leq
-alC
+ceC
+ajd
+qzp
+fqI
+qxt
+qzp
+qzp
+tKU
+dxi
 vuT
-hqf
-lQD
 vuT
-vuT
-lOq
-wFY
-nZC
-nZC
-dgV
-cRz
-cfm
+jwo
+sMX
+cqM
 nib
 aeZ
 aeZ
@@ -129058,19 +129065,19 @@ pxg
 aFD
 euu
 euu
-oIu
-lOq
-uhD
-nZC
-nZC
-hfq
-vUa
-nZC
-nZC
-nZC
-cRz
-cRz
-leD
+hdu
+tKU
+rMb
+vuT
+vuT
+lWk
+pSj
+vuT
+vuT
+vuT
+sMX
+sMX
+lUe
 aeZ
 aeZ
 aeZ
@@ -129315,18 +129322,18 @@ cQQ
 aFD
 euu
 euu
-cRz
-cRz
-nZC
-cRz
-lOq
-jgM
-uhD
-cRz
-hgz
-cRz
-cRz
-cRz
+sMX
+sMX
+vuT
+sMX
+tKU
+mWG
+rMb
+sMX
+fAp
+sMX
+sMX
+sMX
 cGX
 aeZ
 aeZ
@@ -129573,15 +129580,15 @@ oWa
 euu
 euu
 oSU
-cRz
-nZC
-nZC
-ltG
+sMX
 vuT
-lOq
-lOq
-dEu
-cRz
+vuT
+nRk
+qzp
+tKU
+tKU
+hIR
+sMX
 oSU
 oSU
 cGX
@@ -129830,15 +129837,15 @@ aFD
 euu
 euu
 oSU
-cRz
-uvl
+sMX
+ftB
+qzp
+qzp
+fqI
 vuT
-vuT
-hqf
-nZC
-htD
-cRz
-cRz
+crs
+sMX
+sMX
 oSU
 oSU
 cGX
@@ -130087,15 +130094,15 @@ aFD
 euu
 euu
 oSU
-cRz
-dZs
-uMn
-lOq
-lOq
-lOq
-dEu
-dEu
-cRz
+sMX
+mXc
+oEY
+tKU
+tKU
+tKU
+hIR
+hIR
+sMX
 oSU
 oSU
 cGX
@@ -130344,15 +130351,15 @@ aFD
 oSU
 euu
 oSU
-cRz
-cRz
-cRz
-cRz
-vuT
-vuT
-cRz
-cRz
-cRz
+sMX
+sMX
+sMX
+sMX
+qzp
+qzp
+sMX
+sMX
+sMX
 oSU
 oSU
 cGX
@@ -130598,18 +130605,18 @@ aFD
 aFD
 aFD
 aFD
-wSI
+oxS
 euu
 oSU
 oSU
-cRz
-oIu
-rDI
+sMX
+hdu
+iVx
+qzp
 vuT
-nZC
-ipH
-kca
-cRz
+vgv
+azQ
+sMX
 oSU
 oSU
 cGX
@@ -130859,14 +130866,14 @@ oSU
 euu
 oSU
 oSU
-cRz
-nZC
-wXA
-tWt
-nZC
-pse
-tWt
-cRz
+sMX
+vuT
+mAC
+mne
+vuT
+rry
+mne
+sMX
 oSU
 oSU
 cGX
@@ -131116,14 +131123,14 @@ oSU
 euu
 oSU
 oSU
-cRz
-lqv
-oIu
-gkA
-jDo
-ltG
-kGN
-cRz
+sMX
+oqi
+hdu
+juD
+mat
+nRk
+aOp
+sMX
 oSU
 oSU
 cGX
@@ -131364,23 +131371,23 @@ oSU
 oSU
 oSU
 oSU
-wSI
+oxS
 oSU
-wSI
+oxS
 oSU
-wSI
+oxS
 oSU
-cRz
-cRz
-cRz
-cRz
-cRz
-cRz
-nZC
-jgM
-cRz
-cRz
-cRz
+sMX
+sMX
+sMX
+sMX
+sMX
+sMX
+vuT
+mWG
+sMX
+sMX
+sMX
 oSU
 oSU
 cGX
@@ -131627,17 +131634,17 @@ oSU
 oSU
 oSU
 oSU
-cRz
-dxX
-dyr
-eLx
-iJc
-gkA
+sMX
+tPD
+lez
+dHH
+uth
+juD
+qzp
+dki
 vuT
-kbk
-nZC
-hdX
-cRz
+rzu
+sMX
 oSU
 oSU
 cGX
@@ -131884,17 +131891,17 @@ oSU
 oSU
 oSU
 oSU
-cRz
-dNd
+sMX
+eSo
+qzp
+qzp
+mne
+vuT
+pSj
 vuT
 vuT
-tWt
-nZC
-vUa
-nZC
-nZC
-nZC
-cRz
+vuT
+sMX
 oSU
 oSU
 cGX
@@ -132141,17 +132148,17 @@ oSU
 oSU
 oSU
 oSU
-cRz
-vuT
-hqf
-gkA
-vuT
-prS
-vdO
-mDl
-kaV
-pEF
-cRz
+sMX
+qzp
+fqI
+juD
+qzp
+kfp
+wMa
+tNN
+mKn
+sgU
+sMX
 oSU
 oSU
 cGX
@@ -132398,17 +132405,17 @@ oSU
 oSU
 oSU
 oSU
-cRz
-cRz
-cRz
-cRz
-cRz
-cRz
-cRz
-cRz
-cRz
-cRz
-cRz
+sMX
+sMX
+sMX
+sMX
+sMX
+sMX
+sMX
+sMX
+sMX
+sMX
+sMX
 oSU
 oSU
 cGX

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -2321,9 +2321,13 @@
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/siding/green{
+	dir = 1
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "aFJ" = (
@@ -7673,10 +7677,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
 "ccx" = (
-/obj/effect/turf_decal/siding/thinplating_new,
-/obj/structure/ladder,
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/area/station/service/hydroponics/garden)
 "ccz" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -11479,18 +11485,17 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "ddZ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/iron/large,
+/obj/structure/cable,
+/turf/closed/wall,
 /area/station/service/hydroponics/garden)
 "def" = (
 /obj/machinery/dna_infuser,
@@ -15889,9 +15894,6 @@
 /area/station/tcommsat/server)
 "esv" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
@@ -17713,18 +17715,13 @@
 	},
 /area/station/service/chapel)
 "eUA" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/green/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/station/service/hydroponics/garden)
 "eUB" = (
 /obj/machinery/light/small/directional/north,
@@ -27027,11 +27024,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "hBG" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/south{
+	id = "tram_perma_lift"
 	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "tram_perma_lift"
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "hBZ" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/command,
@@ -35114,6 +35115,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "jRM" = (
@@ -41265,15 +41268,13 @@
 "lCb" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "lCc" = (
@@ -41311,6 +41312,12 @@
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/green/corner{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -45287,12 +45294,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mLd" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
 	},
-/obj/structure/sign/poster/contraband/kudzu/directional/north,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "mLf" = (
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
@@ -55028,6 +55036,13 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/fore/lesser)
+"ppj" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/elevator/directional/east,
+/obj/machinery/lift_indicator/directional/east,
+/obj/machinery/door/window/elevator/right/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/garden)
 "ppl" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -56075,12 +56090,9 @@
 /turf/open/floor/iron/large,
 /area/station/medical/break_room)
 "pEs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/siding/green{
-	dir = 8
-	},
-/turf/open/floor/iron/large,
-/area/station/service/hydroponics/garden)
+/obj/structure/transport/linear/public,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "pEE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -60732,19 +60744,7 @@
 /turf/open/misc/asteroid/snow/standard_air,
 /area/station/science/cytology)
 "qTm" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/space/basic,
 /area/station/service/hydroponics/garden)
 "qTq" = (
 /obj/machinery/door/airlock{
@@ -64531,9 +64531,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rVr" = (
-/obj/structure/ladder,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "rVB" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
@@ -65025,11 +65027,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "scr" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/obj/machinery/door/window/elevator/left/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "sct" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -66801,6 +66804,9 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/green{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "sAS" = (
@@ -67193,15 +67199,8 @@
 /turf/open/floor/iron,
 /area/station/security/brig/upper)
 "sGq" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/machinery/status_display/evac/directional/west,
-/turf/open/floor/iron/dark,
+/turf/open/space/basic,
 /area/station/service/hydroponics/garden)
 "sGw" = (
 /obj/structure/sign/warning/secure_area/directional/north,
@@ -67586,6 +67585,11 @@
 /obj/structure/flora/grass/both/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"sMK" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "sML" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68631,9 +68635,8 @@
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "tdp" = (
-/obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/sign/poster/official/random/directional/north,
+/obj/machinery/door/window/elevator/left/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "tdE" = (
@@ -69401,7 +69404,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -71253,13 +71255,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "tNd" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/effect/turf_decal/siding/green{
-	dir = 1
-	},
-/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/siding/green/corner{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -73345,6 +73342,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"utn" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "utr" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -80541,6 +80545,10 @@
 /obj/machinery/griddle,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
+"wAK" = (
+/obj/structure/transport/linear/public,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "wAN" = (
 /obj/structure/sign/warning/directional/east,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -86460,10 +86468,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "ydH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ladder,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers)
 "ydI" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/entry)
@@ -101419,11 +101425,11 @@ oSU
 oSU
 oSU
 oSU
-vBN
-vBN
-vBN
-vBN
-vBN
+gFX
+gFX
+gFX
+gFX
+gFX
 vBN
 lhB
 thA
@@ -101676,14 +101682,14 @@ oSU
 oSU
 oSU
 oSU
+gFX
 vBN
 vBN
 vBN
-vBN
-vBN
-lhB
-rVr
-iDt
+gFX
+gFX
+gFX
+gFX
 ghx
 ghx
 ghx
@@ -101933,14 +101939,14 @@ oSU
 oSU
 oSU
 oSU
+gFX
 vBN
 vBN
 vBN
-vBN
-vBN
-vBN
-vBN
-xxV
+scr
+pEs
+pEs
+gFX
 ghx
 ghx
 ghx
@@ -102194,10 +102200,10 @@ vBN
 vBN
 vBN
 vBN
-lhB
-vBN
-thA
-ghx
+mLd
+pEs
+wAK
+gFX
 ghx
 ghx
 ghx
@@ -102450,11 +102456,11 @@ oSU
 vBN
 vBN
 nHU
-lhB
-vBN
-vBN
-thA
-ghx
+hBG
+gFX
+gFX
+rsO
+gFX
 ghx
 ghx
 ghx
@@ -104508,7 +104514,7 @@ vBN
 wuN
 rOU
 qFF
-wuN
+sMK
 ghx
 ghx
 ghx
@@ -104765,7 +104771,7 @@ vBN
 aMC
 bed
 qFF
-wuN
+cqV
 iDt
 ghx
 ghx
@@ -105793,7 +105799,7 @@ vBN
 aMC
 uWq
 dzI
-wuN
+eiQ
 ghx
 ghx
 ghx
@@ -106050,7 +106056,7 @@ vBN
 aMC
 uWq
 vrk
-wuN
+aMC
 ghx
 ghx
 ghx
@@ -106307,7 +106313,7 @@ nHU
 eiQ
 uWq
 kdq
-aMC
+wuN
 ghx
 ghx
 ghx
@@ -167216,10 +167222,10 @@ tjo
 tjo
 tjo
 tjo
-tjo
-vBN
 ydH
-lhB
+gFX
+wlK
+wlK
 lhB
 uWb
 tjo
@@ -167473,10 +167479,10 @@ tjo
 tjo
 tjo
 tjo
-tjo
+ydH
 vBN
 lhB
-lhB
+wlK
 lhB
 lhB
 tjo
@@ -167730,10 +167736,10 @@ tjo
 tjo
 tjo
 tjo
-tjo
+ydH
 vBN
 lhB
-lhB
+wlK
 lhB
 lhB
 tjo
@@ -167987,10 +167993,10 @@ tjo
 tjo
 tjo
 tjo
-tjo
-vBN
-vBN
-vBN
+ydH
+gFX
+gFX
+gFX
 vBN
 tjo
 tjo
@@ -232757,7 +232763,7 @@ oCO
 oCO
 gyH
 uTI
-ccx
+cuc
 mVE
 mVE
 mVE
@@ -233009,9 +233015,9 @@ lJO
 lJO
 mCT
 blA
-mCT
-sGq
 oCO
+sGq
+qTm
 tdp
 uTI
 kXD
@@ -233266,10 +233272,10 @@ pLZ
 lJO
 aPM
 aPM
-aPM
+oCO
 qTm
-oCO
-oCO
+qTm
+ppj
 tmL
 arG
 cIa
@@ -233525,7 +233531,7 @@ esv
 lCb
 ddZ
 eUA
-scr
+oCO
 oCO
 oCO
 oCO
@@ -233778,9 +233784,9 @@ lJO
 lJO
 lJO
 lJO
-nCr
-eUi
-eBB
+rVr
+utn
+ccx
 tNd
 nor
 sst
@@ -234035,9 +234041,9 @@ bln
 efI
 efI
 lJO
-mLd
-hBG
-pEs
+nCr
+eUi
+eBB
 aFH
 jRI
 nza

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -712,6 +712,10 @@
 /obj/item/clothing/suit/hooded/wintercoat/science,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"alC" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "alD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -1969,10 +1973,6 @@
 	},
 /turf/open/floor/circuit/red,
 /area/station/ai/upload/chamber)
-"aAl" = (
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "aAv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2356,10 +2356,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"aFM" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "aFY" = (
 /obj/structure/railing{
 	dir = 1
@@ -2790,13 +2786,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
-"aMu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/rubble,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "aMA" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron,
@@ -3207,6 +3196,13 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/hallway/secondary/service)
+"aSQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/rubble,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "aSS" = (
 /obj/effect/turf_decal/trimline/dark_red/end,
 /obj/machinery/meter,
@@ -3623,6 +3619,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "aZd" = (
@@ -4776,6 +4775,7 @@
 /obj/structure/tram/spoiler{
 	dir = 8
 	},
+/obj/structure/fluff/tram_rail/electric,
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "bpd" = (
@@ -5159,17 +5159,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
-"btb" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "btg" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance"
@@ -6547,6 +6536,9 @@
 /obj/structure/chair/sofa/bench/tram/left{
 	dir = 1
 	},
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "bKZ" = (
@@ -6624,6 +6616,11 @@
 /obj/structure/sign/warning/secure_area/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
+"bMD" = (
+/obj/structure/holosign/barrier/atmos/tram,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "bMF" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -7301,12 +7298,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron,
 /area/station/metro/outrivals_station)
-"bWr" = (
-/obj/effect/decal/cleanable/insectguts,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "bWv" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -8015,6 +8006,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"cfm" = (
+/obj/structure/barricade/wooden/snowed,
+/turf/closed/wall,
+/area/station/metro/abandoned/abandoned_collector)
 "cfr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8246,10 +8241,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
-"ciO" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "ciS" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -8433,6 +8424,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/metro/outrivals_station)
+"cmE" = (
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "cmJ" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
@@ -8573,15 +8568,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
-"con" = (
-/obj/item/storage/medkit/fire,
-/obj/effect/mob_spawn/corpse/human/charredskeleton,
-/obj/item/ammo_casing/shotgun/buckshot,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "coL" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
@@ -8885,9 +8871,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/service/chapel)
-"csO" = (
-/turf/open/misc/beach/sand,
-/area/station/metro/abandoned/abandoned_collector)
 "csS" = (
 /obj/structure/closet/secure_closet/freezer/meat/all_access,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -10078,13 +10061,6 @@
 /obj/item/coin/diamond,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"cIL" = (
-/obj/effect/decal/cleanable/plastic,
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "cIP" = (
 /obj/machinery/bookbinder,
 /obj/structure/sign/poster/official/random/directional/west,
@@ -10570,7 +10546,7 @@
 /obj/structure/chair/sofa/bench/tram/left,
 /obj/structure/thermoplastic/light,
 /obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/north_tunnel)
 "cPd" = (
 /obj/structure/cable,
@@ -10755,6 +10731,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"cRz" = (
+/turf/closed/wall,
+/area/station/metro/abandoned/abandoned_collector)
 "cRC" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
@@ -11853,6 +11832,12 @@
 /obj/machinery/smartfridge,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
+"dgV" = (
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "dgZ" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
@@ -12262,12 +12247,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
-"dlY" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "dmk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -12557,10 +12536,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
-"dqH" = (
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "dqI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12865,6 +12840,12 @@
 "duh" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/transit_tube)
+"duu" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/titanium,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "duE" = (
 /obj/machinery/atmospherics/components/binary/tank_compressor{
 	dir = 4
@@ -12883,7 +12864,7 @@
 "duW" = (
 /obj/structure/thermoplastic,
 /obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/north_tunnel)
 "duY" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input,
@@ -13170,6 +13151,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/sepia,
 /area/station/security/prison/rec)
+"dxX" = (
+/obj/item/storage/medkit/fire,
+/obj/effect/mob_spawn/corpse/human/charredskeleton,
+/obj/item/ammo_casing/shotgun/buckshot,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "dyf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13182,6 +13172,10 @@
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"dyr" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "dyA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/effect/turf_decal/stripes/line,
@@ -13273,14 +13267,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/mine/eva/lower)
-"dzM" = (
-/obj/effect/decal/fakelattice,
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "dzO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -13398,10 +13384,6 @@
 /obj/structure/sign/poster/official/help_others/directional/west,
 /turf/open/floor/iron/checker,
 /area/station/commons/storage/emergency/port)
-"dBD" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "dBJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13616,6 +13598,10 @@
 	dir = 8
 	},
 /area/station/security/brig/entrance)
+"dEu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "dEv" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
@@ -14178,6 +14164,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"dNd" = (
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "dNw" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -14897,6 +14887,12 @@
 	dir = 8
 	},
 /area/mine/eva)
+"dZs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/corpse/human/charredskeleton,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "dZN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -15061,10 +15057,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/vault)
-"ebM" = (
-/obj/effect/decal/cleanable/shreds,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "ebO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -17453,6 +17445,16 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/brig)
+"eLx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "eLB" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Service - Gambling Lounge"
@@ -17506,10 +17508,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
-"eMv" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "eME" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18047,6 +18045,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/chem_storage)
+"eUJ" = (
+/obj/structure/tram/alt/titanium,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/north_tunnel)
 "eUK" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty{
@@ -18207,12 +18209,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"eWI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/mob_spawn/corpse/human/charredskeleton,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "eWQ" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
@@ -20092,6 +20088,9 @@
 /obj/structure/chair/sofa/bench/tram/right{
 	dir = 1
 	},
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "fyQ" = (
@@ -20830,11 +20829,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
-"fKT" = (
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/barricade/wooden/snowed,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "fKV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22583,6 +22577,12 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"gkA" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "gkN" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/iron/dark/textured,
@@ -22823,6 +22823,12 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/engineering/lobby)
+"gnE" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "gnJ" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -23042,17 +23048,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
-"gqh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "gqj" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -23523,6 +23518,13 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
+"gwB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "gwJ" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 5
@@ -25369,6 +25371,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/evidence)
+"gXj" = (
+/obj/structure/fluff/minepost,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "gXk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25583,6 +25592,13 @@
 /obj/effect/gibspawner/human,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"gZx" = (
+/obj/structure/thermoplastic,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "gZP" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -25848,6 +25864,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/interrogation)
+"hdX" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "heg" = (
 /obj/effect/spawner/random/engineering/canister,
 /turf/open/floor/plating,
@@ -25918,6 +25938,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/textured,
 /area/station/maintenance/starboard/fore)
+"hfq" = (
+/obj/effect/decal/cleanable/greenglow/waste,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "hfs" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -25925,17 +25950,6 @@
 /obj/item/instrument/harmonica,
 /turf/open/floor/iron/grimy,
 /area/station/commons/lounge)
-"hft" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "hfy" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -25970,6 +25984,10 @@
 "hgr" = (
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/secondary/entry)
+"hgz" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "hgK" = (
 /obj/structure/ladder,
 /obj/effect/landmark/blobstart,
@@ -26652,6 +26670,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"hqf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "hqm" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -26904,6 +26928,10 @@
 "htB" = (
 /turf/open/floor/carpet/red,
 /area/station/security/prison/work)
+"htD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/ice/smooth,
+/area/station/metro/abandoned/abandoned_collector)
 "htH" = (
 /obj/structure/table/wood,
 /obj/machinery/fax{
@@ -26930,10 +26958,6 @@
 /obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
-"htX" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "hue" = (
 /obj/structure/chair/comfy/black,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27076,6 +27100,9 @@
 "hwe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/holosign/barrier/atmos/tram,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "hwm" = (
@@ -27137,6 +27164,10 @@
 /obj/effect/mapping_helpers/airlock/unres/delayed,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"hxb" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "hxs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27727,6 +27758,10 @@
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"hGb" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "hGh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29990,12 +30025,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
-"imq" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "imH" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/clothing/gloves,
@@ -30223,6 +30252,17 @@
 "ipE" = (
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"ipH" = (
+/obj/effect/decal/cleanable/chem_pile,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "ipM" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -30787,13 +30827,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"izm" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "izp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -31346,6 +31379,17 @@
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
+"iJc" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "iJh" = (
 /obj/structure/sign/warning/gas_mask/directional/west,
 /turf/open/floor/plating,
@@ -33033,6 +33077,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"jgM" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "jgV" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
@@ -33233,10 +33284,6 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
-"jkc" = (
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "jkn" = (
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /turf/open/floor/iron,
@@ -33460,9 +33507,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"jnP" = (
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "jnR" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
@@ -34567,6 +34611,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/treatment_center)
+"jDo" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "jDz" = (
 /obj/machinery/light/small/directional/east,
 /obj/item/pickaxe,
@@ -34667,6 +34715,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
+"jER" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/misc/beach/sand,
+/area/station/metro/abandoned/abandoned_collector)
 "jEU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -34899,10 +34951,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/textured,
 /area/station/commons/storage/mining)
-"jJb" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "jJd" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -36193,6 +36241,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/security/eva)
+"kaV" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "kaW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36209,6 +36261,10 @@
 /obj/item/clothing/shoes/workboots,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"kbk" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "kbn" = (
 /obj/effect/decal/cleanable/food/pie_smudge,
 /turf/open/floor/iron,
@@ -36246,6 +36302,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"kca" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "kcc" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - Infirmary"
@@ -36346,6 +36406,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "kdA" = (
@@ -36645,6 +36708,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/ai/satellite/atmos)
+"khH" = (
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "khR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
@@ -36905,10 +36972,6 @@
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"kky" = (
-/obj/item/ammo_casing/shotgun/buckshot,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "kkD" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -37395,10 +37458,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/fitness)
-"ksm" = (
-/obj/structure/railing,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "ksn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -37931,10 +37990,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"kzp" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "kzv" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet/any,
@@ -38493,6 +38548,10 @@
 	dir = 1
 	},
 /area/station/commons/storage/art)
+"kGN" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "kGQ" = (
 /obj/structure/table,
 /obj/item/stamp/head/qm,
@@ -38549,6 +38608,10 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"kHJ" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "kHN" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/openspace,
@@ -38749,6 +38812,7 @@
 /obj/structure/tram/spoiler{
 	dir = 1
 	},
+/obj/structure/fluff/tram_rail/electric,
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "kJO" = (
@@ -39163,6 +39227,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"kPC" = (
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/north_tunnel)
 "kPH" = (
 /obj/structure/stairs/south{
 	dir = 8
@@ -40210,6 +40278,15 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/science/research)
+"leq" = (
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/barricade/wooden/snowed,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
+"leD" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "leM" = (
 /obj/structure/railing{
 	dir = 8
@@ -41042,6 +41119,13 @@
 /obj/item/rcl/pre_loaded,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
+"lqv" = (
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "lqz" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -41110,12 +41194,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"lqY" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "lqZ" = (
 /obj/machinery/vending/wardrobe/coroner_wardrobe,
 /obj/effect/turf_decal/siding/dark_blue{
@@ -41271,6 +41349,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/medical/chem_storage)
+"ltG" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "ltP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -42702,6 +42786,9 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"lOq" = (
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "lOr" = (
 /obj/structure/railing,
 /obj/structure/stairs/east,
@@ -42938,6 +43025,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/station/service/library)
+"lQD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "lQE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
@@ -43008,10 +43099,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/chamber)
-"lRC" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "lRD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -43982,11 +44069,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/office)
-"mhE" = (
-/obj/effect/decal/cleanable/greenglow/waste,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "mhG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -45414,6 +45496,17 @@
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"mDl" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "mDq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/east,
@@ -46835,9 +46928,6 @@
 /obj/machinery/light/empty/directional/east,
 /turf/open/floor/iron/white,
 /area/station/maintenance/port/fore)
-"mZu" = (
-/turf/closed/wall,
-/area/station/metro/abandoned/abandoned_collector)
 "mZG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -48738,6 +48828,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"nze" = (
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "nzj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49206,6 +49302,9 @@
 /obj/effect/spawner/random/trash/caution_sign,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"nEt" = (
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/north_tunnel)
 "nEA" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50693,17 +50792,6 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
-"nYs" = (
-/obj/effect/decal/cleanable/chem_pile,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "nYv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50762,6 +50850,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
+"nZC" = (
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "nZH" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
@@ -51244,6 +51335,9 @@
 /obj/structure/thermoplastic/light,
 /obj/machinery/door/airlock/titanium,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "ogl" = (
@@ -51275,10 +51369,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/command/eva)
-"ogC" = (
-/obj/structure/railing,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "ogF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53568,6 +53658,9 @@
 /obj/structure/sign/departments/cargo/directional/west,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
+"oIu" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "oIv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/drip,
@@ -54831,12 +54924,6 @@
 "pbs" = (
 /turf/closed/wall,
 /area/station/ai/satellite/maintenance)
-"pbw" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "pby" = (
 /obj/effect/gibspawner/human,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -55111,6 +55198,11 @@
 /obj/structure/grille/broken,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/explored)
+"pfi" = (
+/obj/structure/tram/alt/titanium,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "pfw" = (
 /obj/structure/flora/grass/green/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -55590,10 +55682,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"plZ" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "pme" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -55809,11 +55897,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/fore/lesser)
-"ppf" = (
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "ppl" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -55965,6 +56048,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/metro/center_station)
+"prS" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "prX" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -55978,6 +56072,17 @@
 "psb" = (
 /turf/closed/wall/ice,
 /area/icemoon/underground/explored)
+"pse" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "psm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -56429,13 +56534,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
-"pyd" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "pyh" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/effect/spawner/random/aimodule/neutral,
@@ -56893,6 +56991,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
+"pEF" = (
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "pER" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon{
@@ -56934,6 +57037,9 @@
 "pFD" = (
 /obj/structure/thermoplastic,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "pFF" = (
@@ -57541,6 +57647,10 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"pPb" = (
+/obj/structure/barricade/wooden,
+/turf/open/genturf/blue,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "pPg" = (
 /obj/structure/stairs/west,
 /turf/open/floor/iron/stairs/medium{
@@ -57731,6 +57841,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/storage/art)
+"pRT" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "pRX" = (
 /obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -57899,10 +58014,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/warden)
-"pTS" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/misc/beach/sand,
-/area/station/metro/abandoned/abandoned_collector)
 "pTT" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -58328,6 +58439,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
+"pZv" = (
+/obj/structure/tram,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "pZB" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Chemistry Access"
@@ -58618,6 +58734,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
+"qcb" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "qch" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/disposalpipe/segment,
@@ -60570,6 +60692,9 @@
 /obj/structure/thermoplastic/light,
 /obj/structure/thermoplastic,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "qFJ" = (
@@ -60919,10 +61044,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
-"qKG" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "qKQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -62741,10 +62862,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/icemoon,
 /area/icemoon/underground/explored)
-"rjc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "rjd" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/isolation/directional/south,
@@ -64306,6 +64423,14 @@
 	dir = 10
 	},
 /area/mine/eva)
+"rDI" = (
+/obj/effect/decal/fakelattice,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "rDJ" = (
 /obj/structure/ladder{
 	name = "upper dispenser access"
@@ -64450,10 +64575,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/eva/lower)
-"rFt" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "rFI" = (
 /obj/structure/cable,
 /obj/machinery/button/door/directional/north{
@@ -65023,7 +65144,7 @@
 /obj/structure/thermoplastic,
 /obj/structure/thermoplastic/light,
 /obj/structure/chair/sofa/bench/tram/right,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/north_tunnel)
 "rPe" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -65200,11 +65321,6 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
-"rRL" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "rRN" = (
 /obj/structure/railing,
 /turf/open/floor/plating,
@@ -65561,12 +65677,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"rWQ" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "rWR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -66177,6 +66287,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"sfB" = (
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "sfF" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Security - Lower Hallway North";
@@ -66543,9 +66657,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"slg" = (
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "slh" = (
 /obj/structure/table,
 /obj/item/flashlight,
@@ -66971,12 +67082,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
-"spW" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "sqb" = (
 /obj/item/coin/iron{
 	pixel_y = -5
@@ -67349,10 +67454,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
-"suO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "suR" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -67421,6 +67522,11 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/station/science/explab)
+"swq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/north_tunnel)
 "sws" = (
 /obj/machinery/door/airlock/security{
 	name = "Permabrig Library"
@@ -67696,6 +67802,9 @@
 "sAc" = (
 /obj/structure/tram,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "sAd" = (
@@ -67742,17 +67851,6 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
-"sAG" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "sAR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -69530,9 +69628,6 @@
 /obj/structure/closet,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
-"tbz" = (
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "tbH" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -70539,6 +70634,10 @@
 /obj/machinery/shower/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"toL" = (
+/obj/structure/thermoplastic/light,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/north_tunnel)
 "toT" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/railing/corner{
@@ -70816,6 +70915,10 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"ttd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/tram,
+/area/station/metro/train_tunnels/north_tunnel)
 "ttw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/smooth_large,
@@ -71082,6 +71185,7 @@
 "txh" = (
 /obj/structure/tram/alt/titanium,
 /obj/machinery/transport/tram_controller,
+/obj/structure/fluff/tram_rail/electric,
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "txj" = (
@@ -72869,6 +72973,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/service/bar/backroom)
+"tWt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "tWy" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -73586,6 +73694,9 @@
 /obj/effect/landmark/navigate_destination/dockaux,
 /turf/open/floor/iron/large,
 /area/station/hallway/secondary/entry)
+"uhD" = (
+/turf/open/misc/beach/sand,
+/area/station/metro/abandoned/abandoned_collector)
 "uhE" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 9
@@ -74512,6 +74623,10 @@
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"uvl" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "uvt" = (
 /turf/closed/wall,
 /area/station/science/robotics/mechbay)
@@ -74682,6 +74797,11 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
+"uyf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "uyi" = (
 /obj/item/chair/stool{
 	pixel_y = 0;
@@ -75639,6 +75759,12 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
+"uMn" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "uMp" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -75845,16 +75971,6 @@
 "uPk" = (
 /turf/closed/wall/r_wall,
 /area/station/security/range)
-"uPm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "uPt" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark,
@@ -76088,6 +76204,13 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
+"uSB" = (
+/obj/structure/tram,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "uTk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -76301,7 +76424,7 @@
 /area/station/commons/dorms)
 "uWq" = (
 /obj/structure/thermoplastic,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/north_tunnel)
 "uWu" = (
 /obj/structure/flora/grass/green/style_random,
@@ -76783,6 +76906,18 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
+"vdO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "vdW" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -77242,10 +77377,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /turf/open/floor/iron/smooth,
 /area/mine/mechbay)
-"vlW" = (
-/obj/structure/barricade/wooden,
-/turf/open/genturf,
-/area/icemoon/underground/unexplored/rivers/deep)
 "vmj" = (
 /obj/structure/chair{
 	dir = 1;
@@ -77703,6 +77834,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/metro/train_tunnels/north_tunnel)
 "vrw" = (
@@ -77948,7 +78082,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "vuT" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/misc/dirt/dark{
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
@@ -78728,6 +78861,14 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"vGp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "vGw" = (
 /obj/structure/transit_tube/station/reverse,
 /obj/structure/sign/warning/secure_area/directional/north,
@@ -79256,10 +79397,6 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
-"vOm" = (
-/obj/structure/barricade/wooden/snowed,
-/turf/closed/wall,
-/area/station/metro/abandoned/abandoned_collector)
 "vOw" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red{
@@ -79601,18 +79738,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/prison/work)
-"vTG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/fakelattice,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "vTJ" = (
 /obj/structure/table,
 /obj/item/toy/plush/slimeplushie{
@@ -79640,6 +79765,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"vUa" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "vUr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -80264,6 +80393,13 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/mine/living_quarters)
+"wcG" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/fluff/tram_rail/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "wcL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -80551,10 +80687,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"whq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "whr" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/cultivator,
@@ -80711,7 +80843,7 @@
 "wjW" = (
 /obj/structure/thermoplastic,
 /obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/north_tunnel)
 "wkb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -82127,6 +82259,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
+"wFY" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "wGa" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
@@ -82714,13 +82850,6 @@
 	dir = 1
 	},
 /area/station/security/prison)
-"wPp" = (
-/obj/structure/fluff/minepost,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "wPr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -82987,6 +83116,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
+"wSI" = (
+/obj/structure/barricade/wooden,
+/turf/open/genturf,
+/area/icemoon/underground/unexplored/rivers/deep)
 "wSL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -83374,6 +83507,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"wXA" = (
+/obj/effect/decal/cleanable/plastic,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "wXW" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -83465,10 +83605,6 @@
 /obj/effect/decal/cleanable/blood/gibs/robot_debris/down,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/port/fore)
-"wZo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/misc/ice/smooth,
-/area/station/metro/abandoned/abandoned_collector)
 "wZr" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -84877,6 +85013,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"xrc" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "xrf" = (
 /obj/structure/railing,
 /obj/structure/cable,
@@ -86193,10 +86335,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
-"xHQ" = (
-/obj/effect/decal/cleanable/ash/large,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "xId" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat/eva{
@@ -86528,7 +86666,7 @@
 /obj/structure/thermoplastic,
 /obj/structure/thermoplastic/light,
 /obj/structure/chair/sofa/bench/tram/solo,
-/turf/open/floor/plating,
+/turf/open/indestructible/tram,
 /area/station/metro/train_tunnels/north_tunnel)
 "xMQ" = (
 /obj/effect/mapping_helpers/ianbirthday,
@@ -104757,8 +104895,8 @@ mlt
 kJS
 uJW
 boY
-aMC
-gcH
+eUJ
+uSB
 sdC
 rVr
 ghx
@@ -105013,7 +105151,7 @@ thA
 mlt
 qGA
 mlt
-aMC
+pfi
 uWq
 bKQ
 gcH
@@ -105270,7 +105408,7 @@ thA
 mlt
 qJB
 cpd
-eiQ
+duu
 uWq
 fyO
 gcH
@@ -105527,9 +105665,9 @@ ghx
 rVr
 jiY
 qGk
-aMC
+pfi
 wjW
-uWq
+gZx
 aMC
 mlt
 ghx
@@ -105784,7 +105922,7 @@ ghx
 rVr
 lFA
 qGk
-gcH
+pZv
 rOU
 qFF
 gTE
@@ -106041,7 +106179,7 @@ ghx
 rVr
 qJB
 jlq
-aMC
+pfi
 cOS
 qFF
 cqV
@@ -106298,8 +106436,8 @@ ghx
 rVr
 qGA
 mlt
-aMC
-aMC
+pfi
+eUJ
 oge
 aMC
 rVr
@@ -106556,8 +106694,8 @@ mlt
 qGA
 xfV
 txh
-cqV
-uWq
+toL
+gZx
 gcH
 mlt
 ghx
@@ -106812,7 +106950,7 @@ ghx
 mlt
 dLW
 oWp
-gcH
+pZv
 xMP
 pFD
 aMC
@@ -107069,7 +107207,7 @@ ghx
 rVr
 qGA
 otE
-aMC
+pfi
 wjW
 pFD
 eiQ
@@ -107321,12 +107459,12 @@ ghx
 ghx
 ghx
 ghx
-thA
+pPb
 ghx
 rVr
 qGA
 mlt
-aMC
+pfi
 duW
 vrk
 aMC
@@ -107583,7 +107721,7 @@ ghx
 rVr
 qJB
 tbc
-eiQ
+duu
 uWq
 kdq
 gcH
@@ -107841,7 +107979,7 @@ rVr
 oti
 lde
 kJN
-aMC
+eUJ
 sAc
 iOk
 ccx
@@ -108097,9 +108235,9 @@ ghx
 mlt
 eha
 uOd
-pGD
-pGD
-gpH
+cmE
+nEt
+gwB
 pGD
 ccx
 ghx
@@ -108354,8 +108492,8 @@ ghx
 mlt
 mlt
 mlt
-sJx
-sJx
+bMD
+kPC
 hwe
 sJx
 mlt
@@ -108611,9 +108749,9 @@ ghx
 ghx
 ghx
 rzh
-pGD
-pGD
-gpH
+cmE
+nEt
+gwB
 pGD
 rzh
 ghx
@@ -108868,9 +109006,9 @@ ghx
 ghx
 ghx
 ghx
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 ghx
 ghx
@@ -109125,9 +109263,9 @@ ghx
 ghx
 ghx
 ghx
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 ghx
 ghx
@@ -109382,9 +109520,9 @@ ghx
 ghx
 ghx
 ghx
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 ghx
 ghx
@@ -109639,9 +109777,9 @@ ghx
 ghx
 ghx
 ghx
-pGD
-pGD
-dPN
+cmE
+nEt
+wcG
 pGD
 ghx
 ghx
@@ -109896,9 +110034,9 @@ ghx
 ghx
 ghx
 ghx
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 ghx
 ghx
@@ -110153,9 +110291,9 @@ ghx
 ghx
 ghx
 ghx
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 ghx
 ghx
@@ -110410,9 +110548,9 @@ ghx
 ghx
 ghx
 ghx
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 thA
 xuo
@@ -110667,9 +110805,9 @@ ghx
 ghx
 ghx
 ghx
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 thA
 xuo
@@ -110924,9 +111062,9 @@ ghx
 ghx
 ghx
 rzh
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 rzh
 thA
@@ -111181,9 +111319,9 @@ ghx
 ghx
 ghx
 ghx
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 thA
 thA
@@ -111438,9 +111576,9 @@ ghx
 ghx
 ghx
 ghx
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 thA
 thA
@@ -111695,9 +111833,9 @@ ghx
 ghx
 ghx
 ghx
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 thA
 thA
@@ -111952,9 +112090,9 @@ ghx
 ghx
 ghx
 ghx
-pGD
-gpH
-pGD
+cmE
+ttd
+nze
 pGD
 thA
 thA
@@ -112209,9 +112347,9 @@ ghx
 ghx
 ghx
 ghx
-dPN
-gpH
-pGD
+pRT
+ttd
+nze
 pGD
 thA
 thA
@@ -112466,9 +112604,9 @@ ghx
 ghx
 ghx
 ghx
-pGD
-gpH
-gpH
+cmE
+ttd
+gwB
 pGD
 thA
 oSU
@@ -112723,11 +112861,11 @@ ghx
 ghx
 ghx
 ghx
+cmE
+nEt
+gwB
 pGD
-pGD
-gpH
-pGD
-pbw
+qcb
 pXV
 oSU
 oSU
@@ -112978,11 +113116,11 @@ thA
 ghx
 ghx
 ghx
-pbw
+qcb
 gpH
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 pGD
 pXV
@@ -113235,11 +113373,11 @@ thA
 ghx
 ghx
 ghx
-wPp
+gXj
 gpH
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 rzh
 pXV
@@ -113494,9 +113632,9 @@ ghx
 pXV
 pGD
 pGD
-pGD
-pGD
-gpH
+cmE
+nEt
+gwB
 pGD
 pGD
 pXV
@@ -113751,8 +113889,8 @@ ghx
 pXV
 sJx
 sJx
-sJx
-sJx
+bMD
+kPC
 hwe
 sJx
 sJx
@@ -114008,9 +114146,9 @@ thA
 pXV
 pGD
 pGD
-pGD
-pGD
-vPp
+cmE
+nEt
+vGp
 pGD
 pGD
 pXV
@@ -114265,9 +114403,9 @@ thA
 pXV
 pGD
 pGD
-pGD
-pGD
-gpH
+cmE
+nEt
+gwB
 pGD
 pGD
 pXV
@@ -114520,13 +114658,13 @@ thA
 thA
 thA
 pXV
-ksm
+khH
 pGD
-gpH
+uyf
+nEt
+vGp
 pGD
-vPp
-pGD
-imq
+xrc
 pXV
 oSU
 oSU
@@ -114779,9 +114917,9 @@ thA
 pXV
 pGD
 pGD
-pGD
-pGD
-vPp
+cmE
+nEt
+vGp
 gpH
 pGD
 pXV
@@ -115036,9 +115174,9 @@ thA
 pXV
 pGD
 pGD
-pGD
-gpH
-gpH
+cmE
+ttd
+gwB
 gpH
 pGD
 pXV
@@ -115293,9 +115431,9 @@ thA
 pXV
 pGD
 pGD
-pGD
-gpH
-gpH
+cmE
+ttd
+gwB
 gpH
 pGD
 pXV
@@ -115550,9 +115688,9 @@ thA
 pXV
 pGD
 pGD
-pGD
-gpH
-gpH
+cmE
+ttd
+gwB
 pGD
 pGD
 pXV
@@ -115807,8 +115945,8 @@ thA
 pXV
 pGD
 pGD
-pGD
-pGD
+cmE
+nEt
 aYR
 pGD
 pGD
@@ -116064,9 +116202,9 @@ thA
 pXV
 pGD
 pGD
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 gpH
 pGD
 pXV
@@ -116319,13 +116457,13 @@ thA
 thA
 thA
 pXV
-ksm
+khH
 pGD
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 gpH
-imq
+xrc
 pXV
 oSU
 oSU
@@ -116578,9 +116716,9 @@ thA
 pXV
 pGD
 pGD
-pGD
-pGD
-dPN
+cmE
+nEt
+wcG
 pGD
 pGD
 pXV
@@ -116835,9 +116973,9 @@ thA
 pXV
 pGD
 pGD
-pGD
-gpH
-gpH
+cmE
+ttd
+gwB
 pGD
 pGD
 pXV
@@ -117092,9 +117230,9 @@ thA
 pXV
 pGD
 pGD
-gpH
-vPp
-pGD
+uyf
+swq
+nze
 pGD
 pGD
 pXV
@@ -117349,9 +117487,9 @@ thA
 pXV
 pGD
 pGD
-gpH
-gpH
-pGD
+uyf
+ttd
+nze
 pGD
 pGD
 pXV
@@ -117606,9 +117744,9 @@ thA
 pXV
 pGD
 gpH
-pGD
-gpH
-pGD
+cmE
+ttd
+nze
 pGD
 pGD
 pXV
@@ -117863,9 +118001,9 @@ thA
 pXV
 pGD
 gpH
-pGD
-gpH
-pGD
+cmE
+ttd
+nze
 pGD
 pGD
 pXV
@@ -118120,9 +118258,9 @@ thA
 pXV
 pGD
 gpH
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 pGD
 pXV
@@ -118375,13 +118513,13 @@ thA
 thA
 thA
 pXV
-ksm
+khH
 gpH
+cmE
+ttd
+nze
 pGD
-gpH
-pGD
-pGD
-imq
+xrc
 pXV
 oSU
 oSU
@@ -118634,9 +118772,9 @@ thA
 pXV
 pGD
 gpH
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 pGD
 pXV
@@ -118891,9 +119029,9 @@ thA
 pXV
 pGD
 gpH
-pGD
-pGD
-dPN
+cmE
+nEt
+wcG
 pGD
 pGD
 pXV
@@ -119148,9 +119286,9 @@ thA
 pXV
 pGD
 pGD
-pGD
-gpH
-pGD
+cmE
+ttd
+nze
 pGD
 wAm
 pXV
@@ -119405,9 +119543,9 @@ thA
 pXV
 pGD
 pGD
-gpH
-pGD
-pGD
+uyf
+nEt
+nze
 pGD
 pGD
 pXV
@@ -119662,9 +119800,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-gpH
-pGD
+cmE
+ttd
+nze
 pGD
 pGD
 pXV
@@ -119919,9 +120057,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 mGh
 bTI
@@ -120174,11 +120312,11 @@ oSU
 oSU
 oSU
 pXV
-ksm
+khH
 pGD
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 aFY
 gYI
@@ -120433,9 +120571,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-vPp
-pGD
+cmE
+swq
+nze
 pGD
 vKn
 wMB
@@ -120690,9 +120828,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-vPp
-pGD
+cmE
+swq
+nze
 pGD
 kxF
 gYI
@@ -120947,9 +121085,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-gpH
-pGD
+cmE
+ttd
+nze
 pGD
 kku
 gzt
@@ -121204,9 +121342,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-pGD
-gpH
+cmE
+nEt
+gwB
 pGD
 djd
 cBz
@@ -121461,9 +121599,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-gpH
-gpH
+cmE
+ttd
+gwB
 pGD
 prM
 hYC
@@ -121718,9 +121856,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-gpH
-pGD
+cmE
+ttd
+nze
 pGD
 ykU
 bTI
@@ -121973,11 +122111,11 @@ oSU
 oSU
 oSU
 pXV
-ksm
+khH
 dPN
-pGD
-gpH
-gpH
+cmE
+ttd
+gwB
 pGD
 prM
 cBz
@@ -122232,9 +122370,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-pGD
-vPp
+cmE
+nEt
+vGp
 pGD
 gBp
 rls
@@ -122489,9 +122627,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-pGD
-gpH
+cmE
+nEt
+gwB
 pGD
 thL
 ert
@@ -122746,9 +122884,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 xMf
 iVP
@@ -123003,9 +123141,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-pGD
-pGD
+cmE
+nEt
+nze
 pGD
 rBl
 hrV
@@ -123260,9 +123398,9 @@ oSU
 pXV
 pGD
 pGD
-pGD
-pGD
-gpH
+cmE
+nEt
+gwB
 pGD
 aFY
 cvb
@@ -123772,7 +123910,7 @@ oSU
 oSU
 oSU
 pXV
-ksm
+khH
 pGD
 pGD
 pGD
@@ -125828,13 +125966,13 @@ oSU
 oSU
 oSU
 euu
-ogC
+sfB
 aFD
 aFD
 aFD
 vOF
 vOF
-spW
+gnE
 euu
 oSU
 oSU
@@ -127124,11 +127262,11 @@ euu
 oSU
 oSU
 oSU
-mZu
-mZu
-mZu
-mZu
-mZu
+cRz
+cRz
+cRz
+cRz
+cRz
 oSU
 oSU
 oSU
@@ -127379,14 +127517,14 @@ vOF
 vOF
 euu
 oSU
-mZu
-mZu
-mZu
-aMu
-htX
-rjc
-mZu
-mZu
+cRz
+cRz
+cRz
+aSQ
+kHJ
+dEu
+cRz
+cRz
 oSU
 oSU
 oSU
@@ -127627,24 +127765,24 @@ oSU
 oSU
 oSU
 euu
-ogC
+sfB
 oWa
 vOF
 vOF
 vOF
 aFD
-spW
+gnE
 euu
 oSU
-mZu
-rjc
-jnP
-pTS
-jnP
-slg
-tbz
-mZu
-mZu
+cRz
+dEu
+nZC
+jER
+nZC
+lOq
+oIu
+cRz
+cRz
 oSU
 oSU
 cGX
@@ -127890,18 +128028,18 @@ vOF
 aFD
 vOF
 qiu
-dqH
+hGb
 euu
 oSU
-mZu
-whq
-jnP
-jnP
-jnP
-izm
-lqY
-rjc
-mZu
+cRz
+lQD
+nZC
+nZC
+nZC
+jgM
+gkA
+dEu
+cRz
 oSU
 oSU
 cGX
@@ -128149,18 +128287,18 @@ pxg
 aFD
 euu
 euu
-mZu
-mZu
-qKG
-mZu
-jnP
-suO
-csO
-mZu
-vuT
-mZu
-mZu
-mZu
+cRz
+cRz
+hgz
+cRz
+nZC
+tWt
+uhD
+cRz
+hqf
+cRz
+cRz
+cRz
 cGX
 aeZ
 aeZ
@@ -128406,18 +128544,18 @@ pxg
 aFD
 euu
 euu
-tbz
-ppf
-izm
-ppf
-jnP
-aFM
-slg
-csO
-jnP
-ppf
-mZu
-mZu
+oIu
+vuT
+jgM
+vuT
+nZC
+hxb
+lOq
+uhD
+nZC
+vuT
+cRz
+cRz
 nib
 aeZ
 aeZ
@@ -128661,20 +128799,20 @@ pxg
 vOF
 gWs
 aFD
-fKT
-dBD
-ppf
+leq
+alC
 vuT
-whq
-ppf
-ppf
-slg
-ebM
-jnP
-jnP
-bWr
-mZu
-vOm
+hqf
+lQD
+vuT
+vuT
+lOq
+wFY
+nZC
+nZC
+dgV
+cRz
+cfm
 nib
 aeZ
 aeZ
@@ -128920,19 +129058,19 @@ pxg
 aFD
 euu
 euu
-tbz
-slg
-csO
-jnP
-jnP
-mhE
-aAl
-jnP
-jnP
-jnP
-mZu
-mZu
-plZ
+oIu
+lOq
+uhD
+nZC
+nZC
+hfq
+vUa
+nZC
+nZC
+nZC
+cRz
+cRz
+leD
 aeZ
 aeZ
 aeZ
@@ -129177,18 +129315,18 @@ cQQ
 aFD
 euu
 euu
-mZu
-mZu
-jnP
-mZu
-slg
-izm
-csO
-mZu
-qKG
-mZu
-mZu
-mZu
+cRz
+cRz
+nZC
+cRz
+lOq
+jgM
+uhD
+cRz
+hgz
+cRz
+cRz
+cRz
 cGX
 aeZ
 aeZ
@@ -129435,15 +129573,15 @@ oWa
 euu
 euu
 oSU
-mZu
-jnP
-jnP
-rWQ
-ppf
-slg
-slg
-rjc
-mZu
+cRz
+nZC
+nZC
+ltG
+vuT
+lOq
+lOq
+dEu
+cRz
 oSU
 oSU
 cGX
@@ -129692,15 +129830,15 @@ aFD
 euu
 euu
 oSU
-mZu
-lRC
-ppf
-ppf
+cRz
+uvl
 vuT
-jnP
-wZo
-mZu
-mZu
+vuT
+hqf
+nZC
+htD
+cRz
+cRz
 oSU
 oSU
 cGX
@@ -129949,15 +130087,15 @@ aFD
 euu
 euu
 oSU
-mZu
-eWI
-dlY
-slg
-slg
-slg
-rjc
-rjc
-mZu
+cRz
+dZs
+uMn
+lOq
+lOq
+lOq
+dEu
+dEu
+cRz
 oSU
 oSU
 cGX
@@ -130206,15 +130344,15 @@ aFD
 oSU
 euu
 oSU
-mZu
-mZu
-mZu
-mZu
-ppf
-ppf
-mZu
-mZu
-mZu
+cRz
+cRz
+cRz
+cRz
+vuT
+vuT
+cRz
+cRz
+cRz
 oSU
 oSU
 cGX
@@ -130460,18 +130598,18 @@ aFD
 aFD
 aFD
 aFD
-vlW
+wSI
 euu
 oSU
 oSU
-mZu
-tbz
-dzM
-ppf
-jnP
-nYs
-jkc
-mZu
+cRz
+oIu
+rDI
+vuT
+nZC
+ipH
+kca
+cRz
 oSU
 oSU
 cGX
@@ -130721,14 +130859,14 @@ oSU
 euu
 oSU
 oSU
-mZu
-jnP
-cIL
-suO
-jnP
-gqh
-suO
-mZu
+cRz
+nZC
+wXA
+tWt
+nZC
+pse
+tWt
+cRz
 oSU
 oSU
 cGX
@@ -130978,14 +131116,14 @@ oSU
 euu
 oSU
 oSU
-mZu
-pyd
-tbz
-lqY
-ciO
-rWQ
-rFt
-mZu
+cRz
+lqv
+oIu
+gkA
+jDo
+ltG
+kGN
+cRz
 oSU
 oSU
 cGX
@@ -131226,23 +131364,23 @@ oSU
 oSU
 oSU
 oSU
-vlW
+wSI
 oSU
-vlW
+wSI
 oSU
-vlW
+wSI
 oSU
-mZu
-mZu
-mZu
-mZu
-mZu
-mZu
-jnP
-izm
-mZu
-mZu
-mZu
+cRz
+cRz
+cRz
+cRz
+cRz
+cRz
+nZC
+jgM
+cRz
+cRz
+cRz
 oSU
 oSU
 cGX
@@ -131489,17 +131627,17 @@ oSU
 oSU
 oSU
 oSU
-mZu
-con
-xHQ
-uPm
-hft
-lqY
-ppf
-jJb
-jnP
-kzp
-mZu
+cRz
+dxX
+dyr
+eLx
+iJc
+gkA
+vuT
+kbk
+nZC
+hdX
+cRz
 oSU
 oSU
 cGX
@@ -131746,17 +131884,17 @@ oSU
 oSU
 oSU
 oSU
-mZu
-kky
-ppf
-ppf
-suO
-jnP
-aAl
-jnP
-jnP
-jnP
-mZu
+cRz
+dNd
+vuT
+vuT
+tWt
+nZC
+vUa
+nZC
+nZC
+nZC
+cRz
 oSU
 oSU
 cGX
@@ -132003,17 +132141,17 @@ oSU
 oSU
 oSU
 oSU
-mZu
-ppf
+cRz
 vuT
-lqY
-ppf
-btb
-vTG
-sAG
-eMv
-rRL
-mZu
+hqf
+gkA
+vuT
+prS
+vdO
+mDl
+kaV
+pEF
+cRz
 oSU
 oSU
 cGX
@@ -132260,17 +132398,17 @@ oSU
 oSU
 oSU
 oSU
-mZu
-mZu
-mZu
-mZu
-mZu
-mZu
-mZu
-mZu
-mZu
-mZu
-mZu
+cRz
+cRz
+cRz
+cRz
+cRz
+cRz
+cRz
+cRz
+cRz
+cRz
+cRz
 oSU
 oSU
 cGX

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -3060,6 +3060,16 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
+"aRv" = (
+/obj/machinery/door/window/elevator/left/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "aRx" = (
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/plating,
@@ -3427,9 +3437,13 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aVL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/elevator/directional/east,
+/obj/machinery/lift_indicator/directional/east,
+/obj/machinery/door/window/elevator/right/directional/north,
+/obj/effect/turf_decal/caution/stand_clear/white,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/garden)
 "aVM" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -4510,6 +4524,11 @@
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/security/prison/mess)
+"blK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/report_crimes/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "blM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -5329,10 +5348,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/brig/upper)
-"bwb" = (
-/obj/structure/transport/linear/public,
-/turf/closed/wall,
-/area/icemoon/underground/explored)
 "bwh" = (
 /turf/closed/wall/mineral/iron,
 /area/icemoon/underground/explored)
@@ -5474,12 +5489,6 @@
 	dir = 5
 	},
 /area/station/maintenance/port/aft)
-"byc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "byl" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -6214,11 +6223,6 @@
 /obj/machinery/smartfridge,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
-"bHK" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "bHO" = (
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 6;
@@ -7674,8 +7678,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
 "ccx" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/enlist/directional/west,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "ccz" = (
 /obj/item/radio/intercom/directional/east,
@@ -7952,12 +7957,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"cfM" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "cfR" = (
 /obj/structure/chair{
 	dir = 1
@@ -7996,6 +7995,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
+"cgH" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "cgR" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -8996,9 +9002,8 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
 "cvr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "cvB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9507,12 +9512,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
-"cBQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/spawner/random/maintenance/dumpster,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "cBT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -9748,11 +9747,6 @@
 	},
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/security/evidence)
-"cEX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing/corner,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "cFp" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10416,7 +10410,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "cOS" = (
-/obj/structure/holosign/barrier/atmos/tram,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
+"cPc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "cPd" = (
@@ -10761,7 +10760,10 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "cUB" = (
-/obj/effect/decal/cleanable/blood/trail,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "cUG" = (
@@ -10830,6 +10832,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
+"cWB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "cWC" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -11628,6 +11635,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"dgo" = (
+/obj/structure/fence{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "dgp" = (
 /obj/machinery/modular_computer/preset/engineering,
 /obj/structure/cable,
@@ -11987,6 +12001,12 @@
 /obj/structure/sign/nanotrasen/directional/east,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/explored)
+"dkB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/crayon,
+/obj/effect/spawner/random/trash/deluxe_garbage,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "dkM" = (
 /obj/structure/table/glass,
 /obj/item/stack/medical/wrap/gauze{
@@ -12120,11 +12140,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
-"dmP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/wood,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "dmV" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -13234,6 +13249,9 @@
 "dBZ" = (
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"dCr" = (
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "dCy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -13869,9 +13887,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"dLR" = (
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers)
 "dLT" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -15141,9 +15156,9 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
 "eha" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/garbage,
-/obj/effect/spawner/random/junk_shell,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "ehc" = (
@@ -15196,6 +15211,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
+"ehK" = (
+/obj/structure/thermoplastic,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "ehL" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -15426,12 +15446,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
-"ekz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/west,
-/obj/machinery/lift_indicator/directional/west,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "ekE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16717,11 +16731,6 @@
 	dir = 1
 	},
 /area/station/maintenance/department/cargo)
-"eEJ" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "eEO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17920,6 +17929,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"eWi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "eWj" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/engine/plasma,
@@ -18082,6 +18096,11 @@
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/iron/textured,
 /area/station/hallway/secondary/entry)
+"eYP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "eYR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -18113,12 +18132,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
-"eYV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/status_display/ai/directional/north,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "eYX" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -19203,14 +19216,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"fqg" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "fqj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19390,6 +19395,11 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern/on,
 /turf/open/misc/hay/icemoon,
+/area/icemoon/underground/explored)
+"fsC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "fsF" = (
 /obj/effect/spawner/structure/window,
@@ -21967,10 +21977,10 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"ggu" = (
+"ggx" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/enlist/directional/west,
-/turf/open/floor/iron/smooth,
+/obj/structure/railing/corner,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "ggz" = (
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -22015,21 +22025,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ghe" = (
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/green/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/duct,
-/obj/structure/table/glass,
-/obj/item/watertank{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/item/plant_analyzer,
-/obj/item/book/manual/hydroponics_pod_people,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/spawner/random/maintenance/dumpster,
 /turf/open/floor/iron,
-/area/station/service/hydroponics)
+/area/icemoon/underground/explored)
 "ghl" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -22448,6 +22448,15 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"gmr" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "gmJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Infiltrate/Filter"
@@ -23001,14 +23010,6 @@
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"gtO" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "gtP" = (
 /obj/structure/table,
 /obj/item/assembly/timer,
@@ -24023,9 +24024,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/mine/mechbay)
-"gIy" = (
-/turf/open/openspace,
-/area/station/hallway/primary/central)
 "gIF" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/showroomfloor,
@@ -25724,13 +25722,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/textured,
 /area/station/maintenance/fore)
-"hiY" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "hjc" = (
 /obj/structure/closet/emcloset,
 /obj/item/pickaxe,
@@ -26137,10 +26128,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"hoC" = (
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/genturf/blue,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "hoD" = (
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -26719,9 +26706,15 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "hwe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence/door,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "hwm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -26871,6 +26864,14 @@
 /obj/structure/sign/xenobio_guide/directional/north,
 /turf/open/openspace,
 /area/station/science/xenobiology)
+"hzi" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "hzo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27114,14 +27115,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "hBG" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/trail,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "hBZ" = (
@@ -28411,6 +28406,13 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/mine/eva)
+"hVQ" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/sign/poster/contraband/kudzu/directional/north,
+/obj/structure/sink/kitchen/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "hVR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -29564,10 +29566,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "ilw" = (
-/obj/effect/spawner/random/trash/bin,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "ily" = (
 /turf/open/openspace,
 /area/station/science/xenobiology)
@@ -34720,11 +34723,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"jLD" = (
-/obj/structure/thermoplastic,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "jLK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35154,6 +35152,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"jQF" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "jQS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -35460,11 +35465,6 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
-"jVV" = (
-/obj/structure/thermoplastic/light,
-/obj/machinery/door/airlock/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "jWb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -35743,17 +35743,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"kao" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "kaw" = (
 /obj/machinery/photocopier/prebuilt,
 /obj/item/radio/intercom/directional/north,
@@ -36864,6 +36853,16 @@
 	},
 /turf/closed/wall,
 /area/station/hallway/primary/central)
+"krx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "krJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -37563,10 +37562,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
-"kAw" = (
-/obj/effect/mapping_helpers/no_atoms_ontop,
-/turf/closed/wall,
-/area/icemoon/underground/explored)
 "kAC" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -37850,13 +37845,6 @@
 	dir = 4
 	},
 /area/mine/eva)
-"kDL" = (
-/obj/structure/fence/door{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "kDO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -38290,8 +38278,8 @@
 /area/station/maintenance/port/greater)
 "kJS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
+/obj/machinery/button/elevator/directional/west,
+/obj/machinery/lift_indicator/directional/west,
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "kJU" = (
@@ -38791,12 +38779,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
-"kQX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/crayon,
-/obj/effect/spawner/random/trash/deluxe_garbage,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "kQY" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 4;
@@ -38856,6 +38838,22 @@
 "kRP" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/central)
+"kRT" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/structure/table/glass,
+/obj/item/watertank{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/plant_analyzer,
+/obj/item/book/manual/hydroponics_pod_people,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "kRU" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -40659,6 +40657,12 @@
 /obj/structure/curtain,
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/captain)
+"lrL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "lrM" = (
 /obj/effect/turf_decal/siding/wideplating_new/light{
 	dir = 4
@@ -41310,15 +41314,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"lAI" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "lAL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41902,16 +41897,6 @@
 /obj/effect/spawner/random/food_or_drink/cups,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"lJB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/glass,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "lJO" = (
 /turf/closed/wall,
 /area/station/maintenance/port/fore)
@@ -42086,8 +42071,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/armory/upper)
 "lMG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/thermoplastic,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "lMK" = (
@@ -42932,10 +42917,6 @@
 	name = "hyper-reinforced wall"
 	},
 /area/station/science/ordnance/bomb/planet)
-"lZu" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "lZP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45359,6 +45340,14 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
+"mJF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "mJM" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -45446,13 +45435,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mLd" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/spawner/random/junk_shell,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "mLf" = (
 /turf/open/openspace/icemoon/keep_below,
@@ -47641,6 +47627,12 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"nqv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "nqx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -48075,11 +48067,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
-"nxF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "nxM" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical/morgue)
@@ -48704,6 +48691,12 @@
 	dir = 8
 	},
 /area/station/security/brig)
+"nEL" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "nEV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -48962,11 +48955,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"nIM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "nIN" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -49158,11 +49146,6 @@
 /obj/structure/mirror/broken/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
-"nKY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "nLb" = (
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/iron/dark/telecomms,
@@ -49406,6 +49389,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"nNN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/west,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "nNZ" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -50286,6 +50274,10 @@
 /obj/machinery/light/small/red/directional/west,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"oam" = (
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "oaG" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 9
@@ -51946,13 +51938,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"oxt" = (
-/obj/structure/fence{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "oxB" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -53302,6 +53287,14 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/aft/greater)
+"oMG" = (
+/obj/structure/toiletbong,
+/obj/structure/thermoplastic,
+/obj/structure/chair/sofa/bench/tram/left,
+/obj/structure/thermoplastic/light,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "oMP" = (
 /obj/effect/spawner/random/entertainment/slot_machine,
 /turf/open/floor/wood,
@@ -53945,13 +53938,6 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"oWZ" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/structure/sign/poster/contraband/kudzu/directional/north,
-/obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "oXb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -54006,6 +53992,10 @@
 /obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology)
+"oXt" = (
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "oXx" = (
 /obj/machinery/mass_driver/trash{
 	dir = 1
@@ -54782,6 +54772,17 @@
 /obj/item/pillow/random,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
+"piK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "piL" = (
 /obj/machinery/door/window/brigdoor/security/cell/left/directional/west{
 	id = "Cell 2";
@@ -55475,8 +55476,7 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/aft/greater)
 "ptt" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/catwalk_floor,
+/turf/open/openspace,
 /area/icemoon/underground/explored)
 "ptQ" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
@@ -56192,6 +56192,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"pDz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "pDA" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/stripes/line{
@@ -56265,11 +56270,10 @@
 /turf/open/floor/iron/large,
 /area/station/medical/break_room)
 "pEs" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "pEE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -56987,10 +56991,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
-"pPW" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "pPY" = (
 /obj/machinery/light/small/dim/directional/west,
 /obj/effect/mapping_helpers/broken_floor,
@@ -57418,6 +57418,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
+"pVP" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "pVQ" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -58526,12 +58535,9 @@
 /turf/open/misc/asteroid/snow/standard_air,
 /area/station/science/cytology)
 "qkn" = (
-/obj/structure/toiletbong,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/left,
-/obj/structure/thermoplastic/light,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/trash/bin,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "qku" = (
 /obj/structure/chair/comfy/beige{
@@ -59635,8 +59641,11 @@
 /turf/open/floor/plating,
 /area/station/security/prison/mess)
 "qCx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/lava/plasma/ice_moon,
+/obj/structure/fence/door{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "qCA" = (
 /obj/structure/table/wood,
@@ -60171,9 +60180,9 @@
 /turf/open/floor/wood/large,
 /area/mine/eva/lower)
 "qJB" = (
-/obj/structure/thermoplastic,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "qJT" = (
 /obj/machinery/light/small/directional/south,
@@ -60195,11 +60204,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
-"qKl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "qKn" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -61951,6 +61955,11 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"rhE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "rhF" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Security - Permabrig Observation North";
@@ -61972,12 +61981,6 @@
 /obj/structure/marker_beacon/burgundy,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"rhO" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "rhQ" = (
 /obj/structure/sign/warning/gas_mask/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -62818,15 +62821,10 @@
 	},
 /area/station/security/prison/safe)
 "rsO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "rsR" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue/full,
@@ -63932,11 +63930,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/station/engineering/main)
-"rJb" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "rJc" = (
 /obj/structure/minecart_rail{
 	dir = 4
@@ -63982,17 +63975,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/fore/lesser)
-"rKn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "rKv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 1
@@ -64723,11 +64705,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
-"rVk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "rVq" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -64738,7 +64715,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rVr" = (
-/turf/open/openspace,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "rVB" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
@@ -64840,13 +64820,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rWJ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/button/elevator/directional/east,
-/obj/machinery/lift_indicator/directional/east,
-/obj/machinery/door/window/elevator/right/directional/north,
-/obj/effect/turf_decal/caution/stand_clear/white,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics/garden)
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/genturf/blue,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "rWO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -65234,11 +65210,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "scr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "sct" = (
 /obj/structure/disposalpipe/segment,
@@ -65361,10 +65335,8 @@
 /turf/open/floor/iron/dark,
 /area/station/command/eva)
 "seb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/random/directional/north,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/smooth,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
 "sen" = (
 /obj/structure/cable,
@@ -65623,6 +65595,11 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"shQ" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "shR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -65755,10 +65732,12 @@
 /turf/closed/wall,
 /area/station/maintenance/fore)
 "skm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "skn" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -67664,6 +67643,11 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
+"sJX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "sKf" = (
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
@@ -68535,6 +68519,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix)
+"sYa" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "sYe" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/suit/red,
@@ -69113,22 +69108,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
-"thy" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "thA" = (
 /turf/open/genturf/blue,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "thB" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "thC" = (
 /obj/structure/closet/crate,
@@ -69512,6 +69501,12 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/security/brig)
+"tly" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "tlA" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -71577,6 +71572,11 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
+"tOO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "tOX" = (
 /obj/machinery/light/small/broken/directional/south,
 /obj/item/trash/energybar,
@@ -72423,11 +72423,6 @@
 	},
 /turf/open/floor/iron/stairs/medium,
 /area/mine/eva/lower)
-"ubH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/report_crimes/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "ubZ" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Security - Permabrig Chapel";
@@ -72976,6 +72971,16 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/command/eva)
+"ukK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "ukN" = (
 /obj/structure/table,
 /obj/machinery/door/poddoor/shutters{
@@ -73154,10 +73159,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"unp" = (
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "unq" = (
 /obj/structure/light_construct/directional/north,
 /obj/effect/spawner/random/structure/closet_private,
@@ -74310,11 +74311,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"uDY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "uEf" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
@@ -74869,6 +74865,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
+"uNK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/door,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "uNN" = (
 /obj/effect/spawner/random/trash/bin,
 /obj/effect/spawner/random/maintenance,
@@ -75910,6 +75911,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/work)
+"vea" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "veh" = (
 /obj/structure/chair{
 	dir = 4
@@ -76268,14 +76273,8 @@
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "vkk" = (
-/obj/machinery/door/window/elevator/left/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "vkz" = (
 /obj/machinery/suit_storage_unit/ce,
@@ -77071,11 +77070,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
-"vvp" = (
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "vvu" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/trimline/neutral/warning{
@@ -78325,6 +78319,11 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"vNt" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "vND" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -78473,16 +78472,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/mine/production)
-"vQJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/south{
-	id = "tram_perma_lift"
-	},
-/obj/machinery/lift_indicator/directional/south{
-	linked_elevator_id = "tram_perma_lift"
-	},
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "vQN" = (
 /obj/structure/cable,
 /obj/machinery/computer/prisoner/management,
@@ -78589,13 +78578,6 @@
 "vSi" = (
 /turf/closed/wall,
 /area/mine/eva)
-"vSu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "vSE" = (
 /obj/machinery/door/window/right/directional/east{
 	name = "Bar Access"
@@ -78614,13 +78596,6 @@
 /obj/item/reagent_containers/syringe,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"vSV" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "vSY" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -79019,6 +78994,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
+"vXQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "vXU" = (
 /obj/item/toy/snowball,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -81310,6 +81292,9 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"wIo" = (
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers)
 "wIz" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/table/wood,
@@ -82063,6 +82048,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
+"wSM" = (
+/obj/effect/mapping_helpers/no_atoms_ontop,
+/turf/closed/wall,
+/area/icemoon/underground/explored)
 "wSU" = (
 /obj/structure/chair{
 	dir = 1
@@ -83351,10 +83340,8 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "xiL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron/smooth,
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "xiO" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -84681,6 +84668,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"xBA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/left/directional/west,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "xBL" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Solar Maintenance - North East Access"
@@ -85220,6 +85213,11 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/iron/textured,
 /area/station/command/eva)
+"xIl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/work_for_a_future/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "xIF" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
@@ -86285,6 +86283,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"xXM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/south{
+	id = "tram_perma_lift"
+	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "tram_perma_lift"
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "xXR" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/security/glass{
@@ -86719,8 +86727,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "ydH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/work_for_a_future/directional/north,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "ydI" = (
@@ -101937,9 +101944,9 @@ oSU
 oSU
 oSU
 gFX
-cBQ
-ggu
-kQX
+ghe
+ccx
+dkB
 gFX
 gFX
 gFX
@@ -102194,10 +102201,10 @@ oSU
 oSU
 oSU
 gFX
-xiL
-byc
+nqv
+tly
 eHt
-vkk
+aRv
 nTH
 nTH
 gFX
@@ -102451,10 +102458,10 @@ oSU
 oSU
 oSU
 gFX
-seb
-skm
+pEs
+rhE
 kdm
-rKn
+piK
 nTH
 nTH
 gFX
@@ -102708,11 +102715,11 @@ oSU
 oSU
 oSU
 gFX
-eYV
-eEJ
-vQJ
+lrL
+scr
+xXM
 gFX
-bwb
+gFX
 gFX
 gFX
 ghx
@@ -102966,10 +102973,10 @@ oSU
 gFX
 gFX
 wMB
-kDL
-oxt
+qCx
+dgo
 wMB
-eha
+mLd
 gFX
 ghx
 ghx
@@ -103221,13 +103228,13 @@ thA
 thA
 thA
 gFX
-ilw
+qkn
 eHt
 bJv
 aCI
 cLf
-lJB
-aVL
+krx
+cOS
 ghx
 ghx
 thA
@@ -103479,10 +103486,10 @@ thA
 thA
 gFX
 kdm
-cEX
-thB
-vSu
-thB
+ggx
+eha
+vXQ
+eha
 gFX
 gFX
 ghx
@@ -103735,13 +103742,13 @@ thA
 thA
 thA
 gFX
-ubH
-qKl
+blK
+eWi
 cjI
 aMC
 wuN
 nLK
-aVL
+cOS
 ghx
 ghx
 thA
@@ -103998,7 +104005,7 @@ aMC
 uWq
 bKQ
 wuN
-aVL
+cOS
 ghx
 ghx
 thA
@@ -104250,12 +104257,12 @@ thA
 thA
 gFX
 cLf
-hBG
+hwe
 eiQ
 uWq
 fHU
 wuN
-aVL
+cOS
 ghx
 ghx
 thA
@@ -104505,11 +104512,11 @@ thA
 thA
 ghx
 ghx
-aVL
+cOS
 cLf
-gtO
+thB
 aMC
-jLD
+ehK
 uWq
 aMC
 gFX
@@ -104762,14 +104769,14 @@ ghx
 ghx
 ghx
 ghx
-aVL
-nKY
-gtO
+cOS
+fsC
+thB
 wuN
 rOU
 qFF
-jVV
-aVL
+shQ
+cOS
 ghx
 ghx
 ijY
@@ -105019,14 +105026,14 @@ ghx
 ghx
 ghx
 ghx
-aVL
+cOS
 cLf
-lAI
+pVP
 aMC
-qkn
+oMG
 qFF
 cqV
-aVL
+cOS
 ghx
 ghx
 ghx
@@ -105276,14 +105283,14 @@ ghx
 ghx
 ghx
 ghx
-aVL
+cOS
 eHt
 gFX
 aMC
 aMC
 oge
 aMC
-aVL
+cOS
 ghx
 ghx
 ghx
@@ -105535,7 +105542,7 @@ ghx
 ghx
 gFX
 eHt
-thy
+mJF
 txh
 cqV
 uWq
@@ -105791,13 +105798,13 @@ thA
 thA
 ghx
 gFX
-ydH
-mLd
+xIl
+gmr
 wuN
 nov
 dzI
 aMC
-aVL
+cOS
 ghx
 ghx
 iDt
@@ -106047,14 +106054,14 @@ ghx
 thA
 thA
 ghx
-aVL
+cOS
 eHt
-fqg
+hzi
 aMC
-jLD
+ehK
 dzI
 eiQ
-aVL
+cOS
 ghx
 ghx
 iDt
@@ -106304,14 +106311,14 @@ ghx
 ghx
 thA
 ghx
-aVL
+cOS
 eHt
 gFX
 aMC
-qJB
+lMG
 vrk
 aMC
-aVL
+cOS
 ghx
 ghx
 iDt
@@ -106561,9 +106568,9 @@ ghx
 ghx
 thA
 ghx
-aVL
+cOS
 cLf
-kao
+sYa
 eiQ
 uWq
 kdq
@@ -106818,14 +106825,14 @@ ghx
 ghx
 ghx
 ghx
-aVL
-dmP
-pEs
+cOS
+tOO
+jQF
 kJN
 aMC
 sAc
 iOk
-qCx
+seb
 ghx
 iDt
 iDt
@@ -107076,13 +107083,13 @@ ghx
 ghx
 ghx
 gFX
-bHK
-rhO
+qJB
+nEL
 vBN
 vBN
 lhB
 vBN
-qCx
+seb
 ghx
 ghx
 iDt
@@ -107335,10 +107342,10 @@ ghx
 gFX
 gFX
 gFX
-cOS
-cOS
-rVk
-cOS
+xiL
+xiL
+pDz
+xiL
 gFX
 ghx
 ghx
@@ -112732,10 +112739,10 @@ ghx
 gFX
 vBN
 vBN
-cOS
-cOS
-rVk
-cOS
+xiL
+xiL
+pDz
+xiL
 vBN
 gFX
 oSU
@@ -119938,7 +119945,7 @@ nqh
 tgU
 gFX
 gFX
-kJS
+rVr
 usr
 usr
 hgg
@@ -120199,7 +120206,7 @@ ohF
 msM
 cBz
 cBz
-uDY
+cWB
 bJv
 aeV
 lLs
@@ -121476,7 +121483,7 @@ lhB
 vBN
 thL
 tgU
-nIM
+eYP
 jRP
 usr
 usr
@@ -133313,7 +133320,7 @@ oSU
 gFX
 lhB
 lhB
-lMG
+cPc
 lhB
 lhB
 gFX
@@ -134862,8 +134869,8 @@ gFX
 nTH
 nTH
 gFX
-pPW
-kAw
+ydH
+wSM
 aKb
 iDt
 iDt
@@ -135115,12 +135122,12 @@ vBN
 vBN
 vBN
 lhB
-ekz
-kdm
-ohF
+kJS
+nNN
+xBA
 efl
 eHt
-lZu
+vkk
 chg
 iDt
 iDt
@@ -135375,9 +135382,9 @@ vBN
 usr
 eHt
 cBz
-hwe
+uNK
 eHt
-kAw
+wSM
 pJm
 iDt
 iDt
@@ -135632,7 +135639,7 @@ lhB
 usr
 eHt
 cBz
-scr
+cUB
 eHt
 gFX
 xMq
@@ -135886,11 +135893,11 @@ vBN
 lhB
 vBN
 vBN
-cvr
+sJX
 kdm
 cBz
-scr
-unp
+cUB
+oXt
 gFX
 iDt
 xMq
@@ -137172,7 +137179,7 @@ vBN
 lhB
 vBN
 gFX
-rJb
+vNt
 bJv
 gFX
 oSU
@@ -138446,11 +138453,11 @@ oSU
 gFX
 gFX
 gFX
-vvp
+rsO
 eHt
 eHt
 eHt
-pPW
+ydH
 cmA
 lhB
 vBN
@@ -138708,14 +138715,14 @@ bJv
 eHt
 bJv
 eHt
-ccx
+cvr
 lhB
 vBN
 vBN
 vBN
 gFX
 eHt
-ptt
+vea
 gFX
 oSU
 oSU
@@ -138972,7 +138979,7 @@ gFX
 gFX
 gFX
 tgU
-ptt
+vea
 gFX
 oSU
 oSU
@@ -139227,8 +139234,8 @@ tgU
 eHt
 usr
 kdm
-cUB
-nxF
+oam
+hBG
 eHt
 gFX
 oSU
@@ -167476,7 +167483,7 @@ tjo
 tjo
 tjo
 tjo
-dLR
+wIo
 gFX
 wlK
 wlK
@@ -167733,9 +167740,9 @@ tjo
 tjo
 tjo
 tjo
-dLR
-rVr
-rVr
+wIo
+ptt
+ptt
 wlK
 lhB
 lhB
@@ -167990,9 +167997,9 @@ tjo
 tjo
 tjo
 tjo
-dLR
-rVr
-rVr
+wIo
+ptt
+ptt
 wlK
 lhB
 lhB
@@ -168247,7 +168254,7 @@ tjo
 tjo
 tjo
 tjo
-dLR
+wIo
 gFX
 gFX
 gFX
@@ -169280,7 +169287,7 @@ tjo
 thA
 thA
 thA
-hoC
+rWJ
 iLh
 pwg
 peG
@@ -185735,7 +185742,7 @@ caA
 mty
 urQ
 sQI
-oWZ
+hVQ
 pme
 pme
 aon
@@ -186247,13 +186254,13 @@ gFX
 uVb
 exw
 mqd
-ghe
+kRT
 wDb
 oZG
 oZG
 rZY
 oZG
-rsO
+ukK
 exw
 exw
 exw
@@ -233529,7 +233536,7 @@ aPM
 oCO
 qTm
 qTm
-rWJ
+aVL
 tmL
 arG
 cIa
@@ -234038,9 +234045,9 @@ lJO
 lJO
 lJO
 lJO
-cfM
-vSV
-hiY
+ilw
+skm
+cgH
 tNd
 nor
 sst
@@ -251523,7 +251530,7 @@ oUO
 kHO
 mQi
 uja
-gIy
+dCr
 hNU
 kyL
 kyL

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1139,6 +1139,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"apV" = (
+/obj/effect/mapping_helpers/no_atoms_ontop,
+/turf/closed/wall,
+/area/icemoon/underground/explored)
 "apX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1594,6 +1598,10 @@
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft/greater)
+"avT" = (
+/obj/structure/cable,
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers/deep)
 "awa" = (
 /turf/open/openspace,
 /area/station/science/ordnance/office)
@@ -2853,6 +2861,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/mine/eva)
+"aOg" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/iron/dark,
+/area/icemoon/underground/explored)
 "aOx" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/vending/clothing,
@@ -2973,15 +2985,6 @@
 /obj/item/clothing/shoes/jackboots,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"aQi" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "aQj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood,
@@ -3097,6 +3100,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/interior)
+"aRE" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "aRR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3437,10 +3450,8 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aVL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/report_crimes/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers/deep)
 "aVM" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -3659,10 +3670,9 @@
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "aZL" = (
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "aZU" = (
 /obj/structure/disposalpipe/segment,
@@ -3946,12 +3956,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
 /turf/open/floor/iron/smooth,
 /area/mine/living_quarters)
-"bdw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/left/directional/west,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "bdx" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -4002,6 +4006,7 @@
 /obj/structure/thermoplastic,
 /obj/structure/chair/sofa/bench/tram/left,
 /obj/structure/thermoplastic/light,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "ben" = (
@@ -5210,6 +5215,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"bus" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/west,
+/obj/machinery/lift_indicator/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/warning,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "buv" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	color = "#ff0000";
@@ -5930,12 +5945,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
-"bEh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "bEk" = (
 /obj/structure/railing/wooden_fence{
 	dir = 4
@@ -6071,6 +6080,11 @@
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
+"bFU" = (
+/obj/effect/decal/cleanable/blood/trail,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "bFW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -6400,6 +6414,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"bKb" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "bKp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Firefighting Equipment"
@@ -6507,12 +6525,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
-"bLS" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "bLW" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -7066,17 +7078,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
-"bUj" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "bUx" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/fore)
@@ -7237,9 +7238,11 @@
 /turf/closed/wall/r_wall,
 /area/station/command/eva)
 "bWp" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "bWv" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -7700,13 +7703,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
 "ccx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/west,
-/obj/machinery/lift_indicator/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
 "ccz" = (
 /obj/item/radio/intercom/directional/east,
@@ -8536,6 +8534,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"cpd" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "cpg" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
@@ -9022,7 +9032,7 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
 "cvr" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "cvB" = (
@@ -9125,6 +9135,12 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"cwL" = (
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "cwO" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
@@ -9350,6 +9366,12 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/workout)
+"cAd" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "cAe" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -9616,6 +9638,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"cDr" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "cDv" = (
 /obj/item/stack/rods/fifty,
 /obj/structure/rack,
@@ -10430,7 +10462,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "cOS" = (
-/turf/open/openspace,
+/obj/structure/toiletbong,
+/obj/structure/thermoplastic,
+/obj/structure/chair/sofa/bench/tram/left,
+/obj/structure/thermoplastic/light,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "cPd" = (
 /obj/structure/cable,
@@ -10707,11 +10744,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"cSK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/window/elevator/left/directional/north,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "cTh" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -10779,10 +10811,10 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "cUB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/holosign/barrier/atmos/tram,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/icemoon/underground/unexplored/rivers/deep)
 "cUG" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /obj/effect/turf_decal/stripes/red/corner{
@@ -10802,6 +10834,10 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"cUT" = (
+/obj/item/pickaxe,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cVk" = (
 /obj/item/storage/box/evidence{
 	pixel_x = -10;
@@ -10899,6 +10935,7 @@
 "cXw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "cXy" = (
@@ -11039,6 +11076,7 @@
 "cYS" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/trash/soap,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "cYT" = (
@@ -11548,6 +11586,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"deB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "deD" = (
 /obj/machinery/modular_computer/preset/id{
 	dir = 4
@@ -11565,6 +11615,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"deI" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "deN" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -11579,6 +11636,8 @@
 "deW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/bacteria,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "deY" = (
@@ -11729,6 +11788,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"dhG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/warm/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "dhH" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/weather/snow/corner{
@@ -12544,6 +12608,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/interrogation)
+"drX" = (
+/obj/structure/transport/linear/public,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "drZ" = (
 /obj/structure/flora/grass/both,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -12695,6 +12764,11 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"duW" = (
+/obj/structure/thermoplastic,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "duY" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input,
 /turf/open/floor/engine/vacuum,
@@ -12992,11 +13066,6 @@
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
-"dys" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "dyA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/effect/turf_decal/stripes/line,
@@ -13198,10 +13267,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/fore/lesser)
-"dBt" = (
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "dBB" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot_white,
@@ -13693,6 +13758,12 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"dIu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plastic,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "dIx" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
@@ -13903,6 +13974,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"dLW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/work_for_a_future/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "dMi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14066,12 +14142,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"dOP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/crayon,
-/obj/effect/spawner/random/trash/deluxe_garbage,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "dOY" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/red/half,
@@ -14183,14 +14253,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"dRc" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "dRx" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14297,6 +14359,11 @@
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"dTo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "dTq" = (
 /obj/structure/fireplace,
 /turf/open/floor/wood,
@@ -15176,11 +15243,10 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
 "eha" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "ehc" = (
@@ -16181,6 +16247,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/range)
+"ewh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ewi" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -16771,6 +16843,12 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
+"eFq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/left/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "eFt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -17348,6 +17426,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"eNZ" = (
+/obj/structure/fence{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "eOl" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -17381,6 +17467,13 @@
 	},
 /turf/open/floor/iron/stairs/medium,
 /area/station/cargo/storage)
+"eOZ" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/sign/poster/contraband/kudzu/directional/north,
+/obj/structure/sink/kitchen/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "ePa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -18035,13 +18128,6 @@
 "eXH" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/chemistry)
-"eXJ" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/structure/sign/poster/contraband/kudzu/directional/north,
-/obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "eYe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18600,6 +18686,12 @@
 	},
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
+"ffL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/crayon,
+/obj/effect/spawner/random/trash/deluxe_garbage,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "ffQ" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -19022,13 +19114,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"flJ" = (
-/obj/structure/transport/linear/public,
-/obj/structure/barricade/wooden{
-	name = "wooden barricade (CLOSED)"
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "flK" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/machinery/status_display/ai/directional/north,
@@ -19329,6 +19414,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"frp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "frt" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -19387,15 +19478,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/holding_cell)
-"fsd" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
-"fsg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "fsj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -19494,6 +19576,12 @@
 /obj/machinery/hydroponics/soil/rich,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
+"ftF" = (
+/obj/effect/spawner/random/trash/bin,
+/obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ftJ" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Lab"
@@ -19780,6 +19868,10 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/mine/production)
+"fxZ" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "fyc" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -19815,12 +19907,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
-"fyO" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "fyQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/meter,
@@ -20510,13 +20596,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"fKn" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "fKr" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -21787,11 +21866,6 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/engineering/atmos/pumproom)
-"gcY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "gcZ" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray,
@@ -22053,8 +22127,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ghe" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "ghl" = (
 /obj/machinery/light/directional/north,
@@ -23002,13 +23076,6 @@
 "gti" = (
 /turf/open/openspace,
 /area/station/maintenance/starboard/aft)
-"gtt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "gtw" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /turf/open/floor/iron/kitchen/diagonal,
@@ -23396,6 +23463,10 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/virology)
+"gze" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "gzz" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/machinery/computer/monitor{
@@ -23753,6 +23824,7 @@
 "gDI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "gDN" = (
@@ -23776,6 +23848,13 @@
 "gDZ" = (
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
+"gEb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "gEd" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "MiniSat External SouthWest";
@@ -23821,6 +23900,10 @@
 "gEE" = (
 /turf/open/openspace,
 /area/station/service/chapel)
+"gEH" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "gER" = (
 /turf/open/floor/iron,
 /area/station/command/bridge)
@@ -24774,6 +24857,11 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/circuit_workshop)
+"gTE" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "gTK" = (
 /turf/closed/wall,
 /area/station/engineering/engine_smes)
@@ -24875,11 +24963,8 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "gVx" = (
-/obj/structure/fence/door{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "gVB" = (
 /obj/structure/chair/stool/directional/west,
@@ -26074,10 +26159,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
-"hnw" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "hnC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26726,8 +26807,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "hwe" = (
-/obj/structure/thermoplastic,
-/obj/machinery/status_display/ai/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/holosign/barrier/atmos/tram,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "hwm" = (
@@ -27121,9 +27202,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "hBG" = (
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/turf/closed/mineral/random/snow,
+/area/station/service/chapel)
 "hBZ" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/command,
@@ -27900,9 +27980,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"hOB" = (
-/turf/open/openspace,
-/area/station/hallway/primary/central)
 "hOG" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
@@ -28050,16 +28127,6 @@
 /obj/machinery/light/small/broken/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"hQA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "hQK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table,
@@ -29101,6 +29168,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"ieN" = (
+/obj/effect/decal/cleanable/blood/trail,
+/obj/machinery/light/small/red/directional/west,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "ife" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29428,12 +29500,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"ijQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/status_display/ai/directional/north,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "ijT" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
@@ -29584,8 +29650,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "ilw" = (
-/turf/closed/mineral/random/snow,
-/area/station/service/chapel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "ily" = (
 /turf/open/openspace,
 /area/station/science/xenobiology)
@@ -29712,6 +29780,25 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
+"inW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/structure/railing,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
+"iod" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/warning,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "iog" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -30056,14 +30143,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/ai/satellite/maintenance)
-"itn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "itt" = (
 /obj/machinery/door/window/brigdoor/right/directional/south{
 	name = "Research Director Observation";
@@ -30653,11 +30732,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"iCN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "iCX" = (
 /obj/machinery/power/solar_control{
 	dir = 4;
@@ -32103,12 +32177,6 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/security/brig)
-"iYX" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "iZj" = (
 /obj/structure/railing/corner/end{
 	dir = 4
@@ -32167,10 +32235,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
-"iZM" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "iZO" = (
 /obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -32957,6 +33021,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"jlq" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "jls" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -33003,6 +33077,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"jmn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "jms" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -33034,10 +33114,6 @@
 "jmI" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/workout)
-"jmM" = (
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "jmR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33356,6 +33432,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"jsb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/spawner/random/junk_shell,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "jsm" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Mech Bay";
@@ -33548,6 +33630,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"jup" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "juq" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
@@ -35286,10 +35373,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
-"jRY" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "jSa" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/dice,
@@ -35392,6 +35475,10 @@
 	},
 /turf/open/floor/plating/snowed/coldroom,
 /area/station/service/kitchen/coldroom)
+"jUd" = (
+/obj/machinery/power/smes/full,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep)
 "jUi" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -35884,6 +35971,16 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/textured,
 /area/station/medical/chem_storage)
+"kcR" = (
+/obj/machinery/door/window/elevator/left/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "kcT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -36861,6 +36958,13 @@
 	dir = 10
 	},
 /area/station/science/xenobiology)
+"krj" = (
+/obj/structure/fence/door{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "krn" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -37125,6 +37229,16 @@
 /obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
+"kuF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "kuJ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
@@ -37694,10 +37808,6 @@
 /obj/structure/sink/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"kBQ" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "kBU" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -37886,6 +37996,10 @@
 	},
 /turf/open/floor/plating/icemoon,
 /area/station/science/ordnance/bomb/planet)
+"kDZ" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "kEa" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -38041,13 +38155,6 @@
 	dir = 1
 	},
 /area/station/commons/storage/art)
-"kGK" = (
-/obj/structure/fence{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "kGQ" = (
 /obj/structure/table,
 /obj/item/stamp/head/qm,
@@ -38309,9 +38416,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "kJS" = (
-/obj/structure/thermoplastic/light,
-/obj/machinery/door/airlock/tram,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/report_crimes/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "kJU" = (
 /obj/structure/girder,
@@ -39494,6 +39602,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
+"laq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/corner,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "laB" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -39640,6 +39753,16 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/dark,
 /area/mine/mechbay)
+"lde" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "ldi" = (
 /obj/structure/table,
 /obj/item/wallframe/camera,
@@ -39922,11 +40045,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/fore)
-"lgQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "lgW" = (
 /obj/machinery/meter/monitored/distro_loop,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
@@ -40175,11 +40293,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom)
-"lkp" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "lkr" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
@@ -40218,6 +40331,14 @@
 /obj/effect/decal/cleanable/food/pie_smudge,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
+"lkX" = (
+/obj/machinery/light/small/red/directional/south,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/item/radio/intercom/chapel/directional/east,
+/turf/open/floor/wood/large,
+/area/icemoon/underground/explored)
 "lli" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
@@ -40427,11 +40548,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/eva)
-"loD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing/corner,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "loF" = (
 /obj/structure/table/wood,
 /obj/item/toy/mecha/honk{
@@ -40781,16 +40897,8 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/service)
-"lsZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 1
-	},
-/turf/open/floor/plating,
+"ltj" = (
+/turf/open/openspace,
 /area/icemoon/underground/explored)
 "ltk" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -40836,6 +40944,12 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"luo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "lux" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -41168,6 +41282,7 @@
 "lyD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "lyG" = (
@@ -42104,12 +42219,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/armory/upper)
 "lMG" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/catwalk_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/enlist/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "lMK" = (
 /obj/structure/table,
@@ -44919,10 +45032,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
 "mCP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/garbage,
-/obj/effect/spawner/random/junk_shell,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock/external/glass,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "mCT" = (
 /turf/open/water/no_planet_atmos/deep,
@@ -45210,6 +45322,12 @@
 /obj/structure/sign/clock/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"mHb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/garbage,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "mHd" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -45461,9 +45579,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mLd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/decal/cleanable/fuel_pool,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "mLf" = (
 /turf/open/openspace/icemoon/keep_below,
@@ -45943,10 +46061,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/hos)
-"mTM" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "mTS" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -47131,10 +47245,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
-"njE" = (
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/genturf/blue,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "njJ" = (
 /turf/closed/wall,
 /area/mine/laborcamp)
@@ -47367,6 +47477,13 @@
 /obj/effect/landmark/navigate_destination/library,
 /turf/open/floor/wood,
 /area/station/service/library)
+"nmS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plastic,
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "nmX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -47600,10 +47717,6 @@
 "npD" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/aft/greater)
-"npE" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "npJ" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/violet/visible,
 /turf/open/floor/iron,
@@ -47798,6 +47911,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"nsx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/light/warm/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "nsM" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/warning/directional/west,
@@ -48353,11 +48474,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/icemoon/keep_below,
 /area/station/maintenance/port/lesser)
-"nAm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "nAr" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -49957,12 +50073,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/command/eva)
-"nUH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "nUJ" = (
 /obj/machinery/flasher/directional/east{
 	id = "brigentry"
@@ -50796,7 +50906,7 @@
 "ohF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/left/directional/north,
+/obj/machinery/door/window/elevator/left/directional/west,
 /turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "ohI" = (
@@ -50804,6 +50914,11 @@
 	dir = 9
 	},
 /turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/underground/explored)
+"ohN" = (
+/obj/effect/decal/cleanable/shreds,
+/obj/effect/decal/cleanable/crayon,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "ohO" = (
 /obj/structure/fluff/tram_rail,
@@ -51334,16 +51449,6 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"ooA" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "ooG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51742,6 +51847,12 @@
 	},
 /turf/open/floor/iron/stairs/medium,
 /area/station/commons/dorms/laundry)
+"oti" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ots" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
@@ -51764,6 +51875,15 @@
 	dir = 1
 	},
 /area/station/commons/storage/mining)
+"otE" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "otG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
@@ -52409,6 +52529,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"oBS" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "oBZ" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52770,16 +52894,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
-"oFH" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "oFI" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -53048,6 +53162,13 @@
 /obj/structure/sign/departments/cargo/directional/west,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
+"oIv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/spawner/random/maintenance/dumpster,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "oIy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -53274,11 +53395,6 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/mine/living_quarters)
-"oLv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/wood,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "oLz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -53424,6 +53540,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"oOi" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "oOo" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light/directional/west,
@@ -53971,6 +54091,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"oWp" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "oWy" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/circuit_workshop)
@@ -54162,11 +54292,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"oZf" = (
-/obj/effect/spawner/random/trash/bin,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "oZk" = (
 /obj/structure/chair{
 	dir = 1
@@ -54183,10 +54308,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/explab)
-"oZq" = (
-/obj/structure/transport/linear/public,
-/turf/open/space/basic,
-/area/icemoon/underground/explored)
 "oZw" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -54446,12 +54567,6 @@
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
-"pcX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/spawner/random/maintenance/dumpster,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "pdd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54580,12 +54695,6 @@
 /obj/structure/grille/broken,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/explored)
-"pfp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/random/directional/north,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "pfw" = (
 /obj/structure/flora/grass/green/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -54605,6 +54714,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"pfJ" = (
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "pfP" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/structure/cable,
@@ -55099,14 +55211,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/hos)
-"pmS" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "pna" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -55178,6 +55282,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
+"pnI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "pnK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/north,
@@ -55391,11 +55500,6 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/mine/living_quarters)
-"pqU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "pra" = (
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
@@ -55542,9 +55646,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/aft/greater)
 "ptt" = (
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/decal/cleanable/fuel_pool,
-/turf/open/floor/plating,
+/obj/machinery/door/window/elevator/right/directional/north,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "ptQ" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
@@ -56333,9 +56437,8 @@
 /turf/open/floor/iron/large,
 /area/station/medical/break_room)
 "pEs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "pEE" = (
@@ -56742,11 +56845,6 @@
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
-"pLb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/west,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "pLg" = (
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/openspace/icemoon/keep_below,
@@ -56838,11 +56936,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
-"pMs" = (
-/obj/machinery/door/window/elevator/right/directional/north,
-/obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "pMu" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -57196,14 +57289,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/commissary)
-"pSe" = (
-/obj/machinery/light/small/red/directional/south,
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/item/radio/intercom/chapel/directional/east,
-/turf/open/floor/wood/large,
-/area/icemoon/underground/explored)
 "pSk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57392,6 +57477,13 @@
 "pUa" = (
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"pUe" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "pUi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57638,6 +57730,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"pXw" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/structure/table/glass,
+/obj/item/watertank{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/plant_analyzer,
+/obj/item/book/manual/hydroponics_pod_people,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "pXA" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -57685,6 +57793,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"pYj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "pYn" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/telescreen/prison/directional/north,
@@ -57702,6 +57815,11 @@
 	dir = 4
 	},
 /area/station/service/chapel)
+"pYG" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "pYK" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -58598,8 +58716,8 @@
 /turf/open/misc/asteroid/snow/standard_air,
 /area/station/science/cytology)
 "qkn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/lava/plasma/ice_moon,
+/obj/effect/decal/cleanable/leaper_sludge,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "qku" = (
 /obj/structure/chair/comfy/beige{
@@ -58750,6 +58868,10 @@
 "qmt" = (
 /turf/closed/wall,
 /area/mine/eva/lower)
+"qmx" = (
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/genturf/blue,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "qmK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -58777,6 +58899,11 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/wood,
 /area/station/service/library)
+"qnn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "qnt" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -58867,6 +58994,11 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"qoS" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/glitter,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "qpb" = (
 /obj/machinery/disposal/bin{
 	desc = "A pneumatic waste disposal unit. This one leads to the morgue.";
@@ -59537,6 +59669,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
+"qzk" = (
+/obj/structure/transport/linear/public,
+/obj/structure/barricade/wooden{
+	name = "wooden barricade (CLOSED)"
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "qzs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59703,10 +59842,9 @@
 /turf/open/floor/plating,
 /area/station/security/prison/mess)
 "qCx" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep)
 "qCA" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -59779,15 +59917,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/donk,
 /area/mine/production)
-"qDB" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "qDI" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -60024,6 +60153,15 @@
 /obj/item/gps/mining,
 /turf/open/floor/iron/smooth,
 /area/mine/eva)
+"qGk" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "qGC" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/on,
 /obj/machinery/airalarm/directional/east,
@@ -60119,10 +60257,6 @@
 	dir = 1
 	},
 /area/station/medical/virology)
-"qHK" = (
-/obj/item/pickaxe,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit/departure_lounge)
 "qHO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench/right{
@@ -60254,12 +60388,7 @@
 /area/mine/eva/lower)
 "qJB" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/glass,
-/obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "qJT" = (
@@ -62385,6 +62514,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"rml" = (
+/obj/structure/fence/door,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "rmn" = (
 /obj/structure/chair/stool/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -62836,6 +62970,13 @@
 /obj/structure/sign/poster/contraband/the_big_gas_giant_truth/directional/north,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"rsj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/warm/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "rsw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -62894,8 +63035,9 @@
 	},
 /area/station/security/prison/safe)
 "rsO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "rsR" = (
 /obj/structure/table/optable,
@@ -63193,6 +63335,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"rxr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/holopay,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "rxx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/camera/directional/east{
@@ -63204,13 +63352,6 @@
 "rxz" = (
 /obj/structure/girder,
 /turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/underground/explored)
-"rxA" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 5
-	},
-/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "rxG" = (
 /obj/structure/ore_vent/starter_resources{
@@ -63278,11 +63419,6 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/checker,
 /area/station/hallway/secondary/service)
-"ryt" = (
-/obj/structure/transport/linear/public,
-/obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "ryu" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/security/execution/transfer)
@@ -63325,6 +63461,10 @@
 /obj/structure/sign/poster/official/nanotrasen_logo/directional/south,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"rzh" = (
+/obj/structure/fluff/minepost,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "rzj" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty{
@@ -63538,11 +63678,6 @@
 "rCf" = (
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
-"rCr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "rCs" = (
 /obj/structure/table,
 /obj/item/food/deadmouse{
@@ -63597,6 +63732,7 @@
 "rCM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "rCO" = (
@@ -63773,6 +63909,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"rEw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/window/elevator/left/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "rEx" = (
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
@@ -63853,6 +63994,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"rFS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "rFU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -64322,11 +64473,6 @@
 /obj/effect/mapping_helpers/no_atoms_ontop,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
-"rOu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/enlist/directional/west,
-/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "rOv" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -64809,14 +64955,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rVr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/south{
-	id = "tram_perma_lift"
-	},
-/obj/machinery/lift_indicator/directional/south{
-	linked_elevator_id = "tram_perma_lift"
-	},
-/turf/open/floor/iron/smooth,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "rVB" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
@@ -64918,12 +65058,11 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rWJ" = (
-/obj/structure/toiletbong,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/left,
-/obj/structure/thermoplastic/light,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "rWO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65312,11 +65451,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "scr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "sct" = (
 /obj/structure/disposalpipe/segment,
@@ -65699,6 +65836,12 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"shP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "shR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -65831,10 +65974,10 @@
 /turf/closed/wall,
 /area/station/maintenance/fore)
 "skm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron/smooth,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "skn" = (
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -66321,11 +66464,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/atrium)
-"spR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "spV" = (
 /obj/effect/spawner/random/trash/bin,
 /obj/item/paper/crumpled{
@@ -67401,16 +67539,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
-"sEW" = (
-/obj/machinery/door/window/elevator/left/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "sEX" = (
 /obj/machinery/computer/atmos_control/air_tank{
 	dir = 1
@@ -67725,6 +67853,10 @@
 /obj/structure/flora/rock/pile/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/labor_camp)
+"sJx" = (
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "sJA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68020,17 +68152,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/security/mechbay)
-"sOM" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "sOO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -68043,6 +68164,14 @@
 /obj/item/storage/bag/trash,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
+"sPb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/warning,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "sPq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -68380,6 +68509,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/storage/mining)
+"sUe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "sUB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68420,9 +68555,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"sVd" = (
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers)
 "sVi" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Break Room"
@@ -68516,6 +68648,15 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/cmo)
+"sWm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/obj/structure/fence/door{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "sWs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -68760,6 +68901,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
+"tar" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/west,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "tau" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/green/half/contrasted,
@@ -68809,6 +68955,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"tbc" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "tbh" = (
 /turf/open/floor/iron/half{
 	dir = 1
@@ -69224,9 +69381,8 @@
 /turf/open/genturf/blue,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "thB" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
@@ -69873,6 +70029,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/large,
 /area/station/command/gateway)
+"tpb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "tpc" = (
 /obj/effect/spawner/random/trash/graffiti{
 	pixel_y = -30
@@ -69897,10 +70060,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"tpp" = (
-/obj/effect/mapping_helpers/no_atoms_ontop,
-/turf/closed/wall,
-/area/icemoon/underground/explored)
 "tpF" = (
 /obj/structure/closet/bombcloset/security,
 /obj/effect/turf_decal/bot,
@@ -71244,6 +71403,17 @@
 	dir = 1
 	},
 /area/station/science/lab)
+"tJH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/south{
+	id = "tram_perma_lift"
+	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "tram_perma_lift"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "tJI" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "robo1"
@@ -72014,6 +72184,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
+"tUw" = (
+/obj/machinery/door/window/elevator/right/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "tUx" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
@@ -72538,12 +72712,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
-"ucd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "ucl" = (
 /obj/machinery/door/window/right/directional/west{
 	name = "Containment Pen 4";
@@ -73153,6 +73321,11 @@
 "ult" = (
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/lab)
+"ulH" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "ulL" = (
 /obj/machinery/modular_computer/preset/id,
 /obj/effect/turf_decal/tile/blue/full,
@@ -73221,6 +73394,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
+"umB" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "umC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73512,22 +73690,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"uqs" = (
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/green/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/duct,
-/obj/structure/table/glass,
-/obj/item/watertank{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/item/plant_analyzer,
-/obj/item/book/manual/hydroponics_pod_people,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "uqz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -73697,6 +73859,14 @@
 /obj/item/toy/crayon/spraycan/roboticist,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"utw" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/elevator/directional/east,
+/obj/machinery/lift_indicator/directional/east,
+/obj/machinery/door/window/elevator/right/directional/north,
+/obj/effect/turf_decal/caution/stand_clear/white,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/garden)
 "utA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -74761,12 +74931,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"uJr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "uJt" = (
 /turf/open/floor/carpet,
 /area/station/service/chapel)
@@ -74800,6 +74964,11 @@
 "uJR" = (
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"uJW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "uJX" = (
 /obj/structure/closet/firecloset,
 /obj/item/radio/intercom/directional/north,
@@ -75008,6 +75177,12 @@
 "uOb" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/toilet)
+"uOd" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "uOf" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningdorm_A";
@@ -75193,6 +75368,11 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/textured,
 /area/station/security/brig)
+"uQJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "uQR" = (
 /obj/machinery/light_switch/directional/east,
 /obj/structure/sign/warning/biohazard/directional/north,
@@ -75249,6 +75429,17 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
+"uRA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "uRJ" = (
 /obj/structure/table,
 /obj/item/kitchen/fork/plastic,
@@ -75943,11 +76134,6 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
-"vcT" = (
-/obj/structure/thermoplastic,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "vcY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -76330,6 +76516,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"vjp" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "vjq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -76383,11 +76575,17 @@
 "vkh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "vkk" = (
-/obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/trimline/yellow/warning,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "vkz" = (
 /obj/machinery/suit_storage_unit/ce,
@@ -76934,6 +77132,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"vrA" = (
+/obj/structure/transport/linear/public,
+/turf/open/space/basic,
+/area/icemoon/underground/explored)
 "vrC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77411,6 +77613,11 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"vxZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "vyd" = (
 /obj/machinery/modular_computer/preset/id,
 /turf/open/floor/carpet/royalblue,
@@ -77892,11 +78099,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/security/brig)
-"vFR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/work_for_a_future/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "vFT" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -79026,6 +79228,12 @@
 /obj/structure/railing,
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
+"vWR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/light/warm/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "vWU" = (
 /obj/structure/table/glass,
 /obj/item/book/bible,
@@ -79880,6 +80088,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/primary/starboard)
+"wjW" = (
+/obj/structure/thermoplastic,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "wkb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/sign/warning/gas_mask/directional/north,
@@ -80112,6 +80325,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/brig)
+"wop" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "wor" = (
 /turf/open/openspace,
 /area/station/medical/medbay/aft)
@@ -81038,14 +81256,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix)
-"wCM" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/button/elevator/directional/east,
-/obj/machinery/lift_indicator/directional/east,
-/obj/machinery/door/window/elevator/right/directional/north,
-/obj/effect/turf_decal/caution/stand_clear/white,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics/garden)
 "wCN" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -81103,6 +81313,12 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"wDA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plastic,
+/obj/machinery/light/small/red/directional/west,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "wDH" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -82680,12 +82896,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"xag" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "xal" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -83205,6 +83415,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage)
+"xfV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "xfZ" = (
 /obj/structure/flora/bush/snow/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -83455,11 +83674,12 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "xiL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/structure/cable,
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/service/hydroponics/garden)
 "xiO" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -84531,6 +84751,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
+"xyi" = (
+/obj/effect/decal/cleanable/wrapping,
+/obj/effect/decal/cleanable/fuel_pool,
+/obj/effect/decal/cleanable/ants,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "xyn" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -84668,6 +84894,12 @@
 /obj/item/storage/medkit/regular,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"xzx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/warm/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "xzH" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -84922,12 +85154,6 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"xDh" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "xDj" = (
 /obj/effect/turf_decal/trimline/yellow/end{
 	dir = 1
@@ -85758,11 +85984,6 @@
 /obj/effect/mapping_helpers/no_atoms_ontop,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
-"xOz" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "xOQ" = (
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -85897,6 +86118,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"xQV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "xQX" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Arrivals Hallway South"
@@ -85991,13 +86217,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/circuit_workshop)
-"xTb" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "xTi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -86333,11 +86552,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
-"xWQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence/door,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "xWT" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/machinery/light_switch/directional/south,
@@ -86627,10 +86841,6 @@
 "yaL" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/engine_smes)
-"yaM" = (
-/obj/machinery/door/window/elevator/right/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "yaN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster/directional/west,
@@ -86850,9 +87060,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "ydH" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/chapel)
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers)
 "ydI" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/entry)
@@ -87184,6 +87393,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"yjI" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "yjV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -87209,10 +87424,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"yky" = (
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "ykA" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -87238,6 +87449,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/light/warm/directional/south,
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "yld" = (
@@ -101810,15 +102022,15 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
+aVL
+aVL
+aVL
 gFX
 gFX
 gFX
 gFX
 gFX
-vBN
+nrp
 lhB
 thA
 iDt
@@ -102067,13 +102279,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-gFX
-pcX
-rOu
-dOP
+aVL
+qCx
+qCx
+ulH
+oIv
+lMG
+ffL
 gFX
 gFX
 gFX
@@ -102324,14 +102536,14 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
+aVL
+cUB
+jUd
 gFX
-skm
-ucd
+ewh
+gEb
 eHt
-sEW
+kcR
 nTH
 nTH
 gFX
@@ -102581,14 +102793,14 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
+aVL
+avT
+aVL
 gFX
-pfp
-rCr
+frp
+dIu
 kdm
-lsZ
+uRA
 nTH
 nTH
 gFX
@@ -102842,9 +103054,9 @@ oSU
 oSU
 oSU
 gFX
-ijQ
-dys
-rVr
+nsx
+vjp
+tJH
 gFX
 gFX
 gFX
@@ -103100,10 +103312,10 @@ oSU
 gFX
 gFX
 wMB
-gVx
-kGK
+krj
+eNZ
 wMB
-mCP
+jsb
 gFX
 ghx
 ghx
@@ -103355,13 +103567,13 @@ thA
 thA
 thA
 gFX
-oZf
-eHt
-bJv
-aCI
+ftF
+cvr
+gVx
+jup
 cLf
-qJB
-rsO
+kuF
+rVr
 ghx
 ghx
 thA
@@ -103612,11 +103824,11 @@ thA
 thA
 thA
 gFX
-kdm
-loD
-iYX
-gtt
-iYX
+qnn
+laq
+thB
+rWJ
+thB
 gFX
 gFX
 ghx
@@ -103869,13 +104081,13 @@ thA
 thA
 thA
 gFX
-aVL
-iCN
+kJS
+uJW
 cjI
 aMC
 wuN
 nLK
-rsO
+rVr
 ghx
 ghx
 thA
@@ -104126,13 +104338,13 @@ thA
 thA
 thA
 gFX
-eHt
+cvr
 gFX
 aMC
 uWq
 bKQ
 wuN
-rsO
+rVr
 ghx
 ghx
 thA
@@ -104383,13 +104595,13 @@ thA
 thA
 thA
 gFX
-cLf
-bUj
+qJB
+cpd
 eiQ
 uWq
 fHU
 wuN
-rsO
+rVr
 ghx
 ghx
 thA
@@ -104639,11 +104851,11 @@ thA
 thA
 ghx
 ghx
-rsO
+rVr
 cLf
-dRc
+qGk
 aMC
-vcT
+wjW
 uWq
 aMC
 gFX
@@ -104896,14 +105108,14 @@ ghx
 ghx
 ghx
 ghx
-rsO
-lgQ
-dRc
+rVr
+pYj
+qGk
 wuN
 rOU
 qFF
-kJS
-rsO
+gTE
+rVr
 ghx
 ghx
 ijY
@@ -105153,14 +105365,14 @@ ghx
 ghx
 ghx
 ghx
-rsO
-cLf
-aQi
+rVr
+qJB
+jlq
 aMC
-rWJ
+cOS
 qFF
 cqV
-rsO
+rVr
 ghx
 ghx
 ghx
@@ -105410,14 +105622,14 @@ ghx
 ghx
 ghx
 ghx
-rsO
-eHt
+rVr
+cvr
 gFX
 aMC
 aMC
 oge
 aMC
-rsO
+rVr
 ghx
 ghx
 ghx
@@ -105668,8 +105880,8 @@ thA
 ghx
 ghx
 gFX
-eHt
-lMG
+cvr
+xfV
 txh
 cqV
 uWq
@@ -105925,13 +106137,13 @@ thA
 thA
 ghx
 gFX
-vFR
-qDB
+dLW
+oWp
 wuN
 nov
 dzI
 aMC
-rsO
+rVr
 ghx
 ghx
 iDt
@@ -106181,14 +106393,14 @@ ghx
 thA
 thA
 ghx
-rsO
-eHt
-pmS
+rVr
+cvr
+otE
 aMC
-vcT
+wjW
 dzI
 eiQ
-rsO
+rVr
 ghx
 ghx
 iDt
@@ -106438,14 +106650,14 @@ ghx
 ghx
 thA
 ghx
-rsO
-eHt
+rVr
+cvr
 gFX
 aMC
-hwe
+duW
 vrk
 aMC
-rsO
+rVr
 ghx
 ghx
 iDt
@@ -106695,9 +106907,9 @@ ghx
 ghx
 thA
 ghx
-rsO
-cLf
-sOM
+rVr
+qJB
+tbc
 eiQ
 uWq
 kdq
@@ -106952,14 +107164,14 @@ ghx
 ghx
 ghx
 ghx
-rsO
-oLv
-rxA
+rVr
+oti
+lde
 kJN
 aMC
 sAc
 iOk
-qkn
+ccx
 ghx
 iDt
 iDt
@@ -107210,13 +107422,13 @@ ghx
 ghx
 ghx
 gFX
-xOz
-xDh
+eha
+uOd
 vBN
 vBN
 lhB
 vBN
-qkn
+ccx
 ghx
 ghx
 iDt
@@ -107469,10 +107681,10 @@ ghx
 gFX
 gFX
 gFX
-hBG
-hBG
-cUB
-hBG
+sJx
+sJx
+hwe
+sJx
 gFX
 ghx
 ghx
@@ -107725,12 +107937,12 @@ ghx
 ghx
 ghx
 ghx
-ghx
+nrp
 vBN
 vBN
 lhB
 vBN
-ghx
+nrp
 ghx
 ghx
 hpE
@@ -110038,12 +110250,12 @@ thA
 ghx
 ghx
 ghx
-ghx
+nrp
 vBN
 vBN
 vBN
 vBN
-thA
+rzh
 thA
 thA
 thA
@@ -112866,10 +113078,10 @@ ghx
 gFX
 vBN
 vBN
-hBG
-hBG
-cUB
-hBG
+sJx
+sJx
+hwe
+sJx
 vBN
 gFX
 oSU
@@ -119301,7 +119513,7 @@ gFX
 vBN
 gFX
 cUg
-hnw
+cvr
 vVn
 cYS
 gFX
@@ -119559,8 +119771,8 @@ vBN
 gFX
 vQb
 waK
-hnw
-hnw
+cvr
+cvr
 gFX
 oSU
 oSU
@@ -119571,7 +119783,7 @@ rxZ
 lhB
 lhB
 lhB
-lhB
+wop
 gFX
 thA
 thA
@@ -119828,7 +120040,7 @@ lnK
 nHU
 vBN
 lhB
-vBN
+qkn
 gFX
 gFX
 gFX
@@ -120069,18 +120281,18 @@ vBN
 kku
 usr
 nqh
-tgU
+wDA
 gFX
 gFX
-xag
+luo
 usr
-mLd
+pEs
 hgg
 dmC
-mLd
-mLd
-iZM
-xiL
+pEs
+pEs
+bKb
+lyD
 huy
 cjI
 aMC
@@ -120088,8 +120300,8 @@ wuN
 nLK
 mKr
 deW
-vBN
-vBN
+qoS
+oWa
 gFX
 oSU
 oSU
@@ -120326,27 +120538,27 @@ vBN
 djd
 cBz
 kdm
-bJv
+fxZ
 gFX
 nTH
-ohF
+eFq
 msM
+uQJ
 cBz
-cBz
-nAm
+ilw
 bJv
 aeV
 lLs
-jmM
+gVx
 jZR
 aMC
 dzI
 bKQ
 wuN
 vfg
-lhB
+nmS
 udj
-vBN
+ohN
 gFX
 oSU
 oSU
@@ -120586,23 +120798,23 @@ kdm
 bJv
 gFX
 nTH
-pqU
+pnI
 eHt
-kdm
+qnn
 eHt
 eHt
 kdm
 eHt
 cLf
-uJr
+sUe
 iva
 eiQ
 dzI
 cyp
 wuN
 vfg
-nHU
-vBN
+skm
+xyi
 uBk
 gFX
 oSU
@@ -120843,15 +121055,15 @@ kdm
 eHt
 wlK
 gFX
-cLf
-cLf
+xzx
+qJB
 vkh
 kdm
 eHt
 eHt
 kdm
 gFX
-qCx
+vWR
 iva
 aMC
 uWq
@@ -121108,7 +121320,7 @@ eHt
 eHt
 kdm
 mJE
-jmM
+gVx
 iva
 wuN
 rOU
@@ -121610,7 +121822,7 @@ lhB
 vBN
 thL
 tgU
-gcY
+dTo
 jRP
 usr
 usr
@@ -121622,7 +121834,7 @@ idf
 usr
 usr
 usr
-nUH
+rCM
 dbl
 aMC
 aMC
@@ -133447,7 +133659,7 @@ oSU
 gFX
 lhB
 lhB
-spR
+xQV
 lhB
 lhB
 gFX
@@ -134739,7 +134951,7 @@ gFX
 gFX
 gFX
 gFX
-gFX
+pYG
 gFX
 xMq
 wUm
@@ -134996,8 +135208,8 @@ gFX
 nTH
 nTH
 gFX
-mTM
-tpp
+scr
+apV
 aKb
 iDt
 iDt
@@ -135243,18 +135455,18 @@ oSU
 oSU
 oSU
 gFX
-eHt
+umB
 jfP
 vBN
 vBN
 vBN
 lhB
-ccx
-pLb
-bdw
+bus
+tar
+ohF
 efl
-eHt
 cvr
+mCP
 chg
 iDt
 iDt
@@ -135500,18 +135712,18 @@ oSU
 oSU
 oSU
 gFX
-ruu
-lDp
+mHb
+jmn
 vBN
 lhB
 vBN
 vBN
-eha
+vkk
 eHt
 cBz
-xWQ
-eHt
-tpp
+tpb
+cvr
+apV
 pJm
 iDt
 iDt
@@ -135758,16 +135970,16 @@ oSU
 oSU
 gFX
 csZ
-rxZ
+sWm
 vBN
 vBN
 vBN
 lhB
-gBp
+sPb
 eHt
-cBz
-scr
-eHt
+rxr
+rml
+cvr
 gFX
 xMq
 xMq
@@ -136015,16 +136227,16 @@ gFX
 gFX
 gFX
 rAE
-lnK
+inW
 vBN
 lhB
 vBN
 vBN
-itn
+iod
 kdm
-cBz
-scr
-yky
+uQJ
+tpb
+bFU
 gFX
 iDt
 xMq
@@ -136266,22 +136478,22 @@ oSU
 oSU
 oSU
 gFX
-oZq
-cSK
+vrA
+rEw
 luS
 pAj
 tgU
 lyD
-huy
+deB
 vBN
 lhB
 lhB
 lhB
-gBp
+sPb
 eHt
 cXw
 gFX
-gFX
+pYG
 gFX
 oSU
 oSU
@@ -136523,20 +136735,20 @@ oSU
 oSU
 oSU
 gFX
-oZq
-yaM
+vrA
+tUw
 eHt
 cLf
 gFX
-eHt
+cvr
 jZR
 vBN
 lhB
 lhB
 vBN
-eha
+vkk
 bJv
-cBz
+uQJ
 gFX
 oSU
 oSU
@@ -136781,19 +136993,19 @@ oSU
 oSU
 gFX
 gFX
-pEs
+shP
 aCI
 cLf
-bJv
+gVx
 vkh
 iva
 vBN
 lhB
 lhB
 vBN
-gBp
+sPb
 usr
-usr
+pEs
 gFX
 oSU
 oSU
@@ -137041,7 +137253,7 @@ gFX
 obY
 bJv
 cLf
-bJv
+gVx
 kdm
 iva
 vBN
@@ -137050,7 +137262,7 @@ lhB
 nHU
 gFX
 tgU
-eHt
+cvr
 gFX
 oSU
 oSU
@@ -137298,7 +137510,7 @@ gFX
 usr
 eHt
 kdm
-kdm
+qnn
 eHt
 iva
 vBN
@@ -137306,8 +137518,8 @@ vBN
 lhB
 vBN
 gFX
-lkp
-bJv
+rsO
+gVx
 gFX
 oSU
 oSU
@@ -137555,7 +137767,7 @@ gFX
 usr
 bJv
 eHt
-bJv
+gVx
 gDI
 jZR
 vBN
@@ -137564,7 +137776,7 @@ vBN
 vBN
 gFX
 usr
-cBz
+uQJ
 gFX
 oSU
 oSU
@@ -137809,11 +138021,11 @@ oSU
 oSU
 oSU
 gFX
-usr
+dhG
 gFX
 eHt
 gFX
-rCM
+rsj
 hjK
 vBN
 lhB
@@ -137821,7 +138033,7 @@ vBN
 vBN
 gFX
 kdm
-kdm
+qnn
 gFX
 oSU
 oSU
@@ -138070,7 +138282,7 @@ usr
 gFX
 eHt
 gFX
-eHt
+cvr
 cmA
 vBN
 vBN
@@ -138078,7 +138290,7 @@ vBN
 vBN
 gFX
 tgU
-cBz
+uQJ
 gFX
 oSU
 oSU
@@ -138323,11 +138535,11 @@ oSU
 oSU
 oSU
 gFX
-kBQ
+ghe
 bJv
 eHt
 bJv
-eHt
+cvr
 cmA
 vBN
 lhB
@@ -138335,7 +138547,7 @@ vBN
 vBN
 gFX
 kdm
-cBz
+uQJ
 gFX
 oSU
 oSU
@@ -138580,19 +138792,19 @@ oSU
 gFX
 gFX
 gFX
-aZL
+cwL
 eHt
 cLf
 cLf
-mTM
-oFH
+scr
+cDr
 lhB
 vBN
 vBN
 vBN
 gFX
 usr
-eHt
+cvr
 gFX
 oSU
 oSU
@@ -138835,21 +139047,21 @@ oSU
 oSU
 oSU
 gFX
-fsd
-flJ
+gze
+qzk
 usr
 bJv
-npE
+gEH
 bJv
-eHt
-thB
+cvr
+deI
 lhB
 vBN
 vBN
 vBN
 gFX
 kdm
-jRY
+aZL
 gFX
 oSU
 oSU
@@ -139092,21 +139304,21 @@ oSU
 oSU
 oSU
 gFX
-ptt
-flJ
-bEh
+mLd
+qzk
+bWp
 bJv
 cLf
 bJv
-kdm
-ooA
+qnn
+aRE
 gFX
 gFX
 gFX
 gFX
 gFX
 tgU
-jRY
+aZL
 gFX
 oSU
 oSU
@@ -139349,21 +139561,21 @@ oSU
 oSU
 oSU
 gFX
-vkk
-ryt
-pMs
+kDZ
+drX
+ptt
 eHt
-npE
+gEH
 gFX
-cLf
-lgQ
+qJB
+pYj
 usr
 eHt
 usr
 kdm
-dBt
-fsg
-kdm
+ieN
+vxZ
+qnn
 gFX
 oSU
 oSU
@@ -139612,15 +139824,15 @@ mJE
 cLf
 cnF
 eHt
-cLf
-eHt
-bJv
-bJv
-kdm
-cBz
-bJv
-eHt
-usr
+qJB
+cvr
+gVx
+gVx
+qnn
+uQJ
+gVx
+cvr
+pEs
 gFX
 oSU
 oSU
@@ -167610,7 +167822,7 @@ tjo
 tjo
 tjo
 tjo
-sVd
+ydH
 gFX
 wlK
 wlK
@@ -167867,9 +168079,9 @@ tjo
 tjo
 tjo
 tjo
-sVd
-cOS
-cOS
+ydH
+ltj
+ltj
 wlK
 lhB
 lhB
@@ -168124,9 +168336,9 @@ tjo
 tjo
 tjo
 tjo
-sVd
-cOS
-cOS
+ydH
+ltj
+ltj
 wlK
 lhB
 lhB
@@ -168381,7 +168593,7 @@ tjo
 tjo
 tjo
 tjo
-sVd
+ydH
 gFX
 gFX
 gFX
@@ -169414,7 +169626,7 @@ tjo
 thA
 thA
 thA
-njE
+qmx
 iLh
 pwg
 peG
@@ -185869,7 +186081,7 @@ caA
 mty
 urQ
 sQI
-eXJ
+eOZ
 pme
 pme
 aon
@@ -186381,13 +186593,13 @@ gFX
 uVb
 exw
 mqd
-uqs
+pXw
 wDb
 oZG
 oZG
 rZY
 oZG
-hQA
+rFS
 exw
 exw
 exw
@@ -201292,7 +201504,7 @@ xeJ
 oTA
 kub
 oTA
-ydH
+oBS
 wrX
 wrX
 wrX
@@ -201800,13 +202012,13 @@ lvt
 lvt
 xMq
 xMq
-ilw
+hBG
 wrX
 gEE
 wrX
 wee
-ghe
-pSe
+aOg
+lkX
 gFX
 xMq
 xMq
@@ -202057,7 +202269,7 @@ lvt
 lvt
 xMq
 xMq
-ilw
+hBG
 wrX
 gEE
 wrX
@@ -233663,7 +233875,7 @@ aPM
 oCO
 qTm
 qTm
-wCM
+utw
 tmL
 arG
 cIa
@@ -234172,9 +234384,9 @@ lJO
 lJO
 lJO
 lJO
-fyO
-xTb
-fKn
+cAd
+xiL
+pUe
 tNd
 nor
 sst
@@ -251657,7 +251869,7 @@ oUO
 kHO
 mQi
 uja
-hOB
+pfJ
 hNU
 kyL
 kyL
@@ -267077,7 +267289,7 @@ nui
 kDs
 kDs
 kDs
-bWp
+oOi
 oOD
 lDH
 qPL
@@ -267336,7 +267548,7 @@ pUa
 kDs
 jZM
 jtG
-qHK
+cUT
 qPL
 ugO
 wLS
@@ -268107,7 +268319,7 @@ pUa
 kDs
 qPL
 nbK
-bLS
+yjI
 ixv
 qPL
 gHD

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -164,6 +164,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"acM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "acN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1827,6 +1833,17 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"ayj" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "ayq" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "atmos-entrance"
@@ -1868,6 +1885,12 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
+"ayQ" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "ayS" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - Permabrig Lower Hallway Stairwell";
@@ -2389,6 +2412,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
+"aHv" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "aHz" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -2593,13 +2621,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aJQ" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/starboard)
 "aJX" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4192,13 +4214,6 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"bhN" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/button/elevator/directional/east,
-/obj/machinery/lift_indicator/directional/east,
-/obj/machinery/door/window/elevator/right/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics/garden)
 "bhQ" = (
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating,
@@ -5189,12 +5204,6 @@
 "btU" = (
 /turf/closed/wall,
 /area/station/medical/morgue)
-"btW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/garbage,
-/obj/effect/spawner/random/junk_shell,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "bum" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -5854,6 +5863,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"bCU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "bDi" = (
 /obj/machinery/door/window/left/directional/west,
 /obj/structure/cable,
@@ -7091,11 +7106,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"bUR" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "bUS" = (
 /obj/structure/railing{
 	dir = 1
@@ -7542,21 +7552,8 @@
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium)
 "caA" = (
-/obj/effect/turf_decal/tile/green/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/structure/table/glass,
-/obj/item/book/manual/hydroponics_pod_people,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/sign/poster/contraband/kudzu/directional/north,
-/obj/machinery/light/small/directional/west,
-/obj/item/plant_analyzer,
-/obj/item/watertank{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/station/service/hydroponics)
 "caC" = (
 /obj/machinery/door/window/right/directional/west{
@@ -7695,8 +7692,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
 "ccx" = (
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "ccz" = (
 /obj/item/radio/intercom/directional/east,
@@ -7973,12 +7974,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"cfI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/status_display/ai/directional/north,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "cfR" = (
 /obj/structure/chair{
 	dir = 1
@@ -8179,11 +8174,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
-"ciJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "ciS" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -9022,9 +9012,8 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
 "cvr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers)
 "cvB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/west,
@@ -9080,6 +9069,12 @@
 "cvS" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical/central)
+"cvX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "cwa" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -9881,6 +9876,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"cHr" = (
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "cHs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -10133,6 +10132,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
+"cLg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/icemoon/underground/unexplored/rivers/deep)
 "cLo" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
@@ -10778,9 +10781,10 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "cUB" = (
-/obj/structure/window/spawner/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "cUG" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /obj/effect/turf_decal/stripes/red/corner{
@@ -10810,6 +10814,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"cVl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/unexplored/rivers/deep)
 "cVz" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -11616,6 +11624,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "dfB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/primary/starboard)
 "dfQ" = (
@@ -11652,12 +11661,6 @@
 /obj/machinery/incident_display/delam/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
-"dgq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/random/directional/north,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "dgt" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/virology{
@@ -11936,6 +11939,14 @@
 	dir = 8
 	},
 /area/station/science/ordnance/office)
+"djN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "djO" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer"
@@ -12056,6 +12067,11 @@
 /obj/effect/landmark/start/cook,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
+"dlr" = (
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "dlt" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
@@ -12362,14 +12378,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
-"dpO" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "dpU" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13951,13 +13959,6 @@
 /obj/item/clothing/under/color/rainbow,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"dMx" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "dMH" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/evac/directional/north,
@@ -15037,6 +15038,9 @@
 "efl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fence{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "efv" = (
@@ -15167,15 +15171,9 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
 "eha" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/blood/trail,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/icemoon/underground/unexplored/rivers/deep)
 "ehc" = (
 /turf/open/floor/plating,
 /area/station/security/prison)
@@ -15201,7 +15199,7 @@
 /area/station/commons/locker)
 "ehq" = (
 /obj/structure/noticeboard/directional/north,
-/turf/open/floor/iron,
+/turf/open/openspace,
 /area/station/hallway/primary/central)
 "ehy" = (
 /obj/effect/spawner/random/contraband/prison,
@@ -15751,9 +15749,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "equ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/starboard)
 "eqE" = (
@@ -17078,10 +17073,6 @@
 /obj/structure/lattice,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/explored)
-"eJj" = (
-/obj/structure/transport/linear/public,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "eJm" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/firealarm/directional/west,
@@ -17301,6 +17292,12 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"eNg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/west,
+/obj/machinery/lift_indicator/directional/west,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "eNh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17743,6 +17740,11 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hos)
+"eUt" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "eUx" = (
 /obj/machinery/light_switch/directional/east,
 /obj/structure/table,
@@ -19000,6 +19002,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"flk" = (
+/obj/structure/thermoplastic,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "flx" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=HOP";
@@ -19531,6 +19538,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"fuu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/enlist/directional/west,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "fuD" = (
 /obj/structure/tank_holder/extinguisher,
 /obj/structure/sign/poster/random/directional/north,
@@ -20195,12 +20207,6 @@
 	dir = 4
 	},
 /area/station/engineering/transit_tube)
-"fFk" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "fFn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -20347,6 +20353,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
+"fHX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "fHZ" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -20608,6 +20625,25 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/reagent_containers/cup/watering_can,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_y = 3
+	},
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/wrench,
+/obj/item/grenade/chem_grenade/antiweed,
+/obj/item/grenade/chem_grenade/antiweed{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/item/wrench,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 8;
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "fLx" = (
@@ -21488,6 +21524,16 @@
 /obj/structure/sign/clock/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
+"fZP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/south{
+	id = "tram_perma_lift"
+	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "tram_perma_lift"
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "fZV" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -22033,7 +22079,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
@@ -22436,9 +22481,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"gmG" = (
-/turf/open/openspace,
-/area/icemoon/underground/explored)
 "gmJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Infiltrate/Filter"
@@ -23118,6 +23160,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"gvJ" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/sign/poster/contraband/kudzu/directional/north,
+/obj/structure/sink/kitchen/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "gvK" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
@@ -23619,6 +23668,11 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/textured,
 /area/station/security/brig)
+"gCS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "gCV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -23833,6 +23887,10 @@
 /area/station/security/prison/toilet)
 "gFX" = (
 /turf/closed/wall,
+/area/icemoon/underground/explored)
+"gGo" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "gGs" = (
 /obj/structure/closet/secure_closet/engineering_welding,
@@ -24078,6 +24136,13 @@
 "gKd" = (
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/cargo/warehouse)
+"gKf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "gKl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25262,6 +25327,13 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"hak" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "hap" = (
 /turf/open/floor/vault,
 /area/station/security/prison/rec)
@@ -26024,11 +26096,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"hni" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/report_crimes/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "hnp" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -27089,8 +27156,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "hBG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/openspace,
 /area/icemoon/underground/explored)
 "hBZ" = (
 /obj/structure/table/wood,
@@ -27831,6 +27897,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/window/elevator/right/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "hOc" = (
@@ -30485,6 +30552,16 @@
 	dir = 4
 	},
 /area/station/service/chapel)
+"iBb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "iBe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -30723,6 +30800,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"iFq" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/unexplored/rivers/deep)
 "iFs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -31388,12 +31469,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"iPG" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "iPI" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
@@ -32596,13 +32671,6 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/maintenance/port/fore)
-"jgJ" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "jgL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -33781,6 +33849,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/engineering)
+"jzj" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "jzk" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/wood,
@@ -33808,14 +33883,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron,
 /area/station/security/brig/upper)
-"jzD" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "jzE" = (
 /obj/structure/railing{
 	dir = 1
@@ -36169,6 +36236,11 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/ai/satellite/atmos)
+"khI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/report_crimes/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "khR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
@@ -36214,6 +36286,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
+"kiN" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "kiO" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -36415,14 +36493,6 @@
 "kkl" = (
 /turf/closed/wall,
 /area/station/security/interrogation)
-"kkr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "kku" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -36506,6 +36576,11 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
+"klQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/door,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "klW" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron,
@@ -38327,11 +38402,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"kKY" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "kLa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38516,10 +38586,6 @@
 "kNW" = (
 /turf/closed/wall,
 /area/station/cargo/warehouse)
-"kNY" = (
-/obj/structure/transport/linear/public,
-/turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "kNZ" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -38564,6 +38630,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/window/elevator/left/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "kOt" = (
@@ -38631,11 +38698,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"kPp" = (
-/obj/structure/thermoplastic,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "kPq" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39559,6 +39621,22 @@
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"lbP" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/structure/table/glass,
+/obj/item/watertank{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/plant_analyzer,
+/obj/item/book/manual/hydroponics_pod_people,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "lch" = (
 /obj/machinery/computer/monitor{
 	dir = 1;
@@ -40192,12 +40270,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"llP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "llT" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -41524,6 +41596,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"lDJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "lDM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -43982,6 +44059,7 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/greater)
 "mqd" = (
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/half,
 /area/station/service/hydroponics)
 "mqe" = (
@@ -45267,6 +45345,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
+"mIy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/work_for_a_future/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "mIE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -45402,9 +45485,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mLd" = (
-/obj/structure/thermoplastic/light,
-/obj/machinery/door/airlock/tram,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "mLf" = (
 /turf/open/openspace/icemoon/keep_below,
@@ -45507,7 +45590,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "mNt" = (
@@ -46937,6 +47019,12 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"nhG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/spawner/random/maintenance/dumpster,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "nhI" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Research Division Genetics Monkey Pen";
@@ -47726,6 +47814,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"nsK" = (
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/unexplored/rivers/deep)
 "nsM" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/warning/directional/west,
@@ -47957,6 +48048,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"nwm" = (
+/obj/structure/fence{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "nwn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -48572,6 +48670,11 @@
 "nDE" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/garden)
+"nDH" = (
+/obj/effect/spawner/random/trash/bin,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "nDJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49396,10 +49499,6 @@
 /obj/item/pillow/random,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
-"nOw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/lava/plasma/ice_moon,
-/area/icemoon/underground/explored)
 "nOx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -49501,6 +49600,13 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"nPw" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "nPI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49812,7 +49918,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/toilet)
 "nTH" = (
-/obj/machinery/door/poddoor/lift,
+/obj/structure/transport/linear/public,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "nTK" = (
@@ -50106,7 +50212,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nYn" = (
@@ -50655,6 +50760,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
+"ogj" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/unexplored/rivers/deep)
 "ogl" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -50689,6 +50799,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/chamber)
+"ogG" = (
+/obj/machinery/door/window/elevator/left/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "oha" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -50955,9 +51075,6 @@
 /obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/iron/checker,
 /area/station/science/lab)
-"ojM" = (
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers)
 "ojW" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -51136,16 +51253,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"omJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/south{
-	id = "tram_perma_lift"
-	},
-/obj/machinery/lift_indicator/directional/south{
-	linked_elevator_id = "tram_perma_lift"
-	},
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "omL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51578,6 +51685,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"osc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/unexplored/rivers/deep)
 "osd" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -52096,6 +52207,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/textured,
 /area/station/commons/toilet)
+"ozm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/unexplored/rivers/deep)
 "ozo" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -52307,6 +52423,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"oBt" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "oBz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -52742,12 +52867,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"oGe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "oGh" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -53193,6 +53312,12 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/mine/living_quarters)
+"oLy" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "oLz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -53281,13 +53406,6 @@
 "oMT" = (
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
-"oNb" = (
-/obj/machinery/door/window/elevator/left/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "oNA" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -53373,6 +53491,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"oOA" = (
+/obj/structure/transport/linear/public,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "oOB" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -54299,13 +54421,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"pcj" = (
-/obj/structure/fence{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "pcr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrous_output{
 	dir = 8
@@ -54527,6 +54642,13 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"pgj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "pgk" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable,
@@ -55162,6 +55284,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/lift_indicator/directional/north,
+/obj/machinery/button/elevator/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "poO" = (
@@ -55537,6 +55661,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/breakroom)
+"puU" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "puX" = (
 /obj/structure/table,
 /obj/item/stock_parts/scanning_module{
@@ -55948,11 +56077,6 @@
 /obj/item/book/manual/wiki/detective,
 /turf/open/floor/carpet/blue,
 /area/station/security/prison/work)
-"pzx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing/corner,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "pzC" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/siding/yellow{
@@ -56230,8 +56354,7 @@
 /turf/open/floor/iron/large,
 /area/station/medical/break_room)
 "pEs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/holosign/barrier/atmos/tram,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "pEE" = (
@@ -56272,6 +56395,9 @@
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -56443,6 +56569,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"pIs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "pIu" = (
 /obj/structure/table,
 /obj/item/binoculars,
@@ -56888,17 +57020,6 @@
 	dir = 4
 	},
 /area/station/service/hydroponics)
-"pPk" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "pPy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -58447,12 +58568,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"qju" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/spawner/random/maintenance/dumpster,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "qjF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -58665,10 +58780,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/plating,
 /area/station/medical/virology)
-"qni" = (
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/genturf/blue,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "qnj" = (
 /turf/closed/wall,
 /area/station/commons/locker)
@@ -59525,13 +59636,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"qAO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "qAP" = (
 /obj/machinery/shower/directional/east,
 /turf/open/floor/iron/smooth,
@@ -60020,6 +60124,11 @@
 	dir = 1
 	},
 /area/station/medical/virology)
+"qHG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "qHO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench/right{
@@ -60144,38 +60253,18 @@
 /obj/structure/sign/warning/radiation/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"qJk" = (
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "qJv" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/cigbutt,
 /turf/open/floor/wood/large,
 /area/mine/eva/lower)
 "qJB" = (
-/obj/effect/turf_decal/tile/green/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/structure/closet/crate/hydroponics,
-/obj/item/wrench,
-/obj/item/wrench,
-/obj/item/grenade/chem_grenade/antiweed{
-	pixel_x = 3;
-	pixel_y = 1
-	},
-/obj/item/grenade/chem_grenade/antiweed,
-/obj/item/shovel/spade,
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_y = 3
-	},
-/obj/item/cultivator,
-/obj/item/shovel/spade,
-/obj/item/reagent_containers/cup/watering_can,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/obj/effect/mapping_helpers/no_atoms_ontop,
+/turf/closed/wall,
+/area/icemoon/underground/explored)
 "qJT" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/snowed/icemoon,
@@ -60566,11 +60655,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"qOR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/work_for_a_future/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "qPb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61594,6 +61678,11 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/icemoon/underground/explored)
+"rcf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "rcj" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Lockers";
@@ -62175,11 +62264,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix)
-"rku" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/wood,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "rkz" = (
 /obj/structure/railing,
 /turf/open/floor/iron/dark,
@@ -62440,12 +62524,10 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"roi" = (
-/obj/structure/fence/door{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
+"rog" = (
+/obj/structure/thermoplastic,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "roj" = (
 /obj/structure/cable,
@@ -64923,12 +65005,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
-"rXz" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "rXP" = (
 /obj/item/pickaxe/improvised{
 	pixel_x = 7
@@ -65058,6 +65134,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
+"saa" = (
+/obj/structure/fence/door{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "sab" = (
 /turf/open/floor/iron/chapel{
 	dir = 4
@@ -65219,9 +65302,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "scr" = (
-/obj/structure/thermoplastic,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/spawner/random/junk_shell,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "sct" = (
 /obj/structure/disposalpipe/segment,
@@ -66223,15 +66307,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/atrium)
-"spS" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "spV" = (
 /obj/effect/spawner/random/trash/bin,
 /obj/item/paper/crumpled{
@@ -66651,17 +66726,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"svz" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "svF" = (
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/transfer)
@@ -67207,16 +67271,6 @@
 /obj/machinery/computer/security/telescreen/engine/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
-"sDN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/glass,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "sDQ" = (
 /obj/item/radio/intercom/prison/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -67805,6 +67859,16 @@
 /obj/structure/flora/grass/both/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"sMB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "sML" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68636,6 +68700,10 @@
 "sZU" = (
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
+"tac" = (
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "taf" = (
 /obj/effect/landmark/start/quartermaster,
 /obj/structure/chair/office{
@@ -68852,6 +68920,7 @@
 "tdp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/door/window/elevator/left/directional/north,
+/obj/effect/turf_decal/caution/stand_clear/white,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "tdE" = (
@@ -69069,11 +69138,6 @@
 /obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"tgk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "tgn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -69131,7 +69195,7 @@
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "thB" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/genturf,
+/turf/open/floor/plating,
 /area/icemoon/underground/unexplored/rivers/deep)
 "thC" = (
 /obj/structure/closet/crate,
@@ -69396,11 +69460,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
-"tjW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/enlist/directional/west,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "tjX" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable,
@@ -69685,11 +69744,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"tnH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "tnI" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 10
@@ -71264,6 +71318,10 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
+"tKT" = (
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "tKV" = (
 /obj/structure/table_frame,
 /obj/effect/decal/cleanable/glass,
@@ -72127,6 +72185,14 @@
 /obj/machinery/light/small/red/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/greater)
+"tXx" = (
+/obj/structure/toiletbong,
+/obj/structure/thermoplastic,
+/obj/structure/chair/sofa/bench/tram/left,
+/obj/structure/thermoplastic/light,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "tXB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72405,6 +72471,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
+"ubb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "ubc" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -72649,6 +72720,14 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"ufA" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "ufF" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner{
@@ -74894,11 +74973,6 @@
 "uOb" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/toilet)
-"uOd" = (
-/obj/effect/spawner/random/trash/bin,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "uOf" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningdorm_A";
@@ -75027,9 +75101,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "uPT" = (
-/obj/machinery/light/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/station/hallway/primary/central)
 "uPY" = (
 /obj/item/stack/sheet/mineral/wood,
@@ -76028,6 +76101,10 @@
 /obj/structure/flora/grass/brown/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"vfC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/underground/explored)
 "vfH" = (
 /obj/structure/closet/crate{
 	name = "Le Caisee D'abeille"
@@ -77437,14 +77514,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/recharge_floor,
 /area/station/science/robotics/mechbay)
-"vAb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "vAq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -78476,6 +78545,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/mine/production)
+"vQF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "vQN" = (
 /obj/structure/cable,
 /obj/machinery/computer/prisoner/management,
@@ -78763,13 +78841,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
-"vUO" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "vUS" = (
 /obj/structure/cable,
 /obj/structure/chair{
@@ -79758,6 +79829,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"wjO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "wjP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/rack,
@@ -80457,6 +80533,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
+"wvQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "wvV" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/pumproom)
@@ -80627,6 +80708,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"wyt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "wyB" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -80674,14 +80761,6 @@
 /obj/effect/spawner/random/clothing/bowler_or_that,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
-"wzh" = (
-/obj/structure/toiletbong,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/left,
-/obj/structure/thermoplastic/light,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "wzi" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/mapping_helpers/no_atoms_ontop,
@@ -83226,6 +83305,10 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
+"xgV" = (
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/genturf/blue,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "xhk" = (
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
@@ -83345,13 +83428,9 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "xiL" = (
-/obj/effect/turf_decal/tile/green/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "xiO" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -83477,6 +83556,14 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
+"xkS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/elevator/directional/east,
+/obj/machinery/lift_indicator/directional/east,
+/obj/machinery/door/window/elevator/right/directional/north,
+/obj/effect/turf_decal/caution/stand_clear/white,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/garden)
 "xkW" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
@@ -84442,6 +84529,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"xyq" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "xyr" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -86716,7 +86814,7 @@
 /area/station/maintenance/department/chapel)
 "ydH" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing,
+/obj/structure/railing/corner,
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "ydI" = (
@@ -86910,15 +87008,6 @@
 	},
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig/upper)
-"ygN" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "ygS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -87018,11 +87107,6 @@
 /obj/structure/sign/warning/cold_temp/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"yjc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "yjh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -87175,6 +87259,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"ymd" = (
+/turf/open/floor/iron,
+/area/icemoon/underground/unexplored/rivers/deep)
 "ymf" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
@@ -87190,6 +87277,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 
@@ -101946,8 +102034,8 @@ oSU
 oSU
 oSU
 gFX
-qju
-tjW
+nhG
+fuu
 rVr
 gFX
 gFX
@@ -102203,12 +102291,12 @@ oSU
 oSU
 oSU
 gFX
-oGe
-llP
+pIs
+wyt
 eHt
-oNb
-eJj
-eJj
+ogG
+nTH
+nTH
 gFX
 ghx
 ghx
@@ -102460,12 +102548,12 @@ oSU
 oSU
 oSU
 gFX
-dgq
-yjc
+bCU
+mLd
 kdm
-vAb
-eJj
-kNY
+fHX
+nTH
+oOA
 gFX
 ghx
 ghx
@@ -102717,9 +102805,9 @@ oSU
 oSU
 oSU
 gFX
-cfI
-kKY
-omJ
+acM
+aHv
+fZP
 gFX
 gFX
 rsO
@@ -102975,10 +103063,10 @@ oSU
 gFX
 gFX
 wMB
-roi
-pcj
+saa
+nwm
 wMB
-btW
+scr
 gFX
 ghx
 ghx
@@ -103230,13 +103318,13 @@ thA
 thA
 thA
 gFX
-uOd
+nDH
 eHt
 bJv
 aCI
 cLf
-sDN
-hBG
+iBb
+pEs
 ghx
 ghx
 thA
@@ -103488,10 +103576,10 @@ thA
 thA
 gFX
 kdm
-pzx
-fFk
-qAO
-fFk
+ydH
+kiN
+pgj
+kiN
 gFX
 gFX
 ghx
@@ -103744,13 +103832,13 @@ thA
 thA
 thA
 gFX
-hni
-ydH
+khI
+ubb
 cjI
 aMC
 wuN
 nLK
-hBG
+pEs
 ghx
 ghx
 thA
@@ -104007,7 +104095,7 @@ aMC
 uWq
 bKQ
 wuN
-hBG
+pEs
 ghx
 ghx
 thA
@@ -104259,12 +104347,12 @@ thA
 thA
 gFX
 cLf
-svz
+xyq
 eiQ
 uWq
 fHU
 wuN
-hBG
+pEs
 ghx
 ghx
 thA
@@ -104514,11 +104602,11 @@ thA
 thA
 ghx
 ghx
-hBG
+pEs
 cLf
-jzD
+ccx
 aMC
-scr
+rog
 uWq
 aMC
 gFX
@@ -104771,14 +104859,14 @@ ghx
 ghx
 ghx
 ghx
-hBG
-tnH
-jzD
+pEs
+wvQ
+ccx
 wuN
 rOU
 qFF
-mLd
-hBG
+puU
+pEs
 ghx
 ghx
 ijY
@@ -105028,14 +105116,14 @@ ghx
 ghx
 ghx
 ghx
-hBG
+pEs
 cLf
-spS
+vQF
 aMC
-wzh
+tXx
 qFF
 cqV
-hBG
+pEs
 ghx
 ghx
 ghx
@@ -105285,14 +105373,14 @@ ghx
 ghx
 ghx
 ghx
-hBG
+pEs
 eHt
 gFX
 aMC
 aMC
 oge
 aMC
-hBG
+pEs
 ghx
 ghx
 ghx
@@ -105544,7 +105632,7 @@ ghx
 ghx
 gFX
 eHt
-kkr
+ufA
 txh
 cqV
 uWq
@@ -105800,13 +105888,13 @@ thA
 thA
 ghx
 gFX
-qOR
-ygN
+mIy
+oBt
 wuN
 nov
 dzI
 aMC
-hBG
+pEs
 ghx
 ghx
 iDt
@@ -106056,14 +106144,14 @@ ghx
 thA
 thA
 ghx
-hBG
+pEs
 eHt
-dpO
+djN
 aMC
-scr
+rog
 dzI
 eiQ
-hBG
+pEs
 ghx
 ghx
 iDt
@@ -106313,14 +106401,14 @@ ghx
 ghx
 thA
 ghx
-hBG
+pEs
 eHt
 gFX
 aMC
-kPp
+flk
 vrk
 aMC
-hBG
+pEs
 ghx
 ghx
 iDt
@@ -106570,9 +106658,9 @@ ghx
 ghx
 thA
 ghx
-hBG
+pEs
 cLf
-pPk
+ayj
 eiQ
 uWq
 kdq
@@ -106827,14 +106915,14 @@ ghx
 ghx
 ghx
 ghx
-hBG
-rku
-dMx
+pEs
+wjO
+hak
 kJN
 aMC
 sAc
 iOk
-nOw
+vfC
 ghx
 iDt
 iDt
@@ -107085,13 +107173,13 @@ ghx
 ghx
 ghx
 gFX
-bUR
-iPG
+eUt
+oLy
 vBN
 vBN
 lhB
 vBN
-nOw
+vfC
 ghx
 ghx
 iDt
@@ -107344,10 +107432,10 @@ ghx
 gFX
 gFX
 gFX
-ccx
-ccx
-pEs
-ccx
+tKT
+tKT
+cUB
+tKT
 gFX
 ghx
 ghx
@@ -112741,10 +112829,10 @@ ghx
 gFX
 vBN
 vBN
-ccx
-ccx
-pEs
-ccx
+tKT
+tKT
+cUB
+tKT
 vBN
 gFX
 oSU
@@ -119944,10 +120032,10 @@ vBN
 kku
 usr
 nqh
+tgU
 gFX
-vBN
-nTH
-usr
+gFX
+cvX
 usr
 usr
 hgg
@@ -120201,14 +120289,14 @@ vBN
 djd
 cBz
 kdm
+bJv
 gFX
-vBN
 nTH
 ohF
 msM
 cBz
 cBz
-tgk
+rcf
 bJv
 aeV
 lLs
@@ -120458,10 +120546,10 @@ vBN
 prM
 hYC
 kdm
+bJv
 gFX
-vBN
 nTH
-eHt
+cBz
 eHt
 kdm
 eHt
@@ -120715,7 +120803,7 @@ vBN
 ykU
 gFX
 kdm
-gFX
+eHt
 wlK
 gFX
 cLf
@@ -121485,7 +121573,7 @@ lhB
 vBN
 thL
 tgU
-ciJ
+lDJ
 jRP
 usr
 usr
@@ -133322,7 +133410,7 @@ oSU
 gFX
 lhB
 lhB
-lhB
+qHG
 lhB
 lhB
 gFX
@@ -134097,9 +134185,9 @@ pxg
 lhB
 lhB
 gFX
-gFX
-gFX
-gFX
+iDt
+iDt
+iDt
 oSU
 oSU
 xMq
@@ -134353,10 +134441,10 @@ lhB
 gQB
 lhB
 lhB
-vBN
-usr
-usr
-kdm
+gFX
+iDt
+iDt
+iDt
 oSU
 oSU
 xMq
@@ -134610,12 +134698,12 @@ vBN
 lhB
 lhB
 vBN
-vBN
-cBz
-cBz
-kdm
-iDt
-iDt
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
 xMq
 wUm
 iDt
@@ -134867,12 +134955,12 @@ vBN
 vBN
 vBN
 lhB
-vBN
-kdm
-kdm
-usr
-iDt
-xYQ
+gFX
+nTH
+nTH
+gFX
+xiL
+qJB
 aKb
 iDt
 iDt
@@ -135124,12 +135212,12 @@ vBN
 vBN
 vBN
 lhB
-vBN
+eNg
 kdm
 ohF
 efl
-iDt
-iDt
+eHt
+tac
 chg
 iDt
 iDt
@@ -135381,12 +135469,12 @@ vBN
 lhB
 vBN
 vBN
-vBN
+usr
 eHt
 cBz
-usr
-iDt
-xYQ
+klQ
+eHt
+qJB
 pJm
 iDt
 iDt
@@ -135638,12 +135726,12 @@ vBN
 vBN
 vBN
 lhB
-vBN
+usr
 eHt
 cBz
-usr
-iDt
-iDt
+gKf
+eHt
+gFX
 xMq
 xMq
 iDt
@@ -135895,12 +135983,12 @@ vBN
 lhB
 vBN
 vBN
-vBN
-eHt
+gCS
+kdm
 cBz
-usr
-iDt
-iDt
+gKf
+cHr
+gFX
 iDt
 xMq
 xMq
@@ -136152,12 +136240,12 @@ vBN
 lhB
 lhB
 lhB
-vBN
+usr
 eHt
 cXw
-usr
-iDt
-iDt
+gFX
+gFX
+gFX
 oSU
 oSU
 xMq
@@ -136400,7 +136488,7 @@ oSU
 oSU
 gFX
 eHt
-cLf
+eHt
 cLf
 gFX
 eHt
@@ -136409,10 +136497,10 @@ vBN
 lhB
 lhB
 vBN
-vBN
+usr
 bJv
 cBz
-eHt
+gFX
 oSU
 oSU
 oSU
@@ -136666,10 +136754,10 @@ vBN
 lhB
 lhB
 vBN
-vBN
-tgU
-tgU
-eHt
+usr
+usr
+usr
+gFX
 oSU
 oSU
 oSU
@@ -136913,7 +137001,7 @@ oSU
 oSU
 oSU
 gFX
-tgU
+obY
 bJv
 cLf
 bJv
@@ -136922,10 +137010,10 @@ iva
 vBN
 vBN
 lhB
-vBN
+nHU
 gFX
-gFX
-gFX
+tgU
+eHt
 gFX
 oSU
 oSU
@@ -137181,9 +137269,9 @@ vBN
 lhB
 vBN
 gFX
-oSU
-oSU
-oSU
+ogj
+nsK
+aVL
 oSU
 oSU
 oSU
@@ -137438,9 +137526,9 @@ lhB
 vBN
 vBN
 gFX
-oSU
-oSU
-oSU
+cLg
+osc
+aVL
 oSU
 oSU
 oSU
@@ -137695,9 +137783,9 @@ lhB
 vBN
 vBN
 gFX
-oSU
-oSU
-oSU
+cVl
+cVl
+aVL
 oSU
 oSU
 oSU
@@ -137947,14 +138035,14 @@ eHt
 gFX
 eHt
 cmA
-oSU
-oSU
-oSU
-oSU
+seb
+seb
+seb
+seb
 gFX
-oSU
-oSU
-oSU
+ymd
+osc
+aVL
 oSU
 oSU
 oSU
@@ -138204,14 +138292,14 @@ eHt
 bJv
 eHt
 cmA
-oSU
+seb
 thB
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+seb
+seb
+aVL
+cVl
+osc
+aVL
 oSU
 oSU
 oSU
@@ -138455,13 +138543,20 @@ oSU
 gFX
 gFX
 gFX
-tgU
+dlr
 eHt
 eHt
 eHt
-eHt
+xiL
 cmA
 thB
+seb
+seb
+seb
+aVL
+ymd
+juV
+aVL
 oSU
 oSU
 oSU
@@ -138497,14 +138592,7 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+juV
 oSU
 oSU
 oSU
@@ -138711,21 +138799,21 @@ oSU
 oSU
 gFX
 vBN
-vBN
+nTH
 usr
 bJv
 eHt
 bJv
 eHt
-vBN
+gGo
 thB
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+seb
+seb
+seb
+aVL
+juV
+iFq
+aVL
 oSU
 oSU
 oSU
@@ -138968,21 +139056,21 @@ oSU
 oSU
 gFX
 vBN
-vBN
+nTH
 pAj
 bJv
 cLf
 bJv
 eHt
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+juV
+aVL
+aVL
+aVL
+aVL
+aVL
+ymd
+iFq
+aVL
 oSU
 oSU
 oSU
@@ -139225,21 +139313,21 @@ oSU
 oSU
 gFX
 vBN
-vBN
+nTH
 tgU
 eHt
 eHt
 gFX
 cLf
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+juV
+ymd
+juV
+cLg
+cVl
+eha
+ozm
+juV
+aVL
 oSU
 oSU
 oSU
@@ -139486,17 +139574,17 @@ gFX
 eHt
 cLf
 cnF
-tgU
-cnF
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+eHt
+cLf
+juV
+nsK
+nsK
+cVl
+osc
+nsK
+juV
+cLg
+aVL
 oSU
 oSU
 oSU
@@ -139739,21 +139827,21 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+aVL
+aVL
+aVL
+aVL
+aVL
+aVL
+aVL
+aVL
+aVL
+aVL
+aVL
+aVL
+aVL
+aVL
+aVL
 oSU
 oSU
 oSU
@@ -167485,7 +167573,7 @@ tjo
 tjo
 tjo
 tjo
-ojM
+cvr
 gFX
 wlK
 wlK
@@ -167742,9 +167830,9 @@ tjo
 tjo
 tjo
 tjo
-ojM
-gmG
-gmG
+cvr
+hBG
+hBG
 wlK
 lhB
 lhB
@@ -167999,9 +168087,9 @@ tjo
 tjo
 tjo
 tjo
-ojM
-gmG
-gmG
+cvr
+hBG
+hBG
 wlK
 lhB
 lhB
@@ -168256,7 +168344,7 @@ tjo
 tjo
 tjo
 tjo
-ojM
+cvr
 gFX
 gFX
 gFX
@@ -169289,7 +169377,7 @@ tjo
 thA
 thA
 thA
-qni
+xgV
 iLh
 pwg
 peG
@@ -185481,7 +185569,7 @@ thA
 thA
 iDt
 iDt
-iDt
+gFX
 exw
 exw
 exw
@@ -185738,13 +185826,13 @@ thA
 thA
 iDt
 iDt
-xMq
-exw
+gFX
+xgy
 caA
 mty
 urQ
 sQI
-bdr
+gvJ
 pme
 pme
 aon
@@ -185995,9 +186083,9 @@ thA
 thA
 xMq
 xMq
-xMq
+gFX
+xgy
 exw
-xiL
 xlm
 xLT
 jgV
@@ -186252,17 +186340,17 @@ xMq
 xMq
 xMq
 xMq
-xMq
+gFX
 uVb
-qJB
+exw
 mqd
-xLT
+lbP
 wDb
 oZG
 oZG
 rZY
 oZG
-eSC
+sMB
 exw
 exw
 exw
@@ -233538,7 +233626,7 @@ aPM
 oCO
 qTm
 qTm
-bhN
+xkS
 tmL
 arG
 cIa
@@ -234047,9 +234135,9 @@ lJO
 lJO
 lJO
 lJO
-rXz
-jgJ
-vUO
+ayQ
+jzj
+nPw
 tNd
 nor
 sst
@@ -251532,7 +251620,7 @@ oUO
 kHO
 mQi
 uja
-kyL
+qJk
 hNU
 kyL
 kyL
@@ -265682,7 +265770,7 @@ urw
 emp
 bvI
 lso
-cUB
+lso
 nYm
 mNi
 yeB
@@ -265939,10 +266027,10 @@ rpC
 oXL
 cYE
 lso
-eha
+tLF
 aJQ
 aJQ
-lso
+tLF
 lZi
 qaE
 mBQ
@@ -266195,8 +266283,8 @@ tva
 wrX
 bQh
 dEV
-cvr
-cvr
+lso
+lso
 equ
 lso
 uuC

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -379,12 +379,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"agt" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "agF" = (
 /obj/structure/rack,
 /obj/item/storage/box/teargas{
@@ -4198,6 +4192,13 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"bhN" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/elevator/directional/east,
+/obj/machinery/lift_indicator/directional/east,
+/obj/machinery/door/window/elevator/right/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/garden)
 "bhQ" = (
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating,
@@ -5188,6 +5189,12 @@
 "btU" = (
 /turf/closed/wall,
 /area/station/medical/morgue)
+"btW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/spawner/random/junk_shell,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "bum" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -7084,6 +7091,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"bUR" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "bUS" = (
 /obj/structure/railing{
 	dir = 1
@@ -7477,13 +7489,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/treatment_center)
-"bZM" = (
-/obj/machinery/door/window/elevator/left/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "bZQ" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/starboard)
@@ -7690,12 +7695,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
 "ccx" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/button/elevator/directional/east,
-/obj/machinery/lift_indicator/directional/east,
-/obj/machinery/door/window/elevator/right/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics/garden)
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "ccz" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -7971,6 +7973,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"cfI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "cfR" = (
 /obj/structure/chair{
 	dir = 1
@@ -8171,6 +8179,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"ciJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "ciS" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -11639,6 +11652,12 @@
 /obj/machinery/incident_display/delam/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
+"dgq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "dgt" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/virology{
@@ -12343,6 +12362,14 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"dpO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "dpU" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13924,6 +13951,13 @@
 /obj/item/clothing/under/color/rainbow,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"dMx" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "dMH" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/evac/directional/north,
@@ -17044,6 +17078,10 @@
 /obj/structure/lattice,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/explored)
+"eJj" = (
+/obj/structure/transport/linear/public,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "eJm" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/firealarm/directional/west,
@@ -20054,13 +20092,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"fDL" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "fDP" = (
 /obj/structure/cable,
 /obj/item/radio/intercom/prison/directional/north,
@@ -20164,6 +20195,12 @@
 	dir = 4
 	},
 /area/station/engineering/transit_tube)
+"fFk" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "fFn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -22100,13 +22137,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/mine/eva/lower)
-"giW" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "gjc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22406,6 +22436,9 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"gmG" = (
+/turf/open/openspace,
+/area/icemoon/underground/explored)
 "gmJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Infiltrate/Filter"
@@ -22427,11 +22460,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
-"gmU" = (
-/obj/structure/thermoplastic/light,
-/obj/machinery/door/airlock/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "gmW" = (
 /turf/closed/wall,
 /area/station/commons/fitness)
@@ -25996,6 +26024,11 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"hni" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/report_crimes/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "hnp" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -27056,11 +27089,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "hBG" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "hBZ" = (
 /obj/structure/table/wood,
@@ -27585,14 +27615,6 @@
 "hJH" = (
 /turf/open/openspace,
 /area/station/science/research)
-"hJO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "hKi" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
@@ -27601,16 +27623,6 @@
 	dir = 8
 	},
 /area/station/engineering/lobby)
-"hKr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/south{
-	id = "tram_perma_lift"
-	},
-/obj/machinery/lift_indicator/directional/south{
-	linked_elevator_id = "tram_perma_lift"
-	},
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "hKu" = (
 /obj/structure/sign/poster/official/cleanliness/directional/east,
 /obj/structure/closet/secure_closet/medical2,
@@ -31376,6 +31388,12 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"iPG" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "iPI" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
@@ -32578,6 +32596,13 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/maintenance/port/fore)
+"jgJ" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "jgL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -33783,6 +33808,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron,
 /area/station/security/brig/upper)
+"jzD" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "jzE" = (
 /obj/structure/railing{
 	dir = 1
@@ -36382,6 +36415,14 @@
 "kkl" = (
 /turf/closed/wall,
 /area/station/security/interrogation)
+"kkr" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "kku" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -38286,6 +38327,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"kKY" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "kLa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38470,6 +38516,10 @@
 "kNW" = (
 /turf/closed/wall,
 /area/station/cargo/warehouse)
+"kNY" = (
+/obj/structure/transport/linear/public,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "kNZ" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -38581,6 +38631,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"kPp" = (
+/obj/structure/thermoplastic,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "kPq" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40137,6 +40192,12 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"llP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "llT" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -41537,10 +41598,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"lEQ" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "lET" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/briefcase/secure{
@@ -43393,11 +43450,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
-"mhL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "mhQ" = (
 /turf/closed/wall/r_wall,
 /area/station/command/teleporter)
@@ -45350,7 +45402,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mLd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/tram,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "mLf" = (
@@ -49343,6 +49396,10 @@
 /obj/item/pillow/random,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
+"nOw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/underground/explored)
 "nOx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -50898,6 +50955,9 @@
 /obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/iron/checker,
 /area/station/science/lab)
+"ojM" = (
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers)
 "ojW" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -51076,6 +51136,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"omJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/south{
+	id = "tram_perma_lift"
+	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "tram_perma_lift"
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "omL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52672,6 +52742,12 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"oGe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "oGh" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -53205,6 +53281,13 @@
 "oMT" = (
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
+"oNb" = (
+/obj/machinery/door/window/elevator/left/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "oNA" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -54216,6 +54299,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"pcj" = (
+/obj/structure/fence{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "pcr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrous_output{
 	dir = 8
@@ -55447,10 +55537,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/breakroom)
-"puT" = (
-/obj/structure/transport/linear/public,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "puX" = (
 /obj/structure/table,
 /obj/item/stock_parts/scanning_module{
@@ -55862,6 +55948,11 @@
 /obj/item/book/manual/wiki/detective,
 /turf/open/floor/carpet/blue,
 /area/station/security/prison/work)
+"pzx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/corner,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "pzC" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/siding/yellow{
@@ -56139,8 +56230,10 @@
 /turf/open/floor/iron/large,
 /area/station/medical/break_room)
 "pEs" = (
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "pEE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -56795,6 +56888,17 @@
 	dir = 4
 	},
 /area/station/service/hydroponics)
+"pPk" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "pPy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -58343,6 +58447,12 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"qju" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/spawner/random/maintenance/dumpster,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "qjF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -58555,6 +58665,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/plating,
 /area/station/medical/virology)
+"qni" = (
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/genturf/blue,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "qnj" = (
 /turf/closed/wall,
 /area/station/commons/locker)
@@ -59411,6 +59525,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"qAO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "qAP" = (
 /obj/machinery/shower/directional/east,
 /turf/open/floor/iron/smooth,
@@ -60445,6 +60566,11 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"qOR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/work_for_a_future/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "qPb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60792,7 +60918,7 @@
 /turf/open/misc/asteroid/snow/standard_air,
 /area/station/science/cytology)
 "qTm" = (
-/turf/open/space/basic,
+/turf/open/openspace,
 /area/station/service/hydroponics/garden)
 "qTq" = (
 /obj/machinery/door/airlock{
@@ -62049,6 +62175,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix)
+"rku" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "rkz" = (
 /obj/structure/railing,
 /turf/open/floor/iron/dark,
@@ -62309,6 +62440,13 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"roi" = (
+/obj/structure/fence/door{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "roj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64579,8 +64717,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rVr" = (
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/crayon,
+/obj/effect/spawner/random/trash/deluxe_garbage,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "rVB" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
@@ -64783,6 +64923,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
+"rXz" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "rXP" = (
 /obj/item/pickaxe/improvised{
 	pixel_x = 7
@@ -65073,15 +65219,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "scr" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/structure/thermoplastic,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "sct" = (
 /obj/structure/disposalpipe/segment,
@@ -66083,6 +66223,15 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/atrium)
+"spS" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "spV" = (
 /obj/effect/spawner/random/trash/bin,
 /obj/item/paper/crumpled{
@@ -66502,6 +66651,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"svz" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "svF" = (
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/transfer)
@@ -67047,6 +67207,16 @@
 /obj/machinery/computer/security/telescreen/engine/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
+"sDN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "sDQ" = (
 /obj/item/radio/intercom/prison/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -67250,7 +67420,7 @@
 /area/station/security/brig/upper)
 "sGq" = (
 /obj/machinery/status_display/evac/directional/west,
-/turf/open/space/basic,
+/turf/open/openspace,
 /area/station/service/hydroponics/garden)
 "sGw" = (
 /obj/structure/sign/warning/secure_area/directional/north,
@@ -68411,10 +68581,6 @@
 	},
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
-"sYH" = (
-/obj/structure/transport/linear/public,
-/turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "sYS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -68903,6 +69069,11 @@
 /obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"tgk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "tgn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -69225,6 +69396,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"tjW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/enlist/directional/west,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "tjX" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable,
@@ -69509,6 +69685,11 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"tnH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "tnI" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 10
@@ -72325,10 +72506,6 @@
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
-"udf" = (
-/obj/structure/railing,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "udj" = (
 /obj/structure/toiletbong,
 /obj/effect/decal/cleanable/dirt,
@@ -74717,6 +74894,11 @@
 "uOb" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/toilet)
+"uOd" = (
+/obj/effect/spawner/random/trash/bin,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "uOf" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningdorm_A";
@@ -75030,13 +75212,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
-"uTe" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "uTk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77262,6 +77437,14 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/recharge_floor,
 /area/station/science/robotics/mechbay)
+"vAb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "vAq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -78580,6 +78763,13 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
+"vUO" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "vUS" = (
 /obj/structure/cable,
 /obj/structure/chair{
@@ -80484,6 +80674,14 @@
 /obj/effect/spawner/random/clothing/bowler_or_that,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"wzh" = (
+/obj/structure/toiletbong,
+/obj/structure/thermoplastic,
+/obj/structure/chair/sofa/bench/tram/left,
+/obj/structure/thermoplastic/light,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "wzi" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/mapping_helpers/no_atoms_ontop,
@@ -81402,10 +81600,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
-"wMR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/lava/plasma/ice_moon,
-/area/icemoon/underground/explored)
 "wMT" = (
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron,
@@ -81879,13 +82073,6 @@
 "wTg" = (
 /turf/closed/wall,
 /area/station/engineering/main)
-"wTl" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "wTA" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/iron/dark/telecomms,
@@ -86528,10 +86715,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "ydH" = (
-/obj/structure/fence/door{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "ydI" = (
 /turf/closed/wall/r_wall,
@@ -86724,6 +86910,15 @@
 	},
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig/upper)
+"ygN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "ygS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -86823,6 +87018,11 @@
 /obj/structure/sign/warning/cold_temp/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"yjc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "yjh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -101746,9 +101946,9 @@ oSU
 oSU
 oSU
 gFX
-tgU
-eHt
-tgU
+qju
+tjW
+rVr
 gFX
 gFX
 gFX
@@ -102003,12 +102203,12 @@ oSU
 oSU
 oSU
 gFX
+oGe
+llP
 eHt
-eHt
-eHt
-bZM
-puT
-puT
+oNb
+eJj
+eJj
 gFX
 ghx
 ghx
@@ -102260,12 +102460,12 @@ oSU
 oSU
 oSU
 gFX
-eHt
-eHt
-eHt
-hJO
-puT
-sYH
+dgq
+yjc
+kdm
+vAb
+eJj
+kNY
 gFX
 ghx
 ghx
@@ -102517,9 +102717,9 @@ oSU
 oSU
 oSU
 gFX
-eHt
-lEQ
-hKr
+cfI
+kKY
+omJ
 gFX
 gFX
 rsO
@@ -102772,13 +102972,13 @@ oSU
 oSU
 oSU
 oSU
-aVL
+gFX
 gFX
 wMB
-ydH
+roi
+pcj
 wMB
-wMB
-tgU
+btW
 gFX
 ghx
 ghx
@@ -103029,14 +103229,14 @@ thA
 thA
 thA
 thA
-rsO
-eHt
+gFX
+uOd
 eHt
 bJv
-bJv
-eHt
-eHt
-mLd
+aCI
+cLf
+sDN
+hBG
 ghx
 ghx
 thA
@@ -103286,12 +103486,12 @@ thA
 thA
 thA
 thA
-rsO
-eHt
-tgU
-tgU
-tgU
-tgU
+gFX
+kdm
+pzx
+fFk
+qAO
+fFk
 gFX
 gFX
 ghx
@@ -103543,14 +103743,14 @@ thA
 thA
 thA
 thA
-rsO
-eHt
-tgU
+gFX
+hni
+ydH
 cjI
 aMC
 wuN
 nLK
-mLd
+hBG
 ghx
 ghx
 thA
@@ -103800,14 +104000,14 @@ thA
 thA
 thA
 thA
-rsO
+gFX
 eHt
 gFX
 aMC
 uWq
 bKQ
 wuN
-mLd
+hBG
 ghx
 ghx
 thA
@@ -104057,14 +104257,14 @@ thA
 thA
 thA
 thA
-rsO
-eHt
-hBG
+gFX
+cLf
+svz
 eiQ
 uWq
 fHU
 wuN
-mLd
+hBG
 ghx
 ghx
 thA
@@ -104314,11 +104514,11 @@ thA
 thA
 ghx
 ghx
-mLd
-eHt
-wTl
+hBG
+cLf
+jzD
 aMC
-uWq
+scr
 uWq
 aMC
 gFX
@@ -104571,14 +104771,14 @@ ghx
 ghx
 ghx
 ghx
-mLd
-eHt
-wTl
+hBG
+tnH
+jzD
 wuN
 rOU
 qFF
-gmU
 mLd
+hBG
 ghx
 ghx
 ijY
@@ -104828,14 +105028,14 @@ ghx
 ghx
 ghx
 ghx
-mLd
-eHt
 hBG
+cLf
+spS
 aMC
-bed
+wzh
 qFF
 cqV
-mLd
+hBG
 ghx
 ghx
 ghx
@@ -105085,14 +105285,14 @@ ghx
 ghx
 ghx
 ghx
-mLd
+hBG
 eHt
 gFX
 aMC
 aMC
 oge
 aMC
-mLd
+hBG
 ghx
 ghx
 ghx
@@ -105344,7 +105544,7 @@ ghx
 ghx
 gFX
 eHt
-wTl
+kkr
 txh
 cqV
 uWq
@@ -105600,13 +105800,13 @@ thA
 thA
 ghx
 gFX
-eHt
-wTl
+qOR
+ygN
 wuN
 nov
 dzI
 aMC
-mLd
+hBG
 ghx
 ghx
 iDt
@@ -105856,14 +106056,14 @@ ghx
 thA
 thA
 ghx
-mLd
-eHt
 hBG
+eHt
+dpO
 aMC
-uWq
+scr
 dzI
 eiQ
-mLd
+hBG
 ghx
 ghx
 iDt
@@ -106113,14 +106313,14 @@ ghx
 ghx
 thA
 ghx
-mLd
+hBG
 eHt
 gFX
 aMC
-uWq
+kPp
 vrk
 aMC
-mLd
+hBG
 ghx
 ghx
 iDt
@@ -106370,9 +106570,9 @@ ghx
 ghx
 thA
 ghx
-mLd
-eHt
-scr
+hBG
+cLf
+pPk
 eiQ
 uWq
 kdq
@@ -106627,14 +106827,14 @@ ghx
 ghx
 ghx
 ghx
-mLd
-eHt
-fDL
+hBG
+rku
+dMx
 kJN
 aMC
 sAc
 iOk
-wMR
+nOw
 ghx
 iDt
 iDt
@@ -106885,13 +107085,13 @@ ghx
 ghx
 ghx
 gFX
-tgU
-udf
+bUR
+iPG
 vBN
 vBN
 lhB
 vBN
-wMR
+nOw
 ghx
 ghx
 iDt
@@ -107144,10 +107344,10 @@ ghx
 gFX
 gFX
 gFX
-rVr
-rVr
-mhL
-rVr
+ccx
+ccx
+pEs
+ccx
 gFX
 ghx
 ghx
@@ -112541,10 +112741,10 @@ ghx
 gFX
 vBN
 vBN
-rVr
-rVr
-mhL
-rVr
+ccx
+ccx
+pEs
+ccx
 vBN
 gFX
 oSU
@@ -120008,7 +120208,7 @@ ohF
 msM
 cBz
 cBz
-cBz
+tgk
 bJv
 aeV
 lLs
@@ -121285,7 +121485,7 @@ lhB
 vBN
 thL
 tgU
-cnF
+ciJ
 jRP
 usr
 usr
@@ -167285,7 +167485,7 @@ tjo
 tjo
 tjo
 tjo
-pEs
+ojM
 gFX
 wlK
 wlK
@@ -167542,9 +167742,9 @@ tjo
 tjo
 tjo
 tjo
-pEs
-vBN
-lhB
+ojM
+gmG
+gmG
 wlK
 lhB
 lhB
@@ -167799,9 +167999,9 @@ tjo
 tjo
 tjo
 tjo
-pEs
-vBN
-lhB
+ojM
+gmG
+gmG
 wlK
 lhB
 lhB
@@ -168056,7 +168256,7 @@ tjo
 tjo
 tjo
 tjo
-pEs
+ojM
 gFX
 gFX
 gFX
@@ -169089,7 +169289,7 @@ tjo
 thA
 thA
 thA
-thA
+qni
 iLh
 pwg
 peG
@@ -233338,7 +233538,7 @@ aPM
 oCO
 qTm
 qTm
-ccx
+bhN
 tmL
 arG
 cIa
@@ -233847,9 +234047,9 @@ lJO
 lJO
 lJO
 lJO
-agt
-uTe
-giW
+rXz
+jgJ
+vUO
 tNd
 nor
 sst

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1625,17 +1625,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/stone,
 /area/station/service/bar/atrium)
-"awj" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "awm" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/textured,
@@ -1980,6 +1969,10 @@
 	},
 /turf/open/floor/circuit/red,
 /area/station/ai/upload/chamber)
+"aAl" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "aAv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1998,10 +1991,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"aBe" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "aBf" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/engine{
@@ -2367,6 +2356,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"aFM" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "aFY" = (
 /obj/structure/railing{
 	dir = 1
@@ -2797,6 +2790,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
+"aMu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/rubble,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "aMA" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron,
@@ -3388,10 +3388,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
-"aUE" = (
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "aUK" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering Equipment Storage"
@@ -3853,16 +3849,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
-"bby" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "bbM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -5033,12 +5019,6 @@
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
-"brX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "brY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -5179,6 +5159,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
+"btb" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "btg" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance"
@@ -5527,10 +5518,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/production)
-"bxE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "bxJ" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -7314,6 +7301,12 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron,
 /area/station/metro/outrivals_station)
+"bWr" = (
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "bWv" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -7570,12 +7563,6 @@
 /obj/structure/sign/poster/official/report_crimes/directional/north,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/explored)
-"bZF" = (
-/obj/effect/decal/cleanable/insectguts,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "bZI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8259,6 +8246,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"ciO" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "ciS" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -8582,6 +8573,15 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
+"con" = (
+/obj/item/storage/medkit/fire,
+/obj/effect/mob_spawn/corpse/human/charredskeleton,
+/obj/item/ammo_casing/shotgun/buckshot,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "coL" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
@@ -8885,6 +8885,9 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/service/chapel)
+"csO" = (
+/turf/open/misc/beach/sand,
+/area/station/metro/abandoned/abandoned_collector)
 "csS" = (
 /obj/structure/closet/secure_closet/freezer/meat/all_access,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -10075,6 +10078,13 @@
 /obj/item/coin/diamond,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"cIL" = (
+/obj/effect/decal/cleanable/plastic,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "cIP" = (
 /obj/machinery/bookbinder,
 /obj/structure/sign/poster/official/random/directional/west,
@@ -12252,6 +12262,12 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"dlY" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "dmk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -12541,6 +12557,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"dqH" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "dqI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12845,10 +12865,6 @@
 "duh" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/transit_tube)
-"duo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "duE" = (
 /obj/machinery/atmospherics/components/binary/tank_compressor{
 	dir = 4
@@ -13257,6 +13273,14 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/mine/eva/lower)
+"dzM" = (
+/obj/effect/decal/fakelattice,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "dzO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -13374,6 +13398,10 @@
 /obj/structure/sign/poster/official/help_others/directional/west,
 /turf/open/floor/iron/checker,
 /area/station/commons/storage/emergency/port)
+"dBD" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "dBJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14355,10 +14383,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/security/prison/toilet)
-"dQW" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "dQZ" = (
 /obj/machinery/door/window/right/directional/west{
 	name = "Containment Pen 9";
@@ -15037,6 +15061,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/vault)
+"ebM" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "ebO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -17162,15 +17190,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
-"eHE" = (
-/obj/item/storage/medkit/fire,
-/obj/effect/mob_spawn/corpse/human/charredskeleton,
-/obj/item/ammo_casing/shotgun/buckshot,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "eHT" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -17487,6 +17506,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"eMv" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "eME" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17767,17 +17790,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
-"eRl" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "eRw" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -18195,6 +18207,12 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
+"eWI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/corpse/human/charredskeleton,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "eWQ" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
@@ -19465,17 +19483,6 @@
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
-"fpY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "fqd" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -20745,13 +20752,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"fJU" = (
-/obj/structure/fluff/minepost,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "fJZ" = (
 /obj/effect/turf_decal/tile/red,
 /obj/structure/railing/corner,
@@ -20830,6 +20830,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
+"fKT" = (
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/barricade/wooden/snowed,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "fKV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20885,10 +20890,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
-"fLs" = (
-/obj/effect/decal/cleanable/shreds,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "fLu" = (
 /obj/effect/turf_decal/tile/green/opposingcorners{
 	dir = 1
@@ -21170,10 +21171,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"fPk" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "fPq" = (
 /obj/structure/thermoplastic/light,
 /obj/structure/thermoplastic,
@@ -22091,10 +22088,6 @@
 /obj/structure/sign/warning/directional/north,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
-"gdq" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "gdv" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
@@ -23049,6 +23042,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
+"gqh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "gqj" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -23319,10 +23323,6 @@
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"gtH" = (
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "gtP" = (
 /obj/structure/table,
 /obj/item/assembly/timer,
@@ -23895,10 +23895,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/prison/work)
-"gBY" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/south_tunnel)
 "gCf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -23941,10 +23937,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
-"gCw" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "gCK" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -25933,6 +25925,17 @@
 /obj/item/instrument/harmonica,
 /turf/open/floor/iron/grimy,
 /area/station/commons/lounge)
+"hft" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "hfy" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -26927,6 +26930,10 @@
 /obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
+"htX" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "hue" = (
 /obj/structure/chair/comfy/black,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27881,13 +27888,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"hIF" = (
-/obj/effect/decal/cleanable/plastic,
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "hIH" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -29990,6 +29990,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"imq" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "imH" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/clothing/gloves,
@@ -30781,6 +30787,13 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"izm" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "izp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -31062,10 +31075,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
-"iEy" = (
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "iEA" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/gloves{
@@ -32671,9 +32680,6 @@
 /obj/item/restraints/legcuffs/beartrap,
 /turf/open/floor/iron,
 /area/station/service/janitor)
-"jbi" = (
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "jbj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33227,6 +33233,10 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
+"jkc" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "jkn" = (
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /turf/open/floor/iron,
@@ -33450,6 +33460,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"jnP" = (
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "jnR" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
@@ -34886,6 +34899,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/textured,
 /area/station/commons/storage/mining)
+"jJb" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "jJd" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -35995,12 +36012,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"jXO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/mob_spawn/corpse/human/charredskeleton,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "jYc" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -36894,6 +36905,10 @@
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"kky" = (
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "kkD" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -37380,6 +37395,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/fitness)
+"ksm" = (
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "ksn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -37912,6 +37931,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"kzp" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "kzv" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet/any,
@@ -41087,6 +41110,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"lqY" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "lqZ" = (
 /obj/machinery/vending/wardrobe/coroner_wardrobe,
 /obj/effect/turf_decal/siding/dark_blue{
@@ -42979,9 +43008,9 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/chamber)
-"lRA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/misc/ice/smooth,
+"lRC" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/sandy_dirt,
 /area/station/metro/abandoned/abandoned_collector)
 "lRD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43953,6 +43982,11 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/office)
+"mhE" = (
+/obj/effect/decal/cleanable/greenglow/waste,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "mhG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -45044,11 +45078,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
-"myV" = (
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "myX" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46272,11 +46301,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/central)
-"mQQ" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "mQW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -46811,6 +46835,9 @@
 /obj/machinery/light/empty/directional/east,
 /turf/open/floor/iron/white,
 /area/station/maintenance/port/fore)
+"mZu" = (
+/turf/closed/wall,
+/area/station/metro/abandoned/abandoned_collector)
 "mZG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -46872,9 +46899,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
-"naL" = (
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "naP" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -47514,13 +47538,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"nin" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "nit" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -47811,9 +47828,6 @@
 /obj/structure/sign/departments/holy/directional/west,
 /turf/open/openspace,
 /area/station/service/chapel)
-"nmF" = (
-/turf/closed/wall,
-/area/station/metro/abandoned/abandoned_collector)
 "nmH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48731,13 +48745,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/transfer)
-"nzk" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/rubble,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "nzl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/item/radio/intercom/directional/east,
@@ -48906,10 +48913,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
-"nAY" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "nBe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -50690,6 +50693,17 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
+"nYs" = (
+/obj/effect/decal/cleanable/chem_pile,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "nYv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51261,6 +51275,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/command/eva)
+"ogC" = (
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "ogF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51275,10 +51293,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"oho" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "ohp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -54356,10 +54370,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
-"oUo" = (
-/obj/structure/barricade/wooden,
-/turf/open/genturf,
-/area/icemoon/underground/unexplored/rivers/deep)
 "oUp" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54504,10 +54514,6 @@
 "oWy" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/circuit_workshop)
-"oWJ" = (
-/obj/structure/railing,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "oWN" = (
 /obj/machinery/requests_console/auto_name/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -54626,11 +54632,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"oXY" = (
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/barricade/wooden/snowed,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "oYa" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
@@ -54830,6 +54831,12 @@
 "pbs" = (
 /turf/closed/wall,
 /area/station/ai/satellite/maintenance)
+"pbw" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "pby" = (
 /obj/effect/gibspawner/human,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -55583,6 +55590,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"plZ" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "pme" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -55798,6 +55809,11 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/fore/lesser)
+"ppf" = (
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "ppl" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -56413,6 +56429,13 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
+"pyd" = (
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "pyh" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/effect/spawner/random/aimodule/neutral,
@@ -57876,6 +57899,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/warden)
+"pTS" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/misc/beach/sand,
+/area/station/metro/abandoned/abandoned_collector)
 "pTT" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -59053,10 +59080,6 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
-"qiU" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/misc/beach/sand,
-/area/station/metro/abandoned/abandoned_collector)
 "qjb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -60066,11 +60089,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"qyr" = (
-/obj/effect/decal/cleanable/greenglow/waste,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "qyG" = (
 /turf/open/floor/wood/large,
 /area/station/security/prison/rec)
@@ -60901,6 +60919,10 @@
 /obj/structure/closet/crate,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"qKG" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "qKQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -62719,6 +62741,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/icemoon,
 /area/icemoon/underground/explored)
+"rjc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "rjd" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/isolation/directional/south,
@@ -62972,10 +62998,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
-"rmy" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/asphalt,
-/area/station/metro/abandoned/abandoned_collector)
 "rmA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -63807,10 +63829,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
-"rxB" = (
-/obj/structure/railing,
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "rxG" = (
 /obj/structure/ore_vent/starter_resources{
 	icon_state = "ore_vent_ice_active";
@@ -64432,6 +64450,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/eva/lower)
+"rFt" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "rFI" = (
 /obj/structure/cable,
 /obj/machinery/button/door/directional/north{
@@ -64596,10 +64618,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
-"rIv" = (
-/obj/item/ammo_casing/shotgun/buckshot,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "rIz" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -65182,6 +65200,11 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
+"rRL" = (
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "rRN" = (
 /obj/structure/railing,
 /turf/open/floor/plating,
@@ -65538,6 +65561,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"rWQ" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "rWR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -66514,6 +66543,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"slg" = (
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "slh" = (
 /obj/structure/table,
 /obj/item/flashlight,
@@ -66939,6 +66971,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
+"spW" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "sqb" = (
 /obj/item/coin/iron{
 	pixel_y = -5
@@ -67311,6 +67349,10 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
+"suO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "suR" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -67700,6 +67742,17 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"sAG" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "sAR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -69477,6 +69530,9 @@
 /obj/structure/closet,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
+"tbz" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "tbH" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -69775,12 +69831,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
-"tfY" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "tgd" = (
 /obj/machinery/door/airlock{
 	name = "Garden"
@@ -69814,12 +69864,6 @@
 /obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"tgm" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "tgn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -70000,12 +70044,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
-"tiE" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "tiI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70434,10 +70472,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"tnD" = (
-/obj/effect/decal/cleanable/ash/large,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "tnI" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 10
@@ -72273,17 +72307,6 @@
 /obj/effect/turf_decal/tile/dark/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"tNm" = (
-/obj/effect/decal/cleanable/chem_pile,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "tNx" = (
 /obj/structure/cable,
 /obj/machinery/light/floor,
@@ -73605,14 +73628,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"uia" = (
-/obj/effect/decal/fakelattice,
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "uif" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74377,18 +74392,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
-"utk" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/fakelattice,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "utr" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -75842,6 +75845,16 @@
 "uPk" = (
 /turf/closed/wall/r_wall,
 /area/station/security/range)
+"uPm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/asphalt,
+/area/station/metro/abandoned/abandoned_collector)
 "uPt" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark,
@@ -75937,10 +75950,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/metro/outrivals_station)
-"uQL" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "uQR" = (
 /obj/machinery/light_switch/directional/east,
 /obj/structure/sign/warning/biohazard/directional/north,
@@ -77233,6 +77242,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /turf/open/floor/iron/smooth,
 /area/mine/mechbay)
+"vlW" = (
+/obj/structure/barricade/wooden,
+/turf/open/genturf,
+/area/icemoon/underground/unexplored/rivers/deep)
 "vmj" = (
 /obj/structure/chair{
 	dir = 1;
@@ -77936,7 +77949,9 @@
 /area/station/medical/treatment_center)
 "vuT" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/misc/sandy_dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/station/metro/abandoned/abandoned_collector)
 "vuW" = (
 /obj/structure/closet/boxinggloves,
@@ -78549,9 +78564,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
-"vDs" = (
-/turf/open/misc/beach/sand,
-/area/station/metro/abandoned/abandoned_collector)
 "vDx" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -79244,6 +79256,10 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
+"vOm" = (
+/obj/structure/barricade/wooden/snowed,
+/turf/closed/wall,
+/area/station/metro/abandoned/abandoned_collector)
 "vOw" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red{
@@ -79585,6 +79601,18 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/prison/work)
+"vTG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/platform/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/dirt/dark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
+/area/station/metro/abandoned/abandoned_collector)
 "vTJ" = (
 /obj/structure/table,
 /obj/item/toy/plush/slimeplushie{
@@ -80229,17 +80257,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/large,
 /area/station/command/heads_quarters/ce)
-"wcz" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/decal/fakelattice,
-/obj/structure/platform/iron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "wcD" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -80320,10 +80337,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
-"wen" = (
-/obj/structure/barricade/wooden/snowed,
-/turf/closed/wall,
-/area/station/metro/abandoned/abandoned_collector)
 "wes" = (
 /obj/effect/turf_decal/siding/wideplating_new/light,
 /obj/item/trash/bee,
@@ -80538,6 +80551,10 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"whq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/sandy_dirt,
+/area/station/metro/abandoned/abandoned_collector)
 "whr" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/cultivator,
@@ -81535,12 +81552,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"wyc" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "wyi" = (
 /obj/structure/fence/door,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -81646,12 +81657,6 @@
 	},
 /turf/open/floor/plating/snowed/coldroom,
 /area/icemoon/underground/explored)
-"wzJ" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "wzK" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Camp Supplies"
@@ -82709,6 +82714,13 @@
 	dir = 1
 	},
 /area/station/security/prison)
+"wPp" = (
+/obj/structure/fluff/minepost,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "wPr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -83453,6 +83465,10 @@
 /obj/effect/decal/cleanable/blood/gibs/robot_debris/down,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/port/fore)
+"wZo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/ice/smooth,
+/area/station/metro/abandoned/abandoned_collector)
 "wZr" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -84669,13 +84685,6 @@
 	},
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
-"xol" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt/dark{
-	initial_gas_mix = "ICEMOON_ATMOS"
-	},
-/area/station/metro/abandoned/abandoned_collector)
 "xoo" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/snowed/icemoon,
@@ -84721,9 +84730,6 @@
 /obj/item/stack/sheet/leather,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
-"xpG" = (
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/station/metro/abandoned/abandoned_collector)
 "xpI" = (
 /obj/effect/decal/cleanable/blood/oil/slippery,
 /turf/open/floor/catwalk_floor,
@@ -84823,10 +84829,6 @@
 /obj/structure/railing,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix)
-"xqx" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/misc/sandy_dirt,
-/area/station/metro/abandoned/abandoned_collector)
 "xqy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -85213,12 +85215,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
-"xwb" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/metro/train_tunnels/north_tunnel)
 "xwc" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/decal/cleanable/dirt,
@@ -86197,6 +86193,10 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
+"xHQ" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/station/metro/abandoned/abandoned_collector)
 "xId" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat/eva{
@@ -112727,7 +112727,7 @@ pGD
 pGD
 gpH
 pGD
-tfY
+pbw
 pXV
 oSU
 oSU
@@ -112978,7 +112978,7 @@ thA
 ghx
 ghx
 ghx
-tfY
+pbw
 gpH
 pGD
 pGD
@@ -113235,7 +113235,7 @@ thA
 ghx
 ghx
 ghx
-fJU
+wPp
 gpH
 pGD
 pGD
@@ -114520,13 +114520,13 @@ thA
 thA
 thA
 pXV
-rxB
+ksm
 pGD
 gpH
 pGD
 vPp
 pGD
-xwb
+imq
 pXV
 oSU
 oSU
@@ -116319,13 +116319,13 @@ thA
 thA
 thA
 pXV
-rxB
+ksm
 pGD
 pGD
 pGD
 pGD
 gpH
-xwb
+imq
 pXV
 oSU
 oSU
@@ -118375,13 +118375,13 @@ thA
 thA
 thA
 pXV
-rxB
+ksm
 gpH
 pGD
 gpH
 pGD
 pGD
-xwb
+imq
 pXV
 oSU
 oSU
@@ -120174,7 +120174,7 @@ oSU
 oSU
 oSU
 pXV
-rxB
+ksm
 pGD
 pGD
 pGD
@@ -121973,7 +121973,7 @@ oSU
 oSU
 oSU
 pXV
-rxB
+ksm
 dPN
 pGD
 gpH
@@ -123772,7 +123772,7 @@ oSU
 oSU
 oSU
 pXV
-rxB
+ksm
 pGD
 pGD
 pGD
@@ -125828,13 +125828,13 @@ oSU
 oSU
 oSU
 euu
-oWJ
+ogC
 aFD
 aFD
 aFD
 vOF
 vOF
-tiE
+spW
 euu
 oSU
 oSU
@@ -127124,11 +127124,11 @@ euu
 oSU
 oSU
 oSU
-nmF
-nmF
-nmF
-nmF
-nmF
+mZu
+mZu
+mZu
+mZu
+mZu
 oSU
 oSU
 oSU
@@ -127379,14 +127379,14 @@ vOF
 vOF
 euu
 oSU
-nmF
-nmF
-nmF
-nzk
-xqx
-bxE
-nmF
-nmF
+mZu
+mZu
+mZu
+aMu
+htX
+rjc
+mZu
+mZu
 oSU
 oSU
 oSU
@@ -127627,24 +127627,24 @@ oSU
 oSU
 oSU
 euu
-oWJ
+ogC
 oWa
 vOF
 vOF
 vOF
 aFD
-tiE
+spW
 euu
 oSU
-nmF
-bxE
-naL
-qiU
-naL
-jbi
-xpG
-nmF
-nmF
+mZu
+rjc
+jnP
+pTS
+jnP
+slg
+tbz
+mZu
+mZu
 oSU
 oSU
 cGX
@@ -127890,18 +127890,18 @@ vOF
 aFD
 vOF
 qiu
-gtH
+dqH
 euu
 oSU
-nmF
-vuT
-naL
-naL
-naL
-xol
-wyc
-bxE
-nmF
+mZu
+whq
+jnP
+jnP
+jnP
+izm
+lqY
+rjc
+mZu
 oSU
 oSU
 cGX
@@ -128149,18 +128149,18 @@ pxg
 aFD
 euu
 euu
-nmF
-nmF
-gCw
-nmF
-naL
-duo
-vDs
-nmF
-brX
-nmF
-nmF
-nmF
+mZu
+mZu
+qKG
+mZu
+jnP
+suO
+csO
+mZu
+vuT
+mZu
+mZu
+mZu
 cGX
 aeZ
 aeZ
@@ -128406,18 +128406,18 @@ pxg
 aFD
 euu
 euu
-xpG
-myV
-xol
-myV
-naL
-fPk
-jbi
-vDs
-naL
-myV
-nmF
-nmF
+tbz
+ppf
+izm
+ppf
+jnP
+aFM
+slg
+csO
+jnP
+ppf
+mZu
+mZu
 nib
 aeZ
 aeZ
@@ -128661,20 +128661,20 @@ pxg
 vOF
 gWs
 aFD
-oXY
-uQL
-myV
-brX
+fKT
+dBD
+ppf
 vuT
-myV
-myV
-jbi
-fLs
-naL
-naL
-bZF
-nmF
-wen
+whq
+ppf
+ppf
+slg
+ebM
+jnP
+jnP
+bWr
+mZu
+vOm
 nib
 aeZ
 aeZ
@@ -128920,19 +128920,19 @@ pxg
 aFD
 euu
 euu
-xpG
-jbi
-vDs
-naL
-naL
-qyr
-aUE
-naL
-naL
-naL
-nmF
-nmF
-gBY
+tbz
+slg
+csO
+jnP
+jnP
+mhE
+aAl
+jnP
+jnP
+jnP
+mZu
+mZu
+plZ
 aeZ
 aeZ
 aeZ
@@ -129177,18 +129177,18 @@ cQQ
 aFD
 euu
 euu
-nmF
-nmF
-naL
-nmF
-jbi
-xol
-vDs
-nmF
-gCw
-nmF
-nmF
-nmF
+mZu
+mZu
+jnP
+mZu
+slg
+izm
+csO
+mZu
+qKG
+mZu
+mZu
+mZu
 cGX
 aeZ
 aeZ
@@ -129435,15 +129435,15 @@ oWa
 euu
 euu
 oSU
-nmF
-naL
-naL
-wzJ
-myV
-jbi
-jbi
-bxE
-nmF
+mZu
+jnP
+jnP
+rWQ
+ppf
+slg
+slg
+rjc
+mZu
 oSU
 oSU
 cGX
@@ -129692,15 +129692,15 @@ aFD
 euu
 euu
 oSU
-nmF
-gdq
-myV
-myV
-brX
-naL
-lRA
-nmF
-nmF
+mZu
+lRC
+ppf
+ppf
+vuT
+jnP
+wZo
+mZu
+mZu
 oSU
 oSU
 cGX
@@ -129949,15 +129949,15 @@ aFD
 euu
 euu
 oSU
-nmF
-jXO
-tgm
-jbi
-jbi
-jbi
-bxE
-bxE
-nmF
+mZu
+eWI
+dlY
+slg
+slg
+slg
+rjc
+rjc
+mZu
 oSU
 oSU
 cGX
@@ -130206,15 +130206,15 @@ aFD
 oSU
 euu
 oSU
-nmF
-nmF
-nmF
-nmF
-myV
-myV
-nmF
-nmF
-nmF
+mZu
+mZu
+mZu
+mZu
+ppf
+ppf
+mZu
+mZu
+mZu
 oSU
 oSU
 cGX
@@ -130460,18 +130460,18 @@ aFD
 aFD
 aFD
 aFD
-oSU
+vlW
 euu
 oSU
 oSU
-nmF
-xpG
-uia
-myV
-naL
-tNm
-iEy
-nmF
+mZu
+tbz
+dzM
+ppf
+jnP
+nYs
+jkc
+mZu
 oSU
 oSU
 cGX
@@ -130721,14 +130721,14 @@ oSU
 euu
 oSU
 oSU
-nmF
-naL
-hIF
-duo
-naL
-fpY
-duo
-nmF
+mZu
+jnP
+cIL
+suO
+jnP
+gqh
+suO
+mZu
 oSU
 oSU
 cGX
@@ -130978,14 +130978,14 @@ oSU
 euu
 oSU
 oSU
-nmF
-nin
-xpG
-wyc
-oho
-wzJ
-aBe
-nmF
+mZu
+pyd
+tbz
+lqY
+ciO
+rWQ
+rFt
+mZu
 oSU
 oSU
 cGX
@@ -131226,23 +131226,23 @@ oSU
 oSU
 oSU
 oSU
-oUo
+vlW
 oSU
-oUo
+vlW
 oSU
-oUo
+vlW
 oSU
-nmF
-nmF
-nmF
-nmF
-nmF
-nmF
-naL
-xol
-nmF
-nmF
-nmF
+mZu
+mZu
+mZu
+mZu
+mZu
+mZu
+jnP
+izm
+mZu
+mZu
+mZu
 oSU
 oSU
 cGX
@@ -131489,17 +131489,17 @@ oSU
 oSU
 oSU
 oSU
-nmF
-eHE
-tnD
-bby
-eRl
-wyc
-myV
-dQW
-naL
-nAY
-nmF
+mZu
+con
+xHQ
+uPm
+hft
+lqY
+ppf
+jJb
+jnP
+kzp
+mZu
 oSU
 oSU
 cGX
@@ -131746,17 +131746,17 @@ oSU
 oSU
 oSU
 oSU
-nmF
-rIv
-myV
-myV
-duo
-naL
-aUE
-naL
-naL
-naL
-nmF
+mZu
+kky
+ppf
+ppf
+suO
+jnP
+aAl
+jnP
+jnP
+jnP
+mZu
 oSU
 oSU
 cGX
@@ -132003,17 +132003,17 @@ oSU
 oSU
 oSU
 oSU
-nmF
-myV
-brX
-wyc
-myV
-wcz
-utk
-awj
-rmy
-mQQ
-nmF
+mZu
+ppf
+vuT
+lqY
+ppf
+btb
+vTG
+sAG
+eMv
+rRL
+mZu
 oSU
 oSU
 cGX
@@ -132260,17 +132260,17 @@ oSU
 oSU
 oSU
 oSU
-nmF
-nmF
-nmF
-nmF
-nmF
-nmF
-nmF
-nmF
-nmF
-nmF
-nmF
+mZu
+mZu
+mZu
+mZu
+mZu
+mZu
+mZu
+mZu
+mZu
+mZu
+mZu
 oSU
 oSU
 cGX

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -294,12 +294,23 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"aeV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "afb" = (
 /obj/structure/railing/corner{
 	dir = 8
 	},
 /turf/open/floor/stone,
 /area/station/commons/lounge)
+"afk" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/icemoon/underground/unexplored/rivers/deep)
 "afp" = (
 /obj/machinery/air_sensor/nitrogen_tank,
 /turf/open/floor/engine/n2,
@@ -837,6 +848,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"ano" = (
+/obj/structure/barricade/wooden/crude,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "anu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2076,6 +2093,10 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"aCI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "aCJ" = (
 /obj/machinery/newscaster/directional/west,
 /obj/effect/spawner/random/structure/twelve_percent_spirit_board,
@@ -2311,6 +2332,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"aFY" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "aGb" = (
 /obj/item/flashlight/lantern/on,
 /turf/open/misc/hay/icemoon,
@@ -2741,6 +2768,10 @@
 /obj/structure/stairs/north,
 /turf/open/floor/iron,
 /area/station/service/chapel)
+"aMC" = (
+/obj/structure/tram/alt/titanium,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "aME" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3398,7 +3429,7 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aVL" = (
-/turf/open/genturf/blue,
+/turf/closed/wall,
 /area/icemoon/underground/unexplored/rivers/deep)
 "aVM" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -3870,6 +3901,10 @@
 "bde" = (
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"bdn" = (
+/obj/structure/barricade/security,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "bdp" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -3945,6 +3980,13 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating/icemoon,
 /area/station/engineering/atmos)
+"bed" = (
+/obj/structure/toiletbong,
+/obj/structure/thermoplastic,
+/obj/structure/chair/sofa/bench/tram/left,
+/obj/structure/thermoplastic/light,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "ben" = (
 /obj/machinery/bluespace_beacon,
 /obj/effect/turf_decal/stripes/line{
@@ -4302,6 +4344,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"bjE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/fluff/paper/stack,
+/obj/structure/glowshroom,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "bjK" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -6192,6 +6241,14 @@
 /obj/structure/ore_box,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"bIf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/wrapping,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "bIl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -6294,6 +6351,9 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/armory/upper)
+"bJv" = (
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "bJD" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 4
@@ -6386,6 +6446,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
+"bKQ" = (
+/obj/structure/thermoplastic/light,
+/obj/structure/chair/sofa/bench/tram/left{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "bKZ" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -7605,6 +7672,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
+"ccx" = (
+/obj/effect/turf_decal/siding/thinplating_new,
+/obj/structure/ladder,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "ccz" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -8014,6 +8086,10 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/mine/living_quarters)
+"chT" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/unexplored/rivers/deep)
 "chZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8086,6 +8162,12 @@
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"cjI" = (
+/obj/structure/tram/spoiler{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "cjJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
@@ -8246,6 +8328,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
+"cmA" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "cmJ" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
@@ -8357,6 +8446,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"cnF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "cnI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8558,6 +8651,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"cqV" = (
+/obj/structure/thermoplastic/light,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "cqW" = (
 /obj/vehicle/ridden/secway,
 /obj/structure/cable,
@@ -8676,6 +8773,13 @@
 "csT" = (
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
+"csZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence{
+	dir = 2
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ctj" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment,
@@ -8823,6 +8927,10 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
+"cvb" = (
+/obj/structure/sign/warning/directional/east,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "cvg" = (
 /obj/effect/mapping_helpers/trapdoor_placer,
 /obj/effect/turf_decal/delivery,
@@ -9086,6 +9194,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"cyp" = (
+/obj/structure/thermoplastic/light,
+/obj/structure/chair/sofa/bench/tram/right{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "cyr" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/surgery{
@@ -9359,6 +9475,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"cBz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "cBG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9977,6 +10097,10 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/grass,
 /area/station/medical/virology)
+"cLf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "cLo" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
@@ -10273,6 +10397,13 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
+"cOS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/unexplored/rivers/deep)
 "cPd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10414,6 +10545,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
+"cQQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "cQV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/siding/dark_blue,
@@ -10591,6 +10728,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"cUg" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep)
 "cUq" = (
 /obj/structure/rack,
 /obj/item/stack/ducts{
@@ -10721,6 +10862,11 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
+"cXw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "cXy" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_half{
@@ -10823,6 +10969,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"cYv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "cYC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -10849,6 +11002,11 @@
 /obj/structure/ore_box,
 /turf/open/floor/iron/dark,
 /area/mine/eva)
+"cYS" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/trash/soap,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep)
 "cYT" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
@@ -11065,6 +11223,16 @@
 /obj/item/cultivator,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"dbl" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "dbm" = (
 /obj/machinery/door/airlock{
 	name = "Private Restroom"
@@ -11375,6 +11543,11 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"deW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/bacteria,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "deY" = (
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -11653,6 +11826,14 @@
 	dir = 1
 	},
 /area/mine/living_quarters)
+"djd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "djh" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/structure/cable,
@@ -11908,6 +12089,10 @@
 	dir = 2
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"dmC" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "dmI" = (
 /obj/machinery/chem_master,
@@ -12845,6 +13030,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"dzI" = (
+/obj/structure/thermoplastic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "dzJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -13463,6 +13653,10 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"dIF" = (
+/obj/effect/mob_spawn/cockroach,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "dIG" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/south,
@@ -13722,6 +13916,13 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"dMS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "dMX" = (
 /obj/structure/chair{
 	dir = 1;
@@ -14781,6 +14982,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/side,
 /area/station/science/explab)
+"efl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "efv" = (
 /obj/item/toy/snowball{
 	pixel_x = -6;
@@ -15072,6 +15278,11 @@
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
+"eiQ" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "eiR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner{
@@ -16689,6 +16900,9 @@
 /obj/machinery/shower/directional/north,
 /turf/open/floor/iron/smooth,
 /area/mine/eva)
+"eHt" = (
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "eHC" = (
 /obj/structure/marker_beacon/burgundy,
 /obj/effect/turf_decal/weather/snow/corner{
@@ -18331,6 +18545,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"ffu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mob_spawn/cockroach,
+/obj/effect/decal/cleanable/confetti,
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/fluff/paper/stack{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "ffQ" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -20049,6 +20273,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"fHU" = (
+/obj/structure/thermoplastic/light,
+/obj/structure/chair/sofa/bench/tram/right{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "fHV" = (
 /obj/machinery/mineral/stacking_unit_console{
 	pixel_x = -32
@@ -20161,6 +20392,15 @@
 	dir = 1
 	},
 /area/station/medical/morgue)
+"fJD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/decal/cleanable/wrapping,
+/obj/structure/fluff/paper/stack{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "fJL" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/nitrogen_input{
 	dir = 1
@@ -21334,6 +21574,12 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"gbi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/holopay,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "gbu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21708,6 +21954,15 @@
 /obj/structure/sign/nanotrasen/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"ghe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/structure/railing,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "ghl" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -22013,6 +22268,16 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"glg" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "glh" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/aft)
@@ -22933,6 +23198,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"gxu" = (
+/obj/structure/barricade/wooden{
+	name = "wooden barricade (CLOSED)"
+	},
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "gxO" = (
 /obj/structure/table/reinforced,
 /obj/item/hand_labeler{
@@ -23181,6 +23452,13 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/station/security/brig/upper)
+"gBp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "gBv" = (
 /obj/machinery/door/window/left/directional/south{
 	name = "Engineering Delivery";
@@ -23372,6 +23650,11 @@
 /obj/structure/sign/warning/biohazard/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"gDI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "gDN" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -24026,6 +24309,9 @@
 /obj/structure/railing/corner,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"gOH" = (
+/turf/open/genturf/blue,
+/area/icemoon/underground/explored)
 "gOI" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -24126,6 +24412,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"gQB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "gQD" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -25225,6 +25517,10 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"hgg" = (
+/obj/effect/decal/cleanable/blood/oil/slippery,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "hgh" = (
 /turf/closed/wall,
 /area/station/medical/medbay/lobby)
@@ -25431,6 +25727,14 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"hjK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "hjM" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/morgue)
@@ -25886,6 +26190,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/drone_bay)
+"hpO" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "hpU" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -26014,6 +26322,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"hrV" = (
+/obj/structure/fence{
+	dir = 2
+	},
+/obj/structure/barricade/wooden{
+	name = "wooden barricade (CLOSED)"
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "hrY" = (
 /obj/structure/stairs/west,
 /turf/open/floor/iron/dark,
@@ -26202,6 +26519,17 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"huy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "huB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26302,6 +26630,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"hwe" = (
+/obj/structure/barricade/wooden{
+	name = "wooden barricade (CLOSED)"
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "hwm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -26985,6 +27319,12 @@
 "hGH" = (
 /turf/closed/wall,
 /area/station/security/lockers)
+"hGT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "hHb" = (
 /turf/closed/wall/r_wall,
 /area/station/ai/satellite/hallway)
@@ -27261,6 +27601,10 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/engineering/atmos)
+"hLW" = (
+/obj/structure/railing,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "hLX" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -28116,6 +28460,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"hYC" = (
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "hYD" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -28547,6 +28895,12 @@
 /obj/effect/turf_decal/tile/red/half,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig/upper)
+"idf" = (
+/obj/effect/decal/cleanable/blood/oil/slippery,
+/obj/structure/sign/poster/contraband/random/directional/east,
+/obj/effect/spawner/random/trash/bin,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "idi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
@@ -29009,6 +29363,12 @@
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"ikf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mob_spawn/cockroach,
+/obj/effect/decal/cleanable/crayon,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "ikk" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
@@ -29110,6 +29470,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"ilw" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "ily" = (
 /turf/open/openspace,
 /area/station/science/xenobiology)
@@ -29681,6 +30045,14 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/glass/reinforced,
 /area/station/security/armory/upper)
+"iva" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "ivi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow,
@@ -30879,6 +31251,12 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"iOk" = (
+/obj/structure/tram/spoiler{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "iOv" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -31374,6 +31752,13 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"iVP" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "iVT" = (
 /obj/machinery/computer/camera_advanced/xenobio,
 /turf/open/floor/iron,
@@ -32102,6 +32487,11 @@
 /obj/machinery/light/small/dim/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"jfP" = (
+/turf/open/floor/iron/stairs/medium{
+	dir = 4
+	},
+/area/icemoon/underground/explored)
 "jfR" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -32235,6 +32625,11 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"jhY" = (
+/obj/structure/thermoplastic/light,
+/obj/structure/thermoplastic,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "jim" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron,
@@ -32624,6 +33019,11 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"jor" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "jpd" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
@@ -33069,6 +33469,9 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
+"juV" = (
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/unexplored/rivers/deep)
 "jvj" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/chair,
@@ -34499,6 +34902,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"jPa" = (
+/obj/machinery/door/poddoor/shutters,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "jPc" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad2"
@@ -34715,6 +35123,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"jRP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "jRS" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
@@ -35194,6 +35610,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
+"jZR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "jZU" = (
 /obj/structure/tank_holder/oxygen,
 /obj/effect/turf_decal/tile/blue{
@@ -35353,6 +35780,19 @@
 	dir = 8
 	},
 /area/station/science/ordnance)
+"kdm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
+"kdq" = (
+/obj/structure/thermoplastic/light,
+/obj/structure/chair/sofa/bench/tram/right{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "kdA" = (
 /obj/machinery/door/firedoor{
 	dir = 8
@@ -35378,6 +35818,13 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"kdP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/door{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "kdS" = (
 /obj/structure/fence{
 	dir = 1
@@ -35885,6 +36332,16 @@
 "kkl" = (
 /turf/closed/wall,
 /area/station/security/interrogation)
+"kku" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/railing/corner/end{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "kkv" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -36384,6 +36841,13 @@
 "ksC" = (
 /turf/open/floor/iron,
 /area/station/security/brig/upper)
+"ksO" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "ksP" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/door/firedoor{
@@ -36731,6 +37195,15 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"kxF" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "kxT" = (
 /obj/structure/railing/corner,
 /turf/open/floor/iron/dark/textured,
@@ -36749,6 +37222,11 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"kyd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "kyf" = (
 /obj/structure/bookcase{
 	name = "Holy Bookcase"
@@ -37559,6 +38037,10 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"kIu" = (
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep)
 "kIy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -37665,6 +38147,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"kJN" = (
+/obj/structure/tram/spoiler{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "kJO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37672,6 +38160,13 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"kJS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence{
+	dir = 2
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/unexplored/rivers/deep)
 "kJU" = (
 /obj/structure/girder,
 /turf/open/floor/iron/dark,
@@ -39304,6 +39799,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"lhB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "lhC" = (
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
@@ -39730,6 +40229,15 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"lnK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/structure/railing,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "lnL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/large,
@@ -40214,6 +40722,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"luS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "lvb" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -40479,6 +40993,11 @@
 /obj/structure/sign/nanotrasen/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"lyD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "lyG" = (
 /turf/open/floor/glass/reinforced,
 /area/station/security/armory/upper)
@@ -40765,6 +41284,14 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"lCf" = (
+/obj/structure/table,
+/obj/item/rag,
+/obj/item/knife/kitchen{
+	pixel_y = 2
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "lCg" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -40851,6 +41378,11 @@
 	},
 /turf/closed/wall,
 /area/station/maintenance/fore)
+"lDp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "lDq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -41310,6 +41842,12 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
+"lLs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "lLA" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = 32;
@@ -41375,6 +41913,12 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
+"lMv" = (
+/obj/structure/thermoplastic/light,
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "lMx" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -41384,6 +41928,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/armory/upper)
+"lMG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/obj/structure/fence/door{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "lMK" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -43505,10 +44057,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"msM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/corner/end/flip{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "msN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
+"msP" = (
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "msT" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
@@ -44401,6 +44964,11 @@
 /obj/structure/cable,
 /turf/closed/wall,
 /area/station/science/xenobiology)
+"mGh" = (
+/turf/open/floor/iron/stairs/medium{
+	dir = 8
+	},
+/area/icemoon/underground/explored)
 "mGs" = (
 /obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
 /obj/structure/cable,
@@ -44628,6 +45196,10 @@
 "mJz" = (
 /turf/open/floor/iron/dark,
 /area/icemoon/underground/explored)
+"mJE" = (
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "mJM" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -44669,6 +45241,11 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/security/evidence)
+"mKr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "mKA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46119,6 +46696,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/mine/eva/lower)
+"nfx" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/sign/warning/directional/north,
+/obj/structure/bed/maint,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "nfB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46702,6 +47288,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
+"nov" = (
+/obj/structure/thermoplastic,
+/obj/structure/thermoplastic/light,
+/obj/structure/chair/sofa/bench/tram/solo,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "noC" = (
 /obj/structure/railing{
 	dir = 4
@@ -46877,6 +47469,13 @@
 /obj/machinery/vitals_reader/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"nqh" = (
+/obj/effect/decal/cleanable/blood/oil/slippery,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack,
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "nqn" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/stripes/box,
@@ -46904,6 +47503,10 @@
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
+"nrp" = (
+/obj/structure/fluff/minepost,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "nrz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
@@ -48154,6 +48757,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
+"nHU" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "nHY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
@@ -48425,6 +49032,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"nLK" = (
+/obj/structure/tram/spoiler,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "nLW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49083,6 +49694,10 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/toilet)
+"nTH" = (
+/obj/machinery/door/poddoor/lift,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "nTK" = (
 /obj/structure/table/glass,
 /obj/machinery/barsign{
@@ -49236,6 +49851,13 @@
 	dir = 5
 	},
 /area/station/maintenance/port/aft)
+"nVV" = (
+/obj/structure/railing,
+/obj/structure/fence/door{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "nWf" = (
 /obj/structure/chair{
 	dir = 1
@@ -49671,6 +50293,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/service/hydroponics)
+"obY" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "obZ" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Xenobiology Test Chamber Access";
@@ -49906,6 +50532,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"oge" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/titanium,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "ogl" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -49965,6 +50597,11 @@
 	dir = 1
 	},
 /area/station/engineering/lobby)
+"ohF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "ohI" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
@@ -52165,6 +52802,14 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
+"oHT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/right/directional/east{
+	name = "Pharmacy Desk";
+	req_access = list("pharmacy")
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "oHV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53076,6 +53721,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/prison)
+"oWa" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "oWk" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -54523,6 +55172,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"prM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "prX" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -54628,6 +55284,10 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/aft/greater)
+"ptt" = (
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "ptQ" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
 /obj/effect/turf_decal/stripes/line,
@@ -54910,6 +55570,11 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"pxg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "pxi" = (
 /obj/machinery/door/window/left/directional/west{
 	name = "Mass Driver";
@@ -55167,6 +55832,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/science/ordnance)
+"pAj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "pAN" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
@@ -56238,6 +56908,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/medical/morgue)
+"pRu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "pRL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57134,6 +57809,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"qcJ" = (
+/obj/structure/barricade/wooden{
+	name = "wooden barricade (CLOSED)"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "qcL" = (
 /obj/effect/turf_decal/siding/yellow/end{
 	dir = 8
@@ -57505,6 +58187,10 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark/side,
 /area/station/service/chapel)
+"qiu" = (
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "qiv" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/siding/thinplating_new/light{
@@ -57642,6 +58328,9 @@
 	},
 /turf/open/misc/asteroid/snow/standard_air,
 /area/station/science/cytology)
+"qkn" = (
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "qku" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
@@ -58743,6 +59432,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/security/prison/mess)
+"qCx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "qCA" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -59008,6 +59701,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
+"qFF" = (
+/obj/structure/thermoplastic/light,
+/obj/structure/thermoplastic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "qFJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
@@ -60314,6 +61013,14 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"qWR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fence/door{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "qWS" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -61383,6 +62090,11 @@
 /obj/structure/railing,
 /turf/open/openspace/icemoon,
 /area/icemoon/underground/explored)
+"rls" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "rlu" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark,
@@ -61926,6 +62638,9 @@
 	dir = 1
 	},
 /area/station/security/prison/safe)
+"rsO" = (
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "rsR" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue/full,
@@ -62071,6 +62786,11 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/storage/gas)
+"ruu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ruw" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 1;
@@ -62242,6 +62962,14 @@
 "rxY" = (
 /turf/closed/wall,
 /area/station/service/bar/backroom)
+"rxZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/obj/structure/fence/door{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "ryf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62404,6 +63132,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
+"rAE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "rAF" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -62433,6 +63168,18 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/eva)
+"rBl" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/fence/door{
+	dir = 4
+	},
+/obj/structure/barricade/wooden{
+	name = "wooden barricade (CLOSED)"
+	},
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "rBo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
@@ -62574,6 +63321,11 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
+"rCM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "rCO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63059,6 +63811,13 @@
 /mob/living/basic/bot/repairbot,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
+"rKW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "rLc" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -63195,6 +63954,14 @@
 	dir = 4
 	},
 /area/mine/living_quarters)
+"rNk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/griddle,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "rNn" = (
 /obj/structure/flora/grass/brown/style_random,
 /obj/structure/sign/nanotrasen/directional/north,
@@ -63348,6 +64115,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/mine/production)
+"rOU" = (
+/obj/structure/thermoplastic,
+/obj/structure/thermoplastic/light,
+/obj/structure/chair/sofa/bench/tram/right,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "rPe" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/toolcloset,
@@ -63757,6 +64530,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"rVr" = (
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "rVB" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
@@ -63856,6 +64633,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"rWJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/unexplored/rivers/deep)
 "rWO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -64368,6 +65150,9 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/command/eva)
+"seb" = (
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep)
 "sen" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -64756,6 +65541,10 @@
 "skl" = (
 /turf/closed/wall,
 /area/station/maintenance/fore)
+"skm" = (
+/obj/structure/barricade/security,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "skn" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -65962,6 +66751,11 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/commons/dorms/laundry)
+"sAc" = (
+/obj/structure/tram,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "sAd" = (
 /obj/structure/fence/post{
 	dir = 8;
@@ -67446,6 +68240,11 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"sWR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "sWU" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
@@ -67948,6 +68747,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"teO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/fuel_pool,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "teP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68088,6 +68893,9 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
+"tgU" = (
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "thq" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -68098,6 +68906,10 @@
 "thA" = (
 /turf/open/genturf/blue,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
+"thB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/genturf,
+/area/icemoon/underground/unexplored/rivers/deep)
 "thC" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/iron/fifty,
@@ -68141,6 +68953,16 @@
 /obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
+"thL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "thM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68685,6 +69507,12 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"tow" = (
+/obj/structure/fluff/paper/stack{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "toG" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -69229,6 +70057,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"txh" = (
+/obj/structure/tram/alt/titanium,
+/obj/machinery/transport/tram_controller,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "txj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -71446,6 +72279,11 @@
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
+"udj" = (
+/obj/structure/toiletbong,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "udo" = (
 /obj/structure/closet{
 	name = "evidence closet 4"
@@ -72298,6 +73136,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/mix)
+"upJ" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "upK" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
 	color = "#0000ff";
@@ -72458,6 +73303,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"usr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "usE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72999,6 +73848,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
+"uBk" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "uBs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -74328,11 +75181,20 @@
 	},
 /turf/open/floor/iron/textured,
 /area/mine/laborcamp/security)
+"uWb" = (
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "uWo" = (
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"uWq" = (
+/obj/structure/thermoplastic,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "uWu" = (
 /obj/structure/flora/grass/green/style_random,
 /obj/structure/sign/warning/directional/south,
@@ -74733,6 +75595,10 @@
 /obj/structure/window/spawner/directional/south,
 /turf/open/floor/plating,
 /area/station/service/kitchen/coldroom)
+"vcG" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/iron,
+/area/icemoon/underground/unexplored/rivers/deep)
 "vcO" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/dark,
@@ -74855,6 +75721,13 @@
 "vey" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/captain)
+"veH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "veK" = (
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
@@ -74882,6 +75755,10 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology)
+"vfg" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "vfj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -75158,6 +76035,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"vkh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
+"vkk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "vkz" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/stripes/line{
@@ -75555,6 +76442,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"vpe" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "vpg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75681,6 +76572,15 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"vrk" = (
+/obj/structure/thermoplastic/light,
+/obj/structure/chair/sofa/bench/tram/left{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "vrw" = (
 /obj/machinery/button/door/directional/west{
 	id = "xenobio3";
@@ -76460,6 +77360,9 @@
 "vBG" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/cmo)
+"vBN" = (
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "vBY" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -76558,6 +77461,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"vEH" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/unexplored/rivers/deep)
 "vEJ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -76996,6 +77905,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
+"vKk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/corner{
+	dir = 10
+	},
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
+"vKn" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/fence/door{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "vKq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77288,6 +78213,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"vQb" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep)
 "vQj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77640,6 +78569,12 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/grimy,
 /area/station/commons/lounge)
+"vVn" = (
+/obj/structure/reagent_dispensers/plumbed{
+	name = "service reservoir"
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/unexplored/rivers/deep)
 "vVt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -78024,6 +78959,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"waK" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/unexplored/rivers/deep)
 "waL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78689,6 +79628,10 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
+"wlK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall,
+/area/icemoon/underground/explored)
 "wlW" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/computer/robotics{
@@ -79197,6 +80140,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
+"wuN" = (
+/obj/structure/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "wvk" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/decal/cleanable/blood/oil/slippery,
@@ -79558,6 +80505,10 @@
 /obj/item/folder/yellow,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"wAm" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "wAv" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -79987,6 +80938,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/service/chapel)
+"wGy" = (
+/obj/structure/railing,
+/turf/open/floor/iron/stairs/medium{
+	dir = 4
+	},
+/area/icemoon/underground/explored)
 "wGE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -80382,6 +81339,12 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/dorms/laundry)
+"wMB" = (
+/obj/structure/fence{
+	dir = 2
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "wMT" = (
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron,
@@ -82538,6 +83501,10 @@
 /obj/item/stack/sheet/leather,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"xpI" = (
+/obj/effect/decal/cleanable/blood/oil/slippery,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "xpJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -84279,6 +85246,18 @@
 /obj/item/gun/syringe,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/storage)
+"xMf" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "xMh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
@@ -85480,6 +86459,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
+"ydH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "ydI" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/entry)
@@ -85651,6 +86635,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"ygI" = (
+/obj/structure/barricade/wooden{
+	name = "wooden barricade (CLOSED)"
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "ygL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/structure/crate,
@@ -85851,6 +86841,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"ykU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "yld" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -100423,13 +101419,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-thA
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
+lhB
 thA
 iDt
 ghx
@@ -100680,13 +101676,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-thA
+vBN
+vBN
+vBN
+vBN
+vBN
+lhB
+rVr
 iDt
 ghx
 ghx
@@ -100937,13 +101933,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-thA
-thA
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 xxV
 ghx
 ghx
@@ -101194,12 +102190,12 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-thA
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
 thA
 ghx
 ghx
@@ -101451,12 +102447,12 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-thA
-thA
+vBN
+vBN
+nHU
+lhB
+vBN
+vBN
 thA
 ghx
 ghx
@@ -101708,12 +102704,12 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-thA
-thA
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 iDt
 ghx
 ghx
@@ -101965,12 +102961,12 @@ thA
 thA
 thA
 thA
-thA
-thA
-oSU
-oSU
-thA
-thA
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 iDt
 ghx
 ghx
@@ -102222,12 +103218,12 @@ thA
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 ghx
 ghx
 ghx
@@ -102479,12 +103475,12 @@ thA
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+cjI
+aMC
+wuN
+nLK
 ghx
 ghx
 ghx
@@ -102736,12 +103732,12 @@ thA
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+aMC
+uWq
+bKQ
+wuN
 ghx
 ghx
 ghx
@@ -102993,12 +103989,12 @@ thA
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+eiQ
+uWq
+fHU
+wuN
 ghx
 ghx
 ghx
@@ -103242,7 +104238,7 @@ thA
 thA
 thA
 thA
-thA
+gOH
 thA
 thA
 thA
@@ -103250,12 +104246,12 @@ thA
 ghx
 ghx
 ghx
-thA
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+aMC
+uWq
+uWq
+aMC
 ghx
 ghx
 ghx
@@ -103507,12 +104503,12 @@ ghx
 ghx
 ghx
 ghx
-thA
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+wuN
+rOU
+qFF
+wuN
 ghx
 ghx
 ghx
@@ -103764,12 +104760,12 @@ ghx
 ghx
 ghx
 ghx
-ghx
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+aMC
+bed
+qFF
+wuN
 iDt
 ghx
 ghx
@@ -104021,12 +105017,12 @@ ghx
 ghx
 ghx
 ghx
-ghx
-ghx
-ghx
-thA
-thA
-thA
+vBN
+vBN
+aMC
+aMC
+oge
+aMC
 iDt
 ghx
 ghx
@@ -104278,12 +105274,12 @@ thA
 ghx
 ghx
 ghx
-ghx
-ghx
-ghx
-thA
-thA
-thA
+vBN
+vBN
+txh
+cqV
+uWq
+wuN
 iDt
 ghx
 ghx
@@ -104535,12 +105531,12 @@ thA
 thA
 ghx
 ghx
-ghx
-ghx
-thA
-thA
-thA
-iDt
+vBN
+vBN
+wuN
+nov
+dzI
+aMC
 iDt
 ghx
 ghx
@@ -104792,12 +105788,12 @@ thA
 thA
 ghx
 ghx
-ghx
-ghx
-ghx
-ghx
-iDt
-iDt
+vBN
+vBN
+aMC
+uWq
+dzI
+wuN
 ghx
 ghx
 ghx
@@ -105049,12 +106045,12 @@ ghx
 thA
 ghx
 ghx
-ghx
-ghx
-ghx
-ghx
-ghx
-ghx
+vBN
+vBN
+aMC
+uWq
+vrk
+wuN
 ghx
 ghx
 ghx
@@ -105306,12 +106302,12 @@ ghx
 thA
 ghx
 ghx
-ghx
-ghx
-ghx
-ghx
-ghx
-ghx
+vBN
+nHU
+eiQ
+uWq
+kdq
+aMC
 ghx
 ghx
 ghx
@@ -105563,12 +106559,12 @@ ghx
 ghx
 ghx
 ghx
-ghx
-ghx
-ghx
-ghx
-ghx
-ghx
+vBN
+vBN
+kJN
+aMC
+sAc
+iOk
 ghx
 ghx
 iDt
@@ -105820,12 +106816,12 @@ ghx
 ghx
 ghx
 ghx
-ghx
-ghx
-ghx
-ghx
-ghx
-ghx
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
 ghx
 ghx
 ghx
@@ -106077,12 +107073,12 @@ ghx
 ghx
 ghx
 ghx
-ghx
-ghx
-ghx
-ghx
-ghx
-ghx
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
 ghx
 ghx
 ghx
@@ -106334,12 +107330,12 @@ ghx
 ghx
 ghx
 ghx
-ghx
-ghx
-ghx
-ghx
-ghx
-ghx
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
 ghx
 ghx
 ghx
@@ -106591,12 +107587,12 @@ ghx
 ghx
 ghx
 ghx
-ghx
-ghx
-ghx
-ghx
-ghx
-ghx
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 ghx
 ghx
 ghx
@@ -106848,12 +107844,12 @@ ghx
 ghx
 ghx
 ghx
-ghx
-ghx
-ghx
-ghx
-ghx
-ghx
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 ghx
 ghx
 ghx
@@ -107105,12 +108101,12 @@ ghx
 ghx
 ghx
 ghx
-ghx
-ghx
-ghx
-ghx
-ghx
-ghx
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 ghx
 ghx
 ghx
@@ -107362,12 +108358,12 @@ ghx
 ghx
 ghx
 ghx
-ghx
-ghx
-ghx
-ghx
-ghx
-ghx
+vBN
+vBN
+vBN
+vBN
+nHU
+vBN
 ghx
 ghx
 ghx
@@ -107619,12 +108615,12 @@ ghx
 ghx
 ghx
 ghx
-ghx
-ghx
-ghx
-ghx
-ghx
-ghx
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 ghx
 ghx
 ghx
@@ -107876,12 +108872,12 @@ ghx
 ghx
 ghx
 ghx
-ghx
-ghx
-thA
-thA
-ghx
-ghx
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 ghx
 ghx
 ghx
@@ -108133,12 +109129,12 @@ thA
 thA
 ghx
 ghx
-ghx
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 thA
 xuo
 psb
@@ -108390,12 +109386,12 @@ thA
 thA
 ghx
 ghx
-ghx
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 thA
 xuo
 xuo
@@ -108647,12 +109643,12 @@ thA
 thA
 ghx
 ghx
-thA
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 thA
 thA
 thA
@@ -108904,12 +109900,12 @@ thA
 thA
 ghx
 ghx
-thA
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 thA
 thA
 thA
@@ -109161,12 +110157,12 @@ thA
 thA
 ghx
 ghx
-thA
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 thA
 thA
 thA
@@ -109418,12 +110414,12 @@ thA
 thA
 ghx
 ghx
-thA
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
 thA
 thA
 thA
@@ -109675,12 +110671,12 @@ thA
 thA
 ghx
 ghx
-thA
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+vBN
+lhB
+vBN
+vBN
 thA
 thA
 thA
@@ -109932,12 +110928,12 @@ thA
 thA
 ghx
 ghx
-thA
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+nHU
+lhB
+vBN
+vBN
 thA
 thA
 thA
@@ -110189,12 +111185,12 @@ thA
 thA
 ghx
 ghx
-thA
-thA
-thA
-thA
-thA
-thA
+vBN
+vBN
+vBN
+lhB
+lhB
+vBN
 thA
 oSU
 oSU
@@ -110446,14 +111442,14 @@ thA
 thA
 ghx
 ghx
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -110703,14 +111699,14 @@ thA
 ghx
 ghx
 ghx
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
+vBN
+lhB
+vBN
+vBN
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -110960,14 +111956,14 @@ thA
 ghx
 ghx
 ghx
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
+nrp
+lhB
+vBN
+vBN
+vBN
+nrp
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -111216,15 +112212,15 @@ thA
 thA
 ghx
 ghx
-thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -111473,15 +112469,15 @@ thA
 ghx
 thA
 ghx
-thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -111730,15 +112726,15 @@ psb
 etz
 thA
 thA
-thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+pxg
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -111987,15 +112983,15 @@ psb
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -112244,15 +113240,15 @@ psb
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+lhB
+vBN
+pxg
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -112501,15 +113497,15 @@ psb
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+pxg
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -112758,15 +113754,15 @@ psb
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+lhB
+lhB
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -113015,15 +114011,15 @@ thA
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+lhB
+lhB
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -113272,15 +114268,15 @@ thA
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+lhB
+lhB
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -113529,15 +114525,15 @@ thA
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+gQB
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -113786,15 +114782,15 @@ thA
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -114043,15 +115039,15 @@ thA
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -114300,15 +115296,15 @@ thA
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+nHU
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -114557,15 +115553,15 @@ thA
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+lhB
+lhB
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -114814,15 +115810,15 @@ thA
 thA
 thA
 thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+lhB
+pxg
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -115071,15 +116067,15 @@ thA
 thA
 thA
 thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+lhB
+lhB
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -115328,15 +116324,15 @@ thA
 thA
 thA
 thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+lhB
+vBN
+lhB
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -115585,15 +116581,15 @@ thA
 thA
 thA
 thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+lhB
+vBN
+lhB
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -115842,15 +116838,15 @@ thA
 thA
 thA
 thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+lhB
+vBN
+vBN
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -116099,15 +117095,15 @@ thA
 thA
 thA
 thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+lhB
+vBN
+lhB
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -116356,15 +117352,15 @@ thA
 thA
 thA
 thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+lhB
+vBN
+vBN
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -116613,15 +117609,15 @@ thA
 thA
 thA
 thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+lhB
+vBN
+vBN
+nHU
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -116870,15 +117866,15 @@ thA
 thA
 thA
 thA
-thA
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+lhB
+vBN
+vBN
+wAm
+gFX
 oSU
 oSU
 oSU
@@ -117127,22 +118123,22 @@ thA
 thA
 thA
 thA
-thA
+gFX
+vBN
+vBN
+lhB
+vBN
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+aVL
+aVL
+aVL
+aVL
+aVL
 oSU
 oSU
 thA
@@ -117384,34 +118380,34 @@ thA
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+lhB
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+aVL
+vEH
+afk
+kIu
+aVL
 oSU
 oSU
 oSU
 thA
 thA
 thA
-thA
-ghx
-ghx
-ghx
-ghx
-ghx
+rsO
+gFX
+gFX
+gFX
+gFX
+gFX
 ghx
 ghx
 iDt
@@ -117641,34 +118637,34 @@ thA
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
+mGh
+gFX
+aVL
+aVL
+aVL
+vcG
+seb
+aVL
+aVL
+aVL
 oSU
 oSU
 oSU
 aVL
-thA
-thA
-ghx
-ghx
-ghx
-ghx
+aVL
+gxu
+ptt
+msP
+msP
+msP
+gFX
 ghx
 ghx
 ghx
@@ -117898,34 +118894,34 @@ thA
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
+aFY
+eHt
+aVL
+seb
+aVL
+cUg
+juV
+vVn
+cYS
+aVL
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-thA
-thA
-thA
-ghx
-ghx
-ghx
+aVL
+rWJ
+vkk
+skm
+hwe
+qcJ
+bdn
+gFX
 ghx
 thA
 thA
@@ -118155,34 +119151,34 @@ thA
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+pxg
+vBN
+vBN
+vKn
+wMB
+aVL
+seb
+aVL
+vQb
+waK
+juV
+juV
+aVL
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-thA
-thA
-ghx
-ghx
-ghx
-ghx
+aVL
+kJS
+lMG
+qCx
+lhB
+lhB
+lhB
+gFX
 thA
 thA
 thA
@@ -118412,38 +119408,38 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-thA
-thA
-thA
-thA
-thA
-thA
-thA
-thA
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+pxg
+vBN
+vBN
+kxF
+eHt
+aVL
+aVL
+aVL
+aVL
+aVL
+aVL
+chT
+aVL
+aVL
+aVL
+aVL
+aVL
+cOS
+ghe
+ilw
+qkn
+qCx
+qkn
+rsO
+rsO
+rsO
+aVL
+aVL
 oSU
 oSU
 oSU
@@ -118669,38 +119665,38 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-thA
-thA
-thA
-thA
-thA
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+lhB
+vBN
+vBN
+kku
+usr
+nqh
+gFX
+vBN
+nTH
+usr
+usr
+usr
+hgg
+dmC
+usr
+usr
+tgU
+lyD
+huy
+cjI
+aMC
+wuN
+nLK
+mKr
+deW
+vBN
+vBN
+aVL
 oSU
 oSU
 oSU
@@ -118926,38 +119922,38 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+djd
+cBz
+kdm
+gFX
+vBN
+nTH
+ohF
+msM
+cBz
+cBz
+cBz
+bJv
+aeV
+lLs
+bJv
+jZR
+aMC
+dzI
+bKQ
+wuN
+vfg
+lhB
+udj
+vBN
+aVL
 oSU
 oSU
 oSU
@@ -119183,38 +120179,38 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+lhB
+lhB
+vBN
+prM
+hYC
+kdm
+gFX
+vBN
+nTH
+eHt
+eHt
+kdm
+eHt
+eHt
+kdm
+eHt
+cLf
+aeV
+iva
+eiQ
+dzI
+cyp
+wuN
+vfg
+nHU
+vBN
+uBk
+aVL
 oSU
 oSU
 oSU
@@ -119440,38 +120436,38 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+lhB
+vBN
+vBN
+ykU
+gFX
+kdm
+gFX
+wlK
+gFX
+cLf
+cLf
+vkh
+kdm
+eHt
+eHt
+kdm
+gFX
+kdm
+iva
+aMC
+uWq
+dzI
+aMC
+gFX
+aVL
+aVL
+aVL
+aVL
 oSU
 oSU
 oSU
@@ -119697,34 +120693,34 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+nHU
+vBN
+lhB
+lhB
+vBN
+prM
+cBz
+eHt
+eHt
+kdm
+eHt
+jor
+cLf
+cLf
+cLf
+eHt
+eHt
+kdm
+mJE
+bJv
+iva
+wuN
+rOU
+qFF
+wuN
+gFX
 oSU
 oSU
 oSU
@@ -119954,34 +120950,34 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+pxg
+vBN
+gBp
+rls
+eHt
+vKk
+qWR
+gbi
+kdP
+dMS
+aeV
+aeV
+bJv
+bJv
+xpI
+eHt
+sWR
+jZR
+aMC
+bed
+jhY
+wuN
+gFX
 oSU
 oSU
 oSU
@@ -120211,34 +121207,34 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+thL
+tgU
+cnF
+jRP
+usr
+usr
+cnF
+rKW
+obY
+cnF
+idf
+usr
+usr
+usr
+rCM
+dbl
+aMC
+aMC
+eiQ
+aMC
+gFX
 oSU
 oSU
 oSU
@@ -120468,34 +121464,34 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
+xMf
+iVP
+gFX
+gFX
+vBN
+vBN
+vBN
+gFX
+jPa
+ano
+gFX
+msP
+oHT
+gFX
+upJ
+glg
+txh
+lMv
+uWq
+wuN
+gFX
 oSU
 oSU
 oSU
@@ -120725,34 +121721,34 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
+rBl
+hrV
+gFX
+gFX
+vBN
+vBN
+vBN
+gFX
+hGT
+ffu
+gFX
+rNk
+bIf
+gFX
+wMB
+nVV
+wuN
+nov
+dzI
+aMC
+gFX
 oSU
 oSU
 oSU
@@ -120982,34 +121978,34 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+aFY
+cvb
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
+ikf
+teO
+gFX
+lCf
+dIF
+gFX
+tow
+hLW
+aMC
+dzI
+dzI
+wuN
+gFX
 oSU
 oSU
 oSU
@@ -121239,34 +122235,34 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+jfP
+gFX
+gFX
 oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+bjE
+fJD
+gFX
+ksO
+pRu
+gFX
+nfx
+wGy
+aMC
+dzI
+bKQ
+wuN
+gFX
 oSU
 oSU
 oSU
@@ -121496,34 +122492,34 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+pxg
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
+gFX
+vBN
+eiQ
+uWq
+fHU
+aMC
+gFX
 oSU
 oSU
 oSU
@@ -121753,6 +122749,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+lhB
+lhB
+ygI
+gFX
 oSU
 oSU
 oSU
@@ -121765,22 +122770,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+nHU
+kJN
+aMC
+wuN
+iOk
+gFX
 oSU
 oSU
 oSU
@@ -122010,6 +123006,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+lhB
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -122022,22 +123027,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -122267,6 +123263,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -122279,22 +123284,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -122524,6 +123520,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+lhB
+uBk
+gFX
 oSU
 oSU
 oSU
@@ -122536,22 +123541,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+vBN
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -122781,6 +123777,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -122793,22 +123798,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+vBN
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -123038,6 +124034,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -123050,22 +124055,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -123295,6 +124291,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+pxg
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -123307,22 +124312,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+pxg
+lhB
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -123552,6 +124548,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+lhB
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -123564,22 +124569,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+lhB
+lhB
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -123809,6 +124805,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -123821,22 +124826,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+pxg
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -124066,6 +125062,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+lhB
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -124078,22 +125083,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+pxg
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -124323,6 +125319,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -124335,22 +125340,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+lhB
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -124580,6 +125576,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+pxg
+gQB
+oWa
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -124592,22 +125597,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+lhB
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -124837,6 +125833,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+lhB
+vBN
+gQB
+lhB
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -124849,22 +125854,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -125094,6 +126090,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+lhB
+lhB
+lhB
+lhB
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -125106,22 +126111,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -125351,6 +126347,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+oWa
+lhB
+lhB
+lhB
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -125363,22 +126368,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -125608,6 +126604,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+lhB
+vBN
+lhB
+qiu
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -125620,22 +126625,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -125865,6 +126861,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+lhB
+vpe
+pxg
+vBN
+gFX
+gFX
 oSU
 oSU
 oSU
@@ -125877,22 +126882,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -126122,6 +127118,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+lhB
+pxg
+pxg
+vBN
+gFX
+gFX
 oSU
 oSU
 oSU
@@ -126134,22 +127139,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+pxg
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -126379,6 +127375,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+pxg
+lhB
+gQB
+vBN
+gFX
+gFX
 oSU
 oSU
 oSU
@@ -126391,22 +127396,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+gQB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -126636,6 +127632,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+pxg
+lhB
+pxg
+vBN
+gFX
+gFX
 oSU
 oSU
 oSU
@@ -126648,22 +127653,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+gQB
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -126893,6 +127889,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+lhB
+kyd
+cQQ
+vBN
+gFX
+gFX
 oSU
 oSU
 oSU
@@ -126905,22 +127910,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+pxg
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -127150,6 +128146,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+pxg
+veH
+kyd
+oWa
+gFX
+gFX
 oSU
 oSU
 oSU
@@ -127162,22 +128167,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+gQB
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -127407,6 +128403,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+pxg
+vBN
+vBN
+gFX
+gFX
 oSU
 oSU
 oSU
@@ -127419,22 +128424,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+gQB
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -127664,6 +128660,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+lhB
+lhB
+vBN
+vBN
+gFX
+gFX
 oSU
 oSU
 oSU
@@ -127676,22 +128681,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+pxg
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -127921,6 +128917,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+hpO
+lhB
+vBN
+vBN
+vBN
+oSU
+gFX
 oSU
 oSU
 oSU
@@ -127933,22 +128938,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+pxg
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -128178,6 +129174,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
+oSU
+gFX
 oSU
 oSU
 oSU
@@ -128190,22 +129195,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+pxg
+gQB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -128435,6 +129431,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+lhB
+vBN
+vBN
+oSU
+gFX
 oSU
 oSU
 oSU
@@ -128447,22 +129452,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+pxg
+pxg
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -128692,6 +129688,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+vBN
+oSU
+gFX
 oSU
 oSU
 oSU
@@ -128704,22 +129709,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -128970,13 +129966,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+lhB
+gQB
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -129227,13 +130223,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+lhB
+pxg
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -129484,13 +130480,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+lhB
+gQB
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -129741,13 +130737,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+uBk
+vBN
+lhB
+pxg
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -129998,13 +130994,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+lhB
+cYv
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -130255,13 +131251,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+pxg
+pxg
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -130512,13 +131508,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+pxg
+pxg
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -130769,13 +131765,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+pxg
+pxg
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -131026,13 +132022,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+vBN
+vBN
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -131283,13 +132279,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+lhB
+lhB
+vBN
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -131540,13 +132536,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+lhB
+vBN
+vBN
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -131797,13 +132793,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+lhB
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -132054,13 +133050,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+lhB
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -132311,13 +133307,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+lhB
+pxg
+gFX
 oSU
 oSU
 oSU
@@ -132568,13 +133564,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+lhB
+lhB
+lhB
+lhB
+lhB
+gFX
 oSU
 oSU
 oSU
@@ -132825,16 +133821,16 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+lhB
+pxg
+lhB
+lhB
+gFX
+gFX
+gFX
+gFX
 oSU
 oSU
 xMq
@@ -133082,16 +134078,16 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+lhB
+gQB
+lhB
+lhB
+vBN
+usr
+usr
+kdm
 oSU
 oSU
 xMq
@@ -133339,16 +134335,16 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+lhB
+lhB
+vBN
+vBN
+cBz
+cBz
+kdm
 iDt
 iDt
 xMq
@@ -133595,17 +134591,17 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-iDt
+gFX
+gFX
+vBN
+vBN
+vBN
+vBN
+lhB
+vBN
+kdm
+kdm
+usr
 iDt
 xYQ
 aKb
@@ -133852,17 +134848,17 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-iDt
-iDt
+gFX
+eHt
+jfP
+vBN
+vBN
+vBN
+lhB
+vBN
+kdm
+ohF
+efl
 iDt
 iDt
 chg
@@ -134109,17 +135105,17 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-iDt
-iDt
+gFX
+ruu
+lDp
+vBN
+lhB
+vBN
+vBN
+vBN
+eHt
+cBz
+usr
 iDt
 xYQ
 pJm
@@ -134366,17 +135362,17 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-iDt
-iDt
+gFX
+csZ
+rxZ
+vBN
+vBN
+vBN
+lhB
+vBN
+eHt
+cBz
+usr
 iDt
 iDt
 xMq
@@ -134619,21 +135615,21 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-iDt
+gFX
+gFX
+gFX
+gFX
+gFX
+rAE
+lnK
+vBN
+lhB
+vBN
+vBN
+vBN
+eHt
+cBz
+usr
 iDt
 iDt
 iDt
@@ -134876,21 +135872,21 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+cnF
+luS
+pAj
+tgU
+lyD
+huy
+vBN
+lhB
+lhB
+lhB
+vBN
+eHt
+cXw
+usr
 iDt
 iDt
 oSU
@@ -135133,21 +136129,21 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+eHt
+cLf
+cLf
+gFX
+eHt
+jZR
+vBN
+lhB
+lhB
+vBN
+vBN
+bJv
+cBz
+eHt
 oSU
 oSU
 oSU
@@ -135390,21 +136386,21 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+cnF
+aCI
+cLf
+bJv
+vkh
+iva
+vBN
+lhB
+lhB
+vBN
+vBN
+tgU
+tgU
+eHt
 oSU
 oSU
 oSU
@@ -135647,21 +136643,21 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+tgU
+bJv
+cLf
+bJv
+kdm
+iva
+vBN
+vBN
+lhB
+vBN
+gFX
+gFX
+gFX
+gFX
 oSU
 oSU
 oSU
@@ -135904,18 +136900,18 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+usr
+eHt
+kdm
+kdm
+eHt
+iva
+vBN
+vBN
+lhB
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -136161,18 +137157,18 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+usr
+bJv
+eHt
+bJv
+gDI
+jZR
+vBN
+lhB
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -136418,18 +137414,18 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+usr
+gFX
+eHt
+gFX
+rCM
+hjK
+vBN
+lhB
+vBN
+vBN
+gFX
 oSU
 oSU
 oSU
@@ -136675,18 +137671,18 @@ oSU
 oSU
 oSU
 oSU
+gFX
+usr
+gFX
+eHt
+gFX
+eHt
+cmA
 oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
 oSU
 oSU
 oSU
@@ -136932,15 +137928,15 @@ oSU
 oSU
 oSU
 oSU
+gFX
+tgU
+bJv
+eHt
+bJv
+eHt
+cmA
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+thB
 oSU
 oSU
 oSU
@@ -137187,16 +138183,16 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+gFX
+gFX
+tgU
+eHt
+eHt
+eHt
+eHt
+cmA
+thB
 oSU
 oSU
 oSU
@@ -137444,16 +138440,16 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+usr
+bJv
+eHt
+bJv
+eHt
+vBN
+thB
 oSU
 oSU
 oSU
@@ -137701,14 +138697,14 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+pAj
+bJv
+cLf
+bJv
+eHt
 oSU
 oSU
 oSU
@@ -137958,14 +138954,14 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+vBN
+vBN
+tgU
+eHt
+eHt
+gFX
+cLf
 oSU
 oSU
 oSU
@@ -138215,14 +139211,14 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
+gFX
+gFX
+gFX
+eHt
+cLf
+cnF
+tgU
+cnF
 oSU
 oSU
 oSU
@@ -165707,10 +166703,10 @@ tjo
 tjo
 tjo
 tjo
-tjo
-tjo
-tjo
-tjo
+vBN
+vBN
+vBN
+vBN
 iDt
 xxV
 gjq
@@ -165964,11 +166960,11 @@ tjo
 tjo
 tjo
 tjo
-tjo
-tjo
-tjo
-tjo
-iDt
+vBN
+lhB
+lhB
+lhB
+lhB
 iDt
 gjq
 gjq
@@ -166221,11 +167217,11 @@ tjo
 tjo
 tjo
 tjo
-tjo
-tjo
-tjo
-tjo
-tjo
+vBN
+ydH
+lhB
+lhB
+uWb
 tjo
 gjq
 gjq
@@ -166478,11 +167474,11 @@ tjo
 tjo
 tjo
 tjo
-tjo
-tjo
-tjo
-tjo
-tjo
+vBN
+lhB
+lhB
+lhB
+lhB
 tjo
 tjo
 tjo
@@ -166735,11 +167731,11 @@ tjo
 tjo
 tjo
 tjo
-tjo
-tjo
-tjo
-tjo
-tjo
+vBN
+lhB
+lhB
+lhB
+lhB
 tjo
 tjo
 tjo
@@ -166992,10 +167988,10 @@ tjo
 tjo
 tjo
 tjo
-tjo
-tjo
-tjo
-tjo
+vBN
+vBN
+vBN
+vBN
 tjo
 tjo
 tjo
@@ -231761,7 +232757,7 @@ oCO
 oCO
 gyH
 uTI
-cuc
+ccx
 mVE
 mVE
 mVE

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -298,7 +298,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
+"aeZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "afb" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -311,7 +315,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/icemoon/underground/explored)
+/area/station/metro/metro_control_room/center_control_room)
 "afp" = (
 /obj/machinery/air_sensor/nitrogen_tank,
 /turf/open/floor/engine/n2,
@@ -854,7 +858,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "anu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1142,7 +1146,7 @@
 "apV" = (
 /obj/effect/mapping_helpers/no_atoms_ontop,
 /turf/closed/wall,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "apX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1601,7 +1605,7 @@
 "avT" = (
 /obj/structure/cable,
 /turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/station/metro/power_substation/arrivals_metro_substation)
 "awa" = (
 /turf/open/openspace,
 /area/station/science/ordnance/office)
@@ -2105,7 +2109,7 @@
 "aCI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "aCJ" = (
 /obj/machinery/newscaster/directional/west,
 /obj/effect/spawner/random/structure/twelve_percent_spirit_board,
@@ -2318,6 +2322,9 @@
 /obj/effect/turf_decal/tile/red/half,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig/upper)
+"aFD" = (
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "aFG" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -2350,7 +2357,7 @@
 	dir = 1
 	},
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "aGb" = (
 /obj/item/flashlight/lantern/on,
 /turf/open/misc/hay/icemoon,
@@ -2601,6 +2608,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"aJN" = (
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/station/metro/arrivals_station)
 "aJQ" = (
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/starboard)
@@ -2778,7 +2789,7 @@
 "aMC" = (
 /obj/structure/tram/alt/titanium,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "aME" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3109,7 +3120,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "aRR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3451,7 +3462,7 @@
 /area/station/tcommsat/computer)
 "aVL" = (
 /turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/station/metro/power_substation/arrivals_metro_substation)
 "aVM" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -3593,6 +3604,12 @@
 "aYJ" = (
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"aYR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "aZd" = (
 /turf/open/floor/plating,
 /area/station/medical/virology)
@@ -3673,7 +3690,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "aZU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3925,7 +3942,7 @@
 "bdn" = (
 /obj/structure/barricade/security,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "bdp" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -4008,7 +4025,7 @@
 /obj/structure/thermoplastic/light,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "ben" = (
 /obj/machinery/bluespace_beacon,
 /obj/effect/turf_decal/stripes/line{
@@ -4372,7 +4389,7 @@
 /obj/structure/fluff/paper/stack,
 /obj/structure/glowshroom,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "bjK" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -4740,6 +4757,12 @@
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/iron/smooth,
 /area/mine/living_quarters)
+"boY" = (
+/obj/structure/tram/spoiler{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "bpd" = (
 /obj/machinery/power/smes/engineering,
 /obj/effect/turf_decal/delivery,
@@ -5224,7 +5247,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/warning,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "buv" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	color = "#ff0000";
@@ -5718,6 +5741,9 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"bBl" = (
+/turf/closed/wall,
+/area/station/metro/metro_control_room/center_control_room)
 "bBw" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating,
@@ -6084,7 +6110,7 @@
 /obj/effect/decal/cleanable/blood/trail,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "bFW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -6173,6 +6199,9 @@
 	dir = 1
 	},
 /area/mine/eva)
+"bGR" = (
+/turf/open/genturf,
+/area/station/metro/power_substation)
 "bGS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6285,7 +6314,7 @@
 	},
 /obj/effect/decal/cleanable/wrapping,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "bIl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -6390,7 +6419,7 @@
 /area/station/security/armory/upper)
 "bJv" = (
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "bJD" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 4
@@ -6417,7 +6446,7 @@
 "bKb" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "bKp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Firefighting Equipment"
@@ -6493,7 +6522,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "bKZ" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -7055,6 +7084,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"bTI" = (
+/turf/closed/wall,
+/area/station/metro/center_station)
 "bTJ" = (
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/power_store/cell/high,
@@ -7242,7 +7274,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "bWv" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -7705,7 +7737,7 @@
 "ccx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/lava/plasma/ice_moon,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "ccz" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -8119,7 +8151,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/metro_control_room/center_control_room)
 "chZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8197,7 +8229,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "cjJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
@@ -8364,7 +8396,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "cmJ" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
@@ -8479,7 +8511,7 @@
 "cnF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "cnI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8545,7 +8577,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "cpg" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
@@ -8696,7 +8728,7 @@
 "cqV" = (
 /obj/structure/thermoplastic/light,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "cqW" = (
 /obj/vehicle/ridden/secway,
 /obj/structure/cable,
@@ -8815,13 +8847,18 @@
 "csT" = (
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
+"csU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/metro/outrivals_station)
 "csZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fence{
 	dir = 2
 	},
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "ctj" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment,
@@ -8972,7 +9009,7 @@
 "cvb" = (
 /obj/structure/sign/warning/directional/east,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "cvg" = (
 /obj/effect/mapping_helpers/trapdoor_placer,
 /obj/effect/turf_decal/delivery,
@@ -9034,7 +9071,7 @@
 "cvr" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "cvB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/west,
@@ -9140,7 +9177,7 @@
 /obj/machinery/lift_indicator/directional/north,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "cwO" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
@@ -9249,7 +9286,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "cyr" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/surgery{
@@ -9532,7 +9569,7 @@
 "cBz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "cBG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9647,7 +9684,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "cDv" = (
 /obj/item/stack/rods/fifty,
 /obj/structure/rack,
@@ -9809,6 +9846,10 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"cFH" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "cFJ" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
@@ -9881,6 +9922,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
+"cGX" = (
+/turf/closed/wall,
+/area/station/metro/train_tunnels/south_tunnel)
 "cGZ" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/stairs/medium{
@@ -10164,7 +10208,7 @@
 "cLf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "cLo" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
@@ -10203,6 +10247,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"cLA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/metro/outrivals_station)
 "cLE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10468,7 +10516,7 @@
 /obj/structure/thermoplastic/light,
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "cPd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10615,7 +10663,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/trail,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "cQV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/siding/dark_blue,
@@ -10796,7 +10844,7 @@
 "cUg" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/metro_control_room/center_control_room)
 "cUq" = (
 /obj/structure/rack,
 /obj/item/stack/ducts{
@@ -10814,7 +10862,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/station/metro/power_substation/arrivals_metro_substation)
 "cUG" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /obj/effect/turf_decal/stripes/red/corner{
@@ -10937,7 +10985,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "cXy" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_half{
@@ -11046,7 +11094,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "cYC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -11078,7 +11126,7 @@
 /obj/effect/spawner/random/trash/soap,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/metro_control_room/center_control_room)
 "cYT" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
@@ -11304,7 +11352,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "dbm" = (
 /obj/machinery/door/airlock{
 	name = "Private Restroom"
@@ -11597,7 +11645,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "deD" = (
 /obj/machinery/modular_computer/preset/id{
 	dir = 4
@@ -11621,7 +11669,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "deN" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -11639,7 +11687,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/garbage_corner)
 "deY" = (
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -11792,7 +11840,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "dhH" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/weather/snow/corner{
@@ -11896,6 +11944,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /turf/open/floor/plating,
 /area/station/ai/satellite/atmos)
+"diw" = (
+/turf/open/floor/iron/smooth,
+/area/station/metro/arrivals_station)
 "dix" = (
 /obj/machinery/light/small/dim/directional/south,
 /turf/open/floor/plating,
@@ -11931,7 +11982,7 @@
 	},
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "djh" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/structure/cable,
@@ -12192,7 +12243,7 @@
 /obj/machinery/vending/snack,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "dmI" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow/full,
@@ -12612,7 +12663,7 @@
 /obj/structure/transport/linear/public,
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "drZ" = (
 /obj/structure/flora/grass/both,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -12768,7 +12819,7 @@
 /obj/structure/thermoplastic,
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "duY" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input,
 /turf/open/floor/engine/vacuum,
@@ -13143,7 +13194,7 @@
 /obj/structure/thermoplastic,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "dzJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -13763,7 +13814,7 @@
 /obj/effect/decal/cleanable/plastic,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "dIx" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
@@ -13771,7 +13822,7 @@
 "dIF" = (
 /obj/effect/mob_spawn/cockroach,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "dIG" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/south,
@@ -13978,7 +14029,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/official/work_for_a_future/directional/north,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "dMi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14042,7 +14093,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "dMX" = (
 /obj/structure/chair{
 	dir = 1;
@@ -14098,6 +14149,11 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/lobby)
+"dOm" = (
+/obj/structure/tram/alt/titanium,
+/obj/machinery/transport/tram_controller,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "dOp" = (
 /obj/structure/table/wood,
 /obj/item/instrument/saxophone,
@@ -14184,6 +14240,10 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/smooth,
 /area/mine/mechbay)
+"dPN" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "dPT" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/unres/delayed{
@@ -14192,6 +14252,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"dQc" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/garbage_corner)
 "dQl" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/warning/cold_temp/directional/north,
@@ -14363,7 +14427,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "dTq" = (
 /obj/structure/fireplace,
 /turf/open/floor/wood,
@@ -15114,7 +15178,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "efv" = (
 /obj/item/toy/snowball{
 	pixel_x = -6;
@@ -15248,7 +15312,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "ehc" = (
 /turf/open/floor/plating,
 /area/station/security/prison)
@@ -15407,7 +15471,7 @@
 /obj/structure/thermoplastic/light,
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "eiR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner{
@@ -15698,6 +15762,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"eoo" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/garbage_corner)
 "eos" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -15926,6 +15994,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"ert" = (
+/turf/open/floor/iron,
+/area/station/metro/center_station)
 "erw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16040,6 +16111,10 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/glass/reinforced,
 /area/station/security/brig/entrance)
+"esO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/arrivals_station)
 "esX" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Equipment Room";
@@ -16182,6 +16257,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"euu" = (
+/turf/closed/wall,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "euw" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -16252,7 +16330,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "ewi" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -16848,7 +16926,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/window/elevator/left/directional/north,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "eFt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -17023,7 +17101,7 @@
 /area/mine/eva)
 "eHt" = (
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "eHC" = (
 /obj/structure/marker_beacon/burgundy,
 /obj/effect/turf_decal/weather/snow/corner{
@@ -17433,7 +17511,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "eOl" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -17778,6 +17856,10 @@
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"eUd" = (
+/obj/structure/transport/linear/public,
+/turf/open/floor/plating,
+/area/station/metro/outrivals_station)
 "eUf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18685,13 +18767,13 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "ffL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/crayon,
 /obj/effect/spawner/random/trash/deluxe_garbage,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "ffQ" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -18802,6 +18884,9 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"fhx" = (
+/turf/closed/wall,
+/area/station/metro/outrivals_station)
 "fhz" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -19089,6 +19174,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"flr" = (
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/station/metro/center_station)
 "flx" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=HOP";
@@ -19419,7 +19508,7 @@
 /obj/structure/sign/poster/random/directional/north,
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "frt" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -19581,7 +19670,7 @@
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "ftJ" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Lab"
@@ -19871,7 +19960,7 @@
 "fxZ" = (
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "fyc" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -19907,6 +19996,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
+"fyO" = (
+/obj/structure/thermoplastic/light,
+/obj/structure/chair/sofa/bench/tram/right{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "fyQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/meter,
@@ -20432,7 +20528,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "fHV" = (
 /obj/machinery/mineral/stacking_unit_console{
 	pixel_x = -32
@@ -20553,7 +20649,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "fJL" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/nitrogen_input{
 	dir = 1
@@ -20979,6 +21075,12 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"fPq" = (
+/obj/structure/thermoplastic/light,
+/obj/structure/thermoplastic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "fPv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -21751,7 +21853,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/holopay,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "gbu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21839,6 +21941,10 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"gcH" = (
+/obj/structure/tram,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "gcP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -22009,6 +22115,10 @@
 "gfb" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/central/greater)
+"gfc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/station/metro/center_station)
 "gff" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -22129,7 +22239,7 @@
 "ghe" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "ghl" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -22444,7 +22554,7 @@
 /obj/structure/railing,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "glh" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/aft)
@@ -22774,6 +22884,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/ai/satellite/interior)
+"gpH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "gpM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -23344,6 +23458,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"gxn" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/station/metro/outrivals_station)
 "gxq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -23370,7 +23488,7 @@
 	name = "wooden barricade (CLOSED)"
 	},
 /turf/closed/wall,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "gxO" = (
 /obj/structure/table/reinforced,
 /obj/item/hand_labeler{
@@ -23466,7 +23584,11 @@
 "gze" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
+"gzt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/metro/center_station)
 "gzz" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/machinery/computer/monitor{
@@ -23629,7 +23751,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "gBv" = (
 /obj/machinery/door/window/left/directional/south{
 	name = "Engineering Delivery";
@@ -23826,7 +23948,7 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "gDN" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -23854,7 +23976,7 @@
 /obj/effect/decal/cleanable/vomit,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "gEd" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "MiniSat External SouthWest";
@@ -23903,7 +24025,7 @@
 "gEH" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "gER" = (
 /turf/open/floor/iron,
 /area/station/command/bridge)
@@ -24269,6 +24391,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
+"gLx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/metro/outrivals_station)
 "gLD" = (
 /obj/structure/table,
 /obj/item/taperecorder,
@@ -24522,6 +24650,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
+"gPk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/station/metro/center_station)
 "gPn" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Armory"
@@ -24593,7 +24725,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "gQD" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -24687,6 +24819,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"gRS" = (
+/obj/structure/thermoplastic,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "gSd" = (
 /obj/structure/fence/door{
 	dir = 4
@@ -24861,7 +24997,7 @@
 /obj/structure/thermoplastic/light,
 /obj/machinery/door/airlock/tram,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "gTK" = (
 /turf/closed/wall,
 /area/station/engineering/engine_smes)
@@ -24965,7 +25101,7 @@
 "gVx" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "gVB" = (
 /obj/structure/chair/stool/directional/west,
 /obj/structure/disposalpipe/segment{
@@ -25077,6 +25213,12 @@
 /obj/structure/sign/warning/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix)
+"gWs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "gWt" = (
 /obj/structure/filingcabinet,
 /obj/machinery/airalarm/directional/north,
@@ -25279,6 +25421,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"gYI" = (
+/turf/open/floor/iron/smooth,
+/area/station/metro/center_station)
 "gYM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25700,7 +25845,7 @@
 /obj/effect/decal/cleanable/blood/oil/slippery,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "hgh" = (
 /turf/closed/wall,
 /area/station/medical/medbay/lobby)
@@ -25910,7 +26055,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "hjM" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/morgue)
@@ -26369,7 +26514,7 @@
 "hpO" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "hpU" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -26506,7 +26651,7 @@
 	name = "wooden barricade (CLOSED)"
 	},
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "hrY" = (
 /obj/structure/stairs/west,
 /turf/open/floor/iron/dark,
@@ -26705,7 +26850,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "huB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26810,7 +26955,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/holosign/barrier/atmos/tram,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "hwm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -27496,7 +27641,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/blood/trail,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "hHb" = (
 /turf/closed/wall/r_wall,
 /area/station/ai/satellite/hallway)
@@ -27525,6 +27670,14 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
+"hHm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/metro/outrivals_station)
 "hHp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -27777,7 +27930,7 @@
 /obj/structure/railing,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "hLX" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -28637,7 +28790,7 @@
 "hYC" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "hYD" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -29063,6 +29216,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden)
+"ida" = (
+/turf/open/floor/plating,
+/area/station/metro/center_station)
 "idd" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -29074,7 +29230,7 @@
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/spawner/random/trash/bin,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "idi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
@@ -29172,7 +29328,7 @@
 /obj/effect/decal/cleanable/blood/trail,
 /obj/machinery/light/small/red/directional/west,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "ife" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29547,7 +29703,7 @@
 /obj/effect/mob_spawn/cockroach,
 /obj/effect/decal/cleanable/crayon,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "ikk" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
@@ -29653,7 +29809,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "ily" = (
 /turf/open/openspace,
 /area/station/science/xenobiology)
@@ -29789,7 +29945,7 @@
 /obj/structure/railing,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "iod" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -29798,7 +29954,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/warning,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "iog" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -30251,7 +30407,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "ivi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow,
@@ -30873,6 +31029,10 @@
 /obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"iFJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall,
+/area/station/metro/center_station)
 "iFX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31453,7 +31613,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "iOv" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -31955,7 +32115,7 @@
 	},
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "iVT" = (
 /obj/machinery/computer/camera_advanced/xenobio,
 /turf/open/floor/iron,
@@ -32664,6 +32824,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"jfa" = (
+/obj/structure/thermoplastic/light,
+/obj/structure/chair/sofa/bench/tram/left{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "jfb" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
@@ -32688,7 +32855,7 @@
 /turf/open/floor/iron/stairs/medium{
 	dir = 4
 	},
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "jfR" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -32826,7 +32993,7 @@
 /obj/structure/thermoplastic/light,
 /obj/structure/thermoplastic,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "jim" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron,
@@ -32853,6 +33020,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/security/lockers)
+"jiY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/station/metro/arrivals_station)
 "jjk" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -33030,7 +33201,7 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "jls" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -33082,7 +33253,7 @@
 /obj/structure/railing,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "jms" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -33236,7 +33407,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "jpd" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
@@ -33437,7 +33608,7 @@
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/spawner/random/junk_shell,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "jsm" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Mech Bay";
@@ -33634,7 +33805,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "juq" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
@@ -35119,11 +35290,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"jOY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/metro/center_station)
 "jPa" = (
 /obj/machinery/door/poddoor/shutters,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "jPc" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad2"
@@ -35349,7 +35525,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "jRS" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
@@ -35478,7 +35654,7 @@
 "jUd" = (
 /obj/machinery/power/smes/full,
 /turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/station/metro/power_substation/arrivals_metro_substation)
 "jUi" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -35843,7 +36019,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "jZU" = (
 /obj/structure/tank_holder/oxygen,
 /obj/effect/turf_decal/tile/blue{
@@ -35980,7 +36156,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "kcT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -36016,7 +36192,7 @@
 "kdm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "kdq" = (
 /obj/structure/thermoplastic/light,
 /obj/structure/chair/sofa/bench/tram/right{
@@ -36025,7 +36201,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "kdA" = (
 /obj/machinery/door/firedoor{
 	dir = 8
@@ -36051,13 +36227,17 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"kdG" = (
+/obj/structure/transport/linear/public,
+/turf/open/floor/plating,
+/area/station/metro/center_station)
 "kdP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fence/door{
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "kdS" = (
 /obj/structure/fence{
 	dir = 1
@@ -36574,7 +36754,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "kkv" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -36964,7 +37144,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "krn" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -37087,7 +37267,7 @@
 	},
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "ksP" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/door/firedoor{
@@ -37238,7 +37418,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "kuJ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
@@ -37453,7 +37633,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "kxT" = (
 /obj/structure/railing/corner,
 /turf/open/floor/iron/dark/textured,
@@ -37476,7 +37656,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/trail,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "kyf" = (
 /obj/structure/bookcase{
 	name = "Holy Bookcase"
@@ -37999,7 +38179,7 @@
 "kDZ" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "kEa" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -38201,6 +38381,11 @@
 "kHr" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/project)
+"kHD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "kHI" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/blue,
@@ -38295,7 +38480,7 @@
 /obj/structure/cable,
 /obj/machinery/power/smes/full,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/metro_control_room/center_control_room)
 "kIy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -38407,7 +38592,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "kJO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38420,7 +38605,7 @@
 /obj/structure/sign/poster/official/report_crimes/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "kJU" = (
 /obj/structure/girder,
 /turf/open/floor/iron/dark,
@@ -39606,7 +39791,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/railing/corner,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "laB" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -39762,7 +39947,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "ldi" = (
 /obj/structure/table,
 /obj/item/wallframe/camera,
@@ -39808,6 +39993,11 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/work)
+"ldF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/metro/center_station)
 "ldH" = (
 /turf/closed/wall,
 /area/station/security/prison/mess)
@@ -40514,7 +40704,7 @@
 	},
 /obj/structure/railing,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "lnL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/large,
@@ -40949,7 +41139,7 @@
 /obj/machinery/button/elevator/directional/north,
 /obj/machinery/lift_indicator/directional/north,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "lux" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -41013,7 +41203,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "lvb" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -41284,7 +41474,7 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "lyG" = (
 /turf/open/floor/glass/reinforced,
 /area/station/security/armory/upper)
@@ -41576,7 +41766,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "lCg" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -41673,7 +41863,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "lDq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -41817,6 +42007,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
 /area/station/security/eva)
+"lFA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/station/metro/arrivals_station)
 "lFG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Bow Solar Access"
@@ -42137,7 +42332,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "lLA" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = 32;
@@ -42208,7 +42403,7 @@
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "lMx" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -42223,7 +42418,7 @@
 /obj/structure/sign/poster/official/enlist/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "lMK" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -43819,6 +44014,9 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/chamber)
+"mlt" = (
+/turf/closed/wall,
+/area/station/metro/arrivals_station)
 "mly" = (
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/recharge_floor,
@@ -44352,7 +44550,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "msN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/closed/wall/r_wall,
@@ -44360,7 +44558,7 @@
 "msP" = (
 /obj/machinery/door/poddoor/shutters,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "msT" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
@@ -45035,7 +45233,7 @@
 /obj/machinery/door/airlock/external/glass,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "mCT" = (
 /turf/open/water/no_planet_atmos/deep,
 /area/station/service/hydroponics/garden)
@@ -45254,7 +45452,7 @@
 /turf/open/floor/iron/stairs/medium{
 	dir = 8
 	},
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "mGs" = (
 /obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
 /obj/structure/cable,
@@ -45327,7 +45525,7 @@
 /obj/effect/decal/cleanable/garbage,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "mHd" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -45491,7 +45689,7 @@
 "mJE" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "mJM" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -45537,7 +45735,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/garbage_corner)
 "mKA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45582,7 +45780,7 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/decal/cleanable/fuel_pool,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "mLf" = (
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
@@ -46925,6 +47123,9 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"neA" = (
+/turf/closed/wall,
+/area/station/metro/abandoned/garbage_corner)
 "neE" = (
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -46995,7 +47196,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "nfB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47150,6 +47351,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
+"nib" = (
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "nid" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -47483,7 +47687,7 @@
 /obj/effect/decal/cleanable/insectguts,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/garbage_corner)
 "nmX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -47591,7 +47795,7 @@
 /obj/structure/thermoplastic/light,
 /obj/structure/chair/sofa/bench/tram/solo,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "noC" = (
 /obj/structure/railing{
 	dir = 4
@@ -47773,7 +47977,7 @@
 /obj/structure/fluff/paper/stack,
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "nqn" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/stripes/box,
@@ -47804,7 +48008,7 @@
 "nrp" = (
 /obj/structure/fluff/minepost,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "nrz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
@@ -47918,7 +48122,7 @@
 /obj/machinery/light/warm/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "nsM" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/warning/directional/west,
@@ -49066,7 +49270,7 @@
 "nHU" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "nHY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
@@ -49216,6 +49420,17 @@
 "nKa" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/medical)
+"nKc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/metro/center_station)
 "nKk" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
@@ -49341,7 +49556,7 @@
 "nLK" = (
 /obj/structure/tram/spoiler,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "nLW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50003,7 +50218,7 @@
 "nTH" = (
 /obj/structure/transport/linear/public,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "nTK" = (
 /obj/structure/table/glass,
 /obj/machinery/barsign{
@@ -50164,7 +50379,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "nWf" = (
 /obj/structure/chair{
 	dir = 1
@@ -50602,7 +50817,7 @@
 "obY" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "obZ" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Xenobiology Test Chamber Access";
@@ -50843,7 +51058,7 @@
 /obj/machinery/door/airlock/titanium,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "ogl" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -50908,7 +51123,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/window/elevator/left/directional/west,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "ohI" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
@@ -50919,7 +51134,7 @@
 /obj/effect/decal/cleanable/shreds,
 /obj/effect/decal/cleanable/crayon,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/garbage_corner)
 "ohO" = (
 /obj/structure/fluff/tram_rail,
 /obj/structure/lattice/catwalk,
@@ -51852,7 +52067,7 @@
 /obj/structure/chair/wood,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "ots" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
@@ -51883,7 +52098,7 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "otG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
@@ -53140,7 +53355,7 @@
 	req_access = list("pharmacy")
 	},
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "oHV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53168,7 +53383,7 @@
 /obj/effect/spawner/random/maintenance/dumpster,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "oIy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -53714,6 +53929,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"oQs" = (
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/plating,
+/area/station/metro/center_station)
 "oQt" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -54065,7 +54284,7 @@
 "oWa" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "oWk" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -54100,7 +54319,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "oWy" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/circuit_workshop)
@@ -55286,7 +55505,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/window/elevator/right/directional/north,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "pnK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/north,
@@ -55539,7 +55758,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "prX" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -55649,7 +55868,7 @@
 /obj/machinery/door/window/elevator/right/directional/north,
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "ptQ" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
 /obj/effect/turf_decal/stripes/line,
@@ -55865,6 +56084,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/service/hydroponics)
+"pvX" = (
+/turf/open/floor/iron/stairs/medium{
+	dir = 4
+	},
+/area/station/metro/center_station)
 "pvY" = (
 /obj/machinery/computer/order_console/mining,
 /obj/machinery/light_switch/directional/north,
@@ -55936,7 +56160,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "pxi" = (
 /obj/machinery/door/window/left/directional/west{
 	name = "Mass Driver";
@@ -56167,6 +56391,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"pzJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
+/area/station/metro/outrivals_station)
 "pzV" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -56198,7 +56426,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "pAN" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
@@ -56440,7 +56668,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "pEE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -56490,6 +56718,11 @@
 /obj/structure/sign/warning/directional/north,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/explored)
+"pFD" = (
+/obj/structure/thermoplastic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "pFF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56549,6 +56782,9 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
+"pGD" = (
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "pGG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/random/directional/south,
@@ -57275,7 +57511,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "pRL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57773,6 +58009,9 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
+"pXV" = (
+/turf/closed/wall,
+/area/station/metro/train_tunnels/north_tunnel)
 "pXY" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -57797,7 +58036,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "pYn" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/telescreen/prison/directional/north,
@@ -57819,7 +58058,7 @@
 /obj/machinery/door/airlock/external/glass,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "pYK" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -58211,7 +58450,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "qcL" = (
 /obj/effect/turf_decal/siding/yellow/end{
 	dir = 8
@@ -58586,7 +58825,7 @@
 "qiu" = (
 /obj/effect/decal/cleanable/blood/trail,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "qiv" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/siding/thinplating_new/light{
@@ -58718,7 +58957,7 @@
 "qkn" = (
 /obj/effect/decal/cleanable/leaper_sludge,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "qku" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
@@ -58903,7 +59142,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "qnt" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -58998,7 +59237,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/glitter,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/garbage_corner)
 "qpb" = (
 /obj/machinery/disposal/bin{
 	desc = "A pneumatic waste disposal unit. This one leads to the morgue.";
@@ -59675,7 +59914,7 @@
 	name = "wooden barricade (CLOSED)"
 	},
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "qzs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59844,7 +60083,7 @@
 "qCx" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep)
+/area/station/metro/power_substation/arrivals_metro_substation)
 "qCA" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -60115,7 +60354,7 @@
 /obj/structure/thermoplastic,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "qFJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
@@ -60161,7 +60400,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
+"qGA" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/metro/arrivals_station)
 "qGC" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/on,
 /obj/machinery/airalarm/directional/east,
@@ -60390,7 +60633,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "qJT" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/snowed/icemoon,
@@ -61404,7 +61647,7 @@
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "qWS" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -62052,6 +62295,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"rfr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/station/metro/arrivals_station)
 "rfu" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/rec)
@@ -62478,7 +62725,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "rlu" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark,
@@ -62518,7 +62765,7 @@
 /obj/structure/fence/door,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "rmn" = (
 /obj/structure/chair/stool/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -62976,7 +63223,7 @@
 /obj/machinery/light/warm/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "rsw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -63038,7 +63285,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "rsR" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue/full,
@@ -63171,6 +63418,10 @@
 	},
 /turf/open/floor/iron/textured,
 /area/mine/mechbay)
+"rtV" = (
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/station/metro/center_station)
 "rud" = (
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/mask/surgical,
@@ -63188,7 +63439,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "ruw" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 1;
@@ -63340,7 +63591,7 @@
 /obj/structure/holopay,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "rxx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/camera/directional/east{
@@ -63373,7 +63624,7 @@
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "ryf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63464,7 +63715,7 @@
 "rzh" = (
 /obj/structure/fluff/minepost,
 /turf/open/floor/plating,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/area/station/metro/train_tunnels/north_tunnel)
 "rzj" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty{
@@ -63546,7 +63797,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "rAF" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -63587,7 +63838,7 @@
 	name = "wooden barricade (CLOSED)"
 	},
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "rBo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
@@ -63734,7 +63985,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "rCO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63913,7 +64164,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/window/elevator/left/directional/north,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "rEx" = (
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
@@ -64241,7 +64492,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "rLc" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -64385,7 +64636,7 @@
 	},
 /obj/machinery/griddle,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "rNn" = (
 /obj/structure/flora/grass/brown/style_random,
 /obj/structure/sign/nanotrasen/directional/north,
@@ -64544,7 +64795,7 @@
 /obj/structure/thermoplastic/light,
 /obj/structure/chair/sofa/bench/tram/right,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "rPe" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/toolcloset,
@@ -64957,7 +65208,7 @@
 "rVr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "rVB" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
@@ -65063,7 +65314,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "rWO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -65454,7 +65705,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "sct" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -65533,6 +65784,10 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"sdC" = (
+/obj/structure/tram/spoiler,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "sdF" = (
 /obj/structure/table,
 /obj/item/grown/log/tree,
@@ -65578,7 +65833,7 @@
 "seb" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/metro_control_room/center_control_room)
 "sen" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -65841,7 +66096,7 @@
 /obj/machinery/button/elevator/directional/north,
 /obj/machinery/lift_indicator/directional/north,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "shR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -65978,7 +66233,7 @@
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/garbage_corner)
 "skn" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -67189,7 +67444,7 @@
 /obj/structure/tram,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "sAd" = (
 /obj/structure/fence/post{
 	dir = 8;
@@ -67197,6 +67452,12 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"sAf" = (
+/obj/structure/thermoplastic,
+/obj/structure/thermoplastic/light,
+/obj/structure/chair/sofa/bench/tram/right,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "sAt" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/food_or_drink/snack,
@@ -67856,7 +68117,7 @@
 "sJx" = (
 /obj/structure/holosign/barrier/atmos/tram,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "sJA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68080,6 +68341,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"sNw" = (
+/obj/structure/tram/spoiler{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "sNA" = (
 /obj/structure/marker_beacon/burgundy,
 /obj/structure/sign/nanotrasen/directional/east,
@@ -68171,7 +68438,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/warning,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "sPq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -68514,7 +68781,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "sUB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68656,7 +68923,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "sWs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -68702,7 +68969,7 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "sWU" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
@@ -68905,7 +69172,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/window/elevator/right/directional/west,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "tau" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/green/half/contrasted,
@@ -68965,7 +69232,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "tbh" = (
 /turf/open/floor/iron/half{
 	dir = 1
@@ -69084,6 +69351,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
+"tcV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/metro/arrivals_station)
 "tcX" = (
 /obj/structure/railing,
 /obj/structure/stairs/east,
@@ -69226,7 +69498,7 @@
 /obj/effect/decal/cleanable/fuel_pool,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "teP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69369,7 +69641,7 @@
 /area/station/commons/storage/tools)
 "tgU" = (
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "thq" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -69385,7 +69657,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "thC" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/iron/fifty,
@@ -69438,7 +69710,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "thM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69988,7 +70260,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "toG" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -70035,7 +70307,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "tpc" = (
 /obj/effect/spawner/random/trash/graffiti{
 	pixel_y = -30
@@ -70544,7 +70816,7 @@
 /obj/structure/tram/alt/titanium,
 /obj/machinery/transport/tram_controller,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "txj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -71413,7 +71685,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "tJI" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "robo1"
@@ -72187,7 +72459,7 @@
 "tUw" = (
 /obj/machinery/door/window/elevator/right/directional/north,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "tUx" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
@@ -72776,7 +73048,7 @@
 /obj/structure/toiletbong,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/garbage_corner)
 "udo" = (
 /obj/structure/closet{
 	name = "evidence closet 4"
@@ -72915,6 +73187,12 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"ufA" = (
+/obj/structure/barricade/wooden{
+	name = "wooden barricade (CLOSED)"
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "ufF" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner{
@@ -73325,7 +73603,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/power_substation/arrivals_metro_substation)
 "ulL" = (
 /obj/machinery/modular_computer/preset/id,
 /obj/effect/turf_decal/tile/blue/full,
@@ -73398,7 +73676,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "umC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73416,6 +73694,11 @@
 /obj/structure/table,
 /turf/open/floor/wood,
 /area/station/maintenance/aft/greater)
+"umI" = (
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "umM" = (
 /obj/effect/landmark/start/clown,
 /turf/open/floor/wood,
@@ -73639,7 +73922,7 @@
 /obj/effect/decal/cleanable/garbage,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "upK" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
 	color = "#0000ff";
@@ -73803,7 +74086,7 @@
 "usr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "usE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74356,7 +74639,7 @@
 "uBk" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "uBs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -74483,6 +74766,13 @@
 /obj/structure/grille/broken,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"uCZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/metro/outrivals_station)
 "uDa" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -74585,6 +74875,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"uDR" = (
+/turf/open/floor/catwalk_floor,
+/area/station/metro/outrivals_station)
 "uDW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74617,6 +74910,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/meeting_room)
+"uEA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence{
+	dir = 2
+	},
+/turf/open/floor/iron/smooth,
+/area/station/metro/center_station)
 "uEI" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -74968,7 +75268,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/railing,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "uJX" = (
 /obj/structure/closet/firecloset,
 /obj/item/radio/intercom/directional/north,
@@ -75182,7 +75482,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "uOf" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningdorm_A";
@@ -75372,7 +75672,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "uQR" = (
 /obj/machinery/light_switch/directional/east,
 /obj/structure/sign/warning/biohazard/directional/north,
@@ -75439,7 +75739,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "uRJ" = (
 /obj/structure/table,
 /obj/item/kitchen/fork/plastic,
@@ -75725,7 +76025,7 @@
 "uWq" = (
 /obj/structure/thermoplastic,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "uWu" = (
 /obj/structure/flora/grass/green/style_random,
 /obj/structure/sign/warning/directional/south,
@@ -76129,7 +76429,7 @@
 "vcG" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/metro_control_room/center_control_room)
 "vcO" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/dark,
@@ -76258,7 +76558,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/trail,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "veK" = (
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
@@ -76289,7 +76589,7 @@
 "vfg" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/garbage_corner)
 "vfj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -76521,7 +76821,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "vjq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -76577,7 +76877,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "vkk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -76586,7 +76886,7 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/turf_decal/trimline/yellow/warning,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "vkz" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/stripes/line{
@@ -76988,7 +77288,7 @@
 "vpe" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "vpg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77123,7 +77423,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "vrw" = (
 /obj/machinery/button/door/directional/west{
 	id = "xenobio3";
@@ -77135,7 +77435,7 @@
 "vrA" = (
 /obj/structure/transport/linear/public,
 /turf/open/space/basic,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "vrC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77366,6 +77666,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"vuT" = (
+/turf/open/genturf,
+/area/station/metro/abandoned/abandoned_collector)
 "vuW" = (
 /obj/structure/closet/boxinggloves,
 /obj/structure/sign/warning/electric_shock/directional/south,
@@ -77617,7 +77920,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/trail,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/outrivals_station)
 "vyd" = (
 /obj/machinery/modular_computer/preset/id,
 /turf/open/floor/carpet/royalblue,
@@ -78018,7 +78321,7 @@
 /obj/item/flashlight/lamp,
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/metro_control_room/center_control_room)
 "vEJ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -78463,7 +78766,7 @@
 	dir = 10
 	},
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "vKn" = (
 /obj/structure/railing{
 	dir = 1
@@ -78472,7 +78775,7 @@
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "vKq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78688,6 +78991,10 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/dark,
 /area/station/ai/upload/chamber)
+"vOF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/abandoned/abandoned_north_east_tunnel)
 "vOG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78736,6 +79043,11 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"vPp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "vPx" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/workout)
@@ -78768,7 +79080,7 @@
 "vQb" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/metro_control_room/center_control_room)
 "vQj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79126,7 +79438,7 @@
 	name = "service reservoir"
 	},
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/metro_control_room/center_control_room)
 "vVt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79233,7 +79545,7 @@
 /obj/structure/cable,
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "vWU" = (
 /obj/structure/table/glass,
 /obj/item/book/bible,
@@ -79316,6 +79628,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
+"vXL" = (
+/obj/structure/tram/alt/titanium,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "vXU" = (
 /obj/item/toy/snowball,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -79521,7 +79837,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/metro_control_room/center_control_room)
 "waL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80092,7 +80408,7 @@
 /obj/structure/thermoplastic,
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "wkb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/sign/warning/gas_mask/directional/north,
@@ -80329,7 +80645,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/chem_pile,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "wor" = (
 /turf/open/openspace,
 /area/station/medical/medbay/aft)
@@ -80632,6 +80948,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
+"wth" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/metro/metro_control_room/center_control_room)
 "wtj" = (
 /obj/structure/flora/grass/brown/style_2,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -80712,7 +81032,7 @@
 "wuN" = (
 /obj/structure/tram,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "wvk" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/decal/cleanable/blood/oil/slippery,
@@ -81077,7 +81397,7 @@
 "wAm" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/north_tunnel)
 "wAv" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -81309,6 +81629,12 @@
 "wDg" = (
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
+"wDh" = (
+/obj/structure/tram/spoiler{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/south_tunnel)
 "wDr" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -81318,7 +81644,7 @@
 /obj/effect/decal/cleanable/plastic,
 /obj/machinery/light/small/red/directional/west,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "wDH" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -81518,7 +81844,7 @@
 /turf/open/floor/iron/stairs/medium{
 	dir = 4
 	},
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "wGE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -81919,7 +82245,12 @@
 	dir = 2
 	},
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
+"wMR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/metro/center_station)
 "wMT" = (
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron,
@@ -83423,7 +83754,7 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/arrivals_station)
 "xfZ" = (
 /obj/structure/flora/bush/snow/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -84087,7 +84418,7 @@
 "xpI" = (
 /obj/effect/decal/cleanable/blood/oil/slippery,
 /turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "xpJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -84338,6 +84669,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"xtP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/station/metro/center_station)
 "xtQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -84756,7 +85092,7 @@
 /obj/effect/decal/cleanable/fuel_pool,
 /obj/effect/decal/cleanable/ants,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/abandoned/garbage_corner)
 "xyn" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -84899,7 +85235,7 @@
 /obj/machinery/light/warm/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "xzH" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -85852,7 +86188,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "xMh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
@@ -85869,6 +86205,12 @@
 "xMq" = (
 /turf/closed/mineral/random/snow,
 /area/icemoon/underground/explored)
+"xMP" = (
+/obj/structure/thermoplastic,
+/obj/structure/thermoplastic/light,
+/obj/structure/chair/sofa/bench/tram/solo,
+/turf/open/floor/plating,
+/area/station/metro/train_tunnels/north_tunnel)
 "xMQ" = (
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/carpet,
@@ -86037,6 +86379,12 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/station/holodeck/rec_center)
+"xPX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/metro/outrivals_station)
 "xQf" = (
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
@@ -86122,7 +86470,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "xQX" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Arrivals Hallway South"
@@ -87238,7 +87586,7 @@
 	name = "wooden barricade (CLOSED)"
 	},
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/metro/train_tunnels/south_tunnel)
 "ygL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/structure/crate,
@@ -87268,6 +87616,12 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"ygZ" = (
+/obj/structure/fence{
+	dir = 2
+	},
+/turf/open/floor/iron/smooth,
+/area/station/metro/arrivals_station)
 "yhe" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
@@ -87451,7 +87805,7 @@
 	},
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/station/metro/center_station)
 "yld" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -99464,7 +99818,7 @@ oSU
 oSU
 oSU
 oSU
-oSU
+bGR
 oSU
 oSU
 oSU
@@ -102025,13 +102379,13 @@ oSU
 aVL
 aVL
 aVL
-gFX
-gFX
-gFX
-gFX
-gFX
+aVL
+mlt
+mlt
+mlt
+mlt
 nrp
-lhB
+esO
 thA
 iDt
 ghx
@@ -102286,10 +102640,10 @@ ulH
 oIv
 lMG
 ffL
-gFX
-gFX
-gFX
-gFX
+mlt
+mlt
+mlt
+mlt
 ghx
 ghx
 ghx
@@ -102539,14 +102893,14 @@ oSU
 aVL
 cUB
 jUd
-gFX
+aVL
 ewh
 gEb
-eHt
+diw
 kcR
 nTH
 nTH
-gFX
+mlt
 ghx
 ghx
 ghx
@@ -102796,14 +103150,14 @@ oSU
 aVL
 avT
 aVL
-gFX
+aVL
 frp
 dIu
-kdm
+rfr
 uRA
 nTH
 nTH
-gFX
+mlt
 ghx
 ghx
 ghx
@@ -103053,14 +103407,14 @@ oSU
 oSU
 oSU
 oSU
-gFX
+mlt
 nsx
 vjp
 tJH
-gFX
-gFX
-gFX
-gFX
+mlt
+mlt
+mlt
+mlt
 ghx
 ghx
 ghx
@@ -103309,14 +103663,14 @@ oSU
 oSU
 oSU
 oSU
-gFX
-gFX
-wMB
+mlt
+mlt
+ygZ
 krj
 eNZ
-wMB
+ygZ
 jsb
-gFX
+mlt
 ghx
 ghx
 ghx
@@ -103566,12 +103920,12 @@ thA
 thA
 thA
 thA
-gFX
+mlt
 ftF
-cvr
-gVx
+qGA
+aJN
 jup
-cLf
+jiY
 kuF
 rVr
 ghx
@@ -103823,14 +104177,14 @@ thA
 thA
 thA
 thA
-gFX
-qnn
+mlt
+tcV
 laq
 thB
 rWJ
 thB
-gFX
-gFX
+mlt
+mlt
 ghx
 ghx
 thA
@@ -104080,13 +104434,13 @@ thA
 thA
 thA
 thA
-gFX
+mlt
 kJS
 uJW
-cjI
+boY
 aMC
-wuN
-nLK
+gcH
+sdC
 rVr
 ghx
 ghx
@@ -104337,13 +104691,13 @@ thA
 thA
 thA
 thA
-gFX
-cvr
-gFX
+mlt
+qGA
+mlt
 aMC
 uWq
 bKQ
-wuN
+gcH
 rVr
 ghx
 ghx
@@ -104594,13 +104948,13 @@ thA
 thA
 thA
 thA
-gFX
+mlt
 qJB
 cpd
 eiQ
 uWq
-fHU
-wuN
+fyO
+gcH
 rVr
 ghx
 ghx
@@ -104852,13 +105206,13 @@ thA
 ghx
 ghx
 rVr
-cLf
+jiY
 qGk
 aMC
 wjW
 uWq
 aMC
-gFX
+mlt
 ghx
 ghx
 thA
@@ -105109,9 +105463,9 @@ ghx
 ghx
 ghx
 rVr
-pYj
+lFA
 qGk
-wuN
+gcH
 rOU
 qFF
 gTE
@@ -105623,8 +105977,8 @@ ghx
 ghx
 ghx
 rVr
-cvr
-gFX
+qGA
+mlt
 aMC
 aMC
 oge
@@ -105879,14 +106233,14 @@ thA
 thA
 ghx
 ghx
-gFX
-cvr
+mlt
+qGA
 xfV
 txh
 cqV
 uWq
-wuN
-gFX
+gcH
+mlt
 ghx
 ghx
 iDt
@@ -106136,12 +106490,12 @@ thA
 thA
 thA
 ghx
-gFX
+mlt
 dLW
 oWp
-wuN
-nov
-dzI
+gcH
+xMP
+pFD
 aMC
 rVr
 ghx
@@ -106394,11 +106748,11 @@ thA
 thA
 ghx
 rVr
-cvr
+qGA
 otE
 aMC
 wjW
-dzI
+pFD
 eiQ
 rVr
 ghx
@@ -106651,8 +107005,8 @@ ghx
 thA
 ghx
 rVr
-cvr
-gFX
+qGA
+mlt
 aMC
 duW
 vrk
@@ -106913,8 +107267,8 @@ tbc
 eiQ
 uWq
 kdq
-wuN
-gFX
+gcH
+mlt
 ghx
 ghx
 iDt
@@ -107421,13 +107775,13 @@ ghx
 ghx
 ghx
 ghx
-gFX
+mlt
 eha
 uOd
-vBN
-vBN
-lhB
-vBN
+pGD
+pGD
+gpH
+pGD
 ccx
 ghx
 ghx
@@ -107678,14 +108032,14 @@ ghx
 ghx
 ghx
 ghx
-gFX
-gFX
-gFX
+mlt
+mlt
+mlt
 sJx
 sJx
 hwe
 sJx
-gFX
+mlt
 ghx
 ghx
 iDt
@@ -107937,12 +108291,12 @@ ghx
 ghx
 ghx
 ghx
-nrp
-vBN
-vBN
-lhB
-vBN
-nrp
+rzh
+pGD
+pGD
+gpH
+pGD
+rzh
 ghx
 ghx
 hpE
@@ -108195,10 +108549,10 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
-vBN
-vBN
+pGD
+pGD
+pGD
+pGD
 ghx
 ghx
 ghx
@@ -108452,10 +108806,10 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
-vBN
-vBN
+pGD
+pGD
+pGD
+pGD
 ghx
 ghx
 ghx
@@ -108709,10 +109063,10 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
-vBN
-vBN
+pGD
+pGD
+pGD
+pGD
 ghx
 ghx
 ghx
@@ -108966,10 +109320,10 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
-nHU
-vBN
+pGD
+pGD
+dPN
+pGD
 ghx
 ghx
 ghx
@@ -109223,10 +109577,10 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
-vBN
-vBN
+pGD
+pGD
+pGD
+pGD
 ghx
 ghx
 ghx
@@ -109480,10 +109834,10 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
-vBN
-vBN
+pGD
+pGD
+pGD
+pGD
 ghx
 ghx
 ghx
@@ -109737,10 +110091,10 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
-vBN
-vBN
+pGD
+pGD
+pGD
+pGD
 thA
 xuo
 psb
@@ -109994,10 +110348,10 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
-vBN
-vBN
+pGD
+pGD
+pGD
+pGD
 thA
 xuo
 xuo
@@ -110250,11 +110604,11 @@ thA
 ghx
 ghx
 ghx
-nrp
-vBN
-vBN
-vBN
-vBN
+rzh
+pGD
+pGD
+pGD
+pGD
 rzh
 thA
 thA
@@ -110508,10 +110862,10 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
-vBN
-vBN
+pGD
+pGD
+pGD
+pGD
 thA
 thA
 thA
@@ -110765,10 +111119,10 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
-vBN
-vBN
+pGD
+pGD
+pGD
+pGD
 thA
 thA
 thA
@@ -111022,10 +111376,10 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
-vBN
-vBN
+pGD
+pGD
+pGD
+pGD
 thA
 thA
 thA
@@ -111279,10 +111633,10 @@ ghx
 ghx
 ghx
 ghx
-vBN
-lhB
-vBN
-vBN
+pGD
+gpH
+pGD
+pGD
 thA
 thA
 thA
@@ -111536,10 +111890,10 @@ ghx
 ghx
 ghx
 ghx
-nHU
-lhB
-vBN
-vBN
+dPN
+gpH
+pGD
+pGD
 thA
 thA
 thA
@@ -111793,10 +112147,10 @@ ghx
 ghx
 ghx
 ghx
-vBN
-lhB
-lhB
-vBN
+pGD
+gpH
+gpH
+pGD
 thA
 oSU
 oSU
@@ -112050,12 +112404,12 @@ ghx
 ghx
 ghx
 ghx
-vBN
-vBN
-lhB
-vBN
-vBN
-gFX
+pGD
+pGD
+gpH
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -112305,14 +112659,14 @@ thA
 ghx
 ghx
 ghx
-vBN
-lhB
-vBN
-vBN
-vBN
-vBN
-vBN
-gFX
+pGD
+gpH
+pGD
+pGD
+pGD
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -112562,14 +112916,14 @@ thA
 ghx
 ghx
 ghx
-nrp
-lhB
-vBN
-vBN
-vBN
-vBN
-nrp
-gFX
+rzh
+gpH
+pGD
+pGD
+pGD
+pGD
+rzh
+pXV
 oSU
 oSU
 oSU
@@ -112818,15 +113172,15 @@ thA
 thA
 ghx
 ghx
-gFX
-vBN
-vBN
-vBN
-vBN
-lhB
-vBN
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+pGD
+gpH
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -113075,15 +113429,15 @@ thA
 ghx
 thA
 ghx
-gFX
-vBN
-vBN
+pXV
+pGD
+pGD
 sJx
 sJx
 hwe
 sJx
-vBN
-gFX
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -113332,15 +113686,15 @@ psb
 etz
 thA
 thA
-gFX
-vBN
-vBN
-vBN
-vBN
-pxg
-vBN
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+pGD
+vPp
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -113589,15 +113943,15 @@ psb
 thA
 thA
 thA
-gFX
-vBN
-vBN
-vBN
-vBN
-lhB
-vBN
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+pGD
+gpH
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -113846,15 +114200,15 @@ psb
 thA
 thA
 thA
-gFX
-vBN
-vBN
-lhB
-vBN
-pxg
-vBN
-vBN
-gFX
+pXV
+pGD
+pGD
+gpH
+pGD
+vPp
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -114103,15 +114457,15 @@ psb
 thA
 thA
 thA
-gFX
-vBN
-vBN
-vBN
-vBN
-pxg
-lhB
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+pGD
+vPp
+gpH
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -114360,15 +114714,15 @@ psb
 thA
 thA
 thA
-gFX
-vBN
-vBN
-vBN
-lhB
-lhB
-lhB
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+gpH
+gpH
+gpH
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -114617,15 +114971,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-vBN
-vBN
-lhB
-lhB
-lhB
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+gpH
+gpH
+gpH
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -114874,15 +115228,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-vBN
-vBN
-lhB
-lhB
-vBN
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+gpH
+gpH
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -115131,15 +115485,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-vBN
-vBN
-vBN
-gQB
-vBN
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+pGD
+aYR
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -115388,15 +115742,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-lhB
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+pGD
+pGD
+gpH
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -115645,15 +115999,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-lhB
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+pGD
+pGD
+gpH
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -115902,15 +116256,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-vBN
-vBN
-vBN
-nHU
-vBN
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+pGD
+dPN
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -116159,15 +116513,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-vBN
-vBN
-lhB
-lhB
-vBN
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+gpH
+gpH
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -116416,15 +116770,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-vBN
-lhB
-pxg
-vBN
-vBN
-vBN
-gFX
+pXV
+pGD
+pGD
+gpH
+vPp
+pGD
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -116673,15 +117027,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-vBN
-lhB
-lhB
-vBN
-vBN
-vBN
-gFX
+pXV
+pGD
+pGD
+gpH
+gpH
+pGD
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -116930,15 +117284,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-lhB
-vBN
-lhB
-vBN
-vBN
-vBN
-gFX
+pXV
+pGD
+gpH
+pGD
+gpH
+pGD
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -117187,15 +117541,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-lhB
-vBN
-lhB
-vBN
-vBN
-vBN
-gFX
+pXV
+pGD
+gpH
+pGD
+gpH
+pGD
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -117444,15 +117798,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-lhB
-vBN
-vBN
-vBN
-vBN
-vBN
-gFX
+pXV
+pGD
+gpH
+pGD
+pGD
+pGD
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -117701,15 +118055,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-lhB
-vBN
-lhB
-vBN
-vBN
-vBN
-gFX
+pXV
+pGD
+gpH
+pGD
+gpH
+pGD
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -117958,15 +118312,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-lhB
-vBN
-vBN
-vBN
-vBN
-vBN
-gFX
+pXV
+pGD
+gpH
+pGD
+pGD
+pGD
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -118215,15 +118569,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-lhB
-vBN
-vBN
-nHU
-vBN
-vBN
-gFX
+pXV
+pGD
+gpH
+pGD
+pGD
+dPN
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
@@ -118472,15 +118826,15 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-vBN
-vBN
-lhB
-vBN
-vBN
+pXV
+pGD
+pGD
+pGD
+gpH
+pGD
+pGD
 wAm
-gFX
+pXV
 oSU
 oSU
 oSU
@@ -118729,22 +119083,22 @@ thA
 thA
 thA
 thA
-gFX
-vBN
-vBN
-lhB
-vBN
-vBN
-vBN
-vBN
-gFX
+pXV
+pGD
+pGD
+gpH
+pGD
+pGD
+pGD
+pGD
+pXV
 oSU
 oSU
-gFX
-gFX
-gFX
-gFX
-gFX
+bBl
+bBl
+bBl
+bBl
+bBl
 oSU
 oSU
 thA
@@ -118986,34 +119340,34 @@ thA
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-lhB
-vBN
-vBN
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+gpH
+pGD
+pGD
+pGD
+pXV
 oSU
 oSU
-gFX
+bBl
 vEH
 afk
 kIu
-gFX
+bBl
 oSU
 oSU
 oSU
 thA
 thA
 thA
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
+cGX
+cGX
+cGX
+cGX
+cGX
+cGX
 ghx
 ghx
 iDt
@@ -119243,34 +119597,34 @@ thA
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-vBN
+pXV
+pGD
+pGD
+pGD
+pGD
+pGD
+pGD
 mGh
-gFX
-gFX
-gFX
-gFX
+bTI
+bTI
+bTI
+bBl
 vcG
 seb
-gFX
-gFX
-gFX
+bBl
+bBl
+bBl
 oSU
 oSU
 oSU
-gFX
-gFX
+bTI
+bTI
 gxu
 msP
 msP
 msP
 msP
-gFX
+cGX
 ghx
 ghx
 ghx
@@ -119500,34 +119854,34 @@ thA
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-vBN
+pXV
+pGD
+pGD
+pGD
+pGD
+pGD
+pGD
 aFY
-eHt
-gFX
-vBN
-gFX
+gYI
+bTI
+ida
+bBl
 cUg
-cvr
+wth
 vVn
 cYS
-gFX
+bBl
 oSU
 oSU
 oSU
-gFX
+bTI
 ruu
 lDp
 bdn
 ygI
 qcJ
 bdn
-gFX
+cGX
 ghx
 thA
 thA
@@ -119757,34 +120111,34 @@ thA
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-pxg
-vBN
-vBN
+pXV
+pGD
+pGD
+pGD
+vPp
+pGD
+pGD
 vKn
 wMB
-gFX
-vBN
-gFX
+bTI
+ida
+bBl
 vQb
 waK
-cvr
-cvr
-gFX
+wth
+wth
+bBl
 oSU
 oSU
 oSU
-gFX
-csZ
+bTI
+uEA
 rxZ
-lhB
-lhB
-lhB
+aeZ
+aeZ
+aeZ
 wop
-gFX
+cGX
 thA
 thA
 thA
@@ -120014,38 +120368,38 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-pxg
-vBN
-vBN
+pXV
+pGD
+pGD
+pGD
+vPp
+pGD
+pGD
 kxF
-eHt
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
+gYI
+bTI
+bTI
+bBl
+bBl
+bBl
+bBl
 chT
-gFX
-gFX
-gFX
-gFX
-gFX
+bBl
+bTI
+bTI
+bTI
+bTI
 rAE
 lnK
 nHU
-vBN
-lhB
+nib
+aeZ
 qkn
-gFX
-gFX
-gFX
-gFX
-gFX
+neA
+neA
+neA
+neA
+neA
 oSU
 oSU
 oSU
@@ -120271,38 +120625,38 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-lhB
-vBN
-vBN
+pXV
+pGD
+pGD
+pGD
+gpH
+pGD
+pGD
 kku
-usr
+gzt
 nqh
 wDA
-gFX
-gFX
+bTI
+bTI
 luo
-usr
-pEs
+gzt
+ldF
 hgg
 dmC
-pEs
-pEs
+ldF
+ldF
 bKb
 lyD
 huy
 cjI
-aMC
+vXL
 wuN
 nLK
 mKr
 deW
 qoS
-oWa
-gFX
+dQc
+neA
 oSU
 oSU
 oSU
@@ -120528,38 +120882,38 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-lhB
-vBN
+pXV
+pGD
+pGD
+pGD
+pGD
+gpH
+pGD
 djd
 cBz
-kdm
+gPk
 fxZ
-gFX
-nTH
+bTI
+kdG
 eFq
 msM
-uQJ
+xtP
 cBz
 ilw
 bJv
 aeV
 lLs
-gVx
-jZR
-aMC
+flr
+nKc
+vXL
 dzI
-bKQ
+jfa
 wuN
 vfg
 nmS
 udj
 ohN
-gFX
+neA
 oSU
 oSU
 oSU
@@ -120785,38 +121139,38 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-lhB
-lhB
-vBN
+pXV
+pGD
+pGD
+pGD
+gpH
+gpH
+pGD
 prM
 hYC
-kdm
+gPk
 bJv
-gFX
-nTH
+bTI
+kdG
 pnI
-eHt
-qnn
-eHt
-eHt
-kdm
-eHt
-cLf
+gYI
+wMR
+gYI
+gYI
+gPk
+gYI
+gfc
 sUe
 iva
-eiQ
+umI
 dzI
 cyp
 wuN
 vfg
 skm
 xyi
-uBk
-gFX
+eoo
+neA
 oSU
 oSU
 oSU
@@ -121042,38 +121396,38 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-lhB
-vBN
-vBN
+pXV
+pGD
+pGD
+pGD
+gpH
+pGD
+pGD
 ykU
-gFX
-kdm
-eHt
-wlK
-gFX
+bTI
+gPk
+gYI
+iFJ
+bTI
 xzx
-qJB
+jOY
 vkh
-kdm
-eHt
-eHt
-kdm
-gFX
+gPk
+gYI
+gYI
+gPk
+bTI
 vWR
 iva
-aMC
-uWq
+vXL
+gRS
 dzI
-aMC
-gFX
-gFX
-gFX
-gFX
-gFX
+vXL
+neA
+neA
+neA
+neA
+neA
 oSU
 oSU
 oSU
@@ -121299,34 +121653,34 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-nHU
-vBN
-lhB
-lhB
-vBN
+pXV
+pGD
+dPN
+pGD
+gpH
+gpH
+pGD
 prM
 cBz
-eHt
-eHt
-kdm
-eHt
+gYI
+gYI
+gPk
+gYI
 jor
-cLf
-cLf
-cLf
-eHt
-eHt
-kdm
-mJE
-gVx
+gfc
+gfc
+gfc
+gYI
+gYI
+gPk
+rtV
+flr
 iva
 wuN
-rOU
-qFF
+sAf
+fPq
 wuN
-gFX
+cGX
 oSU
 oSU
 oSU
@@ -121556,16 +121910,16 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-pxg
-vBN
+pXV
+pGD
+pGD
+pGD
+pGD
+vPp
+pGD
 gBp
 rls
-eHt
+gYI
 vKk
 qWR
 gbi
@@ -121576,14 +121930,14 @@ aeV
 bJv
 bJv
 xpI
-eHt
+gYI
 sWR
-jZR
-aMC
+nKc
+vXL
 bed
 jhY
 wuN
-gFX
+cGX
 oSU
 oSU
 oSU
@@ -121813,34 +122167,34 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-lhB
-vBN
+pXV
+pGD
+pGD
+pGD
+pGD
+gpH
+pGD
 thL
-tgU
+ert
 dTo
 jRP
-usr
-usr
+gzt
+gzt
 cnF
 rKW
 obY
 cnF
 idf
-usr
-usr
-usr
+gzt
+gzt
+gzt
 rCM
 dbl
-aMC
-aMC
-eiQ
-aMC
-gFX
+vXL
+vXL
+umI
+vXL
+cGX
 oSU
 oSU
 oSU
@@ -122070,34 +122424,34 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-vBN
+pXV
+pGD
+pGD
+pGD
+pGD
+pGD
+pGD
 xMf
 iVP
-gFX
-gFX
-vBN
-vBN
-vBN
-gFX
+bTI
+bTI
+ida
+ida
+ida
+bTI
 jPa
 ano
-gFX
-msP
+bTI
+oQs
 oHT
-gFX
+bTI
 upJ
 glg
-txh
+dOm
 lMv
-uWq
+gRS
 wuN
-gFX
+cGX
 oSU
 oSU
 oSU
@@ -122327,34 +122681,34 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-vBN
+pXV
+pGD
+pGD
+pGD
+pGD
+pGD
+pGD
 rBl
 hrV
-gFX
-gFX
-vBN
-vBN
-vBN
-gFX
+bTI
+bTI
+ida
+ida
+ida
+bTI
 hGT
 ffu
-gFX
+bTI
 rNk
 bIf
-gFX
+bTI
 wMB
 nVV
 wuN
 nov
 dzI
-aMC
-gFX
+vXL
+cGX
 oSU
 oSU
 oSU
@@ -122584,34 +122938,34 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-lhB
-vBN
+pXV
+pGD
+pGD
+pGD
+pGD
+gpH
+pGD
 aFY
 cvb
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
+bTI
+bTI
+bTI
+bTI
+bTI
+bTI
 ikf
 teO
-gFX
+bTI
 lCf
 dIF
-gFX
+bTI
 tow
 hLW
-aMC
+vXL
 dzI
 dzI
 wuN
-gFX
+cGX
 oSU
 oSU
 oSU
@@ -122841,34 +123195,34 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-lhB
-vBN
-jfP
-gFX
-gFX
+pXV
+pGD
+pGD
+pGD
+pGD
+gpH
+pGD
+pvX
+bTI
+bTI
 oSU
 oSU
 oSU
 oSU
-gFX
+bTI
 bjE
 fJD
-gFX
+bTI
 ksO
 pRu
-gFX
+bTI
 nfx
 wGy
-aMC
+vXL
 dzI
-bKQ
+jfa
 wuN
-gFX
+cGX
 oSU
 oSU
 oSU
@@ -123098,34 +123452,34 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-pxg
-vBN
-vBN
-gFX
+pXV
+pGD
+pGD
+pGD
+pGD
+vPp
+pGD
+pGD
+pXV
 oSU
 oSU
 oSU
 oSU
 oSU
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
-vBN
-eiQ
-uWq
+bTI
+bTI
+bTI
+bTI
+bTI
+bTI
+bTI
+bTI
+nib
+umI
+gRS
 fHU
-aMC
-gFX
+vXL
+cGX
 oSU
 oSU
 oSU
@@ -123355,15 +123709,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-lhB
-lhB
-ygI
-gFX
+pXV
+pGD
+pGD
+pGD
+pGD
+gpH
+gpH
+ufA
+pXV
 oSU
 oSU
 oSU
@@ -123376,13 +123730,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
+cGX
 nHU
-kJN
-aMC
+sNw
+vXL
 wuN
-iOk
-gFX
+wDh
+cGX
 oSU
 oSU
 oSU
@@ -123612,15 +123966,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-lhB
-lhB
-gFX
+euu
+aFD
+aFD
+aFD
+aFD
+aFD
+vOF
+vOF
+euu
 oSU
 oSU
 oSU
@@ -123633,13 +123987,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-gFX
+cGX
+nib
+nib
+nib
+nib
+nib
+cGX
 oSU
 oSU
 oSU
@@ -123869,15 +124223,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-lhB
-vBN
-gFX
+euu
+aFD
+aFD
+aFD
+aFD
+aFD
+vOF
+aFD
+euu
 oSU
 oSU
 oSU
@@ -123890,13 +124244,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
-vBN
-vBN
-vBN
-gFX
+cGX
+aeZ
+aeZ
+nib
+nib
+nib
+cGX
 oSU
 oSU
 oSU
@@ -124126,15 +124480,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-lhB
-uBk
-gFX
+euu
+aFD
+aFD
+aFD
+aFD
+aFD
+vOF
+cFH
+euu
 oSU
 oSU
 oSU
@@ -124147,13 +124501,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-vBN
-vBN
-vBN
-vBN
-gFX
+cGX
+aeZ
+nib
+nib
+nib
+nib
+cGX
 oSU
 oSU
 oSU
@@ -124383,15 +124737,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-lhB
-vBN
-gFX
+euu
+aFD
+aFD
+aFD
+aFD
+aFD
+vOF
+aFD
+euu
 oSU
 oSU
 oSU
@@ -124404,13 +124758,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-vBN
-vBN
-vBN
-vBN
-gFX
+cGX
+aeZ
+nib
+nib
+nib
+nib
+cGX
 oSU
 oSU
 oSU
@@ -124640,15 +124994,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-lhB
-vBN
-gFX
+euu
+aFD
+aFD
+aFD
+aFD
+aFD
+vOF
+aFD
+euu
 oSU
 oSU
 oSU
@@ -124661,13 +125015,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
-vBN
-vBN
-vBN
-gFX
+cGX
+aeZ
+aeZ
+nib
+nib
+nib
+cGX
 oSU
 oSU
 oSU
@@ -124897,15 +125251,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
+euu
+aFD
+aFD
+aFD
+aFD
+aFD
 pxg
-vBN
-gFX
+aFD
+euu
 oSU
 oSU
 oSU
@@ -124918,13 +125272,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-pxg
-lhB
-vBN
-vBN
-gFX
+cGX
+nib
+kHD
+aeZ
+nib
+nib
+cGX
 oSU
 oSU
 oSU
@@ -125154,15 +125508,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-lhB
-lhB
-vBN
-gFX
+euu
+aFD
+aFD
+aFD
+aFD
+vOF
+vOF
+aFD
+euu
 oSU
 oSU
 oSU
@@ -125175,13 +125529,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-lhB
-lhB
-vBN
-vBN
-gFX
+cGX
+nib
+aeZ
+aeZ
+nib
+nib
+cGX
 oSU
 oSU
 oSU
@@ -125411,15 +125765,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-lhB
-vBN
-vBN
-gFX
+euu
+aFD
+aFD
+aFD
+aFD
+vOF
+aFD
+aFD
+euu
 oSU
 oSU
 oSU
@@ -125432,13 +125786,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-pxg
-vBN
-vBN
-gFX
+cGX
+nib
+nib
+kHD
+nib
+nib
+cGX
 oSU
 oSU
 oSU
@@ -125668,15 +126022,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-lhB
-lhB
-vBN
-gFX
+euu
+aFD
+aFD
+aFD
+aFD
+vOF
+vOF
+aFD
+euu
 oSU
 oSU
 oSU
@@ -125689,13 +126043,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-pxg
-vBN
-vBN
-gFX
+cGX
+nib
+nib
+kHD
+nib
+nib
+cGX
 oSU
 oSU
 oSU
@@ -125925,15 +126279,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-vBN
-vBN
-gFX
+euu
+aFD
+aFD
+aFD
+aFD
+aFD
+aFD
+aFD
+euu
 oSU
 oSU
 oSU
@@ -125946,13 +126300,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
-lhB
-vBN
-gFX
+cGX
+nib
+nib
+aeZ
+aeZ
+nib
+cGX
 oSU
 oSU
 oSU
@@ -126182,15 +126536,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
+euu
+aFD
+aFD
+aFD
 pxg
-gQB
+gWs
 oWa
-vBN
-gFX
+aFD
+euu
 oSU
 oSU
 oSU
@@ -126203,13 +126557,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
-lhB
-vBN
-gFX
+cGX
+nib
+nib
+aeZ
+aeZ
+nib
+cGX
 oSU
 oSU
 oSU
@@ -126439,15 +126793,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
-vBN
-gQB
-lhB
-lhB
-gFX
+euu
+aFD
+aFD
+vOF
+aFD
+gWs
+vOF
+vOF
+euu
 oSU
 oSU
 oSU
@@ -126460,13 +126814,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-lhB
-vBN
-gFX
+cGX
+nib
+nib
+nib
+aeZ
+nib
+cGX
 oSU
 oSU
 oSU
@@ -126696,15 +127050,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
-lhB
-lhB
-lhB
-lhB
-gFX
+euu
+aFD
+aFD
+vOF
+vOF
+vOF
+vOF
+vOF
+euu
 oSU
 oSU
 oSU
@@ -126717,13 +127071,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-gFX
+cGX
+nib
+nib
+nib
+nib
+nib
+cGX
 oSU
 oSU
 oSU
@@ -126953,15 +127307,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
+euu
+aFD
 oWa
-lhB
-lhB
-lhB
-vBN
-vBN
-gFX
+vOF
+vOF
+vOF
+aFD
+aFD
+euu
 oSU
 oSU
 oSU
@@ -126974,13 +127328,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-lhB
-vBN
-gFX
+cGX
+nib
+nib
+nib
+aeZ
+nib
+cGX
 oSU
 oSU
 oSU
@@ -127210,15 +127564,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
-vBN
-lhB
+euu
+aFD
+aFD
+vOF
+aFD
+vOF
 qiu
-vBN
-gFX
+aFD
+euu
 oSU
 oSU
 oSU
@@ -127231,13 +127585,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
-lhB
-lhB
-vBN
-gFX
+cGX
+aeZ
+aeZ
+aeZ
+aeZ
+nib
+cGX
 oSU
 oSU
 oSU
@@ -127467,15 +127821,20 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
+euu
+aFD
+aFD
+vOF
 vpe
 pxg
-vBN
-gFX
-gFX
+aFD
+euu
+euu
+vuT
+vuT
+vuT
+vuT
+vuT
 oSU
 oSU
 oSU
@@ -127483,18 +127842,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-gFX
-lhB
-lhB
-lhB
-lhB
-vBN
-gFX
+cGX
+aeZ
+aeZ
+aeZ
+aeZ
+nib
+cGX
 oSU
 oSU
 oSU
@@ -127724,15 +128078,20 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
+euu
+aFD
+aFD
+vOF
 pxg
 pxg
-vBN
-gFX
-gFX
+aFD
+euu
+euu
+vuT
+vuT
+vuT
+vuT
+vuT
 oSU
 oSU
 oSU
@@ -127740,18 +128099,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-gFX
-lhB
-lhB
-lhB
-pxg
-vBN
-gFX
+cGX
+aeZ
+aeZ
+aeZ
+kHD
+nib
+cGX
 oSU
 oSU
 oSU
@@ -127981,34 +128335,34 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
+euu
+aFD
+aFD
 pxg
-lhB
+vOF
+gWs
+aFD
+euu
+euu
+vuT
+vuT
+vuT
+vuT
+vuT
+oSU
+oSU
+oSU
+oSU
+oSU
+oSU
+oSU
+cGX
+aeZ
+aeZ
+aeZ
 gQB
-vBN
-gFX
-gFX
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-gFX
-lhB
-lhB
-lhB
-gQB
-vBN
-gFX
+nib
+cGX
 oSU
 oSU
 oSU
@@ -128238,15 +128592,20 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
+euu
+aFD
+aFD
 pxg
-lhB
+vOF
 pxg
-vBN
-gFX
-gFX
+aFD
+euu
+euu
+vuT
+vuT
+vuT
+vuT
+vuT
 oSU
 oSU
 oSU
@@ -128254,18 +128613,13 @@ oSU
 oSU
 oSU
 oSU
-oSU
-oSU
-oSU
-oSU
-oSU
-gFX
-lhB
-lhB
-lhB
+cGX
+aeZ
+aeZ
+aeZ
 gQB
-lhB
-gFX
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -128495,15 +128849,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
+euu
+aFD
+aFD
+vOF
 kyd
 cQQ
-vBN
-gFX
-gFX
+aFD
+euu
+euu
 oSU
 oSU
 oSU
@@ -128516,13 +128870,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
-lhB
-pxg
-lhB
-gFX
+cGX
+aeZ
+aeZ
+aeZ
+kHD
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -128752,15 +129106,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
+euu
+aFD
+aFD
 pxg
 veH
 kyd
 oWa
-gFX
-gFX
+euu
+euu
 oSU
 oSU
 oSU
@@ -128773,13 +129127,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
-lhB
+cGX
+aeZ
+aeZ
+aeZ
 gQB
-lhB
-gFX
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -129009,15 +129363,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
+euu
+aFD
+aFD
+aFD
 pxg
-vBN
-vBN
-gFX
-gFX
+aFD
+aFD
+euu
+euu
 oSU
 oSU
 oSU
@@ -129030,13 +129384,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
-lhB
+cGX
+aeZ
+aeZ
+aeZ
 gQB
-lhB
-gFX
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -129266,15 +129620,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
-lhB
-vBN
-vBN
-gFX
-gFX
+euu
+aFD
+aFD
+vOF
+vOF
+aFD
+aFD
+euu
+euu
 oSU
 oSU
 oSU
@@ -129287,13 +129641,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
-lhB
-pxg
-vBN
-gFX
+cGX
+aeZ
+aeZ
+aeZ
+kHD
+nib
+cGX
 oSU
 oSU
 oSU
@@ -129523,17 +129877,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
+euu
+aFD
 hpO
-lhB
-vBN
-vBN
-vBN
+vOF
+aFD
+aFD
+aFD
 oSU
-gFX
-oSU
-oSU
+euu
 oSU
 oSU
 oSU
@@ -129544,13 +129896,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
-lhB
-pxg
-vBN
-gFX
+oSU
+oSU
+cGX
+aeZ
+aeZ
+aeZ
+kHD
+nib
+cGX
 oSU
 oSU
 oSU
@@ -129780,17 +130134,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-vBN
+euu
+aFD
+aFD
+aFD
+aFD
+aFD
+aFD
 oSU
-gFX
-oSU
-oSU
+euu
 oSU
 oSU
 oSU
@@ -129801,13 +130153,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
-pxg
+oSU
+oSU
+cGX
+aeZ
+aeZ
+kHD
 gQB
-vBN
-gFX
+nib
+cGX
 oSU
 oSU
 oSU
@@ -130037,17 +130391,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-lhB
-vBN
-vBN
+euu
+aFD
+aFD
+aFD
+vOF
+aFD
+aFD
 oSU
-gFX
-oSU
-oSU
+euu
 oSU
 oSU
 oSU
@@ -130058,13 +130410,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
-pxg
-pxg
-vBN
-gFX
+oSU
+oSU
+cGX
+aeZ
+aeZ
+kHD
+kHD
+nib
+cGX
 oSU
 oSU
 oSU
@@ -130294,17 +130648,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-vBN
+euu
+aFD
+aFD
+aFD
+aFD
+aFD
+aFD
 oSU
-gFX
-oSU
-oSU
+euu
 oSU
 oSU
 oSU
@@ -130315,13 +130667,15 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-vBN
-gFX
+oSU
+oSU
+cGX
+nib
+nib
+nib
+nib
+nib
+cGX
 oSU
 oSU
 oSU
@@ -130572,13 +130926,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
+cGX
+nib
+nib
+aeZ
 gQB
-lhB
-gFX
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -130829,13 +131183,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
-pxg
-vBN
-gFX
+cGX
+nib
+nib
+aeZ
+kHD
+nib
+cGX
 oSU
 oSU
 oSU
@@ -131086,13 +131440,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
+cGX
+nib
+nib
+aeZ
 gQB
-lhB
-gFX
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -131343,13 +131697,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
+cGX
 uBk
-vBN
-lhB
-pxg
-vBN
-gFX
+nib
+aeZ
+kHD
+nib
+cGX
 oSU
 oSU
 oSU
@@ -131600,13 +131954,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
+cGX
+nib
+nib
+aeZ
 cYv
-vBN
-gFX
+nib
+cGX
 oSU
 oSU
 oSU
@@ -131857,13 +132211,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-pxg
-pxg
-lhB
-gFX
+cGX
+nib
+nib
+kHD
+kHD
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -132114,13 +132468,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-pxg
-pxg
-vBN
-gFX
+cGX
+nib
+nib
+kHD
+kHD
+nib
+cGX
 oSU
 oSU
 oSU
@@ -132371,13 +132725,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-pxg
-pxg
-lhB
-gFX
+cGX
+nib
+nib
+kHD
+kHD
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -132628,13 +132982,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-vBN
-vBN
-lhB
-gFX
+cGX
+nib
+nib
+nib
+nib
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -132885,13 +133239,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-lhB
-lhB
-vBN
-lhB
-gFX
+cGX
+nib
+aeZ
+aeZ
+nib
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -133142,13 +133496,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-lhB
-vBN
-vBN
-lhB
-gFX
+cGX
+nib
+aeZ
+nib
+nib
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -133399,13 +133753,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
-lhB
-lhB
-lhB
-gFX
+cGX
+aeZ
+aeZ
+aeZ
+aeZ
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -133656,13 +134010,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
+cGX
+aeZ
+aeZ
 xQV
-lhB
-lhB
-gFX
+aeZ
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -133913,13 +134267,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
-lhB
-lhB
-pxg
-gFX
+cGX
+aeZ
+aeZ
+aeZ
+aeZ
+kHD
+cGX
 oSU
 oSU
 oSU
@@ -134170,13 +134524,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-lhB
-lhB
-lhB
-lhB
-lhB
-gFX
+cGX
+aeZ
+aeZ
+aeZ
+aeZ
+aeZ
+cGX
 oSU
 oSU
 oSU
@@ -134427,13 +134781,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-lhB
-pxg
-lhB
-lhB
-gFX
+cGX
+nib
+aeZ
+kHD
+aeZ
+aeZ
+cGX
 iDt
 iDt
 iDt
@@ -134684,13 +135038,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-lhB
+cGX
+nib
+aeZ
 gQB
-lhB
-lhB
-gFX
+aeZ
+aeZ
+cGX
 iDt
 iDt
 iDt
@@ -134941,18 +135295,18 @@ oSU
 oSU
 oSU
 oSU
-gFX
-vBN
-vBN
-lhB
-lhB
-vBN
-gFX
-gFX
-gFX
-gFX
+cGX
+nib
+nib
+aeZ
+aeZ
+nib
+fhx
+fhx
+fhx
+fhx
 pYG
-gFX
+fhx
 xMq
 wUm
 iDt
@@ -135197,17 +135551,17 @@ oSU
 oSU
 oSU
 oSU
-gFX
-gFX
-vBN
-vBN
-vBN
-vBN
-lhB
-gFX
-nTH
-nTH
-gFX
+cGX
+cGX
+nib
+nib
+nib
+nib
+aeZ
+fhx
+eUd
+eUd
+fhx
 scr
 apV
 aKb
@@ -135454,13 +135808,13 @@ oSU
 oSU
 oSU
 oSU
-gFX
+fhx
 umB
 jfP
-vBN
-vBN
-vBN
-lhB
+nib
+nib
+nib
+aeZ
 bus
 tar
 ohF
@@ -135711,16 +136065,16 @@ oSU
 oSU
 oSU
 oSU
-gFX
+fhx
 mHb
 jmn
-vBN
-lhB
-vBN
-vBN
+nib
+aeZ
+nib
+nib
 vkk
 eHt
-cBz
+pzJ
 tpb
 cvr
 apV
@@ -135968,19 +136322,19 @@ oSU
 oSU
 oSU
 oSU
-gFX
+fhx
 csZ
 sWm
-vBN
-vBN
-vBN
-lhB
+nib
+nib
+nib
+aeZ
 sPb
 eHt
 rxr
 rml
 cvr
-gFX
+fhx
 xMq
 xMq
 iDt
@@ -136220,24 +136574,24 @@ xMq
 oSU
 oSU
 oSU
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
-rAE
+fhx
+fhx
+fhx
+fhx
+fhx
+fhx
+uCZ
 inW
-vBN
-lhB
-vBN
-vBN
+nib
+aeZ
+nib
+nib
 iod
 kdm
 uQJ
 tpb
 bFU
-gFX
+fhx
 iDt
 xMq
 xMq
@@ -136477,24 +136831,24 @@ xMq
 oSU
 oSU
 oSU
-gFX
+fhx
 vrA
 rEw
 luS
 pAj
 tgU
-lyD
+gLx
 deB
-vBN
-lhB
-lhB
-lhB
+nib
+aeZ
+aeZ
+aeZ
 sPb
 eHt
 cXw
-gFX
+fhx
 pYG
-gFX
+fhx
 oSU
 oSU
 xMq
@@ -136734,22 +137088,22 @@ xMq
 oSU
 oSU
 oSU
-gFX
+fhx
 vrA
 tUw
 eHt
 cLf
-gFX
+fhx
 cvr
 jZR
-vBN
-lhB
-lhB
-vBN
+nib
+aeZ
+aeZ
+nib
 vkk
-bJv
+uDR
 uQJ
-gFX
+fhx
 oSU
 oSU
 oSU
@@ -136991,22 +137345,22 @@ iDt
 oSU
 oSU
 oSU
-gFX
-gFX
+fhx
+fhx
 shP
 aCI
 cLf
 gVx
-vkh
-iva
-vBN
-lhB
-lhB
-vBN
+xPX
+hHm
+nib
+aeZ
+aeZ
+nib
 sPb
 usr
 pEs
-gFX
+fhx
 oSU
 oSU
 oSU
@@ -137249,21 +137603,21 @@ oSU
 oSU
 oSU
 oSU
-gFX
-obY
-bJv
+fhx
+gxn
+uDR
 cLf
 gVx
 kdm
-iva
-vBN
-vBN
-lhB
+hHm
+nib
+nib
+aeZ
 nHU
-gFX
+fhx
 tgU
 cvr
-gFX
+fhx
 oSU
 oSU
 oSU
@@ -137506,21 +137860,21 @@ oSU
 oSU
 oSU
 oSU
-gFX
+fhx
 usr
 eHt
 kdm
 qnn
 eHt
-iva
-vBN
-vBN
-lhB
-vBN
-gFX
+hHm
+nib
+nib
+aeZ
+nib
+fhx
 rsO
 gVx
-gFX
+fhx
 oSU
 oSU
 oSU
@@ -137763,21 +138117,21 @@ oSU
 oSU
 oSU
 oSU
-gFX
+fhx
 usr
-bJv
+uDR
 eHt
 gVx
 gDI
 jZR
-vBN
-lhB
-vBN
-vBN
-gFX
+nib
+aeZ
+nib
+nib
+fhx
 usr
 uQJ
-gFX
+fhx
 oSU
 oSU
 oSU
@@ -138020,21 +138374,21 @@ oSU
 oSU
 oSU
 oSU
-gFX
+fhx
 dhG
-gFX
+fhx
 eHt
-gFX
+fhx
 rsj
 hjK
-vBN
-lhB
-vBN
-vBN
-gFX
+nib
+aeZ
+nib
+nib
+fhx
 kdm
 qnn
-gFX
+fhx
 oSU
 oSU
 oSU
@@ -138277,21 +138631,21 @@ oSU
 oSU
 oSU
 oSU
-gFX
+fhx
 usr
-gFX
+fhx
 eHt
-gFX
+fhx
 cvr
 cmA
-vBN
-vBN
-vBN
-vBN
-gFX
+nib
+nib
+nib
+nib
+fhx
 tgU
 uQJ
-gFX
+fhx
 oSU
 oSU
 oSU
@@ -138534,21 +138888,21 @@ oSU
 oSU
 oSU
 oSU
-gFX
+fhx
 ghe
-bJv
+uDR
 eHt
-bJv
+uDR
 cvr
 cmA
-vBN
-lhB
-vBN
-vBN
-gFX
+nib
+aeZ
+nib
+nib
+fhx
 kdm
 uQJ
-gFX
+fhx
 oSU
 oSU
 oSU
@@ -138789,23 +139143,23 @@ oSU
 oSU
 oSU
 oSU
-gFX
-gFX
-gFX
+fhx
+fhx
+fhx
 cwL
 eHt
 cLf
 cLf
 scr
 cDr
-lhB
-vBN
-vBN
-vBN
-gFX
+aeZ
+nib
+nib
+nib
+fhx
 usr
 cvr
-gFX
+fhx
 oSU
 oSU
 oSU
@@ -139046,23 +139400,23 @@ oSU
 oSU
 oSU
 oSU
-gFX
+fhx
 gze
 qzk
 usr
-bJv
+uDR
 gEH
-bJv
+uDR
 cvr
 deI
-lhB
-vBN
-vBN
-vBN
-gFX
+aeZ
+nib
+nib
+nib
+fhx
 kdm
 aZL
-gFX
+fhx
 oSU
 oSU
 oSU
@@ -139303,23 +139657,23 @@ oSU
 oSU
 oSU
 oSU
-gFX
+fhx
 mLd
 qzk
 bWp
-bJv
+uDR
 cLf
-bJv
+uDR
 qnn
 aRE
-gFX
-gFX
-gFX
-gFX
-gFX
+fhx
+fhx
+fhx
+fhx
+fhx
 tgU
 aZL
-gFX
+fhx
 oSU
 oSU
 oSU
@@ -139560,14 +139914,14 @@ oSU
 oSU
 oSU
 oSU
-gFX
+fhx
 kDZ
 drX
 ptt
 eHt
 gEH
-gFX
-qJB
+fhx
+csU
 pYj
 usr
 eHt
@@ -139576,7 +139930,7 @@ kdm
 ieN
 vxZ
 qnn
-gFX
+fhx
 oSU
 oSU
 oSU
@@ -139817,14 +140171,14 @@ oSU
 oSU
 oSU
 oSU
-gFX
-gFX
-gFX
+fhx
+fhx
+fhx
 mJE
 cLf
-cnF
+cLA
 eHt
-qJB
+csU
 cvr
 gVx
 gVx
@@ -139833,7 +140187,7 @@ uQJ
 gVx
 cvr
 pEs
-gFX
+fhx
 oSU
 oSU
 oSU
@@ -140076,21 +140430,21 @@ oSU
 oSU
 oSU
 oSU
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
-gFX
+fhx
+fhx
+fhx
+fhx
+fhx
+fhx
+fhx
+fhx
+fhx
+fhx
+fhx
+fhx
+fhx
+fhx
+fhx
 oSU
 oSU
 oSU

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -309,6 +309,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/icemoon/underground/explored)
 "afp" = (
@@ -868,13 +869,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
-"anx" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/structure/sign/poster/contraband/kudzu/directional/north,
-/obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "anz" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
@@ -2979,6 +2973,15 @@
 /obj/item/clothing/shoes/jackboots,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"aQi" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "aQj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood,
@@ -3255,11 +3258,6 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
-"aTX" = (
-/obj/machinery/door/window/elevator/right/directional/north,
-/obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "aTZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -3314,10 +3312,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/security/courtroom)
-"aUp" = (
-/obj/item/pickaxe,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit/departure_lounge)
 "aUt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3443,11 +3437,9 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aVL" = (
-/obj/structure/transport/linear/public,
-/obj/structure/barricade/wooden{
-	name = "wooden barricade (CLOSED)"
-	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/report_crimes/directional/north,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "aVM" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -3578,12 +3570,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"aYs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "aYu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/disposalpipe/segment{
@@ -3673,8 +3659,11 @@
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "aZL" = (
-/turf/closed/wall,
-/area/icemoon/underground/unexplored/rivers)
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "aZU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3957,6 +3946,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
 /turf/open/floor/iron/smooth,
 /area/mine/living_quarters)
+"bdw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/left/directional/west,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "bdx" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -4414,11 +4409,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/work)
-"bkj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing/corner,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "bkq" = (
 /obj/machinery/door/window/left/directional/west{
 	name = "Graveyard Access";
@@ -4432,14 +4422,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/service)
-"bkA" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "bkC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5540,11 +5522,6 @@
 /obj/item/trash/semki,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"byx" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "byA" = (
 /obj/structure/table,
 /obj/machinery/firealarm/directional/west,
@@ -5679,12 +5656,6 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/qm)
-"bAk" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
 "bAo" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -5883,16 +5854,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"bCU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
-"bCZ" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/chapel)
 "bDi" = (
 /obj/machinery/door/window/left/directional/west,
 /obj/structure/cable,
@@ -5969,6 +5930,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
+"bEh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "bEk" = (
 /obj/structure/railing/wooden_fence{
 	dir = 4
@@ -6540,6 +6507,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"bLS" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "bLW" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -7093,6 +7066,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"bUj" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "bUx" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/fore)
@@ -7253,16 +7237,9 @@
 /turf/closed/wall/r_wall,
 /area/station/command/eva)
 "bWp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 1
-	},
+/obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/station/hallway/secondary/exit/departure_lounge)
 "bWv" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -7723,12 +7700,14 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
 "ccx" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/west,
+/obj/machinery/lift_indicator/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/area/icemoon/underground/explored)
 "ccz" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -8140,6 +8119,7 @@
 /area/mine/living_quarters)
 "chT" = (
 /obj/machinery/door/airlock/maintenance,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "chZ" = (
@@ -9042,9 +9022,8 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
 "cvr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "cvB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10451,12 +10430,7 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "cOS" = (
-/obj/structure/toiletbong,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/left,
-/obj/structure/thermoplastic/light,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
+/turf/open/openspace,
 /area/icemoon/underground/explored)
 "cPd" = (
 /obj/structure/cable,
@@ -10733,6 +10707,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"cSK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/window/elevator/left/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "cTh" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -10800,12 +10779,10 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "cUB" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "cUG" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /obj/effect/turf_decal/stripes/red/corner{
@@ -12149,6 +12126,7 @@
 /area/icemoon/underground/explored)
 "dmC" = (
 /obj/machinery/vending/snack,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "dmI" = (
@@ -13014,6 +12992,11 @@
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"dys" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "dyA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/effect/turf_decal/stripes/line,
@@ -13215,6 +13198,10 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/fore/lesser)
+"dBt" = (
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "dBB" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot_white,
@@ -13271,10 +13258,6 @@
 "dBZ" = (
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"dCh" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "dCy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -14083,6 +14066,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"dOP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/crayon,
+/obj/effect/spawner/random/trash/deluxe_garbage,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "dOY" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/red/half,
@@ -14194,6 +14183,14 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"dRc" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "dRx" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15179,8 +15176,12 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
 "eha" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron/smooth,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "ehc" = (
 /turf/open/floor/plating,
@@ -16706,9 +16707,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth_large,
 /area/station/command/heads_quarters/hos)
-"eDR" = (
-/turf/open/openspace,
-/area/icemoon/underground/explored)
 "eEl" = (
 /obj/structure/railing{
 	dir = 8
@@ -17577,16 +17575,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/security/brig/upper)
-"eSk" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "eSn" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/assistant,
@@ -17984,12 +17972,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"eWY" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "eXa" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4
@@ -18053,6 +18035,13 @@
 "eXH" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/chemistry)
+"eXJ" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/sign/poster/contraband/kudzu/directional/north,
+/obj/structure/sink/kitchen/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "eYe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19033,6 +19022,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"flJ" = (
+/obj/structure/transport/linear/public,
+/obj/structure/barricade/wooden{
+	name = "wooden barricade (CLOSED)"
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "flK" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/machinery/status_display/ai/directional/north,
@@ -19391,6 +19387,15 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/holding_cell)
+"fsd" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
+"fsg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "fsj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -19810,6 +19815,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
+"fyO" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "fyQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/meter,
@@ -20499,6 +20510,13 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"fKn" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "fKr" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -21769,6 +21787,11 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/engineering/atmos/pumproom)
+"gcY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "gcZ" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray,
@@ -22030,20 +22053,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ghe" = (
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/genturf/blue,
-/area/icemoon/underground/unexplored/rivers/deep/shoreline)
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/iron/dark,
+/area/icemoon/underground/explored)
 "ghl" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"ght" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "ghx" = (
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
@@ -22352,6 +22368,7 @@
 	dir = 4
 	},
 /obj/structure/railing,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "glh" = (
@@ -22985,6 +23002,13 @@
 "gti" = (
 /turf/open/openspace,
 /area/station/maintenance/starboard/aft)
+"gtt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "gtw" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /turf/open/floor/iron/kitchen/diagonal,
@@ -23025,10 +23049,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
-"gul" = (
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "guz" = (
 /obj/structure/rack,
 /obj/item/lighter,
@@ -24294,14 +24314,6 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/lab)
-"gNs" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "gNC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/sign/warning/secure_area/directional/north,
@@ -24400,16 +24412,6 @@
 	},
 /turf/open/openspace,
 /area/station/cargo/storage)
-"gOK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/south{
-	id = "tram_perma_lift"
-	},
-/obj/machinery/lift_indicator/directional/south{
-	linked_elevator_id = "tram_perma_lift"
-	},
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "gOP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -24820,10 +24822,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/stone,
 /area/station/service/bar/atrium)
-"gUw" = (
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "gUx" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -24877,8 +24875,11 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "gVx" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
+/obj/structure/fence/door{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "gVB" = (
 /obj/structure/chair/stool/directional/west,
@@ -25015,11 +25016,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"gXd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/trail,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "gXf" = (
 /obj/machinery/duct,
 /obj/machinery/door/poddoor/preopen{
@@ -25617,6 +25613,7 @@
 /area/station/maintenance/department/cargo)
 "hgg" = (
 /obj/effect/decal/cleanable/blood/oil/slippery,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "hgh" = (
@@ -26077,6 +26074,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
+"hnw" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "hnC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26725,10 +26726,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "hwe" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/structure/thermoplastic,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "hwm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -27121,7 +27121,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "hBG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/holosign/barrier/atmos/tram,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "hBZ" = (
@@ -27695,6 +27695,7 @@
 /area/station/engineering/atmos)
 "hLW" = (
 /obj/structure/railing,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "hLX" = (
@@ -27899,6 +27900,9 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"hOB" = (
+/turf/open/openspace,
+/area/station/hallway/primary/central)
 "hOG" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
@@ -28046,6 +28050,16 @@
 /obj/machinery/light/small/broken/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"hQA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "hQK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table,
@@ -29414,6 +29428,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"ijQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ijT" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
@@ -30036,6 +30056,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/ai/satellite/maintenance)
+"itn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "itt" = (
 /obj/machinery/door/window/brigdoor/right/directional/south{
 	name = "Research Director Observation";
@@ -30625,6 +30653,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"iCN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "iCX" = (
 /obj/machinery/power/solar_control{
 	dir = 4;
@@ -32070,6 +32103,12 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/security/brig)
+"iYX" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "iZj" = (
 /obj/structure/railing/corner/end{
 	dir = 4
@@ -32128,6 +32167,10 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
+"iZM" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "iZO" = (
 /obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -32740,13 +32783,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"jix" = (
-/obj/structure/fence{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "jiU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -32941,11 +32977,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
-"jlz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/west,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "jlF" = (
 /obj/machinery/computer/arcade/amputation{
 	dir = 4
@@ -33003,6 +33034,10 @@
 "jmI" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/workout)
+"jmM" = (
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "jmR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33218,10 +33253,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
-"jqd" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/iron/dark,
-/area/icemoon/underground/explored)
 "jqj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34157,12 +34188,6 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
-"jDL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/crayon,
-/obj/effect/spawner/random/trash/deluxe_garbage,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "jDM" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/flora/bush/sunny/style_random,
@@ -35210,11 +35235,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/science/cytology)
-"jRy" = (
-/obj/structure/thermoplastic/light,
-/obj/machinery/door/airlock/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "jRA" = (
 /turf/open/openspace,
 /area/station/service/bar/atrium)
@@ -35266,6 +35286,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
+"jRY" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "jSa" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/dice,
@@ -35704,10 +35728,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"jZz" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "jZD" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -37260,13 +37280,6 @@
 /obj/structure/mirror/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/mine/laborcamp)
-"kwT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "kwX" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -37681,6 +37694,10 @@
 /obj/structure/sink/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"kBQ" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "kBU" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -37893,12 +37910,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"kEF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/left/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "kEM" = (
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
@@ -38030,6 +38041,13 @@
 	dir = 1
 	},
 /area/station/commons/storage/art)
+"kGK" = (
+/obj/structure/fence{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "kGQ" = (
 /obj/structure/table,
 /obj/item/stamp/head/qm,
@@ -38167,7 +38185,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "kIu" = (
-/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/obj/machinery/power/smes/full,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "kIy" = (
@@ -38290,10 +38309,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "kJS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/status_display/ai/directional/north,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
+/obj/structure/thermoplastic/light,
+/obj/machinery/door/airlock/tram,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "kJU" = (
 /obj/structure/girder,
@@ -38395,11 +38413,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
-"kLk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "kLr" = (
 /obj/structure/table/wood,
@@ -39909,6 +39922,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/fore)
+"lgQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "lgW" = (
 /obj/machinery/meter/monitored/distro_loop,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
@@ -40157,6 +40175,11 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom)
+"lkp" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "lkr" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
@@ -40404,6 +40427,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/eva)
+"loD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/corner,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "loF" = (
 /obj/structure/table/wood,
 /obj/item/toy/mecha/honk{
@@ -40753,6 +40781,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/service)
+"lsZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "ltk" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -41072,11 +41111,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/interior)
-"lxl" = (
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/decal/cleanable/fuel_pool,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "lxu" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -42070,8 +42104,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/armory/upper)
 "lMG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "lMK" = (
@@ -42124,10 +42161,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"lNA" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "lNC" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -42350,12 +42383,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
-"lPN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "lPW" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -42464,14 +42491,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/space_hut/cabin)
-"lRa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "lRc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -43481,11 +43500,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/eva)
-"mhq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "mhx" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/secequipment,
@@ -44254,10 +44268,6 @@
 	dir = 1
 	},
 /area/mine/eva/lower)
-"mto" = (
-/obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "mtq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood,
@@ -44493,22 +44503,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/fore)
-"mxG" = (
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/green/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/duct,
-/obj/structure/table/glass,
-/obj/item/watertank{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/item/plant_analyzer,
-/obj/item/book/manual/hydroponics_pod_people,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "mxK" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -44925,13 +44919,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
 "mCP" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/spawner/random/junk_shell,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "mCT" = (
 /turf/open/water/no_planet_atmos/deep,
@@ -45470,8 +45461,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mLd" = (
-/turf/open/openspace,
-/area/station/hallway/primary/central)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "mLf" = (
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
@@ -45950,6 +45943,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/hos)
+"mTM" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "mTS" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -46882,6 +46879,7 @@
 /obj/structure/fluff/paper/stack{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "nfB" = (
@@ -47066,11 +47064,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"niz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence/door,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "niE" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -47138,6 +47131,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
+"njE" = (
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/genturf/blue,
+/area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "njJ" = (
 /turf/closed/wall,
 /area/mine/laborcamp)
@@ -47226,10 +47223,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/commons/storage/mining)
-"nlG" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "nlJ" = (
 /obj/structure/railing{
 	dir = 5
@@ -47513,11 +47506,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
-"noO" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "noT" = (
 /obj/effect/spawner/random/trash/bin,
 /obj/effect/decal/cleanable/dirt,
@@ -47612,6 +47600,10 @@
 "npD" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/aft/greater)
+"npE" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "npJ" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/violet/visible,
 /turf/open/floor/iron,
@@ -47934,10 +47926,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
-"nuV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/lava/plasma/ice_moon,
-/area/icemoon/underground/explored)
 "nuX" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/bush/snow/style_random,
@@ -48365,6 +48353,11 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/icemoon/keep_below,
 /area/station/maintenance/port/lesser)
+"nAm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "nAr" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -48883,11 +48876,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
-"nGw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/window/elevator/left/directional/north,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "nGA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -49963,20 +49951,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
-"nUn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "nUr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/command/eva)
+"nUH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "nUJ" = (
 /obj/machinery/flasher/directional/east{
 	id = "brigentry"
@@ -50066,6 +50052,7 @@
 /obj/structure/fence/door{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "nWf" = (
@@ -50809,7 +50796,7 @@
 "ohF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/left/directional/west,
+/obj/machinery/door/window/elevator/left/directional/north,
 /turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "ohI" = (
@@ -51347,6 +51334,16 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"ooA" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ooG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52773,6 +52770,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"oFH" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "oFI" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -53267,6 +53274,11 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/mine/living_quarters)
+"oLv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "oLz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -53811,12 +53823,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/disposal/incinerator)
-"oTY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/garbage,
-/obj/effect/spawner/random/junk_shell,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "oUb" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/weather/snow/corner{
@@ -54156,6 +54162,11 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"oZf" = (
+/obj/effect/spawner/random/trash/bin,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "oZk" = (
 /obj/structure/chair{
 	dir = 1
@@ -54172,6 +54183,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/explab)
+"oZq" = (
+/obj/structure/transport/linear/public,
+/turf/open/space/basic,
+/area/icemoon/underground/explored)
 "oZw" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -54431,6 +54446,12 @@
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
+"pcX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/spawner/random/maintenance/dumpster,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "pdd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54558,6 +54579,12 @@
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/openspace/icemoon/keep_below,
+/area/icemoon/underground/explored)
+"pfp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "pfw" = (
 /obj/structure/flora/grass/green/style_random,
@@ -55072,6 +55099,14 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/hos)
+"pmS" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "pna" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -55356,6 +55391,11 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/mine/living_quarters)
+"pqU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "pra" = (
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
@@ -55502,9 +55542,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/aft/greater)
 "ptt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/enlist/directional/west,
-/turf/open/floor/iron/smooth,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/decal/cleanable/fuel_pool,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "ptQ" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
@@ -55788,17 +55828,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
-"pxe" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "pxg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -56304,9 +56333,10 @@
 /turf/open/floor/iron/large,
 /area/station/medical/break_room)
 "pEs" = (
-/obj/structure/thermoplastic,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "pEE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -56712,6 +56742,11 @@
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"pLb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/elevator/right/directional/west,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "pLg" = (
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/openspace/icemoon/keep_below,
@@ -56777,10 +56812,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
-"pLX" = (
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "pLZ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -56807,6 +56838,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
+"pMs" = (
+/obj/machinery/door/window/elevator/right/directional/north,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "pMu" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -56956,14 +56992,6 @@
 "pOL" = (
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
-"pON" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor,
-/area/icemoon/underground/explored)
 "pOV" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -57168,6 +57196,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/commissary)
+"pSe" = (
+/obj/machinery/light/small/red/directional/south,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/item/radio/intercom/chapel/directional/east,
+/turf/open/floor/wood/large,
+/area/icemoon/underground/explored)
 "pSk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57680,10 +57716,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/commons/storage/mining)
-"pYO" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit/departure_lounge)
 "pYT" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
@@ -57752,11 +57784,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
-"pZK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "pZM" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
@@ -58571,12 +58598,8 @@
 /turf/open/misc/asteroid/snow/standard_air,
 /area/station/science/cytology)
 "qkn" = (
-/obj/machinery/light/small/red/directional/south,
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/item/radio/intercom/chapel/directional/east,
-/turf/open/floor/wood/large,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
 "qku" = (
 /obj/structure/chair/comfy/beige{
@@ -58742,13 +58765,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/plating,
 /area/station/medical/virology)
-"qmV" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "qnj" = (
 /turf/closed/wall,
 /area/station/commons/locker)
@@ -59055,11 +59071,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/large,
 /area/station/engineering/storage/tech)
-"qqY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/wood,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "qrb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59478,10 +59489,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"qxU" = (
-/obj/machinery/door/window/elevator/right/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "qxY" = (
 /obj/item/chair/plastic,
 /obj/effect/decal/cleanable/dirt,
@@ -59696,8 +59703,8 @@
 /turf/open/floor/plating,
 /area/station/security/prison/mess)
 "qCx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/work_for_a_future/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "qCA" = (
@@ -59772,6 +59779,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/donk,
 /area/mine/production)
+"qDB" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "qDI" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -59867,11 +59883,6 @@
 /obj/structure/weightmachine,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
-"qEG" = (
-/obj/effect/spawner/random/trash/bin,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "qEJ" = (
 /turf/closed/wall,
 /area/station/service/chapel/office)
@@ -60108,6 +60119,10 @@
 	dir = 1
 	},
 /area/station/medical/virology)
+"qHK" = (
+/obj/item/pickaxe,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qHO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench/right{
@@ -60238,11 +60253,14 @@
 /turf/open/floor/wood/large,
 /area/mine/eva/lower)
 "qJB" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "qJT" = (
 /obj/machinery/light/small/directional/south,
@@ -62818,11 +62836,6 @@
 /obj/structure/sign/poster/contraband/the_big_gas_giant_truth/directional/north,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
-"rsp" = (
-/obj/structure/thermoplastic,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "rsw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -62881,8 +62894,7 @@
 	},
 /area/station/security/prison/safe)
 "rsO" = (
-/obj/structure/transport/linear/public,
-/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "rsR" = (
@@ -63193,6 +63205,13 @@
 /obj/structure/girder,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
+"rxA" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "rxG" = (
 /obj/structure/ore_vent/starter_resources{
 	icon_state = "ore_vent_ice_active";
@@ -63259,6 +63278,11 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/checker,
 /area/station/hallway/secondary/service)
+"ryt" = (
+/obj/structure/transport/linear/public,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "ryu" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/security/execution/transfer)
@@ -63514,6 +63538,11 @@
 "rCf" = (
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"rCr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "rCs" = (
 /obj/structure/table,
 /obj/item/food/deadmouse{
@@ -64067,17 +64096,6 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"rLg" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "rLl" = (
 /obj/structure/sign/nanotrasen/directional/north,
 /turf/open/floor/iron,
@@ -64304,6 +64322,11 @@
 /obj/effect/mapping_helpers/no_atoms_ontop,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"rOu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/enlist/directional/west,
+/turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "rOv" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -64786,8 +64809,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rVr" = (
-/obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/south{
+	id = "tram_perma_lift"
+	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "tram_perma_lift"
+	},
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "rVB" = (
@@ -64890,8 +64918,12 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rWJ" = (
-/obj/effect/mapping_helpers/no_atoms_ontop,
-/turf/closed/wall,
+/obj/structure/toiletbong,
+/obj/structure/thermoplastic,
+/obj/structure/chair/sofa/bench/tram/left,
+/obj/structure/thermoplastic/light,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "rWO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65281,10 +65313,8 @@
 /area/station/medical/medbay/central)
 "scr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/elevator/directional/west,
-/obj/machinery/lift_indicator/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/fence{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
@@ -65409,11 +65439,8 @@
 /turf/open/floor/iron/dark,
 /area/station/command/eva)
 "seb" = (
-/obj/structure/fence/door{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "sen" = (
 /obj/structure/cable,
@@ -65804,11 +65831,11 @@
 /turf/closed/wall,
 /area/station/maintenance/fore)
 "skm" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "skn" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -66294,6 +66321,11 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/atrium)
+"spR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "spV" = (
 /obj/effect/spawner/random/trash/bin,
 /obj/item/paper/crumpled{
@@ -66402,15 +66434,6 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/aft)
-"srv" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "srw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -67378,6 +67401,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
+"sEW" = (
+/obj/machinery/door/window/elevator/left/directional/south{
+	elevator_mode = 1;
+	transport_linked_id = "tram_perma_lift"
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "sEX" = (
 /obj/machinery/computer/atmos_control/air_tank{
 	dir = 1
@@ -67987,6 +68020,17 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/security/mechbay)
+"sOM" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "sOO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -68376,6 +68420,9 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"sVd" = (
+/turf/closed/wall,
+/area/icemoon/underground/unexplored/rivers)
 "sVi" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Break Room"
@@ -68512,6 +68559,7 @@
 "sWR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/icemoon/underground/explored)
 "sWU" = (
@@ -69176,8 +69224,10 @@
 /turf/open/genturf/blue,
 /area/icemoon/underground/unexplored/rivers/deep/shoreline)
 "thB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "thC" = (
@@ -69780,6 +69830,7 @@
 /obj/structure/fluff/paper/stack{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "toG" = (
@@ -69846,6 +69897,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"tpp" = (
+/obj/effect/mapping_helpers/no_atoms_ontop,
+/turf/closed/wall,
+/area/icemoon/underground/explored)
 "tpF" = (
 /obj/structure/closet/bombcloset/security,
 /obj/effect/turf_decal/bot,
@@ -69907,14 +69962,6 @@
 /obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/plating,
 /area/station/medical/morgue)
-"tqB" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/button/elevator/directional/east,
-/obj/machinery/lift_indicator/directional/east,
-/obj/machinery/door/window/elevator/right/directional/north,
-/obj/effect/turf_decal/caution/stand_clear/white,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics/garden)
 "tqJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -69977,16 +70024,6 @@
 /obj/structure/sign/poster/official/obey/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/execution/transfer)
-"trG" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "trK" = (
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron/dark,
@@ -70081,12 +70118,6 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"tti" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/random/directional/north,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "ttw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/smooth_large,
@@ -70390,12 +70421,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"txG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "txI" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating,
@@ -71743,12 +71768,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/storage)
-"tQd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "tQg" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -72200,12 +72219,6 @@
 /obj/machinery/light/small/red/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/greater)
-"tXz" = (
-/obj/machinery/button/elevator/directional/north,
-/obj/machinery/lift_indicator/directional/north,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "tXB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72525,6 +72538,12 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
+"ucd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ucl" = (
 /obj/machinery/door/window/right/directional/west{
 	name = "Containment Pen 4";
@@ -73440,6 +73459,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/garbage,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "upK" = (
@@ -73492,6 +73512,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"uqs" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/structure/table/glass,
+/obj/item/watertank{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/plant_analyzer,
+/obj/item/book/manual/hydroponics_pod_people,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "uqz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -74725,6 +74761,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"uJr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/icemoon/underground/explored)
 "uJt" = (
 /turf/open/floor/carpet,
 /area/station/service/chapel)
@@ -75901,6 +75943,11 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"vcT" = (
+/obj/structure/thermoplastic,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "vcY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -76216,11 +76263,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"vhK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "vhT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
@@ -76294,16 +76336,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"vjs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "vjA" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Service - Kitchen"
@@ -76354,8 +76386,8 @@
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "vkk" = (
-/obj/structure/transport/linear/public,
-/turf/open/space/basic,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
 /area/icemoon/underground/explored)
 "vkz" = (
 /obj/machinery/suit_storage_unit/ce,
@@ -77860,6 +77892,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/security/brig)
+"vFR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/work_for_a_future/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "vFT" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -79274,6 +79311,7 @@
 /area/station/medical/morgue)
 "waK" = (
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/icemoon/underground/explored)
 "waL" = (
@@ -79489,16 +79527,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"weH" = (
-/obj/machinery/door/window/elevator/left/directional/south{
-	elevator_mode = 1;
-	transport_linked_id = "tram_perma_lift"
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "weI" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -81010,6 +81038,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix)
+"wCM" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/elevator/directional/east,
+/obj/machinery/lift_indicator/directional/east,
+/obj/machinery/door/window/elevator/right/directional/north,
+/obj/effect/turf_decal/caution/stand_clear/white,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/garden)
 "wCN" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -82644,6 +82680,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"xag" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/elevator/directional/north,
+/obj/machinery/lift_indicator/directional/north,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "xal" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -83371,11 +83413,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
-"xin" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/report_crimes/directional/north,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
 "xit" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/structure/table/wood,
@@ -83419,8 +83456,9 @@
 /area/icemoon/surface/outdoors/nospawn)
 "xiL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/elevator/right/directional/north,
-/turf/open/floor/catwalk_floor,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "xiO" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -84884,6 +84922,12 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"xDh" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "xDj" = (
 /obj/effect/turf_decal/trimline/yellow/end{
 	dir = 1
@@ -85714,6 +85758,11 @@
 /obj/effect/mapping_helpers/no_atoms_ontop,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/less_spawns)
+"xOz" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "xOQ" = (
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -85942,6 +85991,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/circuit_workshop)
+"xTb" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "xTi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -86277,6 +86333,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
+"xWQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/door,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "xWT" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/machinery/light_switch/directional/south,
@@ -86566,6 +86627,10 @@
 "yaL" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/engine_smes)
+"yaM" = (
+/obj/machinery/door/window/elevator/right/directional/north,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "yaN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster/directional/west,
@@ -86785,15 +86850,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "ydH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/glass,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth,
-/area/icemoon/underground/explored)
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "ydI" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/entry)
@@ -87022,12 +87081,6 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/grimy,
 /area/station/ai/satellite/interior)
-"yhK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/spawner/random/maintenance/dumpster,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "yhM" = (
 /obj/structure/rack,
 /obj/machinery/light/cold/directional/north,
@@ -87156,6 +87209,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"yky" = (
+/obj/effect/decal/cleanable/blood/trail,
+/turf/open/floor/iron/smooth,
+/area/icemoon/underground/explored)
 "ykA" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -102014,9 +102071,9 @@ oSU
 oSU
 oSU
 gFX
-yhK
-ptt
-jDL
+pcX
+rOu
+dOP
 gFX
 gFX
 gFX
@@ -102271,10 +102328,10 @@ oSU
 oSU
 oSU
 gFX
-aYs
-tQd
+skm
+ucd
 eHt
-weH
+sEW
 nTH
 nTH
 gFX
@@ -102528,10 +102585,10 @@ oSU
 oSU
 oSU
 gFX
-tti
-pZK
+pfp
+rCr
 kdm
-bWp
+lsZ
 nTH
 nTH
 gFX
@@ -102785,9 +102842,9 @@ oSU
 oSU
 oSU
 gFX
-kJS
-byx
-gOK
+ijQ
+dys
+rVr
 gFX
 gFX
 gFX
@@ -103043,10 +103100,10 @@ oSU
 gFX
 gFX
 wMB
-seb
-jix
+gVx
+kGK
 wMB
-oTY
+mCP
 gFX
 ghx
 ghx
@@ -103298,13 +103355,13 @@ thA
 thA
 thA
 gFX
-qEG
+oZf
 eHt
 bJv
 aCI
 cLf
-ydH
-hBG
+qJB
+rsO
 ghx
 ghx
 thA
@@ -103556,10 +103613,10 @@ thA
 thA
 gFX
 kdm
-bkj
-hwe
-kwT
-hwe
+loD
+iYX
+gtt
+iYX
 gFX
 gFX
 ghx
@@ -103812,13 +103869,13 @@ thA
 thA
 thA
 gFX
-xin
-mhq
+aVL
+iCN
 cjI
 aMC
 wuN
 nLK
-hBG
+rsO
 ghx
 ghx
 thA
@@ -104075,7 +104132,7 @@ aMC
 uWq
 bKQ
 wuN
-hBG
+rsO
 ghx
 ghx
 thA
@@ -104327,12 +104384,12 @@ thA
 thA
 gFX
 cLf
-rLg
+bUj
 eiQ
 uWq
 fHU
 wuN
-hBG
+rsO
 ghx
 ghx
 thA
@@ -104582,11 +104639,11 @@ thA
 thA
 ghx
 ghx
-hBG
+rsO
 cLf
-pON
+dRc
 aMC
-rsp
+vcT
 uWq
 aMC
 gFX
@@ -104839,14 +104896,14 @@ ghx
 ghx
 ghx
 ghx
-hBG
-vhK
-pON
+rsO
+lgQ
+dRc
 wuN
 rOU
 qFF
-jRy
-hBG
+kJS
+rsO
 ghx
 ghx
 ijY
@@ -105096,14 +105153,14 @@ ghx
 ghx
 ghx
 ghx
-hBG
+rsO
 cLf
-srv
+aQi
 aMC
-cOS
+rWJ
 qFF
 cqV
-hBG
+rsO
 ghx
 ghx
 ghx
@@ -105353,14 +105410,14 @@ ghx
 ghx
 ghx
 ghx
-hBG
+rsO
 eHt
 gFX
 aMC
 aMC
 oge
 aMC
-hBG
+rsO
 ghx
 ghx
 ghx
@@ -105612,7 +105669,7 @@ ghx
 ghx
 gFX
 eHt
-gNs
+lMG
 txh
 cqV
 uWq
@@ -105868,13 +105925,13 @@ thA
 thA
 ghx
 gFX
-qCx
-mCP
+vFR
+qDB
 wuN
 nov
 dzI
 aMC
-hBG
+rsO
 ghx
 ghx
 iDt
@@ -106124,14 +106181,14 @@ ghx
 thA
 thA
 ghx
-hBG
+rsO
 eHt
-bkA
+pmS
 aMC
-rsp
+vcT
 dzI
 eiQ
-hBG
+rsO
 ghx
 ghx
 iDt
@@ -106381,14 +106438,14 @@ ghx
 ghx
 thA
 ghx
-hBG
+rsO
 eHt
 gFX
 aMC
-pEs
+hwe
 vrk
 aMC
-hBG
+rsO
 ghx
 ghx
 iDt
@@ -106638,9 +106695,9 @@ ghx
 ghx
 thA
 ghx
-hBG
+rsO
 cLf
-pxe
+sOM
 eiQ
 uWq
 kdq
@@ -106895,14 +106952,14 @@ ghx
 ghx
 ghx
 ghx
-hBG
-qqY
-qmV
+rsO
+oLv
+rxA
 kJN
 aMC
 sAc
 iOk
-nuV
+qkn
 ghx
 iDt
 iDt
@@ -107153,13 +107210,13 @@ ghx
 ghx
 ghx
 gFX
-noO
-eWY
+xOz
+xDh
 vBN
 vBN
 lhB
 vBN
-nuV
+qkn
 ghx
 ghx
 iDt
@@ -107412,10 +107469,10 @@ ghx
 gFX
 gFX
 gFX
-pLX
-pLX
-cvr
-pLX
+hBG
+hBG
+cUB
+hBG
 gFX
 ghx
 ghx
@@ -112809,10 +112866,10 @@ ghx
 gFX
 vBN
 vBN
-pLX
-pLX
-cvr
-pLX
+hBG
+hBG
+cUB
+hBG
 vBN
 gFX
 oSU
@@ -118987,7 +119044,7 @@ gFX
 gFX
 gFX
 vcG
-vBN
+seb
 gFX
 gFX
 gFX
@@ -119244,7 +119301,7 @@ gFX
 vBN
 gFX
 cUg
-eHt
+hnw
 vVn
 cYS
 gFX
@@ -119502,8 +119559,8 @@ vBN
 gFX
 vQb
 waK
-eHt
-eHt
+hnw
+hnw
 gFX
 oSU
 oSU
@@ -120015,15 +120072,15 @@ nqh
 tgU
 gFX
 gFX
-lPN
+xag
 usr
-usr
+mLd
 hgg
 dmC
-usr
-usr
-tgU
-lyD
+mLd
+mLd
+iZM
+xiL
 huy
 cjI
 aMC
@@ -120272,15 +120329,15 @@ kdm
 bJv
 gFX
 nTH
-kEF
+ohF
 msM
 cBz
 cBz
-lMG
+nAm
 bJv
 aeV
 lLs
-bJv
+jmM
 jZR
 aMC
 dzI
@@ -120529,7 +120586,7 @@ kdm
 bJv
 gFX
 nTH
-xiL
+pqU
 eHt
 kdm
 eHt
@@ -120537,7 +120594,7 @@ eHt
 kdm
 eHt
 cLf
-aeV
+uJr
 iva
 eiQ
 dzI
@@ -120794,7 +120851,7 @@ eHt
 eHt
 kdm
 gFX
-kdm
+qCx
 iva
 aMC
 uWq
@@ -121051,7 +121108,7 @@ eHt
 eHt
 kdm
 mJE
-bJv
+jmM
 iva
 wuN
 rOU
@@ -121553,7 +121610,7 @@ lhB
 vBN
 thL
 tgU
-thB
+gcY
 jRP
 usr
 usr
@@ -121565,7 +121622,7 @@ idf
 usr
 usr
 usr
-rCM
+nUH
 dbl
 aMC
 aMC
@@ -133390,7 +133447,7 @@ oSU
 gFX
 lhB
 lhB
-kLk
+spR
 lhB
 lhB
 gFX
@@ -134939,8 +134996,8 @@ gFX
 nTH
 nTH
 gFX
-nlG
-rWJ
+mTM
+tpp
 aKb
 iDt
 iDt
@@ -135192,12 +135249,12 @@ vBN
 vBN
 vBN
 lhB
-scr
-jlz
-ohF
+ccx
+pLb
+bdw
 efl
 eHt
-lNA
+cvr
 chg
 iDt
 iDt
@@ -135449,12 +135506,12 @@ vBN
 lhB
 vBN
 vBN
-nUn
+eha
 eHt
 cBz
-niz
+xWQ
 eHt
-rWJ
+tpp
 pJm
 iDt
 iDt
@@ -135709,7 +135766,7 @@ lhB
 gBp
 eHt
 cBz
-ght
+scr
 eHt
 gFX
 xMq
@@ -135963,11 +136020,11 @@ vBN
 lhB
 vBN
 vBN
-lRa
+itn
 kdm
 cBz
-ght
-gul
+scr
+yky
 gFX
 iDt
 xMq
@@ -136209,8 +136266,8 @@ oSU
 oSU
 oSU
 gFX
-vkk
-nGw
+oZq
+cSK
 luS
 pAj
 tgU
@@ -136466,8 +136523,8 @@ oSU
 oSU
 oSU
 gFX
-vkk
-qxU
+oZq
+yaM
 eHt
 cLf
 gFX
@@ -136477,7 +136534,7 @@ vBN
 lhB
 lhB
 vBN
-nUn
+eha
 bJv
 cBz
 gFX
@@ -136724,7 +136781,7 @@ oSU
 oSU
 gFX
 gFX
-bCU
+pEs
 aCI
 cLf
 bJv
@@ -137249,7 +137306,7 @@ vBN
 lhB
 vBN
 gFX
-rVr
+lkp
 bJv
 gFX
 oSU
@@ -138266,7 +138323,7 @@ oSU
 oSU
 oSU
 gFX
-gVx
+kBQ
 bJv
 eHt
 bJv
@@ -138523,12 +138580,12 @@ oSU
 gFX
 gFX
 gFX
-tXz
+aZL
 eHt
 cLf
 cLf
-nlG
-eSk
+mTM
+oFH
 lhB
 vBN
 vBN
@@ -138778,21 +138835,21 @@ oSU
 oSU
 oSU
 gFX
-dCh
-aVL
+fsd
+flJ
 usr
 bJv
-eha
+npE
 bJv
 eHt
-qJB
+thB
 lhB
 vBN
 vBN
 vBN
 gFX
 kdm
-jZz
+jRY
 gFX
 oSU
 oSU
@@ -139035,21 +139092,21 @@ oSU
 oSU
 oSU
 gFX
-lxl
-aVL
-txG
+ptt
+flJ
+bEh
 bJv
 cLf
 bJv
 kdm
-trG
+ooA
 gFX
 gFX
 gFX
 gFX
 gFX
 tgU
-jZz
+jRY
 gFX
 oSU
 oSU
@@ -139292,20 +139349,20 @@ oSU
 oSU
 oSU
 gFX
-mto
-rsO
-aTX
+vkk
+ryt
+pMs
 eHt
-eha
+npE
 gFX
 cLf
-vhK
+lgQ
 usr
 eHt
 usr
 kdm
-gUw
-gXd
+dBt
+fsg
 kdm
 gFX
 oSU
@@ -167553,7 +167610,7 @@ tjo
 tjo
 tjo
 tjo
-aZL
+sVd
 gFX
 wlK
 wlK
@@ -167810,9 +167867,9 @@ tjo
 tjo
 tjo
 tjo
-aZL
-eDR
-eDR
+sVd
+cOS
+cOS
 wlK
 lhB
 lhB
@@ -168067,9 +168124,9 @@ tjo
 tjo
 tjo
 tjo
-aZL
-eDR
-eDR
+sVd
+cOS
+cOS
 wlK
 lhB
 lhB
@@ -168324,7 +168381,7 @@ tjo
 tjo
 tjo
 tjo
-aZL
+sVd
 gFX
 gFX
 gFX
@@ -169357,7 +169414,7 @@ tjo
 thA
 thA
 thA
-ghe
+njE
 iLh
 pwg
 peG
@@ -185812,7 +185869,7 @@ caA
 mty
 urQ
 sQI
-anx
+eXJ
 pme
 pme
 aon
@@ -186324,13 +186381,13 @@ gFX
 uVb
 exw
 mqd
-mxG
+uqs
 wDb
 oZG
 oZG
 rZY
 oZG
-vjs
+hQA
 exw
 exw
 exw
@@ -201235,7 +201292,7 @@ xeJ
 oTA
 kub
 oTA
-bCZ
+ydH
 wrX
 wrX
 wrX
@@ -201748,8 +201805,8 @@ wrX
 gEE
 wrX
 wee
-jqd
-qkn
+ghe
+pSe
 gFX
 xMq
 xMq
@@ -233606,7 +233663,7 @@ aPM
 oCO
 qTm
 qTm
-tqB
+wCM
 tmL
 arG
 cIa
@@ -234115,9 +234172,9 @@ lJO
 lJO
 lJO
 lJO
-bAk
-ccx
-cUB
+fyO
+xTb
+fKn
 tNd
 nor
 sst
@@ -251600,7 +251657,7 @@ oUO
 kHO
 mQi
 uja
-mLd
+hOB
 hNU
 kyL
 kyL
@@ -267020,7 +267077,7 @@ nui
 kDs
 kDs
 kDs
-pYO
+bWp
 oOD
 lDH
 qPL
@@ -267279,7 +267336,7 @@ pUa
 kDs
 jZM
 jtG
-aUp
+qHK
 qPL
 ugO
 wLS
@@ -268050,7 +268107,7 @@ pUa
 kDs
 qPL
 nbK
-skm
+bLS
 ixv
 qPL
 gHD

--- a/code/game/area/areas/station/metro.dm
+++ b/code/game/area/areas/station/metro.dm
@@ -1,0 +1,22 @@
+/area/station/metro
+	name = "Generic Metro"
+	icon_state = "hall"
+	ambience_index = AMBIENCE_MAINT
+	area_flags = BLOBS_ALLOWED | CULT_PERMITTED | PERSISTENT_ENGRAVINGS
+	airlock_wires = /datum/wires/airlock/maint
+	sound_environment = SOUND_AREA_TUNNEL_ENCLOSED
+	forced_ambience = TRUE
+	ambient_buzz = 'sound/ambience/maintenance/source_corridor2.ogg'
+	ambient_buzz_vol = 20
+
+/area/station/metro/metro_control_room
+	name = "Generic Metro"
+
+/area/station/metro/power_substation
+
+
+/area/station/metro/arrivals_station
+
+/area/station/metro/center_station
+
+/area/station/metro/outrivals_station

--- a/code/game/area/areas/station/metro.dm
+++ b/code/game/area/areas/station/metro.dm
@@ -1,3 +1,9 @@
+// General types of Metro's area
+// main type of metro is just like metro, for metro stations
+// Control room area for maintainers\service rooms like a office or with cameras or something
+// Substation - small engi rooms on every station with power stuff(smes, emergency generator maybe)
+// Metro Train Tunnels - for tunnels, at which these rippers(trams) are moving
+// Abandoned rooms - dangerous places of Metro
 /area/station/metro
 	name = "Generic Metro"
 	icon_state = "hall"
@@ -11,8 +17,15 @@
 
 /area/station/metro/metro_control_room
 	name = "Generic Metro"
+	icon_state = "engie"
 
 /area/station/metro/power_substation
+
+	name = "Metro's substation"
+	ambience_index = AMBIENCE_ENGI
+	airlock_wires = /datum/wires/airlock/engineering
+	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	icon_state = "engie"
 
 
 /area/station/metro/arrivals_station

--- a/code/game/area/areas/station/metro.dm
+++ b/code/game/area/areas/station/metro.dm
@@ -16,16 +16,35 @@
 	ambient_buzz_vol = 20
 
 /area/station/metro/metro_control_room
-	name = "Generic Metro"
+	name = "Generic Metro control room"
 	icon_state = "engie"
+	sound_environment = SOUND_AREA_WOODFLOOR
+	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	ambient_buzz_vol = 5
 
 /area/station/metro/power_substation
 
 	name = "Metro's substation"
+	icon_state = "engine"
 	ambience_index = AMBIENCE_ENGI
 	airlock_wires = /datum/wires/airlock/engineering
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 	icon_state = "engie"
+
+/area/station/metro/train_tunnels
+	name = "Metro Train's tunnel"
+
+/area/station/metro/abandoned
+	name = "Abandoned Metro's part"
+	ambient_buzz_vol = 30
+	icon_state = "disposal"
+
+
+
+// Actual areas, which are at use
+// - - - - - - - - - - -
+// Metro station's areas
+// - - - - - - - - - - -
 
 
 /area/station/metro/arrivals_station
@@ -33,3 +52,46 @@
 /area/station/metro/center_station
 
 /area/station/metro/outrivals_station
+
+// - - - - - - - - - - -
+// Metro power substation's areas
+// - - - - - - - - - - -
+
+/area/station/metro/power_substation/arrivals_metro_substation
+	name = "Arrivals Metro Substation"
+
+/area/station/metro/power_substation/center_metro_substation
+	name = "Center Metro Substation"
+
+/area/station/metro/power_substation/outrivals_metro_substation
+	name = "Outrivals Metro Substation"
+
+// - - - - - - - - - - -
+// Metro train tunnels areas
+// - - - - - - - - - - -
+
+/area/station/metro/train_tunnels/north_tunnel
+	name = "Metro's North tunnel"
+
+/area/station/metro/train_tunnels/south_tunnel
+	name = "Metro's South tunnel"
+
+// - - - - - - - - - - -
+// Metro control room areas
+// - - - - - - - - - - -
+
+/area/station/metro/metro_control_room/center_control_room
+	name = "Metro's control room"
+
+// - - - - - - - - - - -
+// Metro abandoned part areas
+// - - - - - - - - - - -
+
+/area/station/metro/abandoned/garbage_corner
+	name = "Abandoned Metro's part"
+
+/area/station/metro/abandoned/abandoned_collector
+	name = "Abandoned collector"
+
+/area/station/metro/abandoned/abandoned_north_east_tunnel
+	name = "Abandoned North-East Tunnel"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2218,6 +2218,7 @@
 #include "code\game\area\areas\station\hallway.dm"
 #include "code\game\area\areas\station\maintenance.dm"
 #include "code\game\area\areas\station\medical.dm"
+#include "code\game\area\areas\station\metro.dm"
 #include "code\game\area\areas\station\misc.dm"
 #include "code\game\area\areas\station\science.dm"
 #include "code\game\area\areas\station\security.dm"


### PR DESCRIPTION

## About The Pull Request

**Idea is not mine about metro really, just wanted to try**

Adding Metro on the lowest z-level, with 3 points(Arrivals, Outrivals, Bar - three most important points on the station).

From all points you can get from station to Metro - via Lift(which is not at tg codebase seems now, but will add, it will be actual lift with actual lift doors and buttons, or maybe its somewhere here, but have found only airlock like liftdoors)

Tram-code also needs to be more understood for successful implementation, cause tram like existing, but need to make him work(with some custom logic).

**WORK AT PROGRESS PICTURES:**

<img width="1141" height="1148" alt="image" src="https://github.com/user-attachments/assets/f32b8af2-6628-4dc9-b3d2-201464244c08" />
<img width="497" height="454" alt="image" src="https://github.com/user-attachments/assets/c5e8333a-5f26-4f91-853a-7b8f6a88e40e" />
<img width="694" height="432" alt="image" src="https://github.com/user-attachments/assets/351040ba-5001-47cf-b226-2670b56b0250" />

## Why It's Good For The Game

Positive things for Crew:

- if station at danger, plasmaflood or jsut insane stuff, you dont wanna to get from arrivals to outrivals via main halls, OR MAYBE THESE HALLS ARE HOT EXISTING, so you can use that... IF YOU HAVE MONEY SURE(its half joke, there are ways to get without paying)

- its more easy to move via station even at safe time, if some local stuff happened or you just closer to Metro, rather than to actual point

- its have Mid-point\Mid-station(which on the picture), which have 2 rooms(one fully readed, at second some was killed and butchered for late rent seems), at which you can open your fast-food shop with food from the chef, or you can buy and sell stuff from\to crew(or looks like crew), and anything, cause its like trading route, but its not first line, more cool to open shop at bar\med, but there are no places, here market places are existing and almost ready(YOU CAN EVEN TAKE A PAY FOR PROTECTION, cause one of the room is real proof, what is happening, when you are not paying your rent... seems)

Positive things for Captain\Station\Command:

- Metro has things to get money for moving, so budget will be increasing

- If Metro will be available, it also can make transportation more easy, which is good for economocy(its like cheap oil, if its cheap, its positive factor for economy growth cause cause yeah)

- Captain can make here secret bunker or something, or not captain, but than its not positive for captain

Positive things for Assistants, Looters, Gimmicks mans:

- loot at maints, at rooms

- danger rooms with mobs, but you can die, but if you are assistant its positive, yeah? 

- rooms for gimmicks, like not only these second-line food shop, but room for secret-shadow-goverment-metro bunker, from which you will be sending commands to your satelites\soldiers\revs\anyone

Bad moments for Security:

- the more you have, the more risk you will loose it, so yeah, its criminal space, if you are looking for shit you can patrool here, but its can be just bandits, or like cults(and please they will be blood cult, cause maybe they have some insane gimmick, than you are dead 100%)

Positive moments for Security:

- If WAR, Metro can be used as trenches, fortifictacion, BUT OH MY GOD, THEY HAVE BOMBED OUR CEILING. So Deep Ground low-risk at only short&middle-range, on the Highground more risk, but at the Metro you are cornered, there is no place to retreat, only forward or go deep idk
## Changelog
:cl:
map: adding Metro to Ice Box
/:cl:
