### PR TITLE
Fixes audio not working if you are inside of something

### DIFF
--- a/code/game/sound/sound.dm
+++ b/code/game/sound/sound.dm
@@ -69,7 +69,10 @@
 			listeners += listening_ghost
 
 	for(var/mob/listening_mob in listeners)//had nulls sneak in here, hence the typecheck
-		if(get_dist_euclidean(listening_mob, turf_source) <= maxdistance)
+		var/turf/mob_turf = get_turf(listening_mob)
+		if(!mob_turf)
+			continue
+		if(get_dist_euclidean(mob_turf, turf_source) <= maxdistance)
 			listening_mob.playsound_local(turf_source, soundin, vol, vary, frequency, falloff_exponent, channel, pressure_affected, S, maxdistance, falloff_distance, 1, use_reverb, volume_preference)
 
 	return listeners


### PR DESCRIPTION
get_dist_euclidean needs to have the turf to compare the distance. (this is not required for get_dist since byond handles that automatically)

:cl: CabinetOnFire
fix: You can now hear the outside world when you're inside of something again (e.g. lockers, mechs
/:cl:

sorry!

closes #96454