### PR TITLE
Stops deploying and retracting modsuits from ALWAYS dropping your suit storage

### DIFF
--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -81,7 +81,7 @@
 		var/obj/item/overslot = wearer.get_item_by_slot(part.slot_flags)
 		if(istype(overslot, /obj/item/clothing))
 			part_datum.overslotting = overslot
-			wearer.transferItemToLoc(overslot, part, force = TRUE)
+			transfer_part_to_loc(overslot, part, force = TRUE, preserve_suit_storage = can_preserve_suit_storage(part, wearer.s_store))
 			RegisterSignal(part, COMSIG_ATOM_EXITED, PROC_REF(on_overslot_exit))
 	if(wearer.equip_to_slot_if_possible(part, part.slot_flags, qdel_on_fail = FALSE, disable_warning = TRUE))
 		ADD_TRAIT(part, TRAIT_NODROP, MOD_TRAIT)
@@ -112,6 +112,27 @@
 		playsound(src, 'sound/machines/scanner/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 	return FALSE
 
+/obj/item/mod/control/proc/can_preserve_suit_storage(obj/item/new_suit, obj/item/stored_item)
+	if(!istype(new_suit, /obj/item/clothing) || !stored_item)
+		return FALSE
+	if(HAS_TRAIT(stored_item, TRAIT_NODROP))
+		return FALSE
+	var/obj/item/clothing/new_clothing = new_suit
+	if(is_type_in_typecache(stored_item, GLOB.any_suit_storage) || stored_item.w_class == WEIGHT_CLASS_TINY)
+		return TRUE
+	if(stored_item.w_class > WEIGHT_CLASS_BULKY)
+		return FALSE
+	return is_type_in_list(stored_item, new_clothing.allowed)
+
+/// Moves a MOD part between the wearer and the suit without forcing valid suit-storage contents to drop.
+/obj/item/mod/control/proc/transfer_part_to_loc(obj/item/part, atom/newloc, force = FALSE, preserve_suit_storage = FALSE)
+	if(!preserve_suit_storage)
+		return wearer.transferItemToLoc(part, newloc, force = force)
+	if(!wearer.temporarilyRemoveItemFromInventory(part, force, idrop = FALSE, newloc = newloc))
+		return FALSE
+	part.forceMove(newloc)
+	return TRUE
+
 /// Retract a part of the suit from the user.
 /obj/item/mod/control/proc/retract(mob/user, obj/item/part, instant = FALSE)
 	var/datum/mod_part/part_datum = get_part_datum(part)
@@ -133,7 +154,8 @@
 			playsound(src, 'sound/machines/scanner/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 			return FALSE
 	REMOVE_TRAIT(part, TRAIT_NODROP, MOD_TRAIT)
-	wearer.transferItemToLoc(part, src, force = TRUE)
+	var/preserve_suit_storage = part_datum.overslotting && can_preserve_suit_storage(part_datum.overslotting, wearer.s_store)
+	transfer_part_to_loc(part, src, force = TRUE, preserve_suit_storage = preserve_suit_storage)
 	if(part_datum.overslotting)
 		var/obj/item/overslot = part_datum.overslotting
 		if(!QDELING(wearer) && !wearer.equip_to_slot_if_possible(overslot, overslot.slot_flags, qdel_on_fail = FALSE, disable_warning = TRUE))

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -38,7 +38,7 @@
 		UnregisterSignal(suit, COMSIG_ITEM_PRE_UNEQUIP)
 
 /obj/item/mod/module/storage/proc/on_suit_unequip(obj/item/source, force, atom/newloc, no_move, invdrop, silent)
-	if(QDELETED(source) || !mod.wearer || newloc == mod.wearer || !mod.wearer.s_store)
+	if(QDELETED(source) || !invdrop || !mod.wearer || newloc == mod.wearer || !mod.wearer.s_store)
 		return
 	if(!atom_storage?.attempt_insert(mod.wearer.s_store, mod.wearer, override = TRUE))
 		balloon_alert(mod.wearer, "storage failed!")


### PR DESCRIPTION

## About The Pull Request

It is as the title suggests. Now, when deploying, it checks if the item in your suit storage can be held by your mod. If it can, it stays in your suit storage. When undeploying, it checks if the item in your suit storage can be held on your actual vest. If it can, it stays. Like before, if it can't, it then tries to store it inside itself, and if that doesn't work, it drops to the ground.
## Why It's Good For The Game
Constantly having to pick up my gun is driving me insane. NT please fix.
## Proof Of Testing
ran and tested locally.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl: UvvU
qol: made deploying and undeploying a modsuit no longer ALWAYS drop your suit storage item, instead keeping it if it's valid
/:cl:
