### PR TITLE
Rebalance the work camp again

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -3207,6 +3207,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/ore_box,
 /obj/structure/sign/poster/official/do_not_question/directional/north,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/production)
 "qd" = (
@@ -3375,6 +3376,7 @@
 "rm" = (
 /obj/structure/sign/warning/gas_mask/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/production)
 "ro" = (
@@ -3577,7 +3579,6 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/departments/medbay/alt/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/smooth_edge,
 /area/mine/laborcamp/production)
 "sH" = (
@@ -8054,7 +8055,6 @@
 /area/lavaland/surface/outdoors)
 "Ub" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light/small/directional/west,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
@@ -24775,7 +24775,7 @@ Nz
 Ez
 pQ
 uq
-Jw
+jU
 ff
 Gc
 RV
@@ -25289,7 +25289,7 @@ oq
 fe
 yu
 uq
-jU
+Jw
 ff
 Ge
 dr

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -80,7 +80,7 @@
 	icon_state = "polycrystal"
 	inhand_icon_state = null
 	material_flags = MATERIAL_NO_DESCRIPTORS
-	gulag_valid = TRUE
+	gulag_value = 100
 	mats_per_unit = list(/datum/material/bluespace=SHEET_MATERIAL_AMOUNT)
 	attack_verb_continuous = list("bluespace polybashes", "bluespace polybatters", "bluespace polybludgeons", "bluespace polythrashes", "bluespace polysmashes")
 	attack_verb_simple = list("bluespace polybash", "bluespace polybatter", "bluespace polybludgeon", "bluespace polythrash", "bluespace polysmash")

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -200,7 +200,7 @@ GLOBAL_LIST_INIT(prglass_recipes, list ( \
 	resistance_flags = ACID_PROOF
 	material_flags = NONE
 	merge_type = /obj/item/stack/sheet/plasmarglass
-	gulag_valid = TRUE
+	gulag_value = 5
 	matter_amount = 8
 	table_type = /obj/structure/table/reinforced/plasmarglass
 	pickup_sound = 'sound/items/handling/materials/glass_pick_up.ogg'

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	singular_name = "diamond"
 	construction_path_type = "diamond"
 	mats_per_unit = list(/datum/material/diamond=SHEET_MATERIAL_AMOUNT)
-	gulag_valid = TRUE
+	gulag_value = 100
 	merge_type = /obj/item/stack/sheet/mineral/diamond
 	material_type = /datum/material/diamond
 	walltype = /turf/closed/wall/mineral/diamond
@@ -137,7 +137,7 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 	singular_name = "uranium sheet"
 	construction_path_type = "uranium"
 	mats_per_unit = list(/datum/material/uranium=SHEET_MATERIAL_AMOUNT)
-	gulag_valid = TRUE
+	gulag_value = 50
 	merge_type = /obj/item/stack/sheet/mineral/uranium
 	material_type = /datum/material/uranium
 	walltype = /turf/closed/wall/mineral/uranium
@@ -173,7 +173,7 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
 	mats_per_unit = list(/datum/material/plasma=SHEET_MATERIAL_AMOUNT)
-	gulag_valid = TRUE
+	gulag_value = 5
 	merge_type = /obj/item/stack/sheet/mineral/plasma
 	material_type = /datum/material/plasma
 	walltype = /turf/closed/wall/mineral/plasma
@@ -210,7 +210,7 @@ GLOBAL_LIST_INIT(plasma_recipes, list ( \
 	singular_name = "gold bar"
 	construction_path_type = "gold"
 	mats_per_unit = list(/datum/material/gold=SHEET_MATERIAL_AMOUNT)
-	gulag_valid = TRUE
+	gulag_value = 20
 	merge_type = /obj/item/stack/sheet/mineral/gold
 	material_type = /datum/material/gold
 	walltype = /turf/closed/wall/mineral/gold
@@ -240,7 +240,7 @@ GLOBAL_LIST_INIT(gold_recipes, list ( \
 	singular_name = "silver bar"
 	construction_path_type = "silver"
 	mats_per_unit = list(/datum/material/silver=SHEET_MATERIAL_AMOUNT)
-	gulag_valid = TRUE
+	gulag_value = 10
 	merge_type = /obj/item/stack/sheet/mineral/silver
 	material_type = /datum/material/silver
 	table_type = /obj/structure/table/optable
@@ -269,7 +269,7 @@ GLOBAL_LIST_INIT(silver_recipes, list ( \
 	singular_name = "bananium sheet"
 	construction_path_type = "bananium"
 	mats_per_unit = list(/datum/material/bananium=SHEET_MATERIAL_AMOUNT)
-	gulag_valid = TRUE
+	gulag_value = -5
 	merge_type = /obj/item/stack/sheet/mineral/bananium
 	material_type = /datum/material/bananium
 	walltype = /turf/closed/wall/mineral/bananium
@@ -300,7 +300,7 @@ GLOBAL_LIST_INIT(bananium_recipes, list ( \
 	throw_range = 3
 	construction_path_type = "titanium"
 	mats_per_unit = list(/datum/material/titanium=SHEET_MATERIAL_AMOUNT)
-	gulag_valid = TRUE
+	gulag_value = 10
 	merge_type = /obj/item/stack/sheet/mineral/titanium
 	material_type = /datum/material/titanium
 	walltype = /turf/closed/wall/mineral/titanium
@@ -354,7 +354,7 @@ GLOBAL_LIST_INIT(titanium_recipes, list ( \
 	throw_range = 3
 	construction_path_type = "plastitanium"
 	mats_per_unit = list(/datum/material/alloy/plastitanium=SHEET_MATERIAL_AMOUNT)
-	gulag_valid = TRUE
+	gulag_value = 20
 	material_type = /datum/material/alloy/plastitanium
 	merge_type = /obj/item/stack/sheet/mineral/plastitanium
 	material_flags = NONE
@@ -534,7 +534,7 @@ GLOBAL_LIST_INIT(metalhydrogen_recipes, list(
 	singular_name = "metal hydrogen sheet"
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FIRE_PROOF | LAVA_PROOF | ACID_PROOF | BOMB_PROOF
-	gulag_valid = TRUE
+	gulag_value = 100
 	mats_per_unit = list(/datum/material/metalhydrogen = SHEET_MATERIAL_AMOUNT)
 	material_type = /datum/material/metalhydrogen
 	merge_type = /obj/item/stack/sheet/mineral/metal_hydrogen
@@ -564,7 +564,7 @@ GLOBAL_LIST_INIT(zaukerite_recipes, list(
 	inhand_icon_state = "sheet-zaukerite"
 	singular_name = "zaukerite crystal"
 	w_class = WEIGHT_CLASS_NORMAL
-	gulag_valid = TRUE
+	gulag_value = 100
 	mats_per_unit = list(/datum/material/zaukerite = SHEET_MATERIAL_AMOUNT)
 	merge_type = /obj/item/stack/sheet/mineral/zaukerite
 	material_type = /datum/material/zaukerite

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -169,7 +169,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	obj_flags = CONDUCTS_ELECTRICITY
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/iron
-	gulag_valid = TRUE
+	gulag_value = 5
 	table_type = /obj/structure/table
 	material_type = /datum/material/iron
 	matter_amount = 4
@@ -317,7 +317,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	armor_type = /datum/armor/sheet_plasteel
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/plasteel
-	gulag_valid = TRUE
+	gulag_value = 10
 	table_type = /obj/structure/table/reinforced
 	material_flags = NONE
 	matter_amount = 12

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -22,7 +22,7 @@
 	/// text string used to find typepaths used in door and wall (false and tram too) construction for door assemblies and girders respectively
 	var/construction_path_type = null
 	///If true, this is worth points in the gulag labour stacker
-	var/gulag_valid = FALSE
+	var/gulag_value = FALSE
 	///Set to true if this is vended from a material storage
 	var/manufactured = FALSE
 	/// whether this sheet can be sniffed by the material sniffer
@@ -42,7 +42,7 @@
 
 /obj/item/stack/sheet/examine(mob/user)
 	. = ..()
-	if (manufactured && gulag_valid)
+	if (manufactured && gulag_value)
 		. += span_notice("It has been embossed with a manufacturer's mark of guaranteed quality.")
 
 	var/datum/material/material = get_master_material()

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -22,7 +22,7 @@
 	/// text string used to find typepaths used in door and wall (false and tram too) construction for door assemblies and girders respectively
 	var/construction_path_type = null
 	///If true, this is worth points in the gulag labour stacker
-	var/gulag_value = FALSE
+	var/gulag_value = 0
 	///Set to true if this is vended from a material storage
 	var/manufactured = FALSE
 	/// whether this sheet can be sniffed by the material sniffer

--- a/code/game/objects/structures/lavaland/gulag_vent.dm
+++ b/code/game/objects/structures/lavaland/gulag_vent.dm
@@ -13,7 +13,7 @@
 	anchored = TRUE
 	density = TRUE
 	/// What kind of rock we got in there?
-	var/spawned_boulder = /obj/item/boulder/gulag
+	var/spawned_boulder = /obj/item/boulder/gulag_vent
 	/// Prevents multiple people from hauling at a time
 	var/occupied = FALSE
 

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -178,7 +178,7 @@
 /turf/closed/mineral/proc/change_ore(ore_type, random = TRUE)
 	if (ispath(ore_type, /obj/item/boulder))
 		scan_state = "rock_boulder" // Yes even the lowly boulder has a scan state
-		spawned_boulder = /obj/item/boulder/gulag_expanded
+		spawned_boulder = /obj/item/boulder/gulag
 		return
 
 	if (random)
@@ -727,12 +727,12 @@
 
 /turf/closed/mineral/random/labormineral/mineral_chances()
 	return list(
-		/obj/item/boulder/gulag = 20,
+		/obj/item/boulder/gulag = 30,
 		/obj/item/stack/ore/gold = 10,
-		/obj/item/stack/ore/iron = 20,
-		/obj/item/stack/ore/plasma = 15,
+		/obj/item/stack/ore/iron = 25,
+		/obj/item/stack/ore/plasma = 20,
 		/obj/item/stack/ore/silver = 20,
-		/turf/closed/mineral/gibtonite = 2,
+		/turf/closed/mineral/gibtonite/volcanic = 2,
 	)
 
 /turf/closed/mineral/random/labormineral/volcanic
@@ -741,16 +741,6 @@
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	defer_change = TRUE
-
-/turf/closed/mineral/random/labormineral/volcanic/mineral_chances()
-	return list(
-		/obj/item/boulder/gulag_expanded = 30,
-		/obj/item/stack/ore/gold = 10,
-		/obj/item/stack/ore/iron = 25,
-		/obj/item/stack/ore/plasma = 20,
-		/obj/item/stack/ore/silver = 20,
-		/turf/closed/mineral/gibtonite/volcanic = 2,
-	)
 
 // Subtypes for mappers placing ores manually.
 /turf/closed/mineral/random/labormineral/ice

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -727,7 +727,11 @@
 
 /turf/closed/mineral/random/labormineral/mineral_chances()
 	return list(
-		/obj/item/boulder/gulag = 165,
+		/obj/item/boulder/gulag = 20,
+		/obj/item/stack/ore/gold = 10,
+		/obj/item/stack/ore/iron = 20,
+		/obj/item/stack/ore/plasma = 15,
+		/obj/item/stack/ore/silver = 20,
 		/turf/closed/mineral/gibtonite = 2,
 	)
 
@@ -740,7 +744,11 @@
 
 /turf/closed/mineral/random/labormineral/volcanic/mineral_chances()
 	return list(
-		/obj/item/boulder/gulag_expanded = 166,
+		/obj/item/boulder/gulag_expanded = 30,
+		/obj/item/stack/ore/gold = 10,
+		/obj/item/stack/ore/iron = 25,
+		/obj/item/stack/ore/plasma = 20,
+		/obj/item/stack/ore/silver = 20,
 		/turf/closed/mineral/gibtonite/volcanic = 2,
 	)
 
@@ -760,7 +768,11 @@
 
 /turf/closed/mineral/random/labormineral/ice/mineral_chances()
 	return list(
-		/obj/item/boulder/gulag = 168,
+		/obj/item/boulder/gulag = 20,
+		/obj/item/stack/ore/gold = 10,
+		/obj/item/stack/ore/iron = 20,
+		/obj/item/stack/ore/plasma = 15,
+		/obj/item/stack/ore/silver = 20,
 		/turf/closed/mineral/gibtonite/ice/icemoon = 2,
 	)
 

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -758,10 +758,10 @@
 
 /turf/closed/mineral/random/labormineral/ice/mineral_chances()
 	return list(
-		/obj/item/boulder/gulag = 20,
+		/obj/item/boulder/gulag = 30,
 		/obj/item/stack/ore/gold = 10,
-		/obj/item/stack/ore/iron = 20,
-		/obj/item/stack/ore/plasma = 15,
+		/obj/item/stack/ore/iron = 25,
+		/obj/item/stack/ore/plasma = 20,
 		/obj/item/stack/ore/silver = 20,
 		/turf/closed/mineral/gibtonite/ice/icemoon = 2,
 	)

--- a/code/modules/mining/boulder_processing/boulder_types.dm
+++ b/code/modules/mining/boulder_processing/boulder_types.dm
@@ -56,7 +56,7 @@
 ///Boulders usually spawned in lavaland labour camp area
 /obj/item/boulder/gulag
 	name = "low-quality boulder"
-	desc = "This rocks. It's a low quality boulder, so it's probably not worth as much."
+	desc = "A small amount of ore compacted together. This rocks."
 
 /obj/item/boulder/gulag/Initialize(mapload)
 	. = ..()
@@ -72,12 +72,12 @@
 		/datum/material/uranium = 3,
 	)
 
-	set_custom_materials(list(pick_weight(gulag_minerals) = SHEET_MATERIAL_AMOUNT))
+	set_custom_materials(list(pick_weight(gulag_minerals) = SHEET_MATERIAL_AMOUNT * 4))
 
 ///Boulders usually spawned in lavaland labour camp area but with bluespace material
 /obj/item/boulder/gulag_expanded
 	name = "low-density boulder"
-	desc = "This rocks. It's not very well packed, and can't contain as many minerals."
+	desc = "A medium amount of ore compacted together. This rocks."
 
 /obj/item/boulder/gulag_expanded/Initialize(mapload)
 	. = ..()
@@ -93,7 +93,7 @@
 		/datum/material/titanium = 8,
 		/datum/material/uranium = 3,
 	)
-	set_custom_materials(list(pick_weight(expanded_gulag_minerals) = SHEET_MATERIAL_AMOUNT))
+	set_custom_materials(list(pick_weight(expanded_gulag_minerals) = SHEET_MATERIAL_AMOUNT * 6))
 
 ///lowgrade boulder, Exists as an admin spawn for testing
 /obj/item/boulder/shabby

--- a/code/modules/mining/boulder_processing/boulder_types.dm
+++ b/code/modules/mining/boulder_processing/boulder_types.dm
@@ -53,47 +53,31 @@
 	icon_state = "boulder_artifact_diamond"
 	bonus_mat = /datum/material/diamond
 
-///Boulders usually spawned in lavaland labour camp area
+///Boulders spawned by the vent in the work camp, contain exclusively iron so we can have a reliable payout
+/obj/item/boulder/gulag_vent
+	name = "iron boulder"
+	desc = "Basically just a raw lump of iron. Smash it into bits with a pickaxe."
+	// This produces 5 ore when smashed open because not using a machine reduces the ore count by one. 14 boulders x 15 ore x 5 points = 1050 points
+	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 16)
+
+/// Boulders usually spawned in lavaland labour camp area, broken open with pickaxe like a loot box
 /obj/item/boulder/gulag
 	name = "low-quality boulder"
-	desc = "A small amount of ore compacted together. This rocks."
+	desc = "Smash it with a pickaxe to get a bunch of ore at once. This rocks."
 
 /obj/item/boulder/gulag/Initialize(mapload)
 	. = ..()
 
 	/// Static list of all minerals to populate gulag boulders with.
 	var/static/list/gulag_minerals = list(
-		/datum/material/diamond = 1,
-		/datum/material/gold = 8,
-		/datum/material/iron = 95,
-		/datum/material/plasma = 30,
-		/datum/material/silver = 20,
-		/datum/material/titanium = 8,
-		/datum/material/uranium = 3,
+		/datum/material/gold = 1,
+		/datum/material/iron = 5,
+		/datum/material/plasma = 4,
+		/datum/material/silver = 2,
 	)
 
-	set_custom_materials(list(pick_weight(gulag_minerals) = SHEET_MATERIAL_AMOUNT * 4))
-
-///Boulders usually spawned in lavaland labour camp area but with bluespace material
-/obj/item/boulder/gulag_expanded
-	name = "low-density boulder"
-	desc = "A medium amount of ore compacted together. This rocks."
-
-/obj/item/boulder/gulag_expanded/Initialize(mapload)
-	. = ..()
-
-	/// Static list of all minerals to populate gulag boulders with, but with bluespace added where safe.
-	var/static/list/expanded_gulag_minerals = list(
-		/datum/material/bluespace = 1,
-		/datum/material/diamond = 1,
-		/datum/material/gold = 8,
-		/datum/material/iron = 94,
-		/datum/material/plasma = 30,
-		/datum/material/silver = 20,
-		/datum/material/titanium = 8,
-		/datum/material/uranium = 3,
-	)
-	set_custom_materials(list(pick_weight(expanded_gulag_minerals) = SHEET_MATERIAL_AMOUNT * 6))
+	var/amount = rand(10, 13)
+	set_custom_materials(list(pick_weight(gulag_minerals) = SHEET_MATERIAL_AMOUNT * amount))
 
 ///lowgrade boulder, Exists as an admin spawn for testing
 /obj/item/boulder/shabby

--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -1,5 +1,3 @@
-#define SHEET_POINT_VALUE 33
-
 /**********************Prisoners' Console**************************/
 
 /obj/machinery/mineral/labor_claim_console
@@ -201,8 +199,8 @@
 	if (!istype(input, /obj/item/stack/sheet))
 		return ..()
 	var/obj/item/stack/sheet/sheet = input
-	if (sheet.manufactured && sheet.gulag_valid)
-		points += SHEET_POINT_VALUE * sheet.amount
+	if (sheet.manufactured && sheet.gulag_value)
+		points += sheet.gulag_value * sheet.amount
 	return ..()
 
 /obj/machinery/mineral/stacking_machine/laborstacker/base_item_interaction(mob/living/user, obj/item/weapon, list/modifiers)
@@ -245,5 +243,3 @@
 	vars_and_tooltips_map = list(
 		"PERSON" = "will be replaced with the name of the prisoner."
 	)
-
-#undef SHEET_POINT_VALUE


### PR DESCRIPTION
## About The Pull Request

People had been noting that it was taking longer to pay off a 1000 point gulag sentence than expected, because we made some changes to mining and forgot to update it

So now:
- There are ores in the walls again (iron, plasma, silver, and gold)
- Materials are now worth a variable amount of points (iron = plasma < silver < gold)
- Boulders mined from the walls pop into a large amount of the kinds of ores you can mine
- Boulders dragged out of the infinite use "work pit" contain a guaranteed large amount of iron

The upshot of these changes are:
- You can pull 14 boulders out of the hole for a guaranteed time spent of about 6 and a half quite boring minutes to guarantee finishing your sentence (if you know exactly what you are doing and optimise it, probably a bit longer for many people)
- You can mine the walls for ore at the mercy of RNG, you will _likely_ be done in about 5 minutes of mining if you're an early sentence and obviously it gets harder the more people have already mined out the ores

I aimed for about 5 and 6 minutes as a target because of a combination of travel time, the fact that you need to actively do something, and because of the weather.
Remember that's only 5 or 6 minutes actually doing _mining_ (or... watching progress bars and repeatedly falling over), doesn't include variations in skill or luck, being hustled into the teleporter, suiting up, processing the ores, summoning the shuttle, taking the ores to the shuttle, and an ash storm if you're unlucky. So all around, probably adds up to be reasonably close to a 10 minute brig timer.

We all know most people given a 1 point sentence are just going to kill themselves anyway.

Also I moved some lightbulbs in the mining station work camp area because you couldn't see some of the important tiles and it was annoying me

## Why It's Good For The Game

We advise players that 1000 points in the work camp is work about a 10 minute brig sentence and this is basically ban-baiting from our policy page if it's not actually true

## Changelog

:cl:
balance: Adjusted the values of ores from the work camp to make a 1000 point sentence closer to a 10 minute brig timer
map: Moved some lightbulbs around in the work camp so you can see the bars getting printed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
