### PR TITLE
Add download sprite option to VV for `/atom`

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -88,6 +88,7 @@
 
 // /atom
 #define VV_HK_MODIFY_TRANSFORM "atom_transform"
+#define VV_HK_DOWNLOAD_SPRITE "download_sprite"
 #define VV_HK_SPIN_ANIMATION "atom_spin"
 #define VV_HK_STOP_ALL_ANIMATIONS "stop_animations"
 #define VV_HK_MODIFY_GREYSCALE "modify_greyscale"

--- a/code/game/atom/atom_vv.dm
+++ b/code/game/atom/atom_vv.dm
@@ -12,6 +12,7 @@
 			. += "<a href='byond://?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[curturf.x];Y=[curturf.y];Z=[curturf.z]' style='display:none;'>Jump To</a>"
 	VV_DROPDOWN_OPTION(VV_HK_MODIFY_TRANSFORM, "Modify Transform")
 	VV_DROPDOWN_OPTION(VV_HK_DEBUG_APPEARANCE, "Debug Appearance")
+	VV_DROPDOWN_OPTION(VV_HK_DOWNLOAD_SPRITE, "Download Sprite")
 	VV_DROPDOWN_OPTION(VV_HK_SPIN_ANIMATION, "SpinAnimation")
 	VV_DROPDOWN_OPTION(VV_HK_STOP_ALL_ANIMATIONS, "Stop All Animations")
 	VV_DROPDOWN_OPTION(VV_HK_SHOW_HIDDENPRINTS, "Show Hiddenprint log")
@@ -188,6 +189,10 @@
 
 	if(href_list[VV_HK_TEST_MATRIXES])
 		usr.client?.open_matrix_tester(src)
+
+	if(href_list[VV_HK_DOWNLOAD_SPRITE])
+		var/icon/target_icon = getFlatIcon(src)
+		usr << ftp(target_icon, "[name].png")
 
 /atom/vv_get_header()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Adds an option to the view variables dropdown for atoms that lets you download the sprite (calls `GetFlatIcon` and then uses the `ftp` proc to send it to the user)

## Why It's Good For The Game

Easy way to rip complex sprites where you can't just check the DMI file

## Changelog
:cl:
admin: added download sprite option to view variables dropdown
/:cl:
