### PR TITLE
Add a unit test for language key conflicts

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -212,6 +212,7 @@
 #include "keybinding_init.dm"
 #include "kinetic_crusher.dm"
 #include "knockoff_component.dm"
+#include "language_key_conflicts.dm"
 #include "language_transfer.dm"
 #include "leash.dm"
 #include "lesserform.dm"

--- a/code/modules/unit_tests/language_key_conflicts.dm
+++ b/code/modules/unit_tests/language_key_conflicts.dm
@@ -1,0 +1,15 @@
+/// This test ensures that multiple languages aren't mapped to the same prefix key.
+/datum/unit_test/language_key_conflicts
+
+/datum/unit_test/language_key_conflicts/Run()
+	var/list/used_keys = list()
+	for(var/datum/language/language as anything in subtypesof(/datum/language))
+		var/name = language::name
+		var/key = language::key
+		if(!key)
+			continue
+		if(used_keys[key])
+			var/datum/language/conflicting_language = used_keys[key]
+			TEST_FAIL("[name] ([language]) uses the '[key]' prefix, which is also used by [conflicting_language::name] ([conflicting_language])!")
+		else
+			used_keys[key] = language

--- a/code/modules/unit_tests/language_key_conflicts.dm
+++ b/code/modules/unit_tests/language_key_conflicts.dm
@@ -7,8 +7,8 @@
 		var/name = language::name
 		var/key = language::key
 		if(!key)
-			continue
-		if(used_keys[key])
+			TEST_FAIL("[name] ([language]) does not have a prefix!")
+		else if(used_keys[key])
 			var/datum/language/conflicting_language = used_keys[key]
 			TEST_FAIL("[name] ([language]) uses the '[key]' prefix, which is also used by [conflicting_language::name] ([conflicting_language])!")
 		else


### PR DESCRIPTION

## About The Pull Request

simply adds a new unit test, `language_key_conflicts`, ported from my work on monkestation.

it is exactly what it says on the tin - it ensures two languages do not have the same exact key. i don't think that's an issue here, but better safe than sorry.

## Why It's Good For The Game

more unit test coverage for subtle bugs that might be hard to realize is always nice

## Changelog

No user-facing changes.