### PR TITLE
Move carving block to basic recipes (Allows carving blocks to be made out of any material)

### DIFF
--- a/code/__DEFINES/construction/material.dm
+++ b/code/__DEFINES/construction/material.dm
@@ -26,7 +26,7 @@
 #define MATERIAL_SILO_STORED (1 << 0)
 /// This material can be used in basic recipes, such as chairs/toilets/tiles
 #define MATERIAL_BASIC_RECIPES (1 << 1)
-/// This material counts as a rigid enough solid to be used to craft tough objects like carving blocks or air tanks
+/// This material counts as a rigid enough solid to be used to craft tough objects like air tanks
 #define MATERIAL_CLASS_RIGID (1 << 2)
 /// The opposite of rigid, this means that the material cannot hold a solid form (like sand) and cannot be used in item crafting
 #define MATERIAL_CLASS_AMORPHOUS (1 << 3)

--- a/code/controllers/subsystem/materials.dm
+++ b/code/controllers/subsystem/materials.dm
@@ -23,10 +23,11 @@ SUBSYSTEM_DEF(materials)
 		new /datum/stack_recipe("Material floor tile", /obj/item/stack/tile/material, 1, 4, 20, crafting_flags = CRAFT_SKIP_MATERIALS_PARITY, category = CAT_TILES),
 		new /datum/stack_recipe("Material airlock assembly", /obj/structure/door_assembly/door_assembly_material, 4, time = 5 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND | CRAFT_SKIP_MATERIALS_PARITY, category = CAT_DOORS),
 		new /datum/stack_recipe("Material platform", /obj/structure/platform/material, 2, time = 3 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND | CRAFT_SKIP_MATERIALS_PARITY, trait_booster = TRAIT_QUICK_BUILD, trait_modifier = 0.75, category = CAT_STRUCTURE), \
-	)
-	/// List of stackcrafting recipes for materials using rigid recipes
-	var/list/rigid_stack_recipes = list(
 		new /datum/stack_recipe("Carving block", /obj/structure/carving_block, 5, time = 3 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND | CRAFT_SKIP_MATERIALS_PARITY, category = CAT_STRUCTURE),
+	)
+	/// List of stackcrafting recipes for materials using rigid recipes (none yet)
+	var/list/rigid_stack_recipes = list(
+
 	)
 
 	/// A list of dimensional themes used by the dimensional anomaly and other things, most of which require materials to function.


### PR DESCRIPTION

## About The Pull Request
Allow carving blocks to be made by any material, instead of just rigid materials.
## Why It's Good For The Game
<img width="612" height="70" alt="pride" src="https://github.com/user-attachments/assets/afb5ed16-ba7a-4910-9b36-8fed8267536a" />

This allows for the construction of
Ice Statues (Hot Ice)
Beige Statues (Sand + Sandstone)
Snowpeople (Snow)
Origami Statues (Paper)
Cardboard (Cardboard)
REAL ghosts (Hauntium)
Meat Statue... 🤤🤤🤤🤤 (Meat)
(Not pictured) Pizzer Statue (Pizza)
Also more player expression + if you could make chairs and airlocks and toilets and sinks and all that other shit out of these, why the hell NOT a carving block!?
## Changelog
:cl:
balance: Carving blocks can be made out of any material now!
/:cl:
