### PR TITLE
Makes stumps not see through

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -308,7 +308,8 @@
 
 /obj/structure/flora/tree/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/seethrough, get_seethrough_map())
+	if(get_seethrough_map())
+		AddComponent(/datum/component/seethrough, get_seethrough_map())
 
 /obj/structure/flora/tree/get_potential_products()
 	return list(/obj/item/grown/log/tree = 1)
@@ -344,6 +345,9 @@
 	..()
 	to_chat(user, span_notice("You manage to remove [src]."))
 	qdel(src)
+
+/obj/structure/flora/tree/stump/get_seethrough_map()
+	return FALSE
 
 /obj/structure/flora/tree/dead
 	icon = 'icons/obj/fluff/flora/deadtrees.dmi'


### PR DESCRIPTION

## About The Pull Request
Just made it acctually check if we even have a seethrough map before we bother assigning it so we dont make stumps see through which seems rather silly.
## Why It's Good For The Game
Its not even a tile tall. Why would we need that.
## Changelog
:cl:
fix: Stumps aren't see through
/:cl:
