### PR TITLE
Fixes a few incorrect shuffle() usages

### DIFF
--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -262,7 +262,7 @@
 		// Just pick and take based on weight
 		for(var/i in 1 to wilderness_levels)
 			wilderness_maps_to_spawn += pick_weight_take(wilderness)
-		shuffle(wilderness_maps_to_spawn)
+		shuffle_inplace(wilderness_maps_to_spawn)
 
 	var/list/wilderness_level_traits = json["wilderness_level_traits"]
 	if (islist(wilderness_level_traits))

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -1040,7 +1040,7 @@
 	var/list/items = list()
 	for(var/obj/item/item in range(location, 3))
 		items += item
-	shuffle(items)
+	shuffle_inplace(items)
 	for(var/obj/item/item in items)
 		do_teleport(item, location, 3, no_effects=TRUE)
 		lets_not_go_crazy -= 1

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -184,6 +184,13 @@ if $grep -i '(add_traits|remove_traits)\(.+,\s*src\)' "${code_files[@]}"; then
 	st=1
 fi;
 
+part "incorrect shuffle() usage"
+if $grep '^\t+shuffle\(.*\)$' "${code_files[@]}"; then
+    echo
+    echo -e "${RED}ERROR: shuffle() return was not assigned, use shuffle_inplace() instead if you wish to mutate the passed list!${NC}"
+    st=1
+fi;
+
 part "ensure proper lowertext usage"
 # lowertext() is a BYOND-level proc, so it can be used in any sort of code... including the TGS DMAPI which we don't manage in this repository.
 # basically, we filter out any results with "tgs" in it to account for this edgecase without having to enforce this rule in that separate codebase.


### PR DESCRIPTION

## About The Pull Request

Both wilderness and eigenstate treated shuffle() as shuffle_inplace()

## Changelog
:cl:
fix: Eigenstate and wilderness z levels now randomize properly
/:cl:
