### PR TITLE
Instances of "god" in moodlet descriptions are replaced with the Chaplain's diety for the Chaplain (and their followers)

### DIFF
--- a/code/datums/mood_events/_mood_event.dm
+++ b/code/datums/mood_events/_mood_event.dm
@@ -98,7 +98,7 @@
 
 	add_effects(arglist(mood_args))
 	if(who.mind?.holy_role && GLOB.deity)
-		var/static/regex/god_regex = regex(@"(gods*)([\s.,:;!?]+)", "gi")
+		var/static/regex/god_regex = regex(@"\bgods?\b", "ig")
 		description = god_regex.Replace(description, "[GLOB.deity]$2")
 
 	mood_change = floor(mood_change)

--- a/code/datums/mood_events/_mood_event.dm
+++ b/code/datums/mood_events/_mood_event.dm
@@ -98,8 +98,8 @@
 
 	add_effects(arglist(mood_args))
 	if(who.mind?.holy_role && GLOB.deity)
-		replacetext(description, "god, ", "[GLOB.deity], ")
-		replacetext(description, "god ", "[GLOB.deity] ")
+		var/static/regex/god_regex = regex(@"(gods*)([\s.,:;!?]+)", "gi")
+		description = god_regex.Replace(description, "[GLOB.deity]$2")
 
 	mood_change = floor(mood_change)
 

--- a/code/datums/mood_events/_mood_event.dm
+++ b/code/datums/mood_events/_mood_event.dm
@@ -97,6 +97,9 @@
 			mood_change *= 0.75
 
 	add_effects(arglist(mood_args))
+	if(who.mind?.holy_role && GLOB.deity)
+		replacetext(description, "god, ", "[GLOB.deity], ")
+		replacetext(description, "god ", "[GLOB.deity] ")
 
 	mood_change = floor(mood_change)
 

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -304,7 +304,7 @@
 	event_flags = MOOD_EVENT_SPIRITUAL
 
 /datum/mood_event/sacrifice_good/add_effects(...)
-	if(owner.mind?.hold_role && GLOB.deity)
+	if(owner.mind?.holy_role && GLOB.deity)
 		description = "[GLOB.deity] is pleased with this offering!"
 
 /datum/mood_event/artok

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -303,6 +303,10 @@
 	timeout = 3 MINUTES
 	event_flags = MOOD_EVENT_SPIRITUAL
 
+/datum/mood_event/sacrifice_good/add_effects(...)
+	if(owner.mind?.hold_role && GLOB.deity)
+		description = "[GLOB.deity] is pleased with this offering!"
+
 /datum/mood_event/artok
 	description = "It's nice to see people are making art around here."
 	mood_change = 2


### PR DESCRIPTION
## About The Pull Request

Moodlet descriptions that mention god (as in "Oh god") are modifier for the Chaplain (and their followers), replacing "god" with their deity. 

## Why It's Good For The Game

So you get "Oh Space Jesus that's gross" instead of "Oh god that's gross". For maximum immersion. 

## Changelog

:cl: Melbert
spellcheck: Instances of "god" in moodlet descriptions are replaced with the Chaplain's deity for the Chaplain (and their followers)
/:cl:

