### PR TITLE
Fixes self-climbing crates

### DIFF
--- a/code/datums/elements/climb_walkable.dm
+++ b/code/datums/elements/climb_walkable.dm
@@ -34,6 +34,8 @@
 
 /obj/structure/proc/on_climb_enter(datum/source, atom/movable/arrived)
 	SIGNAL_HANDLER
+	if(arrived == src) //You can't climb onto yourself
+		return
 	if(arrived.density)
 		ADD_TRAIT(arrived, TRAIT_ON_CLIMBABLE, ELEMENT_TRAIT(/datum/element/climb_walkable))
 


### PR DESCRIPTION


## About The Pull Request
Fixes #96687

Basically,  /datum/element/climb_walkable makes it so that if you share a turf with this object, you can keep walking onto other objects with that component. so if you're on a crate you can step onto tables for example.

Issue was, if an with /datum/element/climb_walkable gets initialized it would give itself this trait via COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON, and if it then moved and would be blocked by a crate, it would instead move "onto" the crate.

This is not a perfect fix, I think in general this is not an ideal way to handle elevation movement, but fixing that would turn this into a big refactor.

## Why It's Good For The Game

Prevents roundstart crates from clipping into the backrooms

## Changelog

:cl:
fix: Fixes crates not respecting density in all cases and being able to move into other crates or tables
/:cl: