### PR TITLE
bileworm spewlets spit bile instead of manifesting bullets

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
@@ -194,6 +194,7 @@
 	return ..()
 
 /obj/projectile/bileworm_acid // basically only used by the crusher trophy
+	name = "acidic bile"
 	damage = 20
 	speed = 0.5
 	range = 20

--- a/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
@@ -186,15 +186,28 @@
 	check_flags = NONE
 	owner_has_control = FALSE
 	cooldown_time = 10 SECONDS
-	projectile_type = /obj/projectile/bileworm_acid/crusher
+	projectile_type = /obj/projectile/bileworm_acid
 	projectile_sound = 'sound/mobs/non-humanoids/bileworm/bileworm_spit.ogg'
 
 /datum/action/cooldown/mob_cooldown/projectile_attack/dir_shots/spewlet/New(Target)
 	firing_directions = GLOB.cardinals.Copy()
 	return ..()
 
-/obj/projectile/bileworm_acid/crusher
+/obj/projectile/bileworm_acid // basically only used by the crusher trophy
+	damage = 20
+	speed = 0.5
+	range = 20
+	hitsound = 'sound/items/weapons/sear.ogg'
+	pass_flags = PASSTABLE
+	icon = 'icons/obj/weapons/guns/projectiles.dmi'
+	icon_state = "bile_glob"
+	layer = ABOVE_ALL_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	damage_type = BRUTE // Otherwise the mobs take heavily reduced damage
+
+/obj/projectile/bileworm_acid/crusher/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/parriable_projectile)
 
 /obj/projectile/bileworm_acid/crusher/prehit_pierce(atom/target)
 	if (!isliving(target))

--- a/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
@@ -205,11 +205,11 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	damage_type = BRUTE // Otherwise the mobs take heavily reduced damage
 
-/obj/projectile/bileworm_acid/crusher/Initialize(mapload)
+/obj/projectile/bileworm_acid/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/parriable_projectile)
 
-/obj/projectile/bileworm_acid/crusher/prehit_pierce(atom/target)
+/obj/projectile/bileworm_acid/prehit_pierce(atom/target)
 	if (!isliving(target))
 		return ..()
 	var/mob/living/as_living = target


### PR DESCRIPTION
## About The Pull Request

<img width="310" height="302" alt="dreamseeker_2026-05-28_05-43-17-PM-Thursday" src="https://github.com/user-attachments/assets/f8006886-2e77-48c5-a839-85f701f4a12c" />

Bileworm spewlets on crushers were accidentally shooting bullets instead of spewing bile on mark detonation, fixed by redefining a lot of the relevant variables onto bileworm projectiles.

## Why It's Good For The Game

Maybe my trophies should be throwing acid instead of bullets.

## Changelog

:cl:
fix: Bileworm spewlet trophies no longer spit bullets instead of acidic bile.
/:cl: