### PR TITLE
Renames 2 cameras on MetaStation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -32945,7 +32945,7 @@
 /area/station/cargo/storage)
 "lje" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "Starboard Primary Hallway - Auxiliary Tool Storage"
+	c_tag = "Starboard Primary Hallway - Technical Storage"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36196,7 +36196,7 @@
 /area/station/service/kitchen)
 "mta" = (
 /obj/machinery/camera/directional/north{
-	c_tag = "Starboard Primary Hallway - tech_storage"
+	c_tag = "Starboard Primary Hallway - Auxiliary Tool Storage"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,


### PR DESCRIPTION

## About The Pull Request

fixes https://github.com/tgstation/tgstation/issues/93036, so it's can be called double fix, because of aux storage cam was looked at tech storage, and tech_storage (now with fixed c tag) look at aux storage
## Why It's Good For The Game

bugfix
## Changelog
:cl:
fix: Renamed 2 cameras on MetaStation; first cam was with wrong name and second one was a badnamed
/:cl:
