### PR TITLE
Fix: Water cooler reagents are now visible to observers and scientists (#95636)

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -36,7 +36,7 @@
 	/// is it climbable? some of our wall-mounted dispensers should not have this
 	var/climbable = FALSE
 	/// Flags passed to the reagents datum upon creation
-    var/reagent_flags = DRAINABLE | AMOUNT_VISIBLE
+	var/reagent_flags = DRAINABLE | AMOUNT_VISIBLE
 
 // This check is necessary for assemblies to automatically detect that we are compatible
 /obj/structure/reagent_dispensers/IsSpecialAssembly()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -382,6 +382,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/peppertank, 3
 
 /obj/structure/reagent_dispensers/water_cooler/examine(mob/user)
 	. = ..()
+
+	// Lets the user know what reagents are in the cooler, if they can see them.
+	if(user.can_see_reagents() && reagents.total_volume)
+		for(var/datum/reagent/current_reagent as anything in reagents.reagent_list)
+			. += "&bull; [round(current_reagent.volume, CHEMICAL_VOLUME_ROUNDING)] units of [current_reagent.name]"
+
 	if (paper_cups > 1)
 		. += "There are [paper_cups] paper cups left."
 	else if (paper_cups == 1)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -35,6 +35,8 @@
 	var/last_rigger = ""
 	/// is it climbable? some of our wall-mounted dispensers should not have this
 	var/climbable = FALSE
+	/// Flags passed to the reagents datum upon creation
+    var/reagent_flags = DRAINABLE | AMOUNT_VISIBLE
 
 // This check is necessary for assemblies to automatically detect that we are compatible
 /obj/structure/reagent_dispensers/IsSpecialAssembly()
@@ -152,7 +154,7 @@
 	UnregisterSignal(src, COMSIG_IGNITER_ACTIVATE)
 
 /obj/structure/reagent_dispensers/Initialize(mapload)
-	create_reagents(tank_volume, DRAINABLE | AMOUNT_VISIBLE)
+	create_reagents(tank_volume, reagent_flags)
 	if(reagent_id)
 		reagents.add_reagent(reagent_id, tank_volume)
 	. = ..()
@@ -358,6 +360,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/peppertank, 3
 	desc = "A machine that cools and dispenses liquids to drink. The 'hot' handle doesn't seem to do anything."
 	icon_state = "water_cooler"
 	anchored = TRUE
+	reagent_flags = DRAINABLE | TRANSPARENT
 	tank_volume = 200
 	can_be_tanked = FALSE
 	max_integrity = 150
@@ -382,12 +385,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/peppertank, 3
 
 /obj/structure/reagent_dispensers/water_cooler/examine(mob/user)
 	. = ..()
-
-	// Lets the user know what reagents are in the cooler, if they can see them.
-	if(user.can_see_reagents() && reagents.total_volume)
-		for(var/datum/reagent/current_reagent as anything in reagents.reagent_list)
-			. += "&bull; [round(current_reagent.volume, CHEMICAL_VOLUME_ROUNDING)] units of [current_reagent.name]"
-
 	if (paper_cups > 1)
 		. += "There are [paper_cups] paper cups left."
 	else if (paper_cups == 1)


### PR DESCRIPTION

## About The Pull Request

This PR adds a `can_see_reagents()` check to the `examine()` function of the water cooler (`/obj/structure/reagent_dispensers/water_cooler`). 
It loops through the reagents and prints their specific volume and name, mirroring the behavior of standard transparent containers when examined by an authorized user.

Fixes #95636

## Why It's Good For The Game

The current state of the water cooler is inconsistent with other reagent containers. As reported in the original issue, observers cannot see what custom reagents are inside. 

Furthermore, during local testing, I verified that this also negatively impacts active gameplay, Chemists and Scientists wearing Science Goggles are unable to read the chemical breakdown of the cooler's contents, breaking immersion. 

This PR implements the standard check without altering the cooler's opaque identity for regular players.

**Before:**
<img width="2559" height="1391" alt="Screenshot 2026-06-03 155849" src="https://github.com/user-attachments/assets/8b74fca7-5fe8-4a08-af23-9a1d4b5a5647" />
<img width="819" height="717" alt="Screenshot 2026-06-03 155929" src="https://github.com/user-attachments/assets/21150f27-9806-4a6a-90b0-2ec4129b5492" />

**After:**
<img width="2559" height="1393" alt="Screenshot 2026-06-03 163407" src="https://github.com/user-attachments/assets/84b368c7-46e6-4134-9ccb-65956fa5d58f" />
<img width="2559" height="1390" alt="Screenshot 2026-06-03 163422" src="https://github.com/user-attachments/assets/7b13070f-193b-467f-9166-a00fdf8ea65e" />

## Changelog
:cl:
fix: Water coolers now properly reveal their custom reagents when examined by ghosts or players with science goggles.
/:cl:
