### PR TITLE
De-hardcodes wilderness levels z-traits

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -135,7 +135,7 @@ Always compile, always use that verb, and always make sure that it works for wha
 ///Z level traits for Deep Space
 #define ZTRAITS_SPACE list(ZTRAIT_LINKAGE = CROSSLINKED, ZTRAIT_SPACE_RUINS = TRUE)
 ///Z level traits for
-#define ZTRAITS_WILDS list(\
+#define ZTRAITS_ICY_WILDS list(\
 	ZTRAIT_LINKAGE = GRIDLINKED, \
 	ZTRAIT_ICE_RUINS = TRUE, \
 	ZTRAIT_SNOWSTORM = FALSE, \

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -144,7 +144,7 @@ SUBSYSTEM_DEF(mapping)
 	if(current_map.wilderness_levels)
 		var/list/FailedZs = list()
 
-		LoadGroup(FailedZs, "Wilderness Area", current_map.wilderness_directory, current_map.maps_to_spawn, default_traits = ZTRAITS_WILDS, height_autosetup = FALSE)
+		LoadGroup(FailedZs, "Wilderness Area", current_map.wilderness_directory, current_map.wilderness_maps_to_spawn, default_traits = current_map.wilderness_z_traits, height_autosetup = FALSE)
 
 		if(LAZYLEN(FailedZs))
 			CRASH("Ice wilds failed to load!")

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -34,8 +34,10 @@
 	var/wilderness_levels = 0
 	/// Directory to the wilderness area we can spawn in
 	var/wilderness_directory
+	/// Z-Level traits our wilderness maps will get, ice box traits by default
+	var/list/wilderness_z_traits = ZTRAITS_ICY_WILDS
 	/// Index of map names (inside wilderness_directory) with the amount to spawn. ("ice_planes" = 1) for one ice spawn
-	var/list/maps_to_spawn = list()
+	var/list/wilderness_maps_to_spawn = list()
 
 	///The type of mining Z-level that should be loaded.
 	var/minetype = MINETYPE_LAVALAND
@@ -259,8 +261,12 @@
 
 		// Just pick and take based on weight
 		for(var/i in 1 to wilderness_levels)
-			maps_to_spawn += pick_weight_take(wilderness)
-		shuffle(maps_to_spawn)
+			wilderness_maps_to_spawn += pick_weight_take(wilderness)
+		shuffle(wilderness_maps_to_spawn)
+
+	var/list/wilderness_level_traits = json["wilderness_level_traits"]
+	if (islist(wilderness_level_traits))
+		wilderness_z_traits = wilderness_level_traits
 
 #ifdef UNIT_TESTS
 	// Check for unit tests to skip, no reason to check these if we're not running tests


### PR DESCRIPTION

## About The Pull Request
Tin. If someone decides to add wilderness levels for maps that isnt ice, they will not suffer anymore. Uses default icy wilderness traits (renamed define for clarity), also adjusted another var name, for clarity too.
## Why It's Good For The Game
Allows for a higher degree of customisation for wilderness levels, which is a very good idea, but somehow it was hardcoded to only work with snow maps.
## Changelog
Nothing player facing (i hope)
