### PR TITLE
Fix bodypart caching issues, probably? And spacer appears in prefs preview properly

### DIFF
--- a/code/datums/quirks/positive_quirks/spacer.dm
+++ b/code/datums/quirks/positive_quirks/spacer.dm
@@ -37,6 +37,8 @@
 
 /datum/quirk/spacer_born/add(client/client_source)
 	if(isdummy(quirk_holder))
+		var/mob/living/carbon/human/dummy_quirker = quirk_holder
+		dummy_quirker.set_mob_height(modded_height)
 		return
 
 	// Using Z moved because we don't urgently need to check on every single turf movement for planetary status.

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -126,4 +126,6 @@
 				continue
 			mannequin.add_quirk(quirk_type, parent, announce = FALSE)
 
+	// Height is applied universally once to save on filters
+	mannequin.apply_height(mannequin, ENTIRE_BODY)
 	return mannequin.appearance

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -505,7 +505,7 @@
 	for(var/datum/bodypart_texture/texture as anything in bodypart_textures)
 		if(texture.can_texture_bodypart(src))
 			. += texture.icon_render_key()
-	if(ishuman(owner))
+	if(ishuman(owner) && !isdummy(owner)) // cache height because we apply height filters to bodypart images, but not for dummies, they have an optimization
 		var/mob/living/carbon/human/human_owner = owner
 		. += "[human_owner.mob_height]"
 	SEND_SIGNAL(src, COMSIG_BODYPART_GENERATE_ICON_KEY, .)
@@ -533,7 +533,7 @@
 		if(overlay.can_draw_on_bodypart(src, owner))
 			. += overlay.icon_render_key(src)
 	. += "[LAZYLEN(blood_dna_info) ? get_color_from_blood_list(blood_dna_info) : BLOOD_COLOR_RED]"
-	if(ishuman(owner))
+	if(ishuman(owner) && !isdummy(owner)) // cache height because we apply height filters to bodypart images, but not for dummies, they have an optimization
 		var/mob/living/carbon/human/human_owner = owner
 		. += "[human_owner.mob_height]"
 	return .

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -505,7 +505,9 @@
 	for(var/datum/bodypart_texture/texture as anything in bodypart_textures)
 		if(texture.can_texture_bodypart(src))
 			. += texture.icon_render_key()
-	if(ishuman(owner) && !isdummy(owner)) // cache height because we apply height filters to bodypart images, but not for dummies, they have an optimization
+	if(isdummy(owner)) // dummies always cache as default height because they have optimizations
+		. += /mob/living/carbon/human::mob_height
+	else if(ishuman(owner)) // otherwise cache height because we apply height filters to bodypart images
 		var/mob/living/carbon/human/human_owner = owner
 		. += "[human_owner.mob_height]"
 	SEND_SIGNAL(src, COMSIG_BODYPART_GENERATE_ICON_KEY, .)
@@ -533,7 +535,9 @@
 		if(overlay.can_draw_on_bodypart(src, owner))
 			. += overlay.icon_render_key(src)
 	. += "[LAZYLEN(blood_dna_info) ? get_color_from_blood_list(blood_dna_info) : BLOOD_COLOR_RED]"
-	if(ishuman(owner) && !isdummy(owner)) // cache height because we apply height filters to bodypart images, but not for dummies, they have an optimization
+	if(isdummy(owner)) // dummies always cache as default height because they have optimizations
+		. += /mob/living/carbon/human::mob_height
+	else if(ishuman(owner)) // otherwise cache height because we apply height filters to bodypart images
 		var/mob/living/carbon/human/human_owner = owner
 		. += "[human_owner.mob_height]"
 	return .

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -506,7 +506,7 @@
 		if(texture.can_texture_bodypart(src))
 			. += texture.icon_render_key()
 	if(isdummy(owner)) // dummies always cache as default height because they have optimizations
-		. += /mob/living/carbon/human::mob_height
+		. += "[/mob/living/carbon/human::mob_height]"
 	else if(ishuman(owner)) // otherwise cache height because we apply height filters to bodypart images
 		var/mob/living/carbon/human/human_owner = owner
 		. += "[human_owner.mob_height]"
@@ -536,7 +536,7 @@
 			. += overlay.icon_render_key(src)
 	. += "[LAZYLEN(blood_dna_info) ? get_color_from_blood_list(blood_dna_info) : BLOOD_COLOR_RED]"
 	if(isdummy(owner)) // dummies always cache as default height because they have optimizations
-		. += /mob/living/carbon/human::mob_height
+		. += "[/mob/living/carbon/human::mob_height]"
 	else if(ishuman(owner)) // otherwise cache height because we apply height filters to bodypart images
 		var/mob/living/carbon/human/human_owner = owner
 		. += "[human_owner.mob_height]"

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -88,6 +88,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	delete_equipment()
 	update_lips(null, null, null, update = FALSE)
 	cut_overlays(TRUE)
+	clear_filters()
 
 /mob/living/carbon/human/dummy/setup_human_dna()
 	randomize_human_normie(src, randomize_mutations = FALSE)
@@ -98,11 +99,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 // To speed up the preference menu, we apply one height filter to the entire mob,
 // rather than independently applying offsets and filters to each individual overlay
 // This looks good enough to pass the sniff test and saves a lot of time
-/mob/living/carbon/human/dummy/regenerate_icons()
-	. = ..()
-	apply_height(src, ENTIRE_BODY)
-
-/mob/living/carbon/human/dummy/apply_height(image/appearance, upper_torso)
+/mob/living/carbon/human/dummy/apply_height(image/appearance, body_area)
 	if(appearance == src)
 		return ..()
 


### PR DESCRIPTION
## About The Pull Request

Bodyparts cache height as the filters are applied directly to the bodypart image

This was a problem with dummies (I think) because dummies didn't apply the filter, but did cache height, meaning we'd let slip unfiltered bodypart images into the cache, which the actual player mob would draw from

So to fix it, I made dummies always use the default height cache, then moved around where the height filter is applied to it's consistently applied in prefs

## Changelog

:cl: Melbert
fix: Fixes some niche issues with settler/spacer looking off
fix: Spacer is visible in prefs
/:cl:
