### PR TITLE
Fixes runtime in PAI door hacking

### DIFF
--- a/code/modules/pai/door_jack.dm
+++ b/code/modules/pai/door_jack.dm
@@ -114,6 +114,8 @@
 		balloon_alert(src, "failed! retracting...")
 		QDEL_NULL(hacking_cable)
 		return FALSE
+	if(!hacking_cable?.hacking_machine)
+		return FALSE
 	var/obj/machinery/door/door = hacking_cable.hacking_machine
 	balloon_alert(src, "success")
 	door.open()


### PR DESCRIPTION

## About The Pull Request

15 second `do_after()` with no checks upon completion

## Why It's Good For The Game

<img width="444" height="111" alt="image" src="https://github.com/user-attachments/assets/0b4fc218-860c-4a18-b107-4a0a95719c62" />

## Changelog
:cl:

fix: fixed a runtime when door hacking with a PAI

/:cl:
