### PR TITLE
Changeling biodegrade is now 30->15 chemicals, biodegrade is now innate, void adaption is now innate

### DIFF
--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -1,10 +1,10 @@
 /datum/action/changeling/biodegrade
 	name = "Biodegrade"
-	desc = "Dissolves restraints or other objects preventing free movement. Costs 30 chemicals."
+	desc = "Dissolves restraints or other objects preventing free movement. Costs 15 chemicals."
 	helptext = "This is obvious to nearby people, and can destroy standard restraints and closets. Works against grabs."
 	button_icon_state = "biodegrade"
 	category = "utility"
-	chemical_cost = 20
+	chemical_cost = 15
 	dna_cost = CHANGELING_POWER_INNATE
 	req_human = TRUE
 	disabled_by_fire = FALSE

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -4,8 +4,8 @@
 	helptext = "This is obvious to nearby people, and can destroy standard restraints and closets. Works against grabs."
 	button_icon_state = "biodegrade"
 	category = "utility"
-	chemical_cost = 30
-	dna_cost = 2
+	chemical_cost = 20
+	dna_cost = CHANGELING_POWER_INNATE
 	req_human = TRUE
 	disabled_by_fire = FALSE
 	var/static/bio_acid_path = /datum/reagent/toxin/acid/bio_acid

--- a/code/modules/antagonists/changeling/powers/void_adaption.dm
+++ b/code/modules/antagonists/changeling/powers/void_adaption.dm
@@ -7,7 +7,7 @@
 	category = "utility"
 	button_icon_state = "void_adaption"
 	owner_has_control = FALSE
-	dna_cost = 2
+	dna_cost = CHANGELING_POWER_INNATE
 
 	/// Traits we apply to become immune to the environment
 	var/static/list/gain_traits = list(TRAIT_NO_BREATHLESS_DAMAGE, TRAIT_RESISTCOLD, TRAIT_RESISTLOWPRESSURE, TRAIT_SNOWSTORM_IMMUNE)


### PR DESCRIPTION

## About The Pull Request
This change makes biodegrade innate, and halves its cost. It is a build upon #89620, which reverted my previous change that was meant to enforce changelings being uncontainable in gameplay, as they are already treated that way in Security policy.

The idea came to me as I was fireman carried across the entire station to the permabrig incinerator. As I stood there while the Security officer got their bearings, I said aloud "Man, I feel pretty contained right now.", because I had not spent 2 DNA points (of my 7 available DNA points) on biodegrade. I was swiftly rendered into a pile of ash.

A nearby cyborg commented "I think that was unneccessary. They seemed contained.", to which the valiant Security Officer "No such thing as contained changeling [sic]".

This moment of gameplay inspired me to look up the discourse in the revert PR. It appears there has not been any movement on that front since the revert PR. I feel that this change implements the spirit of my reverted changes; changelings are now uncontainable. As well, I hope it satisfies @necromanceranne in that it does not make it significantly harder for lings to kill one another; in my genius, I had already made biodegrade not allow you to escape grabs from other changelings.

```
/datum/action/changeling/biodegrade/proc/punish_with_acid(mob/living/carbon/human/user, mob/living/hapless_manhandler)
	acid_blast(user, hapless_manhandler)
	playsound(user, 'sound/mobs/non-humanoids/bileworm/bileworm_spit.ogg', 50, TRUE)
	if(IS_CHANGELING(hapless_manhandler))
		user.visible_message(
			span_danger("[user] spews a mist of sizzling acid onto [hapless_manhandler]... but nothing happens!"),
			span_changeling("We prepare our escape, spraying bio-acid on our captor... [span_danger("But nothing happened?!")]"),
			span_danger("You hear retching, then a sizzling that terminates quite abruptly.")
			)
		to_chat(hapless_manhandler, span_changeling("Our prey attempts to dissuade us with one of our biology's simplest adaptions. Quaint."))
		return
```

This does require changeling players to be more mindful of not giving away the game by not pretending to need internals and EVA suits. Void adaption is included so they have a reason to incinerate you, since you breaking out of perma would be otherwise inevitable.

## Why It's Good For The Game
Goonstation is our dad, and their changelings get biodegrade + void adaption for free by automatically dissolving cuffs whenever they resist while cuffed. Since we want to appear like we're not stealing their ideas, I figured just giving changelings biodegrade for free (and halving its cost, since 30 chemicals is almost literally half of your chemical store) will allow Security players to assuage any guilt when they speed incinerate the next gormless ling player, as they are now literally uncontainable (as void adaption is included in this PR).

In summary, sans-sarcasm: Lings now are, actually, uncontainable, aligning their coded abilities with game policy, without interdicting ling-vs-ling conflict.

## Changelog
:cl: Metek
balance: Changelings now receive biodegrade innately.
balance: Changelings now receive void adaption innately.
balance: Biodegrade has had its chemical cost reduced from 30 to 15.
/:cl:
