### PR TITLE
it's no longer possible to craft the jaws of recovery out of the jaws of recovery

### DIFF
--- a/code/datums/components/crafting/tools.dm
+++ b/code/datums/components/crafting/tools.dm
@@ -131,6 +131,10 @@
 	)
 	category = CAT_TOOLS
 
+/datum/crafting_recipe/jaws_of_recovery/New()
+	LAZYADD(blacklist, typecacheof(/obj/item/crowbar/power/paramedic, ignore_root_path = TRUE))
+	return ..()
+
 /datum/crafting_recipe/lantern
 	name = "Lantern"
 	result = /obj/item/flashlight/lantern


### PR DESCRIPTION

## About The Pull Request

i thought this was some sort of strange balance change at first but no it's definitely not intended, this crafting recipe is supposed to basically just be a reskin ability to turn a normal jaws of life into a jaws of recovery. you're not supposed to be able to roundstart shrink the jaws of recovery down to normal size and make them silent and let you break into the pharmacy through the windoors

## Why It's Good For The Game

its kinda cringe man

## Changelog
:cl:
fix: jaws of recovery are blacklisted from crafting the jaws of recovery
/:cl:
