### PR TITLE
Mapped in boulder smelter/refinery fixes

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -18049,7 +18049,9 @@
 /area/station/science/lobby)
 "ewa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/bouldertech/refinery,
+/obj/machinery/bouldertech/refinery{
+	dir = 4
+	},
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "mining"

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -42509,7 +42509,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "mdx" = (
-/obj/machinery/bouldertech/refinery,
+/obj/machinery/bouldertech/refinery{
+	dir = 4
+	},
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "mining_internal"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1978,7 +1978,7 @@
 /area/station/commons/lounge)
 "aKs" = (
 /obj/machinery/bouldertech/refinery{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/conveyor{
 	id = "mining"
@@ -7409,7 +7409,9 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
 "cBZ" = (
-/obj/machinery/bouldertech/refinery/smelter,
+/obj/machinery/bouldertech/refinery/smelter{
+	dir = 1
+	},
 /obj/machinery/conveyor{
 	id = "mining"
 	},

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -50645,7 +50645,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "qLx" = (
-/obj/machinery/bouldertech/refinery,
+/obj/machinery/bouldertech/refinery{
+	dir = 4
+	},
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "mining"

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -23344,7 +23344,7 @@
 /area/station/maintenance/department/engine)
 "iee" = (
 /obj/machinery/bouldertech/refinery/smelter{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/conveyor{
 	dir = 6;
@@ -39003,7 +39003,9 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "nuu" = (
-/obj/machinery/bouldertech/refinery,
+/obj/machinery/bouldertech/refinery{
+	dir = 8
+	},
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "brm"


### PR DESCRIPTION

## About The Pull Request
Fixes the mapped in refinery/smelters facing the wrong direction, causing them to not automatically smelt/refine boulders. Fixes #96253 
## Why It's Good For The Game
The best miner on the station should be able to work without supervision, also bug bad.
## Changelog
:cl:
fix: Starting boulder refineries and smelters should start facing the correct direction.
/:cl:
