### PR TITLE
You can now fish mob parts and some mobs (brimdemons and legions) out of lava.

### DIFF
--- a/code/modules/fishing/sources/subtypes/mining_ruins.dm
+++ b/code/modules/fishing/sources/subtypes/mining_ruins.dm
@@ -53,24 +53,21 @@
 		FISHING_DUD = 5,
 		/obj/item/stack/ore/slag = 15,
 		/obj/item/fish/lavaloop = 15,
+		/obj/item/stack/sheet/animalhide/goliath_hide = 15,
+		/obj/item/stack/sheet/bone = 15,
+		/obj/item/stack/sheet/sinew = 15,
 		/obj/structure/closet/crate/necropolis/tendril = 1,
 		/obj/item/skeleton_key = 1,
 		/obj/item/stack/sheet/mineral/runite = 1,
 		/obj/effect/mob_spawn/corpse/human/charredskeleton = 1,
-		/obj/item/stack/sheet/animalhide/goliath_hide = 15,
 		/mob/living/basic/mining/legion=1,
-		/obj/item/stack/sheet/bone = 15,
 		/mob/living/basic/mining/brimdemon=1,
-		/obj/item/stack/sheet/sinew = 15,
 
 	)
 	fish_counts = list(
 		/obj/structure/closet/crate/necropolis/tendril = 1,
 		/obj/item/skeleton_key = 1,
 		/obj/item/stack/sheet/mineral/runite = 2,
-		/obj/item/stack/sheet/bone = 2,
-		/obj/item/stack/sheet/animalhide/goliath_hide = 1,
-		/obj/item/stack/sheet/sinew = 2,
 	)
 	fish_count_regen = list(
 		/obj/structure/closet/crate/necropolis/tendril = 27 MINUTES,

--- a/code/modules/fishing/sources/subtypes/mining_ruins.dm
+++ b/code/modules/fishing/sources/subtypes/mining_ruins.dm
@@ -60,8 +60,8 @@
 		/obj/item/skeleton_key = 1,
 		/obj/item/stack/sheet/mineral/runite = 1,
 		/obj/effect/mob_spawn/corpse/human/charredskeleton = 1,
-		/mob/living/basic/mining/legion=1,
-		/mob/living/basic/mining/brimdemon=1,
+		/mob/living/basic/mining/legion= 1,
+		/mob/living/basic/mining/brimdemon= 1,
 
 	)
 	fish_counts = list(

--- a/code/modules/fishing/sources/subtypes/mining_ruins.dm
+++ b/code/modules/fishing/sources/subtypes/mining_ruins.dm
@@ -57,11 +57,20 @@
 		/obj/item/skeleton_key = 1,
 		/obj/item/stack/sheet/mineral/runite = 1,
 		/obj/effect/mob_spawn/corpse/human/charredskeleton = 1,
+		/obj/item/stack/sheet/animalhide/goliath_hide = 15,
+		/mob/living/basic/mining/legion=1,
+		/obj/item/stack/sheet/bone = 15,
+		/mob/living/basic/mining/brimdemon=1,
+		/obj/item/stack/sheet/sinew = 15,
+
 	)
 	fish_counts = list(
 		/obj/structure/closet/crate/necropolis/tendril = 1,
 		/obj/item/skeleton_key = 1,
 		/obj/item/stack/sheet/mineral/runite = 2,
+		/obj/item/stack/sheet/bone = 2,
+		/obj/item/stack/sheet/animalhide/goliath_hide = 1,
+		/obj/item/stack/sheet/sinew = 2,
 	)
 	fish_count_regen = list(
 		/obj/structure/closet/crate/necropolis/tendril = 27 MINUTES,


### PR DESCRIPTION

## About The Pull Request

You can now fish watcher sinew, goliath hide, bones, legions, and brimdemons out of lava.

## Why It's Good For The Game

Right now its possible for lavaland resources to go totally extinct because of the tendril rework, this fixes that.
## Changelog

:cl:add
add:You can now fish mining mob parts and mining mobs out of lava
/:cl:add


