### PR TITLE
Fixes floor igniters by refactoring wall button control assemblies

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -400,13 +400,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/button/door, 24)
 
 /obj/machinery/button/door/setup_device(mapload)
 	if(mapload)
-		device = normaldoorcontrol ? new /obj/item/assembly/control/airlock(src) : new /obj/item/assembly/control(src)
+		device = normaldoorcontrol ? new /obj/item/assembly/control/airlock(src) : new /obj/item/assembly/control/blast_door(src)
 
 	if(istype(device, /obj/item/assembly/control/airlock))
 		var/obj/item/assembly/control/airlock/airlock_device = device
 		airlock_device.specialfunctions = specialfunctions
-	else if(istype(device, /obj/item/assembly/control))
-		var/obj/item/assembly/control/control_device = device
+	else if(istype(device, /obj/item/assembly/control/blast_door))
+		var/obj/item/assembly/control/blast_door/control_device = device
 		control_device.sync_doors = sync_doors
 	return ..()
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -69,7 +69,7 @@
 	if(deconstruction == BLASTDOOR_NEEDS_ELECTRONICS && istype(held_item, /obj/item/electronics/airlock))
 		context[SCREENTIP_CONTEXT_LMB] = "Add electronics"
 		return CONTEXTUAL_SCREENTIP_SET
-	if(deconstruction == BLASTDOOR_FINISHED && istype(held_item, /obj/item/assembly/control))
+	if(deconstruction == BLASTDOOR_FINISHED && istype(held_item, /obj/item/assembly/control/blast_door))
 		context[SCREENTIP_CONTEXT_LMB] = "Calibrate ID"
 		return CONTEXTUAL_SCREENTIP_SET
 	//we do not check for special effects like if they can actually perform the action because they will be told they can't do it when they try,
@@ -117,14 +117,14 @@
 		deconstruction = BLASTDOOR_FINISHED
 		return ITEM_INTERACT_SUCCESS
 
-	if(deconstruction == BLASTDOOR_FINISHED && istype(tool, /obj/item/assembly/control))
+	if(deconstruction == BLASTDOOR_FINISHED && istype(tool, /obj/item/assembly/control/blast_door))
 		if(density)
 			balloon_alert(user, "open the door first!")
 			return ITEM_INTERACT_BLOCKING
 		if(!panel_open)
 			balloon_alert(user, "open the panel first!")
 			return ITEM_INTERACT_BLOCKING
-		var/obj/item/assembly/control/controller_item = tool
+		var/obj/item/assembly/control/blast_door/controller_item = tool
 		if(controller_item.id == -1)
 			//collect existing ids
 			var/list/door_ids = list()

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -1,13 +1,17 @@
 /obj/item/assembly/control
-	name = "blast door controller"
-	desc = "A small electronic device able to control a blast door remotely."
+	name = "controller assembly"
+	desc = "An assembly that controls something. It's so vaguely designed that it probably shouldn't exist."
 	icon_state = "control"
-	/// The ID of the blast door electronics to match to the ID of the blast door being used.
+	/// The ID of the electronics to match to the ID of the machine being used.
 	var/id = -1
-	/// Cooldown of the door's controller. Updates when pressed (activate())
+	/// Cooldown of the controller. Updates when pressed (activate())
 	var/cooldown = FALSE
 	/// Should we toggle open/close of doors based on their current state
 	var/sync_doors = TRUE
+	/// If this controller's ID should be adjustable by players through multitools.
+	var/generically_adjustable = FALSE
+	/// If this controller's ID should be copyable by hitting with an identical controller.
+	var/copyable = FALSE
 
 /obj/item/assembly/control/Initialize(mapload)
 	. = ..()
@@ -15,20 +19,59 @@
 
 /obj/item/assembly/control/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = NONE
-	if(istype(held_item, /obj/item/assembly/control))
+	if(istype(held_item, type) && copyable)
 		context[SCREENTIP_CONTEXT_LMB] = "Copy ID"
 		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/assembly/control/examine(mob/user)
 	. = ..()
-	if(id)
-		if(id != -1)
-			. += span_notice("Its channel ID is '[id]'.")
-		else
-			. += span_notice("Interact with pod door to generate an new id")
-	. += span_notice("You can interact with another controller to copy its ID.")
+	if(generically_adjustable)
+		. += span_notice("You can use a [EXAMINE_HINT("multitool")] to adjust its ID.")
+
+	if(copyable)
+		. += span_notice("You can interact with another controller to copy its ID.")
+
+	if(!id)
+		return
+
+	if(id != -1)
+		. += span_notice("Its channel ID is '[id]'.")
 
 /obj/item/assembly/control/multitool_act(mob/living/user)
+	if(!generically_adjustable)
+		return
+
+	var/change_id = tgui_input_number(user, "Set the [name]'s ID", "Controller ID", id, 100)
+	if(!change_id || QDELETED(user) || QDELETED(src) || !usr.can_perform_action(src, FORBID_TELEKINESIS_REACH))
+		return
+	id = change_id
+	to_chat(user, span_notice("You change the ID to [id]."))
+
+/obj/item/assembly/control/interact_with_atom(obj/item/assembly/control/interacting_with, mob/living/user, list/modifiers)
+	. = NONE
+	if(!copyable)
+		return
+
+	if(istype(interacting_with))
+		id = interacting_with.id
+		balloon_alert(user, "id changed")
+		return ITEM_INTERACT_SUCCESS
+
+/obj/item/assembly/control/activate()
+	if(cooldown)
+		return
+
+/obj/item/assembly/control/blast_door
+	name = "blast door controller"
+	desc = "A small electronic device able to control blast doors or shutters remotely."
+	copyable = TRUE
+
+/obj/item/assembly/control/blast_door/examine(mob/user)
+	. = ..()
+	if(id && id == -1)
+		. += span_notice("Interact with a blast door or shutter to generate a new ID")
+
+/obj/item/assembly/control/blast_door/multitool_act(mob/living/user)
 	var/list/door_ids = list()
 	var/list/display_ids = list("UNIQUE")
 	for(var/obj/machinery/door/poddoor/M as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/door/poddoor))
@@ -57,19 +100,10 @@
 	if(id != -1)
 		to_chat(user, span_notice("You change the ID to [id]."))
 	else
-		to_chat(user, span_notice("You now must interact with an pod door to generate an unique ID."))
+		to_chat(user, span_notice("You now must interact with a pod door to generate a unique ID."))
 
-/obj/item/assembly/control/interact_with_atom(obj/item/assembly/control/interacting_with, mob/living/user, list/modifiers)
-	. = NONE
-	if(istype(interacting_with))
-		id = interacting_with.id
-		balloon_alert(user, "id changed")
-		return ITEM_INTERACT_SUCCESS
-
-/obj/item/assembly/control/activate()
+/obj/item/assembly/control/blast_door/activate()
 	var/openclose
-	if(cooldown)
-		return
 	cooldown = TRUE
 	for(var/obj/machinery/door/poddoor/M as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/door/poddoor))
 		if(M.id == src.id)
@@ -81,11 +115,6 @@
 /obj/item/assembly/control/curtain
 	name = "curtain controller"
 	desc = "A small electronic device able to control a mechanical curtain remotely."
-
-/obj/item/assembly/control/curtain/examine(mob/user)
-	. = ..()
-	if(id)
-		. += span_notice("Its channel ID is '[id]'.")
 
 /obj/item/assembly/control/curtain/activate()
 	var/openclose
@@ -179,7 +208,9 @@
 
 /obj/item/assembly/control/igniter
 	name = "ignition controller"
-	desc = "A remote controller for a mounted igniter."
+	desc = "A remote controller for a floor igniter or wall sparker."
+	generically_adjustable = TRUE
+	copyable = TRUE
 
 /obj/item/assembly/control/igniter/activate()
 	if(cooldown)

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -7,6 +7,7 @@
 	/// Cooldown of the controller. Updates when pressed (activate())
 	var/cooldown = FALSE
 	/// Should we toggle open/close of doors based on their current state
+	/// Also used for curtains
 	var/sync_doors = TRUE
 	/// If this controller's ID should be adjustable by players through multitools.
 	var/generically_adjustable = FALSE
@@ -57,10 +58,6 @@
 		balloon_alert(user, "id changed")
 		return ITEM_INTERACT_SUCCESS
 
-/obj/item/assembly/control/activate()
-	if(cooldown)
-		return
-
 /obj/item/assembly/control/blast_door
 	name = "blast door controller"
 	desc = "A small electronic device able to control blast doors or shutters remotely."
@@ -104,6 +101,8 @@
 
 /obj/item/assembly/control/blast_door/activate()
 	var/openclose
+	if(cooldown)
+		return
 	cooldown = TRUE
 	for(var/obj/machinery/door/poddoor/M as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/door/poddoor))
 		if(M.id == src.id)

--- a/code/modules/research/designs/autolathe/engineering_designs.dm
+++ b/code/modules/research/designs/autolathe/engineering_designs.dm
@@ -27,7 +27,7 @@
 	id = "blast"
 	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE
 	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT, /datum/material/glass =SMALL_MATERIAL_AMOUNT*0.5)
-	build_path = /obj/item/assembly/control
+	build_path = /obj/item/assembly/control/blast_door
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_ELECTRONICS,


### PR DESCRIPTION

## About The Pull Request
Constructable atmospheric floor igniters (as introduced in PR #75722 by @SyncIt21) seem to have been broken last year with PR #92494. All button-bound controllers (igniter, airlock, crematorium, curtain, et cetera) are currently subtypes of blast door controllers. Accordingly, the `multitool_act()` proc from the latter PR both broke and erroneously introduced blast door ID-setting functionality to every subtype. 

<details><summary>Faulty <code>examine()</code> for example:</summary>

<img width="415" height="121" alt="Ignition_Controller_Desc" src="https://github.com/user-attachments/assets/ce7b038a-035a-45b1-85f9-1c78ad9b8b63" />

</details>

This PR fixes floor igniters by refactoring blast door controllers into their own subtype of a generic parent type. A few minor grammar corrections have also been included.
## Why It's Good For The Game
There are a lot of different wall buttons in-game that do a lot of different things. Many of those things are far removed from blast doors. Having blast door controllers be the parent type for all other controllers is then likely to cause future problems. Nothing more exemplifies this than the problem fixed here.
## Changelog
:cl:
fix: Fixed floor igniters and ensured that they are linkable to constructed buttons.
fix: All wall-mounted button electronics are no longer arbitrarily alterable with blast doors. 
refactor: Refactored blast doors controllers into their own subtype of a new abstract controller type.
/:cl:
