### PR TITLE
Port - now Carps can swarming like mouses

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -18,6 +18,8 @@
 	icon_living = "base"
 	icon_dead = "base_dead"
 	icon_gib = "carp_gib"
+	density = FALSE
+	pass_flags = PASSTABLE
 	gold_core_spawnable = HOSTILE_SPAWN
 	mob_biotypes = MOB_ORGANIC | MOB_BEAST | MOB_AQUATIC
 	health = 25
@@ -109,6 +111,7 @@
 
 	AddComponent(/datum/component/speechmod, replacements = strings("crustacean_replacement.json", "crustacean"))
 	AddComponent(/datum/component/aggro_emote, emote_list = string_list(list("gnashes")))
+	AddComponent(/datum/component/swarming, 20, 20)
 	AddComponent(/datum/component/regenerator, outline_colour = regenerate_colour)
 	AddComponent(/datum/component/profound_fisher)
 	if (tamer)


### PR DESCRIPTION

## About The Pull Request

Port of https://github.com/ss220club/BandaStation/pull/2513

So now Carps can swarm like mouses, you still can shove them out, can punch them, pull

<img width="485" height="387" alt="image" src="https://github.com/user-attachments/assets/093e7dc5-6992-4692-ad4c-49d6fe293dbc" />

https://github.com/user-attachments/assets/a9b05f3e-a0ac-46fe-bc47-e978449e249b
## Why It's Good For The Game

<img width="639" height="360" alt="image" src="https://github.com/user-attachments/assets/957023ed-2c43-4443-8b83-80ae74a86bd1" />

Fishes are swarming, when you are throwing them a food at the river\lake, except of big fishes, but normal fishes do some swarming
## Changelog
:cl:
balance: Carps now do swarming, like mouses
/:cl:
