### PR TITLE
Fixes a destroy runtime (harddel source) off bodyparts

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -297,7 +297,8 @@
 
 	owner = null
 
-	QDEL_LIST_ASSOC_VAL(applied_items)
+	if(length(applied_items))
+		QDEL_LIST_ASSOC_VAL(applied_items)
 	QDEL_LAZYLIST(scars)
 
 	for(var/atom/movable/movable in contents)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -297,7 +297,7 @@
 
 	owner = null
 
-	if(length(applied_items))
+	if(LAZYLEN(applied_items))
 		QDEL_LIST_ASSOC_VAL(applied_items)
 	QDEL_LAZYLIST(scars)
 


### PR DESCRIPTION

## About The Pull Request

The macro calls Cut() which fails on null, which this can be cause it's a lazylist.
