### PR TITLE
Add root `node_modules` folder to `TguiCleanTarget`

### DIFF
--- a/tools/build/build.ts
+++ b/tools/build/build.ts
@@ -408,6 +408,7 @@ export const AllTarget = new Juke.Target({
 
 export const TguiCleanTarget = new Juke.Target({
   executes: async () => {
+    Juke.rm('node_modules', { recursive: true });
     Juke.rm('tgui/public/.tmp', { recursive: true });
     Juke.rm('tgui/public/*.map');
     Juke.rm('tgui/public/*.{chunk,bundle,hot-update}.*');


### PR DESCRIPTION

## About The Pull Request

The repo has a `node_modules` folder in the root directory for the prettier and biome executables, this directory should be included in the clean target because it's a build artifact and sometimes it needs to be deleted and rebuilt (I just had to do it to get my biome version to update)

## Why It's Good For The Game

Clean should clean

## Changelog

N/A
