### PR TITLE
Add valve sound to portable canisters

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -688,6 +688,7 @@
 /// Opens/closes the canister valve
 /obj/machinery/portable_atmospherics/canister/proc/toggle_valve(mob/user, wire_pulsed = FALSE)
 	valve_open = !valve_open
+	playsound(src, 'sound/effects/valve_opening.ogg', 50, TRUE)
 	if(!valve_open)
 		var/logmsg = "valve was <b>closed</b> by [key_name(user)] [wire_pulsed ? "via wire pulse" : ""], stopping the transfer into \the [holding || "air"].<br>"
 		investigate_log(logmsg, INVESTIGATE_ATMOS)


### PR DESCRIPTION

## About The Pull Request
It plays a valve-twisting sound when a portable canister is opened/closed.

## Why It's Good For The Game
Sound improvements.

## Changelog
:cl:
sound: Add valve sound to portable canisters
/:cl:
