### PR TITLE
Fixes ambience subsystem removing players permanently

### DIFF
--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -22,9 +22,13 @@ SUBSYSTEM_DEF(ambience)
 
 		//Check to see if the client exists and isn't held by a new player
 		var/mob/client_mob = client_iterator?.mob
-		if(isnull(client_iterator) || !client_mob || isnewplayer(client_mob))
+		if(isnull(client_iterator) || !client_mob)
 			ambience_listening_clients -= client_iterator
 			client_old_areas -= client_iterator
+			continue
+
+		// skip them this tick if they're on the lobby screen
+		if(isnewplayer(client_mob))
 			continue
 
 		if(HAS_TRAIT(client_mob, TRAIT_DEAF)) //WHAT? I CAN'T HEAR YOU

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -28,7 +28,7 @@ SUBSYSTEM_DEF(ambience)
 
 		// skip them this tick if they're on the lobby screen or somehow dont have a mob??
 		var/mob/client_mob = client_iterator?.mob
-		if(client_mob || isnewplayer(client_mob))
+		if(!client_mob || isnewplayer(client_mob))
 			continue
 
 		if(HAS_TRAIT(client_mob, TRAIT_DEAF)) //WHAT? I CAN'T HEAR YOU

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -20,15 +20,15 @@ SUBSYSTEM_DEF(ambience)
 		var/client/client_iterator = cached_clients[cached_clients.len]
 		cached_clients.len--
 
-		//Check to see if the client exists and isn't held by a new player
-		var/mob/client_mob = client_iterator?.mob
-		if(isnull(client_iterator) || !client_mob)
+		//Check to see if the client exists
+		if(isnull(client_iterator))
 			ambience_listening_clients -= client_iterator
 			client_old_areas -= client_iterator
 			continue
 
-		// skip them this tick if they're on the lobby screen
-		if(isnewplayer(client_mob))
+		// skip them this tick if they're on the lobby screen or somehow dont have a mob??
+		var/mob/client_mob = client_iterator?.mob
+		if(client_mob || isnewplayer(client_mob))
 			continue
 
 		if(HAS_TRAIT(client_mob, TRAIT_DEAF)) //WHAT? I CAN'T HEAR YOU


### PR DESCRIPTION

## About The Pull Request
Fixes #96497 which was created by #59071

Im not really sure why the mob check exists, im moving it to a continue for the same reason as the newmob check.
## Why It's Good For The Game
Unless this is meant to be a micro op, it just doesn't make sense to completely drop them from the list, especially if we never readd them 😿 
## Changelog
:cl:
fix: Clients who sit in the lobby after pregame will no longer have there ambience disabled till they reconnect
/:cl:
