### PR TITLE
Changes tendril regeneration outlinefrom bright green to maroon red

### DIFF
--- a/code/modules/mob/living/basic/lavaland/tendril/tendril.dm
+++ b/code/modules/mob/living/basic/lavaland/tendril/tendril.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_INIT(tendrils, list())
 	AddComponent(/datum/component/ai_target_timer)
 	AddComponent(/datum/component/gps, "Eerie Signal")
 	AddComponent(/datum/component/basic_mob_attack_telegraph, display_telegraph_overlay = FALSE, telegraph_duration = 0.4 SECONDS)
-	AddComponent(/datum/component/regenerator, regeneration_delay = 30 SECONDS, brute_per_second = 20)
+	AddComponent(/datum/component/regenerator, regeneration_delay = 30 SECONDS, brute_per_second = 20, outline_color = COLOR_CULT_RED)
 	add_traits(list(TRAIT_BACKSTAB_IMMUNE, TRAIT_IMMOBILIZED), INNATE_TRAIT)
 
 	var/static/list/abilities = list(

--- a/code/modules/mob/living/basic/lavaland/tendril/tendril.dm
+++ b/code/modules/mob/living/basic/lavaland/tendril/tendril.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_INIT(tendrils, list())
 	AddComponent(/datum/component/ai_target_timer)
 	AddComponent(/datum/component/gps, "Eerie Signal")
 	AddComponent(/datum/component/basic_mob_attack_telegraph, display_telegraph_overlay = FALSE, telegraph_duration = 0.4 SECONDS)
-	AddComponent(/datum/component/regenerator, regeneration_delay = 30 SECONDS, brute_per_second = 20, outline_color = COLOR_CULT_RED)
+	AddComponent(/datum/component/regenerator, regeneration_delay = 30 SECONDS, brute_per_second = 20, outline_colour = COLOR_CULT_RED)
 	add_traits(list(TRAIT_BACKSTAB_IMMUNE, TRAIT_IMMOBILIZED), INNATE_TRAIT)
 
 	var/static/list/abilities = list(


### PR DESCRIPTION

## About The Pull Request

Did not realize the default args had a color already set until after the PR was merged, bright green looks really out of place on lavaland so I've swapped it for cult red.

## Changelog
:cl:
image: Changed tendril regeneration outlinefrom bright green to maroon red
/:cl:
