### PR TITLE
Stasis crates

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -62,6 +62,7 @@
 #define STASIS_LEGION_EATEN "stasis_eaten"
 #define STASIS_SLIME_BZ "stasis_slime_bz"
 #define STASIS_ELDRITCH_ETHER "stasis_eldritch_ether"
+#define STASIS_CRATE_EFFECT "stasis_crate"
 
 #define STASIS_NETPOD_EFFECT "stasis_netpod"
 

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -61,7 +61,7 @@
 
 /obj/structure/closet/crate/critter/stasis
 	name = "stasis critter crate"
-	desc = "A crate designed for safe transport of specific animals in stasis to prevent them from growing."
+	desc = "A crate designed for safe transport of specific animals in stasis to prevent them from aging or starving."
 	var/stasis_sealed = TRUE
 
 /obj/structure/closet/crate/critter/stasis/Exited(atom/movable/gone, direction)

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -58,3 +58,15 @@
 		return tank.return_analyzable_air()
 	else
 		return null
+
+/obj/structure/closet/crate/critter/stasis
+	name = "stasis critter crate"
+	desc = "A crate designed for safe transport of specific animals in stasis to prevent them from growing."
+
+/obj/structure/closet/crate/critter/stasis/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(HAS_TRAIT(gone, TRAIT_STASIS))
+		remove_stasis(gone)
+
+/obj/structure/closet/crate/critter/stasis/proc/remove_stasis(mob/living/target)
+	target.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_CRATE_EFFECT)

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -62,6 +62,7 @@
 /obj/structure/closet/crate/critter/stasis
 	name = "stasis critter crate"
 	desc = "A crate designed for safe transport of specific animals in stasis to prevent them from growing."
+	var/stasis_sealed = TRUE
 
 /obj/structure/closet/crate/critter/stasis/Exited(atom/movable/gone, direction)
 	. = ..()
@@ -70,3 +71,11 @@
 
 /obj/structure/closet/crate/critter/stasis/proc/remove_stasis(mob/living/target)
 	target.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_CRATE_EFFECT)
+
+/obj/structure/closet/crate/critter/stasis/after_open(mob/living/user, force)
+	. = ..()
+	if(!stasis_sealed)
+		return
+	stasis_sealed = FALSE
+	do_sparks(3, FALSE, src)
+	to_chat(user, span_warning("[src] one-use stasis mechanism has been triggered! It will not work again."))

--- a/code/modules/cargo/packs/livestock.dm
+++ b/code/modules/cargo/packs/livestock.dm
@@ -2,6 +2,15 @@
 	group = "Livestock"
 	crate_type = /obj/structure/closet/crate/critter
 
+/datum/supply_pack/critter/stasis
+	group = "Livestock (Stasis)"
+	crate_type = /obj/structure/closet/crate/critter/stasis
+
+/datum/supply_pack/critter/stasis/generate(atom/A, datum/bank_account/paying_account, crate_override)
+	. = ..()
+	var/mob/living/stasis_mob = locate() in .
+	stasis_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_CRATE_EFFECT)
+
 /datum/supply_pack/critter/parrot
 	name = "Bird Crate"
 	desc = "Contains five expert telecommunication birds."
@@ -260,9 +269,9 @@
 	contains = list(/obj/item/storage/fish_case/tiziran = 2)
 	crate_name = "tiziran fish crate"
 
-/datum/supply_pack/critter/turtle
+/datum/supply_pack/critter/stasis/turtle
 	name = "Turtle Crate"
 	desc = "Cute flora turtles that'll emit good vibes to nearby plants!"
 	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/mob/living/basic/turtle)
-	crate_name = "flora-turtle crate"
+	crate_name = "flora-turtle stasis crate"

--- a/code/modules/cargo/packs/livestock.dm
+++ b/code/modules/cargo/packs/livestock.dm
@@ -6,10 +6,10 @@
 	group = "Livestock (Stasis)"
 	crate_type = /obj/structure/closet/crate/critter/stasis
 
-/datum/supply_pack/critter/stasis/generate(atom/A, datum/bank_account/paying_account, crate_override)
+/datum/supply_pack/critter/stasis/fill(obj/container)
 	. = ..()
-	var/mob/living/stasis_mob = locate() in .
-	stasis_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_CRATE_EFFECT)
+	for(var/mob/living/stasis_mob in container)
+		stasis_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_CRATE_EFFECT)
 
 /datum/supply_pack/critter/parrot
 	name = "Bird Crate"

--- a/code/modules/mob/living/basic/turtle/turtle.dm
+++ b/code/modules/mob/living/basic/turtle/turtle.dm
@@ -94,6 +94,8 @@
 	return destined_path
 
 /mob/living/basic/turtle/process(seconds_per_tick)
+	if(HAS_TRAIT(src, TRAIT_STASIS))
+		return
 	if(isnull(reagents) || !length(reagents.reagent_list)) //if we have no reagents, default to our highest destined path
 		set_plant_growth(retrieve_destined_path(), 0.5)
 		return


### PR DESCRIPTION
## About The Pull Request

Adds stasis crates for critters in cargo. They have no unique sprite or anything, just only used for turtles (atleast currently)
closes #96486

## Why It's Good For The Game

"fixes" problem with turtles growing while theyre still on the shuttle (that includes shuttle transfer time), since turtles ordered from cargo are coming already grown up. this behaviour breaks intended feature where you have to feed them with different reagents in order to get different colored trees. (you cant do that on adult turtles)

## Changelog

:cl:
fix: Turtles now come in the stasis crates and can no longer grow inside of a cargo shuttle (or, well, untill you open the crate in general). This allows you to ACTUALLY interact with turtles growing feature before they come grown up.
/:cl:
