### PR TITLE
Maploading cleans up empty areas

### DIFF
--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -933,6 +933,8 @@ GLOBAL_LIST_EMPTY(map_model_default)
 			old_area.turfs_to_uncontain_by_zlevel[crds.z] += crds
 			area_instance.turfs_by_zlevel[crds.z] += crds
 		area_instance.contents.Add(crds)
+		if(!isnull(old_area) && !old_area.has_contained_turfs())
+			qdel(old_area)
 
 		if(GLOB.use_preloader)
 			world.preloader_load(area_instance)


### PR DESCRIPTION

## About The Pull Request
Adds a check that, when loading a map file, deletes any areas which no longer contain any turfs. A similar check exists in the proc for manually adding/extending areas. This is important because it is assumed that when accessing an initialized unique area eg from areas_by_type, that it will have turfs.  
## Why It's Good For The Game
fixbug
## Changelog
Not player facing
