### PR TITLE
Makes chrabs with the territorial trait angry when growing up

### DIFF
--- a/code/modules/fishing/fish/types/mining.dm
+++ b/code/modules/fishing/fish/types/mining.dm
@@ -93,6 +93,8 @@
 
 /obj/item/fish/chasm_crab/proc/on_growth(datum/source, mob/living/basic/mining/lobstrosity/juvenile/result)
 	SIGNAL_HANDLER
+	if(/datum/fish_trait/territorial in fish_traits)
+		return
 	if(!prob(anger))
 		result.AddElement(/datum/element/ai_retaliate)
 		qdel(result.ai_controller)


### PR DESCRIPTION

## About The Pull Request

Charbs with the territorial trait will be hostile regardless of their anger

## Why It's Good For The Game

This makes it easier to use them for antagonistic stuff. Currently they aren't that usefull in that regards due to pet ones being by default friendly to anyone unless commanded to target a specific person.

It also can be used to sabotage aquariums I guess.

## Changelog
:cl:
add: Chrabs with the "Territorial" trait will be always hostile when growing up
/:cl:
