### PR TITLE
Buffs baseball bats to do more damage and fit on back'

### DIFF
--- a/code/game/objects/items/weaponry/melee/baseball_bat.dm
+++ b/code/game/objects/items/weaponry/melee/baseball_bat.dm
@@ -7,15 +7,16 @@
 	icon_angle = -45
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	force = 12
+	force = 13
 	wound_bonus = -10
-	throwforce = 12
+	throwforce = 13
 	demolition_mod = 1.25
 	attack_verb_continuous = list("beats", "smacks")
 	attack_verb_simple = list("beat", "smack")
 	custom_materials = list(/datum/material/wood = SHEET_MATERIAL_AMOUNT * 3.5)
 	resistance_flags = FLAMMABLE
 	w_class = WEIGHT_CLASS_HUGE
+	slot_flags = ITEM_SLOT_BACK
 	/// Are we able to do a homerun?
 	var/homerun_able = FALSE
 	/// Are we ready to do a homerun?

--- a/code/game/objects/items/weaponry/melee/baseball_bat.dm
+++ b/code/game/objects/items/weaponry/melee/baseball_bat.dm
@@ -3,7 +3,7 @@
 	desc = "There ain't a skull in the league that can withstand a swatter."
 	icon = 'icons/obj/weapons/bat.dmi'
 	icon_state = "baseball_bat"
-	worn_icon_state="staff"
+	worn_icon_state="bostaff0"
 	inhand_icon_state = "baseball_bat"
 	icon_angle = -45
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'

--- a/code/game/objects/items/weaponry/melee/baseball_bat.dm
+++ b/code/game/objects/items/weaponry/melee/baseball_bat.dm
@@ -3,6 +3,7 @@
 	desc = "There ain't a skull in the league that can withstand a swatter."
 	icon = 'icons/obj/weapons/bat.dmi'
 	icon_state = "baseball_bat"
+	worn_icon_state="staff"
 	inhand_icon_state = "baseball_bat"
 	icon_angle = -45
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'


### PR DESCRIPTION

## About The Pull Request

Buffs baseball bats to have equivalent damage to fire extinguishers and fit on the back slot like a spear

## Why It's Good For The Game

Baseball bats have fallen behind recently due to the buffs to improvised weapons, they take effort to create and are less powerful than other options, which I think is a darn shame.

## Changelog

<!--Baseball bats do more damage and fit on the back slot now. -->

:cl:
balance: Baseball bats do more damage and fit on the back slot now. 
/:cl:


