### PR TITLE
fix a hard delete with loot panels

### DIFF
--- a/code/modules/lootpanel/_lootpanel.dm
+++ b/code/modules/lootpanel/_lootpanel.dm
@@ -23,6 +23,8 @@
 
 
 /datum/lootpanel/Destroy(force)
+	SSlooting.backlog -= src
+	SSlooting.processing -= src
 	reset_contents()
 	owner = null
 	source_turf = null

--- a/code/modules/lootpanel/ss_looting.dm
+++ b/code/modules/lootpanel/ss_looting.dm
@@ -18,7 +18,7 @@ SUBSYSTEM_DEF(looting)
 
 
 /datum/controller/subsystem/looting/fire(resumed)
-	if(!length(backlog))
+	if(!length(backlog) && !length(processing))
 		return
 
 	if(!resumed)


### PR DESCRIPTION

## About The Pull Request

fixes `/datum/lootpanel` not being removed from SSlooting's backlog/processing when destroyed.

another native reftracker W

```
[2026-06-04 15:54:59.739] REFSCANNER: native refscan complete for /datum/lootpanel ([0x21068f2e]), took 942 ms
 - === 2 finding(s)===
 - [list]       list #5085 [index 0] (len=1, refs=1)
 - [list_owner] datum #1977 (/datum/controller/subsystem/looting).processing -> list #5085
```

also fixed a bug where SSlooting wouldn't really process after `backlog` was moved to `processing`.

## Why It's Good For The Game

hard delete bad

## Changelog

no player-facing changes
