### PR TITLE
Fix infiniti paper printing from NT Shop app

### DIFF
--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -285,7 +285,9 @@
 
 			var/turf/T = get_turf(computer)
 			var/datum/supply_order/SO = new(pack, name, rank, ckey, reason, account)
-			SO.generateRequisition(T)
+			if(computer.stored_paper >= 1)
+				SO.generateRequisition(T)
+				computer.stored_paper -= 1
 			if((requestonly && !self_paid) || !(computer.stored_id?.GetID()))
 				SSshuttle.request_list += SO
 			else

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -288,6 +288,12 @@
 			if(computer.stored_paper >= 1)
 				SO.generateRequisition(T)
 				computer.stored_paper -= 1
+				if(computer.stored_paper <= 4)
+					computer.say("Paper's storage has only [computer.stored_paper] papers. Refill please!")
+					if(computer.stored_paper <= 1)
+						computer.say("Only 1 paper has left, refill please!")
+			else
+				computer.say("Requisition cannot be printed, paper storage is empty. Please insert more paper!")
 			if((requestonly && !self_paid) || !(computer.stored_id?.GetID()))
 				SSshuttle.request_list += SO
 			else


### PR DESCRIPTION

## About The Pull Request

Fixed infiniti printing via NT shop app

Closed https://github.com/tgstation/tgstation/issues/96154
## Why It's Good For The Game

So I would made a 10 PDA at maints, at different places with integrated circuits, and also these PDAs on looped conveyrs, so they are moving at the circle, so then when TIME HAS COME, I would send via one button circuit-transmitter the signal to 10 PDAs to buy one cheap goodie for 28 credits, then cancel the purchase, than buy again, than I spam that button, or better, I would use clock, so its only one click for 5 purchasing at 1 tick on 1 PDA, so 1 PDA is 5 papers, so 10 PDAs are 50 papers, so 2 ticks are 100 papers, 3 is more and more, and all that shit on conveyers, so its 1000 papers, which are moving at circles with insane speed at only 20 ticks,

but now its not possible
## Changelog
:cl:
fix: fixed NT shop printing infiniti papers, now its linked to computer's(laptop, pda, any) paper storage
/:cl:
