### PR TITLE
Softens material requirements for printing custom material objects

### DIFF
--- a/code/datums/materials/requirements/_requirement.dm
+++ b/code/datums/materials/requirements/_requirement.dm
@@ -3,6 +3,8 @@
 	abstract_type = /datum/material_requirement
 	/// Flags which materials need to have to pass
 	var/required_flags = NONE
+	/// Flags which materials need to not have in order to pass
+	var/blacklisted_flags = NONE
 	/// Minimum property values that materials need to have to pass
 	var/list/property_minimums = null
 	/// Maximum property values that materials need to have to pass
@@ -13,6 +15,8 @@
 	var/list/flag_strings = list()
 	for (var/flag in bitfield_to_list(required_flags))
 		flag_strings += GLOB.material_flags_to_string[flag]
+	for (var/flag in bitfield_to_list(blacklisted_flags))
+		flag_strings += "not [GLOB.material_flags_to_string[flag]]"
 	if (!length(property_minimums) && !length(property_maximums))
 		return "[capitalize(english_list(flag_strings, and_text = " or "))] material"
 
@@ -29,37 +33,28 @@
 	return "[capitalize(english_list(flag_strings, and_text = " or "))] material with [english_list(prop_reqs)]"
 
 /datum/material_requirement/proc/valid_material(datum/material/material)
-	if (required_flags > 0 && !(material.mat_flags & required_flags))
+	if (required_flags && !(material.mat_flags & required_flags))
 		return FALSE
 
-	if (required_flags < 0 && (material.mat_flags & (-required_flags)))
+	if (blacklisted_flags && (material.mat_flags & blacklisted_flags))
 		return FALSE
 
 	for (var/prop_id, min_val in property_minimums)
 		if (material.get_property(prop_id) < min_val)
 			return FALSE
+
 	for (var/prop_id, max_val in property_maximums)
 		if (material.get_property(prop_id) > max_val)
 			return FALSE
+
 	return TRUE
 
 // Actual requirement datums
 /datum/material_requirement/armor_material
 	required_flags = ITEM_MATERIAL_CLASSES
-	property_minimums = list(
-		MATERIAL_HARDNESS = 2,
-	)
-	property_maximums = list(
-		MATERIAL_FLEXIBILITY = 5,
-	)
 
 /datum/material_requirement/solid_material
-	property_minimums = list(
-		MATERIAL_HARDNESS = 2,
-	)
-	property_maximums = list(
-		MATERIAL_FLEXIBILITY = 5,
-	)
+	blacklisted_flags = MATERIAL_CLASS_AMORPHOUS
 
 /datum/material_requirement/rigid_material
 	required_flags = MATERIAL_CLASS_RIGID


### PR DESCRIPTION

## About The Pull Request

Changes hard density and flexibility requirements to be flag checks for valid item crafting flags for armor, and non-amorphous materials for everything else (so basically anything but snow and raw sand (not sandstone))

## Why It's Good For The Game

The restriction was mostly futureproofing and doesn't do much currently, I don't see this adding much, this just ended up removing some content like meat toolboxes/armor on accident. (this was intended to block snow/paper/sand from being made into material items, but after thinking a bit paper material stuff does make some sense)

## Changelog
:cl:
balance: You can make toolboxes out of meat and paper again
/:cl:
