### PR TITLE
Differentiates between mode switches and gizpulse effects

### DIFF
--- a/code/__DEFINES/gizmo.dm
+++ b/code/__DEFINES/gizmo.dm
@@ -21,6 +21,7 @@
 #define GIZMO_PUZZLE_WRONG 		1
 #define GIZMO_PUZZLE_CORRECT	2
 #define GIZMO_PUZZLE_SOLVED		3
+#define GIZMO_PUZZLE_SOLVED_MODE_CONTROL		4
 
 #define GIZMO_INTERFACE_WIRES "gizmo_interface_wires"
 #define GIZMO_INTERFACE_VOICE "gizmo_interface_voices"

--- a/code/__DEFINES/gizmo.dm
+++ b/code/__DEFINES/gizmo.dm
@@ -18,10 +18,10 @@
 /// From base of /datum/gizactive/lights_off/activate(): ()
 #define COMSIG_GIZMO_OFF_STATE "gizmo_off_state"
 
-#define GIZMO_PUZZLE_WRONG 		1
-#define GIZMO_PUZZLE_CORRECT	2
-#define GIZMO_PUZZLE_SOLVED		3
-#define GIZMO_PUZZLE_SOLVED_MODE_CONTROL		4
+#define GIZMO_PUZZLE_WRONG 					1
+#define GIZMO_PUZZLE_CORRECT				2
+#define GIZMO_PUZZLE_SOLVED					3
+#define GIZMO_PUZZLE_SOLVED_MODE_CONTROL	4
 
 #define GIZMO_INTERFACE_WIRES "gizmo_interface_wires"
 #define GIZMO_INTERFACE_VOICE "gizmo_interface_voices"

--- a/code/modules/research/gizmo/gizmodes/gizactives.dm
+++ b/code/modules/research/gizmo/gizmodes/gizactives.dm
@@ -94,8 +94,13 @@
 /// Adds a puzzle for every possible made to select it, and a single wire to activate the selected mode
 /datum/gizpulse/mode_controle/select_mode/setup_mode_controle(datum/gizmodes/master, list/active_gizmodes, list/trigger_callbacks)
 	for(var/active in active_gizmodes)
-		trigger_callbacks += VARSET_CALLBACK(master, current_active, active)
+		trigger_callbacks += CALLBACK(src, PROC_REF(select_mode), master, active)
 	trigger_callbacks += CALLBACK(master, PROC_REF(activate))
+
+/datum/gizpulse/mode_controle/select_mode/proc/select_mode(datum/gizmodes/master, new_active_mode, atom/movable/holder)
+	master.current_active = new_active_mode
+	// Give a hint to the user that something DID happen
+	return GIZMO_PUZZLE_SOLVED_MODE_CONTROL
 
 /// Adds a puzzle to cycle to the next gizpulse, and a puzzle to activate the currently active mode
 /datum/gizpulse/mode_controle/cycle_mode/setup_mode_controle(datum/gizmodes/master, list/active_gizmodes, list/trigger_callbacks)
@@ -105,6 +110,8 @@
 /datum/gizpulse/mode_controle/cycle_mode/proc/cycle_mode(datum/gizmodes/master, atom/movable/holder)
 	// Move to the next mode in the list (and loop back to 1 if needed)
 	master.current_active = master.active_gizmodes[((master.active_gizmodes.Find(master.current_active)) % (master.active_gizmodes.len)) + 1]
+	// Give a hint to the user that something DID happen
+	return GIZMO_PUZZLE_SOLVED_MODE_CONTROL
 
 /// Adds a puzzle for every gizpulse that just immediately activates that gizpulse
 /datum/gizpulse/mode_controle/direct_activate/setup_mode_controle(datum/gizmodes/master, list/active_gizmodes, list/trigger_callbacks)

--- a/code/modules/research/gizmo/gizpuzzle.dm
+++ b/code/modules/research/gizmo/gizpuzzle.dm
@@ -61,11 +61,9 @@
 				succeeded = TRUE
 			if(j == a.len)
 				var/datum/callback/callback = solution_callbacks[i]
-				. = callback.Invoke(holder)
+				. = callback.Invoke(holder) || GIZMO_PUZZLE_SOLVED
 				current_sequence.Cut()
 
-				if(!.)
-					. = GIZMO_PUZZLE_SOLVED
 				break
 
 	if(!succeeded)

--- a/code/modules/research/gizmo/gizpuzzle.dm
+++ b/code/modules/research/gizmo/gizpuzzle.dm
@@ -61,9 +61,11 @@
 				succeeded = TRUE
 			if(j == a.len)
 				var/datum/callback/callback = solution_callbacks[i]
-				callback.Invoke(holder)
+				. = callback.Invoke(holder)
 				current_sequence.Cut()
-				. = GIZMO_PUZZLE_SOLVED
+
+				if(!.)
+					. = GIZMO_PUZZLE_SOLVED
 				break
 
 	if(!succeeded)
@@ -89,6 +91,9 @@
 		if(GIZMO_PUZZLE_SOLVED)
 			holder.balloon_alert(user, "creak")
 			playsound(holder, 'sound/machines/creak.ogg', 30, FALSE)
+		if(GIZMO_PUZZLE_SOLVED_MODE_CONTROL)
+			holder.balloon_alert(user, "clunk")
+			playsound(holder, 'sound/machines/machine_vend.ogg', 30, FALSE)
 
 /// Sequences can be a bit shorter since you have to constantly type and scream them
 /datum/gizmo_puzzle/voice


### PR DESCRIPTION

## About The Pull Request

Adds a sound effect, *clunk*, for succesfully activating a pure mode switch. Hybrid mode switches will still just creak

## Why It's Good For The Game
I'm seeing too many people complain about some gizmo's just doing 'nothing', but that's straight up not a thing. They always do something. This hints a little that some functions are different than others, and might not be immediately visible

## Changelog
:cl:
qol: Gizmo's have some improved feedback to help convey the fact that there's no such thing as 'doing nothing'
/:cl:
