### PR TITLE
[NO GBP] fixed fish traits added through the fish gene gun not updating some things properly.

### DIFF
--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -664,7 +664,7 @@
 
 /obj/item/fish_gene/proc/inject_into_fish(obj/item/fish/fish, mob/living/user, obj/item/tool = src)
 	var/datum/fish_trait/trait = GLOB.fish_traits[trait_type]
-	if(!trait.apply_to_fish(fish))
+	if(!trait.apply_to_fish(fish, initial = FALSE))
 		to_chat(user, span_warning("You can't inject the \"[trait_type::name]\" trait into [fish]. [fish.p_they(TRUE)] either [fish.p_have()] it or [fish.p_are()] incompatible with it."))
 		return ITEM_INTERACT_BLOCKING
 	user.visible_message(span_notice("[user] injects [fish] with [tool]."), span_notice("You inject the \"[trait_type::name]\" trait into [fish]."))

--- a/code/modules/unit_tests/fish_unit_tests.dm
+++ b/code/modules/unit_tests/fish_unit_tests.dm
@@ -155,7 +155,7 @@
 	inheritability = 100
 	reagents_to_add = list(/datum/reagent/fishdummy = FISH_REAGENT_AMOUNT)
 
-/datum/fish_trait/dummy/apply_to_fish(obj/item/fish/fish)
+/datum/fish_trait/dummy/apply_to_fish(obj/item/fish/fish, initial = TRUE)
 	. = ..()
 	ADD_TRAIT(fish, TRAIT_FISH_TESTING, FISH_TRAIT_DATUM)
 


### PR DESCRIPTION
## About The Pull Request
Title. I forgot to include the initial arg in the call

## Why It's Good For The Game
This may be related to the electrogenesis trait not increasing the force of the fish when I injected it.

## Changelog

:cl:
fix: Fish traits injected with the fish gene gun should work a little better in some cases.
/:cl:
