### PR TITLE
Fixes target prioritization not working consistently due to not all mining mobs having ai_retaliate

### DIFF
--- a/code/modules/fishing/fish/types/mining.dm
+++ b/code/modules/fishing/fish/types/mining.dm
@@ -96,7 +96,6 @@
 	if(/datum/fish_trait/territorial in fish_traits)
 		return
 	if(!prob(anger))
-		result.AddElement(/datum/element/ai_retaliate)
 		qdel(result.ai_controller)
 		result.ai_controller = new /datum/ai_controller/basic_controller/lobstrosity/juvenile/calm(result)
 	else if(anger < 30) //not really that mad, just a bit unstable.

--- a/code/modules/mob/living/basic/icemoon/polar_bear/polar_bear.dm
+++ b/code/modules/mob/living/basic/icemoon/polar_bear/polar_bear.dm
@@ -43,7 +43,6 @@
 	. = ..()
 
 	add_traits(list(TRAIT_SPACEWALK, TRAIT_SWIMMER, TRAIT_FENCE_CLIMBER, TRAIT_SNOWSTORM_IMMUNE), INNATE_TRAIT)
-	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_BEAR, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
 	AddElement(/datum/element/change_force_on_death, move_force = MOVE_FORCE_DEFAULT, move_resist = MOVE_RESIST_DEFAULT, pull_force = PULL_FORCE_DEFAULT)
 	AddElement(/datum/element/footstep, footstep_type = FOOTSTEP_MOB_CLAW)

--- a/code/modules/mob/living/basic/icemoon/wolf/wolf.dm
+++ b/code/modules/mob/living/basic/icemoon/wolf/wolf.dm
@@ -58,7 +58,6 @@
 	ADD_TRAIT(src, TRAIT_WOUND_LICKER, INNATE_TRAIT)
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_CLAW)
 	AddElement(/datum/element/ai_flee_while_injured)
-	AddElement(/datum/element/ai_retaliate)
 
 	if(can_tame)
 		make_tameable()

--- a/code/modules/mob/living/basic/lavaland/goliath/goliath.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/goliath.dm
@@ -52,7 +52,6 @@
 /mob/living/basic/mining/goliath/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_TENTACLE_IMMUNE, INNATE_TRAIT)
-	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_HEAVY)
 	AddElement(/datum/element/basic_eating, heal_amt = 10, food_types = goliath_foods)
 	AddElement(\

--- a/code/modules/mob/living/basic/lavaland/gutlunchers/gutlunchers.dm
+++ b/code/modules/mob/living/basic/lavaland/gutlunchers/gutlunchers.dm
@@ -36,7 +36,6 @@
 	GLOB.gutlunch_count++
 	if(greyscale_config)
 		set_greyscale(colors = list(pick(possible_colors)))
-	AddElement(/datum/element/ai_retaliate)
 	if(can_breed)
 		add_breeding_component()
 

--- a/code/modules/mob/living/basic/lavaland/mining.dm
+++ b/code/modules/mob/living/basic/lavaland/mining.dm
@@ -44,6 +44,7 @@
 	// We add this to ensure that mobs will actually receive the above signal, as some will lack AI
 	// handling for retaliation and attack special cases
 	AddElement(/datum/element/relay_attackers)
+	AddElement(/datum/element/ai_retaliate) //Used by priority behaviors
 
 /mob/living/basic/mining/proc/add_ranged_armour(list/vulnerable_projectiles)
 	AddElement(\

--- a/code/modules/mob/living/basic/lavaland/tendril/tendril.dm
+++ b/code/modules/mob/living/basic/lavaland/tendril/tendril.dm
@@ -47,7 +47,6 @@ GLOBAL_LIST_INIT(tendrils, list())
 /mob/living/basic/mining/tendril/Initialize(mapload)
 	. = ..()
 	GLOB.tendrils += src
-	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/death_drops, /obj/structure/closet/crate/necropolis/tendril)
 	AddComponent(/datum/component/ai_target_timer)
 	AddComponent(/datum/component/gps, "Eerie Signal")

--- a/code/modules/mob/living/basic/lavaland/watcher/watcher.dm
+++ b/code/modules/mob/living/basic/lavaland/watcher/watcher.dm
@@ -44,7 +44,6 @@
 
 /mob/living/basic/mining/watcher/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/simple_flying)
 	AddElement(/datum/element/content_barfer)
 	AddComponent(/datum/component/ai_target_timer)


### PR DESCRIPTION
target prioritization makes use of retaliation, but not all mobs had it, now they do (should)

:cl: CabinetOnFire
fix: All mining mobs now remember who hit them, so target prioritization works as intended
/:cl: