### PR TITLE
Makes TESTING mineral depth overlay work on larger rocks

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -429,8 +429,8 @@
 		color = COLOR_BLUE
 	else
 		color = BlendRGB(COLOR_GREEN, COLOR_RED, clamp((open_turf_distance - 1) / 5, 0, 0.99))
-	maptext_x = 4
-	maptext_y = 4
+	maptext_x = -transform.c
+	maptext_y = -transform.f
 	maptext = MAPTEXT_TINY_UNICODE("[open_turf_distance]")
 #endif
 


### PR DESCRIPTION

## About The Pull Request

<img width="345" height="347" alt="dreamseeker_g3fZveerSI" src="https://github.com/user-attachments/assets/bb80332e-8392-4cc4-b754-bf3075da60fb" />

New rocks are noticeably larger and old maptext offsets resulted in depth numbers being partly covered

## Changelog
:cl:
fix: Fixed debug overlays on new biome rocks on lavaland
/:cl:
