### PR TITLE
Allows arbitrary/custom/"unlimited" bodypart overlay layers

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -878,13 +878,9 @@ GLOBAL_ALIST_INIT(human_heights_to_offsets, alist(
 /// (You ONLY need to update this if you add a standing overlay, adding an integer.)
 #define TOTAL_LAYERS 23
 
-//Bitflags for the layers a bodypart overlay can draw on (can be drawn on multiple layers)
-/// Draws overlay on the BODY_FRONT_LAYER
-#define EXTERNAL_FRONT (1 << 0)
-/// Draws overlay on the BODY_ADJ_LAYER
-#define EXTERNAL_ADJACENT (1 << 1)
-/// Draws overlay on the BODY_BEHIND_LAYER
-#define EXTERNAL_BEHIND (1 << 2)
+#define EXTERNAL_FRONT "FRONT"
+#define EXTERNAL_ADJACENT "ADJ"
+#define EXTERNAL_BEHIND "BEHIND"
 
 // Bitflags for external organs restylability
 #define EXTERNAL_RESTYLE_ALL ALL

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -878,6 +878,8 @@ GLOBAL_ALIST_INIT(human_heights_to_offsets, alist(
 /// (You ONLY need to update this if you add a standing overlay, adding an integer.)
 #define TOTAL_LAYERS 23
 
+// Legacy mutant bodypart layering defines for icon states
+// Don't change these without updating all relevant icon states
 #define EXTERNAL_FRONT "FRONT"
 #define EXTERNAL_ADJACENT "ADJ"
 #define EXTERNAL_BEHIND "BEHIND"

--- a/code/datums/bodypart_overlays/bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/bodypart_overlay.dm
@@ -1,16 +1,21 @@
 ///Bodypart ovarlay datum. These can be added to any limb to give them a proper overlay, that'll even stay if the limb gets removed
 ///This is the abstract parent, don't use it!!
 /datum/bodypart_overlay
-	/// Sometimes we need multiple layers, for like the back, middle and front of the person (EXTERNAL_FRONT, EXTERNAL_ADJACENT, EXTERNAL_BEHIND)
-	var/layers
-	/// List of all possible layers to their real layer. Used for looping through in drawing
-	var/static/alist/all_layers = alist(
-		EXTERNAL_FRONT = -BODY_FRONT_LAYER,
-		EXTERNAL_ADJACENT = -BODY_ADJ_LAYER,
-		EXTERNAL_BEHIND = -BODY_BEHIND_LAYER,
-	)
-	/// Key of the icon states of all the sprite_datums for easy caching
-	var/cache_key = ""
+	///
+	///
+	/**
+	 * Assoc list [icon state postfix] to [layer of overlay].
+	 *
+	 * For simple overlays this will be a list of one element,
+	 * but for more complicated overlays, this can be any number of component layers.
+	 *
+	 * Example:
+	 * layers = list("front" = BODY_LAYER_FRONT) // - one layer, with icon state "[iconstate]_front"
+	 * layers = list("adjacent" = BODY_LAYER_ADJACENT, "behind" = BODY_LAYER_BEHIND) // - two layers, one is "[iconstate]_adjacent", the other is "[iconstate]_behind"
+	 * layers = list("layer1" = BODY_LAYER_ADJACENT, "layer2" = BODY_LAYER_BEHIND) // - two layers, with icon states "[iconstate]_layer1" and "[iconstate]_layer2"
+	 * layers = list("" = BODY_LAYER_FRONT) // - one layer, with icon state "[iconstate]"
+	 */
+	var/list/layers
 	/// Whether the overlay blocks emissive light
 	var/blocks_emissive = EMISSIVE_BLOCK_UNIQUE
 	/// Can this overlay be drawn on husked mobs?
@@ -18,15 +23,36 @@
 	/// Determines body area of the overlay for height offsets
 	var/offset_location = NO_MODIFY
 
-///Wrapper for getting the proper image, colored and everything
-/datum/bodypart_overlay/proc/get_overlay(layer, obj/item/bodypart/limb)
-	var/image/main_image = get_image(layer, limb)
+/**
+ * Returns a list of overlays that this overlay datum draws
+ *
+ * * limb: the limb we're drawing onto
+ *
+ * Returns a list of images/mutable appearances
+ */
+/datum/bodypart_overlay/proc/get_all_overlays(obj/item/bodypart/limb)
+	var/list/overlays = list()
+	for(var/overlay_postfix, overlay_layer in layers)
+		overlays += get_overlay(limb, overlay_postfix, -overlay_layer)
+	return overlays
+
+/**
+ * Handles generating an individual overlay or an overlay + an emissive blocker
+ *
+ * * limb: the limb we're drawing onto, can be null if we're just drawing a general overlay for the mob and not a specific limb
+ * * layer_index: the index of the layer we're drawing on, used for generating the image
+ * * layer_real: the actual layer we're drawing on, used for generating the image
+ *
+ * Returns a list of images/mutable appearances, usually just one, but can be two if we need an emissive blocker
+ */
+/datum/bodypart_overlay/proc/get_overlay(obj/item/bodypart/limb, layer_index, layer_real)
+	PROTECTED_PROC(TRUE)
+	var/image/main_image = get_image(limb, layer_index, layer_real)
 
 	if (limb?.is_husked && draw_on_husks != HUSK_OVERLAY_NORMAL)
-		main_image = huskify_image(main_image)
-		main_image.color = limb.husk_color
+		main_image = huskify_image(main_image, limb)
 	else
-		color_image(main_image, layer, limb)
+		color_image(main_image, limb, layer_index)
 
 	var/list/created_overlays = list(main_image)
 	if(blocks_emissive != EMISSIVE_BLOCK_NONE && !isnull(limb))
@@ -34,53 +60,79 @@
 
 	return created_overlays
 
-/datum/bodypart_overlay/proc/huskify_image(image/main_image)
+/// Helper to make an image look like a husk.
+/// Returns the husk-ified image, doesn't modify the original image.
+/datum/bodypart_overlay/proc/huskify_image(image/main_image, obj/item/bodypart/limb)
+	PRIVATE_PROC(TRUE)
 	var/icon/husk_icon = new(main_image.icon)
 	husk_icon.ColorTone(HUSK_COLOR_TONE)
 	main_image.icon = husk_icon
+	main_image.color = limb.husk_color
 	return main_image
 
-///Generate the image. Needs to be overridden
-/datum/bodypart_overlay/proc/get_image(layer, obj/item/bodypart/limb)
+/**
+ * The actual proc where images / mutable appearances are generated for get_overlay
+ * Must be implemented by subtypes, at its simplest it should just return an image
+ *
+ * * limb: the limb we're drawing onto, can be null if we're just drawing a general overlay for the mob and not a specific limb
+ * * layer_index: the index of the layer we're drawing on.
+ * Typically some postfix for an icon state ie. "front" or "behind" (Used like "overlay_front" or "overlay_behind"
+ * * layer_real: the actual layer we're drawing on, used for generating the image.
+ * Some (negative) number like -10 to -30. (Used like layer = layer_real, you shouldn't need to mess with it.)
+ *
+ * Returns an image/mutable appearance to draw on the mob.
+ */
+/datum/bodypart_overlay/proc/get_image(obj/item/bodypart/limb, layer_index, layer_real)
 	CRASH("Get image needs to be overridden")
 
-///Color the image
-/datum/bodypart_overlay/proc/color_image(image/overlay, layer, obj/item/bodypart/limb)
+/**
+ * Used to color the image, if necessary.
+ * By default it does nothing.
+ *
+ * * image: the image generated by get_image() that we want to color
+ * * limb: the limb we're drawing onto, can be null if we're just drawing a general overlay for the mob and not a specific limb.
+ * * layer_index: the index of the layer we're drawing on, used for generating the image.
+ */
+/datum/bodypart_overlay/proc/color_image(image/overlay, obj/item/bodypart/limb, layer_index)
 	return
 
-///Called on being added to a limb
+/// Called on being added to a limb.
 /datum/bodypart_overlay/proc/added_to_limb(obj/item/bodypart/limb)
 	return
 
-///Called on being removed from a limb
+/// Called on being removed from a limb.
 /datum/bodypart_overlay/proc/removed_from_limb(obj/item/bodypart/limb)
 	return
 
-///Use this to change the appearance (and yes you must overwrite hahahahahah) (or don't use this, I just don't want people directly changing the image)
+/**
+ * Used by subtypes to change the appearance of the overlay.
+ * Typically implemented in tandem with a sprite accessory.
+ */
 /datum/bodypart_overlay/proc/set_appearance()
 	CRASH("Update appearance needs to be overridden")
 
-/**This exists so sprite accessories can still be per-layer without having to include that layer's
-*  number in their sprite name, which causes issues when those numbers change.
-*/
-/datum/bodypart_overlay/proc/mutant_bodyparts_layertext(layer)
-	switch(layer)
-		if(-BODY_BEHIND_LAYER)
-			return "BEHIND"
-		if(-BODY_ADJ_LAYER)
-			return "ADJ"
-		if(-BODY_FRONT_LAYER)
-			return "FRONT"
-
-///Check whether we can draw the overlays. You generally don't want lizard snouts to draw over an EVA suit
+/**
+ * Checks whether the bodypart overlay can be drawn on the mob/bodypart.
+ * Used so snouts are hidden by masks and whatnot.
+ *
+ * * bodypart_owner: the bodypart we're trying to draw on, will never be null.
+ * * owner: the mob we're trying to draw on. Likely bodypart_owner.owner, can be null.
+ *
+ * Returns TRUE if we can draw
+ * Returns FALSE if we can't draw
+ */
 /datum/bodypart_overlay/proc/can_draw_on_bodypart(obj/item/bodypart/bodypart_owner, mob/living/carbon/owner)
 	SHOULD_CALL_PARENT(TRUE)
 	return !bodypart_owner.is_husked || draw_on_husks
 
-///Colorizes the limb it's inserted to, if required.
-/datum/bodypart_overlay/proc/override_color(obj/item/bodypart/bodypart_owner)
-	CRASH("External organ color set to override with no override proc.")
-
-///Generate a unique identifier to cache with. If you change something about the image, but the icon cache stays the same, it'll simply pull the unchanged image out of the cache
+/**
+ * Used in human rendering to cache generated bodyparts.
+ * Anything your bodypart overlay can change - such as color, icon state, etc - should be included in this,
+ * otherwise you'll end up with caching issues where different looking overlays will share the same cache and thus look the same.
+ *
+ * * limb: the limb we're drawing onto, can be null if we're just drawing a general overlay for the mob and not a specific limb.
+ *
+ * Returns a list of strings/numbers/whatever that represents the unique appearance of the overlay.
+ */
 /datum/bodypart_overlay/proc/icon_render_key(obj/item/bodypart/limb)
 	return list()

--- a/code/datums/bodypart_overlays/bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/bodypart_overlay.dm
@@ -13,9 +13,9 @@
 	 * layers = list("layer1" = BODY_LAYER_ADJACENT, "layer2" = BODY_LAYER_BEHIND) // - two layers, with icon states "[iconstate]_layer1" and "[iconstate]_layer2"
 	 * layers = list("" = BODY_LAYER_FRONT) // - one layer, with icon state "[iconstate]"
 	 *
-	 * This is cached, so be careful editing it at runtime
+	 * This is cached, so be careful editing it at runtime (use the helpers!)
 	 */
-	var/list/layers
+	VAR_PROTECTED/list/layers
 	/// Whether the overlay blocks emissive light
 	var/blocks_emissive = EMISSIVE_BLOCK_UNIQUE
 	/// Can this overlay be drawn on husked mobs?
@@ -25,8 +25,30 @@
 
 /datum/bodypart_overlay/New()
 	. = ..()
-	if(length(layers))
-		layers = string_assoc_list(layers)
+	set_layers(layers)
+
+/// Used for adding a layer at runtime
+/datum/bodypart_overlay/proc/set_layer(layer_postfix, layer_number)
+	var/list/existing_layers = layers.Copy()
+	existing_layers[layer_postfix] = layer_number
+	layers = string_assoc_list(existing_layers)
+
+/// Used for adding layers at runtime
+/datum/bodypart_overlay/proc/set_layers(list/layer_list)
+	if(!length(layer_list))
+		return
+
+	layers = string_assoc_list(layer_list)
+
+/// Used for removing layers at runtime
+/datum/bodypart_overlay/proc/clear_layer(layer_postfix)
+	var/list/existing_layers = layers.Copy()
+	existing_layers -= layer_postfix
+	if(!length(existing_layers))
+		layers = null
+		return
+
+	layers = string_assoc_list(existing_layers)
 
 /**
  * Returns a list of overlays that this overlay datum draws

--- a/code/datums/bodypart_overlays/bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/bodypart_overlay.dm
@@ -1,8 +1,6 @@
 ///Bodypart ovarlay datum. These can be added to any limb to give them a proper overlay, that'll even stay if the limb gets removed
 ///This is the abstract parent, don't use it!!
 /datum/bodypart_overlay
-	///
-	///
 	/**
 	 * Assoc list [icon state postfix] to [layer of overlay].
 	 *
@@ -14,6 +12,8 @@
 	 * layers = list("adjacent" = BODY_LAYER_ADJACENT, "behind" = BODY_LAYER_BEHIND) // - two layers, one is "[iconstate]_adjacent", the other is "[iconstate]_behind"
 	 * layers = list("layer1" = BODY_LAYER_ADJACENT, "layer2" = BODY_LAYER_BEHIND) // - two layers, with icon states "[iconstate]_layer1" and "[iconstate]_layer2"
 	 * layers = list("" = BODY_LAYER_FRONT) // - one layer, with icon state "[iconstate]"
+	 *
+	 * This is cached, so be careful editing it at runtime
 	 */
 	var/list/layers
 	/// Whether the overlay blocks emissive light
@@ -22,6 +22,11 @@
 	var/draw_on_husks = HUSK_OVERLAY_NONE
 	/// Determines body area of the overlay for height offsets
 	var/offset_location = NO_MODIFY
+
+/datum/bodypart_overlay/New()
+	. = ..()
+	if(length(layers))
+		layers = string_assoc_list(layers)
 
 /**
  * Returns a list of overlays that this overlay datum draws
@@ -123,7 +128,7 @@
  */
 /datum/bodypart_overlay/proc/can_draw_on_bodypart(obj/item/bodypart/bodypart_owner, mob/living/carbon/owner)
 	SHOULD_CALL_PARENT(TRUE)
-	return !bodypart_owner.is_husked || draw_on_husks
+	return !bodypart_owner.is_husked || draw_on_husks != HUSK_OVERLAY_NONE
 
 /**
  * Used in human rendering to cache generated bodyparts.

--- a/code/datums/bodypart_overlays/emote_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/emote_bodypart_overlay.dm
@@ -2,6 +2,7 @@
 /datum/bodypart_overlay/simple/emote
 	icon = 'icons/mob/human/emote_visuals.dmi'
 	offset_location = UPPER_BODY
+	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
 	///The body zone to attach the overlay to, overlay won't be added if no bodypart can be found with this
 	var/attached_body_zone = BODY_ZONE_CHEST
 	///The feature key used to figure out what specific bodily feature we offset this to follow
@@ -11,7 +12,7 @@
 	///The bodypart that the overlay is currently applied to
 	var/datum/weakref/attached_bodypart
 
-/datum/bodypart_overlay/simple/emote/get_image(layer, obj/item/bodypart/limb)
+/datum/bodypart_overlay/simple/emote/get_image(obj/item/bodypart/limb, layer_index, layer_real)
 	var/image/image = ..()
 	feature_offset?.apply_offset(image)
 	return image
@@ -45,18 +46,16 @@
 /datum/bodypart_overlay/simple/emote/tongue
 	icon_state = "tongue"
 	draw_color = COLOR_TONGUE_PINK
-	layers = EXTERNAL_ADJACENT
 	offset_key = OFFSET_FACE
 	attached_body_zone = BODY_ZONE_HEAD
 
 /datum/bodypart_overlay/simple/emote/blush
 	icon_state = "blush"
 	draw_color = COLOR_BLUSH_PINK
-	layers = EXTERNAL_ADJACENT
 	offset_key = OFFSET_FACE
 	attached_body_zone = BODY_ZONE_HEAD
 
-/datum/bodypart_overlay/simple/emote/blush/color_image(image/overlay, layer, obj/item/bodypart/limb)
+/datum/bodypart_overlay/simple/emote/blush/color_image(image/overlay, obj/item/bodypart/limb, layer_index)
 	var/base_color = limb.owner?.get_bloodtype()?.get_damage_color()
 	if(!base_color)
 		return ..()
@@ -72,6 +71,5 @@
 /datum/bodypart_overlay/simple/emote/cry
 	icon_state = "tears"
 	draw_color = COLOR_DARK_CYAN
-	layers = EXTERNAL_ADJACENT
 	offset_key = OFFSET_FACE
 	attached_body_zone = BODY_ZONE_HEAD

--- a/code/datums/bodypart_overlays/markings_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/markings_bodypart_overlay.dm
@@ -1,6 +1,6 @@
 /// For body markings applied on the species, which need some extra code
 /datum/bodypart_overlay/simple/body_marking
-	layers = EXTERNAL_ADJACENT
+	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
 	offset_location = ENTIRE_BODY
 	/// Listen to the gendercode, if the limb is bimorphic
 	var/use_gender = FALSE
@@ -38,9 +38,9 @@
 /datum/bodypart_overlay/simple/body_marking/can_draw_on_bodypart(obj/item/bodypart/bodypart_owner, mob/living/carbon/owner)
 	return ..() && icon_state != SPRITE_ACCESSORY_NONE
 
-/datum/bodypart_overlay/simple/body_marking/get_image(layer, obj/item/bodypart/limb)
+/datum/bodypart_overlay/simple/body_marking/get_image(obj/item/bodypart/limb, layer_index, layer_real)
 	var/gender_string = (use_gender && limb.is_dimorphic) ? (limb.gender == MALE ? MALE : FEMALE + "_") : "" //we only got male and female sprites
-	return mutable_appearance(icon, gender_string + icon_state + "_" + limb.body_zone, layer = layer)
+	return mutable_appearance(icon, gender_string + icon_state + "_" + limb.body_zone, layer = layer_real)
 
 /datum/bodypart_overlay/simple/body_marking/get_accessory(name)
 	return SSaccessories.feature_list[dna_feature_key][name]

--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -40,7 +40,7 @@
 		set_appearance_from_name(feature_name)
 		imprint_on_next_insertion = FALSE
 
-/datum/bodypart_overlay/mutant/get_overlay(layer, obj/item/bodypart/limb)
+/datum/bodypart_overlay/mutant/get_overlay(obj/item/bodypart/limb, layer_index, layer_real)
 	inherit_color(limb) // If draw_color is not set yet, go ahead and do that
 	return ..()
 
@@ -73,25 +73,24 @@
 	return sprite_datum.icon_state
 
 ///Used to build the final incon state for the sprite
-/datum/bodypart_overlay/mutant/proc/build_icon_state(image_layer, obj/item/bodypart/limb)
+/datum/bodypart_overlay/mutant/proc/build_icon_state(layer_index, obj/item/bodypart/limb)
 	PROTECTED_PROC(TRUE)
 	var/gender_key = (sprite_datum.gender_specific && limb?.limb_gender) || "m" // Male is default because sprite accessories are so ancient they predate the concept of not hardcoding gender
 	var/base_state = get_base_icon_state()
-	var/layer_key = mutant_bodyparts_layertext(image_layer)
-	return "[gender_key]_[feature_key]_[base_state]_[layer_key]"
+	return "[gender_key]_[feature_key]_[base_state]_[layer_index]"
 
 ///Get the image we need to draw on the person. Called from get_overlay() which is called from _bodyparts.dm. Limb can be null
-/datum/bodypart_overlay/mutant/get_image(image_layer, obj/item/bodypart/limb)
+/datum/bodypart_overlay/mutant/get_image(obj/item/bodypart/limb, layer_index, layer_real)
 	if(!sprite_datum)
 		CRASH("Trying to call get_image() on [type] while it didn't have a sprite_datum. This shouldn't happen, report it as soon as possible.")
 
-	var/mutable_appearance/appearance = mutable_appearance(sprite_datum.icon, build_icon_state(image_layer, limb), layer = image_layer)
+	var/mutable_appearance/appearance = mutable_appearance(sprite_datum.icon, build_icon_state(layer_index, limb), layer = layer_real)
 	if(sprite_datum.center)
 		center_image(appearance, sprite_datum.dimension_x, sprite_datum.dimension_y)
 
 	return appearance
 
-/datum/bodypart_overlay/mutant/color_image(image/overlay, layer, obj/item/bodypart/limb)
+/datum/bodypart_overlay/mutant/color_image(image/overlay, obj/item/bodypart/limb, layer_index)
 	overlay.color = sprite_datum.color_src ? (dye_color || draw_color) : null
 
 /datum/bodypart_overlay/mutant/added_to_limb(obj/item/bodypart/limb)
@@ -119,6 +118,10 @@
 		stack_trace("External organ has no feature list, it will render invisible")
 		return list()
 	return feature_list
+
+/// Used to add special coloring behavior to certain mutant parts.
+/datum/bodypart_overlay/mutant/proc/override_color(obj/item/bodypart/bodypart_owner)
+	CRASH("External organ color set to override with no override proc.")
 
 ///Give the organ its color. Force will override the existing one.
 /datum/bodypart_overlay/mutant/proc/inherit_color(obj/item/bodypart/bodypart_owner, force)

--- a/code/datums/bodypart_overlays/simple_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/simple_bodypart_overlay.dm
@@ -8,11 +8,10 @@
 	///Color we apply to our overlay (none by default)
 	var/draw_color
 
-/datum/bodypart_overlay/simple/get_image(layer, obj/item/bodypart/limb)
-	return mutable_appearance(icon, icon_state, layer = layer)
+/datum/bodypart_overlay/simple/get_image(obj/item/bodypart/limb, layer_index, layer_real)
+	return mutable_appearance(icon, icon_state, layer = layer_real)
 
-/datum/bodypart_overlay/simple/color_image(image/overlay, layer, obj/item/bodypart/limb)
-
+/datum/bodypart_overlay/simple/color_image(image/overlay, obj/item/bodypart/limb, layer_index)
 	overlay.color = draw_color
 
 /datum/bodypart_overlay/simple/icon_render_key(obj/item/bodypart/limb)
@@ -22,7 +21,7 @@
 ///A sixpack drawn on the chest
 /datum/bodypart_overlay/simple/sixpack
 	icon_state = "sixpack"
-	layers = EXTERNAL_ADJACENT
+	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
 	draw_on_husks = HUSK_OVERLAY_GRAYSCALE
 	offset_location = ENTIRE_BODY
 
@@ -30,11 +29,11 @@
 /datum/bodypart_overlay/simple/bags
 	icon_state = "bags"
 	draw_color = COLOR_WEBSAFE_DARK_GRAY
-	layers = EXTERNAL_ADJACENT
+	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
 	offset_location = UPPER_BODY
 
 ///PENDING eyes drawn on the face
 /datum/bodypart_overlay/simple/soul_pending_eyes
 	icon_state = "soul_pending_eyes"
-	layers = EXTERNAL_FRONT
+	layers = list(EXTERNAL_FRONT = BODY_FRONT_LAYER)
 	offset_location = UPPER_BODY

--- a/code/datums/components/face_decal.dm
+++ b/code/datums/components/face_decal.dm
@@ -38,6 +38,7 @@
 		if(!my_head) //just to be sure
 			qdel(src)
 			return
+		#warn fixme
 		bodypart_overlay = new()
 		bodypart_overlay.layers = layers
 		if(carbon_parent.bodyshape & BODYSHAPE_SNOUTED) //stupid, but external organ bodytypes are not stored on the limb

--- a/code/datums/components/face_decal.dm
+++ b/code/datums/components/face_decal.dm
@@ -38,9 +38,8 @@
 		if(!my_head) //just to be sure
 			qdel(src)
 			return
-		#warn fixme
 		bodypart_overlay = new()
-		bodypart_overlay.layers = layers
+		bodypart_overlay.layers = string_assoc_lists(layers)
 		if(carbon_parent.bodyshape & BODYSHAPE_SNOUTED) //stupid, but external organ bodytypes are not stored on the limb
 			bodypart_overlay.icon_state = "[icon_state]_lizard"
 		else if(my_head.bodyshape & BODYSHAPE_MONKEY)

--- a/code/datums/components/face_decal.dm
+++ b/code/datums/components/face_decal.dm
@@ -39,7 +39,7 @@
 			qdel(src)
 			return
 		bodypart_overlay = new()
-		bodypart_overlay.layers = string_assoc_lists(layers)
+		bodypart_overlay.set_layers(layers)
 		if(carbon_parent.bodyshape & BODYSHAPE_SNOUTED) //stupid, but external organ bodytypes are not stored on the limb
 			bodypart_overlay.icon_state = "[icon_state]_lizard"
 		else if(my_head.bodyshape & BODYSHAPE_MONKEY)

--- a/code/datums/components/splat.dm
+++ b/code/datums/components/splat.dm
@@ -16,7 +16,7 @@
 
 /datum/component/splat/Initialize(
 	icon_state = "creampie",
-	layer = EXTERNAL_FRONT,
+	layer = list(EXTERNAL_FRONT = BODY_FRONT_LAYER),
 	memory_type = /datum/memory/witnessed_creampie,
 	smudge_type = /obj/effect/decal/cleanable/food/pie_smudge,
 	moodlet_type = /datum/mood_event/creampie,

--- a/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/fish_organs.dm
@@ -378,14 +378,14 @@
 /datum/bodypart_overlay/simple/gills
 	icon = 'icons/mob/human/fish_features.dmi'
 	icon_state = "gills"
-	layers = EXTERNAL_ADJACENT
+	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
 	draw_on_husks = HUSK_OVERLAY_GRAYSCALE
 
-/datum/bodypart_overlay/simple/gills/get_image(image_layer, obj/item/bodypart/limb)
+/datum/bodypart_overlay/simple/gills/get_image(obj/item/bodypart/limb, layer_index, layer_real)
 	return image(
 		icon = icon,
-		icon_state = "[icon_state]_[mutant_bodyparts_layertext(image_layer)]",
-		layer = image_layer,
+		icon_state = "[icon_state]_[layer_index]",
+		layer = layer_real,
 	)
 
 /// Subtype of gills that allow the mob to optionally breathe water.

--- a/code/game/machinery/dna_infuser/organ_sets/roach_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/roach_organs.dm
@@ -142,15 +142,18 @@
 // Simple overlay so we can add a roach shell to guys with roach hearts
 /datum/bodypart_overlay/simple/roach_shell
 	icon_state = "roach_shell"
-	layers = EXTERNAL_FRONT|EXTERNAL_BEHIND
+	layers = list(
+		EXTERNAL_FRONT = BODY_FRONT_LAYER,
+		EXTERNAL_BEHIND = BODY_BEHIND_LAYER,
+	)
 	draw_on_husks = HUSK_OVERLAY_GRAYSCALE
 	offset_location = ENTIRE_BODY
 
-/datum/bodypart_overlay/simple/roach_shell/get_image(image_layer, obj/item/bodypart/limb)
+/datum/bodypart_overlay/simple/roach_shell/get_image(obj/item/bodypart/limb, layer_index, layer_real)
 	return image(
 		icon = icon,
-		icon_state = "[icon_state]_[mutant_bodyparts_layertext(image_layer)]",
-		layer = image_layer,
+		icon_state = "[icon_state]_[layer_index]",
+		layer = layer_real,
 	)
 
 /// Roach stomach:

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -863,7 +863,7 @@
 		set_painting_tool_color(COLOR_SILVER)
 	update_appearance()
 	if(actually_paints)
-		user.AddComponent(/datum/component/face_decal, "spray", EXTERNAL_ADJACENT, paint_color)
+		user.AddComponent(/datum/component/face_decal, "spray", list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER), paint_color)
 	reagents.trans_to(user, used, volume_multiplier, transferred_by = user, methods = VAPOR)
 	return OXYLOSS
 
@@ -921,7 +921,7 @@
 			flash_color(carbon_target, flash_color=paint_color, flash_time=40)
 		if(ishuman(carbon_target) && actually_paints)
 			var/mob/living/carbon/human/human_target = carbon_target
-			human_target.AddComponent(/datum/component/face_decal, "spray", EXTERNAL_ADJACENT, paint_color)
+			human_target.AddComponent(/datum/component/face_decal, "spray", list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER), paint_color)
 		use_charges(user, 10, FALSE)
 		var/fraction = min(1, . / reagents.maximum_volume)
 		reagents.expose(carbon_target, VAPOR, fraction * volume_multiplier)

--- a/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
@@ -123,7 +123,11 @@
 /// Body part overlays applied by golem status effects
 /datum/bodypart_overlay/simple/golem_overlay
 	icon = 'icons/mob/human/species/golems.dmi'
-	layers = EXTERNAL_FRONT | EXTERNAL_ADJACENT | EXTERNAL_BEHIND
+	layers = list(
+		EXTERNAL_FRONT = BODY_FRONT_LAYER,
+		EXTERNAL_BEHIND = BODY_BEHIND_LAYER,
+		EXTERNAL_ADJACENT = BODY_ADJ_LAYER,
+	)
 	offset_location = ENTIRE_BODY
 	///The bodypart that the overlay is currently applied to
 	var/datum/weakref/attached_bodypart

--- a/code/game/objects/items/syndie_spraycan.dm
+++ b/code/game/objects/items/syndie_spraycan.dm
@@ -143,7 +143,7 @@
 	user.visible_message(span_suicide("[user] shakes up [src] with a rattle and lifts it to [user.p_their()] mouth, spraying paint across [user.p_their()] teeth!"))
 	user.say("WITNESS ME!!", forced="spraycan suicide")
 	playsound(src, 'sound/effects/spray.ogg', 5, TRUE, 5)
-	suicider.AddComponent(/datum/component/face_decal, "spray", EXTERNAL_ADJACENT, paint_color)
+	suicider.AddComponent(/datum/component/face_decal, "spray", list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER), paint_color)
 	return OXYLOSS
 
 ///Checks if the user is still adjacent to the target (used for do_after extra_checks)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -488,17 +488,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	human.living_flags &= ~STOP_OVERLAY_UPDATE_BODY_PARTS
 
-// This exists so sprite accessories can still be per-layer without having to include that layer's
-// number in their sprite name, which causes issues when those numbers change.
-/datum/species/proc/mutant_bodyparts_layertext(layer)
-	switch(layer)
-		if(BODY_BEHIND_LAYER)
-			return "BEHIND"
-		if(BODY_ADJ_LAYER)
-			return "ADJ"
-		if(BODY_FRONT_LAYER)
-			return "FRONT"
-
 ///Proc that will randomise the hair, or primary appearance element (i.e. for moths wings) of a species' associated mob
 /datum/species/proc/randomize_main_appearance_element(mob/living/carbon/human/human_mob)
 	human_mob.set_hairstyle(random_hairstyle(human_mob.gender), update = FALSE)

--- a/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
@@ -102,7 +102,7 @@
 
 /// Bodypart overlay for the mushroom cap organ
 /datum/bodypart_overlay/mutant/mushroom_cap
-	layers = EXTERNAL_ADJACENT
+	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
 	feature_key = FEATURE_MUSH_CAP
 	dyable = TRUE
 	offset_location = UPPER_BODY

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -335,7 +335,7 @@
 	user.AddComponent(\
 		/datum/component/face_decal/splat,\
 		icon_state = "creampie",\
-		layers = EXTERNAL_FRONT,\
+		layers = list(EXTERNAL_FRONT = BODY_FRONT_LAYER),\
 	)
 	return SHAME
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1393,18 +1393,13 @@
 		if(!overlay.can_draw_on_bodypart(src, owner))
 			continue
 
-		// Some externals have multiple layers for background, foreground and between
-		for(var/external_layer, actual_layer in overlay.all_layers)
-			if(!(overlay.layers & external_layer))
+		for (var/mutable_appearance/actual_overlay as anything in overlay.get_all_overlays(src))
+			if(dropped || isnull(owner))
+				. += image(actual_overlay, dir = SOUTH)
 				continue
 
-			for (var/mutable_appearance/actual_overlay as anything in overlay.get_overlay(actual_layer, src))
-				if(dropped || isnull(owner))
-					. += image(actual_overlay, dir = SOUTH)
-					continue
-
-				owner.apply_height(actual_overlay, overlay.offset_location)
-				. += actual_overlay
+			owner.apply_height(actual_overlay, overlay.offset_location)
+			. += actual_overlay
 
 	// Then texture everything at once, including bodypart overlays
 	for(var/datum/bodypart_texture/texture as anything in bodypart_textures)

--- a/code/modules/surgery/organs/external/_visual_organs.dm
+++ b/code/modules/surgery/organs/external/_visual_organs.dm
@@ -90,13 +90,10 @@ Unlike normal organs, we're actually inside a persons limbs at all times
 /obj/item/organ/update_overlays()
 	. = ..()
 
-	if(!use_mob_sprite_as_obj_sprite)
+	if(!use_mob_sprite_as_obj_sprite || isnull(bodypart_owner) || isnull(bodypart_overlay))
 		return
 
-	//Build the mob sprite and use it as our overlay
-	for(var/external_layer, actual_layer in bodypart_overlay.all_layers)
-		if(bodypart_overlay.layers & external_layer)
-			. += bodypart_overlay.get_overlay(actual_layer, bodypart_owner)
+	. += bodypart_overlay.get_all_overlays(bodypart_owner)
 
 ///The horns of a lizard!
 /obj/item/organ/horns
@@ -115,7 +112,7 @@ Unlike normal organs, we're actually inside a persons limbs at all times
 	organ_flags = parent_type::organ_flags | ORGAN_EXTERNAL
 
 /datum/bodypart_overlay/mutant/horns
-	layers = EXTERNAL_ADJACENT
+	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
 	feature_key = FEATURE_HORNS
 	dyable = TRUE
 	draw_on_husks = HUSK_OVERLAY_NORMAL
@@ -141,7 +138,7 @@ Unlike normal organs, we're actually inside a persons limbs at all times
 	organ_flags = parent_type::organ_flags | ORGAN_EXTERNAL
 
 /datum/bodypart_overlay/mutant/frills
-	layers = EXTERNAL_ADJACENT
+	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
 	feature_key = FEATURE_FRILLS
 	offset_location = UPPER_BODY
 
@@ -153,22 +150,22 @@ Unlike normal organs, we're actually inside a persons limbs at all times
 	if(LAZYLEN(limb?.owner?.hair_masks))
 		. += jointext(limb.owner.hair_masks, ",")
 
-/datum/bodypart_overlay/mutant/frills/get_image(image_layer, obj/item/bodypart/limb)
+/datum/bodypart_overlay/mutant/frills/get_image(obj/item/bodypart/limb, layer_index, layer_real)
 	if(!LAZYLEN(limb?.owner?.hair_masks))
 		return ..()
 
 	var/list/hair_masks_to_use = limb.owner.hair_masks
-	var/icon_state_to_use = build_icon_state(image_layer, limb)
+	var/icon_state_to_use = build_icon_state(layer_index, limb)
 	var/frill_cache_key = "[sprite_datum.type]-[icon_state_to_use]-[jointext(hair_masks_to_use, ",")]"
 	var/static/list/cached_frill_icons
 	var/icon/cached_icon = LAZYACCESS(cached_frill_icons, frill_cache_key)
 	if(isnull(cached_icon))
-		cached_icon = icon(sprite_datum.icon, build_icon_state(image_layer, limb))
+		cached_icon = icon(sprite_datum.icon, build_icon_state(layer_index, limb))
 		for(var/datum/hair_mask/mask as anything in hair_masks_to_use)
 			cached_icon.Blend(icon(mask::icon, mask::icon_state), ICON_ADD)
 		LAZYSET(cached_frill_icons, frill_cache_key, cached_icon)
 
-	var/mutable_appearance/uncached_appearance = mutable_appearance(cached_icon, layer = image_layer)
+	var/mutable_appearance/uncached_appearance = mutable_appearance(cached_icon, layer = layer_real)
 	if(sprite_datum.center)
 		center_image(uncached_appearance, sprite_datum.dimension_x, sprite_datum.dimension_y)
 	return uncached_appearance
@@ -210,7 +207,7 @@ Unlike normal organs, we're actually inside a persons limbs at all times
 	return ..()
 
 /datum/bodypart_overlay/mutant/snout
-	layers = EXTERNAL_ADJACENT
+	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
 	feature_key = FEATURE_SNOUT
 	draw_on_husks = HUSK_OVERLAY_GRAYSCALE
 	offset_location = UPPER_BODY
@@ -280,7 +277,10 @@ Unlike normal organs, we're actually inside a persons limbs at all times
 
 ///Moth antennae datum, with full burning functionality
 /datum/bodypart_overlay/mutant/antennae
-	layers = EXTERNAL_FRONT | EXTERNAL_BEHIND
+	layers = list(
+		EXTERNAL_FRONT = BODY_FRONT_LAYER,
+		EXTERNAL_BEHIND = BODY_BEHIND_LAYER
+	)
 	feature_key = FEATURE_MOTH_ANTENNAE
 	dyable = TRUE
 	offset_location = UPPER_BODY
@@ -319,7 +319,10 @@ Unlike normal organs, we're actually inside a persons limbs at all times
 
 ///Podperson bodypart overlay, with special coloring functionality to render the flowers in the inverse color
 /datum/bodypart_overlay/mutant/pod_hair
-	layers = EXTERNAL_FRONT|EXTERNAL_ADJACENT
+	layers = list(
+		EXTERNAL_FRONT = BODY_FRONT_LAYER,
+		EXTERNAL_ADJACENT = BODY_ADJ_LAYER
+	)
 	feature_key = FEATURE_POD_HAIR
 	dyable = TRUE
 	offset_location = UPPER_BODY
@@ -329,8 +332,8 @@ Unlike normal organs, we're actually inside a persons limbs at all times
 	///The individual rgb colors are subtracted from this to get the color shifted layer
 	var/color_inverse_base = 255
 
-/datum/bodypart_overlay/mutant/pod_hair/color_image(image/overlay, draw_layer, obj/item/bodypart/limb)
-	if(draw_layer != all_layers[color_swapped_layer])
+/datum/bodypart_overlay/mutant/pod_hair/color_image(image/overlay, obj/item/bodypart/limb, layer_index)
+	if(layer_index != color_swapped_layer)
 		return ..()
 
 	var/color_to_use = dye_color || draw_color

--- a/code/modules/surgery/organs/external/spines.dm
+++ b/code/modules/surgery/organs/external/spines.dm
@@ -28,7 +28,10 @@
 
 ///Bodypart overlay for spines
 /datum/bodypart_overlay/mutant/spines
-	layers = EXTERNAL_ADJACENT|EXTERNAL_BEHIND
+	layers = list(
+		EXTERNAL_ADJACENT = BODY_ADJ_LAYER,
+		EXTERNAL_BEHIND = BODY_BEHIND_LAYER
+	)
 	feature_key = FEATURE_SPINES
 	dyable = TRUE
 	draw_on_husks = HUSK_OVERLAY_GRAYSCALE

--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -140,7 +140,10 @@
 
 ///Tail parent type, with wagging functionality
 /datum/bodypart_overlay/mutant/tail
-	layers = EXTERNAL_FRONT|EXTERNAL_BEHIND
+	layers = list(
+		EXTERNAL_FRONT = BODY_FRONT_LAYER,
+		EXTERNAL_BEHIND = BODY_BEHIND_LAYER,
+	)
 	dyable = TRUE
 	offset_location = ENTIRE_BODY
 	var/wagging = FALSE
@@ -252,7 +255,10 @@
 
 ///Bodypart overlay for tail spines. Handled by the tail - has no actual organ associated.
 /datum/bodypart_overlay/mutant/tail_spines
-	layers = EXTERNAL_ADJACENT|EXTERNAL_BEHIND
+	layers = list(
+		EXTERNAL_ADJACENT = BODY_ADJ_LAYER,
+		EXTERNAL_BEHIND = BODY_BEHIND_LAYER
+	)
 	feature_key = FEATURE_TAILSPINES
 	draw_on_husks = HUSK_OVERLAY_GRAYSCALE
 	offset_location = ENTIRE_BODY

--- a/code/modules/surgery/organs/external/wings/moth_wings.dm
+++ b/code/modules/surgery/organs/external/wings/moth_wings.dm
@@ -94,7 +94,10 @@
 ///Moth wing bodypart overlay, including burn functionality!
 /datum/bodypart_overlay/mutant/wings/moth
 	feature_key = FEATURE_MOTH_WINGS
-	layers = EXTERNAL_BEHIND | EXTERNAL_FRONT
+	layers = list(
+		EXTERNAL_FRONT = BODY_FRONT_LAYER,
+		EXTERNAL_BEHIND = BODY_BEHIND_LAYER,
+	)
 	slot_blocker = HIDEMUTWINGS
 	///Accessory datum of the burn sprite
 	var/datum/sprite_accessory/burn_datum = /datum/sprite_accessory/moth_wings/burnt_off

--- a/code/modules/surgery/organs/external/wings/wings.dm
+++ b/code/modules/surgery/organs/external/wings/wings.dm
@@ -22,7 +22,11 @@
 
 ///Bodypart overlay of default wings. Does not have any wing functionality
 /datum/bodypart_overlay/mutant/wings
-	layers = EXTERNAL_FRONT | EXTERNAL_ADJACENT | EXTERNAL_BEHIND
+	layers = list(
+		EXTERNAL_FRONT = BODY_FRONT_LAYER,
+		EXTERNAL_BEHIND = BODY_BEHIND_LAYER,
+		EXTERNAL_ADJACENT = BODY_ADJ_LAYER,
+	)
 	feature_key = FEATURE_WINGS
 	offset_location = ENTIRE_BODY
 	/// Slot we check against

--- a/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
@@ -45,7 +45,7 @@
 		limb.remove_bodypart_overlay(bodypart_aug)
 
 /datum/bodypart_overlay/augment
-	layers = EXTERNAL_ADJACENT
+	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
 	draw_on_husks = HUSK_OVERLAY_NORMAL
 	offset_location = ENTIRE_BODY
 	/// Implant that owns this overlay
@@ -63,8 +63,8 @@
 	. = ..()
 	. += implant.get_overlay_state()
 
-/datum/bodypart_overlay/augment/get_overlay(layer, obj/item/bodypart/limb)
-	var/list/imageset = implant.get_overlay(layer, limb)
+/datum/bodypart_overlay/augment/get_overlay(obj/item/bodypart/limb, layer_index, layer_real)
+	var/list/imageset = implant.get_overlay(layer_real, limb)
 	if(blocks_emissive == EMISSIVE_BLOCK_NONE || !limb)
 		return imageset
 

--- a/code/modules/surgery/organs/internal/ears/_ears.dm
+++ b/code/modules/surgery/organs/internal/ears/_ears.dm
@@ -158,7 +158,10 @@
 
 /// Bodypart overlay for the horrible cat ears
 /datum/bodypart_overlay/mutant/cat_ears
-	layers = EXTERNAL_FRONT | EXTERNAL_BEHIND
+	layers = list(
+		EXTERNAL_FRONT = BODY_FRONT_LAYER,
+		EXTERNAL_BEHIND = BODY_BEHIND_LAYER
+	)
 	color_source = ORGAN_COLOR_HAIR
 	feature_key = FEATURE_EARS
 	dyable = TRUE
@@ -170,24 +173,24 @@
 /datum/bodypart_overlay/mutant/cat_ears/can_draw_on_bodypart(obj/item/bodypart/bodypart_owner, mob/living/carbon/owner)
 	return ..() && !(bodypart_owner.owner?.obscured_slots & HIDEHAIR)
 
-/datum/bodypart_overlay/mutant/cat_ears/get_image(image_layer, obj/item/bodypart/limb)
+/datum/bodypart_overlay/mutant/cat_ears/get_image(obj/item/bodypart/limb, layer_index, layer_real)
 	var/mutable_appearance/base_ears = ..()
 	base_ears.color = (dye_color || draw_color)
 
 	// Only add inner ears on the inner layer
-	if(image_layer != all_layers[inner_layer])
+	if(layer_index != inner_layer)
 		return base_ears
 
 	// Construct image of inner ears, apply to base ears as an overlay
 	feature_key += "inner"
 	var/mutable_appearance/inner_ears = ..()
 	feature_key = initial(feature_key)
-	var/mutable_appearance/ear_holder = mutable_appearance(layer = image_layer)
+	var/mutable_appearance/ear_holder = mutable_appearance(layer = layer_real)
 	ear_holder.overlays += base_ears
 	ear_holder.overlays += inner_ears
 	return ear_holder
 
-/datum/bodypart_overlay/mutant/cat_ears/color_image(image/overlay, layer, obj/item/bodypart/limb)
+/datum/bodypart_overlay/mutant/cat_ears/color_image(image/overlay, obj/item/bodypart/limb, layer_index)
 	return // We color base ears manually above in get_image
 
 /obj/item/organ/ears/cat/cybernetic
@@ -237,16 +240,16 @@
 	/// Color of the inner ear
 	var/inner_color = "#F0004A"
 
-/datum/bodypart_overlay/mutant/cat_ears/cybernetic/get_image(image_layer, obj/item/bodypart/limb)
-	if (image_layer != all_layers[inner_layer])
+/datum/bodypart_overlay/mutant/cat_ears/cybernetic/get_image(obj/item/bodypart/limb, layer_index, layer_real)
+	if (layer_index != inner_layer)
 		return ..()
 	var/mutable_appearance/ear_holder = ..()
 	var/mutable_appearance/inner = ear_holder.overlays[2]
 	inner.color = inner_color
 	return ear_holder
 
-/datum/bodypart_overlay/mutant/cat_ears/cybernetic/get_overlay(layer, obj/item/bodypart/limb)
-	if (layer != all_layers[inner_layer])
+/datum/bodypart_overlay/mutant/cat_ears/cybernetic/get_overlay(obj/item/bodypart/limb, layer_index, layer_real)
+	if (layer_index != inner_layer)
 		return ..()
 	var/list/all_images = ..()
 	var/mutable_appearance/ear_holder = all_images[1]


### PR DESCRIPTION
## About The Pull Request

`EXTERNAL_FRONT`, `EXTERNAL_ADJACENT`, and `EXTERNAL_BEHIND` are no longer bitflags
Instead they are strings, that correspond to the sprite's icon state's postfix ie `wings_FRONT` / `wings_ADJ`

Bodypart overlays now define their layers in terms of `postfix` to `rendering layer`
For example wings are defined as:
```dm
	layers = list(
		EXTERNAL_FRONT = BODY_FRONT_LAYER,
		EXTERNAL_ADJACENT = BODY_ADJ_LAYER,
		EXTERNAL_BEHIND = BODY_BEHIND_LAYER,
	)
```
Which translates to
```dm
	layers = list(
		"FRONT" = 2.5,
		"ADJ" = 22.9,
		"BEHIND" = 32.2,
	)
```
## Why It's Good For The Game

What does this mean?

One, you are no longer constricted to the three existing layers when adding a bodypart overlay. You can decide to put it on whatever layer you need...
```dm
	layers = list(
		"FRONT" = 2.4, // I specifically need this to render above other front overlays!
	)
```

Two, you can easily add a new layer without needing to mess with core bodypart code at all
```dm
	layers = list(
		"FRONT_HIGHER" = 2.4, // I need a special layer
		"FRONT" = 2.3, 
	)
```

Three, you don't have to use the `EXTERNAL_FRONT` `EXTERNAL_ADJACENT` etc. at all if you don't want to. You can organize your layers however you want...
```dm
	layers = list(
		// I can make my icon states `wings_top` and `wings_bottom` instead of `wings_FRONT` and `wings_BEHIND` to make it easier to parse
		"top" = BODY_ADJ_LAYER, 
		"bottom" = BODY_BEHIND_LAYER, 
	)
```

Ultimately, this makes it a ton easier to work with bodypart overlays, as you no longer need to learn what FRONT/ADJ/BEHIND means. You can just add your sprites and define your layers and you're done

## Changelog

:cl: Melbert
refactor: Surprise, a follow up refactor to species part rendering, report any oddities with them (wings/snouts/tails/etc) 
/:cl:

