### PR TITLE
Material spears do not erroneously drop force_unwielded

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -119,7 +119,7 @@
 		src.force_multiplier = force_multiplier
 	if(!isnull(force_wielded))
 		src.force_wielded = force_wielded
-	if(isnull(force_unwielded))
+	if(!isnull(force_unwielded))
 		src.force_unwielded = force_unwielded
 	if(icon_wielded)
 		src.icon_wielded = icon_wielded


### PR DESCRIPTION

## About The Pull Request

Change var when changing to not null

## Why It's Good For The Game

14 damage weapon that attacks two tiles away:

## Changelog
:cl:

fix: Material spears no longer partially avoid the force malus from being unwielded

/:cl:
