### PR TITLE
Fixes the tiles on the Ex-Interdyne Pirate Ship

### DIFF
--- a/_maps/shuttles/pirate/pirate_ex_interdyne.dmm
+++ b/_maps/shuttles/pirate/pirate_ex_interdyne.dmm
@@ -555,10 +555,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/shuttle/pirate)
-"mD" = (
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/pirate)
 "mU" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron/dark,
@@ -1060,7 +1056,7 @@ qy
 ED
 aj
 aj
-mD
+aj
 bB
 Ur
 aj
@@ -1132,7 +1128,7 @@ af
 af
 aO
 DD
-mD
+aj
 DD
 DD
 aO


### PR DESCRIPTION
## About The Pull Request

Removes two turf tile decals that were erroneously placed on walls on the Ex-Interdyne Shuttle.

## Why It's Good For The Game

Looks better, even though this only becomes apparent during pride month (happy pride month btw) turf decals shouldn't be on walls anyhow.

## Changelog

:cl:
fix: Fixed some weird turf decals on walls for the Ex-Interdyne Pirate Ship
/:cl: