### PR TITLE
Fix GBP and auto changelog workflows not working

### DIFF
--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.base_ref }}
 
       - name: Generate App Token
         id: app-token-generation

--- a/.github/workflows/gbp.yml
+++ b/.github/workflows/gbp.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Checkout
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.base_ref }}
       - name: Setup git
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         run: |

--- a/.github/workflows/gbp.yml
+++ b/.github/workflows/gbp.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.base_ref }}
       - name: Run Auto Labeler
         uses: actions/github-script@v9
         with:


### PR DESCRIPTION

## About The Pull Request

The `pull_request_target` trigger by default checks out the head ref of the PR but runs with the secrets of the base ref, which a bad actor can take advantage of, GitHub blocks the most common vector of this by default now. Changes the workflows to explicitly check out the base ref (the branch being PRed to, instead of the branch being PRed) because neither of these jobs specifically requires that it be the head ref being checked out

## Why It's Good For The Game

Changelogs and GBP will work again

## Changelog

No
