### PR TITLE
ChemMaster QoL: Reusable Custom Transfer Amounts

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -33,7 +33,7 @@
 	/// Amount of layers which printed pills will be coated in
 	var/pill_layers = 3
 	/// Current custom transfer amount
-	var/custom_transfer_amount = 10
+	var/custom_transfer_amount = 15
 
 /obj/machinery/chem_master/Initialize(mapload)
 	create_reagents(100)

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -32,6 +32,8 @@
 	var/printing_speed = 0.75 SECONDS
 	/// Amount of layers which printed pills will be coated in
 	var/pill_layers = 3
+	/// Current custom transfer amount
+	var/custom_transfer_amount = 10
 
 /obj/machinery/chem_master/Initialize(mapload)
 	create_reagents(100)
@@ -281,6 +283,7 @@
 	.["selectedPillDuration"] = pill_layers
 	var/obj/item/held_item = user.get_active_held_item()
 	.["hasBeakerInHand"] = held_item?.is_chem_container() || FALSE
+	.["customTransferAmount"] = custom_transfer_amount
 
 	//contents of source beaker
 	var/list/beaker_data = null
@@ -412,6 +415,18 @@
 			if(container?.can_insert_container(ui.user, src))
 				replace_beaker(ui.user, container)
 
+			return TRUE
+
+		if("setCustomTransfer")
+			var/target = params["target"]
+			if(isnull(target))
+				return FALSE
+
+			target = text2num(target)
+			if(isnull(target))
+				return FALSE
+
+			custom_transfer_amount = clamp(target, 0, beaker.volume)
 			return TRUE
 
 		if("transfer")

--- a/tgui/packages/tgui/interfaces/ChemMaster.tsx
+++ b/tgui/packages/tgui/interfaces/ChemMaster.tsx
@@ -392,6 +392,18 @@ const ReagentEntry = (props: ReagentProps) => {
           onClick={() =>
             act('transfer', {
               reagentRef: chemical.ref,
+              amount: customTransferAmount,
+              target: transferTo,
+            })
+          }
+        >
+          {customTransferAmount}
+        </Button>
+        <Button
+          disabled={isPrinting}
+          onClick={() =>
+            act('transfer', {
+              reagentRef: chemical.ref,
               amount: 1000,
               target: transferTo,
             })
@@ -399,18 +411,6 @@ const ReagentEntry = (props: ReagentProps) => {
         >
           All
         </Button>
-        <Button
-          icon="ellipsis-v"
-          tooltip="Use custom"
-          disabled={isPrinting}
-          onClick={() =>
-            act('transfer', {
-              reagentRef: chemical.ref,
-              amount: customTransferAmount,
-              target: transferTo,
-            })
-          }
-        />
         <Button
           icon="ellipsis-h"
           tooltip="Custom amount"

--- a/tgui/packages/tgui/interfaces/ChemMaster.tsx
+++ b/tgui/packages/tgui/interfaces/ChemMaster.tsx
@@ -53,6 +53,7 @@ type AnalyzableBeaker = {
 type Data = {
   categories: Category[];
   isPrinting: BooleanLike;
+  customTransferAmount: number;
   printingProgress: number;
   printingTotal: number;
   selectedPillDuration: number;
@@ -97,6 +98,7 @@ const ChemMasterContent = (props: {
   const { act, data } = useBackend<Data>();
   const {
     isPrinting,
+    customTransferAmount,
     printingProgress,
     printingTotal,
     selectedPillDuration,
@@ -126,6 +128,22 @@ const ChemMasterContent = (props: {
               <Box inline color="label" mr={2}>
                 <AnimatedNumber value={beaker.currentVolume} initial={0} />
                 {` / ${beaker.maxVolume} units`}
+              </Box>
+              <Box inline color="label" mr={2}>
+                <NumberInput
+                  width="55px"
+                  unit="u"
+                  step={5}
+                  stepPixelSize={3}
+                  value={customTransferAmount}
+                  minValue={0}
+                  maxValue={beaker.maxVolume}
+                  onChange={(value) =>
+                    act('setCustomTransfer', {
+                      target: value,
+                    })
+                  }
+                />
               </Box>
               <Button icon="eject" onClick={() => act('eject')}>
                 Eject
@@ -324,7 +342,7 @@ type ReagentProps = {
 const ReagentEntry = (props: ReagentProps) => {
   const { data, act } = useBackend<Data>();
   const { chemical, transferTo, analyze } = props;
-  const { isPrinting } = data;
+  const { isPrinting, customTransferAmount } = data;
   return (
     <Table.Row key={chemical.ref}>
       <Table.Cell color="label">
@@ -381,6 +399,18 @@ const ReagentEntry = (props: ReagentProps) => {
         >
           All
         </Button>
+        <Button
+          icon="ellipsis-v"
+          tooltip="Use custom"
+          disabled={isPrinting}
+          onClick={() =>
+            act('transfer', {
+              reagentRef: chemical.ref,
+              amount: customTransferAmount,
+              target: transferTo,
+            })
+          }
+        />
         <Button
           icon="ellipsis-h"
           tooltip="Custom amount"


### PR DESCRIPTION
## About The Pull Request

https://github.com/user-attachments/assets/a6c6d3d9-3284-4a45-80c4-14dbc4956cf8

Adds custom transfer amount functionality to the ChemMaster UI through a number input (by the eject button) and paired button.

## Why It's Good For The Game

If I have to hit the one-off custom transfer button, several times in a row, for my artisanal chemical atrocities one more time, I'm going to lose it.

Less-jokingly, maybe someone has some oddly specific mixing things they need it for (I know I do!).

## Changelog

:cl:
qol: ChemMasters now have on-the-fly custom transfer amount support. Set it with the number input by the eject button. One-time custom transfer amounts remain usable with the horizontal ellipsis button.
/:cl:
