### PR TITLE
Clarifies Sphere modules lava protecction requirement + typo fix

### DIFF
--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -576,8 +576,8 @@
 
 /obj/item/mod/module/sphere_transform
 	name = "MOD sphere transform module"
-	desc = "A module able to move the suit's parts around, turning it and the user into a sphere. \
-		The sphere can move quickly, even through lava, and launch mining micromissile to decimate terrain and fauna alike."
+	desc = "A module able to move the suit's parts around, turning it and the user into a sphere. If the modsuit is insulated with bileworm skin, the user will be protected from lava while active. \
+		The sphere can move quickly, even through lava, and launch mining micromissiles to decimate terrain and fauna alike."
 	icon_state = "sphere"
 	module_type = MODULE_ACTIVE
 	removable = FALSE


### PR DESCRIPTION

## About The Pull Request
Updates the description of the sphere modsuit module that the modsuit requires bileworm skin in order to get its lava immunity. Also fixes a typo with micromissles
## Why It's Good For The Game
Less new miners dying trying to sphere mode into lava without bileworm skin on their modsuit. Also typo bad.
## Changelog
:cl:
spellcheck: The sphere module now clarifies that the modsuit need to be insulated with bileworm skin in order to wade through lava safely.
spellcheck: Corrects sphere modules micromissle to micromissles
/:cl:
