### PR TITLE
Fixes pirates being unable to sell mobs

### DIFF
--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -379,7 +379,7 @@
 			continue
 		for(var/mob/living/hidden as anything in hidden_mobs)
 			///Sell mobs, but leave their contents intact.
-			export_single_item(hidden, apply_elastic = FALSE, dry_run = dry_run, external_report = report)
+			export_single_item(hidden, apply_elastic = FALSE, dry_run = dry_run, external_report = report, export_markets = list(EXPORT_MARKET_STATION, EXPORT_MARKET_PIRACY))
 		///there are still licing mobs inside that item. Stop, don't sell it ffs.
 		if(locate(/mob/living) in item_on_pad.get_all_contents())
 			continue


### PR DESCRIPTION

## About The Pull Request

pirates were selling mobs on the station market, and the station market does not allow ransoms (surprise)

in this house, we love ransoms. 


closes #93180 

## Changelog

:cl:
fix: You can now ransom mobs when pirateering again
/:cl: