### PR TITLE
Fixes rotation breaking on one votable map

### DIFF
--- a/code/controllers/subsystem/map_vote.dm
+++ b/code/controllers/subsystem/map_vote.dm
@@ -22,6 +22,9 @@ SUBSYSTEM_DEF(map_vote)
 	/// Stores the last amount of potential players to compare next time we're called
 	var/player_cache = -1
 
+	/// Cached list of votable maps
+	var/list/votable_map_cache
+
 	/// Stores a formatted html string of the tally counts
 	var/tally_printout = span_red("Loading...")
 
@@ -113,8 +116,9 @@ SUBSYSTEM_DEF(map_vote)
 	else
 		filter_threshold = length(GLOB.clients)
 
-	if(filter_threshold == player_cache)
-		return null
+	// Cached because it's called off ui_data, I really don't think this is worth it but whatever
+	if(filter_threshold == player_cache && !isnull(votable_map_cache))
+		return votable_map_cache.Copy()
 
 	player_cache = filter_threshold
 	var/list/valid_maps = list()
@@ -130,6 +134,7 @@ SUBSYSTEM_DEF(map_vote)
 			continue
 		valid_maps += possible_config.map_name
 
+	votable_map_cache = valid_maps.Copy()
 	return valid_maps
 
 /datum/controller/subsystem/map_vote/proc/filter_cache_to_valid_maps()

--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -4,14 +4,13 @@
 	count_method = VOTE_COUNT_METHOD_SINGLE
 	winner_method = VOTE_WINNER_METHOD_NONE
 	display_statistics = FALSE
+
 /datum/vote/map_vote/New()
 	. = ..()
 	default_choices = SSmap_vote.get_valid_map_vote_choices()
 
 /datum/vote/map_vote/create_vote()
-	var/list/new_choices = SSmap_vote.get_valid_map_vote_choices()
-	if (new_choices)
-		default_choices = new_choices
+	default_choices = SSmap_vote.get_valid_map_vote_choices()
 	. = ..()
 	if(!.)
 		return FALSE
@@ -43,10 +42,13 @@
 	if(SSmap_vote.next_map_config)
 		return "The next map has already been selected."
 
+	// The below case will be caught in create_vote() if the vote is being forced
+	// This ensures proper map rotation if there aren't enough votable maps for whatever reason
+	if(forced)
+		return VOTE_AVAILABLE
+
 	var/list/new_choices = SSmap_vote.get_valid_map_vote_choices()
-	if (new_choices)
-		default_choices = new_choices
-	var/num_choices = length(default_choices)
+	var/num_choices = length(new_choices)
 	if(num_choices <= 1)
 		return "There [num_choices == 1 ? "is only one map" : "are no maps"] to choose from."
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically, if it's forced, we rely on create_vote to catch the "no options" case.
This used to be the behavior, but it was removed in persistant tallies. I have no idea why.
I've also cleaned up the quite dubious caching code to avoid the bugs I was getting when testing locally.

## Why It's Good For The Game

S been causing forced icebox (15 pop min, meta can't replace it because meta's the only one with 0 minpop) on the servers, that's silly.

Of note, it's possible this will still be an issue due to the stale map system, but yaknow, one thing at a time, and that'll be louder so we should find out pretty fast (fix would be defaulting to some marked default map if only one can be rolled).

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: End of round mapvotes will now properly default to the only option if only one map is votable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
