### PR TITLE
Allows materials to be ejected directly from the autolathe

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -210,11 +210,10 @@
 /obj/machinery/autolathe/ui_data(mob/user)
 	var/list/data = list()
 
-	data["materials"] = list()
+	data["materials"] = materials.ui_data()
 	data["materialtotal"] = materials.total_amount()
 	data["materialsmax"] = materials.max_amount
 	data["active"] = busy
-	data["materials"] = materials.ui_data()
 
 	return data
 
@@ -222,6 +221,27 @@
 	. = ..()
 	if(.)
 		return
+
+	if (action == "eject")
+		var/datum/material/material = locate(params["ref"])
+		if(!istype(material))
+			return
+
+		var/amount = params["amount"]
+		if(isnull(amount))
+			return
+
+		amount = text2num(amount)
+		if(isnull(amount))
+			return
+
+		//we use initial(active_power_usage) because higher tier parts will have higher active usage but we have no benefit from it
+		if(!directly_use_energy(ROUND_UP((amount / MAX_STACK_SIZE) * 0.4 * initial(active_power_usage))))
+			say("No power to dispense sheets")
+			return
+
+		materials.retrieve_stack(amount, material)
+		return TRUE
 
 	//sanity checks to start printing
 	if(action != "make")

--- a/code/modules/research/designs/autolathe/materials.dm
+++ b/code/modules/research/designs/autolathe/materials.dm
@@ -1,31 +1,9 @@
-/datum/design/iron
-	name = "Iron"
-	id = "iron"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/iron
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
-	)
-
 /datum/design/rods
 	name = "Iron Rod"
 	id = "rods"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron =HALF_SHEET_MATERIAL_AMOUNT)
+	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/stack/rods
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
-	)
-
-/datum/design/glass
-	name = "Glass"
-	id = "glass"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/glass = SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/glass
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
@@ -35,131 +13,10 @@
 	name = "Reinforced Glass"
 	id = "rglass"
 	build_type = AUTOLATHE | SMELTER | PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT)
+	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/stack/sheet/rglass
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
-
-/datum/design/silver
-	name = "Silver"
-	id = "silver"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/silver = SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/mineral/silver
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
-	)
-
-/datum/design/gold
-	name = "Gold"
-	id = "gold"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/gold = SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/mineral/gold
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
-	)
-
-/datum/design/diamond
-	name = "Diamond"
-	id = "diamond"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/mineral/diamond
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
-	)
-
-/datum/design/plasma
-	name = "Plasma"
-	id = "plasma"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/plasma = SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/mineral/plasma
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
-	)
-
-/datum/design/uranium
-	name = "Uranium"
-	id = "uranium"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/uranium = SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/mineral/uranium
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
-	)
-
-/datum/design/bananium
-	name = "Bananium"
-	id = "bananium"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/bananium = SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/mineral/bananium
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
-	)
-
-/datum/design/titanium
-	name = "Titanium"
-	id = "titanium"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/titanium = SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/mineral/titanium
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
-	)
-
-/datum/design/plastic
-	name = "Plastic"
-	id = "plastic"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/plastic
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
-	)
-
-/datum/design/bs_crystal
-	name = "Bluespace Crystal"
-	id = "bscrystal"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/bluespace = SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/bluespace_crystal
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
-	)
-
-/datum/design/mythril
-	name = "Mythril"
-	id = "mythril"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/mythril = SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/mineral/mythril
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
-	)
-
-/datum/design/alien_alloy
-	name = "Alien Alloy"
-	id = "allienalloy"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/alloy/alien = SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/mineral/abductor
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS,
-	)

--- a/tgui/packages/tgui/interfaces/Autolathe.tsx
+++ b/tgui/packages/tgui/interfaces/Autolathe.tsx
@@ -16,8 +16,7 @@ import { useBackend } from '../backend';
 import { Window } from '../layouts';
 import { DesignBrowser } from './Fabrication/DesignBrowser';
 import { MaterialCostSequence } from './Fabrication/MaterialCostSequence';
-import type { Design, MaterialMap } from './Fabrication/Types';
-import type { Material } from './Fabrication/Types';
+import type { Design, Material, MaterialMap } from './Fabrication/Types';
 
 type AutolatheDesign = Design & {
   customMaterials: BooleanLike;
@@ -33,7 +32,7 @@ type AutolatheData = {
 };
 
 export const Autolathe = (props) => {
-  const { data } = useBackend<AutolatheData>();
+  const { act, data } = useBackend<AutolatheData>();
   const {
     materialtotal,
     materialsmax,
@@ -84,20 +83,52 @@ export const Autolathe = (props) => {
                             key={material.name}
                             label={capitalize(material.name)}
                           >
-                            <ProgressBar
-                              style={{
-                                transform: 'scaleX(-1) scaleY(1)',
-                              }}
-                              value={materialsmax - material.amount}
-                              maxValue={materialsmax}
-                              backgroundColor={material.color}
-                              color="black"
-                            >
-                              <div style={{ transform: 'scaleX(-1)' }}>
-                                {material.amount / SHEET_MATERIAL_AMOUNT +
-                                  ' sheets'}
-                              </div>
-                            </ProgressBar>
+                            <Stack fill>
+                              <Stack.Item grow>
+                                <ProgressBar
+                                  style={{
+                                    transform: 'scaleX(-1) scaleY(1)',
+                                  }}
+                                  value={materialsmax - material.amount}
+                                  maxValue={materialsmax}
+                                  backgroundColor={material.color}
+                                  color="black"
+                                >
+                                  <div style={{ transform: 'scaleX(-1)' }}>
+                                    {material.amount / SHEET_MATERIAL_AMOUNT +
+                                      ' sheets'}
+                                  </div>
+                                </ProgressBar>
+                              </Stack.Item>
+                              <Stack.Item>Eject:</Stack.Item>
+                              {(material.amount >= SHEET_MATERIAL_AMOUNT * 6
+                                ? [
+                                    1,
+                                    5,
+                                    Math.floor(
+                                      material.amount / SHEET_MATERIAL_AMOUNT,
+                                    ),
+                                  ]
+                                : [1, 5]
+                              ).map((amt) => (
+                                <Stack.Item key={amt}>
+                                  <Button
+                                    disabled={
+                                      material.amount <
+                                      SHEET_MATERIAL_AMOUNT * amt
+                                    }
+                                    onClick={() =>
+                                      act('eject', {
+                                        ref: material.ref,
+                                        amount: amt,
+                                      })
+                                    }
+                                  >
+                                    x{amt}
+                                  </Button>
+                                </Stack.Item>
+                              ))}
+                            </Stack>
                           </LabeledList.Item>
                         ))}
                       </LabeledList>

--- a/tgui/packages/tgui/interfaces/Autolathe.tsx
+++ b/tgui/packages/tgui/interfaces/Autolathe.tsx
@@ -101,33 +101,32 @@ export const Autolathe = (props) => {
                                 </ProgressBar>
                               </Stack.Item>
                               <Stack.Item>Eject:</Stack.Item>
-                              {(material.amount >= SHEET_MATERIAL_AMOUNT * 6
-                                ? [
-                                    1,
-                                    5,
-                                    Math.floor(
-                                      material.amount / SHEET_MATERIAL_AMOUNT,
-                                    ),
-                                  ]
-                                : [1, 5]
-                              ).map((amt) => (
-                                <Stack.Item key={amt}>
-                                  <Button
-                                    disabled={
-                                      material.amount <
-                                      SHEET_MATERIAL_AMOUNT * amt
-                                    }
-                                    onClick={() =>
-                                      act('eject', {
-                                        ref: material.ref,
-                                        amount: amt,
-                                      })
-                                    }
-                                  >
-                                    x{amt}
-                                  </Button>
-                                </Stack.Item>
-                              ))}
+                              {[
+                                1,
+                                5,
+                                Math.floor(
+                                  material.amount / SHEET_MATERIAL_AMOUNT,
+                                ),
+                              ]
+                                .sort()
+                                .map((amt) => (
+                                  <Stack.Item key={amt}>
+                                    <Button
+                                      disabled={
+                                        material.amount <
+                                        SHEET_MATERIAL_AMOUNT * amt
+                                      }
+                                      onClick={() =>
+                                        act('eject', {
+                                          ref: material.ref,
+                                          amount: amt,
+                                        })
+                                      }
+                                    >
+                                      x{amt}
+                                    </Button>
+                                  </Stack.Item>
+                                ))}
                             </Stack>
                           </LabeledList.Item>
                         ))}


### PR DESCRIPTION

## About The Pull Request

<img width="670" height="600" alt="image" src="https://github.com/user-attachments/assets/db451921-5cfa-437d-b9ca-be09f0daa91e" />

Adds buttons to eject 1, 5, or all sheets of any material from the autolathe, and removes sheet designs.

## Why It's Good For The Game

The existing system is insanely stupid and results in most uncommon materials being stuck in the autolathe until it is disassembled, and having to find the sheet manually is annoying. 

## Changelog
:cl:
qol: Materials can now be directly ejected from autolathes rather than needing to be printed.
/:cl:
