### PR TITLE
Drake tail trophy no longer pushes immovable mobs

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher/trophies_megafauna.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_megafauna.dm
@@ -38,7 +38,7 @@
 		living_target.adjust_fire_loss(bonus_value, forced = TRUE)
 
 /obj/item/crusher_trophy/tail_spike/proc/pushback(mob/living/target, mob/living/user)
-	if(!QDELETED(target) && !QDELETED(user) && (!target.anchored || ismegafauna(target))) //megafauna will always be pushed
+	if(!QDELETED(target) && !QDELETED(user) && (!target.anchored || ismegafauna(target)) && target.move_resist < INFINITY) //megafauna will always be pushed
 		step(target, get_dir(user, target))
 
 //bubblegum


### PR DESCRIPTION

## About The Pull Request

Also prevents them from pushing around other stationary mobs like meteor heart, living floors, etc.
Closes #96326 

## Changelog
:cl:
fix: Drake tail trophy no longer pushes immovable mobs
/:cl:
