### PR TITLE
Add immunity checks for atmos traits for simple/basic mobs

### DIFF
--- a/code/datums/elements/atmos_requirements.dm
+++ b/code/datums/elements/atmos_requirements.dm
@@ -49,7 +49,7 @@
 	if(!isopenturf(target.loc))
 		return TRUE
 
-	var/can_breathe_vacuum = HAS_TRAIT(target, TRAIT_NO_BREATHLESS_DAMAGE)
+	var/can_breathe_vacuum = HAS_TRAIT(target, TRAIT_NO_BREATHLESS_DAMAGE) || HAS_TRAIT(target, TRAIT_NOBREATH)
 
 	var/min_oxy = can_breathe_vacuum ? 0 : atmos_requirements["min_oxy"]
 	var/min_plasma = can_breathe_vacuum ? 0 : atmos_requirements["min_plas"]

--- a/code/datums/elements/body_temp_sensitive.dm
+++ b/code/datums/elements/body_temp_sensitive.dm
@@ -49,7 +49,7 @@
 	var/mob/living/living_mob = target
 	var/gave_alert = FALSE
 
-	if(living_mob.bodytemperature < min_body_temp)
+	if(living_mob.bodytemperature < min_body_temp && !HAS_TRAIT(living_mob, TRAIT_RESISTCOLD))
 		living_mob.adjust_fire_loss(cold_damage * seconds_per_tick, forced = TRUE)
 		if(!living_mob.has_status_effect(/datum/status_effect/inebriated))
 			switch(cold_damage)
@@ -61,7 +61,7 @@
 					living_mob.throw_alert(ALERT_TEMPERATURE, /atom/movable/screen/alert/cold, 3)
 			gave_alert = TRUE
 
-	else if(living_mob.bodytemperature > max_body_temp)
+	else if(living_mob.bodytemperature > max_body_temp && !HAS_TRAIT(living_mob, TRAIT_RESISTHEAT))
 		living_mob.adjust_fire_loss(heat_damage * seconds_per_tick, forced = TRUE)
 		switch(heat_damage)
 			if(1 to 5)

--- a/code/modules/vehicles/cars/vim.dm
+++ b/code/modules/vehicles/cars/vim.dm
@@ -97,14 +97,6 @@
 	. = ..()
 	update_appearance()
 
-/obj/vehicle/sealed/car/vim/after_add_occupant(mob/living/basic_mob)
-	. = ..()
-	basic_mob.add_traits(list(TRAIT_WEATHER_IMMUNE, TRAIT_RESISTHEAT, TRAIT_RESISTCOLD, TRAIT_NOBREATH, TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHIGHPRESSURE), VEHICLE_TRAIT)
-
-/obj/vehicle/sealed/car/vim/after_remove_occupant(mob/living/basic_mob)
-	. = ..()
-	basic_mob.remove_traits(list(TRAIT_WEATHER_IMMUNE, TRAIT_RESISTHEAT, TRAIT_RESISTCOLD, TRAIT_NOBREATH, TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHIGHPRESSURE), VEHICLE_TRAIT)
-
 /obj/vehicle/sealed/car/vim/generate_actions()
 	initialize_controller_action_type(/datum/action/vehicle/sealed/climb_out/vim, VEHICLE_CONTROL_DRIVE)
 	initialize_controller_action_type(/datum/action/vehicle/sealed/noise/chime, VEHICLE_CONTROL_DRIVE)

--- a/code/modules/vehicles/cars/vim.dm
+++ b/code/modules/vehicles/cars/vim.dm
@@ -97,6 +97,14 @@
 	. = ..()
 	update_appearance()
 
+/obj/vehicle/sealed/car/vim/after_add_occupant(mob/living/basic_mob)
+	. = ..()
+	basic_mob.add_traits(list(TRAIT_WEATHER_IMMUNE, TRAIT_RESISTHEAT, TRAIT_RESISTCOLD, TRAIT_NOBREATH, TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHIGHPRESSURE), VEHICLE_TRAIT)
+
+/obj/vehicle/sealed/car/vim/after_remove_occupant(mob/living/basic_mob)
+	. = ..()
+	basic_mob.remove_traits(list(TRAIT_WEATHER_IMMUNE, TRAIT_RESISTHEAT, TRAIT_RESISTCOLD, TRAIT_NOBREATH, TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHIGHPRESSURE), VEHICLE_TRAIT)
+
 /obj/vehicle/sealed/car/vim/generate_actions()
 	initialize_controller_action_type(/datum/action/vehicle/sealed/climb_out/vim, VEHICLE_CONTROL_DRIVE)
 	initialize_controller_action_type(/datum/action/vehicle/sealed/noise/chime, VEHICLE_CONTROL_DRIVE)


### PR DESCRIPTION

## About The Pull Request

Slightly refactor the code to include heat/cold/breathing checks inside the atmos elements. 

Fun fact: there doesn't appear to be any way for basic/simple mobs to take pressure damage, but I still went ahead and added the relevant pressure protection just in case it changes in the future.

## Why It's Good For The Game

Better code.

## Changelog
:cl:
code: Add immunity checks for atmos traits for simple/basic mobs
/:cl:
