### PR TITLE
Baby stoats can become adults

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -11,7 +11,8 @@ SUBSYSTEM_DEF(minor_mapping)
 	var/list/vermin_chances = list(
 		/mob/living/basic/mouse = 72,
 		/mob/living/basic/snail = 16,
-		/mob/living/basic/stoat = 10,
+		/mob/living/basic/stoat = 7,
+		/mob/living/basic/stoat/kit = 3,
 		/mob/living/basic/regal_rat/controlled = 2,
 	)
 

--- a/code/modules/mob/living/basic/stoats/stoat.dm
+++ b/code/modules/mob/living/basic/stoats/stoat.dm
@@ -65,15 +65,15 @@
 		/mob/living/basic/stoat/kit = 100 // Placeholder until we get proper baby stoats
 	)
 	AddComponent(\
-	/datum/component/breed,\
-	can_breed_with = typecacheof(list(/mob/living/basic/stoat)),\
-	baby_paths = baby_paths,\
+		/datum/component/breed,\
+		can_breed_with = typecacheof(list(/mob/living/basic/stoat)),\
+		baby_paths = baby_paths,\
 	)
 
 /mob/living/basic/stoat/kit
 	name = "\improper stoat kit"
 	real_name = "stoat"
-	desc = "They're a stoat kit!"
+	desc = "An apex predator, but friend-shaped, and tiny..."
 	icon_state = "kit_stoat"
 	icon_living = "kit_stoat"
 	icon_dead = "kit_stoat_dead"
@@ -82,3 +82,14 @@
 	ai_controller = /datum/ai_controller/basic_controller/stoat/kit
 	mob_size = MOB_SIZE_SMALL
 	can_breed = FALSE
+
+/mob/living/basic/stoat/kit/Initialize(mapload)
+	. = ..()
+	AddComponent(\
+		/datum/component/growth_and_differentiation,\
+		growth_time = 10 MINUTES,\
+		growth_probability = 100,\
+		lower_growth_value = 0.5,\
+		upper_growth_value = 1,\
+		signals_to_kill_on = list(COMSIG_MOB_CLIENT_LOGIN),\
+	)

--- a/code/modules/mob/living/basic/stoats/stoat.dm
+++ b/code/modules/mob/living/basic/stoats/stoat.dm
@@ -88,6 +88,7 @@
 	AddComponent(\
 		/datum/component/growth_and_differentiation,\
 		growth_time = 20 MINUTES,\
+		growth_path = /mob/living/basic/stoat,\
 		growth_probability = 100,\
 		lower_growth_value = 0.5,\
 		upper_growth_value = 1,\

--- a/code/modules/mob/living/basic/stoats/stoat.dm
+++ b/code/modules/mob/living/basic/stoats/stoat.dm
@@ -87,7 +87,7 @@
 	. = ..()
 	AddComponent(\
 		/datum/component/growth_and_differentiation,\
-		growth_time = 10 MINUTES,\
+		growth_time = 20 MINUTES,\
 		growth_probability = 100,\
 		lower_growth_value = 0.5,\
 		upper_growth_value = 1,\

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -438,7 +438,8 @@ GLOBAL_VAR_INIT(disposals_animals_spawned, 0)
 	var/obj/item/dest_tagger/mounted_tagger
 	///a weighted list of all the possible animals we can have
 	var/static/list/weighted_animal_list = list(
-		/mob/living/basic/stoat = 1,
+		/mob/living/basic/stoat = 5,
+		/mob/living/basic/stoat/kit = 1,
 	)
 	/// do we contain an animal?
 	var/contained_animal


### PR DESCRIPTION

## About The Pull Request
Baby stoats can now grow into adult stoats. ive also included kits into the spawn pool of maints, (the overall chance of running into a stoat whether adult/baby remains the same), and you can also now find baby stoats rummaging through bins. since baby stoats are cute ive made their growth rates slow so people can enjoy them at their youths for longer.

## Why It's Good For The Game
fixes an oversight.

## Changelog
:cl:
fix: baby stoats can now become adults
add: baby stoats are added to the spawn pool of maints, (the overall chance of running into a stoat whether adult/baby remains the same)
/:cl:
