### PR TITLE
the shuttle failsafe will also be triggered if all comms consoles are depowered rather than just destroyed

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -542,7 +542,7 @@ SUBSYSTEM_DEF(shuttle)
 				continue
 		else if(istype(thing, /obj/machinery/computer/communications))
 			var/obj/machinery/computer/communications/C = thing
-			if(C.machine_stat & BROKEN)
+			if(C.machine_stat & (BROKEN || NOPOWER))
 				continue
 
 		var/turf/T = get_turf(thing)


### PR DESCRIPTION

## About The Pull Request

the shuttle failsafe calls the emergency shuttle when all AIs are dead and all comms consoles are destroyed. this is intended to prevent rounds from getting softlocked, but unfortunately it doesn't consider depowered comms consoles, which are more frequent than "all comms screens are smashed" on rounds in which this failsafe is needed. if you're worried about powersinks/shuttle autocall from engineers being stinky this shouldn't affect normal gameplay because AIs have SMES units that power them for the whole round and make them immune to powersinks, which prevents the failsafe from activating.

## Why It's Good For The Game

should help with ending 12 hour long giga deadpop rounds where a traitor's mass bombed everything but left the depowered bridge and comms consoles intact, preventing round hostage situations and overall making the shuttle failsafe more effective

## Changelog
:cl:
qol: the emergency shuttle failsafe has been extended to include depowered comms consoles
/:cl:
