### PR TITLE
Makes Destroy() a protected proc to safeguard against improper calls

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -374,7 +374,7 @@ SUBSYSTEM_DEF(garbage)
 	var/start_time = world.time
 	var/start_tick = world.tick_usage
 	SEND_SIGNAL(to_delete, COMSIG_QDELETING, force) // Let the (remaining) components know about the result of Destroy
-	var/hint = to_delete.Destroy(force) // Let our friend know they're about to get fucked up.
+	var/hint = UNLINT(to_delete.Destroy(force)) // Let our friend know they're about to get fucked up.
 
 	if(world.time != start_time)
 		trash.slept_destroy++

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -87,7 +87,7 @@
 
 	/**
 	 * Parent types.
-	 * 
+	 *
 	 * Abstract-ness is a meta-property of a class that is used to indicate
 	 * that the class is intended to be used as a base class for others, and
 	 * should not (or cannot) be instantiated.
@@ -123,6 +123,7 @@
  * Returns [QDEL_HINT_QUEUE]
  */
 /datum/proc/Destroy(force = FALSE)
+	PROTECTED_PROC(TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 	SHOULD_NOT_SLEEP(TRUE)
 	tag = null


### PR DESCRIPTION
## About The Pull Request

Makes `/datum/proc/Destroy()` a SpacemanDMM protected proc & unlints the call in `qdel()`

Taken from
- https://github.com/BeeStation/BeeStation-Hornet/pull/14439

## Why It's Good For The Game

There have been a handful of improper `Destroy()` calls over the years on my codebase and we've elected to make sure that doesn't ever happen again. This is just a safeguard.

/tg/ doesn't have any bad `Destroy()` calls but this will stop newcomers from making this mistake. 

## Changelog

No user facing changes
