### PR TITLE
Update heretic.dmm

### DIFF
--- a/_maps/RandomZLevels/heretic.dmm
+++ b/_maps/RandomZLevels/heretic.dmm
@@ -55,16 +55,6 @@
 	},
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
-"ao" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/machinery/deployable_turret/hmg,
-/turf/open/floor/iron/large,
-/area/awaymission/beach/heretic)
 "aq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50582,7 +50572,7 @@ nI
 nI
 nI
 nI
-ao
+SY
 hY
 Wz
 xH
@@ -51610,7 +51600,7 @@ nI
 nI
 nI
 nI
-ao
+SY
 hY
 Wz
 xH


### PR DESCRIPTION

## About The Pull Request

headmin disabled this map and asked i removed these
i dont think these things are too impactful as they are purely defensive meaning theyre meaningless save for like, icebox security, and escape shuttle but its whatever in the end.

## Why It's Good For The Game

no more mounted guns.

## Changelog

removes both the mounted guns.

:cl:
del: Removed both mounted guns in the heretic gateway per headmin request
/:cl:
