### PR TITLE
Mutation toxins work on skeletons/plasmamen and the undead

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -677,6 +677,7 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM //metabolizes to prevent micro-dosage
 	taste_description = "slime"
+	affected_biotype = MOB_ORGANIC|MOB_SKELETAL|MOB_UNDEAD
 	var/race = /datum/species/human
 	var/list/mutationtexts = list( "You don't feel very well." = MUT_MSG_IMMEDIATE,
 									"Your skin feels a bit abnormal." = MUT_MSG_IMMEDIATE,


### PR DESCRIPTION
## About The Pull Request

Adds `MOB_SKELETAL|MOB_UNDEAD` to affected biotypes of mutation toxin

## Why It's Good For The Game

This solely stemmed from the discovery that you can mutation toxin into plasmamen but you cannot mutation toxin out of plasmaman. Then I figured "why not vampires and zombies too"

## Changelog

:cl: Melbert
balance: Mutation toxins now work on plasmamen, skeletons, zombies, spirits, and vampires
/:cl:
