### PR TITLE
Fixes recovered crew showing up as uncategorized antags

### DIFF
--- a/code/modules/lost_crew/recovered_crew.dm
+++ b/code/modules/lost_crew/recovered_crew.dm
@@ -1,6 +1,7 @@
 /// Revived crew ready to serve once more! Only here for tracking/admin reasons, otherwise hidden
 /datum/antagonist/recovered_crew
 	name = "\improper Recovered Crew"
+	antagpanel_category = "Recovered Crew"
 	show_in_antagpanel = TRUE
 	pref_flag = ROLE_RECOVERED_CREW
 	show_name_in_check_antagonists = TRUE


### PR DESCRIPTION

## About The Pull Request

Groups need to be set to smth or otherwise they show up as uncategorized in both admin observe and antagpanel menus.
<img width="257" height="89" alt="4uXQEAamCb" src="https://github.com/user-attachments/assets/4fd859b6-38e2-4366-b5ba-e0d9ce468a88" />

## Changelog
:cl:
fix: Fixed recovered crew showing up as uncategorized antags
/:cl:
