### PR TITLE
Smelter controllers don't rely on view

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -76,7 +76,7 @@
 
 /obj/machinery/mineral/processing_unit_console/Initialize(mapload)
 	. = ..()
-	processing_machine = locate(/obj/machinery/mineral/processing_unit) in view(2, src)
+	processing_machine = locate(/obj/machinery/mineral/processing_unit) in range(2, src)
 	if (processing_machine)
 		processing_machine.mineral_machine = src
 	else


### PR DESCRIPTION
## About The Pull Request

Use range instead of view for linking smelters

## Why It's Good For The Game

For mapper control

## Changelog

:cl: Melbert
fix: Icebox gulag console doesn't vanish from reality
/:cl:

