### PR TITLE
Plant Analyzer chemical tab bluescreen fix on starthistle seeds

### DIFF
--- a/code/game/objects/items/devices/scanners/plant_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/plant_analyzer.dm
@@ -303,8 +303,8 @@
 	)
 	seed_data["removable_traits"] = list()
 	seed_data["core_traits"] = list()
-	seed_data["distill_reagent"] = list()
-	seed_data["juice_name"] = list()
+	seed_data["distill_reagent"] = ""
+	seed_data["juice_name"] = ""
 	seed_data["grind_results"] = list()
 	for(var/datum/plant_gene/trait/trait in seed.genes)
 		if(trait.mutability_flags & PLANT_GENE_REMOVABLE)

--- a/code/game/objects/items/devices/scanners/plant_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/plant_analyzer.dm
@@ -303,6 +303,9 @@
 	)
 	seed_data["removable_traits"] = list()
 	seed_data["core_traits"] = list()
+	seed_data["distill_reagent"] = list()
+	seed_data["juice_name"] = list()
+	seed_data["grind_results"] = list()
 	for(var/datum/plant_gene/trait/trait in seed.genes)
 		if(trait.mutability_flags & PLANT_GENE_REMOVABLE)
 			seed_data["removable_traits"] += trait.type


### PR DESCRIPTION
## About The Pull Request

When scanning the chemical contents of the starthistle seeds and corpse flowers, the plant analyzer TGUI menu threw a bluescreen related to a null list. This PR fixes that.

The actual problem was that in `code/game/objects/items/devices/scanners/plant_analyzer.dm:285`, `make_seed_data` proc which was responsible for collecting seed data to send to the TGUI only ever initialized the `distill_reagent`, `juice_name` and `grind_results` list entries when the plant had a produce - which starthistles and corpse flowers do not have. I fixed it by simply initializing these 2 entries as empty at the beginning of the proc.

## Why It's Good For The Game

Fixes a UI bluescreen.

Before:
<img width="851" height="708" alt="image" src="https://github.com/user-attachments/assets/16870d25-ece2-4d66-afca-53bd598a63ec" />
Upon opening the chemical tab of the plant analyzer when analyzing corpse flowers, the tab bluescreens.

After:
<img width="896" height="807" alt="image" src="https://github.com/user-attachments/assets/ff74e799-edef-4c10-97d9-42d4b650338d" />
The chemical tab not bluescreening.

## Changelog

:cl: Swan
fix: fixes the chemical tab of the plant analyzer bluescreening on certain seeds.
/:cl: