### PR TITLE
Fixes gas mask filter runtime

### DIFF
--- a/code/modules/clothing/masks/gas_filter.dm
+++ b/code/modules/clothing/masks/gas_filter.dm
@@ -68,28 +68,31 @@
 	var/danger_points = 0
 
 	for(var/gas_id in breath.gases)
+		var/iterating_gas = breath.gases[gas_id]
+		if(!iterating_gas)
+			continue
 		if(gas_id in high_filtering_gases)
-			if(breath.gases[gas_id][MOLES] > HIGH_FILTERING_MOLES)
-				breath.set_gas(gas_id, max(breath.gases[gas_id][MOLES] - filter_strength_high * filter_efficiency * HIGH_FILTERING_RATIO, 0))
+			if(iterating_gas[MOLES] > HIGH_FILTERING_MOLES)
+				breath.set_gas(gas_id, max(iterating_gas[MOLES] - filter_strength_high * filter_efficiency * HIGH_FILTERING_RATIO, 0))
 				danger_points += 1
 				continue
-			breath.set_gas(gas_id, max(breath.gases[gas_id][MOLES] - filter_strength_high * filter_efficiency * LOW_FILTERING_RATIO, 0))
+			breath.set_gas(gas_id, max(iterating_gas[MOLES] - filter_strength_high * filter_efficiency * LOW_FILTERING_RATIO, 0))
 			danger_points += 0.2
 			continue
 		if(gas_id in mid_filtering_gases)
-			if(breath.gases[gas_id][MOLES] > MID_FILTERING_MOLES)
-				breath.set_gas(gas_id, max(breath.gases[gas_id][MOLES] - filter_strength_mid * filter_efficiency * HIGH_FILTERING_RATIO, 0))
+			if(iterating_gas[MOLES] > MID_FILTERING_MOLES)
+				breath.set_gas(gas_id, max(iterating_gas[MOLES] - filter_strength_mid * filter_efficiency * HIGH_FILTERING_RATIO, 0))
 				danger_points += 1.25
 				continue
-			breath.set_gas(gas_id, max(breath.gases[gas_id][MOLES] - filter_strength_mid * filter_efficiency * LOW_FILTERING_RATIO, 0))
+			breath.set_gas(gas_id, max(iterating_gas[MOLES] - filter_strength_mid * filter_efficiency * LOW_FILTERING_RATIO, 0))
 			danger_points += 0.25
 			continue
 		if(gas_id in low_filtering_gases)
-			if(breath.gases[gas_id][MOLES] > LOW_FILTERING_MOLES)
-				breath.set_gas(gas_id, max(breath.gases[gas_id][MOLES] - filter_strength_low * filter_efficiency * HIGH_FILTERING_RATIO, 0))
+			if(iterating_gas[MOLES] > LOW_FILTERING_MOLES)
+				breath.set_gas(gas_id, max(iterating_gas[MOLES] - filter_strength_low * filter_efficiency * HIGH_FILTERING_RATIO, 0))
 				danger_points += 1.5
 				continue
-			breath.set_gas(gas_id, max(breath.gases[gas_id][MOLES] - filter_strength_low * filter_efficiency * LOW_FILTERING_RATIO, 0))
+			breath.set_gas(gas_id, max(iterating_gas[MOLES] - filter_strength_low * filter_efficiency * LOW_FILTERING_RATIO, 0))
 			danger_points += 0.5
 			continue
 


### PR DESCRIPTION

## About The Pull Request

It's just a check for if the gas is still there, the same bandaid fix for the same issue as #96392. The issue being that gases with 0 moles are entering gas mixtures, somehow, and then being deleted midway through a loop iterating through that mixture.

## Why It's Good For The Game

I can't figure out what's causing the 0 moles, which is the real root issue that needs the real fix, but I do know that this caused more than five hundred runtimes in the (lowpop) round I saw it in, all of which fucked up somebody's breathing, so it's probably worth dealing with prior to the real fix
<img width="573" height="239" alt="image" src="https://github.com/user-attachments/assets/08b91c88-9bf3-416a-879c-5b3eb3e29a8f" />

(the `check_breath()` runtime is caused by the gas mask runtiming and not returning a value)

## Changelog
:cl:

fix: "fixed" a runtime with gas mask filters

/:cl:
