### PR TITLE
use the chat spritesheet for byond member ooc icons

### DIFF
--- a/code/modules/asset_cache/assets/chat.dm
+++ b/code/modules/asset_cache/assets/chat.dm
@@ -11,3 +11,7 @@
 		if (icon != 'icons/ui/chat/language.dmi')
 			var/icon_state = initial(L.icon_state)
 			insert_icon("language-[icon_state]", uni_icon(icon, icon_state))
+
+	var/datum/universal_icon/byond_member = uni_icon('icons/ui/chat/member_content.dmi', "blag")
+	byond_member.scale(16, 16)
+	insert_icon("byond_member", byond_member)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -77,12 +77,27 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	mob.log_talk(raw_msg, LOG_OOC)
 
 	var/keyname = key
-	if(prefs.unlock_content)
-		if(prefs.toggles & MEMBER_PUBLIC)
-			keyname = "<font color='[prefs.read_preference(/datum/preference/color/ooc_color) || GLOB.normal_ooc_colour]'>[icon2html('icons/ui/chat/member_content.dmi', world, "blag")][keyname]</font>"
+	var/list/key_tags
+	var/key_prefix = ""
+	var/visible_unlock = prefs.unlock_content && (prefs.toggles & MEMBER_PUBLIC)
+
+	// heart first lol
 	if(prefs.hearted)
-		var/datum/asset/spritesheet_batched/sheet = get_asset_datum(/datum/asset/spritesheet_batched/chat)
-		keyname = "[sheet.icon_tag("emoji-heart")][keyname]"
+		LAZYADD(key_tags, "emoji-heart")
+	if(visible_unlock)
+		LAZYADD(key_tags, "byond_member")
+
+	if(LAZYLEN(key_tags))
+		var/datum/asset/spritesheet_batched/chat/sheet = get_asset_datum(/datum/asset/spritesheet_batched/chat)
+		for(var/icon_name in key_tags)
+			key_prefix = "[key_prefix][sheet.icon_tag(icon_name)]"
+		key_prefix = "<span style='vertical-align: text-top; padding-right: 0.2em'>[key_prefix]</span>"
+
+	keyname = "[key_prefix][keyname]"
+
+	if(visible_unlock)
+		keyname = "<font color='[prefs.read_preference(/datum/preference/color/ooc_color) || GLOB.normal_ooc_colour]'>[keyname]</font>"
+
 	//The linkify span classes and linkify=TRUE below make ooc text get clickable chat href links if you pass in something resembling a url
 	for(var/client/receiver as anything in GLOB.clients)
 		if(!receiver.prefs) // Client being created or deleted. Despite all, this can be null.


### PR DESCRIPTION

## About The Pull Request

partial port of my fixups from https://github.com/Monkestation/Monkestation2.0/pull/11644

this refactors the byond member icon in OOC use the chat spritesheet, instead of `icon2html`.
<img width="772" height="387" alt="2026-06-06 (1780794864) ~ dreamseeker" src="https://github.com/user-attachments/assets/9e4c0e3e-280f-4fda-b0ee-c78b8aa33e76" />

also as a result, this makes the byond member icon align better with the text and be slightly less crunchy.
here's how it was before, for reference:
<img width="293" height="32" alt="image" src="https://github.com/user-attachments/assets/15c8a78d-7752-4c07-a2d4-b4ceebc7f362" />

## Why It's Good For The Game

why did this use icon2html that's dumb. better performance i guess. and looks better on the eyes.

## Changelog
:cl:
fix: Made the BYOND member OOC icon better aligned to the text.
/:cl:
