### PR TITLE
use the `dm-lang.org` mirror by default in CI instead of `byond.com`

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -33,4 +33,3 @@ export CUTTER_REPO=spacestation13/hypnagogic
 
 #hypnagogic git tag
 export CUTTER_VERSION=v5.0.0
-

--- a/tools/ci/download_byond.sh
+++ b/tools/ci/download_byond.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 set -e
 source dependencies.sh
-echo "Downloading BYOND version $BYOND_MAJOR.$BYOND_MINOR"
-curl -H "User-Agent: tgstation/1.0 CI Script" "http://www.byond.com/download/build/$BYOND_MAJOR/$BYOND_MAJOR.${BYOND_MINOR}_byond.zip" -o C:/byond.zip
+echo "Downloading BYOND version ${BYOND_MAJOR}.${BYOND_MINOR}"
+
+if [ "$DOWNLOAD_FROM_BYOND_WEBSITE" = "1" ]; then
+	base_url="http://www.byond.com/download/build"
+else
+	base_url="https://byond-builds.dm-lang.org"
+fi
+
+curl -H "User-Agent: tgstation/1.0 CI Script" "${base_url}/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond.zip" -o C:/byond.zip

--- a/tools/ci/download_byond.sh
+++ b/tools/ci/download_byond.sh
@@ -3,7 +3,7 @@ set -e
 source dependencies.sh
 echo "Downloading BYOND version ${BYOND_MAJOR}.${BYOND_MINOR}"
 
-if [ "$DOWNLOAD_FROM_BYOND_WEBSITE" = "1" ]; then
+if [ "${DOWNLOAD_FROM_BYOND_WEBSITE:-}" = "1" ]; then
 	base_url="http://www.byond.com/download/build"
 else
 	base_url="https://byond-builds.dm-lang.org"

--- a/tools/ci/install_byond.sh
+++ b/tools/ci/install_byond.sh
@@ -6,19 +6,25 @@ if [ -z "${BYOND_MAJOR+x}" ]; then
   source dependencies.sh
 fi
 
-if [ -d "$HOME/BYOND/byond/bin" ] && grep -Fxq "${BYOND_MAJOR}.${BYOND_MINOR}" $HOME/BYOND/version.txt;
+if [ "${DOWNLOAD_FROM_BYOND_WEBSITE}" = "1" ]; then
+  base_url="http://www.byond.com/download/build"
+else
+  base_url="https://byond-builds.dm-lang.org"
+fi
+
+if [ -d "${HOME}/BYOND/byond/bin" ] && grep -Fxq "${BYOND_MAJOR}.${BYOND_MINOR}" ${HOME}/BYOND/version.txt;
 then
   echo "Using cached directory."
 else
   echo "Setting up BYOND."
-  rm -rf "$HOME/BYOND"
-  mkdir -p "$HOME/BYOND"
-  cd "$HOME/BYOND"
-  curl -H "User-Agent: tgstation/1.0 CI Script" "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip
+  rm -rf "${HOME}/BYOND"
+  mkdir -p "${HOME}/BYOND"
+  cd "${HOME}/BYOND"
+  curl -H "User-Agent: tgstation/1.0 CI Script" "${base_url}/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip
   unzip byond.zip
   rm byond.zip
   cd byond
   make here
-  echo "$BYOND_MAJOR.$BYOND_MINOR" > "$HOME/BYOND/version.txt"
+  echo "${BYOND_MAJOR}.${BYOND_MINOR}" > "${HOME}/BYOND/version.txt"
   cd ~/
 fi

--- a/tools/ci/install_byond.sh
+++ b/tools/ci/install_byond.sh
@@ -6,7 +6,7 @@ if [ -z "${BYOND_MAJOR+x}" ]; then
   source dependencies.sh
 fi
 
-if [ "${DOWNLOAD_FROM_BYOND_WEBSITE}" = "1" ]; then
+if [ "${DOWNLOAD_FROM_BYOND_WEBSITE:-}" = "1" ]; then
   base_url="http://www.byond.com/download/build"
 else
   base_url="https://byond-builds.dm-lang.org"

--- a/tools/ci/install_byond.sh
+++ b/tools/ci/install_byond.sh
@@ -12,7 +12,7 @@ else
   base_url="https://byond-builds.dm-lang.org"
 fi
 
-if [ -d "${HOME}/BYOND/byond/bin" ] && grep -Fxq "${BYOND_MAJOR}.${BYOND_MINOR}" ${HOME}/BYOND/version.txt;
+if [ -d "${HOME}/BYOND/byond/bin" ] && grep -Fxq "${BYOND_MAJOR}.${BYOND_MINOR}" "${HOME}/BYOND/version.txt";
 then
   echo "Using cached directory."
 else


### PR DESCRIPTION
## About The Pull Request

CI now uses the `byond-builds.dm-lang.org` mirror to download byond builds by default, instead of `byond.com`

if ever desired, i.e if the mirror no worky, set the `DOWNLOAD_FROM_BYOND_WEBSITE` env var to `1` and it'll go back to using `byond.com` just as before.

(i'm throwing shit at the wall to try to fix the weird CI errors https://github.com/tgstation/tgstation/pull/96330 had. i am completely _guessing_ at what the issue might be lmao)

## Why It's Good For The Game

Hopefully makes CI less vulnerable to Stupid Shit:tm: because byond.com is weird sometimes.

## Changelog

No player-facing changes.