### PR TITLE
ambience uses sound enviroment

### DIFF
--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -59,6 +59,7 @@ SUBSYSTEM_DEF(ambience)
 	/// volume modifier for ambience as set by the player in preferences.
 	var/volume_modifier = (M.client?.prefs.read_preference(/datum/preference/numeric/volume/sound_ambience_volume))/100
 	new_sound = sound(new_sound, repeat = 0, wait = 0, volume = volume*volume_modifier, channel = CHANNEL_AMBIENCE)
+	new_sound.environment = M.get_sound_enviroment()
 	SEND_SOUND(M, new_sound)
 
 	var/sound_length = SSsounds.get_sound_length(new_sound.file)
@@ -141,4 +142,6 @@ SUBSYSTEM_DEF(ambience)
 			return
 
 		client.current_ambient_sound = sound_to_use
-		SEND_SOUND(src, sound(my_area.ambient_buzz, repeat = 1, wait = 0, volume = my_area.ambient_buzz_vol * (volume_modifier / 100), channel = CHANNEL_BUZZ))
+		var/sound/new_sound_to_use = sound(sound_to_use, repeat = 1, wait = 0, volume = my_area.ambient_buzz_vol * (volume_modifier / 100), channel = CHANNEL_BUZZ)
+		new_sound_to_use.environment = get_sound_enviroment()
+		SEND_SOUND(src, new_sound_to_use)

--- a/code/game/sound/sound.dm
+++ b/code/game/sound/sound.dm
@@ -154,14 +154,7 @@
 
 		sound_to_use.falloff = max_distance || 1 //use max_distance, else just use 1 as we are a direct sound so falloff isnt relevant.
 
-		// Sounds can't have their own environment. A sound's environment will be:
-		// 1. the mob's
-		// 2. the area's (defaults to SOUND_ENVRIONMENT_NONE)
-		if(sound_environment_override != SOUND_ENVIRONMENT_NONE)
-			sound_to_use.environment = sound_environment_override
-		else
-			var/area/A = get_area(src)
-			sound_to_use.environment = A.sound_environment
+		sound_to_use.environment = get_sound_enviroment()
 
 		if(!use_reverb || sound_to_use.environment == SOUND_ENVIRONMENT_NONE)
 			sound_to_use.echo ||= new /list(18)
@@ -180,6 +173,19 @@
 
 	SEND_SOUND(src, sound_to_use)
 	return TRUE
+
+/**
+ * Sounds can't have their own environment. A sound's environment will be:
+ * 1. the mob's
+ * 2. the area's (defaults to SOUND_ENVRIONMENT_NONE)
+ */
+/mob/proc/get_sound_enviroment()
+	if(sound_environment_override != SOUND_ENVIRONMENT_NONE)
+		return sound_environment_override
+	else
+		var/area/my_area = get_area(src)
+		return my_area.sound_environment
+
 
 /proc/sound_to_playing_players(soundin, volume = 100, vary = FALSE, frequency = 0, channel = 0, pressure_affected = FALSE, sound/S, datum/preference/numeric/volume/volume_preference = null)
 	if(!S)


### PR DESCRIPTION

## About The Pull Request
Ambience systems pull the sound environment out by abstracting the code local sound uses to get its area (to make sure it includes the mobs sound environment override)

My only minor issue is I dont see an amazing way to make sure we change the environment for the buzz / looping sound outside adding like a `current_ambient_sound_sound_enviroment` var that mimmics the same thin `current_ambient_sound` does tho that feels a little clunkly

Spaces sound environment is "underwater" so it should be one of the more noticeable changes. IDK its subtle.

New:

https://github.com/user-attachments/assets/34d8bd03-ba70-4280-8695-a8760ad69d02
## Why It's Good For The Game
Its pretty subtle but having the ambience use the same sound environment as most other noise should help it blend in and feel more like its a sound happening around you.
## Changelog
:cl:
add: Ambience now uses the sound environment of the area it was played in
/:cl:
