### PR TITLE
Fix: Prevent infinite recursion in light destruction (#96126)

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -677,17 +677,19 @@
 	var/obj/item/light/light_tube = drop_light_tube()
 	return light_tube.attack_tk(user)
 
-// break the light and make sparks if was on
+// break the light and make sparks if was on, state is mutated BEFORE firing side-effects to prevent re-entrancy loops from synchronous signals.
 /obj/machinery/light/proc/break_light_tube(skip_sound_and_sparks = FALSE)
 	if(status == LIGHT_EMPTY || status == LIGHT_BROKEN)
 		return
 
+	var/was_ok = (status == LIGHT_OK || status == LIGHT_BURNED)
+	status = LIGHT_BROKEN
+
 	if(!skip_sound_and_sparks)
-		if(status == LIGHT_OK || status == LIGHT_BURNED)
+		if(was_ok)
 			playsound(loc, 'sound/effects/glass/glasshit.ogg', 75, TRUE)
 		if(on)
 			do_sparks(3, TRUE, src)
-	status = LIGHT_BROKEN
 	update()
 
 /obj/machinery/light/proc/fix()


### PR DESCRIPTION

## About The Pull Request

A synchronous signal re-entrancy vulnerability caused a server crash when plasma-infused floor lights were ignited.
When on_deconstruction() called break_light_tube(), the tube spawned sparks before updating its internal broken state. The sparks ignited the plasma, which triggered a secondary on_deconstruction() on the same tick, resulting in an infinite recursion loop and eventual Overflow.
<img width="2559" height="1391" alt="Screenshot 2026-06-04 151658" src="https://github.com/user-attachments/assets/e8f1b5fa-826e-4c76-8d04-3ba6c424822a" />

This PR applies a State-Before-Side-Effects pattern, the status = LIGHT_BROKEN mutation is now applied before do_sparks() is invoked (caching the previous state for the effects). This kills any synchronous recursive loops originating from the sparks.
<img width="2559" height="1389" alt="Screenshot 2026-06-04 155247" src="https://github.com/user-attachments/assets/db5b346e-d525-493b-ab64-00acc48493cd" />

Fixes #96126

## Why It's Good For The Game

Fixes a reproducible server crash that could be triggered by a single player in seconds if they got metalgen (funny but broken). It also hardens the core light machinery architecture against future re-entrancy bugs caused by synchronous environmental events.

## Changelog

:cl:
fix: Fixed a server crash caused by igniting plasma-covered floor lights.
/:cl:
