### PR TITLE
You no longer waddle when buckled to something

### DIFF
--- a/code/datums/elements/waddling.dm
+++ b/code/datums/elements/waddling.dm
@@ -18,7 +18,7 @@
 		return
 	if(isliving(moved))
 		var/mob/living/living_moved = moved
-		if (living_moved.incapacitated || (living_moved.body_position == LYING_DOWN && !HAS_TRAIT(living_moved, TRAIT_FLOPPING)))
+		if (living_moved.buckled || living_moved.incapacitated || (living_moved.body_position == LYING_DOWN && !HAS_TRAIT(living_moved, TRAIT_FLOPPING)))
 			return
 	waddling_animation(moved)
 


### PR DESCRIPTION
## About The Pull Request
Add a buckled check to the waddling element.

## Why It's Good For The Game
Waddling is supposed to represent, well, waddling, like how you walk funny when you're wearing big, clumsy clown shoes. If you're riding an ATV, you aren't actually walking with those big clumsy clown shoes, therefore, you shouldn't be waddling (also because waddling looks too jittery at higher speeds).

## Changelog

:cl:
fix: You no longer waddle when buckled to something.
/:cl:
