### PR TITLE
Replaces flawed shuffle() algorithms with Fisher-Yates shuffling

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -671,20 +671,23 @@
 /proc/shuffle(list/inserted_list)
 	if(!inserted_list)
 		return
-	inserted_list = inserted_list.Copy()
 
-	for(var/i in 1 to inserted_list.len - 1)
-		inserted_list.Swap(i, rand(i, inserted_list.len))
+	var/pick_list = inserted_list.Copy()
+	var/list/new_list = list()
 
-	return inserted_list
+	for(var/i in 1 to inserted_list.len)
+		new_list += pick_n_take(pick_list)
+
+	return new_list
 
 ///same as shuffle, but acts on list in place, and returns same list
 /proc/shuffle_inplace(list/inserted_list)
 	if(!inserted_list)
 		return
 
-	for(var/i in 1 to inserted_list.len - 1)
-		inserted_list.Swap(i, rand(i, inserted_list.len))
+	var/pick_list = inserted_list.Copy()
+	for(var/i in 1 to inserted_list.len)
+		inserted_list[i] = pick_n_take(pick_list)
 
 	return inserted_list
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -674,8 +674,7 @@
 
 	inserted_list = inserted_list.Copy()
 	for(var/i in 1 to inserted_list.len)
-		// Re-use the list for in-place swaps
-		inserted_list.Swap(1, rand(inserted_list.len - (i - 1), inserted_list.len))
+		inserted_list.Swap(i, rand(0, i))
 
 	return inserted_list
 
@@ -685,8 +684,7 @@
 		return
 
 	for(var/i in 1 to inserted_list.len)
-		// Re-use the list for in-place swaps
-		inserted_list.Swap(1, rand(inserted_list.len - (i - 1), inserted_list.len))
+		inserted_list.Swap(i, rand(0, i))
 
 	return inserted_list
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -674,7 +674,7 @@
 
 	inserted_list = inserted_list.Copy()
 	for(var/i in 1 to inserted_list.len)
-		inserted_list.Swap(i, rand(0, i))
+		inserted_list.Swap(i, rand(1, i))
 
 	return inserted_list
 
@@ -684,7 +684,7 @@
 		return
 
 	for(var/i in 1 to inserted_list.len)
-		inserted_list.Swap(i, rand(0, i))
+		inserted_list.Swap(i, rand(1, i))
 
 	return inserted_list
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -672,22 +672,21 @@
 	if(!inserted_list)
 		return
 
-	var/pick_list = inserted_list.Copy()
-	var/list/new_list = list()
-
+	inserted_list = inserted_list.Copy()
 	for(var/i in 1 to inserted_list.len)
-		new_list += pick_n_take(pick_list)
+		// Re-use the list for in-place swaps
+		inserted_list.Swap(1, rand(inserted_list.len - (i - 1), inserted_list.len))
 
-	return new_list
+	return inserted_list
 
 ///same as shuffle, but acts on list in place, and returns same list
 /proc/shuffle_inplace(list/inserted_list)
 	if(!inserted_list)
 		return
 
-	var/pick_list = inserted_list.Copy()
 	for(var/i in 1 to inserted_list.len)
-		inserted_list[i] = pick_n_take(pick_list)
+		// Re-use the list for in-place swaps
+		inserted_list.Swap(1, rand(inserted_list.len - (i - 1), inserted_list.len))
 
 	return inserted_list
 


### PR DESCRIPTION

## About The Pull Request
Current shuffle() is biased to inverse the list rather than properly randomize it. I've replaced it with in-place Fisher-Yates shuffling so we can guarantee proper randomness.

## Changelog
:cl:
fix: Some randomization is now slightly more random than before. 
/:cl:
