### PR TITLE
Smooths arrow key and search snapping in TGUI list windows

### DIFF
--- a/tgui/packages/tgui/interfaces/ListInputWindow/ListInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/ListInputWindow/ListInputModal.tsx
@@ -33,18 +33,24 @@ export const ListInputModal = (props: ListInputModalProps) => {
     if (key === KEY_DOWN) {
       if (selected === null || selected === len) {
         setSelected(0);
-        document!.getElementById('0')?.scrollIntoView();
+        document!.getElementById('0')?.scrollIntoView({ behavior: 'smooth' });
       } else {
         setSelected(selected + 1);
-        document!.getElementById((selected + 1).toString())?.scrollIntoView();
+        document!
+          .getElementById((selected + 1).toString())
+          ?.scrollIntoView({ behavior: 'smooth' });
       }
     } else if (key === KEY_UP) {
       if (selected === null || selected === 0) {
         setSelected(len);
-        document!.getElementById(len.toString())?.scrollIntoView();
+        document!
+          .getElementById(len.toString())
+          ?.scrollIntoView({ behavior: 'smooth' });
       } else {
         setSelected(selected - 1);
-        document!.getElementById((selected - 1).toString())?.scrollIntoView();
+        document!
+          .getElementById((selected - 1).toString())
+          ?.scrollIntoView({ behavior: 'smooth' });
       }
     }
   };
@@ -71,7 +77,9 @@ export const ListInputModal = (props: ListInputModalProps) => {
     if (foundItem) {
       const foundIndex = items.indexOf(foundItem);
       setSelected(foundIndex);
-      document!.getElementById(foundIndex.toString())?.scrollIntoView();
+      document!
+        .getElementById(foundIndex.toString())
+        ?.scrollIntoView({ behavior: 'smooth' });
     }
   };
   // User types into search bar
@@ -81,7 +89,7 @@ export const ListInputModal = (props: ListInputModalProps) => {
     }
     setSearchQuery(query);
     setSelected(0);
-    document!.getElementById('0')?.scrollIntoView();
+    document!.getElementById('0')?.scrollIntoView({ behavior: 'smooth' });
   };
   // User presses the search button
   const onSearchBarToggle = () => {

--- a/tgui/packages/tgui/interfaces/SpawnSearch.tsx
+++ b/tgui/packages/tgui/interfaces/SpawnSearch.tsx
@@ -182,11 +182,15 @@ export function SpawnSearch() {
     if (key === KEY_DOWN) {
       const next = selected >= len ? 0 : selected + 1;
       setSelected(next);
-      document?.getElementById(next.toString())?.scrollIntoView();
+      document
+        ?.getElementById(next.toString())
+        ?.scrollIntoView({ behavior: 'smooth' });
     } else if (key === KEY_UP) {
       const prev = selected <= 0 ? len : selected - 1;
       setSelected(prev);
-      document?.getElementById(prev.toString())?.scrollIntoView();
+      document
+        ?.getElementById(prev.toString())
+        ?.scrollIntoView({ behavior: 'smooth' });
     }
   }
 
@@ -231,7 +235,7 @@ export function SpawnSearch() {
 
     setQuery(newQuery);
     setSelected(0);
-    document!.getElementById('0')?.scrollIntoView();
+    document!.getElementById('0')?.scrollIntoView({ behavior: 'smooth' });
   }
 
   // Grabs the cursor when no search bar is visible.


### PR DESCRIPTION

## About The Pull Request

TGUI list selectors and Spawn verb now use smooth scrolling with arrow keys or when using the searchbar, rather than instantly snapping to the selected element.

<img width="325" height="330" alt="iCHXgplljX" src="https://github.com/user-attachments/assets/9dfa87e3-740b-40a2-96ac-9769ca0b9482" />

(The gif has me using arrow keys)

## Why It's Good For The Game

Looks nicer

## Changelog
:cl:
qol: TGUI list selectors and Spawn verb now use smooth scrolling with arrow keys
/:cl:
