### PR TITLE
Fixes pinpointers when AI shunts

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_silicon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_silicon.dm
@@ -8,9 +8,6 @@
 	#define COMSIG_BORG_HUG_HANDLED 1
 ///called from /mob/living/silicon/attack_hand proc
 #define COMSIG_MOB_PAT_BORG "mob_pat_borg"
-///called when an AI (malf or perhaps combat upgraded or some other circumstance that has them inhabit
-///an APC) enters an APC
-#define COMSIG_SILICON_AI_OCCUPY_APC "AI_occupy_apc"
 ///called when an AI vacates an APC
 #define COMSIG_SILICON_AI_VACATE_APC "AI_vacate_apc"
 ///called when an AI's control is toggled

--- a/code/modules/power/apc/apc_malf.dm
+++ b/code/modules/power/apc/apc_malf.dm
@@ -56,8 +56,6 @@
 		disk_pinpointers.switch_mode_to(TRACK_MALF_AI) //Pinpointer will track the shunted AI
 	var/datum/action/innate/core_return/return_action = new
 	return_action.Grant(occupier)
-	SEND_SIGNAL(src, COMSIG_SILICON_AI_OCCUPY_APC, occupier)
-	SEND_SIGNAL(occupier, COMSIG_SILICON_AI_OCCUPY_APC, occupier)
 	occupier.cancel_camera()
 
 /obj/machinery/power/apc/proc/malfvacate(forced)
@@ -71,6 +69,12 @@
 		occupier.gib(DROP_ALL_REMAINS)
 		occupier = null
 		return
+
+	if(!occupier.nuking) //Pinpointers go back to tracking the nuke disk, as long as the AI (somehow) isn't mid-nuking.
+		for(var/obj/item/pinpointer/nuke/disk_pinpointers in GLOB.pinpointer_list)
+			disk_pinpointers.switch_mode_to(TRACK_NUKE_DISK)
+			disk_pinpointers.alert = FALSE
+
 	if(occupier.linked_core)
 		occupier.shunted = FALSE
 		occupier.resolve_core_link()
@@ -78,10 +82,6 @@
 	else
 		stack_trace("An AI: [occupier] has vacated an APC with no linked core and without being gibbed.")
 
-	if(!occupier.nuking) //Pinpointers go back to tracking the nuke disk, as long as the AI (somehow) isn't mid-nuking.
-		for(var/obj/item/pinpointer/nuke/disk_pinpointers in GLOB.pinpointer_list)
-			disk_pinpointers.switch_mode_to(TRACK_NUKE_DISK)
-			disk_pinpointers.alert = FALSE
 
 /obj/machinery/power/apc/transfer_ai(interaction, mob/user, mob/living/silicon/ai/AI, obj/item/aicard/card)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Checking `occupier` right after `occupier` is nulled

Also, entirely unused signal, deleted.

## Why It's Good For The Game

Runtime Error

## Changelog
:cl:

fix: Pinpointers stop tracking a shunted ai when that ai is no longer shunted

/:cl:
