### PR TITLE
Hides projectile lighting from the right click menu

### DIFF
--- a/code/game/objects/effects/temporary_visuals/projectiles/projectile_effects.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/projectile_effects.dm
@@ -48,6 +48,7 @@
 		pixel_y += round((cos(angle_override)+16*cos(angle_override)*2), 1)
 
 /obj/effect/abstract/projectile_lighting
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/effect/abstract/projectile_lighting/Initialize(mapload, color, range, intensity)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Fixes this

<img width="294" height="181" alt="dreamseeker_ktDfO4mbM9" src="https://github.com/user-attachments/assets/3150a452-93bc-44a0-895b-e2d02b5ac15a" />

## Changelog
:cl:
fix: Projectile lighting is no longer shown in the right click menu
/:cl:
