### PR TITLE
status topic reports hostedby config as a backup

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -201,7 +201,7 @@
 	.["respawn"] = config ? !!CONFIG_GET(flag/allow_respawn) : FALSE // show respawn as true regardless of "respawn as char" or "free respawn"
 	.["enter"] = !LAZYACCESS(SSlag_switch.measures, DISABLE_NON_OBSJOBS)
 	.["ai"] = CONFIG_GET(flag/allow_ai)
-	.["host"] = world.host ? world.host : null
+	.["host"] = world.host ? world.host : CONFIG_GET(string/hostedby)
 	.["round_id"] = GLOB.round_id
 	.["players"] = GLOB.clients.len
 	.["revision"] = GLOB.revdata.commit

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -201,7 +201,7 @@
 	.["respawn"] = config ? !!CONFIG_GET(flag/allow_respawn) : FALSE // show respawn as true regardless of "respawn as char" or "free respawn"
 	.["enter"] = !LAZYACCESS(SSlag_switch.measures, DISABLE_NON_OBSJOBS)
 	.["ai"] = CONFIG_GET(flag/allow_ai)
-	.["host"] = world.host ? world.host : CONFIG_GET(string/hostedby)
+	.["host"] = world?.host || CONFIG_GET(string/hostedby)
 	.["round_id"] = GLOB.round_id
 	.["players"] = GLOB.clients.len
 	.["revision"] = GLOB.revdata.commit


### PR DESCRIPTION

## About The Pull Request
Makes the topic report use the hostedby config as a backup. 

Right now we report nothing for all the TG servers, some downstreams MIGHT have a host assuming i understand this right and its only going to show up if you arent using TGS. 

https://hub.harry.live/s/51.79.52.10/1887
<img width="886" height="711" alt="image" src="https://github.com/user-attachments/assets/2f45f2e8-c38d-478b-b073-c495733446ce" />
## Why It's Good For The Game
As far as I can tell, most servers dont have a world.host anymore as that seemingly is not used by tgs.

Creates slightly better parody with the hub status as well. 
<img width="425" height="330" alt="image" src="https://github.com/user-attachments/assets/cfecf318-7b80-4666-a5b6-2bca0432050b" />
## Changelog
:cl:
server: status topic reports hostby config if we have no true world.host
/:cl:
