### PR TITLE
Fixes bug where sig_remove_from_blackboard would try to numerically index a regular list

### DIFF
--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -935,7 +935,6 @@ multiple modular subtrees with behaviors
 	while(index <= length(remove_queue))
 		var/list/next_to_clear = remove_queue[index]
 		for(var/inner_value in next_to_clear)
-			var/associated_value = next_to_clear[inner_value]
 			// We are a lists of lists, add the next value to the queue so we can handle references in there
 			// (But we only need to bother checking the list if it's not empty.)
 			if(islist(inner_value) && length(inner_value))
@@ -945,6 +944,11 @@ multiple modular subtrees with behaviors
 			else if(inner_value == source)
 				next_to_clear -= inner_value
 
+			//if this is the case stop here. This means the list isn't associative (because an assoc list couldnt have a key for a number!)
+			if(isnum(inner_value))
+				continue
+
+			var/associated_value = next_to_clear[inner_value]
 			// We are an assoc lists of lists, the list at the next value so we can handle references in there
 			// (But again, we only need to bother checking the list if it's not empty.)
 			if(islist(associated_value) && length(associated_value))

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -949,6 +949,8 @@ multiple modular subtrees with behaviors
 				continue
 
 			var/associated_value = next_to_clear[inner_value]
+			if(!associated_value) //This wasn't an associated list! we lied! its all been a trick. Try again next time.
+				continue
 			// We are an assoc lists of lists, the list at the next value so we can handle references in there
 			// (But again, we only need to bother checking the list if it's not empty.)
 			if(islist(associated_value) && length(associated_value))


### PR DESCRIPTION
:cl: CabinetOnFire
fix: Fixes bug where sig_remove_from_blackboard would try to numerically index a regular list
/:cl:

fixes a runtime thats been spamming every round recently.

The cause of the bug seems to stem from that in sig_remove_from_blackboard we try to recursively get all the contents of the blackboard to check if the datum that was deleted is in there.

The issue is, we assume any nested list is associative. and try to get its associated value. In most cases this is fine (If you index a normal list with a non-number it just silently returns null)

however, if its a list of numbers, you end up trying to index the list with random numbers, which in most cases results in a big fat runtime.