### PR TITLE
Patches an exploit allowing ghosts to interact with the world by sticking it behind the GHOST_INTERACTION config.

### DIFF
--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -34,7 +34,10 @@
 		return
 	flick("ecto_sniffer_flick", src)
 	playsound(loc, 'sound/machines/ectoscope_beep.ogg', 75)
-	say("Reporting [pick(world.file2list("strings/spook_levels.txt"))] levels of paranormal activity!")
+	if(CONFIG_GET(flag/ghost_interaction))
+		say("Reporting [pick(world.file2list("strings/spook_levels.txt"))] levels of paranormal activity!")
+	else
+		ballon_alert_to_viewers("[pick(world.file2list("strings/spook_levels.txt"))] level of paranormal activity")
 	if(activator?.ckey)
 		ectoplasmic_residues += activator.ckey
 		addtimer(CALLBACK(src, PROC_REF(clear_residue), activator.ckey), 15 SECONDS)

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -37,7 +37,7 @@
 	if(CONFIG_GET(flag/ghost_interaction))
 		say("Reporting [pick(world.file2list("strings/spook_levels.txt"))] levels of paranormal activity!")
 	else
-		ballon_alert_to_viewers("[pick(world.file2list("strings/spook_levels.txt"))] level of paranormal activity")
+		balloon_alert_to_viewers("[pick(world.file2list("strings/spook_levels.txt"))] level of paranormal activity")
 	if(activator?.ckey)
 		ectoplasmic_residues += activator.ckey
 		addtimer(CALLBACK(src, PROC_REF(clear_residue), activator.ckey), 15 SECONDS)


### PR DESCRIPTION
## About The Pull Request

Patches an exploit allowing ghosts to interact with the world by sticking it behind the GHOST_INTERACTION config. It now makes a balloon alert to viewers instead of speaking if the config is disabled.

## Why It's Good For The Game

Dead players being able to detonate bombs posthumously by sticking circuit microphone signallers next to the ectosniffer is bad, actually.

## Changelog
:cl:
fix: Patches an exploit allowing ghosts to interact with the world by sticking it behind the GHOST_INTERACTION config.
/:cl:
