### PR TITLE
"Conserved Genetics" - A trait to prevent cross-pollination instability change in plants with the gene.

### DIFF
--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -15,7 +15,8 @@
 	growthstages = 2
 	icon_grow = "grass-grow"
 	icon_dead = "grass-dead"
-	genes = list(/datum/plant_gene/trait/repeated_harvest)
+	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/safe_instability)
+	graft_gene = /datum/plant_gene/trait/safe_instability
 	mutatelist = list(/obj/item/seeds/grass/carpet, /obj/item/seeds/grass/fairy)
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.02, /datum/reagent/hydrogen = 0.05)
 
@@ -53,7 +54,7 @@
 	product = /obj/item/food/grown/grass/fairy
 	icon_grow = "fairygrass-grow"
 	icon_dead = "fairygrass-dead"
-	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/glow/blue)
+	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/glow/blue, /datum/plant_gene/trait/safe_instability)
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.02, /datum/reagent/hydrogen = 0.05, /datum/reagent/drug/space_drugs = 0.15)
 	graft_gene = /datum/plant_gene/trait/glow/blue
 	mutatelist = null

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -851,7 +851,8 @@
 			continue
 		if(T.myseed && T.plant_status != HYDROTRAY_PLANT_DEAD)
 			T.myseed.set_potency(round((T.myseed.potency+(1/10)*(myseed.potency-T.myseed.potency))))
-			T.myseed.set_instability(round((T.myseed.instability+(1/10)*(myseed.instability-T.myseed.instability))))
+			if(!T.myseed.get_gene(/datum/plant_gene/trait/safe_instability))
+				T.myseed.set_instability(round((T.myseed.instability+(1/10)*(myseed.instability-T.myseed.instability))))
 			T.myseed.set_yield(round((T.myseed.yield+(1/2)*(myseed.yield-T.myseed.yield))))
 			being_pollinated = TRUE
 			add_shared_particles(/particles/pollen)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -295,6 +295,14 @@
 /datum/plant_gene/trait/slip/proc/handle_slip(obj/item/food/grown/our_plant, mob/slipped_target)
 	SEND_SIGNAL(our_plant, COMSIG_PLANT_ON_SLIP, slipped_target)
 
+/// Prevents instability from being shared in cross-pollination.
+/datum/plant_gene/trait/safe_instability
+	name = "Conserved Genetics"
+	description = "With highly conserved genetics, this plant doesn't lose or gain instability in cross-pollination."
+	icon = FA_ICON_SEEDLING
+	rate = 1
+	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
+
 /*
  * Cell recharging trait. Charges all mob's power cells to (potency*rate)% mark when eaten.
  * Generates sparks on squash.

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -295,7 +295,7 @@
 /datum/plant_gene/trait/slip/proc/handle_slip(obj/item/food/grown/our_plant, mob/slipped_target)
 	SEND_SIGNAL(our_plant, COMSIG_PLANT_ON_SLIP, slipped_target)
 
-/// Prevents instability from being gained/lost by the plant in cross-pollination.
+/// Prevents instability from being changed BY cross-pollination.
 /datum/plant_gene/trait/safe_instability
 	name = "Conserved Genetics"
 	description = "With highly conserved genetics, this plant doesn't lose or gain instability in cross-pollination."

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -295,7 +295,7 @@
 /datum/plant_gene/trait/slip/proc/handle_slip(obj/item/food/grown/our_plant, mob/slipped_target)
 	SEND_SIGNAL(our_plant, COMSIG_PLANT_ON_SLIP, slipped_target)
 
-/// Prevents instability from being shared in cross-pollination.
+/// Prevents instability from being gained/lost by the plant in cross-pollination.
 /datum/plant_gene/trait/safe_instability
 	name = "Conserved Genetics"
 	description = "With highly conserved genetics, this plant doesn't lose or gain instability in cross-pollination."


### PR DESCRIPTION

## About The Pull Request

Cross-pollination has a lot of potential for fun, but the aspect of instability loss and gain in plants makes me experience great suffering. Therefore, it has been suggested that I can get rid of this great pain by just preventing it with a plant trait! Magnificent!

Grass was chosen to receive this trait because of its.. _checks notes_ "[remarkable conservation of gene content and gene order](https://pmc.ncbi.nlm.nih.gov/articles/PMC33824/)"! How wonderful! I hope I'm interpreting that correctly!

## Why It's Good For The Game

The trait allows for botanists to achieve a finer control over which plants are altered during cross-pollination, preventing undesired instability loss or gain. 
With this, the experience of setting up trays next to each other comes with fewer pains, and enables more sophisticated cross-poll. setups as one wishes, preventing undesired mutations or reagent changes. 

## Changelog

:cl:
add: Adds "Conserved Genetics", a plant trait which prevents the plant from having its instability be altered by cross-pollination.
/:cl:


