### PR TITLE
Bumps Cutter to 5.0.1

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -32,5 +32,5 @@ export DREAMLUAU_VERSION=0.1.2
 export CUTTER_REPO=spacestation13/hypnagogic
 
 #hypnagogic git tag
-export CUTTER_VERSION=v5.0.0
+export CUTTER_VERSION=v5.0.1
 


### PR DESCRIPTION

## About The Pull Request

Pretty minor version bump, just a bugfix that I figure oughta see the light of day.
Might be faster now? I bumped the dmi crate and that got optimized some a few months back

See https://github.com/spacestation13/hypnagogic/releases/tag/v5.0.1 for specifics.