### PR TITLE
Change blood deficiency to start with 85% blood instead of 80% to stop gasping, blurriness, and stamloss

### DIFF
--- a/code/datums/quirks/negative_quirks/blood_deficiency.dm
+++ b/code/datums/quirks/negative_quirks/blood_deficiency.dm
@@ -9,7 +9,7 @@
 	hardcore_value = 8
 	mail_goodies = list(/obj/item/reagent_containers/blood/o_minus) // universal blood type that is safe for all
 	/// Minimum amount of blood the paint is set to
-	var/min_blood = BLOOD_VOLUME_SAFE - 25 // just barely survivable without treatment
+	var/min_blood = BLOOD_VOLUME_SAFE + 1 // just barely survivable without treatment
 
 /datum/quirk/blooddeficiency/add(client/client_source)
 	RegisterSignal(quirk_holder, COMSIG_HUMAN_ON_HANDLE_BLOOD, PROC_REF(lose_blood))


### PR DESCRIPTION

## About The Pull Request
In https://github.com/tgstation/tgstation/pull/96206#issuecomment-4580112741 people were complaining that the blood deficiency quirk now gives players gasping and blurriness due to my fix from:

- #96206

All the negative effects from bloodloss were being ignored so the low blood caused from blood deficiency was not being felt. These effects are inside of:

https://github.com/tgstation/tgstation/blob/92541130cb57cf6b55685bad351d7ad9c8431627/code/modules/mob/living/blood.dm#L208-L217

By changing their blood minimum to be slightly higher than 85%, you can avoid all the negatives.

## Why It's Good For The Game
I am kind of on the fence about this. The original PR adding blood deficiency intended for it to be something that requires micromanging with meds from the user to avoid the penalties.

<img width="885" height="556" alt="chrome_6SK6STQrG8" src="https://github.com/user-attachments/assets/489d10b9-644a-4f8b-9e02-05dec04b0500" />

I think later it was deemed too intense and they reworked the quirk. I don't ever play with this quirk, but this is the simple fix to mitigate the quirk if neccessary.

## Changelog
:cl:
balance: Change blood deficiency to start with 85% blood instead of 80%
fix: Fix blood deficiency from causing gasping, stamina loss, and blurriness 
/:cl:
