### PR TITLE
Fixes runtime when fishing up a dud

### DIFF
--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -281,9 +281,10 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	if(!success)
 		return
 	var/atom/movable/reward = dispense_reward(challenge.reward_path, user, challenge.location, challenge.used_rod)
-	if(reward)
-		user.add_mob_memory(/datum/memory/caught_fish, protagonist = user, deuteragonist = reward.name)
 	SEND_SIGNAL(challenge.used_rod, COMSIG_FISHING_ROD_CAUGHT_FISH, reward, user)
+	if(!reward)
+		return
+	user.add_mob_memory(/datum/memory/caught_fish, protagonist = user, deuteragonist = reward.name)
 	challenge.used_rod.on_reward_caught(reward, user)
 	REMOVE_TRAIT(reward, TRAIT_FISH_JUST_SPAWNED, TRAIT_GENERIC)
 

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -282,10 +282,10 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 		return
 	var/atom/movable/reward = dispense_reward(challenge.reward_path, user, challenge.location, challenge.used_rod)
 	SEND_SIGNAL(challenge.used_rod, COMSIG_FISHING_ROD_CAUGHT_FISH, reward, user)
+	challenge.used_rod.on_reward_caught(reward, user)
 	if(!reward)
 		return
 	user.add_mob_memory(/datum/memory/caught_fish, protagonist = user, deuteragonist = reward.name)
-	challenge.used_rod.on_reward_caught(reward, user)
 	REMOVE_TRAIT(reward, TRAIT_FISH_JUST_SPAWNED, TRAIT_GENERIC)
 
 /// Gives out the reward if possible


### PR DESCRIPTION

## About The Pull Request

Early return if no fish. The signalling stays despite no reward because the heretic enchanted rod doesn't care if there wasn't a reward

## Why It's Good For The Game

<img width="591" height="89" alt="image" src="https://github.com/user-attachments/assets/c9258e5f-f1e3-43d3-b346-12011cd1560d" />

## Changelog
:cl:
fix: fixed a runtime when fishing up no fish
/:cl:
