### PR TITLE
Blood worms are no longer fully immune to space/cold

### DIFF
--- a/code/modules/antagonists/blood_worm/blood_worm_mob.dm
+++ b/code/modules/antagonists/blood_worm/blood_worm_mob.dm
@@ -24,11 +24,12 @@
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
 
-	minimum_survivable_temperature = 0
+	minimum_survivable_temperature = ICEBOX_MIN_TEMPERATURE
 	maximum_survivable_temperature = T0C + 100
-	unsuitable_cold_damage = 0
+	unsuitable_cold_damage = 1
+	unsuitable_atmos_damage = 2
 
-	habitable_atmos = null
+	habitable_atmos = list("min_oxy" = 5, "max_oxy" = 0)
 
 	// A vivid red.
 	lighting_cutoff_red = 40

--- a/code/modules/antagonists/blood_worm/blood_worm_mob.dm
+++ b/code/modules/antagonists/blood_worm/blood_worm_mob.dm
@@ -26,8 +26,8 @@
 
 	minimum_survivable_temperature = ICEBOX_MIN_TEMPERATURE
 	maximum_survivable_temperature = T0C + 100
-	unsuitable_cold_damage = 0.5
-	unsuitable_atmos_damage = 1
+	unsuitable_cold_damage = 1
+	unsuitable_atmos_damage = 2
 
 	habitable_atmos = list("min_oxy" = 5, "max_oxy" = 0)
 

--- a/code/modules/antagonists/blood_worm/blood_worm_mob.dm
+++ b/code/modules/antagonists/blood_worm/blood_worm_mob.dm
@@ -26,8 +26,8 @@
 
 	minimum_survivable_temperature = ICEBOX_MIN_TEMPERATURE
 	maximum_survivable_temperature = T0C + 100
-	unsuitable_cold_damage = 1
-	unsuitable_atmos_damage = 2
+	unsuitable_cold_damage = 0.5
+	unsuitable_atmos_damage = 1
 
 	habitable_atmos = list("min_oxy" = 5, "max_oxy" = 0)
 


### PR DESCRIPTION
## About The Pull Request

Blood worms take 2 damage/second from being in extreme pressure, and 1 damage/second from being in extreme cold

Note that it doesn't stop their regen (up to 0.5 damage/secon) so the number is closer to 1.5 damage/second and 0.5 damage/second (for the elders)

## Why It's Good For The Game

Blood Worm's space immunity is kind of at odds with their intended design/gameplay loop of stealing people's identities, as more often than not, the identities they steal are not immune to space. 

It is not an uncommon sight to see bworms completely ditch the disguise mechanic and just go around busting windows to "expand their domain" of places that they can't be chased

Thus I am opting to remove the full immunity to pressure and cold from bworms. They are still quite resilient to pressure and cold (if my math is correct it would take at least a minute to die to pressure damage as an elder) but lacking full immunity should disincentivize them from spacing themselves unless in complete necessity. 


## Changelog

:cl: Melbert
balance: Blood worms are no longer fully immune to extreme pressures and cold, such as the vacuum of space
/:cl:
