### PR TITLE
Sets `pressure_affected` to FALSE on Void heretic ascension ambience 

### DIFF
--- a/code/datums/looping_sounds/weather.dm
+++ b/code/datums/looping_sounds/weather.dm
@@ -52,6 +52,8 @@
 	volume = 100
 	extra_range = 30
 	pressure_affected = FALSE
+	reserve_random_channel = TRUE
+	use_sound_tokens = TRUE
 
 /datum/looping_sound/snowstorm
 	mid_sounds = list(

--- a/code/datums/looping_sounds/weather.dm
+++ b/code/datums/looping_sounds/weather.dm
@@ -51,6 +51,7 @@
 	mid_length = 166.9 SECONDS // exact length of the music in ticks
 	volume = 100
 	extra_range = 30
+	pressure_affected = FALSE
 
 /datum/looping_sound/snowstorm
 	mid_sounds = list(


### PR DESCRIPTION

## About The Pull Request
This PR is a ~one line adjustment to a boolean variable (`pressure_affected`)~ three line adjustment to three booleans (`pressure_affected`, `reserve_random_channel`, and `use_sound_tokens`) on the soundloop used for thematic waltz music by ascended Void heretics. I presume this soundloop should not be affected by atmospheric pressure.

According to Git blame, this particular soundloop has remained relatively unchanged since its introduction in PR #54252 by @Djiq.
## Why It's Good For The Game
This seems like an oversight given that an ascended Void heretic will tend to depressurize any area they linger in. 

The loop is also mostly unheard on account of its length. Sound tokens may fix that.
## Changelog
:cl:
fix: The music emitted by ascended Void heretics is no longer affected by pressure (or more likely the lack thereof).
/:cl:
