### PR TITLE
Fix TGUI spawn panel dir option not working

### DIFF
--- a/code/modules/admin/spawn_panel/spawn_panel.dm
+++ b/code/modules/admin/spawn_panel/spawn_panel.dm
@@ -131,7 +131,7 @@
 			var/list/spawn_params = list(
 				"selected_atom" = selected_atom,
 				"offset" = params["offset"],
-				"atom_dir" = text2num(params["dir"]) || 1,
+				"atom_dir" = text2num(params["atom_dir"]) || 1,
 				"atom_amount" = text2num(params["atom_amount"]) || 1,
 				"atom_name" = params["atom_name"],
 				"where_target_type" = params["where_target_type"] || WHERE_FLOOR_BELOW_MOB,


### PR DESCRIPTION

## About The Pull Request

The parameter is `atom_dir` not `dir`

## Why It's Good For The Game

`dir` doesn't exist so it was always falling back to the default of north regardless of what you picked

## Changelog
:cl:
fix: fixed TGUI spawn panel direction option not working
/:cl:
