### PR TITLE
Assorted Nanopaint-related Fixes

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1426,7 +1426,7 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 
 // Reorder the 2d pixel data of the passed in frames into a data string that can be passed to rustg_dmi_create_png
 /proc/reorder_pixels(icon_width, icon_height, grid_width, grid_height, list/frames)
-	var/file_height = icon_height * grid_height
+	var/file_width = icon_width * grid_width
 
 	// This little trick right here reduces the total iteration of repeat_string from the product of the arguments to their sum.
 	// Can't be applied to the general case without a complex partitioning algorithm,
@@ -1443,7 +1443,7 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 		var/column = (i-1)%grid_width
 		for(var/y in 1 to length(frame))
 			var/list/row = jointext(frame[y], "")
-			var/splice_start = (row_index+y-1)*file_height + column*icon_width + 1
+			var/splice_start = (row_index*icon_height+y-1)*file_width + column*icon_width + 1
 			linear_pixels = splicetext(linear_pixels, (splice_start-1)*9+1, (splice_start+icon_width-1)*9+1, row)
 	var/zero_alpha_regex = regex(@@#(?:(?!a0a0a0)([0-9]|[a-f]){6}00)@, "gi")
 	linear_pixels = replacetext(linear_pixels, zero_alpha_regex, COLOR_DMI_MASK)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -286,6 +286,16 @@
 
 	return TRUE
 
+/proc/filter_illegal_filename_chars(name)
+	var/regex/illegal_chars = new("\[\\/:*?\"<>|]", "g")
+	return !findtext(name, illegal_chars)
+
+/proc/filter_filename_pda(name)
+	if(is_ic_filtered_for_pdas(name) || is_soft_ic_filtered_for_pdas(name))
+		return FALSE
+	if(!filter_illegal_filename_chars(name))
+		return FALSE
+	return TRUE
 
 //html_encode helper proc that returns the smallest non null of two numbers
 //or 0 if they're both null (needed because of findtext returning 0 when a value is not present)

--- a/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
@@ -127,7 +127,7 @@
 			if(!channel)
 				return
 			var/logname = trim(params["log_name"], MAX_MESSAGE_LEN)
-			if(!logname || !filter_filename_pda(logname))
+			if(!length(logname) || !filter_filename_pda(logname))
 				return
 			var/datum/computer_file/data/text/logfile = new()
 			// Now we will generate HTML-compliant file that can actually be viewed/printed.

--- a/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/chatroom/ntnrc_client.dm
@@ -126,8 +126,8 @@
 		if("PRG_savelog")
 			if(!channel)
 				return
-			var/logname = stripped_input(params["log_name"])
-			if(!logname)
+			var/logname = trim(params["log_name"], MAX_MESSAGE_LEN)
+			if(!logname || !filter_filename_pda(logname))
 				return
 			var/datum/computer_file/data/text/logfile = new()
 			// Now we will generate HTML-compliant file that can actually be viewed/printed.

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -119,8 +119,8 @@ GLOBAL_LIST_INIT(print_types, init_print_types())
 			var/datum/computer_file/file = computer.find_file_by_name(params["name"])
 			if(!file)
 				return
-			var/newname = reject_bad_name(params["new_name"], allow_numbers = TRUE, cap_after_symbols = FALSE, cap_at_start = FALSE)
-			if(!newname || newname != params["new_name"])
+			var/newname = trim(params["new_name"], MAX_MESSAGE_LEN)
+			if(!filter_filename_pda(newname))
 				playsound(computer, 'sound/machines/terminal/terminal_error.ogg', 25, FALSE)
 				return
 			file.filename = newname
@@ -131,8 +131,8 @@ GLOBAL_LIST_INIT(print_types, init_print_types())
 			var/datum/computer_file/file = computer.find_file_by_name(params["name"], computer.inserted_disk)
 			if(!file)
 				return
-			var/newname = reject_bad_name(params["new_name"], allow_numbers = TRUE, cap_after_symbols = FALSE, cap_at_start = FALSE)
-			if(!newname || newname != params["new_name"])
+			var/newname = trim(params["new_name"], MAX_MESSAGE_LEN)
+			if(!filter_filename_pda(newname))
 				playsound(computer, 'sound/machines/terminal/terminal_error.ogg', 25, FALSE)
 				return
 			file.filename = newname

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -120,7 +120,7 @@ GLOBAL_LIST_INIT(print_types, init_print_types())
 			if(!file)
 				return
 			var/newname = trim(params["new_name"], MAX_MESSAGE_LEN)
-			if(!filter_filename_pda(newname))
+			if(!length(newname) || !filter_filename_pda(newname))
 				playsound(computer, 'sound/machines/terminal/terminal_error.ogg', 25, FALSE)
 				return
 			file.filename = newname
@@ -132,7 +132,7 @@ GLOBAL_LIST_INIT(print_types, init_print_types())
 			if(!file)
 				return
 			var/newname = trim(params["new_name"], MAX_MESSAGE_LEN)
-			if(!filter_filename_pda(newname))
+			if(!length(newname) || !filter_filename_pda(newname))
 				playsound(computer, 'sound/machines/terminal/terminal_error.ogg', 25, FALSE)
 				return
 			file.filename = newname

--- a/code/modules/modular_computers/file_system/programs/nanopaint.dm
+++ b/code/modules/modular_computers/file_system/programs/nanopaint.dm
@@ -175,11 +175,14 @@ GLOBAL_LIST_INIT(nanopaint_supported_filetypes, zebra_typecacheof(list(\
 				return
 			dialog = null
 			var/uid = params["uid"]
-			var/new_file_name = params["name"]
+			var/new_file_name = trim(params["name"], MAX_MESSAGE_LEN)
 			var/saving_to_disk = params["onDisk"]
 			var/datum/computer_file/new_file_type = text2path(params["typepath"])
 			var/extension = new_file_type::filetype
 			var/datum/computer_file/existing_file
+			if(!length(new_file_name))
+				dialog = list("type" = "error", "message" = "No name specified.")
+				return TRUE
 			if(saving_to_disk)
 				if(!computer.inserted_disk)
 					dialog = list("type" = "error", "message" = "[new_file_name] - The disk has been removed.")
@@ -207,6 +210,12 @@ GLOBAL_LIST_INIT(nanopaint_supported_filetypes, zebra_typecacheof(list(\
 						)
 				else
 					INVOKE_ASYNC(src, PROC_REF(write_to_file), user, existing_file)
+				return TRUE
+			if(is_ic_filtered_for_pdas(new_file_name) || is_soft_ic_filtered_for_pdas(new_file_name))
+				dialog = list("type" = "error", "message" = "The entered file name violates company policy.")
+				return TRUE
+			if(!filter_illegal_filename_chars(new_file_name))
+				dialog = list("type" = "error", "message" = "[new_file_name] - File names cannot include the following characters. \n \\ / : * ? \" < > |")
 				return TRUE
 			INVOKE_ASYNC(src, PROC_REF(save_file), user, new_file_name, new_file_type, saving_to_disk && computer.inserted_disk)
 			return TRUE
@@ -283,7 +292,7 @@ GLOBAL_LIST_INIT(nanopaint_supported_filetypes, zebra_typecacheof(list(\
 
 /datum/computer_file/program/nanopaint/proc/save_file(mob/user, name, file_type, obj/item/disk/computer/target_disk)
 	var/datum/computer_file/file = new file_type()
-	file.filename = reject_bad_name(name, allow_numbers = TRUE, cap_after_symbols = FALSE, cap_at_start = FALSE)
+	file.filename = name
 	var/file_stored
 	if(target_disk)
 		file_stored = target_disk.add_file(file)


### PR DESCRIPTION
## About The Pull Request

This PR fixes non-square sprite editor sprites saving to icons incorrectly, and changes the way user-provided filenames are handled for modular computer apps.

## Why It's Good For The Game

Fixes #96269
Fixes #96270
Also yeah I don't think we want people naming the files on their PDA racial slurs.

## Changelog

:cl:
fix: Non-square paint canvases and Nanopaint projects correctly save to icons.
fix: You can no longer enter empty filenames when saving Nanopaint files.
spellcheck: User-provided modular computer filenames are now checked against the pda IC filter.
/:cl:
