### PR TITLE
Extends CI's unit tests timeout to 55 minutes

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -27,7 +27,7 @@ jobs:
     # For example, `Run Tests (runtimestation; 515)`.
     name: Run Tests (${{ inputs.major && format('{0}.{1}; ', inputs.major, inputs.minor) || '' }}${{ inputs.map }}; ${{ inputs.max_required_byond_client }})
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 55
     steps:
       - uses: actions/checkout@v6
       - name: Restore BYOND from Cache


### PR DESCRIPTION

## About The Pull Request

We allow C&D to run at most 50 minutes as its hard timeout, so we should have a matching timeout on the tests.

I'm open to lowering both of these, I do think 15 is far too small in the case of hard deletes however, you want to be able to track those down effectively and searching can take a while.
