### PR TITLE
Triples testers in hemoparasite tester crate

### DIFF
--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -408,5 +408,5 @@
 		The DeForest Medical Corporation claims no liability for any mental and/or physical trauma caused to patients from the improper use of these devices."
 	cost = CARGO_CRATE_VALUE * 50 // These aren't meant to be bought en-masse.
 	access_view = ACCESS_SECURITY
-	contains = list(/obj/item/blood_worm_tester = 4)
+	contains = list(/obj/item/blood_worm_tester = 12)
 	crate_name = "hemoparasite testing crate"


### PR DESCRIPTION
## About The Pull Request
W.I.S.O.T.T.


## Why It's Good For The Game

This thing is the second most expensive thing in the security cargo catalogue, is on a Very Long cooldown via department order, and it's completely a joke. Bloodworms reproduce like spiders, are capable of maintaining perfect stealth, and can be killing machines in both human-possession form and simplemob form. Testing crates only give you four testers, which in conjunction with the cost issue, makes any widespread testing and containment before they swarm the station impossible, to the point where security players try to get Mind Reader from genetics as soon as bloodworms are called. While this change doesn't change that, it should make security feel better about actually ordering these things as a first reaction instead of a last-resort, as well as assuaging the pain when both genetics and cargo don't have the answers.

## Changelog
:cl: XYC
balance: hemoparasite testers in crate 4-->12
/:cl:


