### PR TITLE
Ooze mob QoL + mending globule fix

### DIFF
--- a/code/_onclick/hud/ooze.dm
+++ b/code/_onclick/hud/ooze.dm
@@ -1,5 +1,5 @@
 ///Hud type with targeting dol and a nutrition bar
-/datum/hud/ooze/initialize_screen_objects()
+/datum/hud/living/ooze/initialize_screen_objects()
 	. = ..()
 	add_screen_object(/atom/movable/screen/zone_sel, HUD_MOB_ZONE_SELECTOR, HUD_GROUP_STATIC, ui_style)
 	add_screen_object(/atom/movable/screen/ooze_nutrition_display, HUD_OOZE_NUTRITION_DISPLAY)

--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -11,7 +11,7 @@
 	emote_see = list("jiggles", "bounces in place")
 	speak_emote = list("blorbles")
 	atmos_requirements = null
-	hud_type = /datum/hud/ooze
+	hud_type = /datum/hud/living/ooze
 	minbodytemp = 250
 	maxbodytemp = INFINITY
 	faction = list(FACTION_SLIME)
@@ -322,7 +322,7 @@
 ///Ability that allows the owner to fire healing globules at mobs, targeting specific limbs.
 /datum/action/cooldown/globules
 	name = "Fire Mending globule"
-	desc = "Fires a mending globule at someone, healing a specific limb of theirs."
+	desc = "Fires a mending globule at someone, healing a specific limb of theirs. Costs 5 nutrition."
 	background_icon_state = "bg_hive"
 	overlay_icon_state = "bg_hive_border"
 	button_icon = 'icons/mob/actions/actions_slime.dmi'
@@ -332,10 +332,16 @@
 	click_to_activate = TRUE
 
 /datum/action/cooldown/globules/set_click_ability(mob/on_who)
+	var/mob/living/simple_animal/hostile/ooze/oozy_owner = owner
+	if(istype(oozy_owner))
+		if(oozy_owner.ooze_nutrition < 5)
+			to_chat(oozy_owner, span_warning("You need at least 5 nutrition to launch a mending globule."))
+			return
 	. = ..()
 	if(!.)
 		return
 
+	oozy_owner.adjust_ooze_nutrition(-5)
 	to_chat(on_who, span_notice("You prepare to launch a mending globule. <B>Left-click to fire at a target!</B>"))
 
 /datum/action/cooldown/globules/unset_click_ability(mob/on_who, refund_cooldown = TRUE)
@@ -344,20 +350,9 @@
 		return
 
 	if(refund_cooldown)
+		var/mob/living/simple_animal/hostile/ooze/oozy_owner = owner
+		oozy_owner.adjust_ooze_nutrition(5)
 		to_chat(on_who, span_notice("You stop preparing your mending globules."))
-
-/datum/action/cooldown/globules/Activate(atom/target)
-	. = ..()
-	if(!.)
-		return FALSE
-
-	var/mob/living/simple_animal/hostile/ooze/oozy_owner = owner
-	if(istype(oozy_owner))
-		if(oozy_owner.ooze_nutrition < 5)
-			to_chat(oozy_owner, span_warning("You need at least 5 nutrition to launch a mending globule."))
-			return FALSE
-
-	return TRUE
 
 /datum/action/cooldown/globules/InterceptClickOn(mob/living/clicker, params, atom/target)
 	. = ..()
@@ -426,7 +421,7 @@
 ///This action lets you put a mob inside of a cacoon that will inject it with some chemicals.
 /datum/action/cooldown/gel_cocoon
 	name = "Gel Cocoon"
-	desc = "Puts a mob inside of a cocoon, allowing it to slowly heal."
+	desc = "Puts a mob inside of a cocoon, allowing it to slowly heal. Costs 30 nutrition."
 	background_icon_state = "bg_hive"
 	overlay_icon_state = "bg_hive_border"
 	button_icon = 'icons/mob/actions/actions_slime.dmi'


### PR DESCRIPTION

## About The Pull Request

Mending globule can no longer be cast if you don't have enough nutrition to do so.

The ooze hud now inherits the living hud, meaning ooze mobs can see their health and all of the other stuff.
<img width="1186" height="776" alt="image" src="https://github.com/user-attachments/assets/068cc22d-5721-4c90-ac38-bcdda9af9dcc" />
The combination of the nutrition display and the health doll is kinda ugly for now but probably better than nothing.

The descriptions of shoolean grapes abilities now include the cost of the ability in question.

## Why It's Good For The Game

Not being able to see how wounded you are is kinda bad, and being able to see that is kinda good. Knowing how much your abilities cost is good too.

## Changelog
:cl:
qol: Ooze mobs from cytology now have the same type of HUD as other mobs, allowing them to see their health
qol: The abilities of shoolean grapes now have their cost specified in their description
fix: The mending globule ability used by shoolean grapes no longer can be cast while there isn't enough nutrition to do so
/:cl:
