### PR TITLE
Semi Port - Add Wine/Linux users CID to an ignore list

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -809,3 +809,6 @@
 
 /datum/config_entry/string/policy_json_path
 	default = "policy.json"
+
+/datum/config_entry/str_list/ignored_cids
+	protection = CONFIG_ENTRY_LOCKED

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -810,5 +810,5 @@
 /datum/config_entry/string/policy_json_path
 	default = "policy.json"
 
-/datum/config_entry/str_list/ignored_cids
-	protection = CONFIG_ENTRY_LOCKED
+/datum/config_entry/number_list/ignored_cids
+	default = list()

--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -4,13 +4,14 @@ SUBSYSTEM_DEF(stickyban)
 
 	var/list/cache = list()
 	var/list/dbcache = list()
-	var/list/confirmed_exempt = list()
+	var/list/ignored_cids = list()
 	var/dbcacheexpire = 0
 
 
 /datum/controller/subsystem/stickyban/Initialize()
 	if (length(GLOB.stickybanadminexemptions))
 		restore_stickybans()
+
 	var/list/bannedkeys = sticky_banned_ckeys()
 	//sanitize the sticky ban list
 
@@ -217,5 +218,19 @@ SUBSYSTEM_DEF(stickyban)
 	if (length(sqlips))
 		SSdbcore.MassInsert(format_table_name("stickyban_matched_ip"), sqlips, ignore_errors = TRUE)
 
+
+	return TRUE
+
+
+/datum/controller/subsystem/stickyban/proc/add_matched_cid(existing_ban_id, cid)
+	// Skip configured ignored CIDs
+	if ((("" + cid) in ignored_cids))
+		return TRUE
+
+	// Insert and let DB or periodic cache refresh handle duplicates
+	var/list/sqlcid = list()
+	sqlcid["stickyban"] = existing_ban_id
+	sqlcid["matched_cid"] = cid
+	SSdbcore.MassInsert(format_table_name("stickyban_matched_cid"), list(sqlcid), ignore_errors = TRUE)
 
 	return TRUE

--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -4,11 +4,18 @@ SUBSYSTEM_DEF(stickyban)
 
 	var/list/cache = list()
 	var/list/dbcache = list()
-	var/list/ignored_cids = list()
+	var/list/ignored_cids = list() // will be used as numeric-keyed map
 	var/dbcacheexpire = 0
 
 
 /datum/controller/subsystem/stickyban/Initialize()
+	// load IGNORED_CIDS as number_list into a fast lookup map
+	var/list/ignored_conf = CONFIG_GET(number_list/ignored_cids)
+	if (ignored_conf && ignored_conf.len)
+		for (var/num in ignored_conf)
+			if (isnum(num))
+				ignored_cids[num2text(num)] = TRUE
+
 	if (length(GLOB.stickybanadminexemptions))
 		restore_stickybans()
 
@@ -218,19 +225,5 @@ SUBSYSTEM_DEF(stickyban)
 	if (length(sqlips))
 		SSdbcore.MassInsert(format_table_name("stickyban_matched_ip"), sqlips, ignore_errors = TRUE)
 
-
-	return TRUE
-
-
-/datum/controller/subsystem/stickyban/proc/add_matched_cid(existing_ban_id, cid)
-	// Skip configured ignored CIDs
-	if ((("" + cid) in ignored_cids))
-		return TRUE
-
-	// Insert and let DB or periodic cache refresh handle duplicates
-	var/list/sqlcid = list()
-	sqlcid["stickyban"] = existing_ban_id
-	sqlcid["matched_cid"] = cid
-	SSdbcore.MassInsert(format_table_name("stickyban_matched_cid"), list(sqlcid), ignore_errors = TRUE)
 
 	return TRUE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -435,6 +435,12 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 	tgui_say.initialize()
 
 	if(alert_mob_dupe_login && !holder)
+		// Notify admins if the connecting player's CID is configured to be ignored by stickybans
+		if (SSstickyban && (("" + computer_id) in SSstickyban.ignored_cids))
+			message_admins("<B>MULTIKEYING: </B></span><span class='notice'>[key_name_admin(src)] Connecting player joined with IGNORED CID [computer_id].")
+			log_admin_private("MULTIKEYING: [key_name(src)] Connecting player joined with IGNORED CID [computer_id].")
+
+		// Notify admins if the connecting player's CID is a duplicate of another player's CID
 		var/dupe_login_message = "Your ComputerID has already logged in with another key this round, please log out of this one NOW or risk being banned!"
 		if (alert_admin_multikey)
 			dupe_login_message += "\nAdmins have been informed."

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -436,12 +436,14 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 
 	if(alert_mob_dupe_login && !holder)
 		// Notify admins if the connecting player's CID is configured to be ignored by stickybans
-		if (SSstickyban && (("" + computer_id) in SSstickyban.ignored_cids))
+		if (SSstickyban && (computer_id in SSstickyban.ignored_cids))
 			message_admins("<B>MULTIKEYING: </B></span><span class='notice'>[key_name_admin(src)] Connecting player joined with IGNORED CID [computer_id].")
 			log_admin_private("MULTIKEYING: [key_name(src)] Connecting player joined with IGNORED CID [computer_id].")
+			return
 
-		// Notify admins if the connecting player's CID is a duplicate of another player's CID
+		// If the CID is not ignored, notify the player with the pop-up.
 		var/dupe_login_message = "Your ComputerID has already logged in with another key this round, please log out of this one NOW or risk being banned!"
+		// Notify admins if the connecting player's CID is a duplicate of another player's CID
 		if (alert_admin_multikey)
 			dupe_login_message += "\nAdmins have been informed."
 			message_admins(span_danger("<B>MULTIKEYING: </B></span><span class='notice'>[key_name_admin(src)] has a matching CID+IP with another player and is clearly multikeying. They have been warned to leave the server or risk getting banned."))

--- a/config/config.txt
+++ b/config/config.txt
@@ -652,3 +652,8 @@ GENERATE_ASSETS_IN_INIT
 ## Path from the config folder to the policy json
 POLICY_JSON_PATH policy.json
 
+# Which CIDs will not be considered for stickybans. This is the default CID that Wine spits out,
+# and for the purpose of not default banning all Linux players, we'll just ignore it.
+# People can spoof this CID and ignore that element of stickybans forever, but they can equally
+# just keep generating new ones. Kind of doesn't matter.
+IGNORED_CIDS 4055623708


### PR DESCRIPTION

## About The Pull Request

This PR attempts to somewhat port https://github.com/cmss13-devs/cmss13/pull/11252
In order to add Wine/Linux CID into an ignore list to stop the
`Your ComputerID has already logged in with another key this round, please log out of this one NOW or risk being banned!`
Jumpscare message from appearing and log users which connect with ignored CID's to admins properly.

### Testing the Pull Reuqest
I've attempted to test the PR locally, but I have been unable to replicate the duplicated CID message, so this might need to be **test merged** if approved.

In addition, please review the code, my experience with Byond is very limited so feel free to edit, commit, or requested changes per need.

## Why It's Good For The Game
If two players with the same CID (such as the case with players who play using Wine), the joining players will get a pop-up saying they are using the same CID and get a **scary** message that they risk getting banned for multiboxing if they don't log off.

Experienced game staff, most of the time already know to ignore the CID `4055623708` which is often thrown by Wine.

However, players could abuse this fact to still and try to multibox for whatever reason, and even if a legit Linux player uses this CID, giving the admins a separate log for it is useful, to be distinct from normal multibox messages.
`MULTIKEYING: [key_name(src)] Connecting player joined with IGNORED CID [computer_id].`

## Changelog
:cl: Richard Blonski
admin: Added Ignored CIDs, a message will appear when a player joins with an Ignored CID.
/:cl:
