### PR TITLE
Fixes runtimes from cyborg "surgery"

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -13,7 +13,6 @@
 	health = 100
 	bubble_icon = "robot"
 	designation = "Default" //used for displaying the prefix & getting the current model of cyborg
-	has_limbs = TRUE
 	hud_type = /datum/hud/robot
 	unique_name = TRUE
 	mouse_drop_zone = TRUE


### PR DESCRIPTION

## About The Pull Request

Cyborgs do not have limbs or organs, why was this even set to TRUE in the first place? Its only used in surgery code and for string descriptions of where the mob was hit, which made zero sense for cyborgs in the latter case as well.

## Changelog
:cl:
fix: Fixed a bunch of runtimes caused when you try to perform surgery on cyborgs (which cannot be done in the first place)
/:cl:
