### PR TITLE
Proofreads all chaplain sects

### DIFF
--- a/code/modules/religion/burdened/burdened_trauma.dm
+++ b/code/modules/religion/burdened/burdened_trauma.dm
@@ -2,7 +2,7 @@
 /datum/brain_trauma/special/burdened
 	name = "Flagellating Compulsions"
 	desc = "Patient feels compelled to injure themselves in various incapacitating and horrific ways. \
-		There seems to be an odd genetic... trigger, following these compulsions may lead to?"
+		There seems to be an odd genetic \"sequence\" gradually expressed upon following these compulsions."
 	scan_desc = "damaged frontal lobe"
 	symptoms = "Experiences an overwhelming compulsion to self-harm, often engaging in behaviors that lead to significant physical injury. \
 		This compulsion is driven by an intense psychological need to feel pain and suffering, \

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -1,6 +1,6 @@
 /obj/item/organ/brain/psyker
 	name = "psyker brain"
-	desc = "This brain is blue, split into two hemispheres, and has immense psychic powers. What kind of monstrosity would use that?"
+	desc = "This brain is blue, split into two hemispheres, and aflush with psychic power. What kind of monstrosity would use this?"
 	icon_state = "brain-psyker"
 	actions_types = list(
 		/datum/action/cooldown/spell/pointed/psychic_projection,
@@ -249,7 +249,7 @@
 
 /datum/action/cooldown/spell/pointed/psychic_projection
 	name = "Psychic Projection"
-	desc = "Project your psychics into a target to warp their view, and instill absolute terror that will cause them to fire their gun rapidly."
+	desc = "Project your psyche into a target to warp their view and instill absolute terror. This will cause them to fire any held gun rapidly."
 	ranged_mousepointer = 'icons/effects/mouse_pointers/cult_target.dmi'
 	button_icon_state = "blind"
 	school = SCHOOL_PSYCHIC

--- a/code/modules/religion/deaconize.dm
+++ b/code/modules/religion/deaconize.dm
@@ -5,8 +5,8 @@
  */
 /datum/religion_rites/deaconize
 	name = "Deaconize"
-	desc = "Converts someone to your sect. They must be willing, so the first invocation will instead prompt them to join. \
-		They will gain the same holy abilities as you, this is a one-time use so make sure they are worthy!"
+	desc = "Converts someone to your sect. They must be willing, so the first invocation will only prompt them to join. \
+		They will gain the same holy abilities as you. This is a one-time use rite, so make sure they are worthy!"
 	ritual_length = 30 SECONDS
 	ritual_invocations = list(
 		"A good, honorable person has been brought here by faith ...",
@@ -41,7 +41,7 @@
 	//no one invited or this is not the invited person
 	if(!potential_deacon || (possible_deacon != potential_deacon))
 		INVOKE_ASYNC(src, PROC_REF(invite_deacon), possible_deacon)
-		to_chat(user, span_notice("They have been offered the oppertunity to join our ranks. Wait for them to decide and try again."))
+		to_chat(user, span_notice("They have been offered the opportunity to join our ranks. Wait for them to decide and try again."))
 		return FALSE
 	return ..()
 
@@ -64,7 +64,7 @@
 	var/datum/brain_trauma/special/honorbound/honor = user.has_trauma_type(/datum/brain_trauma/special/honorbound)
 	if(honor && (potential_deacon in honor.guilty))
 		honor.guilty -= potential_deacon
-	to_chat(user, span_notice("[GLOB.deity] has bound [potential_deacon] to the code! They are now a holy role! (albeit the lowest level of such)"))
+	to_chat(user, span_notice("[GLOB.deity] has bound [potential_deacon] to the code! They are now a holy role (albeit the lowest level of such)!"))
 	potential_deacon.mind.set_holy_role(HOLY_ROLE_DEACON)
 	GLOB.religious_sect.on_conversion(potential_deacon)
 	playsound(get_turf(religious_tool), 'sound/effects/pray.ogg', 50, TRUE)
@@ -85,7 +85,7 @@
  * If they accept, the deaconize rite can now recruit them instead of just offering more invites.
  */
 /datum/religion_rites/deaconize/proc/invite_deacon(mob/living/carbon/human/invited)
-	var/ask = tgui_alert(invited, "Join [GLOB.deity]? You will be expected to follow the Chaplain's order.", "Invitation", list("Yes", "No"), 60 SECONDS)
+	var/ask = tgui_alert(invited, "Join [GLOB.deity]? You will be expected to follow the chaplain's order.", "Invitation", list("Yes", "No"), 60 SECONDS)
 	if(ask != "Yes")
 		return
 	potential_deacon = invited

--- a/code/modules/religion/dreams/banish_nightmare.dm
+++ b/code/modules/religion/dreams/banish_nightmare.dm
@@ -1,14 +1,14 @@
 /datum/religion_rites/banish_nightmare
 	name = "Banish Nightmare"
-	desc = "Banish the corpse of a Nightmare or its heart back from whence it came, protecting the dreams of \
-		the station and earning favor. If a heart is present, you will be rewarded with a special blessing."
+	desc = "Banish the corpse of a Nightmare (or its heart) back from whence it came. In protecting the dreams of \
+		the station, you will earn favor. If a heart is present, you will be rewarded with a special blessing."
 	favor_cost = 0
 	ritual_length = 20 SECONDS
 
 /datum/religion_rites/banish_nightmare/New()
 	. = ..()
 	ritual_invocations = list(
-		"We have bested a terrible Nightmare that plagued our station!..",
+		"We have bested a terrible Nightmare, a plague upon our station!..",
 		"With the power of [GLOB.deity], we cast it out!..",
 		"This invader of dreams has no place here...",
 		"May it trouble our flock no longer.",
@@ -27,7 +27,7 @@
 			break
 
 	if(!has_nightmare)
-		to_chat(user, span_warning("There is no corpse or heart of a Nightmare to banish!"))
+		to_chat(user, span_warning("There is no Nightmare corpse or heart to banish!"))
 		return FALSE
 
 	return ..()

--- a/code/modules/religion/dreams/deaconize_dreamer.dm
+++ b/code/modules/religion/dreams/deaconize_dreamer.dm
@@ -1,5 +1,5 @@
 /datum/religion_rites/deaconize/dreamers
-	desc = "Converts someone to your sect. They must be willing, so the first invocation will instead prompt them to join. \
+	desc = "Converts someone to your sect. They must be willing, so the first invocation will only prompt them to join. \
 		They will gain the same holy abilities as you. You can deaconize up to three followers, so choose wisely!"
 	rite_flags = parent_type::rite_flags & ~RITE_ONE_TIME_USE
 

--- a/code/modules/religion/dreams/dream_portent.dm
+++ b/code/modules/religion/dreams/dream_portent.dm
@@ -177,7 +177,7 @@
 				heretic_text += "countless warriors grappling in an endless war"
 				heretic_text += "the sound of clashing steel and cries of the fallen fill the air"
 			if(PATH_LOCK)
-				heretic_text += "beyond it, you see an endless " + "[prob(10) ? "furniture store" : "labyrinth"]"
+				heretic_text += "beyond it, you see an endless labyrinth"
 				heretic_text += "the walls shifting and changing as you navigate it"
 				heretic_text += "no matter which turn you take, you cannot find an exit"
 			if(PATH_MOON)

--- a/code/modules/religion/dreams/dream_portent.dm
+++ b/code/modules/religion/dreams/dream_portent.dm
@@ -136,7 +136,7 @@
 				list("you have a terrible nightmare", "filled with indescribable horrors", "leaving you with a lingering sense of dread"),
 				list("you have a terrible nightmare", "filled with visions of your own death", "leaving you with a lingering sense of doom"),
 				list("you have a terrible nightmare", "filled with horrible memories of your past", "leaving you with a lingering sense of sadness"),
-				list("you have a terrible nightmare", "filled with fear of the unknown", "leaving you with a lingering sense of anxiety"),
+				list("you have a terrible nightmare", "filled with the influence of an uncertain presence", "leaving you with a lingering sense of anxiety"),
 				list("you have a terrible nightmare", "filled with stabbing pain and suffocating darkness", "leaving you with a lingering sense of panic"),
 			))
 
@@ -154,7 +154,7 @@
 				"a great [IS_HERETIC(dreamer) ? "force" : "evil"] locked away for good",
 			)
 
-		var/list/heretic_text = list("the doors of the Mansus loom ahead of you", "intricately decorated - and ajar", "you look through the crack")
+		var/list/heretic_text = list("the doors of the Mansus loom ahead of you", "intricately decorated and ajar", "you look through the crack")
 		switch(prob(75) ? heretic.heretic_path.route : null)
 			if(PATH_ASH)
 				heretic_text += "beyond it, you see a barren wasteland"
@@ -177,7 +177,7 @@
 				heretic_text += "countless warriors grappling in an endless war"
 				heretic_text += "the sound of clashing steel and cries of the fallen fill the air"
 			if(PATH_LOCK)
-				heretic_text += "beyond it, you see an endless labyrinth"
+				heretic_text += "beyond it, you see an endless " + "[prob(10) ? "furniture store" : "labyrinth"]"
 				heretic_text += "the walls shifting and changing as you navigate it"
 				heretic_text += "no matter which turn you take, you cannot find an exit"
 			if(PATH_MOON)
@@ -186,7 +186,7 @@
 				heretic_text += "you can't shake the feeling something is wrong"
 			else
 				heretic_text += "what lies beyond cannot be comprehended"
-				heretic_text += "the sheer magnitude of overwhelms you"
+				heretic_text += "the sheer magnitude of it overwhelms you"
 				heretic_text += "you feel a strange mix of awe and terror"
 
 		return heretic_text
@@ -226,7 +226,7 @@
 			"a robed figure manifests in your dream",
 			"they introduce themselves as the magician",
 			"a demonstration of their powers leaves you in awe",
-			"they leave as suddenly as they arrived",
+			"they depart as suddenly as they arrived",
 		)
 
 	for(var/obj/machinery/nuclearbomb/bomb as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/nuclearbomb))
@@ -235,7 +235,7 @@
 				list("you see", "a supernova", "bright and blinding", "consuming everything in an instant"),
 				list("you see", "a mushroom cloud on the horizon", "a sign of devastation and ruin"),
 				list("you see", "a ticking clock", "counting down to an inevitable disaster"),
-				list("you see", "a looming tower atop a rocky mountain", "a lightning strikes it, bringing it down", "a sign of imminent calamity"),
+				list("you see", "a looming tower atop a rocky mountain", "lightning strikes, bringing it down", "this reads as active calamity"),
 			))
 
 	for(var/obj/item/disk/nuclear/nuke_disk as anything in SSpoints_of_interest.real_nuclear_disks)
@@ -243,9 +243,9 @@
 		if(!istype(disk_loc, /area/station) && !istype(disk_loc, /area/space))
 			return pick(list(
 				list("you see", "a dying star", "slowly dimming", "on the verge of collapse"),
-				list("you see", "a fool, dancing aimlessly", "they holds a ticking bomb", "a sign of recklessness"),
-				list("you see", "a hanging man", "swaying gently in the breeze", "a sign of surrender"),
-				list("you see", "a looming tower atop a rocky mountain", "it rains heavily around you", "a sign of calamity"),
+				list("you see", "a fool, dancing aimlessly", "they hold a ticking bomb", "a sign of recklessness"),
+				list("you see", "an inverted man", "swaying gently by one ankle", "this reads as suspense"),
+				list("you see", "a looming tower atop a rocky mountain", "it rains heavily, there is distant thunder", "this reads as imminent calamity"),
 			))
 
 	for(var/mob/living/carbon/human/clone as anything in GLOB.human_list)
@@ -276,9 +276,9 @@
 				if(PATH_FLESH)
 					return list("you see", "a legion of amalgamations ahead", "twisted and grotesque", "marching in unison towards an unknown destination")
 				if(PATH_VOID)
-					return list("you see", "nothingness ahead", "a void that seems to swallow all light and hope", "the silence deafening and oppressive")
+					return list("you see", "nothing", "a void that seems to swallow all light and hope", "the silence deafening and oppressive")
 				if(PATH_COSMIC)
-					return list("you see", "the birth of a new star", "radiant and full of potential", "an awe-inspiring sight")
+					return list("you see", "the birth of a new star", "radiant and reaching out", "you are not alone")
 				if(PATH_BLADE)
 					return list("you see", "a towering fortress ahead", "its walls lined with stalwart defenders", "each and every one bowing in respect to you")
 				if(PATH_LOCK)
@@ -351,7 +351,7 @@
 					list("you find yourself", "in an old city", "still bustling with activity", "but with an omnipresent feel of decay"),
 				))
 			if(3)
-				return list("you find yourself", "in a burning city", "flames reaching high", "but everyone doing their best to survive")
+				return list("you find yourself", "in a burning city", "flames reaching high", "but with everyone doing their best to survive")
 			if(4)
 				return list("you find yourself", "in a chaotic battlefield", "with no clear sides or victors", "only endless conflict and suffering")
 

--- a/code/modules/religion/dreams/dream_projection.dm
+++ b/code/modules/religion/dreams/dream_projection.dm
@@ -1,17 +1,18 @@
 /datum/religion_rites/dream_projection
 	name = "Dream Projection"
 	desc = "Astrally project your dream consciousness into the mind of one of your followers. \
-		While projecting, you are asleep, and can communicate with only and see through the eyes of the chosen follower, \
-		but cannot interact with the world in any way. The projection can be ended at any time, \
-			ends if you are woken up or attacked, and ends if the follower dies."
+		While projecting, you are asleep, and can see through the eyes of the chosen follower. \
+		They alone can hear you, and you cannot interact with the world in any way. \
+		The projection can be ended at any time, but it will end early if you are woken up, if you are attacked, \
+		or if the follower dies."
 	favor_cost = 100
 	ritual_length = 15 SECONDS
 
 /datum/religion_rites/dream_projection/New()
 	. = ..()
 	ritual_invocations = list(
-		"A member of the flock has gone astray, lost in the waking world...",
-		"It is the duty of the shepherd to guide them back to the fold, even if they cannot find their way themselves...",
+		"A member of our flock has gone astray, lost in the waking world...",
+		"It is the duty of the shepherd to guide those who cannot find their way...",
 		"Let me walk through their waking dream, and show them the way back...",
 	)
 
@@ -166,6 +167,7 @@
 /mob/eye/imaginary_friend/dream_projection/greet()
 	return
 
+// The IC tab was removed recently as of commenting. This should probably be adjusted.
 /mob/eye/imaginary_friend/dream_projection/verb/stop_projection()
 	set category = "IC"
 	set name = "Stop Projection"

--- a/code/modules/religion/festival/festival_violin.dm
+++ b/code/modules/religion/festival/festival_violin.dm
@@ -24,6 +24,6 @@
 	analysis += span_revenbignotice("[src] speaks to you...")
 	analysis += span_revennotice("\"This song has <b>[song.lines.len]</b> lines and a tempo of <b>[song.tempo]</b>.\"")
 	analysis += span_revennotice("\"Multiplying these together gives a song length of <b>[song_length]</b>.\"")
-	analysis += span_revennotice("\"To get a bonus effect from [GLOB.deity] upon finishing a performance, you need a song length of <b>[FESTIVAL_SONG_LONG_ENOUGH]</b>.\"")
+	analysis += span_revennotice("\"To get a finishing effect from [GLOB.deity], your songs must conclude with a length of <b>[FESTIVAL_SONG_LONG_ENOUGH]</b>.\"")
 
 	to_chat(playing_song, analysis.Join("\n"))

--- a/code/modules/religion/festival/instrument_rites.dm
+++ b/code/modules/religion/festival/instrument_rites.dm
@@ -15,10 +15,10 @@
 
 /datum/religion_rites/portable_song_tuning
 	name = "Portable Song Tuning"
-	desc = "Empowers an instrument on the table to work as a portable altar for tuning songs. Will need to be recharged after 5 rites."
+	desc = "Empowers a provided instrument to work as a portable altar for tuning songs. It will need to be recharged after five rites."
 	ritual_length = 6 SECONDS
 	ritual_invocations = list("Allow me to bring your holy inspirations ...")
-	invoke_msg = "... And send them with the winds my tunes ride with!"
+	invoke_msg = "... And send them with the winds my tunes ride!"
 	favor_cost = 10
 	///instrument to empower
 	var/obj/item/instrument/instrument_target
@@ -149,7 +149,7 @@
 
 /datum/religion_rites/song_tuner/nullwave
 	name = "Nullwave Vibrato"
-	desc = "Sing a dull song, protecting those who listen from magic."
+	desc = "Sing a dull song, protecting listeners from magic."
 	particles_path = /particles/musical_notes/nullwave
 	song_invocation_message = "You've prepared an antimagic song!"
 	song_start_message = span_nicegreen("This music makes you feel protected!")
@@ -161,7 +161,7 @@
 
 /datum/religion_rites/song_tuner/pain
 	name = "Murderous Chord"
-	desc = "Sing a sharp song, cutting those around you. Works less effectively on fellow priests. At the end of the song, you'll open the wounds of all listeners."
+	desc = "Sing a sharp song, cutting those around you. Works less effectively on fellow priests. At the end of the song, you'll open dozens of cuts on all listeners."
 	particles_path = /particles/musical_notes/harm
 	song_invocation_message = "You've prepared a painful song!"
 	song_start_message = span_danger("This music cuts like a knife!")
@@ -181,7 +181,7 @@
 
 /datum/religion_rites/song_tuner/lullaby
 	name = "Spiritual Lullaby"
-	desc = "Sing a lullaby, tiring those around you, making them slower. At the end of the song, you'll put people who are tired enough to sleep."
+	desc = "Sing a lullaby, tiring and slowing those around you. At the end of the song, you'll lull all listeners to sleep."
 	particles_path = /particles/musical_notes/sleepy
 	song_invocation_message = "You've prepared a sleepy song!"
 	song_start_message = span_warning("This music's making you feel drowsy...")

--- a/code/modules/religion/honorbound/honorbound_rites.dm
+++ b/code/modules/religion/honorbound/honorbound_rites.dm
@@ -84,7 +84,7 @@
 	<br>
 	2.) Thou shalt not attack the just!<br>
 	Those who fight for justice and good must not be harmed. Security is uncorruptable and must
-	be respected. Healers are mostly uncorruptable and if you are truly sure Medical has fallen
+	be respected. Healers are mostly uncorruptable, and if you are truly sure medical has fallen
 	to the scourge of evil, use a declaration of evil.
 	<br>
 	<br>
@@ -98,7 +98,7 @@
 	4.) Thou shalt not use profane magicks!<br>
 	You are not a warlock, you are an honorable warrior. There is nothing more corruptive than
 	the vile magicks used by witches, warlocks, and necromancers. There are exceptions to this rule.<br>
-	You may use holy magic, and, if you recruit one, the mime may use holy mimery. Restoration has also
+	You may use holy magic, and (if you recruit one) a mime may use holy mimery. Restoration has also
 	been allowed as it is a school focused on the light and mending of this world.
 	"}
 	return ..()
@@ -117,7 +117,7 @@
  */
 /datum/religion_rites/deaconize/crusader
 	name = "Join Crusade"
-	desc = "Converts someone to your sect. They must be willing, so the first invocation will instead prompt them to join. \
+	desc = "Converts someone to your sect. They must be willing, so the first invocation will only prompt them to join. \
 	They will become honorbound like you, and you will gain a massive favor boost!"
 	ritual_length = 30 SECONDS
 	ritual_invocations = list(

--- a/code/modules/religion/honorbound/honorbound_trauma.dm
+++ b/code/modules/religion/honorbound/honorbound_trauma.dm
@@ -221,7 +221,7 @@
 
 /datum/action/cooldown/spell/pointed/declare_evil
 	name = "Declare Evil"
-	desc = "If someone is so obviously an evil of this world you can spend a huge amount of favor to declare them guilty."
+	desc = "If someone is so obviously an evil of this world then you can spend a huge amount of favor to declare them guilty."
 	button_icon_state = "declaration"
 	ranged_mousepointer = 'icons/effects/mouse_pointers/honorbound.dmi'
 

--- a/code/modules/religion/pyre/pyre_rites.dm
+++ b/code/modules/religion/pyre/pyre_rites.dm
@@ -10,7 +10,7 @@
 	name = "Unmelting Protection"
 	desc = "Grants fire immunity to any piece of clothing."
 	ritual_length = 12 SECONDS
-	ritual_invocations = list("And so to support the holder of the Ever-Burning candle ...",
+	ritual_invocations = list("And so to support the holder of the Ever-Burning Candle ...",
 	"... allow this unworthy apparel to serve you ...",
 	"... make it strong enough to burn a thousand times and more ...")
 	invoke_msg = "... Come forth in your new form, and join the unmelting wax of the one true flame!"
@@ -43,7 +43,7 @@
 
 /datum/religion_rites/burning_sacrifice
 	name = "Burning Offering"
-	desc = "Sacrifice a buckled burning or husked corpse for favor, the more burn damage the corpse has the more favor you will receive."
+	desc = "Sacrifice a buckled burning or husked corpse for favor. The more burn damage the corpse has the more favor you will receive."
 	ritual_length = 15 SECONDS
 	ritual_invocations = list("Burning body ...",
 	"... cleansed by the flame ...",
@@ -100,7 +100,7 @@
 
 /datum/religion_rites/infinite_candle
 	name = "Immortal Candles"
-	desc = "Creates 5 candles that never run out of wax."
+	desc = "Create five unextinguishable candles that never run out of wax."
 	ritual_length = 10 SECONDS
 	invoke_msg = "Burn bright, little candles, for you will only extinguish along with the universe."
 	favor_cost = 200
@@ -118,7 +118,7 @@
 	desc = "Enchants a holy arrow to set someone on fire on hit, or if the victim is already on fire... note, this consumes the arrow."
 	ritual_length = 15 SECONDS
 	ritual_invocations = list(
-		"And so to keep the Ever-Burning candle protected ...",
+		"And so to keep the Ever-Burning Candle protected ...",
 		"... grant this feeble bolt your blessing ...",
 		"... make it burn bright ...",
 	)

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -513,7 +513,7 @@
 
 /datum/religion_sect/music
 	name = "Festival God"
-	quote = "Everything follows a rhythm- The heartbeat of the universe!"
+	quote = "Everything follows a rhythm: the heartbeat of the universe!"
 	desc = "Make wonderful music! Sooth or serrate your friends and foes with the beat."
 	tgui_icon = "music"
 	altar_icon_state = "convertaltar-festival"

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -79,7 +79,7 @@
 
 /datum/religion_rites/synthconversion
 	name = "Synthetic Conversion"
-	desc = "Convert a human-esque individual into a (superior) Android. Buckle a human to convert them, otherwise it will convert you."
+	desc = "Convert a humanoid individual into a (superior) android. Buckle a human to convert them, otherwise this rite will convert you."
 	ritual_length = 30 SECONDS
 	ritual_invocations = list("By the inner workings of our god ...",
 						"... We call upon you, in the face of adversity ...",
@@ -202,8 +202,8 @@
 	. = ..()
 
 /datum/religion_rites/greed/vendatray
-	name = "Purchase Vend-a-tray"
-	desc = "Summons a Vend-a-tray. You can use it to sell items!"
+	name = "Purchase Vend-A-Tray"
+	desc = "Summons a vend-a-tray. You can use it to sell items!"
 	invoke_msg = "I need a vend-a-tray to make some more money!"
 	money_cost = 300
 
@@ -234,8 +234,8 @@
 	desc = "Begin your metamorphasis into a being more fit for Maintenance."
 	ritual_length = 10 SECONDS
 	ritual_invocations = list("I abandon the world ...",
-	"... to become one with the deep.",
-	"My form will become twisted ...")
+	"... to become one with the deep ...",
+	"... My form will become twisted ...")
 	invoke_msg = "... but my smile I will keep!"
 	favor_cost = 150 //150u of organic slurry
 
@@ -325,7 +325,7 @@
 
 /datum/religion_rites/ritual_totem
 	name = "Create Ritual Totem"
-	desc = "Creates a Ritual Totem, a portable tool for performing rites on the go. Requires wood. Can only be picked up by the holy."
+	desc = "Creates a ritual totem, a portable tool for performing rites on the go. Requires wood. Can only be picked up by the holy."
 	favor_cost = 100
 	invoke_msg = "Padala!!"
 	///the food that will be molded, only one per rite
@@ -335,7 +335,7 @@
 	for(var/obj/item/stack/sheet/mineral/wood/could_totem in get_turf(religious_tool))
 		converted = could_totem //totemify this o great one
 		return ..()
-	to_chat(user, span_warning("You need at least 1 wood to do this!"))
+	to_chat(user, span_warning("You need a piece of wood to do this!"))
 	return FALSE
 
 /datum/religion_rites/ritual_totem/invoke_effect(mob/living/user, atom/movable/religious_tool)
@@ -418,7 +418,7 @@
 
 /datum/religion_rites/ceremonial_weapon
 	name = "Forge Ceremonial Gear"
-	desc = "Turn some material into ceremonial gear. Ceremonial blades are weak outside of sparring, and are quite heavy to lug around."
+	desc = "Turn some material into ceremonial gear. Ceremonial blades are weak outside of sparring and quite heavy to lug around."
 	ritual_length = 10 SECONDS
 	invoke_msg = "Weapons in your name! Battles with your blood!"
 	favor_cost = 0
@@ -443,7 +443,7 @@
 	if(not_rigid)
 		to_chat(user, span_warning("[not_rigid] is not suitable for being made into gear!"))
 	else
-		to_chat(user, span_warning("You need at least 5 sheets of a rigid material that can be made into gear!"))
+		to_chat(user, span_warning("You need at least five sheets of a rigid material to make gear!"))
 	return FALSE
 
 /datum/religion_rites/ceremonial_weapon/invoke_effect(mob/living/user, atom/movable/religious_tool)

--- a/code/modules/religion/sparring/sparring_contract.dm
+++ b/code/modules/religion/sparring/sparring_contract.dm
@@ -85,7 +85,7 @@
 			resolved_opponents += resolved
 
 	if((user in resolved_opponents) && params["stakes"] == STAKES_HOLY_MATCH)
-		to_chat(user, span_warning("This contract refuses to be signed up for a holy match by a previous holy match loser. Pick a different stake!"))
+		to_chat(user, span_warning("This contract refuses to allow a holy match with a previous holy match loser. Pick a different stake!"))
 
 	//any updating of the terms should update the UI to display new terms
 	. = TRUE


### PR DESCRIPTION

## About The Pull Request
This PR makes many small adjustments to the textual content of chaplain sects. Most changes are for grammar, consistency with game mechanics, and (to a much lesser extent) thematic appropriateness. 

<details><summary><s>A <i>small</i> probability/easter egg has also been introduced where. . .</summary>

. . .dream sect chaplains may find their visions of an ascended Knock heretic clouded with a labyrinthine equivalent.

</s></details>

## Why It's Good For The Game
Improvements to grammar (hopefully) equate to improvements in readability. If anything seems amiss then I should be able to adjust or explain it. 
## Changelog
:cl:
spellcheck: Proofread most text associated with chaplain sects.
/:cl:
