### PR TITLE
Fix `limbgrower/fullupgrade` having invalid designs

### DIFF
--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -345,4 +345,4 @@
 	for(var/id in SSresearch.techweb_designs)
 		var/datum/design/found_design = SSresearch.techweb_design_by_id(id)
 		if((found_design.build_type & LIMBGROWER) && !(RND_CATEGORY_HACKED in found_design.category))
-			imported_designs |= found_design.id
+			imported_designs[found_design.id] = TRUE


### PR DESCRIPTION

## About The Pull Request

The format for the `imported_designs` list is `"design id" = TRUE`, this code was making it a non-associated list and thus the buttons wouldn't work

## Why It's Good For The Game

Bug fix

## Changelog

N/A 
