### PR TITLE
cryoxadone is capable of healing you

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -154,9 +154,11 @@
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	metabolization_rate = REAGENTS_METABOLISM * (0.00001 * (affected_mob.bodytemperature ** 2) + 0.5)
-	if(affected_mob.bodytemperature >= T0C || !HAS_TRAIT(affected_mob, TRAIT_KNOCKEDOUT))
+	if(affected_mob.bodytemperature >= T0C)
 		return
 	var/power = -0.00003 * (affected_mob.bodytemperature ** 2) + 3
+	if(HAS_TRAIT(affected_mob, TRAIT_KNOCKEDOUT)) //Significantly more effective when unconscious
+		power *= 2
 	var/need_mob_update
 	need_mob_update = affected_mob.adjust_oxy_loss(-1.5 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	need_mob_update += affected_mob.adjust_brute_loss(-0.5 * power * metabolization_ratio * seconds_per_tick, updating_health = FALSE, required_bodytype = affected_bodytype)


### PR DESCRIPTION

## About The Pull Request

Closes #96078

Cryox has been nerfcrept over the years so hard that at the moment you can use it to softlock people by trapping them inside with burn damage, as cryoxadone heals so slowly that the 73k air will hurt you nearly more than the cryox even heals you. This PR changes cryox so that sleeping is no longer a hard requirement, rather it simply doubles the "power" of the cryoxadone, like how being on fire doubles the power of pyroxadone. Even with this it's still not a great heal, doing about 2-3 of each damage per tick, far inferior to a proper healmix. When you're awake it heals you the same as it does now.
## Why It's Good For The Game

Helps cryoxadone actually fill its niche a bit better (Healing wounds/triage with the cryo tubes/less efficient new player fallback option) without reintroducing the abusive abilities that got cryox nerfed in the first place, namely naked spacewalking since pressure damage has been doubled and waking cryox will no longer let you outheal it. The hard requirement on unconsciousness is also very uninteresting and anti-sandbox (you MUST use the cryo tube or this reagent does NOTHING)

## Changelog
:cl:
balance: instead of the hard requirement for sleeping, cryox's healing power is doubled by being asleep instead
fix: on default settings a cryo tube filled with cryoxadone can no longer softlock you by outdamaging its own healing potential
/:cl:
