### PR TITLE
Adds reverse operation for widen cavity / Fix bones acts as mend incision analog for limbs without skin

### DIFF
--- a/code/modules/surgery/operations/operation_cavity_implant.dm
+++ b/code/modules/surgery/operations/operation_cavity_implant.dm
@@ -34,6 +34,41 @@
 	. = ..()
 	limb.add_surgical_state(SURGERY_CAVITY_WIDENED)
 
+/datum/surgery_operation/limb/undo_prepare_cavity
+	name = "close chest cavity"
+	desc = "Reset a patient's chest cavity."
+	implements = list(
+		TOOL_RETRACTOR = 1,
+		TOOL_CROWBAR = 1.5,
+	)
+	time = 4.8 SECONDS
+	preop_sound = 'sound/items/handling/surgery/retractor1.ogg'
+	success_sound = 'sound/items/handling/surgery/retractor2.ogg'
+	all_surgery_states_required = SURGERY_SKIN_OPEN|SURGERY_ORGANS_CUT|SURGERY_CAVITY_WIDENED
+
+/datum/surgery_operation/limb/undo_prepare_cavity/get_default_radial_image()
+	return image(/obj/item/retractor)
+
+/datum/surgery_operation/limb/undo_prepare_cavity/all_required_strings()
+	return list("operate on chest (target chest)") + ..()
+
+/datum/surgery_operation/limb/undo_prepare_cavity/state_check(obj/item/bodypart/chest/limb)
+	return limb.body_zone == BODY_ZONE_CHEST
+
+/datum/surgery_operation/limb/undo_prepare_cavity/on_preop(obj/item/bodypart/chest/limb, mob/living/surgeon, tool, list/operation_args)
+	display_results(
+		surgeon,
+		limb.owner,
+		span_notice("You begin to close [FORMAT_LIMB_OWNER(limb)] cavity..."),
+		span_notice("[surgeon] begins to close [FORMAT_LIMB_OWNER(limb)] cavity."),
+		span_notice("[surgeon] begins to close [FORMAT_LIMB_OWNER(limb)] cavity."),
+	)
+	display_pain(limb.owner, "You can feel pressure as your [limb.plaintext_zone] is being closed!")
+
+/datum/surgery_operation/limb/undo_prepare_cavity/on_success(obj/item/bodypart/chest/limb, mob/living/surgeon, tool, list/operation_args)
+	. = ..()
+	limb.remove_surgical_state(SURGERY_CAVITY_WIDENED)
+
 /datum/surgery_operation/limb/cavity_implant
 	name = "cavity implant"
 	desc = "Implant an item into a patient's body cavity."

--- a/code/modules/surgery/operations/operation_generic.dm
+++ b/code/modules/surgery/operations/operation_generic.dm
@@ -386,7 +386,7 @@
 	)
 	time = 4 SECONDS
 	all_surgery_states_required = SURGERY_SKIN_OPEN
-	any_surgery_states_required = SURGERY_BONE_SAWED|SURGERY_BONE_DRILLED
+	any_surgery_states_required = ALL_SURGERY_BONE_STATES
 	allow_stumps = TRUE
 
 /datum/surgery_operation/limb/fix_bones/get_default_radial_image()
@@ -418,7 +418,10 @@
 
 /datum/surgery_operation/limb/fix_bones/on_success(obj/item/bodypart/limb)
 	. = ..()
-	limb.remove_surgical_state(SURGERY_BONE_SAWED|SURGERY_BONE_DRILLED)
+	// if the limb lacks skin, fix bones needs to act as an analog to mend incision (clearing most surgical states)
+	if(!LIMB_HAS_SKIN(limb))
+		limb.remove_surgical_state(ALL_SURGERY_STATES_UNSET_ON_CLOSE)
+	limb.remove_surgical_state(ALL_SURGERY_BONE_STATES)
 	limb.heal_damage(40)
 
 /datum/surgery_operation/limb/drill_bones


### PR DESCRIPTION
## About The Pull Request

1. Adds a reverse operation for "widen cavity", ie an operation that removes the widen cavity state
2. "Fix bone" operation acts as an analog to "mend incision" for limbs without skin (primarily for Plasmamen) 

## Why It's Good For The Game

Some surgery QoL, makes Plasmamen surgery states reversible 

## Changelog

:cl: Melbert
qol: Adds an operation to un-widen the chest cavity
qol: "Fix bones" operation will wipe all surgical states for limbs without skin, acting as an analog to "Mend incision" for species like Plasmamen
/:cl:


