### PR TITLE
Adds a config option to disable ascension for Heretics

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -52,6 +52,8 @@
 
 /datum/config_entry/flag/disable_warops
 
+/datum/config_entry/flag/disable_ascension
+
 /datum/config_entry/number/traitor_scaling_coeff //how much does the amount of players get divided by to determine traitors
 	default = 6
 	integer = FALSE

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -56,8 +56,8 @@
 	)
 	/// Whether or not the heretic can make unlimited blades, but unable to blade break to teleport
 	var/unlimited_blades = FALSE
-	/// Whether we are allowed to ascend
-	var/feast_of_owls = FALSE
+	/// Whether we are allowed to ascend, enabled in on_gain()
+	var/feast_of_owls = TRUE
 	/// Whether we give this antagonist objectives on gain.
 	var/give_objectives = TRUE
 	/// Whether we've ascended! (Completed one of the final rituals)
@@ -339,6 +339,8 @@
 	return ..()
 
 /datum/antagonist/heretic/on_gain()
+	if(!CONFIG_GET(flag/disable_ascension))
+		feast_of_owls = FALSE
 	generate_heretic_starting_knowledge(heretic_shops[HERETIC_KNOWLEDGE_START])
 	if(!length(path_info))
 		for(var/datum/heretic_knowledge_tree_column/path as anything in subtypesof(/datum/heretic_knowledge_tree_column))

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -56,8 +56,8 @@
 	)
 	/// Whether or not the heretic can make unlimited blades, but unable to blade break to teleport
 	var/unlimited_blades = FALSE
-	/// Whether we are allowed to ascend, enabled in on_gain()
-	var/feast_of_owls = TRUE
+	/// Whether we are allowed to ascend
+	var/feast_of_owls = FALSE
 	/// Whether we give this antagonist objectives on gain.
 	var/give_objectives = TRUE
 	/// Whether we've ascended! (Completed one of the final rituals)
@@ -339,8 +339,9 @@
 	return ..()
 
 /datum/antagonist/heretic/on_gain()
-	if(!CONFIG_GET(flag/disable_ascension))
-		feast_of_owls = FALSE
+	if(CONFIG_GET(flag/disable_ascension))
+		feast_of_owls = TRUE
+		adjust_knowledge_points(5)
 	generate_heretic_starting_knowledge(heretic_shops[HERETIC_KNOWLEDGE_START])
 	if(!length(path_info))
 		for(var/datum/heretic_knowledge_tree_column/path as anything in subtypesof(/datum/heretic_knowledge_tree_column))

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -149,7 +149,7 @@ ALLOW_LATEJOIN_ANTAGONISTS
 ## Uncomment to prevent the nuclear operative leader from getting the war declaration item
 #DISABLE_WAROPS
 
-## Uncomment to disable Heretic ascension
+## Uncomment to disable Heretic ascension, will give the heretic 5 knowledge points of compensation if enabled.
 #DISABLE_ASCENSION
 
 ## Uncomment to enable dynamic ruleset config file.

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -149,6 +149,9 @@ ALLOW_LATEJOIN_ANTAGONISTS
 ## Uncomment to prevent the nuclear operative leader from getting the war declaration item
 #DISABLE_WAROPS
 
+## Uncomment to disable Heretic ascension
+#DISABLE_ASCENSION
+
 ## Uncomment to enable dynamic ruleset config file.
 DYNAMIC_CONFIG_ENABLED
 


### PR DESCRIPTION

## About The Pull Request

Adds a config option to disable heretics from ascending, and gives them 5 points, essentially forcibly triggering feast of owls when a heretic is created. Defaults to off (so heretic ascension is enabled)

## Why It's Good For The Game

Server operators have more granular control over heretic rather than just hard disabling it entirely

## Changelog
:cl:
config: Heretics may now be configurably prevented from ascending
/:cl:
