### PR TITLE
[no gbp] Gizmo burgerfix and code improvement

### DIFF
--- a/code/modules/research/gizmo/gizmo_machines.dm
+++ b/code/modules/research/gizmo/gizmo_machines.dm
@@ -16,10 +16,10 @@
 	/// Reference to the gizmo. We dont actually need to track this for anything but ease of vv
 	var/datum/gizmo_controller/controller = /datum/gizmo_controller
 	/// Possible names to pick from to keep things confusing
-	var/list/possible_names = list(
+	var/static/list/possible_names = list(
 		"gizmo", "jigger", "doohickey", "particle inverter", "polarity superplexer", "flitcher poster", "natty gonk", "quantum quantum",
 		"entropy nilum", "tachyon streamer", "doing device", "task operator", "interface responder", "kinetic observer", "turbo encabulator",
-		"statistic responder", "possibility matrix", "toety aaier", "phase anchor",
+		"statistic responder", "possibility matrix", "toety aaier", "phase anchor", "thingamajing",
 	)
 
 /obj/machinery/gizmo/Initialize(mapload)

--- a/code/modules/research/gizmo/gizmodes/giz_filler.dm
+++ b/code/modules/research/gizmo/gizmodes/giz_filler.dm
@@ -92,7 +92,7 @@
 /datum/gizpulse/dispense/food
 	possible_objects = list(
 		/obj/item/food/donut/plain = 1,
-		/obj/item/food/burger = 1,
+		/obj/item/food/burger/plain = 1,
 	)
 
 /datum/gizpulse/dispense/food/modify(atom/movable/new_object)


### PR DESCRIPTION

## About The Pull Request
Grabs an easy fix and code improvement from https://github.com/tgstation/tgstation/pull/96255

Gizmo burger uses the proper type and is no longer called 'food'
Makes the name list static
Adds a new gizmo name

## Changelog
:cl:
fix: Gizmo burgers are no longer burgerless
/:cl:
There's more on my docket but I got no coderjuice so it'll be a few days/weeks/months/years before I can start doing a proper second code/feature/design pass for gizmo's