### PR TITLE
Adds pride station prefixes on pride week

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -111,34 +111,42 @@ GLOBAL_VAR(command_name)
 
 /proc/new_station_name()
 	var/random = rand(1,5)
-	var/name = ""
 	var/new_station_name = ""
+
+	var/prefix = ""
+	var/main = ""
 
 	//Rare: Pre-Prefix
 	if (prob(10))
-		name = pick(GLOB.station_prefixes)
-		new_station_name = name + " "
-		name = ""
+		prefix = pick(GLOB.station_prefixes)
 
 	if(prob(0.1))
 		random = 999999999 //ridiculously long name in written numbers
 
 	// Prefix
-	var/holiday_name = length(GLOB.holidays) && pick(GLOB.holidays)
-	if(holiday_name)
-		var/datum/holiday/holiday = GLOB.holidays[holiday_name]
+	var/picked_holiday = length(GLOB.holidays) && pick(GLOB.holidays)
+	if(picked_holiday)
+		var/datum/holiday/holiday = GLOB.holidays[picked_holiday]
 		if(istype(holiday, /datum/holiday/friday_thirteenth))
 			random = 13
-		name = holiday.getStationPrefix()
-		//get normal name
-	if(!name)
-		name = pick(GLOB.station_names)
-	if(name)
-		new_station_name += name + " "
+
+		var/holiday_prefix = holiday.get_station_prefix()
+		if(holiday_prefix)
+			prefix = holiday_prefix
+
+		var/holiday_base_name = holiday.get_station_name()
+		if(holiday_base_name)
+			main = holiday_base_name
+
+	// Prefix
+	if(prefix)
+		new_station_name += "[prefix] "
+
+	// Normal name
+	new_station_name += "[main || pick(GLOB.station_names)] "
 
 	// Suffix
-	name = pick(GLOB.station_suffixes)
-	new_station_name += name + " "
+	new_station_name += "[pick(GLOB.station_suffixes)] "
 
 	// ID Number
 	switch(random)

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -47,11 +47,16 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/proc/greet()
 	return "Have a happy [name]!"
 
-// Returns special prefixes for the station name on certain days. You wind up with names like "Christmas Object Epsilon". See new_station_name()
-/datum/holiday/proc/getStationPrefix()
-	//get the first word of the Holiday and use that
-	var/i = findtext(name, " ")
-	return copytext(name, 1, i)
+/// Returns special prefix station name on certain days. (See new_station_name())
+/// Turns "Experimental Research City" into "Christmas Research City"
+/datum/holiday/proc/get_station_prefix()
+	return ""
+
+/// Returns special names for the station name on certain days. (See new_station_name())
+/// Turns "Experimental Research City" into "Experimental Christmas City"
+/datum/holiday/proc/get_station_name()
+	// By default get the first word of the Holiday and use that
+	return copytext(name, 1, findtext(name, " "))
 
 // Return 1 if this holidy should be celebrated today
 /datum/holiday/proc/shouldCelebrate(dd, mm, yyyy, ddd)
@@ -103,7 +108,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/fleet_day/greet()
 	return "This day commemorates another year of successful survival aboard the Mothic Grand Nomad Fleet. Moths galaxywide are encouraged to eat, drink, and be merry."
 
-/datum/holiday/fleet_day/getStationPrefix()
+/datum/holiday/fleet_day/get_station_name()
 	return pick("Moth", "Fleet", "Nomadic")
 
 // FEBRUARY
@@ -113,7 +118,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	begin_day = 2
 	begin_month = FEBRUARY
 
-/datum/holiday/groundhog/getStationPrefix()
+/datum/holiday/groundhog/get_station_name()
 	return pick("Deja Vu") //I have been to this place before
 
 /datum/holiday/nz
@@ -128,7 +133,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		COLOR_WHITE,
 	)
 
-/datum/holiday/nz/getStationPrefix()
+/datum/holiday/nz/get_station_name()
 	return pick("Aotearoa","Kiwi","Fish 'n' Chips","Kākāpō","Southern Cross")
 
 /datum/holiday/nz/greet()
@@ -149,7 +154,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		/obj/item/food/grown/rose,
 		)
 
-/datum/holiday/valentines/getStationPrefix()
+/datum/holiday/valentines/get_station_name()
 	return pick("Love","Amore","Single","Smootch","Hug")
 
 /datum/holiday/birthday
@@ -233,7 +238,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		/obj/item/food/pieslice/xemeatpie,
 	)
 
-/datum/holiday/pi/getStationPrefix()
+/datum/holiday/pi/get_station_name()
 	return pick("Sine","Cosine","Tangent","Secant", "Cosecant", "Cotangent")
 
 /datum/holiday/no_this_is_patrick
@@ -253,7 +258,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		/obj/item/reagent_containers/cup/glass/drinkingglass/filled/irish_cream,
 	)
 
-/datum/holiday/no_this_is_patrick/getStationPrefix()
+/datum/holiday/no_this_is_patrick/get_station_name()
 	return pick("Blarney","Green","Leprechaun","Booze")
 
 /datum/holiday/no_this_is_patrick/greet()
@@ -301,7 +306,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	)
 	holiday_mail = list(/obj/item/cigarette/rollie/cannabis)
 
-/datum/holiday/fourtwenty/getStationPrefix()
+/datum/holiday/fourtwenty/get_station_name()
 	return pick("Snoop","Blunt","Toke","Dank","Cheech","Chong")
 
 /datum/holiday/tea
@@ -310,7 +315,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	begin_month = APRIL
 	holiday_mail = list(/obj/item/reagent_containers/cup/glass/mug/tea)
 
-/datum/holiday/tea/getStationPrefix()
+/datum/holiday/tea/get_station_name()
 	return pick("Crumpet","Assam","Oolong","Pu-erh","Sweet Tea","Green","Black")
 
 /datum/holiday/earth
@@ -325,7 +330,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	begin_month = APRIL
 	holiday_hat = /obj/item/food/grown/poppy
 
-/datum/holiday/anz/getStationPrefix()
+/datum/holiday/anz/get_station_name()
 	return pick("Australian","New Zealand","Poppy", "Southern Cross")
 
 /datum/holiday/chernobyl
@@ -333,7 +338,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	begin_day = 26
 	begin_month = APRIL
 
-/datum/holiday/chernobyl/getStationPrefix()
+/datum/holiday/chernobyl/get_station_name()
 	if(prob(3))
 		return "Not Great, Not Terrible"
 
@@ -361,7 +366,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/draconic_day/greet()
 	return "On this day, Lizardkind celebrates their language with literature and other cultural works."
 
-/datum/holiday/draconic_day/getStationPrefix()
+/datum/holiday/draconic_day/get_station_name()
 	return pick("Draconic", "Literature", "Reading")
 
 /datum/holiday/firefighter
@@ -371,7 +376,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	holiday_hat = /obj/item/clothing/head/utility/hardhat/red
 	holiday_mail = list(/obj/item/extinguisher/mini)
 
-/datum/holiday/firefighter/getStationPrefix()
+/datum/holiday/firefighter/get_station_name()
 	return pick("Burning","Blazing","Plasma","Fire")
 
 /datum/holiday/bee
@@ -385,7 +390,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		/obj/item/toy/plush/beeplushie,
 	)
 
-/datum/holiday/bee/getStationPrefix()
+/datum/holiday/bee/get_station_name()
 	return pick("Bee","Honey","Hive","Africanized","Mead","Buzz")
 
 /datum/holiday/goth
@@ -402,7 +407,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		COLOR_BLACK,
 	)
 
-/datum/holiday/goth/getStationPrefix()
+/datum/holiday/goth/get_station_name()
 	return pick("Goth", "Sanguine", "Tenebris", "Lacrimosa", "Umbra", "Noctis")
 
 // JUNE
@@ -416,7 +421,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/atrakor_festival/greet()
 	return "On this day, the Lizards traditionally celebrate the Festival of Atrakor's Might, where they honour the moon god with lavishly adorned clothing, large portions of food, and a massive celebration into the night."
 
-/datum/holiday/atrakor_festival/getStationPrefix()
+/datum/holiday/atrakor_festival/get_station_name()
 	return pick("Moon", "Night Sky", "Celebration")
 
 /// Garbage DAYYYYY
@@ -467,6 +472,14 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		return
 	holiday_colors = pick(LESBIAN_FLAG_COLORS, GAY_MAN_FLAG_COLORS, TRANS_FLAG_COLORS, BI_FLAG_COLORS, ACE_FLAG_COLORS, PAN_FLAG_COLORS)
 
+/datum/holiday/pride_week/get_station_prefix()
+	if(prob(10))
+		return pick("Gay", "Trans", "Bi", "Lesbian", "Pan", "Ace", "Aro", "Nonbinary", "Enby", "Asexual", "Aromantic", "Agender", "Intersex")
+	return pick("Rainbow", "Pride", "Queer")
+
+/datum/holiday/pride_week/get_station_name()
+	return ""
+
 // JULY
 
 /datum/holiday/doctor
@@ -492,7 +505,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		/obj/item/toy/toy_xeno,
 	)
 
-/datum/holiday/ufo/getStationPrefix() //Is such a thing even possible?
+/datum/holiday/ufo/get_station_name() //Is such a thing even possible?
 	return pick("Ayy","Truth","Tsoukalos","Mulder","Scully") //Yes it is!
 
 /datum/holiday/usa
@@ -511,7 +524,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	)
 
 
-/datum/holiday/usa/getStationPrefix()
+/datum/holiday/usa/get_station_name()
 	return pick("Independent","American","Burger","Bald Eagle","Star-Spangled", "Fireworks")
 
 /datum/holiday/writer
@@ -534,7 +547,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	)
 	holiday_pattern = PATTERN_VERTICAL_STRIPE
 
-/datum/holiday/france/getStationPrefix()
+/datum/holiday/france/get_station_name()
 	return pick("Francais", "Fromage", "Zut", "Merde", "Sacrebleu")
 
 /datum/holiday/france/greet()
@@ -556,7 +569,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	begin_day = 27
 	holiday_hat = /obj/item/clothing/head/wizard
 
-/datum/holiday/wizards_day/getStationPrefix()
+/datum/holiday/wizards_day/get_station_name()
 	return pick("Dungeon", "Elf", "Magic", "D20", "Edition")
 
 /datum/holiday/friendship
@@ -575,7 +588,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	begin_month = AUGUST
 	begin_day = 9
 
-/datum/holiday/indigenous/getStationPrefix()
+/datum/holiday/indigenous/get_station_name()
 	return pick("Endangered language", "Word", "Language", "Language revitalization", "Potato", "Corn")
 
 // AUGUST
@@ -586,7 +599,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	begin_day = 24
 	holiday_colors = list(COLOR_TRUE_BLUE, COLOR_TANGERINE_YELLOW)
 
-/datum/holiday/ukraine/getStationPrefix()
+/datum/holiday/ukraine/get_station_name()
 	return pick("Kyiv", "Ukraine")
 
 // SEPTEMBER
@@ -602,7 +615,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/tiziran_unification/greet()
 	return "On this day over 400 years ago, Lizardkind first united under a single banner, ready to face the stars as one unified people."
 
-/datum/holiday/tiziran_unification/getStationPrefix()
+/datum/holiday/tiziran_unification/get_station_name()
 	return pick("Tizira", "Lizard", "Imperial")
 
 /datum/holiday/ianbirthday
@@ -624,7 +637,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/ianbirthday/greet()
 	return "Happy birthday, Ian!"
 
-/datum/holiday/ianbirthday/getStationPrefix()
+/datum/holiday/ianbirthday/get_station_name()
 	return pick("Ian", "Corgi", "Erro")
 
 /datum/holiday/pirate
@@ -637,7 +650,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/pirate/greet()
 	return "Ye be talkin' like a pirate today or else ye'r walkin' tha plank, matey!"
 
-/datum/holiday/pirate/getStationPrefix()
+/datum/holiday/pirate/get_station_name()
 	return pick("Yarr","Scurvy","Yo-ho-ho")
 
 /datum/holiday/questions
@@ -655,7 +668,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	begin_day = 4
 	begin_month = OCTOBER
 
-/datum/holiday/animal/getStationPrefix()
+/datum/holiday/animal/get_station_name()
 	return pick("Parrot","Corgi","Cat","Pug","Goat","Fox")
 
 /datum/holiday/smile
@@ -679,7 +692,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/un_day/greet()
 	return "On this day in 1945, the United Nations was founded, laying the foundation for humanity's united government!"
 
-/datum/holiday/un_day/getStationPrefix()
+/datum/holiday/un_day/get_station_name()
 	return pick("United", "Cooperation", "Humanitarian")
 
 /datum/holiday/halloween
@@ -697,7 +710,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/halloween/greet()
 	return "Have a spooky Halloween!"
 
-/datum/holiday/halloween/getStationPrefix()
+/datum/holiday/halloween/get_station_name()
 	return pick("Bone-Rattling","Mr. Bones' Own","2SPOOKY","Spooky","Scary","Skeletons")
 
 // NOVEMBER
@@ -708,7 +721,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	begin_month = NOVEMBER
 	holiday_mail = list(/obj/item/food/tofu)
 
-/datum/holiday/vegan/getStationPrefix()
+/datum/holiday/vegan/get_station_name()
 	return pick("Tofu", "Tempeh", "Seitan", "Tofurkey")
 
 /datum/holiday/october_revolution
@@ -722,7 +735,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		COLOR_MEDIUM_DARK_RED,
 	)
 
-/datum/holiday/october_revolution/getStationPrefix()
+/datum/holiday/october_revolution/get_station_name()
 	return pick("Communist", "Soviet", "Bolshevik", "Socialist", "Red", "Workers'")
 
 /datum/holiday/remembrance_day
@@ -739,7 +752,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/remembrance_day/greet()
 	return "Lest we forget."
 
-/datum/holiday/remembrance_day/getStationPrefix()
+/datum/holiday/remembrance_day/get_station_name()
 	return pick("Peace", "Armistice", "Poppy")
 
 /datum/holiday/lifeday
@@ -747,7 +760,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	begin_day = 17
 	begin_month = NOVEMBER
 
-/datum/holiday/lifeday/getStationPrefix()
+/datum/holiday/lifeday/get_station_name()
 	return pick("Itchy", "Lumpy", "Malla", "Kazook") //he really pronounced it "Kazook", I wish I was making shit up
 
 /datum/holiday/kindness
@@ -795,7 +808,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/holy_lights/greet()
 	return "The Festival of Holy Lights is the final day of the Ethereal calendar. It is typically a day of prayer followed by celebration to close out the year in style."
 
-/datum/holiday/holy_lights/getStationPrefix()
+/datum/holiday/holy_lights/get_station_name()
 	return pick("Ethereal", "Lantern", "Holy")
 
 // DECEMBER
@@ -847,7 +860,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		COLOR_CHRISTMAS_RED,
 	)
 
-/datum/holiday/xmas/getStationPrefix()
+/datum/holiday/xmas/get_station_name()
 	return pick(
 		"Bible",
 		"Birthday",
@@ -911,7 +924,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	holiday_hat = /obj/item/clothing/head/costume/festive
 	no_mail_holiday = TRUE
 
-/datum/holiday/new_year/getStationPrefix()
+/datum/holiday/new_year/get_station_name()
 	return pick("Party","New","Hangover","Resolution", "Auld")
 
 // MOVING DATES
@@ -924,7 +937,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		return TRUE
 	return FALSE
 
-/datum/holiday/friday_thirteenth/getStationPrefix()
+/datum/holiday/friday_thirteenth/get_station_name()
 	return pick("Mike","Friday","Evil","Myers","Murder","Deathly","Stabby")
 
 /datum/holiday/programmers
@@ -941,7 +954,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 				return TRUE
 	return FALSE
 
-/datum/holiday/programmers/getStationPrefix()
+/datum/holiday/programmers/get_station_name()
 	return pick("span>","DEBUG: ","null","/list","EVENT PREFIX NOT FOUND") //Portability
 
 // ISLAMIC
@@ -959,7 +972,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	begin_day = 1
 	end_day = 3
 
-/datum/holiday/islamic/ramadan/getStationPrefix()
+/datum/holiday/islamic/ramadan/get_station_name()
 	return pick("Haram","Halaal","Jihad","Muslim", "Al", "Mohammad", "Rashidun", "Umayyad", "Abbasid", "Abdul", "Fatimid", "Ayyubid", "Almohad", "Abu")
 
 /datum/holiday/islamic/ramadan/end
@@ -987,7 +1000,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/hebrew/hanukkah/greet()
 	return "Happy [pick("Hanukkah", "Chanukah")]!"
 
-/datum/holiday/hebrew/hanukkah/getStationPrefix()
+/datum/holiday/hebrew/hanukkah/get_station_name()
 	return pick("Dreidel", "Menorah", "Latkes", "Gelt")
 
 /datum/holiday/hebrew/passover
@@ -996,7 +1009,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 	begin_month = 1
 	end_day = 22
 
-/datum/holiday/hebrew/passover/getStationPrefix()
+/datum/holiday/hebrew/passover/get_station_name()
 	return pick("Matzah", "Moses", "Red Sea")
 
 // EASTER (this having its own spot should be understandable)
@@ -1056,7 +1069,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 /datum/holiday/easter/greet()
 	return "Greetings! Have a Happy Easter and keep an eye out for Easter Bunnies!"
 
-/datum/holiday/easter/getStationPrefix()
+/datum/holiday/easter/get_station_name()
 	return pick("Fluffy","Bunny","Easter","Egg")
 
 /// Takes a holiday datum, a starting month, ending month, max amount of days to test in, and min/max year as input

--- a/code/modules/holiday/nth_week.dm
+++ b/code/modules/holiday/nth_week.dm
@@ -64,7 +64,7 @@
 	begin_month = AUGUST
 	begin_weekday = FRIDAY
 
-/datum/holiday/beer/getStationPrefix()
+/datum/holiday/beer/get_station_name()
 	return pick("Stout","Porter","Lager","Ale","Malt","Bock","Doppelbock","Hefeweizen","Pilsner","IPA","Lite") //I'm sorry for the last one
 
 /datum/holiday/nth_week/moth
@@ -82,7 +82,7 @@
 		end_week += 1
 	return ..(dd, mm, yyyy, ddd)
 
-/datum/holiday/nth_week/moth/getStationPrefix()
+/datum/holiday/nth_week/moth/get_station_name()
 	return pick("Mothball","Lepidopteran","Lightbulb","Moth","Giant Atlas","Twin-spotted Sphynx","Madagascan Sunset","Luna","Death's Head","Emperor Gum","Polyphenus","Oleander Hawk","Io","Rosy Maple","Cecropia","Noctuidae","Giant Leopard","Dysphania Militaris","Garden Tiger")
 
 /datum/holiday/nth_week/ice_cream
@@ -91,5 +91,5 @@
 	begin_month = JULY
 	begin_weekday = SUNDAY
 
-/datum/holiday/nth_week/ice_cream/getStationPrefix()
+/datum/holiday/nth_week/ice_cream/get_station_name()
 	return pick("Ice Cream", "Gelato", "Semifreddo", "Cornuto", "Soft Serve", "Cone", "Ice", "Cream", "I Scream", "Parfait", "Straccciatella", "Sherbet", "Snow", "Affogato", "Mochi", "Tartufo", "Sundae", "Neapolitan")


### PR DESCRIPTION
## About The Pull Request

- Cleaned up station naming a bit

- `getStationPrefix` has been changed to `get_station_name` to reflect it changes the station's name

- `get_station_prefix` has been added for changing the station's prefix

- Adds pride prefixes to the in game pride holiday: 

```dm
/datum/holiday/pride_week/get_station_prefix()
	if(prob(10))
		return pick("Gay", "Trans", "Bi", "Lesbian", "Pan", "Ace", "Aro", "Nonbinary", "Enby", "Asexual", "Aromantic", "Agender", "Intersex")
	return pick("Rainbow", "Pride", "Queer")
```

This will result in names like "Pride Home Office 82" or "Gay Crab Town 91" 

## Why It's Good For The Game

I'm surprised we didn't have any set

## Changelog

:cl: Melbert
code: Cleaned up station name generation, report any weird looking auto-generated station names
add: Pride holiday now has unique station prefixes
/:cl:
