### PR TITLE
Fixes runtime when creating a stack out of a stack with full hands with a stack below you

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -475,12 +475,13 @@
 
 		if(isstack(created))
 			var/obj/item/stack/crafted_stack = created
-			if(recipe.res_amount > 0 && recipe.req_amount != recipe.res_amount)
-				var/scale = recipe.req_amount / recipe.res_amount
-				for(var/mat in result_mats)
-					result_mats[mat] *= scale
-			crafted_stack.mats_per_unit = SSmaterials.get_material_set_cache(result_mats)
-			crafted_stack.update_custom_materials()
+			if(crafted_stack.amount) // If our stack's been emptied, it means another stack's already eaten it, and that stack'll deal with materials
+				if(recipe.res_amount > 0 && recipe.req_amount != recipe.res_amount)
+					var/scale = recipe.req_amount / recipe.res_amount
+					for(var/mat in result_mats)
+						result_mats[mat] *= scale
+				crafted_stack.mats_per_unit = SSmaterials.get_material_set_cache(result_mats)
+				crafted_stack.update_custom_materials()
 		else
 			created.set_custom_materials(result_mats, recipe.req_amount * multiplier)
 


### PR DESCRIPTION

## About The Pull Request

Stack's made, eaten by other stack the second it's created, tries to initialize materials with an amount of 0, predictably runtimes. Don't bother with materials if the stack's already eaten.

## Why It's Good For The Game

<img width="677" height="93" alt="image" src="https://github.com/user-attachments/assets/79e6c8f0-b3e3-4b8d-9bcb-00974f3545f0" />

## Changelog
:cl:

fix: fixed a runtime when creating a stack via another stack that's then eaten by another stack when it's created

/:cl:
