### PR TITLE
Material Fishing Rods can be made out of any material now

### DIFF
--- a/code/datums/materials/requirements/_requirement.dm
+++ b/code/datums/materials/requirements/_requirement.dm
@@ -61,5 +61,13 @@
 		MATERIAL_FLEXIBILITY = 5,
 	)
 
+/datum/material_requirement/any_material
+	property_minimums = list(
+
+	)
+	property_maximums = list(
+
+	)
+
 /datum/material_requirement/rigid_material
 	required_flags = MATERIAL_CLASS_RIGID

--- a/code/modules/research/designs/autolathe/service_designs.dm
+++ b/code/modules/research/designs/autolathe/service_designs.dm
@@ -542,7 +542,7 @@
 	name = "Material Fishing Rod"
 	id = "fishing_rod_material"
 	build_type = AUTOLATHE
-	materials = list(/datum/material_requirement/solid_material = SMALL_MATERIAL_AMOUNT * 4)
+	materials = list(/datum/material_requirement/any_material = SMALL_MATERIAL_AMOUNT * 4)
 	build_path = /obj/item/fishing_rod/material
 	category = list(
 		RND_CATEGORY_INITIAL,


### PR DESCRIPTION

## About The Pull Request
Removes the material restriction on material fishing rod, this lets them be made of Hauntium, Snow, Sand, Meat, Pizza, Paper, or Cardboard now.
<img width="171" height="339" alt="all impossible fishing rods" src="https://github.com/user-attachments/assets/d74b462b-484e-42a3-9250-c5f6db7e1354" />
## Why It's Good For The Game
All of these materials were pretty illogically disallowed from being a fishing rod for no real good reason. This means you can now make a shit ton of each materials if you know what you are doing.
## Changelog
:cl:
add: You can now make material fishing rods out of any material!
/:cl:
