### PR TITLE
Makes so blob_act() can't destroy indestructible items. 

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -366,7 +366,7 @@
 	return TRUE
 
 /obj/item/blob_act(obj/structure/blob/B)
-	if(B && B.loc == loc)
+	if(B && B.loc == loc && !(resistance_flags & INDESTRUCTIBLE))
 		atom_destruction(MELEE)
 
 /**Makes cool stuff happen when you suicide with an item


### PR DESCRIPTION

## About The Pull Request

Currently, items like the nuke disk can be deleted by the blob. This aims to solve that.

## Why It's Good For The Game

I figure this flag would be set for a reason. ``/obj/blob_act()`` will have ``take_damage()`` cancel out if the flag is there. ``/obj/item/blob_act()`` does not supercall, nor does ``take_damage()`` return anything that might null out the parent proc.

This is the most direct method.  I believe it's intended because ``/obj/blob_act()`` will handle structures. It would be running an unnecessary somewhat lengthy proc on hundreds of items that are going to get qdeleted anyway if I was to supercall it.

Also, shit is indestructible for a reason. 
## Changelog

:cl:
fix: Blobs can no longer destroy indestructible items, like the disk.
/:cl:

