### PR TITLE
capitalizes butterbeans when planted

### DIFF
--- a/code/modules/hydroponics/grown/beans.dm
+++ b/code/modules/hydroponics/grown/beans.dm
@@ -69,7 +69,7 @@
 	desc = "These seeds grow into butterbean plants."
 	icon_state = "seed-butterbean"
 	species = "butterbean"
-	plantname = "butterbean Plants"
+	plantname = "Butterbean Plants"
 	product = /obj/item/food/grown/butterbeans
 	potency = 10
 	mutatelist = null


### PR DESCRIPTION
## About The Pull Request

Capitalizes the butterbean plant name when planted so it shows up as `hydroponics tray (Butterbean Plant)`, instead of `hydroponics tray (butterbean Plant)`.

## Why It's Good For The Game

Consistency (this one thing has bugged me for a while and I have only just now decided to fix it).

## Changelog

:cl:
spellcheck: Butterbean plants are now capitalized properly when planted.
/:cl: