### PR TITLE
Patrol bounties pay money

### DIFF
--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -68,6 +68,7 @@
 	start_tracking(id_card)
 
 /datum/bounty/patrol/proc/start_tracking(obj/item/card/id/id_card)
+	contribution |= id_card.registered_account
 	tracker = AddComponent(/datum/component/connect_containers, id_card, list(COMSIG_MOVABLE_MOVED = PROC_REF(on_card_moved)))
 	RegisterSignal(id_card, COMSIG_MOVABLE_MOVED, PROC_REF(on_card_moved))
 


### PR DESCRIPTION

## About The Pull Request

Because patrols do not send anything material via the pad, they never register `contribution` naturally, and thus runtime when their cube is created. 

Makes patrol bounties register ID `contribution` when they begin tracking an ID's movements.

## Why It's Good For The Game

I did thousands of credits of unpaid labor before i realized these weren't working

## Changelog
:cl:

fix: Patrol bounties properly pay those who complete them

/:cl:
