### PR TITLE
Adds a VV option on movable to assign a TTS voice.

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -109,6 +109,7 @@
 #define VV_HK_DEADCHAT_PLAYS "deadchat_plays"
 #define VV_HK_ADD_REMOVE_FACTION "add_remove_faction"
 #define VV_HK_GET_FACTIONS "add_remove_factions"
+#define VV_HK_ASSIGN_TTS_VOICE "assign_tts_voice"
 
 // /obj
 #define VV_HK_OSAY "osay"

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1738,6 +1738,7 @@
 	VV_DROPDOWN_OPTION(VV_HK_EDIT_PARTICLES, "Edit Particles")
 	VV_DROPDOWN_OPTION(VV_HK_DEADCHAT_PLAYS, "Start/Stop Deadchat Plays")
 	VV_DROPDOWN_OPTION(VV_HK_ADD_FANTASY_AFFIX, "Add Fantasy Affix")
+	VV_DROPDOWN_OPTION(VV_HK_ASSIGN_TTS_VOICE, "Set TTS Voice")
 
 /atom/movable/vv_do_topic(list/href_list)
 	. = ..()
@@ -1793,6 +1794,12 @@
 		to_chat(usr, span_notice("Deadchat now control [src]."))
 		log_admin("[key_name(usr)] has added deadchat control to [src]")
 		message_admins(span_notice("[key_name(usr)] has added deadchat control to [src]"))
+
+	if(href_list[VV_HK_ASSIGN_TTS_VOICE])
+		var/new_voice = tgui_input_list(usr, "Select a new TTS voice for this mob.", "TTS Voice", SStts.available_speakers, "invalid")
+		if(!new_voice)
+			return
+		src.voice = new_voice
 
 /**
 * A wrapper for setDir that should only be able to fail by living mobs.


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. TTS voice is as simple as var-editing the voice string on a movable object, so this just adds a quick and easy way to set a new TTS voice onto something for that purpose.

## Why It's Good For The Game

Additional, easy admin tooling, which is all the more valuable after we just added about 100 new voices to the voice pool.

Also valuable for admins who need to set a mob's voice to something that isn't a godless, horrid, screaming voice if and when the TTS goes off the rails.

## Changelog

:cl:
admin: You can now VV a movable atom to set its TTS voice from any of the standard character creation options.
/:cl:
