### PR TITLE
Fixes inverted do_after on shiv crafting

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -381,7 +381,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 
 	var/obj/item/stack/sheet/cloth/cloth = tool
 	to_chat(user, span_notice("You begin to wrap the [cloth] around the [src]..."))
-	if(do_after(user, craft_time, target = src))
+	if(!do_after(user, craft_time, target = src))
 		return ITEM_INTERACT_FAILURE
 
 	var/obj/item/knife/shiv/shiv = new shiv_type


### PR DESCRIPTION


## About The Pull Request

flips do_after that was succeeding on do after failure

fixes #96688 

## Why It's Good For The Game
fix bug

## Changelog

:cl:
fix: Crafting shivs no longer inverts the do_after check
/:cl: