### PR TITLE
Fix disease copies not registering relevant disease signals

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -77,8 +77,8 @@
 	SSdisease.active_diseases += D //Add it to the active diseases list, now that it's actually in a mob and being processed.
 
 	D.after_add()
+	D.register_disease_signals()
 	infectee.med_hud_set_status()
-	register_disease_signals()
 
 	var/turf/source_turf = get_turf(infectee)
 	log_virus("[key_name(infectee)] was infected by virus: [src.admin_details()] at [loc_name(source_turf)]")

--- a/code/datums/quirks/negative_quirks/chronic_illness.dm
+++ b/code/datums/quirks/negative_quirks/chronic_illness.dm
@@ -10,8 +10,8 @@
 	mail_goodies = list(/obj/item/storage/pill_bottle/sansufentanyl)
 
 /datum/quirk/item_quirk/chronic_illness/add(client/client_source)
-	var/datum/disease/chronic_illness/hms = new /datum/disease/chronic_illness()
-	quirk_holder.ForceContractDisease(hms)
+	var/datum/disease/chronic_illness/hms = new()
+	quirk_holder.ForceContractDisease(hms, make_copy = FALSE, del_on_fail = TRUE)
 
 /datum/quirk/item_quirk/chronic_illness/add_unique(client/client_source)
 	give_item_to_holder(/obj/item/storage/pill_bottle/sansufentanyl, list(LOCATION_BACKPACK), flavour_text = "You've been provided with medication to help manage your condition. Take it regularly to avoid complications.", notify_player = TRUE)


### PR DESCRIPTION
## About The Pull Request

`/datum/disease/proc/infect(mob/living/infectee, make_copy = TRUE)` does NOT always represent the disease infecting someone. 

If you pass `make_copy = TRUE`, the proc actually handles the *copy* infecting the mob, rather than the disease itself. 

(The issue here arises from `register_disease_signals` here being called on the disease itself rather than the potential copy. )

This itself could(should) easily be fixed, by making a copy before going into `infect`, but this is an easy fix in the meanwhile. 

Fixes #96372

## Changelog

:cl: Melbert
fix: Fixed a bug where diseases wouldn't trigger their regular effects when applied in certain contexts
fix: Fixed a bug where airborne diseases wouldn't spread via breathing when applied in certain contexts
/:cl:
