### PR TITLE
Being given a nonfunctional skeleton arm no longer disables both hands

### DIFF
--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -434,6 +434,7 @@
 	limb_id = BODYPART_ID_BONE
 	// These are always disabled
 	disabling_threshold_percentage = 0
+	bodypart_disabled = TRUE
 
 /obj/item/bodypart/head/skeleton/nonfunctional/Initialize(mapload)
 	. = ..()
@@ -442,6 +443,7 @@
 /obj/item/bodypart/chest/skeleton/nonfunctional
 	limb_id = BODYPART_ID_BONE
 	disabling_threshold_percentage = 0
+	bodypart_disabled = TRUE
 
 /obj/item/bodypart/chest/skeleton/nonfunctional/Initialize(mapload)
 	. = ..()
@@ -460,6 +462,7 @@
 /obj/item/bodypart/arm/left/skeleton/nonfunctional
 	limb_id = BODYPART_ID_BONE
 	disabling_threshold_percentage = 0
+	bodypart_disabled = TRUE
 
 /obj/item/bodypart/arm/left/skeleton/nonfunctional/Initialize(mapload)
 	. = ..()
@@ -468,6 +471,7 @@
 /obj/item/bodypart/arm/right/skeleton/nonfunctional
 	limb_id = BODYPART_ID_BONE
 	disabling_threshold_percentage = 0
+	bodypart_disabled = TRUE
 
 /obj/item/bodypart/arm/right/skeleton/nonfunctional/Initialize(mapload)
 	. = ..()
@@ -476,6 +480,7 @@
 /obj/item/bodypart/leg/left/skeleton/nonfunctional
 	limb_id = BODYPART_ID_BONE
 	disabling_threshold_percentage = 0
+	bodypart_disabled = TRUE
 
 /obj/item/bodypart/leg/left/skeleton/nonfunctional/Initialize(mapload)
 	. = ..()
@@ -484,6 +489,7 @@
 /obj/item/bodypart/leg/right/skeleton/nonfunctional
 	limb_id = BODYPART_ID_BONE
 	disabling_threshold_percentage = 0
+	bodypart_disabled = TRUE
 
 /obj/item/bodypart/leg/right/skeleton/nonfunctional/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Being given a fresh nonfunctional skeleton arm no longer disables both hands, and also doesn't prevent two handed items from being used even after it's fixed. Also, presumably the same problem with legs.

The problem is that these limbs are disabled in that the moment `update_disabled()` is called they'll flip to disabled and stay there, but they're not already set to disabled. `update_disabled()` is called within `apply_ownership()` within `update_owner()` within `add_bodypart()`. So, when a limb is replaced with the nonfunctional skeleton arm, the following occurs:
- Initial limb torn off. Decrement `usable_arms`.
- `add_bodypart()` called, above chain goes down, `update_disabled()` called, because the limb isn't already disabled, it officially disables it and decrements `usable_arms` for a second time
- a few lines later, where new limbs are supposed to increment `usable_arms`, it doesn't because it's now officially disabled
- now you can't do anything because `usable_arms` is 0. Even when you get the limb fixed, usable_arms only increments once, so you're permanently locked out of two-handed items.

Setting all these nonfunctional limbs to disabled at base prevents the second decrement, fixing the problem.

## Why It's Good For The Game

having all of the organic tissue ripped off my arm all at once would probably make me unable to use my hands for a while too, but our spacemen are built stronger.

## Changelog
:cl:

fix: Being given a nonfunctional skeleton arm no longer disables both hands

/:cl:
