### PR TITLE
Fixes some Booze-o-mat item organization

### DIFF
--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -11,32 +11,31 @@
 			"icon" = "wine-bottle",
 			"products" = list(
 				/obj/item/reagent_containers/cup/glass/bottle/curacao = 5,
+				/obj/item/reagent_containers/cup/glass/bottle/coconut_rum = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/applejack = 5,
-				/obj/item/reagent_containers/cup/glass/bottle/wine_voltaic = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/tequila = 5,
+				/obj/item/reagent_containers/cup/glass/bottle/aperitivo = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/rum = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/cognac = 5,
+				/obj/item/reagent_containers/cup/glass/bottle/maraschino = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/wine = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/absinthe = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/vermouth = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/gin = 5,
-				/obj/item/reagent_containers/cup/glass/bottle/grenadine = 4,
 				/obj/item/reagent_containers/cup/glass/bottle/hcider = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/amaretto = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/ale = 6,
+				/obj/item/reagent_containers/cup/glass/bottle/yuyake = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/grappa = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/navy_rum = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/maltliquor = 6,
 				/obj/item/reagent_containers/cup/glass/bottle/kahlua = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/sake = 5,
+				/obj/item/reagent_containers/cup/glass/bottle/shochu = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/beer = 6,
 				/obj/item/reagent_containers/cup/glass/bottle/vodka = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/whiskey = 5,
-				/obj/item/reagent_containers/cup/glass/bottle/coconut_rum = 5,
-				/obj/item/reagent_containers/cup/glass/bottle/yuyake = 5,
-				/obj/item/reagent_containers/cup/glass/bottle/shochu = 5,
-				/obj/item/reagent_containers/cup/glass/bottle/aperitivo = 5,
-				/obj/item/reagent_containers/cup/glass/bottle/maraschino = 5,
+				/obj/item/reagent_containers/cup/glass/bottle/wine_voltaic = 5,
 				/obj/item/reagent_containers/cup/soda_cans/beer = 10,
 				/obj/item/reagent_containers/cup/soda_cans/beer/rice = 10,
 			),
@@ -46,7 +45,10 @@
 			"name" = "Non-Alcoholic",
 			"icon" = "bottle-water",
 			"products" = list(
+				/obj/item/reagent_containers/cup/glass/bottle/hakka_mate = 5,
 				/obj/item/reagent_containers/cup/glass/ice = 10,
+				/obj/item/reagent_containers/cup/glass/bottle/grenadine = 4,
+				/obj/item/reagent_containers/cup/soda_cans/melon_soda = 5,
 				/obj/item/reagent_containers/cup/glass/bottle/juice/lemonjuice = 4,
 				/obj/item/reagent_containers/cup/glass/bottle/juice/limejuice = 4,
 				/obj/item/reagent_containers/cup/glass/bottle/juice/orangejuice = 4,
@@ -57,8 +59,6 @@
 				/obj/item/reagent_containers/cup/soda_cans/sol_dry = 8,
 				/obj/item/reagent_containers/cup/soda_cans/cola = 8,
 				/obj/item/reagent_containers/cup/soda_cans/tonic = 8,
-				/obj/item/reagent_containers/cup/glass/bottle/hakka_mate = 5,
-				/obj/item/reagent_containers/cup/soda_cans/melon_soda = 5,
 			),
 		),
 
@@ -76,16 +76,16 @@
 	)
 
 	contraband = list(
+		/obj/item/reagent_containers/cup/glass/bottle/herbal_liqueur = 2,
 		/obj/item/reagent_containers/cup/glass/mug/tea = 12,
 		/obj/item/reagent_containers/cup/glass/bottle/fernet = 5,
-		/obj/item/reagent_containers/cup/glass/bottle/herbal_liqueur = 2,
 	)
 	premium = list(
+		/obj/item/reagent_containers/cup/glass/bottle/bitters = 5,
+		/obj/item/reagent_containers/cup/glass/bottle/herbal_liqueur = 2,
 		/obj/item/reagent_containers/cup/bottle/ethanol = 4,
 		/obj/item/reagent_containers/cup/glass/bottle/champagne = 5,
 		/obj/item/reagent_containers/cup/glass/bottle/trappist = 5,
-		/obj/item/reagent_containers/cup/glass/bottle/bitters = 5,
-		/obj/item/reagent_containers/cup/glass/bottle/herbal_liqueur = 2,
 	)
 
 	product_slogans = "I hope nobody asks me for a bloody cup o' tea...;Alcohol is humanity's friend. Would you abandon a friend?;Quite delighted to serve you!;Is nobody thirsty on this station?"


### PR DESCRIPTION
Re-alphabetized the incorrectly placed items from a few relatively recent PRs, and also moved grenadine to the non-alcoholic section
## About The Pull Request

Fixes a few annoying inconsistencies with how certain items in the booze-o-mat were organized. Specifically, moves grenadine, which is a non-alcoholic syrup, from the alcoholic section and into the non-alcoholic section. Additionally, a few bottles which were added in somewhat recent PRs and which had been simply appended at the end of the list after been properly moved to be alphabetized with the rest of the items.
## Why It's Good For The Game

UX consistency makes things easier to use and less confusing.
## Changelog
:cl:
qol: Bottles in the booze-o-mat vending machine have been re-alphabetized.
fix: Jester's Grenadine has been moved to the non-alcoholic section of the booze-o-mat.
/:cl:
