### PR TITLE
Use lore time for a couple spots that list NST 

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(statpanels)
 
 		global_data += list(
 			"Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]",
-			"Server Time/NST: [server_timestamp(format = "YYYY-MM-DD hh:mm:ss")]",
+			"Server Time/NST: [server_timestamp(format = "YYYY-MM-DD hh:mm:ss", ic_time = TRUE)]",
 			"Shift Time/PT: [(SSticker.round_start_time == 0) ? "Pre-Game" : round_timestamp()]",
 			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)",
 		)

--- a/code/modules/escape_menu/details.dm
+++ b/code/modules/escape_menu/details.dm
@@ -7,7 +7,7 @@
 	var/new_maptext = {"
 		<span style='text-align: right; line-height: 0.7'>
 			Round ID: [GLOB.round_id || "Unset"]<br />
-			Server Time (NST): [server_timestamp(format = "hh:mm:ss", ic_time = TRUE, twelve_hour_clock = client_owner.prefs.read_preference(/datum/preference/toggle/twelve_hour))]<br />
+			Server Time (NST): [server_timestamp(format = "YYYY-MM-DD hh:mm:ss", ic_time = TRUE, twelve_hour_clock = client_owner.prefs.read_preference(/datum/preference/toggle/twelve_hour))]<br />
 			Shift Time (PT): [(SSticker.round_start_time == 0) ? "Pre-Game" : round_timestamp()]<br />
 			Map: [SSmapping.current_map.return_map_name(webmap_included = TRUE) || "Loading..."]<br />
 			Time Dilation: [round(SStime_track.time_dilation_current, 1)]%<br />

--- a/code/modules/escape_menu/details.dm
+++ b/code/modules/escape_menu/details.dm
@@ -7,7 +7,7 @@
 	var/new_maptext = {"
 		<span style='text-align: right; line-height: 0.7'>
 			Round ID: [GLOB.round_id || "Unset"]<br />
-			Server Time (NST): [server_timestamp(format = "YYYY-MM-DD hh:mm:ss", ic_time = TRUE, twelve_hour_clock = client_owner.prefs.read_preference(/datum/preference/toggle/twelve_hour))]<br />
+			Server Time (NST): [server_timestamp(format = "hh:mm:ss", ic_time = TRUE, twelve_hour_clock = client_owner.prefs.read_preference(/datum/preference/toggle/twelve_hour))]<br />
 			Shift Time (PT): [(SSticker.round_start_time == 0) ? "Pre-Game" : round_timestamp()]<br />
 			Map: [SSmapping.current_map.return_map_name(webmap_included = TRUE) || "Loading..."]<br />
 			Time Dilation: [round(SStime_track.time_dilation_current, 1)]%<br />


### PR DESCRIPTION

## About The Pull Request
Use the year offset value to display accurate time in statpanel 
<img width="351" height="84" alt="image" src="https://github.com/user-attachments/assets/302782c8-3e7d-463c-8a2d-1feecd8a1f4b" />
Statpanel won't doesn't have access to client prefs and I'm not fixing that so no 12hr clock
## Why It's Good For The Game
muh immersion
## Changelog
:cl:
fix: statpanel uses year offset
/:cl:
