### PR TITLE
Fix deep fryers to be refillable

### DIFF
--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -118,6 +118,9 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	if(user.combat_mode)
 		return ITEM_INTERACT_SKIP_TO_ATTACK // allow a thwack
 
+	if(tool.is_drainable())
+		return NONE // pour it in
+
 	if(!reagents.has_reagent(/datum/reagent/consumable/nutriment/fat, check_subtypes = TRUE))
 		to_chat(user, span_warning("[src] has no fat or oil to fry with!"))
 		return ITEM_INTERACT_BLOCKING
@@ -125,9 +128,6 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	if(tool.resistance_flags & INDESTRUCTIBLE)
 		to_chat(user, span_warning("You don't feel it would be wise to fry [tool]..."))
 		return ITEM_INTERACT_BLOCKING
-
-	if(tool.is_drainable())
-		return NONE // pour it in
 
 	var/deepfry_blacklisted = is_type_in_typecache(tool, deepfry_blacklisted_items) || is_type_in_typecache(tool, GLOB.oilfry_blacklisted_items)
 	var/is_storage = !!tool.atom_storage


### PR DESCRIPTION

## About The Pull Request
- Fixes #96520

There was an early block interaction that prevented reagents from being inserted into the deep fryer if it was empty. You just needed to swap the order of the if statements so that refillable is higher precedence. 

## Why It's Good For The Game
Deep fryers now work again.

## Changelog
:cl:
fix: Fix deep fryer to be refillable
/:cl:
