### PR TITLE
LET THE DRONES HAVE HEAD ARMOR

### DIFF
--- a/code/modules/mob/living/basic/drone/interaction.dm
+++ b/code/modules/mob/living/basic/drone/interaction.dm
@@ -122,7 +122,7 @@
 
 /// Returns a multiplier for any head armor you wear as a drone.
 /mob/living/basic/drone/proc/get_armor_effectiveness()
-	return 0
+	return 0.8
 
 /**
  * Hack or unhack a drone


### PR DESCRIPTION
## About The Pull Request
The code has been sitting there for 10 years now, but drones still don't benefit from head armor because they've a multiplier that unfortunately sets the armor value to 0, and nowhere in the code is it overridden.

https://github.com/tgstation/tgstation/commit/2d765a9197c16f9c302f8190eb43b022133118c5

I'm surprisingly irked about that fact.

## Why It's Good For The Game
Let the drones protect themselves with hard hats and whatever.

## Changelog

:cl:
balance: Wearing a hard hat or any helmet as a station drone will actually improve your armor values now!
/:cl:
