### PR TITLE
Cursed limb removal fix

### DIFF
--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -73,7 +73,7 @@
 
 		qdel(organ)
 
-/mob/living/carbon/spread_bodyparts(drop_bitflags=NONE)
+/mob/living/carbon/spread_bodyparts(drop_bitflags = NONE, gibbed = FALSE)
 	for(var/obj/item/bodypart/part as anything in get_bodyparts())
 		if(part.body_zone == BODY_ZONE_CHEST)
 			continue // never drop this
@@ -84,12 +84,16 @@
 		for(var/obj/item/organ/leftover in part)
 			leftover_organs += leftover
 
-		part.drop_limb(TRUE)
+		part.drop_limb(special = gibbed, dismembered = !gibbed)
 		part.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
 		// any organs that weren't throw out already about need to follow the bodypart out
 		for(var/obj/item/organ/leftover as anything in leftover_organs)
-			leftover.Remove(src, TRUE)
-			leftover.bodypart_insert(part)
+			// depending on whether gibbed flag was set changes how the organs are removed,
+			// so just let's be... very careful here and double check everything
+			if(leftover.owner == src)
+				leftover.Remove(src, gibbed)
+			if(leftover.loc != part)
+				leftover.bodypart_insert(part)
 
 /mob/living/carbon/set_suicide(suicide_state) //you thought that box trick was pretty clever, didn't you? well now hardmode is on, boyo.
 	. = ..()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -23,7 +23,7 @@
 	spill_organs(drop_bitflags)
 
 	if(drop_bitflags & DROP_BODYPARTS)
-		spread_bodyparts(drop_bitflags)
+		spread_bodyparts(drop_bitflags, gibbed = TRUE)
 
 	// failsafe for if we fuck up and leave our brain behind. (other organs are replaceable so we can ignore them.)
 	var/obj/item/organ/brain/brain = get_organ_slot(ORGAN_SLOT_BRAIN)
@@ -83,7 +83,7 @@
  * drop_bitflags: (see code/__DEFINES/blood.dm)
  * * DROP_BRAIN - Detaches the head from the mob and launches it away from the body
 **/
-/mob/living/proc/spread_bodyparts(drop_bitflags=NONE)
+/mob/living/proc/spread_bodyparts(drop_bitflags = NONE, gibbed = FALSE)
 	return
 
 /// Length of the animation in dust_animation.dmi


### PR DESCRIPTION
## About The Pull Request

Cursed quirk called `spread_bodyparts`, which drops limbs using `special = TRUE` due to it being used in gibbing. 
To fix this I had to add a `gibbed` flag that changes it to drop with `special = FALSE` if not being called via gib.

## Changelog

:cl: Melbert
fix: Losing your limbs via the cursed quirk now gives you limb stumps (so you can get your limbs back afterwards) 
/:cl:
