### PR TITLE
Goliath tentacles now detach when the goliath dies

### DIFF
--- a/code/modules/mob/living/basic/lavaland/goliath/tentacle.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/tentacle.dm
@@ -171,6 +171,8 @@
 	RegisterSignal(beam_effect.visuals, COMSIG_CLICK, PROC_REF(on_beam_click))
 	RegisterSignals(user, list(SIGNAL_ADDTRAIT(TRAIT_TENTACLE_IMMUNE), COMSIG_BRIMDUST_EXPLOSION), PROC_REF(release))
 	RegisterSignals(tentacle, list(COMSIG_QDELETING, COMSIG_GOLIATH_TENTACLE_RETRACTING), PROC_REF(on_tentacle_left))
+	if (tentalce.owner)
+		RegisterSignal(tentacle.owner, COMSIG_MOB_STATCHANGE, PROC_REF(on_tentacle_left))
 	RegisterSignal(leash, COMSIG_QDELETING, PROC_REF(release))
 
 /obj/item/restraints/legcuffs/goliath_tentacle/proc/on_beam_click(atom/source, atom/location, control, params, mob/user)

--- a/code/modules/mob/living/basic/lavaland/goliath/tentacle.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/tentacle.dm
@@ -171,7 +171,7 @@
 	RegisterSignal(beam_effect.visuals, COMSIG_CLICK, PROC_REF(on_beam_click))
 	RegisterSignals(user, list(SIGNAL_ADDTRAIT(TRAIT_TENTACLE_IMMUNE), COMSIG_BRIMDUST_EXPLOSION), PROC_REF(release))
 	RegisterSignals(tentacle, list(COMSIG_QDELETING, COMSIG_GOLIATH_TENTACLE_RETRACTING), PROC_REF(on_tentacle_left))
-	if (tentalce.owner)
+	if (tentacle.owner)
 		RegisterSignal(tentacle.owner, COMSIG_MOB_STATCHANGE, PROC_REF(on_tentacle_left))
 	RegisterSignal(leash, COMSIG_QDELETING, PROC_REF(release))
 

--- a/code/modules/mob/living/basic/lavaland/goliath/tentacle.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/tentacle.dm
@@ -229,7 +229,7 @@
 	beam_effect = user.Beam(tentacle.owner, "goliath_tentacle", beam_type = /obj/effect/ebeam/goliath, emissive = FALSE)
 	RegisterSignal(beam_effect.visuals, COMSIG_CLICK, PROC_REF(on_beam_click))
 	RegisterSignals(user, list(SIGNAL_ADDTRAIT(TRAIT_TENTACLE_IMMUNE), COMSIG_BRIMDUST_EXPLOSION), PROC_REF(release))
-	RegisterSignals(tentacle.owner, COMSIG_QDELETING, PROC_REF(on_tentacle_left))
+	RegisterSignals(tentacle.owner, list(COMSIG_QDELETING, COMSIG_MOB_STATCHANGE), PROC_REF(on_tentacle_left))
 	RegisterSignal(leash, COMSIG_QDELETING, PROC_REF(release))
 	tentacle.retract()
 	tentacle = null


### PR DESCRIPTION

## About The Pull Request

Doesn't make sense for tentacles to keep pulling you towards the goliath after it dies

## Changelog
:cl:
fix: Goliath tentacles now detach when the goliath dies
/:cl:
