### PR TITLE
Makes smartfridges smarter (deletes attackby)

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -260,64 +260,59 @@
 	playsound(src, SFX_SHATTER, 50, TRUE)
 	return ..()
 
-/obj/machinery/smartfridge/attackby(obj/item/weapon, mob/living/user, list/modifiers, list/attack_modifiers)
-	if(!machine_stat)
-		var/shown_contents_length = visible_items()
-		if(shown_contents_length >= max_n_of_items)
-			balloon_alert(user, "no space!")
-			return FALSE
+/obj/machinery/smartfridge/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	. = NONE
 
-		if(!(weapon.item_flags & ABSTRACT) && \
-			!(weapon.flags_1 & HOLOGRAM_1) && \
-			accept_check(weapon) \
-		)
-			load(weapon, user)
-			user.visible_message(span_notice("[user] adds \the [weapon] to \the [src]."), span_notice("You add \the [weapon] to \the [src]."))
-			SStgui.update_uis(src)
-			if(visible_contents)
-				update_appearance()
-			return TRUE
+	if(!istype(tool))
+		return
 
-		if(istype(weapon, /obj/item/storage/bag))
-			var/obj/item/storage/bag = weapon
-			var/loaded = 0
-			for(var/obj/item/object in bag.contents)
-				if(shown_contents_length >= max_n_of_items)
-					break
-				if(!(object.item_flags & ABSTRACT) && \
-					!(object.flags_1 & HOLOGRAM_1) && \
-					accept_check(object) \
-				)
-					load(object, user)
-					loaded++
-			SStgui.update_uis(src)
+	if(machine_stat)
+		if(machine_stat & NOPOWER)
+			to_chat(user, span_warning("\The [src]'s magnetic door won't open without power!"))
+		return ITEM_INTERACT_BLOCKING
 
-			if(loaded)
-				if(shown_contents_length >= max_n_of_items)
-					user.visible_message(span_notice("[user] loads \the [src] with \the [weapon]."), \
-						span_notice("You fill \the [src] with \the [weapon]."))
-				else
-					user.visible_message(span_notice("[user] loads \the [src] with \the [weapon]."), \
-						span_notice("You load \the [src] with \the [weapon]."))
-				if(weapon.contents.len)
-					to_chat(user, span_warning("Some items are refused."))
-				if (visible_contents)
-					update_appearance()
-				return TRUE
+	var/shown_contents_length = visible_items()
+	if(shown_contents_length >= max_n_of_items)
+		balloon_alert(user, "no space!")
+		return ITEM_INTERACT_BLOCKING
+
+	if(!(tool.item_flags & ABSTRACT) && !(tool.flags_1 & HOLOGRAM_1) && accept_check(tool))
+		load(tool, user)
+		user.visible_message(span_notice("[user] adds \the [tool] to \the [src]."), span_notice("You add \the [tool] to \the [src]."))
+		SStgui.update_uis(src)
+		if(visible_contents)
+			update_appearance()
+		return ITEM_INTERACT_SUCCESS
+
+	if(istype(tool, /obj/item/storage/bag))
+		var/loaded = 0
+		for(var/obj/item/object in tool.contents)
+			if(shown_contents_length >= max_n_of_items)
+				break
+			if(!(object.item_flags & ABSTRACT) && !(object.flags_1 & HOLOGRAM_1) && accept_check(object))
+				load(object, user)
+				loaded++
+		SStgui.update_uis(src)
+
+		if(loaded)
+			if(shown_contents_length >= max_n_of_items)
+				user.visible_message(span_notice("[user] loads \the [src] with \the [tool]."), \
+					span_notice("You fill \the [src] with \the [tool]."))
 			else
-				to_chat(user, span_warning("There is nothing in [weapon] to put in [src]!"))
-				return FALSE
+				user.visible_message(span_notice("[user] loads \the [src] with \the [tool]."), \
+					span_notice("You load \the [src] with \the [tool]."))
+			if(length(tool.contents))
+				to_chat(user, span_warning("Some items are refused."))
+			if (visible_contents)
+				update_appearance()
+			return ITEM_INTERACT_SUCCESS
 
-	if(!powered())
-		to_chat(user, span_warning("\The [src]'s magnetic door won't open without power!"))
-		return FALSE
+		else
+			to_chat(user, span_warning("There is nothing in [tool] to put in [src]!"))
+			return ITEM_INTERACT_BLOCKING
 
-	if(!user.combat_mode || (weapon.item_flags & NOBLUDGEON))
-		to_chat(user, span_warning("\The [src] smartly refuses [weapon]."))
-		return FALSE
-
-	else
-		return ..()
+	to_chat(user, span_warning("\The [src] smartly refuses [tool]."))
+	return ITEM_INTERACT_BLOCKING
 
 /**
  * Can this item be accepted by the smart fridge

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -185,7 +185,7 @@
 	. = ..()
 
 	if(in_range(user, src) || isobserver(user))
-		. += span_notice("The status display reads: This unit can hold a maximum of <b>[max_n_of_items]</b> items.")
+		. += status_examine()
 
 	. += structure_examine()
 
@@ -210,6 +210,12 @@
 		. += span_info("It is [EXAMINE_HINT("wrenched")] down on the floor.")
 	else
 		. += span_info("It could be [EXAMINE_HINT("wrenched")] down.")
+
+/// Returns details related to the fridge status
+/obj/machinery/smartfridge/proc/status_examine()
+	. = list()
+
+	. += span_notice("The status display reads: This unit can hold a maximum of <b>[max_n_of_items]</b> items.")
 
 /obj/machinery/smartfridge/update_appearance(updates=ALL)
 	. = ..()
@@ -580,6 +586,10 @@
 		tool_tip_set = TRUE
 
 	return tool_tip_set ? CONTEXTUAL_SCREENTIP_SET : NONE
+
+/obj/machinery/smartfridge/drying/rack/status_examine()
+	. = list()
+	. += span_notice("It looks like this unit can hold a maximum of <b>[max_n_of_items]</b> items.")
 
 /obj/machinery/smartfridge/drying/rack/structure_examine()
 	. = ..()

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -288,7 +288,7 @@
 			update_appearance()
 		return ITEM_INTERACT_SUCCESS
 
-	// Loading from a bag (until fridge isfull)
+	// Loading from a bag (until fridge is full)
 	if(istype(tool, /obj/item/storage/bag))
 		var/loaded = 0
 		for(var/obj/item/object in tool.contents)

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -264,9 +264,8 @@
 	return !(loadable.item_flags & ABSTRACT) && !(loadable.flags_1 & HOLOGRAM_1) && accept_check(loadable)
 
 /obj/machinery/smartfridge/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	. = NONE
-	if(!istype(tool))
-		return
+	if(user.combat_mode)
+		return NONE
 	if(machine_stat)
 		if(machine_stat & NOPOWER)
 			to_chat(user, span_warning("\The [src]'s magnetic door won't open without power!"))

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -260,56 +260,63 @@
 	playsound(src, SFX_SHATTER, 50, TRUE)
 	return ..()
 
+/obj/machinery/smartfridge/proc/can_load_item(obj/item/loadable)
+	return !(loadable.item_flags & ABSTRACT) && !(loadable.flags_1 & HOLOGRAM_1) && accept_check(loadable)
+
 /obj/machinery/smartfridge/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	. = NONE
-
 	if(!istype(tool))
 		return
-
 	if(machine_stat)
 		if(machine_stat & NOPOWER)
 			to_chat(user, span_warning("\The [src]'s magnetic door won't open without power!"))
 		return ITEM_INTERACT_BLOCKING
 
-	var/shown_contents_length = visible_items()
-	if(shown_contents_length >= max_n_of_items)
+	var/loaded_count = visible_items()
+	if(loaded_count >= max_n_of_items)
 		balloon_alert(user, "no space!")
 		return ITEM_INTERACT_BLOCKING
 
-	if(!(tool.item_flags & ABSTRACT) && !(tool.flags_1 & HOLOGRAM_1) && accept_check(tool))
+	// Loading a single item
+	if(can_load_item(tool))
 		load(tool, user)
-		user.visible_message(span_notice("[user] adds \the [tool] to \the [src]."), span_notice("You add \the [tool] to \the [src]."))
+		user.visible_message(
+			span_notice("[user] adds \the [tool] to \the [src]."),
+			span_notice("You add \the [tool] to \the [src]."),
+		)
 		SStgui.update_uis(src)
 		if(visible_contents)
 			update_appearance()
 		return ITEM_INTERACT_SUCCESS
 
+	// Loading from a bag (until fridge isfull)
 	if(istype(tool, /obj/item/storage/bag))
 		var/loaded = 0
 		for(var/obj/item/object in tool.contents)
-			if(shown_contents_length >= max_n_of_items)
+			if(loaded_count >= max_n_of_items)
 				break
-			if(!(object.item_flags & ABSTRACT) && !(object.flags_1 & HOLOGRAM_1) && accept_check(object))
-				load(object, user)
-				loaded++
+			if(!can_load_item(object))
+				continue
+			load(object, user)
+			loaded++
+			loaded_count++
+
 		SStgui.update_uis(src)
 
-		if(loaded)
-			if(shown_contents_length >= max_n_of_items)
-				user.visible_message(span_notice("[user] loads \the [src] with \the [tool]."), \
-					span_notice("You fill \the [src] with \the [tool]."))
-			else
-				user.visible_message(span_notice("[user] loads \the [src] with \the [tool]."), \
-					span_notice("You load \the [src] with \the [tool]."))
-			if(length(tool.contents))
-				to_chat(user, span_warning("Some items are refused."))
-			if (visible_contents)
-				update_appearance()
-			return ITEM_INTERACT_SUCCESS
-
-		else
+		if(!loaded)
 			to_chat(user, span_warning("There is nothing in [tool] to put in [src]!"))
 			return ITEM_INTERACT_BLOCKING
+
+		var/filled = loaded_count >= max_n_of_items
+		user.visible_message(
+			span_notice("[user] loads \the [src] with \the [tool]."),
+			span_notice("You [filled ? "fill" : "load"] \the [src] with \the [tool]."),
+		)
+		if(length(tool.contents))
+			to_chat(user, span_warning("Some items are refused."))
+		if(visible_contents)
+			update_appearance()
+		return ITEM_INTERACT_SUCCESS
 
 	to_chat(user, span_warning("\The [src] smartly refuses [tool]."))
 	return ITEM_INTERACT_BLOCKING


### PR DESCRIPTION
## About The Pull Request

Refactors smartfridges to use `item_interact` instead of `attackby` and cleans up the code + fixes a logic error.

<details><summary>Still works</summary>

<img width="1441" height="990" alt="dreamseeker_KACT01jssN" src="https://github.com/user-attachments/assets/b473b0d6-142a-4eab-89b1-bd4a71900939" />

</details>

## Why It's Good For The Game

Better, cleaner, more modern code.

## Changelog

:cl:
fix: fixed an issue where you could exceed the smartfridge's capacity by using a plant bag
/:cl: