### PR TITLE
Supports AIs being placed on Lift Platforms

### DIFF
--- a/code/game/machinery/ai_core/_core.dm
+++ b/code/game/machinery/ai_core/_core.dm
@@ -152,15 +152,17 @@
 		return TRUE
 	if(!active)
 		return FALSE
-	var/turf/T = get_turf(src)
-	var/area/A = get_area(src)
-	if(!(A.area_flags & BLOBS_ALLOWED))
+	var/turf/ai_turf = get_turf(src)
+	var/area/ai_area = get_area(src)
+	if(!(ai_area.area_flags & BLOBS_ALLOWED))
 		return FALSE
-	if(!A.power_equip)
+	if(!ai_area.power_equip)
 		return FALSE
-	if(!SSmapping.level_trait(T.z,ZTRAIT_STATION))
+	if(!SSmapping.level_trait(ai_turf.z, ZTRAIT_STATION))
 		return FALSE
-	if(!isfloorturf(T))
+	if(!isfloorturf(ai_turf))
+		if(locate(/obj/structure/transport/linear) in ai_turf.contents) // carveout for maps that have the AI core on a lift platform.
+			return TRUE
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request

Fixes #96630

Latejoin AIs will no longer brick on CatwalkStation as Catwalk has a feature where AIs are placed on the lift. This works fine for roundstart AIs, but not for latejoin variants. Just a weird gap in coverage that's nice to have addressed now.
## Why It's Good For The Game

Makes map features work as intended while still preserving the intent of the code.
## Changelog
:cl:
fix: Latejoining as an AI on CatwalkStation should now work.
/:cl:
