### PR TITLE
Fixes runtime when attempting to use farsight inside something

### DIFF
--- a/code/datums/mutations/farsight.dm
+++ b/code/datums/mutations/farsight.dm
@@ -57,6 +57,9 @@
 		cooldown_time *= 0.5
 	build_all_button_icons(UPDATE_BUTTON_STATUS)
 
+/datum/action/cooldown/spell/farsight/get_caster_from_target(atom/target)
+	return target // This ability only effect's the caster's client, no reason to try and fail to effect the closet or mech we're inside.
+
 /datum/action/cooldown/spell/farsight/is_action_active(atom/movable/screen/movable/action_button/current_button)
 	return active
 


### PR DESCRIPTION

## About The Pull Request

farsight only has effects on the user's client, no reason it should ever effect anything the user's inside

## Why It's Good For The Game

<img width="573" height="97" alt="image" src="https://github.com/user-attachments/assets/8d1c686a-c35d-40e7-9e67-186951d30fd4" />

## Changelog
:cl:

fix: fixed a runtime when attempting to use the farsight mutation while inside something

/:cl:
