### PR TITLE
DNA console now shows sequences of held genetic sequence scanners

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -411,10 +411,9 @@
 			continue
 		var/list/scanner_data = list()
 		for(var/mutation_type in scanner.buffer)
-			var/datum/mutation/HM = GET_INITIALIZED_MUTATION(mutation_type)
-			if(!HM)
-				continue
-			scanner_data[HM.alias] = scanner.buffer[mutation_type]
+			var/datum/mutation/mutation = GET_INITIALIZED_MUTATION(mutation_type)
+			if(mutation)
+				scanner_data[mutation.alias] = scanner.buffer[mutation_type]
 		data["heldScannerBuffer"] = scanner_data
 
 	return data

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -405,6 +405,18 @@
 	data["storage"]["injector"] = tgui_advinjector_mutations
 	data["maxAdvInjectors"] = max_injector_selections
 
+	data["heldScannerBuffer"] = null
+	for(var/obj/item/sequence_scanner/scanner in user.held_items) //We got one or more scanners in our hands, lets get the data from them.
+		if(!LAZYLEN(scanner.buffer))
+			continue
+		var/list/scanner_data = list()
+		for(var/mutation_type in scanner.buffer)
+			var/datum/mutation/HM = GET_INITIALIZED_MUTATION(mutation_type)
+			if(!HM)
+				continue
+			scanner_data[HM.alias] = scanner.buffer[mutation_type]
+		data["heldScannerBuffer"] = scanner_data
+
 	return data
 
 /obj/machinery/computer/dna_console/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)

--- a/tgui/packages/tgui/interfaces/DnaConsole/DnaConsoleSequencer.jsx
+++ b/tgui/packages/tgui/interfaces/DnaConsole/DnaConsoleSequencer.jsx
@@ -15,22 +15,38 @@ import {
 import { MutationInfo } from './MutationInfo';
 
 const GenomeImage = (props) => {
-  const { url, selected, onClick } = props;
+  const { url, selected, inScanner, onClick } = props;
   let outline;
   if (selected) {
     outline = '2px solid #22aa00';
   }
   return (
-    <Image
-      src={url}
-      style={{
-        width: '64px',
-        margin: '2px',
-        marginLeft: '4px',
-        outline,
-      }}
-      onClick={onClick}
-    />
+    <Box
+      inline
+      position="relative"
+      style={{ margin: '2px', marginLeft: '4px' }}
+    >
+      <Image
+        src={url}
+        style={{
+          width: '64px',
+          display: 'block',
+          outline,
+        }}
+        onClick={onClick}
+      />
+      {inScanner && (
+        <Box
+          position="absolute"
+          bottom="2px"
+          right="2px"
+          color="good"
+          style={{ fontSize: '10px', lineHeight: 1, pointerEvents: 'none' }}
+        >
+          <b>M</b>
+        </Box>
+      )}
+    </Box>
   );
 };
 
@@ -87,47 +103,12 @@ function isPairMatched(sequence, index) {
   );
 }
 
-const GenomeSequencer = (props) => {
-  const { mutation } = props;
-  if (!mutation) {
-    return <Box color="average">No genome selected for sequencing.</Box>;
-  }
-  if (mutation.Scrambled) {
-    return (
-      <Box color="average">
-        Sequence unreadable due to unpredictable mutation.
-      </Box>
-    );
-  }
-  // Create gene cycler buttons
-  const sequence = mutation.Sequence;
-  const defaultSeq = mutation.DefaultSeq;
-  const buttons = [];
-  for (let i = 0; i < sequence.length; i++) {
-    const gene = sequence.charAt(i);
-    const button = (
-      <GeneCycler
-        width="22px"
-        textAlign="center"
-        disabled={!!mutation.Scrambled || mutation.Class !== MUT_NORMAL}
-        className={
-          defaultSeq?.charAt(i) === 'X' && !mutation.Active
-            ? classes(['outline-solid', 'outline-color-orange'])
-            : false
-        }
-        gene={gene}
-        index={i}
-        alias={mutation.Alias}
-      />
-    );
-    buttons.push(button);
-  }
-  // Render genome in two rows
+function buildGenomePairs(sequence, renderGene) {
   const pairs = [];
-  for (let i = 0; i < buttons.length; i += 2) {
+  for (let i = 0; i < sequence.length; i += 2) {
     const pair = (
       <Box key={i} inline m={0.5}>
-        {buttons[i]}
+        {renderGene(i)}
         <Box
           mt="-2px"
           ml="10px"
@@ -135,7 +116,7 @@ const GenomeSequencer = (props) => {
           height="8px"
           backgroundColor={isPairMatched(sequence, i) ? 'label' : 'red'}
         />
-        {buttons[i + 1]}
+        {renderGene(i + 1)}
       </Box>
     );
 
@@ -156,6 +137,38 @@ const GenomeSequencer = (props) => {
 
     pairs.push(pair);
   }
+  return pairs;
+}
+
+const GenomeSequencer = (props) => {
+  const { mutation } = props;
+  if (!mutation) {
+    return <Box color="average">No genome selected for sequencing.</Box>;
+  }
+  if (mutation.Scrambled) {
+    return (
+      <Box color="average">
+        Sequence unreadable due to unpredictable mutation.
+      </Box>
+    );
+  }
+  const sequence = mutation.Sequence;
+  const defaultSeq = mutation.DefaultSeq;
+  const pairs = buildGenomePairs(sequence, (i) => (
+    <GeneCycler
+      width="22px"
+      textAlign="center"
+      disabled={!!mutation.Scrambled || mutation.Class !== MUT_NORMAL}
+      className={
+        defaultSeq?.charAt(i) === 'X' && !mutation.Active
+          ? classes(['outline-solid', 'outline-color-orange'])
+          : false
+      }
+      gene={sequence.charAt(i)}
+      index={i}
+      alias={mutation.Alias}
+    />
+  ));
   return (
     <>
       <Box m={-0.5}>{pairs}</Box>
@@ -167,14 +180,42 @@ const GenomeSequencer = (props) => {
   );
 };
 
+// Read only version of the genome sequencer.
+const GenomeSequencerReadOnly = (props) => {
+  const { sequence } = props;
+  const pairs = buildGenomePairs(sequence, (i) => {
+    const gene = sequence.charAt(i);
+    return (
+      <Button
+        key={i}
+        width="22px"
+        textAlign="center"
+        color={GENE_COLORS[gene] || GENE_COLORS.X}
+        style={{ pointerEvents: 'none' }} //Probably a better way but hehe >:)
+      >
+        {gene}
+      </Button>
+    );
+  });
+  return <Box m={-0.5}>{pairs}</Box>;
+};
+
 export const DnaConsoleSequencer = (props) => {
   const { data, act } = useBackend();
   const mutations = data.storage?.occupant ?? [];
-  const { isJokerReady, isMonkey, jokerSeconds, subjectStatus } = data;
+  const {
+    isJokerReady,
+    isMonkey,
+    jokerSeconds,
+    subjectStatus,
+    heldScannerBuffer,
+  } = data;
   const { sequencerMutation, jokerActive } = data.view;
   const mutation = mutations.find(
     (mutation) => mutation.Alias === sequencerMutation,
   );
+  const scannerSequence =
+    heldScannerBuffer && mutation && heldScannerBuffer[mutation.Alias];
   return (
     <>
       <Stack mb={1}>
@@ -189,6 +230,7 @@ export const DnaConsoleSequencer = (props) => {
                 key={mutation.Alias}
                 url={resolveAsset(mutation.Image)}
                 selected={mutation.Alias === sequencerMutation}
+                inScanner={!!heldScannerBuffer?.[mutation.Alias]}
                 onClick={() => {
                   act('set_view', {
                     sequencerMutation: mutation.Alias,
@@ -222,44 +264,51 @@ export const DnaConsoleSequencer = (props) => {
             Genetic sequence corrupted. Subject diagnostic report: TRANSFORMING.
           </Section>
         )) || (
-          <Section
-            title="Genome Sequencer™"
-            buttons={
-              (!isJokerReady && (
-                <Box lineHeight="20px" color="label">
-                  Joker on cooldown ({jokerSeconds}s)
-                </Box>
-              )) ||
-              (jokerActive && (
-                <>
-                  <Box mr={1} inline color="label">
-                    Click on a gene to reveal it.
+          <>
+            <Section
+              title="Genome Sequencer™"
+              buttons={
+                (!isJokerReady && (
+                  <Box lineHeight="20px" color="label">
+                    Joker on cooldown ({jokerSeconds}s)
                   </Box>
+                )) ||
+                (jokerActive && (
+                  <>
+                    <Box mr={1} inline color="label">
+                      Click on a gene to reveal it.
+                    </Box>
+                    <Button
+                      content="Cancel Joker"
+                      onClick={() =>
+                        act('set_view', {
+                          jokerActive: '',
+                        })
+                      }
+                    />
+                  </>
+                )) || (
                   <Button
-                    content="Cancel Joker"
+                    icon="crown"
+                    color="purple"
+                    content="Use Joker"
                     onClick={() =>
                       act('set_view', {
-                        jokerActive: '',
+                        jokerActive: '1',
                       })
                     }
                   />
-                </>
-              )) || (
-                <Button
-                  icon="crown"
-                  color="purple"
-                  content="Use Joker"
-                  onClick={() =>
-                    act('set_view', {
-                      jokerActive: '1',
-                    })
-                  }
-                />
-              )
-            }
-          >
-            <GenomeSequencer mutation={mutation} />
-          </Section>
+                )
+              }
+            >
+              <GenomeSequencer mutation={mutation} />
+            </Section>
+            {!!scannerSequence && (
+              <Section title="Held Scanner">
+                <GenomeSequencerReadOnly sequence={scannerSequence} />
+              </Section>
+            )}
+          </>
         )}
     </>
   );


### PR DESCRIPTION
## About The Pull Request

I was playing/learning geneticist a while back, and noticed its quite annoying to scan people to get their mutations. So I figured; why not make the UI/UX for this a bit more useful.

Now if you use the genetic sequence scanner on someone, and then open the console while holding it, if there is a match between the scanner and the person in the dna console, the sequence will have a small M(atch) in the corner.

<img width="164" height="89" alt="image" src="https://github.com/user-attachments/assets/9fbd2b82-9fb0-4ed8-a926-4bb2180c0ecf" />

If you then click on this sequence, the sequence from the scanner will be shown below the sequence of the person you're messing with. Make it a lot easier to go through mutations.

This does make geneticist a bit easier maybe? but it's also a nice QoL. Let me know your thoughts on this.


https://github.com/user-attachments/assets/dc8bc90b-b5f1-4c17-9b70-f17e45fa2509



## Why It's Good For The Game

I think its nice QoL to not have to jump between dna console, a tgui input, and the constantly moving chat.

## Changelog

:cl:
qol: DNA console now automatically matches genetic data with any held genetic sequence scanner, for more efficient geneticist shenanigans!
/:cl:

