### PR TITLE
storage diagnostics + persistence

### DIFF
--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -21,6 +21,11 @@ type StorageBackend = {
   clear(): Promise<void>;
 };
 
+export type StorageDiagnostic = {
+  level: 'info' | 'warn' | 'error';
+  message: string;
+};
+
 const testGeneric = (testFn: () => boolean) => (): boolean => {
   try {
     return Boolean(testFn());
@@ -78,6 +83,7 @@ class IFrameIndexedDbBackend implements StorageBackend {
   async ready(): Promise<boolean | null> {
     const iframe = document.createElement('iframe');
     iframe.style.display = 'none';
+    iframe.allow = 'storage-access';
     iframe.src = Byond.storageCdn;
 
     const completePromise: Promise<boolean> = new Promise((resolve) => {
@@ -171,6 +177,11 @@ class IFrameIndexedDbBackend implements StorageBackend {
 class StorageProxy implements StorageBackend {
   private backendPromise: Promise<StorageBackend>;
   public impl: StorageImplementation = IMPL_IFRAME_INDEXED_DB;
+  public diagnostics: StorageDiagnostic[] = [];
+
+  private log(level: StorageDiagnostic['level'], message: string) {
+    this.diagnostics.push({ level, message });
+  }
 
   constructor() {
     this.backendPromise = (async () => {
@@ -181,6 +192,8 @@ class StorageProxy implements StorageBackend {
         const iframe = new IFrameIndexedDbBackend();
 
         if ((await iframe.ready()) === true) {
+          this.log('info', `Using iframe storage (${Byond.storageCdn})`);
+
           if (await iframe.get('byondstorage-migrated')) return iframe;
 
           const iframeHasPersistedStorage = (
@@ -190,6 +203,7 @@ class StorageProxy implements StorageBackend {
           ).some((settings) => settings !== undefined);
 
           if (!iframeHasPersistedStorage) {
+            this.log('info', 'No existing iframe data, migrating from byondstorage');
             const hubStorageWasEnabled = testHubStorage();
             if (!hubStorageWasEnabled) {
               Byond.winset(null, 'browser-options', '+byondstorage');
@@ -218,10 +232,10 @@ class StorageProxy implements StorageBackend {
                   const settings = await hub.get(setting);
                   if (settings !== undefined) {
                     await iframe.set(setting, settings);
+                    this.log('info', `Migrated '${setting}' from byondstorage`);
                   }
                 } catch {
-                  // Ignore unreadable legacy storage entries. A bad old cache
-                  // key should not keep the client on byondstorage.
+                  this.log('warn', `Failed to migrate '${setting}' from byondstorage`);
                 }
               }),
             );
@@ -236,14 +250,19 @@ class StorageProxy implements StorageBackend {
           return iframe;
         }
 
+        this.log('warn', `Iframe storage failed to load from ${Byond.storageCdn}`);
         iframe.destroy();
+      } else {
+        this.log('info', 'No storage CDN configured');
       }
 
       if (testHubStorage()) {
+        this.log('warn', 'Falling back to hubStorage (byondstorage)');
         return new HubStorageBackend();
       }
 
       // IFrame hasn't worked out for us, we'll need to enable byondstorage
+      this.log('warn', 'Enabling byondstorage as last resort');
       Byond.winset(null, 'browser-options', '+byondstorage');
 
       return new Promise((resolve) => {

--- a/tgui/packages/tgui-panel/chat/use-chat-persistence.ts
+++ b/tgui/packages/tgui-panel/chat/use-chat-persistence.ts
@@ -1,4 +1,4 @@
-import { storage } from 'common/storage';
+import { storage, type StorageDiagnostic } from 'common/storage';
 import DOMPurify from 'dompurify';
 import { useAtom, useAtomValue } from 'jotai';
 import { useEffect } from 'react';
@@ -55,6 +55,8 @@ export function useChatPersistence() {
       storage.get('chat-messages'),
     ]);
 
+    surfaceStorageDiagnostics(storage.diagnostics);
+
     if (messages) {
       handleMessages(messages);
     }
@@ -68,6 +70,24 @@ export function useChatPersistence() {
     } else {
       // Discard incompatible versions
       console.log('Discarded incompatible chat state from storage:', state);
+    }
+  }
+
+  function surfaceStorageDiagnostics(diagnostics: StorageDiagnostic[]) {
+    const hasIssues = diagnostics.some((d) => d.level !== 'info');
+    if (!hasIssues) return;
+
+    const batch = diagnostics
+      .filter((d) => d.level !== 'info')
+      .map((d) =>
+        createMessage({
+          type: 'internal/storage',
+          text: `[Storage] ${d.message}`,
+        }),
+      );
+
+    if (batch.length) {
+      chatRenderer.processBatch(batch, { prepend: true });
     }
   }
 

--- a/tgui/public/iframe.html
+++ b/tgui/public/iframe.html
@@ -14,25 +14,39 @@
 
       const MAX_MESSAGES = 1000;
 
-      const dbPromise = new Promise((resolve, reject) => {
-        const indexedDB = window.indexedDB;
-        const req = indexedDB.open(INDEXED_DB_NAME, INDEXED_DB_VERSION);
-        req.onupgradeneeded = (event) => {
+      const dbPromise = (async () => {
+        if (document.requestStorageAccess) {
           try {
-            if (event.oldVersion < 1) {
-              req.result.createObjectStore(INDEXED_DB_STORE_NAME);
+            const hasAccess = await document.hasStorageAccess();
+            if (!hasAccess) {
+              await document.requestStorageAccess({ all: true });
             }
-          } catch (err) {
-            reject(new Error('Failed to upgrade IDB: ' + req.error));
-          }
-        };
+          } catch {}
+        }
 
-        req.onsuccess = () => resolve(req.result);
+        if (navigator.storage && navigator.storage.persist) {
+          navigator.storage.persist().catch(() => {});
+        }
 
-        req.onerror = () => {
-          reject(new Error('Failed to open IDB: ' + req.error));
-        };
-      });
+        return new Promise((resolve, reject) => {
+          const req = indexedDB.open(INDEXED_DB_NAME, INDEXED_DB_VERSION);
+          req.onupgradeneeded = (event) => {
+            try {
+              if (event.oldVersion < 1) {
+                req.result.createObjectStore(INDEXED_DB_STORE_NAME);
+              }
+            } catch (err) {
+              reject(new Error('Failed to upgrade IDB: ' + req.error));
+            }
+          };
+
+          req.onsuccess = () => resolve(req.result);
+
+          req.onerror = () => {
+            reject(new Error('Failed to open IDB: ' + req.error));
+          };
+        });
+      })();
 
       window.addEventListener('message', (messageEvent) => {
         switch (messageEvent.data.type) {
@@ -94,9 +108,9 @@
         store.clear();
       };
 
-      window.onload = () => {
+      dbPromise.then(() => {
         window.parent.postMessage("ready", "*");
-      }
+      });
     </script>
   </head>
 </html>


### PR DESCRIPTION

## About The Pull Request
so chat storage is hell and remains worse with my iframe migration and the spurious errors drive me mad, so this primarily adds diagnostics that output to the chat when we fail to restore storage for whatever reason

also tightens up not making the iframe persistent properly, so if you stopped playing for a few weeks you could come back and your chat settings would've got purged

## Why It's Good For The Game
chat settings disappearing is immensely frustrating

## Changelog
:cl:
qol: added chat messages when your chat storage has been reset
fix: if you've not been playing for awhile and came back, your chat storage may have been reset. this should no longer happen
/:cl:
