### PR TITLE
Changes slaughter/laughter demons to use sentient mob pref

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -1032,7 +1032,7 @@
 	candidate_role = "Slaughter Demon"
 	// preview_antag_datum = /datum/antagonist/slaughter // Doesn't actually have its own pref
 	midround_type = HEAVY_MIDROUND
-	jobban_flag = ROLE_ALIEN
+	jobban_flag = ROLE_SENTIENCE
 	ruleset_flags = RULESET_INVADER
 	weight = 0
 	min_pop = 20

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -272,7 +272,7 @@
 		return
 	if(used)
 		return
-	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(check_jobban = ROLE_ALIEN, role = ROLE_ALIEN, poll_time = 5 SECONDS, checked_target = src, alert_pic = demon_type, jump_target = src, role_name_text = initial(demon_type.name))
+	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(check_jobban = ROLE_SENTIENCE, role = ROLE_SENTIENCE, poll_time = 5 SECONDS, checked_target = src, alert_pic = demon_type, jump_target = src, role_name_text = initial(demon_type.name))
 	if(chosen_one)
 		if(used || QDELETED(src))
 			return

--- a/code/modules/antagonists/wizard/slaughter_antag.dm
+++ b/code/modules/antagonists/wizard/slaughter_antag.dm
@@ -3,7 +3,7 @@
 	roundend_category = "demons"
 	show_name_in_check_antagonists = TRUE
 	ui_name = "AntagInfoDemon"
-	pref_flag = ROLE_ALIEN
+	pref_flag = ROLE_SENTIENCE
 	show_in_antagpanel = FALSE
 	show_to_ghosts = TRUE
 	antagpanel_category = ANTAG_GROUP_WIZARDS


### PR DESCRIPTION

## About The Pull Request
changes the slaughter and laughter demon antag spawner (blood/tickle vial) and midround event to use the sentient creature pref, instead of the xenomorph pref.
## Why It's Good For The Game
Sentient creature fits them much more than xenomorph, especially considering that it doesn't really have to follow any kind of command structure that xenos have.
## Changelog
:cl:
code: Slaughter/laughter demons now use the sentient creature pref, instead of the xenomorph pref
/:cl:
