### PR TITLE
Fixes issue where if 2 sound tokens would play the same sound, they would keep interupting each other.

### DIFF
--- a/code/datums/sound_token.dm
+++ b/code/datums/sound_token.dm
@@ -160,7 +160,7 @@
 /datum/sound_token/proc/send_listener_sound(mob/listener_mob, update_sound)
 	PRIVATE_PROC(TRUE)
 
-	sound.status = SOUND_STREAM|sound_status|listeners[listener_mob]
+	sound.status = sound_status|listeners[listener_mob]
 	if(update_sound)
 		sound.status |= SOUND_UPDATE
 	else


### PR DESCRIPTION
stupid sound streams

:cl:
fix: Sound tokens no longer interupt each other if they have the same sound
/:cl: