### PR TITLE
Fix paramedic power crowbar in medical belt

### DIFF
--- a/code/datums/storage/subtypes/belts.dm
+++ b/code/datums/storage/subtypes/belts.dm
@@ -14,10 +14,11 @@
 ///Medical belt
 /datum/storage/medical_belt
 	max_total_storage = 21
+	exception_max = 1
 
 /datum/storage/medical_belt/New(atom/parent, max_slots, max_specific_storage, max_total_storage, rustle_sound, remove_rustle_sound)
 	. = ..()
-	set_holdable(list(
+	set_holdable(can_hold_list = list(
 		/obj/item/bikehorn/rubberducky,
 		/obj/item/blood_filter,
 		/obj/item/blood_scanner,
@@ -32,7 +33,6 @@
 		/obj/item/clothing/mask/surgical,
 		/obj/item/clothing/neck/stethoscope,
 		/obj/item/construction/plumbing,
-		/obj/item/crowbar/power/paramedic,
 		/obj/item/dnainjector,
 		/obj/item/extinguisher/mini,
 		/obj/item/flashlight/pen,
@@ -76,6 +76,9 @@
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tourniquet,
 		/obj/item/wrench/medical,
+	),
+	exception_hold_list = list(
+		/obj/item/crowbar/power/paramedic,
 	))
 
 ///Security belt


### PR DESCRIPTION
## About The Pull Request

Fixes the power crowbar from being rejected despite being in the EMT belt's allow list.

## Why It's Good For The Game

Fix bug

## Changelog

:cl: LT3
fix: Fixed jaws of recovery not being able to be stored in the paramedic EMT belt
/:cl: