### PR TITLE
Adds <small> to Say html options. Uses ^ as its prefix.

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -268,6 +268,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	input = remove_escape_backlashes.Replace_char(input, "$1")
 	return input
 
+#undef ENCODE_HTML_EMPHASIS
+
 /// Modifies the message by comparing the languages of the speaker with the languages of the hearer. Called on the hearer.
 /atom/movable/proc/translate_language(atom/movable/speaker, datum/language/language, raw_message, list/spans, list/message_mods)
 	if(!language)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -262,11 +262,11 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	ENCODE_HTML_EMPHASIS(input, "\\|", "i", italics)
 	ENCODE_HTML_EMPHASIS(input, "\\+", "b", bold)
 	ENCODE_HTML_EMPHASIS(input, "\\_", "u", underline)
-	var/static/regex/remove_escape_backlashes = regex("\\\\(\\_|\\+|\\|)", "g") // Removes backslashes used to escape text modification.
+	ENCODE_HTML_EMPHASIS(input, "\\-", "s", strike)
+	ENCODE_HTML_EMPHASIS(input, "\\^", "small", small)
+	var/static/regex/remove_escape_backlashes = regex("\\\\(\\_|\\+|\\||\\-|\\^)", "g") // Removes backslashes used to escape text modification.
 	input = remove_escape_backlashes.Replace_char(input, "$1")
 	return input
-
-#undef ENCODE_HTML_EMPHASIS
 
 /// Modifies the message by comparing the languages of the speaker with the languages of the hearer. Called on the hearer.
 /atom/movable/proc/translate_language(atom/movable/speaker, datum/language/language, raw_message, list/spans, list/message_mods)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -262,9 +262,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	ENCODE_HTML_EMPHASIS(input, "\\|", "i", italics)
 	ENCODE_HTML_EMPHASIS(input, "\\+", "b", bold)
 	ENCODE_HTML_EMPHASIS(input, "\\_", "u", underline)
-	ENCODE_HTML_EMPHASIS(input, "\\-", "s", strike)
-	ENCODE_HTML_EMPHASIS(input, "\\^", "small", small)
-	var/static/regex/remove_escape_backlashes = regex("\\\\(\\_|\\+|\\||\\-|\\^)", "g") // Removes backslashes used to escape text modification.
+	ENCODE_HTML_EMPHASIS(input, "\\#", "small", small)
+	var/static/regex/remove_escape_backlashes = regex("\\\\(\\_|\\+|\\||\\^)", "g") // Removes backslashes used to escape text modification.
 	input = remove_escape_backlashes.Replace_char(input, "$1")
 	return input
 

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -1,4 +1,4 @@
-@You can <i>italicize</i>, <b>embolden</b>, <small>shrink</small>, <s>strikethrough</s>, or <u>underline</u> portions of your messages by enclosing them with |, +, ^, -, or _ respectively. You can also avoid this by adding backslashes (they won't show in the message) before these characters.
+@You can <i>italicize</i>, <b>embolden</b>, <small>shrink</small>, or <u>underline</u> portions of your messages by enclosing them with |, +, #, or _ respectively. You can also avoid this by adding backslashes (they won't show in the message) before these characters.
 ♪ Hey, have you ever tried appending the % character before your messages when speaking in-game? ♫
 A Scientist will pay top dollar for your frogs!
 A thrown glass of water can make a slippery tile, allowing you to slow down your pursuers in a pinch.

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -1,4 +1,4 @@
-@You can <i>italicize</i>, <b>embolden</b> or <u>underline</u> portions of your messages by enclosing them with |, + or _ respectively. You can also avoid this by adding backslashes (they won't show in the message) before these characters.
+@You can <i>italicize</i>, <b>embolden</b>, <small>shrink</small>, <s>strikethrough</s>, or <u>underline</u> portions of your messages by enclosing them with |, +, ^, -, or _ respectively. You can also avoid this by adding backslashes (they won't show in the message) before these characters.
 ♪ Hey, have you ever tried appending the % character before your messages when speaking in-game? ♫
 A Scientist will pay top dollar for your frogs!
 A thrown glass of water can make a slippery tile, allowing you to slow down your pursuers in a pinch.


### PR DESCRIPTION

## About The Pull Request
``
^this is small text^
``

<img width="458" height="17" alt="image" src="https://github.com/user-attachments/assets/f2850440-bdd5-4cfa-b3e1-963e54f895b8" />


## Why It's Good For The Game

Allows a greater range of creativity and emphasis for people when they're talking to each other. Overall, there's a level of freedom this would unlock for people and I think it'll primarily be fun. Muttering, saying something under your breath. Stuff like that.

:cl:
add: Added a new <small> html option for Say. Use ^text^ for smaller text.
/:cl:
