### PR TITLE
Removes Kapu, Zephyr, and Pickle from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,10 @@
 /tools/Tgstation.DiscordDiscussions/ @Cyberboss
 /tools/Tgstation.PRAnnouncer/ @Cyberboss
 
+# Tattle
+
+/code/__HELPERS/logging/ @dragomagol
+
 # Cobby
 
 /code/modules/reagents/ @ExcessiveUseOfCobblestone
@@ -70,7 +74,9 @@
 /code/modules/autowiki/ @Mothblocks
 /code/modules/unit_tests/ @Mothblocks
 /code/modules/client/preferences/ @Mothblocks
+/code/modules/client/preferences.dm @Mothblocks
 /code/modules/client/preferences_menu.dm @Mothblocks
+/code/modules/client/preferences_savefile.dm @Mothblocks
 /tgui/packages/tgui/interfaces/PreferencesMenu/ @Mothblocks
 /tools/ezdb/ @Mothblocks
 /tools/maplint/source/ @Mothblocks
@@ -153,17 +159,6 @@
 /code/modules/antagonists/traitor/ @Watermelon914
 /code/controllers/subsystem/tts.dm @Watermelon914
 
-# ZephyrTFA
-
-/code/__HELPERS/admin_verb.dm @ZephyrTFA
-/code/controllers/subsystem/admin_verbs.dm @ZephyrTFA
-/code/datums/json_savefile.dm @ZephyrTFA
-/code/datums/armor/ @ZephyrTFA
-/code/modules/admin/verbs/ @ZephyrTFA
-/code/modules/logging/ @ZephyrTFA
-/tools/ci/check_grep.sh @ZephyrTFA
-
-
 # CONTRIBUTORS
 
 # grungussuss
@@ -175,13 +170,6 @@
 /code/controllers/subsystem/dbcore.dm @Jordie0608
 /tools/SQLAlertEmail/ @Jordie0608
 
-# Kapu1178
-
-/code/modules/surgery/bodyparts/ @Kapu1178
-/code/modules/surgery/organs/ @Kapu1178
-/code/modules/mob/living/carbon/carbon_update_icons.dm @Kapu1178
-/code/modules/mob/living/carbon/human/human_update_icons.dm @Kapu1178
-
 # loganuk
 
 /_maps/map_files/CatwalkStation/ @loganuk
@@ -190,13 +178,6 @@
 
 /code/modules/capture_the_flag/ @NamelessFairy
 /_maps/minigame/CTF/ @NamelessFairy
-
-# Pickle-Coding
-
-/code/__DEFINES/atmospherics/ @Pickle-Coding
-/code/__DEFINES/reactions.dm @Pickle-Coding
-/code/modules/atmospherics/ @Pickle-Coding
-/code/modules/power/ @Pickle-Coding
 
 # FalloutFalcon
 /code/__HELPERS/abstract_types.dm @FalloutFalcon
@@ -211,13 +192,7 @@
 /icons/ @Imaginos16 @Krysonism @Twaticus @Wallemations
 
 /code/__DEFINES/atmospherics/ @Ghilker @LemonInTheDark
-
-/code/__HELPERS/logging/ @dragomagol @ZephyrTFA
-
 /code/modules/atmospherics/ @Ghilker @LemonInTheDark
-
-/code/modules/client/preferences.dm @Mothblocks @ZephyrTFA
-/code/modules/client/preferences_savefile.dm @Mothblocks @ZephyrTFA
 
 /code/modules/jobs/job_types/chief_medical_officer.dm @ExcessiveUseOfCobblestone @Ryll-Ryll
 /code/modules/jobs/job_types/medical_doctor.dm @ExcessiveUseOfCobblestone @Ryll-Ryll


### PR DESCRIPTION

## About The Pull Request

@ZephyrTFA retired, @Kapu1178 (I assume) does not want to be in the codeowners org team, and @Pickle-Coding isn't active anymore so I can't really ask

I'm only doing this for cleanup purposes, if these people want to be readded then that would be just fine. they just need read access to make the codeowner bit actually work
