### PR TITLE
Fixed the ninja e-katana not being linked to the recall module.

### DIFF
--- a/code/modules/antagonists/space_ninja/outfit.dm
+++ b/code/modules/antagonists/space_ninja/outfit.dm
@@ -22,8 +22,8 @@
 	var/obj/item/mod/module/dna_lock/reinforced/lock = locate(/obj/item/mod/module/dna_lock/reinforced) in mod.modules
 	lock.dna = ninja.dna.unique_enzymes
 	var/obj/item/mod/module/weapon_recall/recall = locate(/obj/item/mod/module/weapon_recall) in mod.modules
-	var/obj/item/weapon = ninja.belt
-	if(!istype(weapon, recall.accepted_type))
+	var/obj/item/weapon = locate(recall.accepted_type) in ninja.get_all_contents()
+	if(!weapon)
 		return
 	recall.set_weapon(weapon)
 


### PR DESCRIPTION

## About The Pull Request
Whoever gave the ninja outfit a sheath for the energy katana and moved the latter from the belt slot and into the sheath (which is attached to the suit slot) woefully forgot to also edit the post_equip() proc of the outfit found just a few lines under. This has made a few players pitifully lose against random officers because of the oversight.
## Why It's Good For The Game
Fixing an issue with ninjas
## Changelog
:cl:
fix: Fixed the e-katana not being linked to the recall module automatically when rolling ninja.
/:cl:
