### PR TITLE
Fixes runtime when an exodrone rolls the shrubbery crate from the abandoned cargo ship

### DIFF
--- a/code/modules/cargo/packs/exploration.dm
+++ b/code/modules/cargo/packs/exploration.dm
@@ -34,9 +34,5 @@
 	name = "Shrubbery Crate"
 	desc = "Crate full of hedge shrubs."
 	cost = CARGO_CRATE_VALUE * 5
+	contains = list(/obj/item/grown/shrub = 8)
 	crate_name = "shrubbery crate"
-	var/shrub_amount = 8
-
-/datum/supply_pack/exploration/shrubbery/fill(obj/container)
-	for(var/i in 1 to shrub_amount)
-		new /obj/item/grown/shrub(container)


### PR DESCRIPTION

## About The Pull Request

Shrubbery crate by virtue of manually filling itself for an indiscernible reason wasn't added to `SSshuttle.supply_packs`, runtimed when attempted to be found from there by the exodrone loot thing

## Why It's Good For The Game

cant find a round it happened in but the runtime is `cannot read null.order_flags` [here](https://github.com/lelandkemble/tgstation/blob/479d1b1828f882c5662fb9de10784c4b0800fae0/code/modules/explorer_drone/loot.dm#L46-L49)

## Changelog
:cl:

fix: fixed a runtime when an exodrone rolls the shrubbery crate cargo crate chip from the abandoned cargo ship
/:cl:
