### PR TITLE
fixes transforming weapons throwspeed when turned off

### DIFF
--- a/code/datums/components/transforming.dm
+++ b/code/datums/components/transforming.dm
@@ -284,7 +284,7 @@
 	if(!isnull(throwforce_on))
 		source.throwforce = throwforce_off
 	if(!isnull(throw_speed_on))
-		source.throw_speed = throwforce_off
+		source.throw_speed = throw_speed_off
 
 	if(LAZYLEN(attack_verb_continuous_on))
 		source.attack_verb_continuous = attack_verb_continuous_off


### PR DESCRIPTION
## About The Pull Request

Fixes transforming weapons inheriting `throwforce_off` as their throw speed when off.

## Why It's Good For The Game

I don't think I'm supposed to be throwing disabled energy swords with enough force to embed.

<img width="669" height="184" alt="image" src="https://github.com/user-attachments/assets/eca912cc-85d8-4094-ae75-ac80f469f12e" />


## Changelog

:cl:
fix: Inactive transforming weapons should now use their base throwspeeds properly when turned off.
/:cl: