### PR TITLE
Makes prefs application for ghost roles more flexible and granular

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -231,8 +231,8 @@
 		return
 	candidate.transfer_to(body, force_key_move = TRUE) // yoinks the candidate's client
 	if(ishuman(body))
-		apply_prefs_to_body(human_body)
-		post_apply_prefs(human_body)
+		apply_prefs_to_body(body)
+		post_apply_prefs(body)
 
 /**
  * Handles making the body for the candidate

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -528,7 +528,7 @@
 /datum/dynamic_ruleset/midround/from_ghosts/nightmare/apply_prefs_to_body(mob/living/carbon/human/body)
 	return null
 
-/datum/dynamic_ruleset/midround/from_ghosts/nightmare/nightmare/can_be_selected()
+/datum/dynamic_ruleset/midround/from_ghosts/nightmare/can_be_selected()
 	return ..() && !isnull(find_maintenance_spawn(atmos_sensitive = TRUE, require_darkness = TRUE))
 
 /datum/dynamic_ruleset/midround/from_ghosts/nightmare/assign_role(datum/mind/candidate)

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -231,10 +231,8 @@
 		return
 	candidate.transfer_to(body, force_key_move = TRUE) // yoinks the candidate's client
 	if(ishuman(body))
-		var/mob/living/carbon/human/human_body = body
-		body.client?.prefs.safe_transfer_prefs_to(body)
-		human_body.dna.remove_all_mutations()
-		human_body.dna.update_dna_identity()
+		apply_prefs_to_body(human_body)
+		post_apply_prefs(human_body)
 
 /**
  * Handles making the body for the candidate
@@ -261,6 +259,21 @@
 		alert_pic = signup_atom_appearance,
 		role_name_text = readable_poll_role,
 	)
+
+/**
+ * Handles prepping the body with the candidate's prefs
+ *
+ * Applies prefs to a given body. Usually that's what you want, but sometimes you don't, in which case you can override this proc.
+ */
+/datum/dynamic_ruleset/midround/from_ghosts/proc/apply_prefs_to_body(mob/living/carbon/human/body)
+	body.client?.prefs.safe_transfer_prefs_to(body)
+
+/**
+ * Handles anything you want to happen after applying prefs, such as stripping mutations
+ */
+/datum/dynamic_ruleset/midround/from_ghosts/proc/post_apply_prefs(mob/living/carbon/human/body)
+	body.dna.remove_all_mutations()
+	body.dna.update_dna_identity()
 
 /datum/dynamic_ruleset/midround/from_ghosts/wizard
 	name = "Wizard"
@@ -512,7 +525,10 @@
 	max_antag_cap = 1
 	signup_atom_appearance = /obj/item/light_eater
 
-/datum/dynamic_ruleset/midround/from_ghosts/nightmare/can_be_selected()
+/datum/dynamic_ruleset/midround/from_ghosts/nightmare/apply_prefs_to_body(mob/living/carbon/human/body)
+	return null
+
+/datum/dynamic_ruleset/midround/from_ghosts/nightmare/nightmare/can_be_selected()
 	return ..() && !isnull(find_maintenance_spawn(atmos_sensitive = TRUE, require_darkness = TRUE))
 
 /datum/dynamic_ruleset/midround/from_ghosts/nightmare/assign_role(datum/mind/candidate)

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -231,8 +231,7 @@
 		return
 	candidate.transfer_to(body, force_key_move = TRUE) // yoinks the candidate's client
 	if(ishuman(body))
-		if(apply_prefs_to_body(body))
-			on_prefs_applied(body)
+		apply_prefs_to_body(body)
 
 /**
  * Handles making the body for the candidate
@@ -268,7 +267,7 @@
  */
 /datum/dynamic_ruleset/midround/from_ghosts/proc/apply_prefs_to_body(mob/living/carbon/human/body)
 	body.client?.prefs.safe_transfer_prefs_to(body)
-	return TRUE
+	on_prefs_applied(body)
 
 /**
  * Handles anything you want to happen after applying prefs, such as stripping mutations
@@ -528,7 +527,7 @@
 	signup_atom_appearance = /obj/item/light_eater
 
 /datum/dynamic_ruleset/midround/from_ghosts/nightmare/apply_prefs_to_body(mob/living/carbon/human/body)
-	return null
+	return
 
 /datum/dynamic_ruleset/midround/from_ghosts/nightmare/can_be_selected()
 	return ..() && !isnull(find_maintenance_spawn(atmos_sensitive = TRUE, require_darkness = TRUE))

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -231,8 +231,8 @@
 		return
 	candidate.transfer_to(body, force_key_move = TRUE) // yoinks the candidate's client
 	if(ishuman(body))
-		apply_prefs_to_body(body)
-		post_apply_prefs(body)
+		if(apply_prefs_to_body(body))
+			on_prefs_applied(body)
 
 /**
  * Handles making the body for the candidate
@@ -264,14 +264,16 @@
  * Handles prepping the body with the candidate's prefs
  *
  * Applies prefs to a given body. Usually that's what you want, but sometimes you don't, in which case you can override this proc.
+ * Returns TRUE if 
  */
 /datum/dynamic_ruleset/midround/from_ghosts/proc/apply_prefs_to_body(mob/living/carbon/human/body)
 	body.client?.prefs.safe_transfer_prefs_to(body)
+	return TRUE
 
 /**
  * Handles anything you want to happen after applying prefs, such as stripping mutations
  */
-/datum/dynamic_ruleset/midround/from_ghosts/proc/post_apply_prefs(mob/living/carbon/human/body)
+/datum/dynamic_ruleset/midround/from_ghosts/proc/on_prefs_applied(mob/living/carbon/human/body)
 	body.dna.remove_all_mutations()
 	body.dna.update_dna_identity()
 

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -264,7 +264,7 @@
  * Handles prepping the body with the candidate's prefs
  *
  * Applies prefs to a given body. Usually that's what you want, but sometimes you don't, in which case you can override this proc.
- * Returns TRUE if we want to run on_prefs_applied() as well (which by default, removes mutations + calls update_dna_identiy()
+ * Returns TRUE if we want to run on_prefs_applied() as well (which by default, removes mutations + calls update_dna_identity())
  */
 /datum/dynamic_ruleset/midround/from_ghosts/proc/apply_prefs_to_body(mob/living/carbon/human/body)
 	body.client?.prefs.safe_transfer_prefs_to(body)

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -263,7 +263,6 @@
  * Handles prepping the body with the candidate's prefs
  *
  * Applies prefs to a given body. Usually that's what you want, but sometimes you don't, in which case you can override this proc.
- * Returns TRUE if we want to run on_prefs_applied() as well (which by default, removes mutations + calls update_dna_identity())
  */
 /datum/dynamic_ruleset/midround/from_ghosts/proc/apply_prefs_to_body(mob/living/carbon/human/body)
 	body.client?.prefs.safe_transfer_prefs_to(body)

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -230,8 +230,8 @@
 	if(isnull(body))
 		return
 	candidate.transfer_to(body, force_key_move = TRUE) // yoinks the candidate's client
-	if(ishuman(body))
-		apply_prefs_to_body(body)
+	if(ishuman(body) && apply_prefs_to_body(body))
+		on_prefs_applied(body)
 
 /**
  * Handles making the body for the candidate
@@ -263,17 +263,18 @@
  * Handles prepping the body with the candidate's prefs
  *
  * Applies prefs to a given body. Usually that's what you want, but sometimes you don't, in which case you can override this proc.
+ * Returns TRUE if prefs were applied
  */
 /datum/dynamic_ruleset/midround/from_ghosts/proc/apply_prefs_to_body(mob/living/carbon/human/body)
 	body.client?.prefs.safe_transfer_prefs_to(body)
-	on_prefs_applied(body)
-
-/**
- * Handles anything you want to happen after applying prefs, such as stripping mutations
- */
-/datum/dynamic_ruleset/midround/from_ghosts/proc/on_prefs_applied(mob/living/carbon/human/body)
 	body.dna.remove_all_mutations()
 	body.dna.update_dna_identity()
+
+/**
+ * Handles anything extra you want to happen after applying prefs
+ */
+/datum/dynamic_ruleset/midround/from_ghosts/proc/on_prefs_applied(mob/living/carbon/human/body)
+	return
 
 /datum/dynamic_ruleset/midround/from_ghosts/wizard
 	name = "Wizard"
@@ -526,7 +527,7 @@
 	signup_atom_appearance = /obj/item/light_eater
 
 /datum/dynamic_ruleset/midround/from_ghosts/nightmare/apply_prefs_to_body(mob/living/carbon/human/body)
-	return
+	return FALSE
 
 /datum/dynamic_ruleset/midround/from_ghosts/nightmare/can_be_selected()
 	return ..() && !isnull(find_maintenance_spawn(atmos_sensitive = TRUE, require_darkness = TRUE))

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -269,6 +269,7 @@
 	body.client?.prefs.safe_transfer_prefs_to(body)
 	body.dna.remove_all_mutations()
 	body.dna.update_dna_identity()
+	return TRUE
 
 /**
  * Handles anything extra you want to happen after applying prefs

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -264,7 +264,7 @@
  * Handles prepping the body with the candidate's prefs
  *
  * Applies prefs to a given body. Usually that's what you want, but sometimes you don't, in which case you can override this proc.
- * Returns TRUE if 
+ * Returns TRUE if we want to run on_prefs_applied() as well (which by default, removes mutations + calls update_dna_identiy()
  */
 /datum/dynamic_ruleset/midround/from_ghosts/proc/apply_prefs_to_body(mob/living/carbon/human/body)
 	body.client?.prefs.safe_transfer_prefs_to(body)


### PR DESCRIPTION
## About The Pull Request

Tin, also applies this to the nightmare role since they shouldn't be getting prefs applied to their mob.

## Why It's Good For The Game

You don't always want prefs to be applied the same way (or sometimes, at all) for each ghost role, and by just moving that logic out to overridable procs. this allows for granular control over that

## Changelog

:cl:
fix: shadows will no longer get the candidate's prefs applied to their mob
/:cl: