### PR TITLE
Fix(Atmos): Guard process_active_turfs and process_cell against closed turfs (#89649)

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -378,6 +378,9 @@ SUBSYSTEM_DEF(air)
 		var/turf/open/T = currentrun[currentrun.len]
 		currentrun.len--
 		if (T)
+			if(!isopenturf(T))
+				active_turfs -= T
+				continue
 			T.process_cell(fire_count)
 		if (MC_TICK_CHECK)
 			return

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -279,6 +279,9 @@
 			continue
 		#endif
 
+		if(!isopenturf(enemy_tile))
+			continue
+
 		// This var is only rarely set, exists so turfs can request to share at the end of our sharing
 		// We need this so we can assume share is communative, which we need to do to avoid a hellish amount of garbage_collect()s
 		if(enemy_tile.run_later)


### PR DESCRIPTION

## About The Pull Request

This implements the isopenturf() type check fix proposed by timothymtorres in #89649.

Two guards are added:
In process_active_turfs, before process_cell() is called, each turf is checked with isopenturf(). If the check fails, the turf is evicted from the master active_turfs list immediately via active_turfs -= T and the loop continues. This is an O(1) native list operation that runs at the list boundary, before any atmos proc has a chance to touch the bad datum.
In process_cell, a continue is added at the top of the adjacent_turfs loop immediately after the existing UNIT_TESTS guard. This protects all subsequent accesses on enemy_tile, including run_later, air, and excited_group. The pattern mirrors the existing UNIT_TESTS check.

I considered alternative approaches, primarily attempting to prevent closed turfs from entering the master list in the first place. However, as investigated by timothymtorres in the original issue, these insertions are a side effect of the engine's native new() turf replacement behavior during maploading. Attempting to build an interception layer at the maploader level would be highly invasive and would primarily slow down maploading during world initialize. The defensive type guards implemented here are a much safer alternative, they are fast, require zero changes to the maploader, and guarantee subsystem safety regardless of how turfs are swapped in memory.

## Why It's Good For The Game

Fixes #89649. 

As investigated in the issue, shuttle building and lazyloaded map operations can occasionally leave uninitialized closed turfs trapped in SSair.active_turfs due to how the engine handles turf replacements.
When Atmos attempts to process these replaced turfs, it triggers runtime spam that clears up after loading is complete. 
This fix is minimal, safe, and entirely localized. It immunizes the Atmos subsystem from maploading type-confusion without altering the core logic for valid turfs, and avoids risking any invasive changes to the complex maploading pipeline.

### Before
<img width="2559" height="1390" alt="bad" src="https://github.com/user-attachments/assets/35d56ee1-1a32-4838-881f-0038f292b44f" />

### After
<img width="2559" height="1390" alt="good" src="https://github.com/user-attachments/assets/83d52d2a-4ed9-4e6e-a656-f2a9227efafc" />

## Changelog
:cl:
fix: fixed localized atmospheric runtime noise that occurs when closed turfs are unexpectedly processed during lazy template and maploading operations.
/:cl:
