### PR TITLE
Mobs that are wet become frozen in freezing temperatures

### DIFF
--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -346,6 +346,14 @@
 	adjust_stacks(decay * seconds_between_ticks)
 	if(stacks <= 0)
 		qdel(src)
+		return
+
+	if(HAS_TRAIT(owner, TRAIT_RESISTCOLD))
+		return
+
+	if(owner.bodytemperature <= WATER_VAPOR_DEPOSITION_POINT)
+		owner.apply_status_effect(/datum/status_effect/freon, stacks SECONDS)
+		qdel(src)
 
 /datum/status_effect/fire_handler/wet_stacks/check_basic_mob_immunity(mob/living/basic/basic_owner)
 	return !(basic_owner.basic_mob_flags & IMMUNE_TO_GETTING_WET)

--- a/code/datums/status_effects/gas.dm
+++ b/code/datums/status_effects/gas.dm
@@ -1,6 +1,6 @@
 /datum/status_effect/freon
 	id = "frozen"
-	duration = 100
+	duration = 10 SECONDS
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = /atom/movable/screen/alert/status_effect/freon
 	var/icon/cube
@@ -10,6 +10,11 @@
 	name = "Frozen Solid"
 	desc = "You're frozen inside an ice cube, and cannot move! You can still do stuff, like shooting. Resist out of the cube!"
 	icon_state = "frozen"
+
+/datum/status_effect/freon/on_creation(mob/living/new_owner, set_duration)
+	if(isnum(set_duration))
+		duration = set_duration
+	return ..()
 
 /datum/status_effect/freon/on_apply()
 	. = ..()
@@ -21,7 +26,6 @@
 		to_chat(owner, span_userdanger("You become frozen in a cube!"))
 	cube = icon('icons/effects/freeze.dmi', "ice_cube")
 	owner.add_overlay(cube)
-
 
 /datum/status_effect/freon/tick(seconds_between_ticks)
 	if(can_melt && owner.bodytemperature >= owner.get_body_temp_normal())
@@ -47,7 +51,7 @@
 	return ..()
 
 /datum/status_effect/freon/watcher
-	duration = 8
+	duration = 0.8 SECONDS
 	can_melt = FALSE
 
 /datum/status_effect/freon/watcher/extended


### PR DESCRIPTION

## About The Pull Request
If a mob's body temperature is below freezing and they are wet, they will now become frozen based on how wet they are. The effect is only triggered based on the mob's internal body temperature, so spacesuits and winter clothing should still do a good job at preventing you from freezing while wet. 

Also, wetstacks decay over time, so this effect triggering is likely to occur under rare circumstances. 

## Why It's Good For The Game
We have code where if you are covered in flammable liquid, it causes your character to combust when exposed to a spark. I took that as inspiration to make this because being covered in water in freezing temps should cause you to freeze.

I also think environmental effects are a neat mechanic, and we should have more of them. 

## Changelog
:cl:
add: Mobs that are wet become frozen in freezing temperatures
/:cl:
