### PR TITLE
chuunicasting notifies when healing is on cooldown

### DIFF
--- a/code/datums/components/chuunibyou.dm
+++ b/code/datums/components/chuunibyou.dm
@@ -97,6 +97,7 @@
 
 	casting_spell = FALSE
 	if(!COOLDOWN_FINISHED(src, heal_cooldown))
+		to_chat(source, span_danger("Your chuuni powers are on cooldown! You fail to heal!"))
 		return
 	COOLDOWN_START(src, heal_cooldown, CHUUNIBYOU_COOLDOWN_TIME)
 


### PR DESCRIPTION
## About The Pull Request
now notifies in chat when your chuuni heal on spellcast fails due to the cooldown
## Why It's Good For The Game
clarity good, theres no indication of the healing cooldown anywhere else
## Changelog
:cl: xyc
fix: chuuni casting now notifies you when the healing on spellcast is on cooldown
/:cl:
