### PR TITLE
[NO GBP] retrieve_stack should actually work with sand now...

### DIFF
--- a/code/datums/material/material_container.dm
+++ b/code/datums/material/material_container.dm
@@ -684,7 +684,8 @@
  */
 /datum/material_container/proc/retrieve_stack(stack_amt, datum/material/material, atom/target = null, atom/context = parent, alist/user_data)
 	//do we support sheets of this material
-	if(!material.sheet_type)
+	var/type_to_retrieve = material.sheet_type || material.ore_type
+	if(!type_to_retrieve)
 		return 0 //Add greyscale sheet handling here later
 	if(!can_hold_material(material))
 		return 0
@@ -703,7 +704,6 @@
 	//eject sheets based on available amount after each iteration
 	var/count = 0
 	while(stack_amt > 0)
-		var/type_to_retrieve = material.sheet_type || material.ore_type
 		//don't merge yet. we need to do stuff with it first
 		var/obj/item/stack/new_stack = new type_to_retrieve(target, min(stack_amt, MAX_STACK_SIZE), FALSE)
 		if(istype(new_stack, /obj/item/stack/sheet))


### PR DESCRIPTION

## About The Pull Request
I've checked retrieve_stack() again after looking at #96487 and I noticed that sand, well... it cannot be retrieved this way apparently, because there's a `!material.sheet_type` check at the start of the proc anyway, despite the rest of the proc supporting more generic stacks and not just sheets. I dunno if it was my fault, but I'm not bothering using git blame on that line.
## Why It's Good For The Game
Makes it possible to retrieve sand from lathes.
## Changelog
N/A it's a very minor thing, not worth the CL entry.