### PR TITLE
Fix pirate boots not having storage

### DIFF
--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -192,6 +192,7 @@
 
 /obj/item/clothing/shoes/pirate/Initialize(mapload)
 	. = ..()
+	create_storage(storage_type = /datum/storage/pockets/shoes)
 	AddElement(/datum/element/adjust_fishing_difficulty, -4)
 
 /obj/item/clothing/shoes/pirate/armored


### PR DESCRIPTION

## About The Pull Request
- Fixes #96586

Pirate boots lacked internal storage and could not hold small items like knifes.

## Why It's Good For The Game
This should behave like other boots where you can store items.

## Changelog
:cl:
fix: Fix pirate boots not having storage
/:cl:
