### PR TITLE
botanic trays transfer soil properly again

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1118,6 +1118,7 @@
 
 		oursoil.transfer_soil(src, inside_tray = TRUE)
 
+		current_soil = locate(/obj/machinery/hydroponics/soil) in contents
 		RefreshParts()
 		tray_flags = current_soil.tray_flags
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1116,9 +1116,7 @@
 		if(!do_after(user, 2 SECONDS, src))
 			return
 
-		oursoil.transfer_soil(src, inside_tray = TRUE)
-
-		current_soil = locate(/obj/machinery/hydroponics/soil) in contents
+		current_soil = oursoil.transfer_soil(src, inside_tray = TRUE)
 		RefreshParts()
 		tray_flags = current_soil.tray_flags
 

--- a/code/modules/hydroponics/soil.dm
+++ b/code/modules/hydroponics/soil.dm
@@ -184,7 +184,9 @@
 	playsound(target, placement_sound, 65, vary = TRUE)
 	if(!inside_tray)
 		stored_soil.on_place()
+	var/obj/machinery/hydroponics/soil_ref = stored_soil
 	stored_soil.forceMove(target) //stored_soil is set to null at this point, and the soil sack is deleted when that happens
+	return soil_ref
 
 /obj/item/soil_sack/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
 	if(attack_type == OVERWHELMING_ATTACK)


### PR DESCRIPTION
## About The Pull Request

After #96352 got merged, the actual interaction for dumping a bag of soil/vermaculite/etc. into a hydroponics tray broke because the current_soil (and subsequently soil flags) weren't being transferred properly. This fixes that by adjusting transfer_soil() to return the placed/moved soil, allowing us to grab the soil flags and whatnot.

## Why It's Good For The Game

I think dumping soil into the tray should probably work right.

## Changelog

96352 didn't have a changelog so maybe this one shouldn't either.