### PR TITLE
Fixes wraith cloaking module runtimes

### DIFF
--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -540,11 +540,16 @@
 /obj/item/mod/module/stealth/wraith/unstealth(datum/source)
 	if(!stealth_active)
 		return
-	. = ..()
-	if(mod.active)
-		COOLDOWN_START(src, recloak_timer, 20 SECONDS)
-		addtimer(CALLBACK(src, PROC_REF(start_stealth)), 20 SECONDS)
-		stealth_active = FALSE
+	to_chat(mod.wearer, span_warning("[src] gets discharged from contact!"))
+	do_sparks(2, TRUE, src)
+	drain_power(use_energy_cost)
+	// Don't deactivate() directly as the module may not be active in the first place when stealthing
+	on_deactivation()
+	if(!mod.active)
+		return
+	COOLDOWN_START(src, recloak_timer, 20 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(start_stealth)), 20 SECONDS)
+	stealth_active = FALSE
 
 /obj/item/mod/module/stealth/wraith/examine_more(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

The module was active but stealth itself was passive, so calling deactivate() would runtime as the module would not necessarily be active at this point.

## Changelog
:cl:
fix: Fixed wraith cloaking module runtimes
/:cl:
