### PR TITLE
Adds var to species datum for electrocution overlay to use

### DIFF
--- a/code/modules/hallucination/shock.dm
+++ b/code/modules/hallucination/shock.dm
@@ -4,12 +4,13 @@
 	hallucination_tier = HALLUCINATION_TIER_COMMON
 
 	var/electrocution_icon = 'icons/mob/human/human.dmi'
-	var/electrocution_icon_state = "electrocuted_base"
+	var/electrocution_icon_state = "electrocuted_generic"
 	var/image/shock_image
 	var/image/electrocution_skeleton_anim
 
 /datum/hallucination/shock/New(mob/living/hallucinator)
-	electrocution_icon_state = ishuman(hallucinator) ? "electrocuted_base" : "electrocuted_generic"
+	var/mob/living/carbon/human/human_hallucinator = hallucinator
+	electrocution_icon_state = human_hallucinator ? human_hallucinator.dna.species.electrocution_overlay : initial(electrocution_icon_state)
 	return ..()
 
 /datum/hallucination/shock/Destroy()

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -130,6 +130,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	/// The icon_state of the fire overlay added when sufficently ablaze and standing. see onfire.dmi
 	var/fire_overlay = "human"
+	/// The icon_state of the electrocutions overlay added when zapped. see electrocution_animation()
+	var/electrocution_overlay = "electrocuted_base"
 
 	/// Generic traits tied to having the species.
 	var/list/inherent_traits = list()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -636,7 +636,7 @@
 	// If we have a species, we need to handle mutant parts and stuff
 	if(dna?.species)
 		add_atom_colour(COLOR_BLACK, TEMPORARY_COLOUR_PRIORITY)
-		var/mutable_appearance/shock_animation_dna = mutable_appearance(icon, "electrocuted_base", appearance_flags = RESET_COLOR|KEEP_APART)
+		var/mutable_appearance/shock_animation_dna = mutable_appearance(icon, dna.species.electrocution_overlay, appearance_flags = RESET_COLOR|KEEP_APART)
 		apply_height_filters(shock_animation_dna)
 		zap_appearance = shock_animation_dna
 


### PR DESCRIPTION
## About The Pull Request

Checks species for what electrocution overlay to display.

## Why It's Good For The Game

Just like the rest (fire overlay, gib/dust anim) this should be tune-able on the species datum.
It'll allow for better customization of species with different bodyshapes. Digitigrade skeletons anyone?

## Changelog

:cl:
code: The vfx that plays on electrocution now checks what overlay to use from a character's species datum
/:cl:

