### PR TITLE
Fix antag teams not clearing refs from objective properly when deleted

### DIFF
--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -29,6 +29,9 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 /datum/team/Destroy(force)
 	GLOB.antagonist_teams -= src
 	members = null
+	for(var/datum/objective/objective as anything in objectives)
+		if(objective.team == src)
+			objective.team = null
 	objectives = null
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

Whenever an antag team is deleted, it wouldn't properly clear the `team` var from its objectives - resulting in a hard delete.
## Why It's Good For The Game

Fixes a hard delete.
## Changelog
:cl:

/:cl:
