### PR TITLE
Makes playsound respect max_range and makes sound use euclidean distance

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -18,33 +18,9 @@
 
 #define MAX_INSTRUMENT_CHANNELS (128 * 6)
 
-/// This is the lowest volume that can be used by playsound otherwise it gets ignored
-/// Most sounds around 10 volume can barely be heard. Almost all sounds at 5 volume or below are inaudible
-/// This is to prevent sound being spammed at really low volumes due to distance calculations
-/// Recommend setting this to anywhere from 10-3 (or 0 to disable any sound minimum volume restrictions)
-/// Ex. For a 70 volume sound, 17 tile range, 3 exponent, 2 falloff_distance:
-/// Setting SOUND_AUDIBLE_VOLUME_MIN to 0 for the above will result in 17x17 radius (289 turfs)
-/// Setting SOUND_AUDIBLE_VOLUME_MIN to 5 for the above will result in 14x14 radius (196 turfs)
-/// Setting SOUND_AUDIBLE_VOLUME_MIN to 10 for the above will result in 11x11 radius (121 turfs)
-#define SOUND_AUDIBLE_VOLUME_MIN 3
-
-/* Calculates the max distance of a sound based on audible volume
- *
- * Note - you should NEVER pass in a volume that is lower than SOUND_AUDIBLE_VOLUME_MIN otherwise distance will be insanely large (like +250,000)
- *
- * Arguments:
- * * volume: The initial volume of the sound being played
- * * max_distance: The range of the sound in tiles (technically not real max distance since the furthest areas gets pruned due to SOUND_AUDIBLE_VOLUME_MIN)
- * * falloff_distance: Distance at which falloff begins. Sound is at peak volume (in regards to falloff) aslong as it is in this range.
- * * falloff_exponent: Rate of falloff for the audio. Higher means quicker drop to low volume. Should generally be over 1 to indicate a quick dive to 0 rather than a slow dive.
- * Returns: The max distance of a sound based on audible volume range
- */
-#define CALCULATE_MAX_SOUND_AUDIBLE_DISTANCE(volume, max_distance, falloff_distance, falloff_exponent)\
-	floor(((((-(max(max_distance - falloff_distance, 0) ** (1 / falloff_exponent)) / volume) * (SOUND_AUDIBLE_VOLUME_MIN - volume)) ** falloff_exponent) + falloff_distance))
-
 /* Calculates the volume of a sound based on distance
  *
- * https://www.desmos.com/calculator/shjpmz3ck7
+ * https://www.desmos.com/calculator/ing6lxgd0m Update this when changed please
  *
  * Arguments:
  * * volume: The initial volume of the sound being played
@@ -53,16 +29,16 @@
  * * falloff_exponent: Rate of falloff for the audio. Higher means quicker drop to low volume. Should generally be over 1 to indicate a quick dive to 0 rather than a slow dive.
  * Returns: The max distance of a sound based on audible volume range
  */
-#define CALCULATE_SOUND_VOLUME(volume, distance, max_distance, falloff_distance, falloff_exponent)\
-	((max(distance - falloff_distance, 0) ** (1 / falloff_exponent)) / ((max(max_distance, distance) - falloff_distance) ** (1 / falloff_exponent)) * volume)
+#define CALCULATE_SOUND_VOLUME_RATIO(volume, distance, max_distance, falloff_distance, falloff_exponent)\
+	((max(distance - falloff_distance, 0) / (max(max_distance, distance) - falloff_distance)) ** (1 / falloff_exponent))
 
 ///Default range of a sound.
-#define SOUND_RANGE 17
-#define MEDIUM_RANGE_SOUND_EXTRARANGE -5
+#define SOUND_RANGE 15
+#define MEDIUM_RANGE_SOUND_EXTRARANGE -3
 ///default extra range for sounds considered to be quieter
-#define SHORT_RANGE_SOUND_EXTRARANGE -9
+#define SHORT_RANGE_SOUND_EXTRARANGE -7
 ///The range deducted from sound range for things that are considered silent / sneaky
-#define SILENCED_SOUND_EXTRARANGE -11
+#define SILENCED_SOUND_EXTRARANGE -10
 ///Percentage of sound's range where no falloff is applied
 #define SOUND_DEFAULT_FALLOFF_DISTANCE 0 //Disabled because it doesn't actually have a nice effect, it just makes the jump to fall-off more shocking. maybe delete
 ///The default exponent of sound falloff

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -80,8 +80,9 @@
  * * view_radius - what radius search circle we are using, worse performance as this increases
  * * source - object at the center of our search area. everything in get_turf(source) is guaranteed to be part of the search area
  * * contents_type - the type of contents we want to be looking for. defaults to hearing sensitive
+ * * euclidean_distance - whether to use Euclidean distance instead of get_dist
  */
-/proc/get_hearers_in_view(view_radius, atom/source, contents_type=RECURSIVE_CONTENTS_HEARING_SENSITIVE)
+/proc/get_hearers_in_view(view_radius, atom/source, contents_type=RECURSIVE_CONTENTS_HEARING_SENSITIVE, euclidean_distance = FALSE)
 	var/turf/center_turf = get_turf(source)
 	if(!center_turf)
 		return
@@ -113,6 +114,9 @@
 	//on a whole this can outperform iterating through all movables in view() by ~2x especially when hearables are a tiny percentage of movables in view
 	//using hearers is a further optimization of that because for our purposes its the same as view except we dont have to set center's luminosity to 6 and then unset it
 	for(var/mob/oranges_ear/ear in hearers(view_radius, center_turf))
+		if(euclidean_distance)
+			if(get_dist_euclidean(center_turf, ear) > view_radius)
+				continue
 		. += ear.references
 
 	for(var/mob/oranges_ear/remaining_ear as anything in assigned_oranges_ears)//we need to clean up our mess
@@ -129,8 +133,9 @@
  * * radius - what radius search circle we are using, worse performance as this increases
  * * source - object at the center of our search area. everything in get_turf(source) is guaranteed to be part of the search area
  * * contents_type - the type of contents we want to be looking for. defaults to hearing sensitive
+ * * euclidean_distance - whether to use Euclidean distance instead of get_dist
  */
-/proc/get_hearers_in_range(range, atom/source, contents_type=RECURSIVE_CONTENTS_HEARING_SENSITIVE)
+/proc/get_hearers_in_range(range, atom/source, contents_type=RECURSIVE_CONTENTS_HEARING_SENSITIVE, euclidean_distance = FALSE)
 	var/turf/center_turf = get_turf(source)
 	if(!center_turf)
 		return
@@ -150,7 +155,7 @@
 		return .
 
 	for(var/atom/movable/hearable as anything in hearables_from_grid)
-		if (get_dist(center_turf, hearable) <= range)
+		if (euclidean_distance ? get_dist_euclidean(center_turf, hearable) <= range : get_dist(center_turf, hearable) <= range)
 			. += hearable
 
 	return .

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -80,9 +80,8 @@
  * * view_radius - what radius search circle we are using, worse performance as this increases
  * * source - object at the center of our search area. everything in get_turf(source) is guaranteed to be part of the search area
  * * contents_type - the type of contents we want to be looking for. defaults to hearing sensitive
- * * euclidean_distance - whether to use Euclidean distance instead of get_dist
  */
-/proc/get_hearers_in_view(view_radius, atom/source, contents_type=RECURSIVE_CONTENTS_HEARING_SENSITIVE, euclidean_distance = FALSE)
+/proc/get_hearers_in_view(view_radius, atom/source, contents_type=RECURSIVE_CONTENTS_HEARING_SENSITIVE)
 	var/turf/center_turf = get_turf(source)
 	if(!center_turf)
 		return
@@ -114,9 +113,6 @@
 	//on a whole this can outperform iterating through all movables in view() by ~2x especially when hearables are a tiny percentage of movables in view
 	//using hearers is a further optimization of that because for our purposes its the same as view except we dont have to set center's luminosity to 6 and then unset it
 	for(var/mob/oranges_ear/ear in hearers(view_radius, center_turf))
-		if(euclidean_distance)
-			if(get_dist_euclidean(center_turf, ear) > view_radius)
-				continue
 		. += ear.references
 
 	for(var/mob/oranges_ear/remaining_ear as anything in assigned_oranges_ears)//we need to clean up our mess
@@ -133,9 +129,8 @@
  * * radius - what radius search circle we are using, worse performance as this increases
  * * source - object at the center of our search area. everything in get_turf(source) is guaranteed to be part of the search area
  * * contents_type - the type of contents we want to be looking for. defaults to hearing sensitive
- * * euclidean_distance - whether to use Euclidean distance instead of get_dist
  */
-/proc/get_hearers_in_range(range, atom/source, contents_type=RECURSIVE_CONTENTS_HEARING_SENSITIVE, euclidean_distance = FALSE)
+/proc/get_hearers_in_range(range, atom/source, contents_type=RECURSIVE_CONTENTS_HEARING_SENSITIVE)
 	var/turf/center_turf = get_turf(source)
 	if(!center_turf)
 		return
@@ -155,7 +150,7 @@
 		return .
 
 	for(var/atom/movable/hearable as anything in hearables_from_grid)
-		if (euclidean_distance ? get_dist_euclidean(center_turf, hearable) <= range : get_dist(center_turf, hearable) <= range)
+		if (get_dist(center_turf, hearable) <= range)
 			. += hearable
 
 	return .

--- a/code/datums/looping_sounds/machinery_sounds.dm
+++ b/code/datums/looping_sounds/machinery_sounds.dm
@@ -140,7 +140,7 @@
 	mid_length = 1.8 SECONDS
 	end_sound = 'sound/machines/computer/computer_end.ogg'
 	end_volume = 1 SECONDS
-	volume = SOUND_AUDIBLE_VOLUME_MIN
+	volume = 3
 	falloff_exponent = 4 //Ultra quiet very fast
 	extra_range = -12
 	falloff_distance = 0 //Instant falloff after initial tile

--- a/code/datums/sound_token.dm
+++ b/code/datums/sound_token.dm
@@ -123,7 +123,7 @@
 	if(source_turf.z != listener_turf.z)
 		should_be_muted = TRUE
 
-	var/distance = get_dist(source_turf, listener_turf)
+	var/distance = get_dist_euclidean(source_turf, listener_turf)
 	if(distance > range)
 		should_be_muted = TRUE
 		if(should_be_muted && is_muted)
@@ -195,7 +195,7 @@
 		return
 	if(player_turf.z != source_turf.z)
 		return
-	if(get_dist(source_turf, player_turf) > range)
+	if(get_dist_euclidean(source_turf, player_turf) > range)
 		return
 	add_or_update_listener(player)
 

--- a/code/game/sound/sound.dm
+++ b/code/game/sound/sound.dm
@@ -16,7 +16,7 @@
  * * volume_preference - Optional: Will be checked to modify the volume of the sound for each listener.
  * * min_volume - minimum volume the sound can reach at max_range.
  */
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE, datum/preference/numeric/volume/volume_preference = null, min_volume = 5)
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE, datum/preference/numeric/volume/volume_preference = null, min_volume = 3)
 	if(isarea(source))
 		CRASH("playsound(): source is an area")
 
@@ -66,11 +66,11 @@
 		if(below_turf && istransparentturf(turf_source))
 			listeners += get_hearers_in_view(maxdistance, below_turf, RECURSIVE_CONTENTS_CLIENT_MOBS, TRUE)
 		for(var/mob/listening_ghost as anything in SSmobs.dead_players_by_zlevel[source_z])
-			if(get_dist_euclidean(listening_ghost, turf_source) <= maxdistance)
-				listeners += listening_ghost
+			listeners += listening_ghost
 
 	for(var/mob/listening_mob in listeners)//had nulls sneak in here, hence the typecheck
-		listening_mob.playsound_local(turf_source, soundin, vol, vary, frequency, falloff_exponent, channel, pressure_affected, S, maxdistance, falloff_distance, 1, use_reverb, volume_preference)
+		if(get_dist_euclidean(listening_mob, turf_source) <= maxdistance)
+			listening_mob.playsound_local(turf_source, soundin, vol, vary, frequency, falloff_exponent, channel, pressure_affected, S, maxdistance, falloff_distance, 1, use_reverb, volume_preference)
 
 	return listeners
 

--- a/code/game/sound/sound.dm
+++ b/code/game/sound/sound.dm
@@ -14,8 +14,9 @@
  * * ignore_walls - Whether or not the sound can pass through walls.
  * * falloff_distance - Distance at which falloff begins. Sound is at peak volume (in regards to falloff) aslong as it is in this range.
  * * volume_preference - Optional: Will be checked to modify the volume of the sound for each listener.
+ * * min_volume - minimum volume the sound can reach at max_range.
  */
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE, datum/preference/numeric/volume/volume_preference = null)
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE, datum/preference/numeric/volume/volume_preference = null, min_volume = 5)
 	if(isarea(source))
 		CRASH("playsound(): source is an area")
 
@@ -25,8 +26,6 @@
 	if(!soundin)
 		CRASH("playsound(): no soundin passed")
 
-	if(vol < SOUND_AUDIBLE_VOLUME_MIN) // never let sound go below SOUND_AUDIBLE_VOLUME_MIN or bad things will happen
-		CRASH("playsound(): volume below SOUND_AUDIBLE_VOLUME_MIN. [vol] < [SOUND_AUDIBLE_VOLUME_MIN]")
 
 	var/turf/turf_source = get_turf(source)
 	if (!turf_source)
@@ -50,26 +49,24 @@
 	var/turf/above_turf = GET_TURF_ABOVE(turf_source)
 	var/turf/below_turf = GET_TURF_BELOW(turf_source)
 
-	var/audible_distance = CALCULATE_MAX_SOUND_AUDIBLE_DISTANCE(vol, maxdistance, falloff_distance, falloff_exponent)
-
 	if(ignore_walls)
-		listeners = get_hearers_in_range(audible_distance, turf_source, RECURSIVE_CONTENTS_CLIENT_MOBS)
+		listeners = get_hearers_in_range(maxdistance, turf_source, RECURSIVE_CONTENTS_CLIENT_MOBS, TRUE)
 		if(above_turf && istransparentturf(above_turf))
-			listeners += get_hearers_in_range(audible_distance, above_turf, RECURSIVE_CONTENTS_CLIENT_MOBS)
+			listeners += get_hearers_in_range(maxdistance, above_turf, RECURSIVE_CONTENTS_CLIENT_MOBS, TRUE)
 
 		if(below_turf && istransparentturf(turf_source))
-			listeners += get_hearers_in_range(audible_distance, below_turf, RECURSIVE_CONTENTS_CLIENT_MOBS)
+			listeners += get_hearers_in_range(maxdistance, below_turf, RECURSIVE_CONTENTS_CLIENT_MOBS, TRUE)
 
 	else //these sounds don't carry through walls
-		listeners = get_hearers_in_view(audible_distance, turf_source, RECURSIVE_CONTENTS_CLIENT_MOBS)
+		listeners = get_hearers_in_view(maxdistance, turf_source, RECURSIVE_CONTENTS_CLIENT_MOBS, TRUE)
 
 		if(above_turf && istransparentturf(above_turf))
-			listeners += get_hearers_in_view(audible_distance, above_turf, RECURSIVE_CONTENTS_CLIENT_MOBS)
+			listeners += get_hearers_in_view(maxdistance, above_turf, RECURSIVE_CONTENTS_CLIENT_MOBS, TRUE)
 
 		if(below_turf && istransparentturf(turf_source))
-			listeners += get_hearers_in_view(audible_distance, below_turf, RECURSIVE_CONTENTS_CLIENT_MOBS)
+			listeners += get_hearers_in_view(maxdistance, below_turf, RECURSIVE_CONTENTS_CLIENT_MOBS, TRUE)
 		for(var/mob/listening_ghost as anything in SSmobs.dead_players_by_zlevel[source_z])
-			if(get_dist(listening_ghost, turf_source) <= audible_distance)
+			if(get_dist_euclidean(listening_ghost, turf_source) <= maxdistance)
 				listeners += listening_ghost
 
 	for(var/mob/listening_mob in listeners)//had nulls sneak in here, hence the typecheck
@@ -96,8 +93,9 @@
  * * distance_multiplier - Default 1, multiplies the maximum distance of our sound
  * * use_reverb - bool default TRUE, determines if our sound has reverb
  * * volume_preference - Optional: Will be checked to modify the volume of the sound.
+ * * min_volume - minimum volume the sound can reach at max_range.
  */
-/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff_exponent = SOUND_FALLOFF_EXPONENT, channel = 0, pressure_affected = TRUE, sound/sound_to_use, max_distance, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, distance_multiplier = 1, use_reverb = TRUE, datum/preference/numeric/volume/volume_preference = null)
+/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff_exponent = SOUND_FALLOFF_EXPONENT, channel = 0, pressure_affected = TRUE, sound/sound_to_use, max_distance, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, distance_multiplier = 1, use_reverb = TRUE, datum/preference/numeric/volume/volume_preference = null, min_volume = 5)
 	if(!client || HAS_TRAIT(src, TRAIT_DEAF))
 		return
 
@@ -120,10 +118,10 @@
 		var/turf/turf_loc = get_turf(src)
 
 		//sound volume falloff with distance
-		distance = get_dist(turf_loc, turf_source) * distance_multiplier
+		distance = get_dist_euclidean(turf_loc, turf_source) * distance_multiplier
 
 		if(max_distance) //If theres no max_distance we're not a 3D sound, so no falloff.
-			sound_to_use.volume -= CALCULATE_SOUND_VOLUME(vol, distance, max_distance, falloff_distance, falloff_exponent)
+			sound_to_use.volume -= CALCULATE_SOUND_VOLUME_RATIO(vol, distance, max_distance, falloff_distance, falloff_exponent) * (vol - min_volume)
 
 		if(pressure_affected)
 			//Atmosphere affects sound
@@ -143,9 +141,6 @@
 
 			sound_to_use.volume *= pressure_factor
 			//End Atmosphere affecting sound
-
-		if(sound_to_use.volume < SOUND_AUDIBLE_VOLUME_MIN)
-			return FALSE
 
 		var/dx = turf_source.x - turf_loc.x // Hearing from the right/left
 		sound_to_use.x = dx * distance_multiplier
@@ -174,7 +169,7 @@
 	if(ispath(volume_preference) && client.prefs)
 		var/client_volume_modifier = client.prefs.read_preference(volume_preference)
 		sound_to_use.volume *= (client_volume_modifier / 100)
-		if(sound_to_use.volume < SOUND_AUDIBLE_VOLUME_MIN)
+		if(sound_to_use.volume < 0.1)
 			return FALSE
 
 	if(HAS_TRAIT(src, TRAIT_SOUND_DEBUGGED))


### PR DESCRIPTION
## About The Pull Request
This PR makes a few changes:
1. It makes audio respect max_range correctly. Due to the way we used fall-off before, we would often get sounds that ended up going below 3 volume, due to an earlier PR, we made any sound below 3 volume not play. This meant that if you had a sound wiht a max_range of 17, it would not even play beyond 15~ range.

This change makes it so there's a min volume of 3 (changeable per playsound use, but I havnt changed the default anywhere), and falloff caps at this volume. This makes it so we always play at max_range still. I reduced default sound range to 15 to compensate for this, which is roughly what the distance would have been in the old system.

The sound curve now looks like this:
<img width="1322" height="861" alt="image" src="https://github.com/user-attachments/assets/c11a02e7-877c-4467-bb10-129b3f59188b" />

The second change is that instead of using chebyshev distance, we now use euclidean distance to determine the volume of sound.
The reason for this is that chebyshev distance does not respect diagonals, which means a lot of tiles are treated as the same distance which makes them sound the exact same too. 
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/b5e40f12-619a-42ad-94fb-85e7fef58adb" />

With Euclidean distance, we use the literal distance for diagonals, which results in much more accurate falloff, and means you notice falloff much better when walking past something

<img width="252" height="251" alt="image" src="https://github.com/user-attachments/assets/a9bd5255-9207-4775-b3fb-1b8ca8a63bd3" />

BEFORE:

https://github.com/user-attachments/assets/1c327557-283c-49fc-9231-8425a29f7a83


AFTER:

https://github.com/user-attachments/assets/e7f88409-c2fc-4ba8-8dd9-3e23b2eec5c2


## Why It's Good For The Game

makes falloff more accurate to your position, which to me sounds better.
also it makes max_range actually do what it says; be the range at which you can hear the sound.

## Changelog

:cl: CabinetOnFire
sound: Sound now makes use of euclidean distance for falloff
code: max_range on playsound now ensures the sound is audible up to that range.
/:cl:

