### PR TITLE
Muzzles prevent verbal spellcasting

### DIFF
--- a/code/datums/elements/muffles_speech.dm
+++ b/code/datums/elements/muffles_speech.dm
@@ -62,4 +62,6 @@
 /datum/element/muffles_speech/proc/fail_spellcast(mob/living/source, datum/action/cooldown/spell/spell)
 	spell.invocation(source)
 	to_chat(source, span_warning("Your mouth covering is making it difficult to say the correct words to cast [spell]..."))
+	if(source.click_intercept == spell)
+		spell.unset_click_ability(source, refund_cooldown = TRUE)
 	spell.StartCooldown(2 SECONDS)

--- a/code/datums/elements/muffles_speech.dm
+++ b/code/datums/elements/muffles_speech.dm
@@ -17,10 +17,11 @@
 	if(source.slot_flags & slot)
 		RegisterSignal(user, COMSIG_MOB_SAY, PROC_REF(muzzle_talk))
 		RegisterSignal(user, COMSIG_MOB_PRE_EMOTED, PROC_REF(emote_override))
+		RegisterSignal(user, COMSIG_MOB_BEFORE_SPELL_CAST, PROC_REF(try_spellcast))
 
 /datum/element/muffles_speech/proc/dropped(obj/item/source, mob/user)
 	SIGNAL_HANDLER
-	UnregisterSignal(user, list(COMSIG_MOB_PRE_EMOTED, COMSIG_MOB_SAY))
+	UnregisterSignal(user, list(COMSIG_MOB_PRE_EMOTED, COMSIG_MOB_SAY, COMSIG_MOB_BEFORE_SPELL_CAST))
 
 /datum/element/muffles_speech/proc/emote_override(mob/living/source, key, params, type_override, intentional, datum/emote/emote)
 	SIGNAL_HANDLER
@@ -48,3 +49,17 @@
 			words[ind] = yell_suffix ? uppertext(new_word) : new_word
 		spoken_message = "[jointext(words, " ")][yell_suffix]"
 	speech_args[SPEECH_MESSAGE] = spoken_message
+
+/datum/element/muffles_speech/proc/try_spellcast(mob/living/source, datum/action/cooldown/spell/spell, ...)
+	SIGNAL_HANDLER
+
+	if(spell.invocation_type != INVOCATION_WHISPER && spell.invocation_type != INVOCATION_SHOUT)
+		return NONE
+
+	INVOKE_ASYNC(src, PROC_REF(fail_spellcast), source, spell)
+	return SPELL_CANCEL_CAST
+
+/datum/element/muffles_speech/proc/fail_spellcast(mob/living/source, datum/action/cooldown/spell/spell)
+	spell.invocation(source)
+	to_chat(source, span_warning("Your mouth covering is making it difficult to say the correct words to cast [spell]..."))
+	spell.StartCooldown(2 SECONDS)

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -313,6 +313,8 @@
 				if(!caster.get_organ_slot(ORGAN_SLOT_TONGUE))
 					invocation(caster)
 					to_chat(caster, span_warning("Your lack of tongue is making it difficult to say the correct words to cast [src]..."))
+					if(caster.click_intercept == src)
+						unset_click_ability(caster, refund_cooldown = TRUE)
 					StartCooldown(2 SECONDS)
 					return SPELL_CANCEL_CAST
 
@@ -324,6 +326,8 @@
 						ignored_mobs = caster,
 					)
 					to_chat(caster, span_warning("You can't position your hands correctly to invoke [src][caster.num_hands > 0 ? "" : ", as you have none"]..."))
+					if(caster.click_intercept == src)
+						unset_click_ability(caster, refund_cooldown = TRUE)
 					StartCooldown(2 SECONDS)
 					return SPELL_CANCEL_CAST
 


### PR DESCRIPTION
## About The Pull Request

Being muzzles prevents you from casting verbal spells, like it used to pre-rework.

## Why It's Good For The Game

Feels like an oversight from when rework.

## Changelog

:cl: Melbert
balance: Muzzles prevent verbal spellcasting
/:cl:
