### PR TITLE
Drake swoop no longer misleadingly claims you fall into lava if it fails to spawn said lava

### DIFF
--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -274,6 +274,10 @@
 	light_color = LIGHT_COLOR_FIRE
 	duration = 10
 
+/obj/effect/temp_visual/fire/light
+	icon_state = "light"
+	color = COLOR_DARK_ORANGE
+
 /obj/effect/temp_visual/revenant
 	name = "spooky lights"
 	icon_state = "purplesparkles"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -213,27 +213,34 @@
 	animate(src, alpha = 255, time = duration)
 
 /obj/effect/temp_visual/lava_warning/proc/fall(reset_time)
-	var/turf/T = get_turf(src)
-	playsound(T,'sound/effects/magic/fleshtostone.ogg', 80, TRUE)
+	var/turf/our_turf = get_turf(src)
+	playsound(our_turf,'sound/effects/magic/fleshtostone.ogg', 80, TRUE)
 	sleep(duration)
-	playsound(T,'sound/effects/magic/fireball.ogg', 200, TRUE)
+	playsound(our_turf,'sound/effects/magic/fireball.ogg', 200, TRUE)
+	var/can_transform_turf = !isclosedturf(our_turf) && !islava(our_turf)
 
-	for(var/mob/living/L in T.contents - owner)
-		if(istype(L, /mob/living/simple_animal/hostile/megafauna/dragon))
+	for(var/mob/living/victim in our_turf)
+		if(istype(victim, /mob/living/simple_animal/hostile/megafauna/dragon) || victim == owner)
 			continue
-		L.adjust_fire_loss(10)
-		to_chat(L, span_userdanger("You fall directly into the pool of lava!"))
+		victim.adjust_fire_loss(10)
+		if(can_transform_turf)
+			to_chat(victim, span_userdanger("You fall directly into the pool of lava!"))
+		else
+			to_chat(victim, span_userdanger("You are set ablaze by a fireball from above!"))
 
 	// deals damage to mechs
-	for(var/obj/vehicle/sealed/mecha/M in T.contents)
-		M.take_damage(45, BRUTE, MELEE, 1)
+	for(var/obj/vehicle/sealed/mecha/mech in our_turf)
+		mech.take_damage(45, BRUTE, MELEE, 1)
 
-	// changes turf to lava temporarily
-	if(!isclosedturf(T) && !islava(T))
-		var/lava_turf = /turf/open/lava/smooth
-		var/reset_turf = T.type
-		T.TerraformTurf(lava_turf, flags = CHANGETURF_INHERIT_AIR)
-		addtimer(CALLBACK(T, TYPE_PROC_REF(/turf, ChangeTurf), reset_turf, null, CHANGETURF_INHERIT_AIR), reset_time, TIMER_OVERRIDE|TIMER_UNIQUE)
+	// changes turf to lava temporarily if possible, create a fire visual otherwise
+	if(!can_transform_turf)
+		new /obj/effect/temp_visual/fire/light(our_turf)
+		return
+
+	var/lava_turf = /turf/open/lava/smooth
+	var/reset_turf = our_turf.type
+	our_turf.TerraformTurf(lava_turf, flags = CHANGETURF_INHERIT_AIR)
+	addtimer(CALLBACK(our_turf, TYPE_PROC_REF(/turf, ChangeTurf), reset_turf, null, CHANGETURF_INHERIT_AIR), reset_time, TIMER_OVERRIDE|TIMER_UNIQUE)
 
 /obj/effect/temp_visual/drakewall
 	desc = "An ash drakes true flame."


### PR DESCRIPTION

## About The Pull Request

If drake swoop (the one where it creates a box of fire around you) fails to spawn lava underneath it instead creates a fire visual (not an actual hotspot, does not set you on fire) and gives a separate text instead of claiming you fell into nonexistent lava

## Why It's Good For The Game

Consistency

## Changelog
:cl:
fix: Drake swoop no longer misleadingly claims you fall into lava if it fails to spawn said lava
/:cl:
