### PR TITLE
Fixes radstorms rendering above HUDs and other weather bugs

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -35,8 +35,8 @@
 
 #define DEFAULT_PLANE 0 //Marks out the default plane, even if we don't use it
 
-#define WEATHER_PLANE 1
-#define PARTICLE_WEATHER_PLANE 2
+#define PARTICLE_WEATHER_PLANE 1
+#define WEATHER_PLANE 2
 #define AREA_PLANE 3
 #define MASSIVE_OBJ_PLANE 4
 #define GHOST_PLANE 5

--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -328,22 +328,23 @@
 	. = ..()
 	if(!.)
 		return
-	home.AddComponent(/datum/component/hide_weather_planes, src, particle_weather)
+	home.AddComponent(/datum/component/hide_weather_planes, src)
+	RegisterSignal(home, COMSIG_GROUP_HUD_CHANGED, PROC_REF(hud_changed))
+	update_state(home.our_hud?.mymob)
+
+/atom/movable/screen/plane_master/weather/proc/hud_changed(datum/source, datum/hud/old_hud, datum/hud/new_hud)
+	SIGNAL_HANDLER
+	update_state(new_hud?.mymob)
 
 /atom/movable/screen/plane_master/weather/proc/update_state(mob/mymob)
 	if(!istype(mymob))
 		return
 
 	// If the client wants particle weather, only show the PARTICLE_WEATHER_PLANE, otherwise only show the normal WEATHER_PLANE
-	if (mymob.canon_client?.prefs?.read_preference(/datum/preference/toggle/particle_weather) != particle_weather)
-		hide_from(mymob)
-	else
-		show_to(mymob)
-
-/atom/movable/screen/plane_master/weather/show_to(mob/mymob)
-	// Only show ourselves if the player wants it
 	if (mymob.canon_client?.prefs?.read_preference(/datum/preference/toggle/particle_weather) == particle_weather)
-		return ..()
+		set_alpha(255)
+	else
+		set_alpha(0)
 
 /atom/movable/screen/plane_master/weather/particle
 	name = "Particle Weather"
@@ -365,7 +366,7 @@
 	. = ..()
 	if(!.)
 		return
-	home.AddComponent(/datum/component/hide_weather_planes, src, TRUE)
+	home.AddComponent(/datum/component/hide_weather_planes, src)
 
 /atom/movable/screen/plane_master/massive_obj
 	name = "Massive object"

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -73,7 +73,7 @@
 	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_EMISSIVE_BLOOM, offset), blend_override = BLEND_MULTIPLY)
 
 /atom/movable/screen/plane_master/rendering_plate/particle_weather
-	name = "Particle Weather"
+	name = "Particle Weather Holder Plate"
 	documentation = "Plane used to render particle weather, masked by WEATHER_MASK_PLANE. \
 		Cannot be a single screen object as it needs to be a planemaster in order to be properly masked by the weather mask."
 	plane = RENDER_PLANE_PARTICLE_WEATHER
@@ -89,7 +89,7 @@
 	. = ..()
 	if(!.)
 		return
-	home.AddComponent(/datum/component/hide_weather_planes, src, TRUE)
+	home.AddComponent(/datum/component/hide_weather_planes, src)
 	RegisterSignal(home, COMSIG_GROUP_HUD_CHANGED, PROC_REF(hud_changed))
 	update_state(home.our_hud?.mymob)
 
@@ -117,7 +117,7 @@
 	return ..()
 
 /atom/movable/screen/plane_master/rendering_plate/particle_weather/emissive
-	name = "Emissive Particle Weather"
+	name = "Emissive Particle Weather Holder Plate"
 	documentation = "Secondary particle weather plane for emissive parts of weather, which is additionally rendered onto the emissive plane after being masked."
 	plane = RENDER_PLANE_EMISSIVE_PARTICLE_WEATHER
 

--- a/code/datums/weather/weather_types/rain_storm.dm
+++ b/code/datums/weather/weather_types/rain_storm.dm
@@ -6,12 +6,18 @@
 	min_severity = 30
 
 	telegraph_message = span_danger("Thunder rumbles far above. You hear droplets drumming against the canopy.")
+	telegraph_overlay = "rain_low"
 	telegraph_duration = 30 SECONDS
 
 	weather_message = span_userdanger("<i>Rain pours down around you!</i>")
+	weather_overlay = "rain_high"
 
 	end_message = span_bolddanger("The downpour gradually slows to a light shower.")
+	end_overlay = "rain_low"
 	end_duration = 30 SECONDS
+
+	// Don't display overlays when using particle weather
+	weather_alpha = 0
 
 	weather_duration_lower = 3 MINUTES
 	weather_duration_upper = 5 MINUTES

--- a/code/modules/client/preferences/particle_weather.dm
+++ b/code/modules/client/preferences/particle_weather.dm
@@ -8,8 +8,11 @@
 	for(var/atom/movable/screen/plane_master/rendering_plate/particle_weather/plane_master as anything in client.mob?.hud_used?.get_true_plane_masters(RENDER_PLANE_PARTICLE_WEATHER))
 		plane_master.update_state(client.mob)
 
+	for(var/atom/movable/screen/plane_master/rendering_plate/particle_weather/emissive/plane_master as anything in client.mob?.hud_used?.get_true_plane_masters(RENDER_PLANE_EMISSIVE_PARTICLE_WEATHER))
+		plane_master.update_state(client.mob)
+
 	for(var/atom/movable/screen/plane_master/weather/plane_master as anything in client.mob?.hud_used?.get_true_plane_masters(WEATHER_PLANE))
 		plane_master.update_state(client.mob)
 
-	for(var/atom/movable/screen/plane_master/weather/plane_master as anything in client.mob?.hud_used?.get_true_plane_masters(PARTICLE_WEATHER_PLANE))
+	for(var/atom/movable/screen/plane_master/weather/particle/plane_master as anything in client.mob?.hud_used?.get_true_plane_masters(PARTICLE_WEATHER_PLANE))
 		plane_master.update_state(client.mob)


### PR DESCRIPTION

## About The Pull Request

Closes #96601
Also fixes pref button breaking one of the modes permanently when swapped within a round, rain not displaying (due to missing overlay states) when particle weather is disabled, and weather particle plates having the same name as weather planes (causes dupe entries in the planecube debugger)

## Changelog
:cl:
fix: Radstorms (and other weather) no longer go over your hud on multi-z maps
fix: Rain is no longer invisible when you have particle weather disabled
fix: Changing the particle weather pref no longer permanently breaks some weathers for the round
/:cl:
