### PR TITLE
Moves a great many more things from attackby() to item_interaction()

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -351,25 +351,34 @@
 	locked = !locked
 	to_chat(user, span_notice("You [src.locked ? "lock" : "unlock"] the controls."))
 
-/obj/machinery/power/emitter/attackby(obj/item/item, mob/user, list/modifiers, list/attack_modifiers)
-	if(item.GetID())
+/obj/machinery/power/emitter/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(tool.GetID())
 		togglelock(user)
-		return
+		return ITEM_INTERACT_SUCCESS
 
-	if(is_wire_tool(item) && panel_open)
+	if(!panel_open)
+		return NONE
+
+	if(is_wire_tool(tool))
 		wires.interact(user)
-		return
-	if(panel_open && !gun && istype(item,/obj/item/gun/energy))
+		return ITEM_INTERACT_SUCCESS
+
+	if(gun)
+		return NONE
+
+	if(istype(tool, /obj/item/gun/energy))
 		if(diskie)
 			to_chat(user, span_warning("Remove the Diode Disk before inserting a gun."))
-			return
-		if(integrate(item,user))
-			return
-	if(panel_open && !gun && istype(item,/obj/item/emitter_disk))
-		var/obj/item/emitter_disk/config_disk = item
+			return ITEM_INTERACT_BLOCKING
+		if(!integrate(tool,user))
+			return ITEM_INTERACT_BLOCKING
+		return ITEM_INTERACT_SUCCESS
+
+	if(istype(tool, /obj/item/emitter_disk))
+		var/obj/item/emitter_disk/config_disk = tool
 		if(!user.transferItemToLoc(config_disk, src))
 			balloon_alert(user, "stuck in hand!")
-			return
+			return ITEM_INTERACT_BLOCKING
 		if(diskie)
 			user.put_in_hands(diskie)
 			balloon_alert(user, "disks swapped!")
@@ -385,7 +394,9 @@
 		update_appearance()
 		if(diskie.consumable)
 			qdel(diskie)
-	return ..()
+		return ITEM_INTERACT_SUCCESS
+
+	return NONE
 
 
 /obj/machinery/power/emitter/proc/integrate(obj/item/gun/energy/energy_gun, mob/user)

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -122,6 +122,7 @@
 		external_power_trickle += 500
 		log_activation(who = user, how = destabilizing_crystal)
 		qdel(destabilizing_crystal)
+		return ITEM_INTERACT_SUCCESS
 
 	return NONE
 

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -75,54 +75,55 @@
 		qdel(rip_u)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
-/obj/machinery/power/supermatter_crystal/attackby(obj/item/item, mob/user, list/modifiers, list/attack_modifiers)
-	if(istype(item, /obj/item/scalpel/supermatter))
-		var/obj/item/scalpel/supermatter/scalpel = item
+/obj/machinery/power/supermatter_crystal/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(istype(tool, /obj/item/scalpel/supermatter))
+		var/obj/item/scalpel/supermatter/scalpel = tool
 		to_chat(user, span_notice("You carefully begin to scrape \the [src] with \the [scalpel]..."))
 		if(!scalpel.use_tool(src, user, 60, volume=100))
-			return
-		if (scalpel.usesLeft)
-			to_chat(user, span_danger("You extract a sliver from \the [src]. \The [src] begins to react violently!"))
-			new /obj/item/nuke_core/supermatter_sliver(src.drop_location())
-			supermatter_sliver_removed = TRUE
-			external_power_trickle += 800
-			log_activation(who = user, how = scalpel)
-			scalpel.usesLeft--
-			if (!scalpel.usesLeft)
-				to_chat(user, span_notice("A tiny piece of \the [scalpel] falls off, rendering it useless!"))
-		else
+			return ITEM_INTERACT_BLOCKING
+		if (!scalpel.usesLeft)
 			to_chat(user, span_warning("You fail to extract a sliver from \the [src]! \The [scalpel] isn't sharp enough anymore."))
-		return
+			return ITEM_INTERACT_BLOCKING
+		to_chat(user, span_danger("You extract a sliver from \the [src]. \The [src] begins to react violently!"))
+		new /obj/item/nuke_core/supermatter_sliver(src.drop_location())
+		supermatter_sliver_removed = TRUE
+		external_power_trickle += 800
+		log_activation(who = user, how = scalpel)
+		scalpel.usesLeft--
+		if (!scalpel.usesLeft)
+			to_chat(user, span_notice("A tiny piece of \the [scalpel] falls off, rendering it useless!"))
+		return ITEM_INTERACT_SUCCESS
 
-	if(istype(item, /obj/item/hemostat/supermatter))
-		to_chat(user, span_warning("You poke [src] with [item]'s hyper-noblium tips. Nothing happens."))
-		return
+	if(istype(tool, /obj/item/hemostat/supermatter))
+		to_chat(user, span_warning("You poke [src] with [tool]'s hyper-noblium tips. Nothing happens."))
+		return ITEM_INTERACT_BLOCKING
 
-	if(istype(item, /obj/item/destabilizing_crystal))
-		var/obj/item/destabilizing_crystal/destabilizing_crystal = item
+	if(istype(tool, /obj/item/destabilizing_crystal))
+		var/obj/item/destabilizing_crystal/destabilizing_crystal = tool
 
 		if(!is_main_engine)
 			to_chat(user, span_warning("You can't use \the [destabilizing_crystal] on \a [name]."))
-			return
+			return ITEM_INTERACT_BLOCKING
 
 		if(get_integrity_percent() < SUPERMATTER_CASCADE_PERCENT)
 			to_chat(user, span_warning("You can only apply \the [destabilizing_crystal] to \a [name] that is at least [SUPERMATTER_CASCADE_PERCENT]% intact."))
-			return
+			return ITEM_INTERACT_BLOCKING
 
 		to_chat(user, span_warning("You begin to attach \the [destabilizing_crystal] to \the [src]..."))
-		if(do_after(user, 3 SECONDS, src))
-			message_admins("[ADMIN_LOOKUPFLW(user)] attached [destabilizing_crystal] to the supermatter at [ADMIN_VERBOSEJMP(src)].")
-			user.log_message("attached [destabilizing_crystal] to the supermatter", LOG_GAME)
-			user.investigate_log("attached [destabilizing_crystal] to a supermatter crystal.", INVESTIGATE_ENGINE)
-			to_chat(user, span_danger("\The [destabilizing_crystal] snaps onto \the [src]."))
-			set_delam(SM_DELAM_PRIO_IN_GAME, /datum/sm_delam/cascade)
-			external_damage_immediate += 10
-			external_power_trickle += 500
-			log_activation(who = user, how = destabilizing_crystal)
-			qdel(destabilizing_crystal)
-		return
+		if(!do_after(user, 3 SECONDS, src))
+			return ITEM_INTERACT_BLOCKING
 
-	return ..()
+		message_admins("[ADMIN_LOOKUPFLW(user)] attached [destabilizing_crystal] to the supermatter at [ADMIN_VERBOSEJMP(src)].")
+		user.log_message("attached [destabilizing_crystal] to the supermatter", LOG_GAME)
+		user.investigate_log("attached [destabilizing_crystal] to a supermatter crystal.", INVESTIGATE_ENGINE)
+		to_chat(user, span_danger("\The [destabilizing_crystal] snaps onto \the [src]."))
+		set_delam(SM_DELAM_PRIO_IN_GAME, /datum/sm_delam/cascade)
+		external_damage_immediate += 10
+		external_power_trickle += 500
+		log_activation(who = user, how = destabilizing_crystal)
+		qdel(destabilizing_crystal)
+
+	return NONE
 
 //Do not blow up our internal radio
 /obj/machinery/power/supermatter_crystal/contents_explosion(severity, target)

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -137,9 +137,14 @@
 /obj/item/ammo_casing/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(!istype(tool, /obj/item/ammo_box))
 		return NONE
-	var/obj/item/ammo_box/box = tool
 	if(!isturf(loc))
 		return ITEM_INTERACT_BLOCKING
+	if(!collect_into_box(user, tool))
+		return ITEM_INTERACT_BLOCKING
+	return ITEM_INTERACT_SUCCESS
+
+/// Collects the casing and its like on its tile into the passed box, TRUE if anything collected.
+/obj/item/ammo_casing/proc/collect_into_box(mob/living/user, obj/item/ammo_box/box)
 	var/boolets = 0
 	for(var/obj/item/ammo_casing/bullet in loc)
 		if (box.stored_ammo.len >= box.max_ammo)
@@ -151,11 +156,10 @@
 
 	if (!boolets)
 		to_chat(user, span_warning("You fail to collect anything!"))
-		return ITEM_INTERACT_BLOCKING
+		return FALSE
 	box.update_appearance()
 	to_chat(user, span_notice("You collect [boolets] [box.casing_phrasing]\s. [box] now contains [box.stored_ammo.len] [box.casing_phrasing]\s."))
-	return ITEM_INTERACT_SUCCESS
-
+	return TRUE
 
 /obj/item/ammo_casing/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	bounce_away(FALSE, NONE)

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -134,26 +134,28 @@
 	if(!loaded_projectile)
 		loaded_projectile = new projectile_type(src, src)
 
-/obj/item/ammo_casing/attackby(obj/item/I, mob/user, list/modifiers, list/attack_modifiers)
-	if(istype(I, /obj/item/ammo_box))
-		var/obj/item/ammo_box/box = I
-		if(isturf(loc))
-			var/boolets = 0
-			for(var/obj/item/ammo_casing/bullet in loc)
-				if (box.stored_ammo.len >= box.max_ammo)
-					break
-				if (bullet.loaded_projectile)
-					if (box.give_round(bullet, 0))
-						boolets++
-				else
-					continue
-			if (boolets > 0)
-				box.update_appearance()
-				to_chat(user, span_notice("You collect [boolets] [box.casing_phrasing]\s. [box] now contains [box.stored_ammo.len] [box.casing_phrasing]\s."))
-			else
-				to_chat(user, span_warning("You fail to collect anything!"))
-	else
-		return ..()
+/obj/item/ammo_casing/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/ammo_box))
+		return NONE
+	var/obj/item/ammo_box/box = tool
+	if(!isturf(loc))
+		return ITEM_INTERACT_BLOCKING
+	var/boolets = 0
+	for(var/obj/item/ammo_casing/bullet in loc)
+		if (box.stored_ammo.len >= box.max_ammo)
+			break
+		if (!bullet.loaded_projectile)
+			continue
+		if (box.give_round(bullet, 0))
+			boolets++
+
+	if (!boolets)
+		to_chat(user, span_warning("You fail to collect anything!"))
+		return ITEM_INTERACT_BLOCKING
+	box.update_appearance()
+	to_chat(user, span_notice("You collect [boolets] [box.casing_phrasing]\s. [box] now contains [box.stored_ammo.len] [box.casing_phrasing]\s."))
+	return ITEM_INTERACT_SUCCESS
+
 
 /obj/item/ammo_casing/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	bounce_away(FALSE, NONE)

--- a/code/modules/projectiles/ammunition/ballistic/foam.dm
+++ b/code/modules/projectiles/ammunition/ballistic/foam.dm
@@ -52,6 +52,7 @@
 	dart.set_embed(null) // Cap is what makes them sticky
 	to_chat(user, span_notice("You pop the safety cap off [src]."))
 	update_appearance()
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/ammo_casing/foam_dart/riot
 	name = "riot foam dart"

--- a/code/modules/projectiles/ammunition/ballistic/foam.dm
+++ b/code/modules/projectiles/ammunition/ballistic/foam.dm
@@ -42,11 +42,9 @@
 		. += span_notice("[modified ? "You can" : "If you removed the safety cap with a screwdriver, you could"] insert a small item\
 			[length(type_initial_names) ? ", such as [english_list(type_initial_names, and_text = "or ", final_comma_text = ", ")]" : ""].")
 
-
-/obj/item/ammo_casing/foam_dart/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
-	if (attacking_item.tool_behaviour != TOOL_SCREWDRIVER || modified)
-		return ..()
-
+/obj/item/ammo_casing/foam_dart/screwdriver_act(mob/living/user, obj/item/tool)
+	if(modified)
+		return NONE
 	var/obj/projectile/bullet/foam_dart/dart = loaded_projectile
 	modified = TRUE
 	dart.modified = TRUE

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -207,8 +207,9 @@
 	. = ..()
 	create_reagents(reagent_amount, OPENCONTAINER)
 
-/obj/item/ammo_casing/shotgun/dart/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	return NONE
+// Can't be collected into an ammo box from the floor, for whatever reason.
+/obj/item/ammo_casing/shotgun/dart/collect_into_box(mob/living/user, obj/item/ammo_box/box)
+	return FALSE
 
 /obj/item/ammo_casing/shotgun/dart/large
 	name = "XL shotgun dart"

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -207,8 +207,8 @@
 	. = ..()
 	create_reagents(reagent_amount, OPENCONTAINER)
 
-/obj/item/ammo_casing/shotgun/dart/attackby()
-	return
+/obj/item/ammo_casing/shotgun/dart/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	return NONE
 
 /obj/item/ammo_casing/shotgun/dart/large
 	name = "XL shotgun dart"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -313,11 +313,11 @@
 		return
 	..()
 
-/obj/item/gun/ballistic/automatic/l6_saw/attackby(obj/item/A, mob/user, list/modifiers, list/attack_modifiers)
-	if(!cover_open && istype(A, accepted_magazine_type))
+/obj/item/gun/ballistic/automatic/l6_saw/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!cover_open && istype(tool, accepted_magazine_type))
 		balloon_alert(user, "open the cover!")
-		return
-	..()
+		return ITEM_INTERACT_BLOCKING
+	return ..()
 
 // Laser rifle (rechargeable magazine) //
 

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -21,9 +21,9 @@
 /obj/item/gun/ballistic/revolver/grenadelauncher/unrestricted/tear
 	spawn_magazine_type = /obj/item/ammo_box/magazine/internal/grenadelauncher/tear
 
-/obj/item/gun/ballistic/revolver/grenadelauncher/attackby(obj/item/A, mob/user, list/modifiers, list/attack_modifiers)
-	..()
-	if(istype(A, /obj/item/ammo_box) || isammocasing(A))
+/obj/item/gun/ballistic/revolver/grenadelauncher/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	. = ..()
+	if(istype(tool, /obj/item/ammo_box) || isammocasing(tool))
 		chamber_round()
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -23,7 +23,7 @@
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	. = ..()
-	if(istype(tool, /obj/item/ammo_box) || isammocasing(tool))
+	if((. = ITEM_INTERACT_SUCCESS) && (istype(tool, /obj/item/ammo_box) || isammocasing(tool)))
 		chamber_round()
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel

--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -165,16 +165,15 @@
 	setting_overlay = mutable_appearance(icon,setting_iconstate())
 	add_overlay(setting_overlay)
 
-/obj/item/gun/energy/dueling/attackby(obj/item/W, mob/user, list/modifiers, list/attack_modifiers)
-	if(istype(W, /obj/item/gun/energy/dueling))
-		var/obj/item/gun/energy/dueling/other_gun = W
-
-		if(!check_valid_duel(user, FALSE) && !other_gun.check_valid_duel(user, FALSE))
-			var/datum/duel/D = new(src, other_gun)
-			to_chat(user,span_notice("Pairing established. Pairing code: [D.pairing_code]"))
-			return
-
-	return ..()
+/obj/item/gun/energy/dueling/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/gun/energy/dueling))
+		return NONE
+	var/obj/item/gun/energy/dueling/other_gun = tool
+	if(check_valid_duel(user, FALSE) || other_gun.check_valid_duel(user, FALSE))
+		return ITEM_INTERACT_BLOCKING
+	var/datum/duel/newduel = new(src, other_gun)
+	to_chat(user,span_notice("Pairing established. Pairing code: [newduel.pairing_code]"))
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/gun/energy/dueling/examine_more(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -141,12 +141,11 @@
 	if(istype(arrived, /obj/item/borg/upgrade/modkit))
 		modkits |= arrived
 
-/obj/item/gun/energy/recharge/kinetic_accelerator/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/borg/upgrade/modkit))
-		var/obj/item/borg/upgrade/modkit/MK = I
-		MK.install(src, user)
-	else
-		return ..()
+/obj/item/gun/energy/recharge/kinetic_accelerator/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/borg/upgrade/modkit))
+		return NONE
+	astype(tool, /obj/item/borg/upgrade/modkit).install(src, user)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/gun/energy/recharge/kinetic_accelerator/proc/get_remaining_mod_capacity()
 	var/current_capacity_used = 0
@@ -319,11 +318,11 @@
 	. = ..()
 	. += span_notice("Occupies <b>[cost]%</b> of mod capacity.")
 
-/obj/item/borg/upgrade/modkit/attackby(obj/item/A, mob/user)
-	if(istype(A, /obj/item/gun/energy/recharge/kinetic_accelerator) && !issilicon(user))
-		install(A, user)
-	else
-		return ..()
+/obj/item/borg/upgrade/modkit/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/gun/energy/recharge/kinetic_accelerator) || issilicon(user))
+		return NONE
+	install(tool, user)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/borg/upgrade/modkit/action(mob/living/silicon/robot/R)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -54,11 +54,12 @@
 	else
 		..()
 
-/obj/item/minigunpack/attackby(obj/item/W, mob/user, list/modifiers, list/attack_modifiers)
-	if(W == gun) //Don't need armed check, because if you have the gun assume its armed.
-		user.dropItemToGround(gun, TRUE)
-	else
-		..()
+/obj/item/minigunpack/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(tool != gun) //Don't need armed check, because if you have the gun assume its armed.
+		return NONE
+	user.dropItemToGround(gun, TRUE)
+	return ITEM_INTERACT_SUCCESS
+
 
 /obj/item/minigunpack/dropped(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -359,14 +359,17 @@
 	var/firing_core = FALSE
 	gun_flags = NOT_A_REAL_GUN
 
-/obj/item/gun/energy/gravity_gun/attackby(obj/item/C, mob/user)
-	if(istype(C, /obj/item/assembly/signaler/anomaly/grav))
-		to_chat(user, span_notice("You insert [C] into the gravitational manipulator and the weapon gently hums to life."))
-		firing_core = TRUE
-		playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
-		qdel(C)
-		return
-	return ..()
+/obj/item/gun/energy/gravity_gun/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/assembly/signaler/anomaly/grav))
+		return NONE
+	if(firing_core)
+		user.balloon_alert(user, "already has a core!")
+		return ITEM_INTERACT_BLOCKING
+	to_chat(user, span_notice("You insert [tool] into the gravitational manipulator and the weapon gently hums to life."))
+	firing_core = TRUE
+	playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
+	qdel(tool)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/gun/energy/gravity_gun/can_shoot()
 	if(!firing_core)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -218,13 +218,17 @@
 	. = ..()
 	. += span_notice("<b>Left-click</b> to fire blue wormholes and <b><font color=orange>right-click</font></b> to fire orange wormholes.")
 
-/obj/item/gun/energy/wormhole_projector/attackby(obj/item/C, mob/user)
-	if(istype(C, /obj/item/assembly/signaler/anomaly/bluespace))
-		to_chat(user, span_notice("You insert [C] into the wormhole projector and the weapon gently hums to life."))
-		firing_core = TRUE
-		playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
-		qdel(C)
-		return
+/obj/item/gun/energy/wormhole_projector/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/assembly/signaler/anomaly/bluespace))
+		return NONE
+	if(firing_core)
+		user.balloon_alert(user, "already has a core!")
+		return ITEM_INTERACT_BLOCKING
+	to_chat(user, span_notice("You insert [tool] into the wormhole projector and the weapon gently hums to life."))
+	firing_core = TRUE
+	playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
+	qdel(tool)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/gun/energy/wormhole_projector/can_shoot()
 	if(!firing_core)

--- a/code/modules/projectiles/guns/special/blastcannon.dm
+++ b/code/modules/projectiles/guns/special/blastcannon.dm
@@ -89,24 +89,25 @@
 	inhand_icon_state = icon_state
 	return ..()
 
-/obj/item/gun/blastcannon/attackby(obj/item/transfer_valve/bomb_to_attach, mob/user)
-	if(!istype(bomb_to_attach))
-		return ..()
-
+/obj/item/gun/blastcannon/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/transfer_valve))
+		return NONE
+	var/obj/item/transfer_valve/bomb_to_attach = tool
 	if(bomb)
 		to_chat(user, span_warning("[bomb] is already attached to [src]!"))
-		return
+		return ITEM_INTERACT_BLOCKING
 	if(!bomb_to_attach.ready())
 		to_chat(user, span_warning("What good would an incomplete bomb do?"))
-		return FALSE
+		return ITEM_INTERACT_BLOCKING
 	if(!user.transferItemToLoc(bomb_to_attach, src))
 		to_chat(user, span_warning("[bomb_to_attach] seems to be stuck to your hand!"))
-		return FALSE
+		return ITEM_INTERACT_BLOCKING
 
-	user.visible_message(span_warning("[user] attaches [bomb_to_attach] to [src]!"))
+	user.visible_message(span_warning("[user] attaches [bomb_to_attach] to [src]!"),
+						span_notice("You attach bomb_to_attach to [src]."))
 	bomb = bomb_to_attach
 	update_appearance()
-	return TRUE
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/gun/blastcannon/try_fire_gun(atom/target, mob/living/user, params)
 	if((!bomb && bombcheck) || isnull(target) || (get_dist(get_turf(target), get_turf(user)) <= 2))

--- a/code/modules/projectiles/guns/special/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/special/grenade_launcher.dm
@@ -25,18 +25,19 @@
 	max_grenades = reset_fantasy_variable("max_syringes", max_grenades)
 	return ..()
 
-/obj/item/gun/grenadelauncher/attackby(obj/item/I, mob/user, list/modifiers, list/attack_modifiers)
-
-	if(istype(I, /obj/item/grenade/c4))
-		return
-	if((isgrenade(I)))
-		if(grenades.len < max_grenades)
-			if(!user.transferItemToLoc(I, src))
-				return
-			grenades += I
-			balloon_alert(user, "[grenades.len] / [max_grenades] grenades loaded")
-		else
-			balloon_alert(user, "it's already full!")
+/obj/item/gun/grenadelauncher/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!isgrenade(tool))
+		return NONE
+	if(istype(tool, /obj/item/grenade/c4))
+		return NONE
+	if(grenades.len == max_grenades)
+		balloon_alert(user, "it's already full!")
+		return ITEM_INTERACT_BLOCKING
+	if(!user.transferItemToLoc(tool, src))
+		return ITEM_INTERACT_BLOCKING
+	grenades += tool
+	balloon_alert(user, "[grenades.len] / [max_grenades] grenades loaded")
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/gun/grenadelauncher/can_shoot()
 	return grenades.len

--- a/code/modules/projectiles/guns/special/hand_of_midas.dm
+++ b/code/modules/projectiles/guns/special/hand_of_midas.dm
@@ -75,14 +75,15 @@
 	return ITEM_INTERACT_SUCCESS
 
 // If we botch a shot, we have to start over again by inserting gold coins into the gun. Can only be done if it has no charges or gold.
-/obj/item/gun/magic/midas_hand/attackby(obj/item/I, mob/living/user, list/modifiers, list/attack_modifiers)
-	. = ..()
+/obj/item/gun/magic/midas_hand/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/coin/gold))
+		return NONE
 	if(charges || gold_timer)
 		balloon_alert(user, "already loaded")
-		return
-	if(istype(I, /obj/item/coin/gold))
-		handle_gold_charges(user, 1.5 SECONDS)
-		qdel(I)
+		return ITEM_INTERACT_BLOCKING
+	handle_gold_charges(user, 1.5 SECONDS)
+	qdel(tool)
+	return ITEM_INTERACT_SUCCESS
 
 /// Handles recharging & inserting gold amount
 /obj/item/gun/magic/midas_hand/proc/handle_gold_charges(user, gold_amount)

--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -173,31 +173,35 @@
 /obj/item/burner/grind_results()
 	return list(/datum/reagent/consumable/ethanol = 5, /datum/reagent/silicon = 10)
 
-/obj/item/burner/attackby(obj/item/I, mob/living/user, list/modifiers, list/attack_modifiers)
-	. = ..()
-	if(is_reagent_container(I))
-		if(lit)
-			var/obj/item/reagent_containers/container = I
-			container.reagents.expose_temperature(get_temperature())
-			to_chat(user, span_notice("You heat up the [I] with the [src]."))
-			playsound(user.loc, 'sound/effects/chemistry/heatdam.ogg', 50, TRUE)
-			return
-		else if(I.is_drainable()) //Transfer FROM it TO us. Special code so it only happens when flame is off.
-			var/obj/item/reagent_containers/container = I
-			if(!container.reagents.total_volume)
-				to_chat(user, span_warning("[container] is empty and can't be poured!"))
-				return
+/obj/item/burner/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!is_reagent_container(tool))
+		if(tool.heat >= 1000)
+			set_lit(TRUE)
+			user.visible_message(span_notice("[user] lights up the [src]."))
+			return ITEM_INTERACT_SUCCESS
+		return NONE
 
-			if(reagents.holder_full())
-				to_chat(user, span_warning("[src] is full."))
-				return
+	if(lit)
+		tool.reagents.expose_temperature(get_temperature())
+		to_chat(user, span_notice("You heat up the [tool] with the [src]."))
+		playsound(user.loc, 'sound/effects/chemistry/heatdam.ogg', 50, TRUE)
+		return ITEM_INTERACT_SUCCESS
 
-			var/trans = container.reagents.trans_to(src, container.amount_per_transfer_from_this, transferred_by = user)
-			to_chat(user, span_notice("You fill [src] with [trans] unit\s of the contents of [container]."))
-	if(I.heat < 1000)
-		return
-	set_lit(TRUE)
-	user.visible_message(span_notice("[user] lights up the [src]."))
+	if(tool.is_drainable()) //Transfer FROM it TO us. Special code so it only happens when flame is off.
+		var/obj/item/reagent_containers/container = tool
+		if(!container.reagents.total_volume)
+			to_chat(user, span_warning("[container] is empty and can't be poured!"))
+			return ITEM_INTERACT_BLOCKING
+
+		if(reagents.holder_full())
+			to_chat(user, span_warning("[src] is full."))
+			return ITEM_INTERACT_BLOCKING
+
+		var/trans = container.reagents.trans_to(src, container.amount_per_transfer_from_this, transferred_by = user)
+		to_chat(user, span_notice("You fill [src] with [trans] unit\s of the contents of [container]."))
+		return ITEM_INTERACT_SUCCESS
+
+	return NONE
 
 /obj/item/burner/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!lit)

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -80,33 +80,33 @@
 		update_appearance()
 		SStgui.update_uis(src)
 
-/obj/machinery/computer/pandemic/attackby(obj/item/held_item, mob/user, list/modifiers, list/attack_modifiers)
+/obj/machinery/computer/pandemic/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	//Advanced science! Precision instruments (eg droppers and syringes) are precise enough to modify the loaded sample!
-	if(istype(held_item, /obj/item/reagent_containers/dropper) || istype(held_item, /obj/item/reagent_containers/syringe))
+	if(istype(tool, /obj/item/reagent_containers/dropper) || istype(tool, /obj/item/reagent_containers/syringe))
 		if(!beaker)
 			balloon_alert(user, "no beaker!")
-			return ..()
-		if(istype(held_item, /obj/item/reagent_containers/syringe) && LAZYACCESS(modifiers, RIGHT_CLICK))
-			held_item.interact_with_atom_secondary(beaker, user)
+			return ITEM_INTERACT_BLOCKING
+		if(istype(tool, /obj/item/reagent_containers/syringe) && LAZYACCESS(modifiers, RIGHT_CLICK))
+			tool.interact_with_atom_secondary(beaker, user)
 		else
-			held_item.interact_with_atom(beaker, user)
+			tool.interact_with_atom(beaker, user)
 		SStgui.update_uis(src)
-		return TRUE
+		return ITEM_INTERACT_SUCCESS
 
-	if(!is_reagent_container(held_item) || held_item.item_flags & ABSTRACT || !held_item.is_open_container())
-		return ..()
-	. = TRUE //no afterattack
+	if(!is_reagent_container(tool) || tool.item_flags & ABSTRACT || !tool.is_open_container())
+		return NONE
 	if(machine_stat & (NOPOWER|BROKEN))
-		return ..()
+		return ITEM_INTERACT_BLOCKING
 	if(beaker)
 		balloon_alert(user, "beaker swapped")
 		try_put_in_hand(beaker, usr)
 	else
 		balloon_alert(user, "beaker loaded")
-	user.transferItemToLoc(held_item, src)
-	beaker = held_item
+	user.transferItemToLoc(tool, src)
+	beaker = tool
 	update_appearance()
 	SStgui.update_uis(src)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/computer/pandemic/on_deconstruction(disassembled)
 	eject_beaker()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -85,21 +85,19 @@
 		if(tank_volume && (damage_flag == BULLET || damage_flag == LASER))
 			boom()
 
-/obj/structure/reagent_dispensers/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
-	if(attacking_item.is_refillable())
-		return FALSE //so we can refill them via their afterattack.
-	if(istype(attacking_item, /obj/item/assembly_holder) && accepts_rig)
+/obj/structure/reagent_dispensers/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(istype(tool, /obj/item/assembly_holder) && accepts_rig)
 		if(rig)
 			balloon_alert(user, "another device is in the way!")
-			return ..()
-		var/obj/item/assembly_holder/holder = attacking_item
+			return ITEM_INTERACT_BLOCKING
+		var/obj/item/assembly_holder/holder = tool
 		if(!(locate(/obj/item/assembly/igniter) in holder.assemblies))
-			return ..()
+			return ITEM_INTERACT_BLOCKING
 
 		user.balloon_alert_to_viewers("attaching rig...")
 		add_fingerprint(user)
 		if(!do_after(user, 2 SECONDS, target = src) || !user.transferItemToLoc(holder, src))
-			return
+			return ITEM_INTERACT_BLOCKING
 		rig = holder
 		holder.master = src
 		holder.on_attach()
@@ -111,10 +109,10 @@
 		log_bomber(user, "attached [holder.name] to ", src)
 		last_rigger = user
 		user.balloon_alert_to_viewers("attached rig")
-		return
+		return ITEM_INTERACT_SUCCESS
 
-	if(istype(attacking_item, /obj/item/stack/sheet/iron) && can_be_tanked)
-		var/obj/item/stack/sheet/iron/metal_stack = attacking_item
+	if(istype(tool, /obj/item/stack/sheet/iron) && can_be_tanked)
+		var/obj/item/stack/sheet/iron/metal_stack = tool
 		metal_stack.use(1)
 		var/obj/structure/reagent_dispensers/plumbed/storage/new_tank = new /obj/structure/reagent_dispensers/plumbed/storage(drop_location())
 		new_tank.reagents.maximum_volume = reagents.maximum_volume
@@ -123,9 +121,9 @@
 		new_tank.update_appearance(UPDATE_OVERLAYS)
 		new_tank.set_anchored(anchored)
 		qdel(src)
-		return FALSE
+		return ITEM_INTERACT_SUCCESS
 
-	return ..()
+	return NONE
 
 /obj/structure/reagent_dispensers/Exited(atom/movable/gone, direction)
 	. = ..()
@@ -294,39 +292,37 @@
 	// if this sucks, feel free to change it, but make sure the damn thing will log. thanks.
 	return ..()
 
-/obj/structure/reagent_dispensers/fueltank/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
-	if(attacking_item.tool_behaviour != TOOL_WELDER)
-		return ..()
-
-	var/obj/item/weldingtool/refilling_welder = attacking_item
+/obj/structure/reagent_dispensers/fueltank/welder_act(mob/living/user, obj/item/tool)
+	var/obj/item/weldingtool/refilling_welder = tool
 	if(istype(refilling_welder) && !refilling_welder.welding)
 		if(refilling_welder.reagents.has_reagent(/datum/reagent/fuel, refilling_welder.max_fuel))
 			to_chat(user, span_warning("Your [refilling_welder.name] is already full!"))
-			return
+			return ITEM_INTERACT_BLOCKING
 		reagents.trans_to(refilling_welder, refilling_welder.max_fuel, transferred_by = user)
 		user.visible_message(span_notice("[user] refills [user.p_their()] [refilling_welder.name]."), span_notice("You refill [refilling_welder]."))
 		playsound(src, 'sound/effects/refill.ogg', 50, TRUE)
 		refilling_welder.update_appearance()
-		return
+		return ITEM_INTERACT_SUCCESS
 
-	var/obj/item/lighter/refilling_lighter = attacking_item
+	var/obj/item/lighter/refilling_lighter = tool
 	if(istype(refilling_lighter) && !refilling_lighter.lit)
 		if(refilling_lighter.reagents.has_reagent(/datum/reagent/fuel, refilling_lighter.maximum_fuel))
 			to_chat(user, span_warning("Your [refilling_lighter.name] is already full!"))
-			return
+			return ITEM_INTERACT_BLOCKING
 		reagents.trans_to(refilling_lighter, refilling_lighter.maximum_fuel, transferred_by = user)
 		user.visible_message(span_notice("[user] refills [user.p_their()] [refilling_lighter.name]."), span_notice("You refill [refilling_lighter]."))
 		playsound(src, 'sound/effects/refill.ogg', 25, TRUE)
-		return
+		return ITEM_INTERACT_SUCCESS
 
 	if(!reagents.has_reagent(/datum/reagent/fuel))
 		to_chat(user, span_warning("[src] is out of fuel!"))
-		return
+		return ITEM_INTERACT_BLOCKING
 	user.visible_message(
-		span_danger("[user] catastrophically fails at refilling [user.p_their()] [attacking_item.name]!"),
+		span_danger("[user] catastrophically fails at refilling [user.p_their()] [tool.name]!"),
 		span_userdanger("That was stupid of you."))
-	log_bomber(user, "detonated a", src, "via [attacking_item.name]")
+	log_bomber(user, "detonated a", src, "via [tool.name]")
 	boom()
+	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/reagent_dispensers/fueltank/large
 	name = "high capacity fuel tank"

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -293,75 +293,85 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	GLOB.move_manager.stop_looping(thing, SSconveyors)
 
 // attack with item, place item on conveyor
-/obj/machinery/conveyor/attackby(obj/item/attacking_item, mob/living/user, list/modifiers, list/attack_modifiers)
-	if(attacking_item.tool_behaviour == TOOL_CROWBAR)
-		user.visible_message(span_notice("[user] struggles to pry up [src] with [attacking_item]."), \
-		span_notice("You struggle to pry up [src] with [attacking_item]."))
-
-		if(!attacking_item.use_tool(src, user, 4 SECONDS, volume = 40))
-			return
-		set_operating(FALSE)
-		var/obj/item/stack/conveyor/belt_item = new /obj/item/stack/conveyor(loc, 1, TRUE, null, null, id)
-		if(!QDELETED(belt_item)) //God I hate stacks
-			transfer_fingerprints_to(belt_item)
-
-		to_chat(user, span_notice("You remove [src]."))
-		qdel(src)
-
-	else if(attacking_item.tool_behaviour == TOOL_WRENCH)
-		attacking_item.play_tool_sound(src)
-		setDir(turn(dir, -45))
-		to_chat(user, span_notice("You rotate [src]."))
-
-	else if(attacking_item.tool_behaviour == TOOL_SCREWDRIVER)
-		attacking_item.play_tool_sound(src)
-		inverted = !inverted
-		update_move_direction()
-		to_chat(user, span_notice("You set [src]'s direction [inverted ? "backwards" : "back to default"]."))
-	else if(attacking_item.tool_behaviour == TOOL_MULTITOOL)
-		attacking_item.play_tool_sound(src)
-		wire_mode = !wire_mode
-		update_cable()
-		power_change()
-		if(wire_mode)
-			START_PROCESSING(SSmachines, src)
-		else
-			STOP_PROCESSING(SSmachines, src)
-		to_chat(user, span_notice("You set [src]'s wire mode [wire_mode ? "on" : "off"]."))
-	else if(istype(attacking_item, /obj/item/stack/conveyor))
+/obj/machinery/conveyor/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(istype(tool, /obj/item/stack/conveyor))
 		// We should place a new conveyor belt machine on the output turf the conveyor is pointing to.
 		var/turf/target_turf = get_step(get_turf(src), forwards)
-		if(!target_turf)
-			return ..()
+		if(!target_turf || isclosedturf(target_turf))
+			return ITEM_INTERACT_BLOCKING
 		for(var/obj/machinery/conveyor/belt in target_turf)
 			to_chat(user, span_warning("You cannot place a conveyor belt on top of another conveyor belt."))
-			return ..()
+			return ITEM_INTERACT_BLOCKING
 
-		var/obj/item/stack/conveyor/belt_item = attacking_item
+		var/obj/item/stack/conveyor/belt_item = tool
 		belt_item.use(1)
 		new /obj/machinery/conveyor(target_turf, forwards, id)
+		return ITEM_INTERACT_SUCCESS
 
-	else if(!user.combat_mode || (attacking_item.item_flags & NOBLUDGEON))
-		user.transfer_item_to_turf(attacking_item, drop_location())
+	if(!user.combat_mode || (tool.item_flags & NOBLUDGEON))
+		user.transfer_item_to_turf(tool, drop_location())
+		return ITEM_INTERACT_SUCCESS
+
+	return NONE
+
+/obj/machinery/conveyor/crowbar_act(mob/living/user, obj/item/tool)
+	user.visible_message(span_notice("[user] struggles to pry up [src] with [tool]."), \
+	span_notice("You struggle to pry up [src] with [tool]."))
+
+	if(!tool.use_tool(src, user, 4 SECONDS, volume = 40))
+		return ITEM_INTERACT_BLOCKING
+	set_operating(FALSE)
+	var/obj/item/stack/conveyor/belt_item = new /obj/item/stack/conveyor(loc, 1, TRUE, null, null, id)
+	if(!QDELETED(belt_item)) //God I hate stacks
+		transfer_fingerprints_to(belt_item)
+
+	to_chat(user, span_notice("You remove [src]."))
+	qdel(src)
+	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/conveyor/wrench_act(mob/living/user, obj/item/tool)
+	tool.play_tool_sound(src)
+	setDir(turn(dir, -45))
+	to_chat(user, span_notice("You rotate [src]."))
+	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/conveyor/screwdriver_act(mob/living/user, obj/item/tool)
+	tool.play_tool_sound(src)
+	inverted = !inverted
+	update_move_direction()
+	to_chat(user, span_notice("You set [src]'s direction [inverted ? "backwards" : "back to default"]."))
+	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/conveyor/multitool_act(mob/living/user, obj/item/tool)
+	tool.play_tool_sound(src)
+	wire_mode = !wire_mode
+	update_cable()
+	power_change()
+	if(wire_mode)
+		START_PROCESSING(SSmachines, src)
 	else
-		return ..()
+		STOP_PROCESSING(SSmachines, src)
+	to_chat(user, span_notice("You set [src]'s wire mode [wire_mode ? "on" : "off"]."))
+	return ITEM_INTERACT_SUCCESS
 
-/obj/machinery/conveyor/attackby_secondary(obj/item/attacking_item, mob/living/user, list/modifiers, list/attack_modifiers)
-	if(attacking_item.tool_behaviour == TOOL_SCREWDRIVER)
-		attacking_item.play_tool_sound(src)
-		flipped = !flipped
-		update_move_direction()
-		to_chat(user, span_notice("You flip [src]'s belt [flipped ? "around" : "back to normal"]."))
+/obj/machinery/conveyor/item_interaction_secondary(mob/living/user, obj/item/tool, list/modifiers)
+	if(user.combat_mode)
+		return NONE
+	user.transferItemToLoc(tool, drop_location())
+	return ITEM_INTERACT_SUCCESS
 
-	else if(attacking_item.tool_behaviour == TOOL_WRENCH)
-		attacking_item.play_tool_sound(src)
-		setDir(turn(dir, 45))
-		to_chat(user, span_notice("You rotate [src]."))
+/obj/machinery/conveyor/screwdriver_act_secondary(mob/living/user, obj/item/tool)
+	tool.play_tool_sound(src)
+	flipped = !flipped
+	update_move_direction()
+	to_chat(user, span_notice("You flip [src]'s belt [flipped ? "around" : "back to normal"]."))
+	return ITEM_INTERACT_SUCCESS
 
-	else if(!user.combat_mode)
-		user.transferItemToLoc(attacking_item, drop_location())
-
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+/obj/machinery/conveyor/wrench_act_secondary(mob/living/user, obj/item/tool)
+	tool.play_tool_sound(src)
+	setDir(turn(dir, 45))
+	to_chat(user, span_notice("You rotate [src]."))
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/conveyor/powered(chan = power_channel, ignore_use_power = FALSE)
 	if(!wire_mode)
@@ -548,10 +558,11 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 /obj/machinery/conveyor_switch/attack_robot_secondary(mob/user, list/modifiers)
 	return attack_hand_secondary(user, modifiers)
 
-/obj/machinery/conveyor_switch/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
-	if(is_wire_tool(attacking_item))
-		wires.interact(user)
-		return TRUE
+/obj/machinery/conveyor_switch/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!is_wire_tool(tool))
+		return NONE
+	wires.interact(user)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/conveyor_switch/multitool_act(mob/living/user, obj/item/I)
 	var/input_speed = tgui_input_number(user, "Set the speed of the conveyor belts in seconds", "Speed", conveyor_speed, 20, 0.2, round_value = FALSE)
@@ -663,12 +674,13 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	use(1)
 	return ITEM_INTERACT_SUCCESS
 
-/obj/item/stack/conveyor/attackby(obj/item/item_used, mob/user, list/modifiers, list/attack_modifiers)
-	..()
-	if(istype(item_used, /obj/item/conveyor_switch_construct))
-		to_chat(user, span_notice("You link the switch to the conveyor belt assembly."))
-		var/obj/item/conveyor_switch_construct/switch_construct = item_used
-		id = switch_construct.id
+/obj/item/stack/conveyor/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/conveyor_switch_construct))
+		return NONE
+	to_chat(user, span_notice("You link the switch to the conveyor belt assembly."))
+	var/obj/item/conveyor_switch_construct/switch_construct = tool
+	id = switch_construct.id
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/stack/conveyor/update_weight()
 	return FALSE

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -147,7 +147,7 @@ GLOBAL_VAR_INIT(disposals_animals_spawned, 0)
 		return ITEM_INTERACT_BLOCKING
 	to_chat(user, span_notice("You slice the floorweld off \the [src]."))
 	deconstruct()
-	return
+	return ITEM_INTERACT_SUCCESS
 
 /// The regal rat spawns ratty treasures from the disposal
 /obj/machinery/disposal/proc/rat_rummage(mob/living/basic/regal_rat/king)

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -119,32 +119,35 @@ GLOBAL_VAR_INIT(disposals_animals_spawned, 0)
 	air_contents.merge(removed)
 	trunk_check()
 
-/obj/machinery/disposal/attackby(obj/item/I, mob/living/user, list/modifiers, list/attack_modifiers)
+/obj/machinery/disposal/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	add_fingerprint(user)
-	if(!pressure_charging && !full_pressure && !flush)
-		if(I.tool_behaviour == TOOL_SCREWDRIVER)
-			toggle_panel_open()
-			I.play_tool_sound(src)
-			to_chat(user, span_notice("You [panel_open ? "remove":"attach"] the screws around the power connection."))
-			return
-		else if(I.tool_behaviour == TOOL_WELDER && panel_open)
-			if(!I.tool_start_check(user, amount=1, heat_required = HIGH_TEMPERATURE_REQUIRED))
-				return
-
-			to_chat(user, span_notice("You start slicing the floorweld off \the [src]..."))
-			if(I.use_tool(src, user, 20, volume=SMALL_MATERIAL_AMOUNT) && panel_open)
-				to_chat(user, span_notice("You slice the floorweld off \the [src]."))
-				deconstruct()
-			return
-
-	if(!user.combat_mode || (I.item_flags & NOBLUDGEON))
-		if(I.item_flags & ABSTRACT)
-			return
-		if(place_item_in_disposal(I, user))
+	if(!user.combat_mode || (tool.item_flags & NOBLUDGEON))
+		if(tool.item_flags & ABSTRACT)
+			return ITEM_INTERACT_BLOCKING
+		if(place_item_in_disposal(tool, user))
 			update_appearance()
-			return TRUE //no afterattack
-	else
-		return ..()
+			return ITEM_INTERACT_SUCCESS
+	return NONE
+
+/obj/machinery/disposal/screwdriver_act(mob/living/user, obj/item/tool)
+	if(pressure_charging || full_pressure || flush)
+		return NONE
+	toggle_panel_open()
+	tool.play_tool_sound(src)
+	to_chat(user, span_notice("You [panel_open ? "remove":"attach"] the screws around the power connection."))
+	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/disposal/welder_act(mob/living/user, obj/item/tool)
+	if(pressure_charging || full_pressure || flush || !panel_open)
+		return NONE
+	if(!tool.tool_start_check(user, amount=1, heat_required = HIGH_TEMPERATURE_REQUIRED))
+		return ITEM_INTERACT_BLOCKING
+	to_chat(user, span_notice("You start slicing the floorweld off \the [src]..."))
+	if(!tool.use_tool(src, user, 20, volume=SMALL_MATERIAL_AMOUNT) || !panel_open)
+		return ITEM_INTERACT_BLOCKING
+	to_chat(user, span_notice("You slice the floorweld off \the [src]."))
+	deconstruct()
+	return
 
 /// The regal rat spawns ratty treasures from the disposal
 /obj/machinery/disposal/proc/rat_rummage(mob/living/basic/regal_rat/king)
@@ -449,35 +452,31 @@ GLOBAL_VAR_INIT(disposals_animals_spawned, 0)
 	if(mapload && prob(CONTAINS_ANIMAL_CHANCE) && GLOB.disposals_animals_spawned < MAXIMUM_ANIMAL_SPAWNS)
 		spawn_contained_animal()
 
-// attack by item places it in to disposal
-/obj/machinery/disposal/bin/attackby(obj/item/weapon, mob/user, list/modifiers, list/attack_modifiers)
-	if(istype(weapon, /obj/item/storage/bag/trash)) //Not doing component overrides because this is a specific type.
-		var/obj/item/storage/bag/trash/bag = weapon
-		to_chat(user, span_warning("You empty the bag."))
-		bag.atom_storage.remove_all(src)
-		update_appearance()
-	else
+/obj/machinery/disposal/bin/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/storage/bag/trash))
 		return ..()
-// handle machine interaction
+	var/obj/item/storage/bag/trash/bag = tool
+	to_chat(user, span_warning("You empty the bag."))
+	bag.atom_storage.remove_all(src)
+	update_appearance()
+	return ITEM_INTERACT_SUCCESS
 
-/obj/machinery/disposal/bin/attackby_secondary(obj/item/weapon, mob/user, list/modifiers, list/attack_modifiers)
-	if(istype(weapon, /obj/item/dest_tagger))
-		var/obj/item/dest_tagger/new_tagger = weapon
-		if(mounted_tagger)
-			balloon_alert(user, "already has a tagger!")
-			return
-		if(HAS_TRAIT(new_tagger, TRAIT_NODROP) || !user.transferItemToLoc(new_tagger, src))
-			balloon_alert(user, "stuck to your hand!")
-			return
-		new_tagger.moveToNullspace()
-		user.visible_message(span_notice("[user] snaps \the [new_tagger] onto [src]!"))
-		balloon_alert(user, "tagger returned")
-		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
-		mounted_tagger = new_tagger
-		update_appearance()
-		return
-	else
+/obj/machinery/disposal/bin/item_interaction_secondary(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/dest_tagger))
 		return ..()
+	if(mounted_tagger)
+		balloon_alert(user, "already has a tagger!")
+		return ITEM_INTERACT_BLOCKING
+	if(HAS_TRAIT(tool, TRAIT_NODROP) || !user.transferItemToLoc(tool, src))
+		balloon_alert(user, "stuck to your hand!")
+		return ITEM_INTERACT_BLOCKING
+	tool.moveToNullspace()
+	user.visible_message(span_notice("[user] snaps \the [tool] onto [src]!"))
+	balloon_alert(user, "tagger returned")
+	playsound(src, 'sound/machines/click.ogg', 50, TRUE)
+	mounted_tagger = tool
+	update_appearance()
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/disposal/bin/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()

--- a/code/modules/recycling/disposal/pipe_sorting.dm
+++ b/code/modules/recycling/disposal/pipe_sorting.dm
@@ -55,20 +55,21 @@
 	else
 		. += "It has no sorting tags set."
 
-/obj/structure/disposalpipe/sorting/mail/attackby(obj/item/I, mob/user, list/modifiers, list/attack_modifiers)
-	if(istype(I, /obj/item/dest_tagger))
-		var/obj/item/dest_tagger/O = I
+/obj/structure/disposalpipe/sorting/mail/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/dest_tagger))
+		return NONE
+	var/relevant_tag = astype(tool, /obj/item/dest_tagger).currTag
 
-		if(O.currTag)// Tagger has a tag set
-			if(O.currTag in sortTypes)
-				sortTypes -= O.currTag
-				to_chat(user, span_notice("Removed \"[GLOB.TAGGERLOCATIONS[O.currTag]]\" filter."))
-			else
-				sortTypes |= O.currTag
-				to_chat(user, span_notice("Added \"[GLOB.TAGGERLOCATIONS[O.currTag]]\" filter."))
-			playsound(src, 'sound/machines/beep/twobeep_high.ogg', 100, TRUE)
+	if(!relevant_tag)// Tagger has a tag set
+		return ITEM_INTERACT_BLOCKING
+	if(relevant_tag in sortTypes)
+		sortTypes -= relevant_tag
+		to_chat(user, span_notice("Removed \"[GLOB.TAGGERLOCATIONS[relevant_tag]]\" filter."))
 	else
-		return ..()
+		sortTypes |= relevant_tag
+		to_chat(user, span_notice("Added \"[GLOB.TAGGERLOCATIONS[relevant_tag]]\" filter."))
+	playsound(src, 'sound/machines/beep/twobeep_high.ogg', 100, TRUE)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/disposalpipe/sorting/mail/check_sorting(obj/structure/disposalholder/H)
 	return (H.destinationTag in sortTypes)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -104,52 +104,57 @@
 	if(sticker)
 		. += "[base_icon_state]_barcode"
 
-/obj/item/delivery/attackby(obj/item/item, mob/user, list/modifiers, list/attack_modifiers)
-	if(istype(item, /obj/item/dest_tagger))
-		var/obj/item/dest_tagger/dest_tagger = item
+/obj/item/delivery/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(istype(tool, /obj/item/dest_tagger))
+		var/relevant_tag = astype(tool, /obj/item/dest_tagger).currTag
+		if(sort_tag == relevant_tag)
+			return ITEM_INTERACT_BLOCKING
+		var/tag = uppertext(GLOB.TAGGERLOCATIONS[relevant_tag])
+		to_chat(user, span_notice("*[tag]*"))
+		sort_tag = relevant_tag
+		playsound(loc, 'sound/machines/beep/twobeep_high.ogg', 100, TRUE)
+		update_appearance()
+		return ITEM_INTERACT_SUCCESS
 
-		if(sort_tag != dest_tagger.currTag)
-			var/tag = uppertext(GLOB.TAGGERLOCATIONS[dest_tagger.currTag])
-			to_chat(user, span_notice("*[tag]*"))
-			sort_tag = dest_tagger.currTag
-			playsound(loc, 'sound/machines/beep/twobeep_high.ogg', 100, TRUE)
-			update_appearance()
-
-	else if(istype(item, /obj/item/stack/wrapping_paper) && !giftwrapped)
-		var/obj/item/stack/wrapping_paper/wrapping_paper = item
-		if(wrapping_paper.use(3))
-			user.visible_message(span_notice("[user] wraps the package in festive paper!"))
-			giftwrapped = TRUE
-			greyscale_config = text2path("/datum/greyscale_config/gift[icon_state]")
-			set_greyscale(colors = wrapping_paper.greyscale_colors)
-			update_appearance()
-		else
+	if(istype(tool, /obj/item/stack/wrapping_paper))
+		if(giftwrapped)
+			return ITEM_INTERACT_BLOCKING
+		var/obj/item/stack/wrapping_paper/wrapping_paper = tool
+		if(!wrapping_paper.use(3))
 			to_chat(user, span_warning("You need more paper!"))
+			return ITEM_INTERACT_BLOCKING
+		user.visible_message(span_notice("[user] wraps the package in festive paper!"))
+		giftwrapped = TRUE
+		greyscale_config = text2path("/datum/greyscale_config/gift[icon_state]")
+		set_greyscale(colors = wrapping_paper.greyscale_colors)
+		update_appearance()
+		return ITEM_INTERACT_SUCCESS
 
-	else if(istype(item, /obj/item/paper))
+	if(istype(tool, /obj/item/paper))
 		if(note)
 			to_chat(user, span_warning("This package already has a note attached!"))
-			return
-		if(!user.transferItemToLoc(item, src))
-			to_chat(user, span_warning("For some reason, you can't attach [item]!"))
-			return
-		user.visible_message(span_notice("[user] attaches [item] to [src]."), span_notice("You attach [item] to [src]."))
-		note = item
+			return ITEM_INTERACT_BLOCKING
+		if(!user.transferItemToLoc(tool, src))
+			to_chat(user, span_warning("For some reason, you can't attach [tool]!"))
+			return ITEM_INTERACT_BLOCKING
+		user.visible_message(span_notice("[user] attaches [tool] to [src]."), span_notice("You attach [tool] to [src]."))
+		note = tool
 		update_appearance()
+		return ITEM_INTERACT_SUCCESS
 
-	else if(istype(item, /obj/item/universal_scanner))
-		var/obj/item/universal_scanner/sales_tagger = item
+	if(istype(tool, /obj/item/universal_scanner))
+		var/obj/item/universal_scanner/sales_tagger = tool
 		if(sales_tagger.scanning_mode != SCAN_SALES_TAG)
-			return
+			return ITEM_INTERACT_BLOCKING
 		if(sticker)
 			to_chat(user, span_warning("This package already has a barcode attached!"))
-			return
+			return ITEM_INTERACT_BLOCKING
 		if(!(sales_tagger.payments_acc))
 			to_chat(user, span_warning("Swipe an ID on [sales_tagger] first!"))
-			return
+			return ITEM_INTERACT_BLOCKING
 		if(sales_tagger.paper_count <= 0)
 			to_chat(user, span_warning("[sales_tagger] is out of paper!"))
-			return
+			return ITEM_INTERACT_BLOCKING
 		user.visible_message(span_notice("[user] attaches a barcode to [src]."), span_notice("You attach a barcode to [src]."))
 		sales_tagger.paper_count -= 1
 		sticker = new /obj/item/barcode(src)
@@ -161,38 +166,39 @@
 				continue
 			wrapped_item.AddComponent(/datum/component/pricetag, list(sticker.payments_acc), sales_tagger.cut_multiplier)
 		update_appearance()
+		return ITEM_INTERACT_SUCCESS
 
-	else if(istype(item, /obj/item/barcode))
-		var/obj/item/barcode/stickerA = item
+	if(istype(tool, /obj/item/barcode))
+		var/obj/item/barcode/stickerA = tool
 		if(sticker)
 			to_chat(user, span_warning("This package already has a barcode attached!"))
-			return
+			return ITEM_INTERACT_BLOCKING
 		if(!(stickerA.payments_acc))
 			to_chat(user, span_warning("This barcode seems to be invalid. Guess it's trash now."))
-			return
-		if(!user.transferItemToLoc(item, src))
-			to_chat(user, span_warning("For some reason, you can't attach [item]!"))
-			return
+			return ITEM_INTERACT_BLOCKING
+		if(!user.transferItemToLoc(tool, src))
+			to_chat(user, span_warning("For some reason, you can't attach [tool]!"))
+			return ITEM_INTERACT_BLOCKING
 		sticker = stickerA
 		for(var/obj/wrapped_item in get_all_contents())
 			if(HAS_TRAIT(wrapped_item, TRAIT_NO_BARCODES))
 				continue
 			wrapped_item.AddComponent(/datum/component/pricetag, list(sticker.payments_acc), sticker.cut_multiplier)
 		update_appearance()
+		return ITEM_INTERACT_SUCCESS
 
-	else if(istype(item, /obj/item/boxcutter))
-		var/obj/item/boxcutter/boxcutter_item = item
-		if(HAS_TRAIT(boxcutter_item, TRAIT_TRANSFORM_ACTIVE))
-			if(!attempt_pre_unwrap_contents(user, time = 0.5 SECONDS))
-				return
-			unwrap_contents()
-			balloon_alert(user, "cutting open package...")
-			post_unwrap_contents(user, rip_open = FALSE)
-		else
+	if(istype(tool, /obj/item/boxcutter))
+		var/obj/item/boxcutter/boxcutter_item = tool
+		if(!HAS_TRAIT(boxcutter_item, TRAIT_TRANSFORM_ACTIVE))
 			balloon_alert(user, "prime the boxcutter!")
+			return ITEM_INTERACT_BLOCKING
+		if(!attempt_pre_unwrap_contents(user, time = 0.5 SECONDS))
+			return ITEM_INTERACT_BLOCKING
+		unwrap_contents()
+		post_unwrap_contents(user, rip_open = FALSE)
+		return ITEM_INTERACT_SUCCESS
 
-	else
-		return ..()
+	return NONE
 
 /obj/item/delivery/nameformat(input, user)
 	playsound(src, SFX_WRITING_PEN, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, SOUND_FALLOFF_EXPONENT + 3, ignore_walls = FALSE)
@@ -348,34 +354,34 @@
 	if(payments_acc)
 		. += span_notice("<b>Ctrl-click</b> to clear the registered account.")
 
-/obj/item/sales_tagger/attackby(obj/item/item, mob/living/user, list/modifiers, list/attack_modifiers)
-	. = ..()
-	if(isidcard(item))
-		var/obj/item/card/id/potential_acc = item
-		if(potential_acc.registered_account)
-			if(payments_acc == potential_acc.registered_account)
-				to_chat(user, span_notice("ID card already registered."))
-				return
-			else
-				payments_acc = potential_acc.registered_account
-				playsound(src, 'sound/machines/ping.ogg', 40, TRUE)
-				to_chat(user, span_notice("[src] registers the ID card. Tag a wrapped item to create a barcode."))
-		else if(!potential_acc.registered_account)
+/obj/item/sales_tagger/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(isidcard(tool))
+		var/obj/item/card/id/potential_acc = tool
+		if(!potential_acc.registered_account)
 			to_chat(user, span_warning("This ID card has no account registered!"))
-			return
-	if(istype(item, /obj/item/paper))
-		if (!(paper_count >= max_paper_count))
-			paper_count += 10
-			qdel(item)
-			if (paper_count >= max_paper_count)
-				paper_count = max_paper_count
-				to_chat(user, span_notice("[src]'s paper supply is now full."))
-				return
-			to_chat(user, span_notice("You refill [src]'s paper supply, you have [paper_count] left."))
-			return
-		else
+			return ITEM_INTERACT_BLOCKING
+		if(payments_acc == potential_acc.registered_account)
+			to_chat(user, span_notice("ID card already registered."))
+			return ITEM_INTERACT_BLOCKING
+		payments_acc = potential_acc.registered_account
+		playsound(src, 'sound/machines/ping.ogg', 40, TRUE)
+		to_chat(user, span_notice("[src] registers the ID card. Tag a wrapped item to create a barcode."))
+		return ITEM_INTERACT_SUCCESS
+
+	if(istype(tool, /obj/item/paper))
+		if ((paper_count >= max_paper_count))
 			to_chat(user, span_notice("[src]'s paper supply is full."))
-			return
+			return ITEM_INTERACT_BLOCKING
+		paper_count += 10
+		qdel(tool)
+		if (paper_count >= max_paper_count)
+			paper_count = max_paper_count
+			to_chat(user, span_notice("[src]'s paper supply is now full."))
+			return ITEM_INTERACT_SUCCESS
+		to_chat(user, span_notice("You refill [src]'s paper supply, you have [paper_count] left."))
+		return ITEM_INTERACT_SUCCESS
+
+	return NONE
 
 /obj/item/sales_tagger/attack_self(mob/user)
 	. = ..()

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -190,10 +190,10 @@
 /obj/item/gun/ballistic/revolver/chaplain/attack_self(mob/living/user)
 	pray_refill(user)
 
-/obj/item/gun/ballistic/revolver/chaplain/attackby(obj/item/possibly_ammo, mob/user, list/modifiers, list/attack_modifiers)
-	if (isammocasing(possibly_ammo) || istype(possibly_ammo, /obj/item/ammo_box))
+/obj/item/gun/ballistic/revolver/chaplain/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if (isammocasing(tool) || istype(tool, /obj/item/ammo_box))
 		user.balloon_alert(user, "no manual reloads!")
-		return
+		return ITEM_INTERACT_BLOCKING
 
 	return ..()
 

--- a/code/modules/shuttle/misc/special.dm
+++ b/code/modules/shuttle/misc/special.dm
@@ -60,8 +60,8 @@
 		active = FALSE
 	update_appearance()
 
-/obj/machinery/power/emitter/energycannon/magical/attackby(obj/item/W, mob/user, list/modifiers, list/attack_modifiers)
-	return
+/obj/machinery/power/emitter/energycannon/magical/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	return NONE
 
 /obj/machinery/power/emitter/energycannon/magical/ex_act(severity)
 	return FALSE
@@ -249,8 +249,8 @@
 /obj/machinery/scanner_gate/luxury_shuttle/auto_scan(atom/movable/AM)
 	return
 
-/obj/machinery/scanner_gate/luxury_shuttle/attackby(obj/item/W, mob/user, list/modifiers, list/attack_modifiers)
-	return
+/obj/machinery/scanner_gate/luxury_shuttle/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	return NONE
 
 /obj/machinery/scanner_gate/luxury_shuttle/emag_act(mob/user, obj/item/card/emag/emag_card)
 	return FALSE

--- a/code/modules/shuttle/mobile_port/variants/emergency/emergency_console.dm
+++ b/code/modules/shuttle/mobile_port/variants/emergency/emergency_console.dm
@@ -42,10 +42,11 @@
 		if(hijack_announce)
 			. += span_warning("It is probably best to fortify your position as to be uninterrupted during the attempt, given the automatic announcements..")
 
-/obj/machinery/computer/emergency_shuttle/attackby(obj/item/I, mob/user,list/modifiers)
-	if(isidcard(I))
-		say("Please equip your ID card into your ID slot to authenticate.")
-	. = ..()
+/obj/machinery/computer/emergency_shuttle/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!isidcard(tool))
+		return NONE
+	say("Please equip your ID card into your ID slot to authenticate.")
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/computer/emergency_shuttle/ui_state(mob/user)
 	return GLOB.human_adjacent_state

--- a/code/modules/spells/spell_types/self/spacetime_distortion.dm
+++ b/code/modules/spells/spell_types/self/spacetime_distortion.dm
@@ -141,11 +141,12 @@
 	if(!busy)
 		walk_link(AM)
 
-/obj/effect/cross_action/spacetime_dist/attackby(obj/item/W, mob/user, list/modifiers, list/attack_modifiers)
-	if(user.temporarilyRemoveItemFromInventory(W))
-		walk_link(W)
+/obj/effect/cross_action/spacetime_dist/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(user.temporarilyRemoveItemFromInventory(tool))
+		walk_link(tool)
 	else
 		walk_link(user)
+	return ITEM_INTERACT_SUCCESS
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/effect/cross_action/spacetime_dist/attack_hand(mob/user, list/modifiers)

--- a/code/modules/transport/tram/tram_signals.dm
+++ b/code/modules/transport/tram/tram_signals.dm
@@ -175,20 +175,19 @@
 	find_uplink()
 	return CLICK_ACTION_SUCCESS
 
-/obj/machinery/transport/crossing_signal/attackby_secondary(obj/item/weapon, mob/user, list/modifiers, list/attack_modifiers)
-	. = ..()
+/obj/machinery/transport/crossing_signal/wrench_act_secondary(mob/living/user, obj/item/tool)
+	if(!panel_open)
+		return NONE
+	switch(sign_dir)
+		if(INBOUND)
+			sign_dir = OUTBOUND
+		if(OUTBOUND)
+			sign_dir = INBOUND
 
-	if(weapon.tool_behaviour == TOOL_WRENCH && panel_open)
-		switch(sign_dir)
-			if(INBOUND)
-				sign_dir = OUTBOUND
-			if(OUTBOUND)
-				sign_dir = INBOUND
+	to_chat(user, span_notice("You flip directions on [src]."))
+	update_appearance()
+	return ITEM_INTERACT_SUCCESS
 
-		to_chat(user, span_notice("You flip directions on [src]."))
-		update_appearance()
-
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/transport/crossing_signal/proc/link_sensor()
 	sensor_ref = WEAKREF(find_closest_valid_sensor())

--- a/code/modules/transport/tram/tram_structures.dm
+++ b/code/modules/transport/tram/tram_structures.dm
@@ -163,53 +163,66 @@
 		update_appearance()
 	return ITEM_INTERACT_SUCCESS
 
-/obj/structure/tram/attackby_secondary(obj/item/tool, mob/user, list/modifiers, list/attack_modifiers)
-	switch(state)
-		if(TRAM_SCREWED_TO_FRAME)
-			if(tool.tool_behaviour == TOOL_SCREWDRIVER)
-				user.visible_message(span_notice("[user] begins to unscrew the tram panel from the frame..."),
-				span_notice("You begin to unscrew the tram panel from the frame..."))
-				if(tool.use_tool(src, user, 1 SECONDS, volume = 50))
-					state = TRAM_IN_FRAME
-					to_chat(user, span_notice("The screws come out, and a gap forms around the edge of the pane."))
-					return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-			if(tool.tool_behaviour)
+/obj/structure/tram/item_interaction_secondary(mob/living/user, obj/item/tool, list/modifiers)
+	if(tool.tool_behaviour)
+		switch(state)
+			if(TRAM_SCREWED_TO_FRAME)
 				to_chat(user, span_warning("The security screws need to be removed first!"))
+				return ITEM_INTERACT_BLOCKING
 
+			if(TRAM_OUT_OF_FRAME)
+				to_chat(user, span_warning("The cabling need to be cut first!"))
+				return ITEM_INTERACT_BLOCKING
+	return NONE
+
+/obj/structure/tram/crowbar_act_secondary(mob/living/user, obj/item/tool)
+	switch(state)
 		if(TRAM_IN_FRAME)
-			if(tool.tool_behaviour == TOOL_CROWBAR)
-				user.visible_message(span_notice("[user] wedges \the [tool] into the tram panel's gap in the frame and starts prying..."),
-				span_notice("You wedge \the [tool] into the tram panel's gap in the frame and start prying..."))
-				if(tool.use_tool(src, user, 1 SECONDS, volume = 50))
-					state = TRAM_OUT_OF_FRAME
-					to_chat(user, span_notice("The panel pops out of the frame, exposing some cabling that look like they can be cut."))
-					return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-			if(tool.tool_behaviour == TOOL_SCREWDRIVER)
-				user.visible_message(span_notice("[user] resecures the tram panel to the frame..."),
-				span_notice("You resecure the tram panel to the frame..."))
-				state = TRAM_SCREWED_TO_FRAME
-				return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+			user.visible_message(span_notice("[user] wedges \the [tool] into the tram panel's gap in the frame and starts prying..."),
+								span_notice("You wedge \the [tool] into the tram panel's gap in the frame and start prying..."))
+			if(!tool.use_tool(src, user, 1 SECONDS, volume = 50))
+				return ITEM_INTERACT_BLOCKING
+			state = TRAM_OUT_OF_FRAME
+			to_chat(user, span_notice("The panel pops out of the frame, exposing some cabling that look like they can be cut."))
+			return ITEM_INTERACT_SUCCESS
 
 		if(TRAM_OUT_OF_FRAME)
-			if(tool.tool_behaviour == TOOL_WIRECUTTER)
-				user.visible_message(span_notice("[user] starts cutting the connective cabling on \the [src]..."),
-				span_notice("You start cutting the connective cabling on \the [src]"))
-				if(tool.use_tool(src, user, 1 SECONDS, volume = 50))
-					to_chat(user, span_notice("The panels falls out of the way exposing the frame backing."))
-					deconstruct(disassembled = TRUE)
+			user.visible_message(span_notice("[user] snaps the tram panel into place."),
+								span_notice("You snap the tram panel into place."))
+			state = TRAM_IN_FRAME
+			return ITEM_INTERACT_SUCCESS
 
-			if(tool.tool_behaviour == TOOL_CROWBAR)
-				user.visible_message(span_notice("[user] snaps the tram panel into place."),
-				span_notice("You snap the tram panel into place..."))
-				state = TRAM_IN_FRAME
-				return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return NONE //Head back to item_interaction_secondary() to get the same message as other unsuitable tools
 
-			if(tool.tool_behaviour)
-				to_chat(user, span_warning("The cabling need to be cut first!"))
+/obj/structure/tram/screwdriver_act_secondary(mob/living/user, obj/item/tool)
+	switch(state)
+		if(TRAM_SCREWED_TO_FRAME)
+			user.visible_message(span_notice("[user] begins to unscrew the tram panel from the frame..."),
+								span_notice("You begin to unscrew the tram panel from the frame..."))
+			if(!tool.use_tool(src, user, 1 SECONDS, volume = 50))
+				return ITEM_INTERACT_BLOCKING
+			state = TRAM_IN_FRAME
+			to_chat(user, span_notice("The screws come out, and a gap forms around the edge of the pane."))
+			return ITEM_INTERACT_SUCCESS
 
-	return ..()
+		if(TRAM_IN_FRAME)
+			user.visible_message(span_notice("[user] resecures the tram panel to the frame..."),
+								span_notice("You resecure the tram panel to the frame."))
+			state = TRAM_SCREWED_TO_FRAME
+			return ITEM_INTERACT_SUCCESS
+
+	return NONE
+
+/obj/structure/tram/wirecutter_act_secondary(mob/living/user, obj/item/tool)
+	if(state != TRAM_OUT_OF_FRAME)
+		return NONE
+	user.visible_message(span_notice("[user] starts cutting the connective cabling on \the [src]..."),
+						span_notice("You start cutting the connective cabling on \the [src]"))
+	if(!tool.use_tool(src, user, 1 SECONDS, volume = 50))
+		return ITEM_INTERACT_BLOCKING
+	to_chat(user, span_notice("The panels falls out of the way exposing the frame backing."))
+	deconstruct(disassembled = TRUE)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/tram/atom_deconstruct(disassembled = TRUE)
 	if(disassembled)

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -745,11 +745,12 @@
 
 	return open_lift_radial(user)
 
-/obj/structure/transport/linear/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+/obj/structure/transport/linear/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(!radial_travel)
-		return ..()
+		return NONE
 
-	return open_lift_radial(user)
+	open_lift_radial(user)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/transport/linear/attack_robot(mob/living/user)
 	if(!radial_travel)

--- a/code/modules/wiremod/components/abstract/module.dm
+++ b/code/modules/wiremod/components/abstract/module.dm
@@ -229,11 +229,11 @@
 	. = list()
 	.["global_port_types"] = GLOB.wiremod_basic_types
 
-/obj/item/circuit_component/module/attackby(obj/item/I, mob/living/user, list/modifiers, list/attack_modifiers)
-	if(istype(I, /obj/item/circuit_component))
-		internal_circuit.attackby(I, user, modifiers)
-		return
-	return ..()
+/obj/item/circuit_component/module/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/circuit_component))
+		return NONE
+	internal_circuit.item_interaction(user, tool, modifiers)
+	return ITEM_INTERACT_SUCCESS
 
 #define WITHIN_RANGE(id, table) (id >= 1 && id <= length(table))
 


### PR DESCRIPTION

## About The Pull Request

30 more(files, counting by files now). In combination with the other pr this means that we are now at more `item_interaction()` overrides than `attackby()` overrides, not counting `[tool]_act()`s.

Changes beyond conversion:
You can no longer repeatedly put gravitational or bluespace cores into the gravity and wormhole guns, respectively. One's enough.
A runtime that occured when boxcuttering a package open no longer occurs

## Why It's Good For The Game

300 GBP for the cost of 3. A steal if I've ever seen one. You should get in on this.

## Changelog
:cl:

fix: You can no longer repeatedly put anomaly cores into the anomaly core guns
fix: A runtime that occured when opening a package with a boxcutter no longer occurs.

code: 30 files have been moved from attackby() to item_interaction()

/:cl:
