### PR TITLE
Fix moth flight in space

### DIFF
--- a/code/datums/components/jetpack.dm
+++ b/code/datums/components/jetpack.dm
@@ -136,13 +136,21 @@
 	if(source.client.intended_direction && check_on_move.Invoke(TRUE)) //You use jet when press keys. yes.
 		trail?.generate_effect()
 
+/// Handles all active 0g movement, including both manual (trying to move a direction in 0g) and automatic (drifting idly in 0g)
 /datum/component/jetpack/proc/stabilize(mob/source, movement_dir, continuous_move, backup)
 	SIGNAL_HANDLER
-	if(!continuous_move && movement_dir)
-		return COMSIG_MOVABLE_STOP_SPACEMOVE
-	// Check if we have the fuel to stop this. Do NOT consume any fuel, just check
-	// This is done because things other then us can use our fuel
-	if(stabilize && check_on_move.Invoke(FALSE))
+	/*
+	 * Checks if we should stop any active drift
+	 *
+	 * Obviously we stop drifting if we have stabilizers active
+	 * less obviously, we stop drift if we are trying to move in a different direction than our current drift
+	 * Without checking the latter, jetpacks will feel very janky, as every movement will fight against your drift
+	 *
+	 * Either way, we need to check that we have the "fuel" to stop this
+	 * DO NOT CONSUME FUEL HERE, just check if we have it
+	 * This is done because things other then us can use our fuel
+	 */
+	if((stabilize || (!continuous_move && movement_dir)) && check_on_move.Invoke(FALSE))
 		return COMSIG_MOVABLE_STOP_SPACEMOVE
 	return NONE
 

--- a/code/datums/components/jetpack.dm
+++ b/code/datums/components/jetpack.dm
@@ -140,11 +140,12 @@
 /datum/component/jetpack/proc/stabilize(mob/source, movement_dir, continuous_move, backup)
 	SIGNAL_HANDLER
 	/*
-	 * Checks if we should stop any active drift
+	 * Checks if we should stop any active movement
 	 *
-	 * Obviously we stop drifting if we have stabilizers active
-	 * less obviously, we stop drift if we are trying to move in a different direction than our current drift
-	 * Without checking the latter, jetpacks will feel very janky, as every movement will fight against your drift
+	 * Obviously we stop all forms of drifting if we have stabilizers active (allowing free space movement)
+	 * Less obviously, we stop need to stop drift if we are trying to move *while passively drifting*
+	 * (Without checking the latter, jetpacks will act very weird and jank. As you move in one direction,
+	 * you will simultaneously drift in that direction, causing you to jump/skip a tile every so often.)
 	 *
 	 * Either way, we need to check that we have the "fuel" to stop this
 	 * DO NOT CONSUME FUEL HERE, just check if we have it


### PR DESCRIPTION
## About The Pull Request

Fixes #96344

The `if(!continuous_move && movement_dir)` did not respect whether the "jetpack" was usable or not, allowing you to free-float regardless of context. 

I wrapped them in the same check and it seems to work fine in both contexts (stabilizers on or actively moving). 

I presume this affected more than just moth wings (empty jetpacks, probably) but I'm not going to check 

## Changelog

:cl: Melbert
fix: Fix moths being able to fly in space
/:cl:
