### PR TITLE
Parthenogenesis no longer makes your material fish have null weights

### DIFF
--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -823,7 +823,7 @@ GLOBAL_LIST_INIT(fish_compatible_fluid_types, list(
 
 /obj/item/fish/remove_material_effects(replace_mats = TRUE)
 	. = ..()
-	if(replace_mats || !(material_flags & MATERIAL_EFFECTS) || material_weight_mult == 1)
+	if(replace_mats || !(material_flags & MATERIAL_EFFECTS) )
 		return
 	maximum_weight /= material_weight_mult
 	update_size_and_weight(size, weight / material_weight_mult)

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -816,7 +816,7 @@ GLOBAL_LIST_INIT(fish_compatible_fluid_types, list(
 /obj/item/fish/apply_material_effects()
 	. = ..()
 	//Either effects aren't applied of he materials are simply being increased/decreased along with the weight. Avoids recursion.
-	if(!(material_flags & MATERIAL_EFFECTS) || (fish_flags & FISH_FLAG_UPDATING_SIZE_AND_WEIGHT) || material_weight_mult == 1)
+	if(!(material_flags & MATERIAL_EFFECTS) || (fish_flags & FISH_FLAG_UPDATING_SIZE_AND_WEIGHT) )
 		return
 	maximum_weight *= material_weight_mult
 	update_size_and_weight(size, (temp_weight || weight) * material_weight_mult, update_materials = FALSE)


### PR DESCRIPTION

## About The Pull Request
Removes a check that checks if material_weight_mult is equal to 1 in fish's apply_material_effects.
## Why It's Good For The Game
Fixes #96308
Also fixes #96357
## Changelog
:cl:
fix: Parthenogenesis no longer makes your material fish have null weights
/:cl:
