### PR TITLE
Changing from 1:5 organ removal chance to 1:25 of drill-mech weapon 

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -209,7 +209,7 @@
 	target.create_splatter(get_dir(chassis, target))
 
 	//organs go everywhere
-	if(target_part && blocked < 100 && prob(10 * drill_level))
+	if(target_part && blocked < 100 && prob(2 * drill_level))
 		target_part.dismember(BRUTE)
 
 /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill


### PR DESCRIPTION

## About The Pull Request

My bet is not 1:5, not removal, but 1:25, just changing one of the number

Alt to https://github.com/tgstation/tgstation/pull/96250
## Why It's Good For The Game

Its removal, not impossible chance, not like will offen happen, not just smaller then happens average, but happens really rare - 1:25(4%)
## Changelog
:cl:
balance: now chance to remove organs by drill is decreased from 1:5 to 1:25(from 10 * drill_level to 2 * drill level)
/:cl:
