### PR TITLE
Fix runtime for spacetime distortion not playing sound

### DIFF
--- a/code/modules/spells/spell_types/self/spacetime_distortion.dm
+++ b/code/modules/spells/spell_types/self/spacetime_distortion.dm
@@ -132,7 +132,7 @@
 	busy = TRUE
 	flick("purplesparkles", src)
 	AM.forceMove(get_turf(src))
-	playsound(loc, SFX_PORTAL_ENTER, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	playsound(src, SFX_PORTAL_ENTER, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	busy = FALSE
 
 /obj/effect/cross_action/spacetime_dist/proc/on_entered(datum/source, atom/movable/AM)

--- a/code/modules/spells/spell_types/self/spacetime_distortion.dm
+++ b/code/modules/spells/spell_types/self/spacetime_distortion.dm
@@ -101,7 +101,6 @@
 	var/antimagic_flags = MAGIC_RESISTANCE
 	var/obj/effect/cross_action/spacetime_dist/linked_dist
 	var/busy = FALSE
-	var/sound
 	var/walks_left = 50 //prevents the game from hanging in extreme cases (such as minigun fire)
 
 /obj/effect/cross_action/singularity_act()
@@ -133,7 +132,7 @@
 	busy = TRUE
 	flick("purplesparkles", src)
 	AM.forceMove(get_turf(src))
-	playsound(get_turf(src),sound,70,FALSE)
+	playsound(loc, SFX_PORTAL_ENTER, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	busy = FALSE
 
 /obj/effect/cross_action/spacetime_dist/proc/on_entered(datum/source, atom/movable/AM)


### PR DESCRIPTION

## About The Pull Request
- Fixes #96656

Running into a spacetime distortion portal would trigger a runtime due to attemping to play a null sound. I swapped the sound to use the same one from the teleporter sound effects.

## Why It's Good For The Game
Better code.

## Changelog
:cl:
fix: Fix runtime for spacetime distortion not playing sound
sound: Spacetime distortion portals now play the same sound as the teleporter portals. 
/:cl:
