### PR TITLE
Fixes a signal override for Sound Tokens and potentially fixes a harddel when clients logged out while hearing sound tokens

### DIFF
--- a/code/datums/sound_token.dm
+++ b/code/datums/sound_token.dm
@@ -51,6 +51,8 @@
 	update_tracked_cells()
 
 	RegisterSignal(SSdcs, COMSIG_GLOB_PLAYER_LOGIN, PROC_REF(player_login))
+	RegisterSignal(SSdcs, COMSIG_GLOB_PLAYER_LOGOUT, PROC_REF(player_logout))
+
 
 /datum/sound_token/Destroy(force, ...)
 	for(var/listener in listeners)
@@ -198,6 +200,11 @@
 	if(get_dist_euclidean(source_turf, player_turf) > range)
 		return
 	add_or_update_listener(player)
+
+/// Respond to any cliented mob becoming uncliented
+/datum/sound_token/proc/player_logout(datum/source, mob/player)
+	SIGNAL_HANDLER
+	remove_listener(player)
 
 /// If the sound source moves, update tracked cells then refresh all listener positions.
 /datum/sound_token/proc/source_moved()

--- a/code/datums/sound_token.dm
+++ b/code/datums/sound_token.dm
@@ -89,7 +89,8 @@
 
 	listeners[listener_mob] = NONE
 	listener_mob.client.sound_tokens += src
-	RegisterSignal(listener_mob, COMSIG_QDELETING, PROC_REF(listener_deleted))
+	if(source != listener_mob) //this is possible...yea... :/
+		RegisterSignal(listener_mob, COMSIG_QDELETING, PROC_REF(listener_deleted))
 	RegisterSignals(listener_mob, list(SIGNAL_ADDTRAIT(TRAIT_DEAF), SIGNAL_REMOVETRAIT(TRAIT_DEAF)), PROC_REF(listener_deafness_update))
 	update_listener(listener_mob, FALSE)
 	return TRUE

--- a/code/datums/sound_token.dm
+++ b/code/datums/sound_token.dm
@@ -51,7 +51,6 @@
 	update_tracked_cells()
 
 	RegisterSignal(SSdcs, COMSIG_GLOB_PLAYER_LOGIN, PROC_REF(player_login))
-	RegisterSignal(SSdcs, COMSIG_GLOB_PLAYER_LOGOUT, PROC_REF(player_logout))
 
 /datum/sound_token/Destroy(force, ...)
 	for(var/listener in listeners)
@@ -89,7 +88,8 @@
 
 	listeners[listener_mob] = NONE
 	listener_mob.client.sound_tokens += src
-	RegisterSignal(listener_mob, COMSIG_QDELETING, PROC_REF(listener_deleted))
+	if(source != listener_mob) //this is possible...yea... :/
+		RegisterSignal(listener_mob, COMSIG_QDELETING, PROC_REF(listener_deleted))
 	RegisterSignals(listener_mob, list(SIGNAL_ADDTRAIT(TRAIT_DEAF), SIGNAL_REMOVETRAIT(TRAIT_DEAF)), PROC_REF(listener_deafness_update))
 	update_listener(listener_mob, FALSE)
 	return TRUE
@@ -198,11 +198,6 @@
 	if(get_dist_euclidean(source_turf, player_turf) > range)
 		return
 	add_or_update_listener(player)
-
-/// Respond to any cliented mob becoming uncliented
-/datum/sound_token/proc/player_logout(datum/source, mob/player)
-	SIGNAL_HANDLER
-	remove_listener(player)
 
 /// If the sound source moves, update tracked cells then refresh all listener positions.
 /datum/sound_token/proc/source_moved()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -645,9 +645,6 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 	QDEL_NULL(loot_panel)
 	QDEL_NULL(parallax_rock)
 	seen_messages = null
-	for(var/tokiewokie in sound_tokens)
-		var/datum/sound_token/sound_token = tokiewokie
-		sound_token.remove_listener(player)
 	sound_tokens = null
 	Master.UpdateTickRate()
 	..() //Even though we're going to be hard deleted there are still some things that want to know the destroy is happening

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -632,6 +632,8 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 
 	QDEL_LIST_ASSOC_VAL(char_render_holders)
 
+	sound_tokens = null
+
 	SSambience.remove_ambience_client(src)
 	SSmouse_entered.hovers -= src
 	SSping.currentrun -= src

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -643,6 +643,10 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 	QDEL_NULL(loot_panel)
 	QDEL_NULL(parallax_rock)
 	seen_messages = null
+	for(var/tokiewokie in sound_tokens)
+		var/datum/sound_token/sound_token = tokiewokie
+		sound_token.remove_listener(player)
+	sound_tokens = null
 	Master.UpdateTickRate()
 	..() //Even though we're going to be hard deleted there are still some things that want to know the destroy is happening
 	return QDEL_HINT_HARDDEL_NOW


### PR DESCRIPTION
:cl:
fix: Fixes a hard-del and signal override with sound tokens
/:cl:


The comsig issue was basically: both source and listener register for qdel, but they can be the same thing resulting in a double register. lame!

the hard-del was caused by me running remove_listener when a client logged out of a mob...but at that point the client is null...so we cant clear its sound tokens. boo! not smart!