### PR TITLE
Uncuffing/Unbuckling cancels doafters if done early

### DIFF
--- a/code/__DEFINES/_flags.dm
+++ b/code/__DEFINES/_flags.dm
@@ -323,6 +323,9 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define IGNORE_SLOWDOWNS (1<<4)
 /// Cancel the action if the user does another action (mainly via clicking)
 #define DO_AFTER_CHECK_NEXT_MOVE (1<<5)
+/// Show progress bar over the user instead of the target
+#define PROGRESSBAR_OVER_USER (1<<6)
+
 
 // Spacevine-related flags
 /// Is the spacevine / flower bud heat resistant

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -243,7 +243,7 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 
 	if(progress)
 		if(user.client || bar_override?.client)
-			progbar = new(bar_override || user, delay, target || user)
+			progbar = new(bar_override || user, delay, (timed_action_flags & PROGRESSBAR_OVER_USER) ? user : (target || user))
 
 		if(!hidden && delay >= 1 SECONDS)
 			cog = new(bar_override || user, icon, iconstate)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -156,7 +156,7 @@
 				span_notice("You attempt to unbuckle yourself... \
 				(This will take around [DisplayTimeText(buckle_cd)] and you must stay still.)"))
 
-	if(!do_after(src, buckle_cd, target = src, timed_action_flags = IGNORE_HELD_ITEM, hidden = TRUE))
+	if(!do_after(src, buckle_cd, target = buckled, timed_action_flags = IGNORE_HELD_ITEM|IGNORE_TARGET_LOC_CHANGE|PROGRESSBAR_OVER_USER, hidden = TRUE))
 		if(buckled)
 			to_chat(src, span_warning("You fail to unbuckle yourself!"))
 		return
@@ -207,7 +207,7 @@
 	if(!cuff_break)
 		visible_message(span_warning("[src] attempts to remove [cuffs]!"))
 		to_chat(src, span_notice("You attempt to remove [cuffs]... (This will take around [DisplayTimeText(breakouttime)] and you need to stand still.)"))
-		if(do_after(src, breakouttime, target = src, timed_action_flags = IGNORE_HELD_ITEM, hidden = TRUE))
+		if(do_after(src, breakouttime, target = cuffs, timed_action_flags = IGNORE_HELD_ITEM|PROGRESSBAR_OVER_USER, hidden = TRUE))
 			. = clear_cuffs(cuffs, cuff_break)
 		else
 			to_chat(src, span_warning("You fail to remove [cuffs]!"))
@@ -216,7 +216,7 @@
 		breakouttime = 5 SECONDS
 		visible_message(span_warning("[src] is trying to break [cuffs]!"))
 		to_chat(src, span_notice("You attempt to break [cuffs]... (This will take around 5 seconds and you need to stand still.)"))
-		if(do_after(src, breakouttime, target = src, timed_action_flags = IGNORE_HELD_ITEM))
+		if(do_after(src, breakouttime, target = cuffs, timed_action_flags = IGNORE_HELD_ITEM|PROGRESSBAR_OVER_USER))
 			. = clear_cuffs(cuffs, cuff_break)
 		else
 			to_chat(src, span_warning("You fail to break [cuffs]!"))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -156,7 +156,7 @@
 				span_notice("You attempt to unbuckle yourself... \
 				(This will take around [DisplayTimeText(buckle_cd)] and you must stay still.)"))
 
-	if(!do_after(src, buckle_cd, target = buckled, timed_action_flags = IGNORE_HELD_ITEM|IGNORE_TARGET_LOC_CHANGE|PROGRESSBAR_OVER_USER, hidden = TRUE))
+	if(!do_after(src, buckle_cd, target = buckled, timed_action_flags = IGNORE_HELD_ITEM|IGNORE_TARGET_LOC_CHANGE, hidden = TRUE))
 		if(buckled)
 			to_chat(src, span_warning("You fail to unbuckle yourself!"))
 		return


### PR DESCRIPTION
## About The Pull Request

Uncuffing or unbuckling yourself will cancel out if the item you're removing/unbuckling from is destroyed or otherwise moved.

Closets and bodybags don't use this code so it doesn't affect them at all

## Why It's Good For The Game

If someone removes your handcuffs early you'll still have a progressbar over your head for nothing.

## Changelog

:cl:
fix: Being uncuffed or unbuckled early while you're resisting out of it will clear the progress bar.
/:cl: