### PR TITLE
More clothing use the clothing_traits var. Accessories can use it as well now.

### DIFF
--- a/code/modules/cargo/markets/market_items/hostages.dm
+++ b/code/modules/cargo/markets/market_items/hostages.dm
@@ -78,7 +78,7 @@
 		var/obj/item/clothing/under/misc/syndicate_souvenir/souvenir = new(loc)
 		humie.equip_to_slot_if_possible(souvenir, ITEM_SLOT_ICLOTHING, indirect_action = TRUE)
 		var/obj/item/clothing/accessory/anti_sec_pin/pin = new(loc)
-		pin.attach(souvenir)
+		pin.try_attach(souvenir)
 
 	if(isnull(humie.w_uniform))
 		//FUCKING SLAVES, GET YOUR CLOTHES BACK ON!

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -592,16 +592,7 @@
 	color_cutoffs = null
 	vision_flags = SEE_TURFS|SEE_MOBS|SEE_OBJS
 	glass_colour_type = /datum/client_colour/glass_colour/lightblue
-
-/obj/item/clothing/glasses/thermal/xray/equipped(mob/living/carbon/human/user, slot)
-	. = ..()
-	if(!(slot & ITEM_SLOT_EYES) || !istype(user))
-		return
-	ADD_TRAIT(user, TRAIT_XRAY_VISION, GLASSES_TRAIT)
-
-/obj/item/clothing/glasses/thermal/xray/dropped(mob/living/carbon/human/user)
-	. = ..()
-	REMOVE_TRAIT(user, TRAIT_XRAY_VISION, GLASSES_TRAIT)
+	clothing_traits = list(TRAIT_XRAY_VISION)
 
 /obj/item/clothing/glasses/thermal/syndi
 	name = "chameleon thermals"

--- a/code/modules/clothing/head/frenchberet.dm
+++ b/code/modules/clothing/head/frenchberet.dm
@@ -2,18 +2,8 @@
 	name = "french beret"
 	desc = "A quality beret, infused with the aroma of chain-smoking, wine-swilling Parisians. You feel less inclined to engage in military conflict, for some reason."
 	flags_1 = NO_NEW_GAGS_PREVIEW_1
+	clothing_traits = list(TRAIT_GARLIC_BREATH)
 
 /obj/item/clothing/head/beret/frenchberet/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/speechmod, replacements = strings("french_replacement.json", "french"), end_string = list(" Honh honh honh!"," Honh!"," Zut Alors!"), end_string_chance = 3, slots = ITEM_SLOT_HEAD)
-
-/obj/item/clothing/head/beret/frenchberet/equipped(mob/user, slot, initial)
-	. = ..()
-	if (slot & ITEM_SLOT_HEAD)
-		ADD_TRAIT(user, TRAIT_GARLIC_BREATH, type)
-	else
-		REMOVE_TRAIT(user, TRAIT_GARLIC_BREATH, type)
-
-/obj/item/clothing/head/beret/frenchberet/dropped(mob/user, silent)
-	. = ..()
-	REMOVE_TRAIT(user, TRAIT_GARLIC_BREATH, type)

--- a/code/modules/clothing/suits/ablativecoat.dm
+++ b/code/modules/clothing/suits/ablativecoat.dm
@@ -7,6 +7,7 @@
 	flags_inv = HIDEHAIR|HIDEEARS
 	armor_type = /datum/armor/hooded_ablative
 	strip_delay = 3 SECONDS
+	clothing_traits = list(TRAIT_SECURITY_HUD)
 	var/hit_reflect_chance = 50
 
 /datum/armor/hooded_ablative
@@ -50,11 +51,9 @@
 /obj/item/clothing/suit/hooded/ablative/on_hood_up(obj/item/clothing/head/hooded/hood)
 	. = ..()
 	var/mob/living/carbon/user = loc
-	ADD_TRAIT(user, TRAIT_SECURITY_HUD, HELMET_TRAIT)
 	balloon_alert(user, "hud enabled")
 
 /obj/item/clothing/suit/hooded/ablative/on_hood_down(obj/item/clothing/head/hooded/hood)
 	var/mob/living/carbon/user = loc
-	REMOVE_TRAIT(user, TRAIT_SECURITY_HUD, HELMET_TRAIT)
 	balloon_alert(user, "hud disabled")
 	return ..()

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -351,14 +351,11 @@
 		return
 	if(user && !user.temporarilyRemoveItemFromInventory(accessory))
 		return
-	if(!accessory.attach(src, user))
+	if(!accessory.try_attach(src, user))
 		return
 
-	LAZYADD(attached_accessories, accessory)
-	accessory.forceMove(src)
-
 	// Allow for accessories to react to the acccessory list now
-	accessory.successful_attach(src)
+	accessory.attach(src)
 
 	if(user && attach_message)
 		balloon_alert(user, "accessory attached")

--- a/code/modules/clothing/under/accessories/_accessories.dm
+++ b/code/modules/clothing/under/accessories/_accessories.dm
@@ -74,11 +74,11 @@
 	attached_to.update_accessory_overlay()
 
 /**
- * Actually attach this accessory to the passed clothing article.
+ * Try to attach this accessory to the passed clothing article.
  *
  * The accessory is not yet within the clothing's loc at this point, this hapens after success.
  */
-/obj/item/clothing/accessory/proc/attach(obj/item/clothing/under/attach_to, mob/living/attacher)
+/obj/item/clothing/accessory/proc/try_attach(obj/item/clothing/under/attach_to, mob/living/attacher)
 	SHOULD_CALL_PARENT(TRUE)
 
 	if(atom_storage)
@@ -103,9 +103,12 @@
 
 	return TRUE
 
-/// Called after attach is completely successful and the accessory is in the clothing's loc
-/obj/item/clothing/accessory/proc/successful_attach(obj/item/clothing/under/attached_to)
+/// Called after try_attach returns TRUE and thus the accessory can be finally be moved into its target
+/obj/item/clothing/accessory/proc/attach(obj/item/clothing/under/attached_to)
 	SHOULD_CALL_PARENT(TRUE)
+
+	LAZYADD(attached_to.attached_accessories, src)
+	forceMove(attached_to)
 
 	if(!attached_to.accessory_overlay)
 		attached_to.accessory_overlay = mutable_appearance()
@@ -179,12 +182,14 @@
 /// Called when the uniform this accessory is pinned to is equipped in a valid slot
 /obj/item/clothing/accessory/proc/accessory_equipped(obj/item/clothing/under/clothes, mob/living/user)
 	equipped(user, user.get_slot_by_item(clothes)) // so we get any actions, item_flags get set, etc
+	for(var/trait in clothing_traits) // Accessory don't have slot flags by def, but they still apply clothing traits when the suit is equipped in the right slot.
+		ADD_CLOTHING_TRAIT(user, trait)
 	user.update_clothing(ITEM_SLOT_OCLOTHING|ITEM_SLOT_NECK)
 	return
 
 /// Called when the uniform this accessory is pinned to is dropped
 /obj/item/clothing/accessory/proc/accessory_dropped(obj/item/clothing/under/clothes, mob/living/user)
-	dropped(user)
+	dropped(user) //This handles removing clothing traits from the user by default everytime.
 	return
 
 /// Signal proc for [COMSIG_CLOTHING_UNDER_ADJUSTED] on the uniform we're pinned to
@@ -195,8 +200,7 @@
 	if(can_attach_accessory(source))
 		return
 
-	source.remove_accessory(src)
-	forceMove(source.drop_location())
+	forceMove(source.drop_location()) //This calls remove_accessory()
 	source.visible_message(span_warning("[src] falls off of [source]!"))
 
 /// Signal proc for [COMSIG_ATOM_UPDATE_OVERLAYS] on the uniform we're pinned to to add our overlays to the inventory icon

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -131,11 +131,9 @@
 	. += display
 
 // Examining the clothes will display the examine message of the dogtag
-/obj/item/clothing/accessory/dogtag/attach(obj/item/clothing/under/attach_to, mob/living/attacher)
+/obj/item/clothing/accessory/dogtag/attach(obj/item/clothing/under/attached_to)
 	. = ..()
-	if(!.)
-		return
-	RegisterSignal(attach_to, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+	RegisterSignal(attached_to, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 
 /obj/item/clothing/accessory/dogtag/detach(obj/item/clothing/under/detach_from)
 	. = ..()
@@ -238,12 +236,13 @@
 	name = "subversive pin"
 	desc = "A badge which loudly and proudly proclaims your hostility to the Nanotrasen Security Team, and authority in general."
 	icon_state = "anti_sec"
+	clothing_traits = list(TRAIT_ALWAYS_WANTED)
 
 /obj/item/clothing/accessory/anti_sec_pin/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/pinnable_accessory, silent = TRUE, pinning_time = 5 SECONDS)
 
-/obj/item/clothing/accessory/anti_sec_pin/attach(obj/item/clothing/under/attach_to, mob/living/attacher)
+/obj/item/clothing/accessory/anti_sec_pin/try_attach(obj/item/clothing/under/attach_to, mob/living/attacher)
 	. = ..()
 	if (!. || isnull(attacher))
 		return
@@ -254,14 +253,12 @@
 
 /obj/item/clothing/accessory/anti_sec_pin/accessory_equipped(obj/item/clothing/under/clothes, mob/living/user)
 	. = ..()
-	ADD_TRAIT(user, TRAIT_ALWAYS_WANTED, "[CLOTHING_TRAIT]_[REF(src)]")
 	if (ishuman(user))
 		var/mob/living/carbon/human/human_wearer = user
 		human_wearer.sec_hud_set_security_status()
 
 /obj/item/clothing/accessory/anti_sec_pin/accessory_dropped(obj/item/clothing/under/clothes, mob/living/user)
 	. = ..()
-	REMOVE_TRAIT(user, TRAIT_ALWAYS_WANTED, "[CLOTHING_TRAIT]_[REF(src)]")
 	if (ishuman(user))
 		var/mob/living/carbon/human/human_wearer = user
 		human_wearer.sec_hud_set_security_status()

--- a/code/modules/clothing/under/accessories/medals.dm
+++ b/code/modules/clothing/under/accessories/medals.dm
@@ -22,7 +22,7 @@
 	commendation_message = tgui_input_text(user, "Reason for this commendation? It will be recorded by Nanotrasen.", "Commendation", max_length = 140)
 	return !!commendation_message
 
-/obj/item/clothing/accessory/medal/attach(obj/item/clothing/under/attach_to, mob/living/attacher)
+/obj/item/clothing/accessory/medal/try_attach(obj/item/clothing/under/attach_to, mob/living/attacher)
 	var/mob/living/distinguished = attach_to.loc
 	if(isnull(attacher) || !istype(distinguished) || distinguished == attacher || awarded_to)
 		// You can't be awarded by nothing, you can't award yourself, and you can't be awarded someone else's medal


### PR DESCRIPTION
## About The Pull Request
While working on some other PR, something caught my eyes. Some clothing still use the old method of `equipped()` and `dropped()` overrides for adding traits to the wearer when we already have a clothing_traits variable to streamline this behavior. This should make short work of that.

This also improves the accessories code a tiny bit by giving two of the procs apter names and implements the clothing_traits var onto accessories as well.

## Why It's Good For The Game
Better, shorter code.

## Changelog
N/A, if something breaks and goes undetected, then we need more unit tests.