### PR TITLE
Remove slavery joke from cotton seed description

### DIFF
--- a/code/modules/hydroponics/grown/cotton.dm
+++ b/code/modules/hydroponics/grown/cotton.dm
@@ -1,6 +1,6 @@
 /obj/item/seeds/cotton
 	name = "cotton seed pack"
-	desc = "A pack of seeds that'll grow into a cotton plant. Assistants make good free labor if neccesary."
+	desc = "A pack of seeds that'll grow into a cotton plant."
 	icon_state = "seed-cotton"
 	species = "cotton"
 	plantname = "Cotton"


### PR DESCRIPTION

## About The Pull Request

Remove a joke about enslaving assistants to farm cotton from the description for cotton seeds

## Why It's Good For The Game

It's a pretty tasteless and pointlessly edgy thing to include

## Changelog
Probably not 
