### PR TITLE
adds a sound preview button to the emote panel

### DIFF
--- a/code/modules/emote_panel/emote_panel.dm
+++ b/code/modules/emote_panel/emote_panel.dm
@@ -44,11 +44,23 @@
 			if(emote.message_param && use_params)
 				emote_param = tgui_input_text(ui.user, "Add params to the emote...", emote.message_param, max_length = MAX_MESSAGE_LEN)
 			ui.user.emote(emote_key, message = emote_param, intentional = TRUE)
+		if("preview_sound")
+			var/emote_key = params["emote_key"]
+			if(isnull(emote_key) || !GLOB.emote_list[emote_key])
+				return
+			var/datum/emote/emote = GLOB.emote_list[emote_key][1]
+			var/emote_sound = get_sfx(emote.get_sound(ui.user))
+			if(!emote_sound)
+				to_chat(ui.user, span_warning("Couldn't get a preview sound for [emote.name]."), type = MESSAGE_TYPE_INFO)
+				return
+			SEND_SOUND(ui.user, sound(emote_sound, volume = 75))
+			to_chat(ui.user, span_warning("Previewed sound for [emote.name]."), type = MESSAGE_TYPE_INFO)
 
 /datum/emote_panel/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "EmotePanel")
+		ui.set_autoupdate(FALSE)
 		ui.open()
 
 /datum/emote_panel/ui_state(mob/user)

--- a/tgui/packages/tgui/interfaces/EmotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/EmotePanel.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Box, Button, Flex, Icon, Section } from 'tgui-core/components';
+import { useMemo, useState } from 'react';
+import { Box, Button, Flex, Icon, Section, Stack } from 'tgui-core/components';
 import type { BooleanLike } from 'tgui-core/react';
 import { capitalizeFirst } from 'tgui-core/string';
 
@@ -42,6 +42,34 @@ export const EmotePanelContent = (props) => {
   const [showNames, toggleShowNames] = useState(true);
 
   const [showIcons, toggleShowIcons] = useState(false);
+
+  const filteredEmotes = useMemo(
+    () =>
+      emotes
+        .filter(
+          (emote) =>
+            emote.key &&
+            (searchText.length > 0
+              ? emote.key.toLowerCase().includes(searchText.toLowerCase()) ||
+                emote.name.toLowerCase().includes(searchText.toLowerCase())
+              : true) &&
+            (filterVisible ? emote.visible : true) &&
+            (filterAudible ? emote.audible : true) &&
+            (filterSound ? emote.sound : true) &&
+            (filterHands ? emote.hands : true) &&
+            (filterUseParams ? emote.use_params : true),
+        )
+        .sort((a, b) => (a.name > b.name ? 1 : -1)),
+    [
+      emotes,
+      searchText,
+      filterVisible,
+      filterAudible,
+      filterSound,
+      filterHands,
+      filterUseParams,
+    ],
+  );
 
   return (
     <Section>
@@ -136,71 +164,99 @@ export const EmotePanelContent = (props) => {
       >
         <Flex>
           <Flex.Item>
-            {emotes
-              .filter(
-                (emote) =>
-                  emote.key &&
-                  (searchText.length > 0
-                    ? emote.key
-                        .toLowerCase()
-                        .includes(searchText.toLowerCase()) ||
-                      emote.name
-                        .toLowerCase()
-                        .includes(searchText.toLowerCase())
-                    : true) &&
-                  (filterVisible ? emote.visible : true) &&
-                  (filterAudible ? emote.audible : true) &&
-                  (filterSound ? emote.sound : true) &&
-                  (filterHands ? emote.hands : true) &&
-                  (filterUseParams ? emote.use_params : true),
-              )
-              .sort((a, b) => (a.name > b.name ? 1 : -1))
-              .map((emote) => (
-                <Button
-                  width={showIcons ? 16 : 8}
-                  key={emote.name}
-                  tooltip={
-                    showIcons ? undefined : (
-                      <EmoteIcons
-                        visible={emote.visible}
-                        audible={emote.audible}
-                        sound={emote.sound}
-                        hands={emote.hands}
-                        use_params={emote.use_params}
-                        margin={0.5}
-                      />
-                    )
-                  }
-                  onClick={() =>
-                    act('play_emote', {
-                      emote_key: emote.key,
-                      use_params: useParams,
-                    })
-                  }
-                >
-                  <Box inline width="50%">
-                    {showNames
-                      ? capitalizeFirst(emote.name.toLowerCase())
-                      : emote.key}
-                  </Box>
-                  {showIcons ? (
-                    <EmoteIcons
-                      visible={emote.visible}
-                      audible={emote.audible}
-                      sound={emote.sound}
-                      hands={emote.hands}
-                      use_params={emote.use_params}
-                      margin={0}
-                    />
-                  ) : (
-                    ''
-                  )}
-                </Button>
-              ))}
+            {filteredEmotes.map((emote) => (
+              <EmoteButton
+                emote={emote}
+                key={emote.name}
+                showIcons={showIcons}
+                showNames={showNames}
+                onPlay={() =>
+                  act('play_emote', {
+                    emote_key: emote.key,
+                    use_params: useParams,
+                  })
+                }
+                onPreview={() =>
+                  act('preview_sound', {
+                    emote_key: emote.key,
+                  })
+                }
+              />
+            ))}
           </Flex.Item>
         </Flex>
       </Section>
     </Section>
+  );
+};
+
+type EmoteButtonProps = {
+  emote: Emote;
+  showIcons: boolean;
+  showNames: boolean;
+  onPlay: () => void;
+  onPreview: () => void;
+};
+
+const EmoteButton = (props: EmoteButtonProps) => {
+  const { emote, showIcons, showNames, onPlay, onPreview } = props;
+
+  return (
+    <Stack
+      inlineFlex
+      align="center"
+      width={showIcons ? 16 : 8}
+      mb={0.5}
+      mr={0.5}
+      style={{ gap: '0.25em' }}
+    >
+      <Stack.Item grow basis={0}>
+        <Button
+          fluid
+          tooltip={
+            showIcons ? undefined : (
+              <EmoteIcons
+                visible={emote.visible}
+                audible={emote.audible}
+                sound={emote.sound}
+                hands={emote.hands}
+                use_params={emote.use_params}
+                margin={0.5}
+              />
+            )
+          }
+          onClick={onPlay}
+        >
+          <Box inline width="50%">
+            {showNames ? capitalizeFirst(emote.name.toLowerCase()) : emote.key}
+          </Box>
+          {showIcons ? (
+            <EmoteIcons
+              visible={emote.visible}
+              audible={emote.audible}
+              sound={emote.sound}
+              hands={emote.hands}
+              use_params={emote.use_params}
+              margin={0}
+            />
+          ) : (
+            ''
+          )}
+        </Button>
+      </Stack.Item>
+      {emote.sound ? (
+        <Stack.Item width={1.75}>
+          <Button
+            fluid
+            icon="volume-up"
+            tooltip="Preview Sound"
+            onClick={onPreview}
+          />
+        </Stack.Item>
+      ) : (
+        ''
+      )}
+    </Stack>
   );
 };
 


### PR DESCRIPTION

## About The Pull Request

This adds a button next to sound emotes in the emote panel, allowing you to preview the emote sound without actually having to do said emote.

The sound just plays for the user - nobody else hears it, it's just a `SEND_SOUND`

https://github.com/user-attachments/assets/d4774769-c4ff-4d2a-98c9-2c8095b66998

(im not sure how nicely to fix that issue with the "Gasp (Shock)" button, tho)

also cleaned up emote panel tgui a bit.

## Why It's Good For The Game

Makes it easier to know what emote sounds like what without confusing people about why you're making 50 different sounds lol

## Changelog
:cl:
qol: You can now preview what different emotes sound like via the emote panel.
/:cl:
