### PR TITLE
Removes RNG instakill from mech drills entirely

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -120,7 +120,7 @@
 		return
 
 	target.visible_message(span_warning("[chassis] starts to drill [target]."), \
-				span_userdanger("[chassis] starts to drill [target]..."), \
+				span_userdanger("[chassis] starts to drill you!"), \
 				span_hear("You hear drilling."))
 
 	log_message("Started drilling [target]", LOG_MECHA)
@@ -200,17 +200,19 @@
 		return
 
 	//drill makes a hole
-	var/def_zone = target.get_random_valid_zone(BODY_ZONE_CHEST)
-	var/obj/item/bodypart/target_part = target.get_bodypart(def_zone)
-	var/blocked = target.run_armor_check(def_zone, MELEE)
-	target.apply_damage(10, BRUTE, def_zone, blocked)
+	var/def_zone = target.get_random_valid_zone(user.zone_selected)
+	target.apply_damage(
+		10,
+		BRUTE,
+		def_zone,
+		blocked = target.run_armor_check(def_zone, MELEE),
+		wound_bonus = 30,
+		exposed_wound_bonus = 50,
+		sharpness = SHARP_POINTY
+	)
 
 	//blood splatters
 	target.create_splatter(get_dir(chassis, target))
-
-	//organs go everywhere
-	if(target_part && blocked < 100 && prob(10 * drill_level))
-		target_part.dismember(BRUTE)
 
 /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill
 	name = "diamond-tipped exosuit drill"


### PR DESCRIPTION

## About The Pull Request

Alternative to #96235

Removes the RNG-based organ removal instant kill from the exosuit drill entirely, replacing it with an very high wounding chance (30 wound bonus, 50 exposed wound bonus). This wounding chance is enough to dismember unprotected limbs very quickly, and heavily wound protected ones.

Additionally, enables targeting limbs with the drill, for easier dismemberment.

## Why It's Good For The Game

If you stand still for 0.4 seconds, you have a 1 in 5 chance to instantly die. This is not an enjoyable mechanic. A mining tool should not be more powerful than actual combat mech melees. 

## Changelog
:cl:
balance: The RNG instant kill via organ removal of the mech drill has been removed, and replaced with a very high wounding chance
/:cl:
