### PR TITLE
Revert "Don't run CI on pushed commits (while keeping pull requests)"

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -1,6 +1,12 @@
 name: CI Suite
 
 on:
+  push:
+    branches:
+    - master
+    - 'project/**'
+    - 'gh-readonly-queue/master/**'
+    - 'gh-readonly-queue/project/**'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
This makes it far harder to find like, the first instance of master breaking in ci, which annoys me, and I'm not sure it's worth the time it saves.

Reverts tgstation/tgstation#91163