### PR TITLE
Revert "Borg Fix & OmniTool Welder Qol"

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -73,7 +73,7 @@
 			return
 
 		if(W == A)
-			W.attack_self(src, modifiers)
+			W.attack_self(src)
 			return
 
 		// cyborgs are prohibited from using storage items so we can I think safely remove (A.loc in contents)

--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -252,7 +252,7 @@
 
 	return tool
 
-/obj/item/borg/cyborg_omnitool/attack_self(mob/user, modifiers)
+/obj/item/borg/cyborg_omnitool/attack_self(mob/user)
 	//build the radial menu options
 	var/list/radial_menu_options = list()
 	var/list/tool_map = list()
@@ -277,8 +277,9 @@
 		return ..()
 	var/mob/living/silicon/robot/user = usr
 	if (!(src in user.held_items))
-		attack_self(user, modifiers)
-	return ..()
+		attack_self(user)
+	. = ..()
+	user.select_module(user.held_items.Find(src))
 
 /obj/item/borg/cyborg_omnitool/update_icon_state()
 	if (reference)
@@ -333,6 +334,19 @@
 	. = ..()
 	RegisterSignal(src, COMSIG_SILICON_MODULE_ACTIVATION, PROC_REF(welder_toggle))
 
+/obj/item/borg/cyborg_omnitool/engineering/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if (!issilicon(user) || tool_behaviour != TOOL_WELDER)
+		return
+
+	context[SCREENTIP_CONTEXT_CTRL_LMB] = "Toggle welder"
+	return CONTEXTUAL_SCREENTIP_SET
+
+/obj/item/borg/cyborg_omnitool/engineering/examine(mob/user)
+	. = ..()
+	if(tool_behaviour == TOOL_WELDER)
+		. += span_notice("Use [EXAMINE_HINT("Ctrl Click")] to toggle welder")
+
 /obj/item/borg/cyborg_omnitool/engineering/update_overlays()
 	. = ..()
 	if(tool_behaviour == TOOL_WELDER)
@@ -340,19 +354,24 @@
 		if(tool?.welding)
 			. |= tool.update_overlays()
 
-/obj/item/borg/cyborg_omnitool/engineering/attack_self(mob/user, modifiers)
-	if(tool_behaviour == TOOL_WELDER && LAZYACCESS(modifiers, LEFT_CLICK))
-		welder_toggle(src, null, user)
-
-		return NONE
-
-	return ..()
-
 /obj/item/borg/cyborg_omnitool/engineering/set_internal_tool(obj/item/tool)
 	if(tool_behaviour == TOOL_WELDER)
 		welder_toggle(src, FALSE)
 
-	return ..()
+	. = ..()
+
+	if(tool_behaviour == TOOL_WELDER)
+		welder_toggle(src, TRUE)
+
+/obj/item/borg/cyborg_omnitool/engineering/item_ctrl_click(mob/user)
+	. = NONE
+	if(tool_behaviour == TOOL_WELDER)
+		var/mob/living/silicon/robot/borgy = loc
+		if(!istype(borgy) || borgy.module_active != src)
+			return
+
+		welder_toggle(src, null)
+		return CLICK_ACTION_SUCCESS
 
 ///Reflects internal welder icon onto the omnitool
 /obj/item/borg/cyborg_omnitool/engineering/proc/welder_update(source)
@@ -362,7 +381,7 @@
 	update_appearance(UPDATE_OVERLAYS)
 
 ///Toggles welder on/off when module slot is selected/deselected
-/obj/item/borg/cyborg_omnitool/engineering/proc/welder_toggle(datum/omnitool, state, mob/self_user)
+/obj/item/borg/cyborg_omnitool/engineering/proc/welder_toggle(datum/omnitool, state)
 	PRIVATE_PROC(TRUE)
 	SIGNAL_HANDLER
 
@@ -374,9 +393,8 @@
 			return
 
 		if(state)
-			RegisterSignal(tool, COMSIG_ATOM_UPDATE_APPEARANCE, PROC_REF(welder_update), override = TRUE)
-			if(self_user)
-				tool.switched_on(self_user)
+			RegisterSignal(tool, COMSIG_ATOM_UPDATE_APPEARANCE, PROC_REF(welder_update))
+			tool.switched_on(usr)
 		else
 			tool.switched_off()
 			UnregisterSignal(tool, COMSIG_ATOM_UPDATE_APPEARANCE)


### PR DESCRIPTION
Reverts tgstation/tgstation#96216

## About The Pull Request

We're 3 weeks into this ordeal with no end in sight, welding tools were kept seperate from the omnitool for the very obvious reason of both requiring the use key. By trying to force them together for the sake of confomority we've only recieved issues with usability and confused players wondering if things are bugged due to how unintuitive this system is, or suffering in game due to how unmanageable it is. 

Most cyborg players I know hate omnitools and i'm not a fan of them either to be honest, however this isn't that battle. You can still use those tools in a reasonable way, the welding tool is a different story and has just left silicon players baffled and annoyed.

## Why It's Good For The Game

Being able to use your modules is a good thing. 

This has been such a frustrating experience.