### PR TITLE
ADD: Adding a gap between shots for shrink ray pistol

### DIFF
--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -285,8 +285,7 @@
 /obj/item/gun/energy/shrink_ray/can_shoot()
 	if(!COOLDOWN_FINISHED(src, shrink_cooldown))
 		return FALSE
-
-    return ..()
+	return ..()
 
 /obj/item/gun/energy/shrink_ray/shoot_live_shot(mob/living/user, pointblank = FALSE, atom/pbtarget = null, message = TRUE)
 	. = ..()

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -283,8 +283,9 @@
     COOLDOWN_DECLARE(shrink_cooldown)
 
 /obj/item/gun/energy/shrink_ray/can_shoot()
-    if(!COOLDOWN_FINISHED(src, shrink_cooldown))
+	if(!COOLDOWN_FINISHED(src, shrink_cooldown))
     	return FALSE
+
     return ..()
 
 /obj/item/gun/energy/shrink_ray/shoot_live_shot(mob/living/user, pointblank = FALSE, atom/pbtarget = null, message = TRUE)

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -261,8 +261,8 @@
 	inhand_icon_state = "shrink_ray"
 	icon_state = "shrink_ray"
 	automatic_charge_overlays = FALSE
-	fire_delay = 3 SECONDS
 	selfcharge = 1//shot costs 200 energy, has a max capacity of 1000 for 5 shots. self charge returns 25 energy every couple ticks, so about 1 shot charged every 12~ seconds
+	self_charge_amount = 2000
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL// variable-size trigger, get it? (abductors need this to be set so the gun is usable for them)
 
 /obj/item/gun/energy/shrink_ray/suicide_act(mob/living/user)
@@ -278,6 +278,21 @@
 	// Have to wait until the animate is done
 	sleep(30 SECONDS)
 	user.gib(DROP_ALL_REMAINS)
+
+/obj/item/gun/energy/shrink_ray
+    COOLDOWN_DECLARE(shrink_cooldown)
+
+/obj/item/gun/energy/shrink_ray/can_shoot()
+    if(!COOLDOWN_FINISHED(src, shrink_cooldown))
+        return FALSE
+    return ..()
+
+/obj/item/gun/energy/shrink_ray/shoot_live_shot(mob/living/user, pointblank = FALSE, atom/pbtarget = null, message = TRUE)
+    . = ..()
+    if(.)
+        COOLDOWN_START(src, shrink_cooldown, 2 SECONDS)
+        playsound(src, "sound/items/eshield_recharge.ogg", 30, TRUE)
+
 
 /obj/item/paper/guides/antag/abductor
 	name = "Dissection Guide"

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -284,15 +284,14 @@
 
 /obj/item/gun/energy/shrink_ray/can_shoot()
     if(!COOLDOWN_FINISHED(src, shrink_cooldown))
-        return FALSE
+    	return FALSE
     return ..()
 
 /obj/item/gun/energy/shrink_ray/shoot_live_shot(mob/living/user, pointblank = FALSE, atom/pbtarget = null, message = TRUE)
-    . = ..()
-    if(.)
-        COOLDOWN_START(src, shrink_cooldown, 2 SECONDS)
-        playsound(src, "sound/items/eshield_recharge.ogg", 30, TRUE)
-
+	. = ..()
+	if(.)
+		COOLDOWN_START(src, shrink_cooldown, 2 SECONDS)
+		playsound(src, "sound/items/eshield_recharge.ogg", 30, TRUE)
 
 /obj/item/paper/guides/antag/abductor
 	name = "Dissection Guide"

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -280,11 +280,11 @@
 	user.gib(DROP_ALL_REMAINS)
 
 /obj/item/gun/energy/shrink_ray
-    COOLDOWN_DECLARE(shrink_cooldown)
+	COOLDOWN_DECLARE(shrink_cooldown)
 
 /obj/item/gun/energy/shrink_ray/can_shoot()
 	if(!COOLDOWN_FINISHED(src, shrink_cooldown))
-    	return FALSE
+		return FALSE
 
     return ..()
 


### PR DESCRIPTION

## About The Pull Request

Adding a working cooldown between shots to replace the non-functional fire_delay for the abductor's pistol.
Also, following this addition, the charge accumulation rate is now increased.

## Why It's Good For The Game

The original fire_delay variable didn't work because the weapon wasn't ballistic. It now works properly.
This rather powerful weapon won't be overly spammed; it will be more skill-dependent.

## Changelog

:cl:
balance: Added a new variable cooldown for the Thermal Receiver-Abductor pistol - the shot is now played with a 2-second delay, accompanied by a sound signal.
balance: The pistol's charge accumulation rate has been changed from 20% to 30% every 12.5 seconds. 
fix: Fixed a non-functional cooldown variable for the abductor thermal beam pistol and replaced it with a functional one.
/:cl: