### PR TITLE
Flaky issue bot leaves comments on existing issues

### DIFF
--- a/tools/pull_request_hooks/rerunFlakyTests.js
+++ b/tools/pull_request_hooks/rerunFlakyTests.js
@@ -277,8 +277,20 @@ export async function reportFlakyTests({ github, context }) {
     );
 
     if (existingIssueId !== undefined) {
-      // Maybe in the future, if it's helpful, update the existing issue with new links
       console.log(`Existing issue found: #${existingIssueId}`);
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: existingIssueId,
+        body: createBody(
+          details,
+          `https://github.com/${context.repo.owner}/${
+            context.repo.repo
+          }/actions/runs/${context.payload.workflow_run.id}/attempts/${
+            context.payload.workflow_run.run_attempt - 1
+          }`,
+        ),
+      });
       return;
     }
 


### PR DESCRIPTION

## About The Pull Request

With #93691 merged, flaky issues that are still happening but aren't being fixed lead to a bit of "churn" where a flaky issue report is opened, sits for a month, then gets staled out, and then an identical issue gets opened as soon as it happens again. This change will serve both to prevent that (if the bot comments on the issue with a new error report, the stale timer will get reset) and to provide more data on flaky bugs in the process (grouping all instances of them happening into one issue so patterns can be observed)

## Why It's Good For The Game

Stop identical issues from being closed and then opened again, provides more logs on flaky errors

## Changelog

N/A
