### PR TITLE
giant killer armor draft

### DIFF
--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -681,22 +681,23 @@
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/giant_killerunfiredhelmet
-	name= "Unfired Giant-Killer Helmet"
-	result=/obj/item/clothing/head/helmet/giant_killerunfired
-	time= 15 SECONDS
-	reqs=list(
+	name = "Unfired Giant-Killer Helmet"
+	result = /obj/item/clothing/head/helmet/giant_killerunfired
+	time = 15 SECONDS
+	reqs = list(
 		/obj/item/stack/sheet/titanium = 3,
 		/obj/item/stack/sheet/plasteel = 8,
-		/obj/item/stack/sheet/duct_tape=5,
-	)"
+		/obj/item/stack/sheet/duct_tape = 5,
+	)
 category = CAT_CLOTHING
+
 /datum/crafting_recipe/giant-killerunfiredarmor
-	name= "Unfired Giant-Killer Armor"
-	result=/obj/item/clothing/suit/armor/giant_killerunfired
-	time= 15 SECONDS
-	reqs=list(
+	name = "Unfired Giant-Killer Armor"
+	result = /obj/item/clothing/suit/armor/giant_killerunfired
+	time = 15 SECONDS
+	reqs = list(
 		/obj/item/stack/sheet/titanium = 3,
 		/obj/item/stack/sheet/plasteel = 8,
-		/obj/item/stack/sheet/duct_tape=5,
-	)"
+		/obj/item/stack/sheet/duct_tape = 5,
+	)
 category = CAT_CLOTHING

--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -680,7 +680,7 @@
 	)
 	category = CAT_CLOTHING
 
-/datum/crafting_recipe/giant-killerunfiredhelmet
+/datum/crafting_recipe/giant_killerunfiredhelmet
 	name= "Unfired Giant-Killer Helmet"
 	result=/obj/item/clothing/head/helmet/giant_killerunfired
 	time= 15 SECONDS

--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -679,3 +679,13 @@
 		/obj/item/clothing/mask/gas/clown_hat = 1,
 	)
 	category = CAT_CLOTHING
+
+/datum/crafting_recipe/giant-killerunfiredarmor
+	name= "Unfired Giant-Killer Helmet"
+	result=/obj/item/clothing/head/helmet/giant_killerunfired
+	time= 15 SECONDS
+	reqs=list(
+		/obj/item/stack/sheet/titanium = 3,
+		/obj/item/stack/sheet/plasteel = 8,
+	)"
+category = CAT_CLOTHING

--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -680,12 +680,23 @@
 	)
 	category = CAT_CLOTHING
 
-/datum/crafting_recipe/giant-killerunfiredarmor
+/datum/crafting_recipe/giant-killerunfiredhelmet
 	name= "Unfired Giant-Killer Helmet"
 	result=/obj/item/clothing/head/helmet/giant_killerunfired
 	time= 15 SECONDS
 	reqs=list(
 		/obj/item/stack/sheet/titanium = 3,
 		/obj/item/stack/sheet/plasteel = 8,
+		/obj/item/stack/sheet/duct_tape=5,
+	)"
+category = CAT_CLOTHING
+/datum/crafting_recipe/giant-killerunfiredarmor
+	name= "Unfired Giant-Killer Armor"
+	result=/obj/item/clothing/suit/armor/giant_killerunfired
+	time= 15 SECONDS
+	reqs=list(
+		/obj/item/stack/sheet/titanium = 3,
+		/obj/item/stack/sheet/plasteel = 8,
+		/obj/item/stack/sheet/duct_tape=5,
 	)"
 category = CAT_CLOTHING

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -591,7 +591,7 @@
 	wound = 0
 
 	/obj/item/clothing/head/helmet/giant_killerunfired/fire_act(exposed_temperature, exposed_volume)
-	var/obj/item/spear/dragonator/dragonator = new(loc)
+	var/obj/clothing/head/helmet/giant_killerunfired/= new(loc)
 	dragonator.set_material_slots(material_slots)
 	dragonator.set_custom_materials(custom_materials.Copy())
 	playsound(giant_killer.loc, 'sound/effects/magic/staff_change.ogg',5)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -590,7 +590,7 @@
 	acid = 0
 	wound = 0
 
-	/obj/item/clothing/head/helmet/giant_killerunfired/fire_act(exposed_temperature, exposed_volume)
+/obj/item/clothing/head/helmet/giant_killerunfired/fire_act(exposed_temperature, exposed_volume)
 	var/obj/clothing/head/helmet/giant_killerunfired = new(loc)
 	dragonator.set_material_slots(material_slots)
 	dragonator.set_custom_materials(custom_materials.Copy())

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -536,6 +536,67 @@
 	armor_type = /datum/armor/knight_greyscale
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS //Can change color and add prefix
 
+/obj/item/clothing/head/helmet/giant_killer
+	name = "Giant-Killer helmet"
+	desc = "A knight helmet forged in lava."
+	icon_state = "knight_green"
+	inhand_icon_state = "knight_helmet"
+	armor_type = /datum/armor/helmet_giant_killer
+	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	resistance_flags = NONE
+	strip_delay = 8 SECONDS
+	dog_fashion = null
+	clothing_traits = list(TRAIT_HEAD_INJURY_BLOCKED)
+
+/obj/item/clothing/head/helmet/giant_killer/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/adjust_fishing_difficulty, 3)
+
+/datum/armor/helmet_giant_killer
+	melee = 50
+	bullet = 10
+	laser = 10
+	energy = 20
+	bomb = 50
+	fire = 50
+	acid = 50
+	wound = 10
+
+	/obj/item/clothing/head/helmet/giant_killerunfired
+	name = "unfiredGiant-Killer helmet"
+	desc = "A knight helmet to be forged in lava."
+	icon_state = "knight_green"
+	inhand_icon_state = "knight_helmet"
+	armor_type = /datum/armor/helmet_giant_killerunfired
+	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	resistance_flags = NONE
+	strip_delay = 8 SECONDS
+	dog_fashion = null
+	clothing_traits = list(TRAIT_HEAD_INJURY_BLOCKED)
+
+/obj/item/clothing/head/helmet/giant_killerunfired/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/adjust_fishing_difficulty, 3)
+
+/datum/armor/helmet_giant_killer
+	melee = 50
+	bullet = 10
+	laser = 10
+	energy = 20
+	bomb = 50
+	fire = 50
+	acid = 50
+	wound = 10
+
+	/obj/item/clothing/head/helmet/giant_killerunfired/fire_act(exposed_temperature, exposed_volume)
+	var/obj/item/spear/dragonator/dragonator = new(loc)
+	dragonator.set_material_slots(material_slots)
+	dragonator.set_custom_materials(custom_materials.Copy())
+	playsound(giant_killer.loc, 'sound/effects/magic/staff_change.ogg',5)
+	qdel(src)
+
 /obj/item/clothing/head/helmet/durathread
 	name = "durathread helmet"
 	desc = "A helmet made from durathread and leather."

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -591,7 +591,7 @@
 	wound = 0
 
 	/obj/item/clothing/head/helmet/giant_killerunfired/fire_act(exposed_temperature, exposed_volume)
-	var/obj/clothing/head/helmet/giant_killerunfired/= new(loc)
+	var/obj/clothing/head/helmet/giant_killerunfired = new(loc)
 	dragonator.set_material_slots(material_slots)
 	dragonator.set_custom_materials(custom_materials.Copy())
 	playsound(giant_killer.loc, 'sound/effects/magic/staff_change.ogg',5)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -564,7 +564,7 @@
 	wound = 10
 
 	/obj/item/clothing/head/helmet/giant_killerunfired
-	name = "unfiredGiant-Killer helmet"
+	name = "unfired Giant-Killer helmet"
 	desc = "A knight helmet to be forged in lava."
 	icon_state = "knight_green"
 	inhand_icon_state = "knight_helmet"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -580,15 +580,15 @@
 	. = ..()
 	AddElement(/datum/element/adjust_fishing_difficulty, 3)
 
-/datum/armor/helmet_giant_killer
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 20
-	bomb = 50
-	fire = 50
-	acid = 50
-	wound = 10
+/datum/armor/helmet_giant_killerunfired
+	melee = 0
+	bullet = 0
+	laser = 0
+	energy = 0
+	bomb = 0
+	fire = 0
+	acid = 0
+	wound = 0
 
 	/obj/item/clothing/head/helmet/giant_killerunfired/fire_act(exposed_temperature, exposed_volume)
 	var/obj/item/spear/dragonator/dragonator = new(loc)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -563,7 +563,7 @@
 	acid = 50
 	wound = 10
 
-	/obj/item/clothing/head/helmet/giant_killerunfired
+/obj/item/clothing/head/helmet/giant_killerunfired
 	name = "unfired Giant-Killer helmet"
 	desc = "A knight helmet to be forged in lava."
 	icon_state = "knight_green"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -565,7 +565,7 @@
 	fire = 40
 	acid = 40
 
-	/obj/item/clothing/suit/armor/riot/knight/giant-killer
+/obj/item/clothing/suit/armor/riot/knight/giant-killer
 	name = "Giant-Killer armor"
 	desc = "A knight's armor, forged in lava."
 	icon_state = "knight_greyscale"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -618,6 +618,18 @@
 	armor_type = /datum/armor/vest_durathread
 	dog_fashion = null
 
+/obj/item/clothing/suit/armor/vest/durathread/Initialize(mapload)
+	. = ..()
+	allowed |= /obj/item/clothing/suit/apron::allowed
+
+/datum/armor/vest_durathread
+	melee = 20
+	bullet = 10
+	laser = 30
+	energy = 40
+	bomb = 15
+	fire = 40
+	acid = 50
 
 /obj/item/clothing/suit/armor/vest/russian
 	name = "russian vest"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -599,7 +599,7 @@
 	acid = 0
 	wound = 0
 
-	/obj/item/clothing/suit/armor/riot/knight/giant-killerunfired/fire_act(exposed_temperature, exposed_volume)
+/obj/item/clothing/suit/armor/riot/knight/giant-killerunfired/fire_act(exposed_temperature, exposed_volume)
 	var/obj/item//clothing/suit/armor/riot/knight/giant-killer= new(loc)
 	dragonator.set_material_slots(material_slots)
 	dragonator.set_custom_materials(custom_materials.Copy())

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -582,7 +582,7 @@
 	acid = 50
 	wound = 10
 
-	obj/item/clothing/suit/armor/riot/knight/giant-killerunfiredarmor
+/obj/item/clothing/suit/armor/riot/knight/giant-killerunfiredarmor
 	name = "unfired Giant-Killer armor"
 	desc = "A knight's armor, to be forged in lava."
 	icon_state = "knight_greyscale"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -565,6 +565,47 @@
 	fire = 40
 	acid = 40
 
+	/obj/item/clothing/suit/armor/riot/knight/giant-killer
+	name = "Giant-Killer armor"
+	desc = "A knight's armor, forged in lava."
+	icon_state = "knight_greyscale"
+	inhand_icon_state = null
+	armor_type = /datum/armor/knight_giantkillerarmor
+
+/datum/armor/knight_giantkillerarmor
+	melee = 50
+	bullet = 10
+	laser = 10
+	energy = 20
+	bomb = 50
+	fire = 50
+	acid = 50
+	wound = 10
+
+	obj/item/clothing/suit/armor/riot/knight/giant-killerunfiredarmor
+	name = "unfired Giant-Killer armor"
+	desc = "A knight's armor, to be forged in lava."
+	icon_state = "knight_greyscale"
+	inhand_icon_state = null
+	armor_type = /datum/armor/knight_giantkillerunfiredarmor
+
+/datum/armor/knight_giantkillerunfiredarmor
+	melee = 0
+	bullet = 0
+	laser = 0
+	energy = 0
+	bomb = 0
+	fire = 0
+	acid = 0
+	wound = 0
+
+	/obj/item/clothing/suit/armor/riot/knight/giant-killerunfired/fire_act(exposed_temperature, exposed_volume)
+	var/obj/item//clothing/suit/armor/riot/knight/giant-killer= new(loc)
+	dragonator.set_material_slots(material_slots)
+	dragonator.set_custom_materials(custom_materials.Copy())
+	playsound(giant_killer.loc, 'sound/effects/magic/staff_change.ogg',5)
+	qdel(src)
+
 /obj/item/clothing/suit/armor/vest/durathread
 	name = "durathread vest"
 	desc = "A vest made of durathread with strips of leather acting as trauma plates."
@@ -577,18 +618,6 @@
 	armor_type = /datum/armor/vest_durathread
 	dog_fashion = null
 
-/obj/item/clothing/suit/armor/vest/durathread/Initialize(mapload)
-	. = ..()
-	allowed |= /obj/item/clothing/suit/apron::allowed
-
-/datum/armor/vest_durathread
-	melee = 20
-	bullet = 10
-	laser = 30
-	energy = 40
-	bomb = 15
-	fire = 40
-	acid = 50
 
 /obj/item/clothing/suit/armor/vest/russian
 	name = "russian vest"


### PR DESCRIPTION

## About The Pull Request

Adds an inferior but crew craftable version of the explorer suit. Equivalent to level two goliath plates but cannot be upgraded and blocks eating.

Blessings and future sprites by King Kuma
Special thanks: KIngkumaAr (github),Timothymtorres (github), Aliceee2h (github, and Rager Gamer Deluxe (discord)
## Why It's Good For The Game
 Adds defense against lavaland mobs, useful for people like paramedics.

## Changelog



:cl:
feature: Adds Giant-Killer Armor to match the Giant-Killer Spear, go hunt monsters.
/:cl:
