### PR TITLE
Categories with no items are no longer shown on black market uplink and cargo console UIs

### DIFF
--- a/code/modules/cargo/markets/_market.dm
+++ b/code/modules/cargo/markets/_market.dm
@@ -31,6 +31,7 @@
 	available_items[item.category] -= item.identifier
 	if(!length(available_items[item.category]))
 		available_items -= item.category
+		categories -= item.category
 
 /**
  * Handles buying the item for a market.

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -150,14 +150,14 @@
 	data["supplies"] = list()
 
 	for(var/pack_id in SSshuttle.supply_packs)
-		var/list/packs = get_packs_data(pack.group)
-		if(!length(packs)) //No available packs, hide category
-			continue
 		var/datum/supply_pack/pack = SSshuttle.supply_packs[pack_id]
+		var/list/available_packs = get_packs_data(pack.group)
+		if(!length(available_packs)) //No available packs, hide category
+			continue
 		if(!data["supplies"][pack.group])
 			data["supplies"][pack.group] = list(
 				"name" = pack.group,
-				"packs" = packs,
+				"packs" = available_packs,
 			)
 
 	data["displayed_currency_full_name"] = " [MONEY_NAME]"

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -150,11 +150,14 @@
 	data["supplies"] = list()
 
 	for(var/pack_id in SSshuttle.supply_packs)
+		var/list/packs = get_packs_data(pack.group)
+		if(!length(packs)) //No available packs, hide category
+			continue
 		var/datum/supply_pack/pack = SSshuttle.supply_packs[pack_id]
 		if(!data["supplies"][pack.group])
 			data["supplies"][pack.group] = list(
 				"name" = pack.group,
-				"packs" = get_packs_data(pack.group),
+				"packs" = packs,
 			)
 
 	data["displayed_currency_full_name"] = " [MONEY_NAME]"


### PR DESCRIPTION
## About The Pull Request
This makes it so that if the fenced goods, local goods or hostage categories on the black market end up being empty once more, they'll be cleared properly from the uplink UI.

As for cargo, we've had this ever-empty outsourced category ever since exodrones were added (that thing nobody quite uses much). This will make it only show up if any of its packs becomes available.

## Why It's Good For The Game
Less UI categories clutter.

## Changelog

:cl:
fix: The cargo console UI no longer shows an Outsourced category if it's empty. Same for the black market uplink UI with its Goods, Fenced Goods or Hostage categories.
/:cl:

