### PR TITLE
Speeedy disabling

### DIFF
--- a/code/datums/storage/subtypes/belts.dm
+++ b/code/datums/storage/subtypes/belts.dm
@@ -103,7 +103,6 @@
 		/obj/item/radio,
 		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/restraints/handcuffs,
-		/obj/item/gun/energy/disabler,
 		/obj/item/restraints/legcuffs/bola,
 	))
 

--- a/code/datums/storage/subtypes/belts.dm
+++ b/code/datums/storage/subtypes/belts.dm
@@ -103,6 +103,7 @@
 		/obj/item/radio,
 		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/restraints/handcuffs,
+		/obj/item/gun/energy/disabler,
 		/obj/item/restraints/legcuffs/bola,
 	))
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -172,6 +172,7 @@
 	name = "disabler beam"
 	icon_state = "omnilaser"
 	damage = 30
+	speed = 1.6
 	damage_type = STAMINA
 	armor_flag = ENERGY
 	hitsound = 'sound/items/weapons/sear_disabler.ogg'
@@ -183,13 +184,14 @@
 
 /obj/projectile/beam/disabler/weak
 	damage = 15
+	speed = 1 //why you need speed with shotgun?
 
 /obj/projectile/beam/disabler/scatter
 	name = "scatter disabler"
 	icon_state = "scatterdisabler"
 	damage = 5.5
 	damage_falloff_tile = -0.5
-	speed = 1.2
+	speed = 1 //same, that's a shotgun, you dont need speed on shotgun 
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	tracer_type = /obj/effect/projectile/tracer/xray
 	muzzle_type = /obj/effect/projectile/muzzle/xray

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -190,7 +190,7 @@
 	icon_state = "scatterdisabler"
 	damage = 5.5
 	damage_falloff_tile = -0.5
-	speed = 1 //same, that's a shotgun, you dont need speed on shotgun 
+	speed = 1.2
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	tracer_type = /obj/effect/projectile/tracer/xray
 	muzzle_type = /obj/effect/projectile/muzzle/xray

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -184,7 +184,6 @@
 
 /obj/projectile/beam/disabler/weak
 	damage = 15
-	speed = 1 //why you need speed with shotgun?
 
 /obj/projectile/beam/disabler/scatter
 	name = "scatter disabler"


### PR DESCRIPTION
## About the pull request 
Makes normal disabler projectiles faster.

## Why its good for game
If someone can use lethal laser instead of disabling, they use it.
Why? Because when you hit someone with laser he will not regenerate and will run fast again, thats bad.
"Normal" disabling shots now have alot more speed 

## Changelog
🆑
balance: Disabler shots is now have 1.6 speed instead of 1.25 sorry mine skill issue
/:cl: