### PR TITLE
Pinpointer tweaks and ventpointer buff.

### DIFF
--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -96,13 +96,13 @@
 		return "pinon[alert ? "alert" : ""]direct[icon_suffix]"
 	else
 		setDir(get_dir(here, there))
-		switch(get_dist(here, there))
-			if(1 to close_range)
-				return "pinon[alert ? "alert" : "close"][icon_suffix]"
-			if((close_range + 1) to medium_range)
-				return "pinon[alert ? "alert" : "medium"][icon_suffix]"
-			if(medium_range to INFINITY)
-				return "pinon[alert ? "alert" : "far"][icon_suffix]"
+		var/current_distance = get_dist(here, there)
+		if(current_distance >= 1 && current_distance <= close_range)
+			return "pinon[alert ? "alert" : "close"][icon_suffix]"
+		else if(current_distance > (close_range + 1) && current_distance <= medium_range)
+			return "pinon[alert ? "alert" : "medium"][icon_suffix]"
+		else if(current_distance > medium_range)
+			return "pinon[alert ? "alert" : "far"][icon_suffix]"
 
 /obj/item/pinpointer/crew // A replacement for the old crew monitoring consoles
 	name = "crew pinpointer"

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -17,12 +17,23 @@
 	sound_vary = TRUE
 	pickup_sound = SFX_GENERIC_DEVICE_PICKUP
 	drop_sound = SFX_GENERIC_DEVICE_DROP
+	/// Is the pinpointer on?
 	var/active = FALSE
-	var/atom/movable/target //The thing we're searching for
-	var/minimum_range = 0 //at what range the pinpointer declares you to be at your destination
-	var/alert = FALSE // TRUE to display things more seriously
-	var/process_scan = TRUE // some pinpointers change target every time they scan, which means we can't have it change very process but instead when it turns on.
-	var/icon_suffix = "" // for special pinpointer icons
+	///The thing we're searching for
+	var/atom/movable/target
+	/// TRUE to display things more seriously
+	var/alert = FALSE
+	/// Some pinpointers change target every time they scan, which means we can't have it change every process() but instead when it turns on.
+	var/process_scan = TRUE
+	/// Icon_state suffix for special pinpointer icons
+	var/icon_suffix = ""
+
+	/// At what range the pinpointer declares you to be at your destination. Use to hide the exact location of your target.
+	var/minimum_range = 0
+	/// From 1 to this value, the sprite will display as though you're close.
+	var/close_range = 8
+	/// From close_range + 1 to this value, the sprite will display as though you're medium distance away. Past this value, we'll display as though you're far.
+	var/medium_range = 16
 
 /obj/item/pinpointer/Initialize(mapload)
 	. = ..()
@@ -86,11 +97,11 @@
 	else
 		setDir(get_dir(here, there))
 		switch(get_dist(here, there))
-			if(1 to 8)
+			if(1 to close_range)
 				return "pinon[alert ? "alert" : "close"][icon_suffix]"
-			if(9 to 16)
+			if((close_range + 1) to medium_range)
 				return "pinon[alert ? "alert" : "medium"][icon_suffix]"
-			if(16 to INFINITY)
+			if(medium_range to INFINITY)
 				return "pinon[alert ? "alert" : "far"][icon_suffix]"
 
 /obj/item/pinpointer/crew // A replacement for the old crew monitoring consoles
@@ -100,9 +111,14 @@
 	worn_icon_state = "pinpointer_crew"
 	custom_price = PAYCHECK_CREW * 6
 	custom_premium_price = PAYCHECK_CREW * 6
-	var/has_owner = FALSE
+	/// The mob that the pinpointer is owned by.
 	var/pinpointer_owner = null
-	var/ignore_suit_sensor_level = FALSE /// Do we find people even if their suit sensors are turned off
+	/// Do we find people even if their suit sensors are turned off
+	var/ignore_suit_sensor_level = FALSE
+
+/obj/item/pinpointer/crew/Destroy()
+	. = ..()
+	pinpointer_owner = null
 
 /obj/item/pinpointer/crew/proc/trackable(mob/living/carbon/human/H)
 	var/turf/here = get_turf(src)
@@ -120,7 +136,7 @@
 		user.visible_message(span_notice("[user] deactivates [user.p_their()] pinpointer."), span_notice("You deactivate your pinpointer."))
 		return
 
-	if (has_owner && !pinpointer_owner)
+	if (!pinpointer_owner)
 		pinpointer_owner = user
 
 	if (pinpointer_owner && pinpointer_owner != user)
@@ -173,6 +189,7 @@
 /obj/item/pinpointer/pair
 	name = "pair pinpointer"
 	desc = "A handheld tracking device that locks onto its other half of the matching pair."
+	/// Reference to the other, specific pinpointer that it's bought with. Assigned on /obj/item/storage/box/pinpointer_pairs.
 	var/other_pair
 
 /obj/item/pinpointer/pair/Destroy()
@@ -197,6 +214,7 @@
 	icon_state = "pinpointer_hunter"
 	worn_icon_state = "pinpointer_black"
 	icon_suffix = "_hunter"
+	/// Reference to the bounty hunter shuttle's docking port.
 	var/obj/docking_port/mobile/shuttleport
 
 /obj/item/pinpointer/shuttle/Initialize(mapload)

--- a/code/modules/antagonists/traitor/contractor/contractor_items.dm
+++ b/code/modules/antagonists/traitor/contractor/contractor_items.dm
@@ -4,7 +4,6 @@
 	icon_state = "pinpointer_syndicate"
 	worn_icon_state = "pinpointer_black"
 	minimum_range = 25
-	has_owner = TRUE
 	ignore_suit_sensor_level = TRUE
 
 /obj/item/paper/contractor_guide

--- a/code/modules/mining/equipment/vent_pointer.dm
+++ b/code/modules/mining/equipment/vent_pointer.dm
@@ -2,7 +2,9 @@
 	name = "ventpointer"
 	desc = "A handheld tracking device. It will locate and point to nearby vents. A bit unreliable though."
 	icon_state = "pinpointer_vent"
-	minimum_range = 14 //gotta use them eyes
+	minimum_range = 8 //gotta use them eyes
+	close_range = 12
+	medium_range = 20
 
 /obj/item/pinpointer/vent/scan_for_target()
 	var/closest_dist = INFINITY


### PR DESCRIPTION
## About The Pull Request

Pretty simple one this time.

Cleans up pinpointer code, previously the ranges at which pinpointer arrows determined how close you were to an object were hardcoded numbers, now I've moved those numbers over to a set of variables so you can determine what's close/medium/far.

Autodocs pinpointer variables and subtype variables as well.

Removed a functionally useless variable off of crew pinpointers, moving from a boolean-`has_owner` to just checking against the assigned `pinpointer_owner` mob.

Lastly, tweaked some of the numbers on the ventpointer, a pinpointer purchasable by shaft miners for points. Namely, I've lowered it's minimum range to 8 from 14, meaning that you can get closer before it says that you've arrived at your vent, as before you could still be completely off screen and be unable to find the vent. In addition, I adjusted the close and medium range variables to be wider than the standard range, since in practice using the ventpointer in-round tends to just show a red arrow for the vast majority of the time you're using it.

## Why It's Good For The Game

Pinpointer code improvements were mostly because I was in the area and in theory, pinpointer code should be more flexible considering how much of the game's core game-modes rely on pinpointers to function properly.

On ventpointers, these things are clearly meant to be somewhat inaccurate, but due to having the distance values on pinpointers hardcoded, It was previously impossible to ever even reach close range on the vent before it claimed you had arrived. I've lowered the close range value to be in the ballpark of a single screenwidth of tiles in all directions, and adjusted the other colors so that you can get a better idea if you've switched vent targets. As a result, the ventpointer should be a more valuable investment as a direct result.

## Changelog

:cl:
balance: The mining ventpointer has been adjusted so that it can now more accurately show the distance to the nearest vent, and will now claim you've arrived if you're within 8 tiles away from a vent, down from 14.
code: Several backend improvements to the pinpointer functionality and adjustability.
/:cl: