### PR TITLE
Adds a hotkey which cancels your `do_after`s (if possible)

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -63,6 +63,7 @@
 #define COMSIG_KB_LIVING_HOLDTHROWMODE_DOWN "keybinding_living_holdthrowmode_down"
 #define COMSIG_KB_LIVING_GIVEITEM_DOWN "keybinding_living_giveitem_down"
 #define COMSIG_KB_LIVING_VIEW_PET_COMMANDS "keybinding_living_view_pet_commands"
+#define COMSIG_KB_LIVING_STOP_INTERACTIONS_DOWN "keybinding_living_stop_interactions_down"
 
 //Mob
 #define COMSIG_KB_MOB_FACENORTH_DOWN "keybinding_mob_facenorth_down"

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -247,7 +247,7 @@
 	if(.)
 		return
 	var/mob/living/mob_user = user.mob
-	if(!LAZYLEN(mob_user.do_afters))
+	if(!LAZYLEN(mob_user.do_afters) || HAS_TRAIT(mob_user, TRAIT_INCAPACITATED))
 		return
 	// this is currently the best way to stop all ongoing doafters
 	mob_user.incapacitate(0.1 SECONDS, ignore_canstun = TRUE)

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -238,7 +238,8 @@
 /datum/keybinding/living/cancel_interactions
 	name = "stop_interactions"
 	full_name = "Cancel Interactions"
-	description = "Cancels any ongoing interactions (such as using a tool, performing surgery, or climbing)."
+	description = "Cancels any ongoing interactions (such as using a tool, performing surgery, or climbing) \
+		Note that some interactions cannot be interrupted, and it does not affect other player's interacting with you."
 	keybind_signal = COMSIG_KB_LIVING_STOP_INTERACTIONS_DOWN
 
 /datum/keybinding/living/cancel_interactions/down(client/user, turf/target, mousepos_x, mousepos_y)

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -227,3 +227,26 @@
 	if(!HAS_TRAIT(living_user, TRAIT_CAN_HOLD_ITEMS))
 		return
 	living_user.give()
+
+/datum/keybinding/living/view_pet_data
+	hotkey_keys = list("Shift")
+	name = "view_pet_commands"
+	full_name = "View Pet Commands"
+	description = "Hold down to see all the commands you can give your pets!"
+	keybind_signal = COMSIG_KB_LIVING_VIEW_PET_COMMANDS
+
+/datum/keybinding/living/cancel_interactions
+	name = "stop_interactions"
+	full_name = "Cancel Interactions"
+	description = "Cancels any ongoing interactions (such as using a tool, performing surgery, or climbing)."
+	keybind_signal = COMSIG_KB_LIVING_STOP_INTERACTIONS_DOWN
+
+/datum/keybinding/living/cancel_interactions/down(client/user, turf/target, mousepos_x, mousepos_y)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/mob_user = user.mob
+	if(!LAZYLEN(mob_user.do_afters))
+		return
+	// this is currently the best way to stop all ongoing doafters
+	mob_user.incapacitate(0.1 SECONDS, ignore_canstun = TRUE)

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -238,8 +238,8 @@
 /datum/keybinding/living/cancel_interactions
 	name = "stop_interactions"
 	full_name = "Cancel Interactions"
-	description = "Cancels any ongoing interactions (such as using a tool, performing surgery, or climbing) \
-		Note that some interactions cannot be interrupted, and it does not affect other player's interacting with you."
+	description = "Cancels any ongoing interactions (such as using a tool, performing surgery, or climbing). \
+		Note that some interactions cannot be interrupted, and you can't cancel other player's interaction with this hotkey."
 	keybind_signal = COMSIG_KB_LIVING_STOP_INTERACTIONS_DOWN
 
 /datum/keybinding/living/cancel_interactions/down(client/user, turf/target, mousepos_x, mousepos_y)

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -246,10 +246,3 @@
 	if(.)
 		return
 	user.movement_locked = FALSE
-
-/datum/keybinding/living/view_pet_data
-	hotkey_keys = list("Shift")
-	name = "view_pet_commands"
-	full_name = "View Pet Commands"
-	description = "Hold down to see all the commands you can give your pets!"
-	keybind_signal = COMSIG_KB_LIVING_VIEW_PET_COMMANDS


### PR DESCRIPTION
## About The Pull Request

Adds a hotkey `Cancel Interactions` which stops (most) of your active `do_after`s

This only applies to `do_after`s you are doing obviously. You can't cancel other people's interactions vs you. 
Also it doesn't work on any `do_after` that is not interrupted if the user is incapacitated. Which is very few ultimately. 

## Why It's Good For The Game

Typically you just do a tile-shuffle or a hand-shuffle to cancel a `do_after`, so I see no reason not to add an "official keybind" so you don't have to do the tile-shuttle or hand-shuffle. 

## Changelog

:cl: Melbert
qol: Adds "cancel interaction" keybinding, unbound by default, it cancels (most) interactions you're doing without needing to move or swap items. 
/:cl:
