### PR TITLE
Cybernetic cat ears can no longer be restyled with flesh reshapers

### DIFF
--- a/code/modules/surgery/organs/internal/ears/_ears.dm
+++ b/code/modules/surgery/organs/internal/ears/_ears.dm
@@ -199,6 +199,7 @@
 	sprite_accessory_override = /datum/sprite_accessory/ears/cat/cybernetic
 	organ_flags = ORGAN_ROBOTIC
 	failing_desc = "seems to be broken."
+	restyle_flags = NONE
 
 /obj/item/organ/ears/cat/cybernetic/upgraded
 	name = "cybernetic cat ears"


### PR DESCRIPTION
## About The Pull Request

I intentionally left them restyleable because they used the same sprites as regular cat ears, but after #94099 (which is an awesome pr btw) restyling them now removes the emissive bits and turns them into plain white cat ears. Restyling them back doesn't even fix this. I wouldn't be against someone adding a cybernetic sprite for every cat ear shape but for now I think disabling restyling is a good idea. Plus, they're called flesh reshapers and not metal reshapers.

## Why It's Good For The Game

Stops you from breaking your cat ears.

## Changelog
:cl:
fix: Cybernetic cat ears can no longer be restyled with flesh reshapers (because it broke them)
/:cl:
