### PR TITLE
Fix build script always recompiling `dm` target

### DIFF
--- a/code/controllers/subsystem/greyscale_previews.dm
+++ b/code/controllers/subsystem/greyscale_previews.dm
@@ -204,12 +204,10 @@ SUBSYSTEM_DEF(greyscale_previews)
 	#endif
 
 	var/filepath = "icons/map_icons/[filename].dmi"
-#ifdef UNIT_TESTS
 	var/old_md5 = rustg_hash_file(RUSTG_HASH_MD5, filepath)
-#endif
-	fcopy(holder, filepath)
-#ifdef UNIT_TESTS
-	var/new_md5 = rustg_hash_file(RUSTG_HASH_MD5, filepath)
+	var/new_md5 = rustg_hash_file(RUSTG_HASH_MD5, holder)
 	if(old_md5 != new_md5)
+		fcopy(holder, filepath)
+#ifdef UNIT_TESTS
 		stack_trace("Generated map icons were different than what is currently saved. If you see this in a CI run it means you need to run the game once through initialization and commit the resulting files in 'icons/map_icons/'")
 #endif


### PR DESCRIPTION

## About The Pull Request

Juke is supposed to use file modification times to decide whether a target needs to be rebuilt, this isn't working because the Greyscale Previews system always replaces the DMIs in `icons/map_icons` even if they haven't changed, so everything in that folder will end up with a more recent modification time than the DMB. Tweaks the code so that the copy only happens if the file has changed

## Why It's Good For The Game

If I'm doing debugging that requires repeatedly launching the server with no code modifications in between, it'd be nice to not have to wait for a pointless compilation every time

## Changelog

N/A
