### PR TITLE
Drastically lowers the amount of gibtonite on icebox, fixes incorrect wall typepath

### DIFF
--- a/code/datums/mapgen/Cavegens/IcemoonCaves.dm
+++ b/code/datums/mapgen/Cavegens/IcemoonCaves.dm
@@ -2,7 +2,7 @@
 	weighted_open_turf_types = list(/turf/open/misc/asteroid/snow/icemoon = 19, /turf/open/misc/ice/icemoon = 1)
 	weighted_closed_turf_types = list(
 		/turf/closed/mineral/random/snow = 100,
-		/turf/closed/mineral/gibtonite/ice/icemoon = 4,
+		/turf/closed/mineral/gibtonite/ice/icemoon = 2,
 	)
 
 	weighted_mob_spawn_list = list(
@@ -82,7 +82,7 @@
 /datum/map_generator/cave_generator/icemoon/surface/noruins //use this for when you don't want ruins to spawn in a certain area
 
 /datum/map_generator/cave_generator/icemoon/deep
-	weighted_closed_turf_types = list(/turf/closed/mineral/random/snow = 1)
+	weighted_closed_turf_types = list(/turf/closed/mineral/random/snow/underground = 1)
 	weighted_mob_spawn_list = list(
 		SPAWN_MEGAFAUNA = 1,
 		/mob/living/basic/mining/ice_demon = 100,

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -702,7 +702,6 @@
 	turf_flags = NO_RUINS
 
 /turf/closed/mineral/random/snow/underground
-	baseturfs = /turf/open/misc/asteroid/snow/icemoon
 	// abundant ore
 	mineral_chance = 11
 

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -692,7 +692,7 @@
 		/obj/item/stack/ore/silver = 8,
 		/obj/item/stack/ore/titanium = 11,
 		/obj/item/stack/ore/uranium = 5,
-		/turf/closed/mineral/gibtonite/ice/icemoon = 4,
+		/turf/closed/mineral/gibtonite/ice/icemoon = 2,
 	)
 
 /// Near exact same subtype as parent, just used in ruins to prevent other ruins/chasms from spawning on top of it.
@@ -717,7 +717,7 @@
 		/obj/item/stack/ore/silver = 24,
 		/obj/item/stack/ore/titanium = 22,
 		/obj/item/stack/ore/uranium = 10,
-		/turf/closed/mineral/gibtonite/ice/icemoon = 8,
+		/turf/closed/mineral/gibtonite/ice/icemoon = 2,
 	)
 
 /turf/closed/mineral/random/snow/high_chance


### PR DESCRIPTION

## About The Pull Request

Significantly reduces the amount of gibtonite spawned on icebox, and fixes underground cavegen spawning normal icemoon walls rather than special underground ones (which have numbers equals to those of lavaland walls, rather than reduced surface numbers) which caused icebox to have significantly less ore than intended.

## Why It's Good For The Game

Its everywhere man, I'm pretty sure underground has more gibtonite than titanium at this point. Its so common that I've had 5-6 long chain reactions occur just from shooting one of them, which caused the station to shake for half a minute straight.

<img width="533" height="619" alt="dreamseeker_WiZO1oTeM6" src="https://github.com/user-attachments/assets/04080f36-5687-42d3-9754-a93a2b26c3fc" />

## Changelog
:cl:
balance: Drastically reduced the amount of gibtonite spawning on icebox
fix: Fixed icebox underground spawning significantly less ores than intended
/:cl:
