### PR TITLE
Fixes manual switching of night lighting on APCs

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -661,7 +661,11 @@
 			lighting = autoset(lighting, AUTOSET_ON)
 			environ = autoset(environ, AUTOSET_ON)
 			//If nightlights are on, and we're recovering from low power event, we'll remove it.
-			var/nightshift_disabled = !(locate(/datum/round_event/nightshift) in SSevents.running)
+			var/nightshift_disabled
+			if(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED)
+				nightshift_disabled = TRUE
+			else
+				nightshift_disabled = !(locate(/datum/round_event/nightshift) in SSevents.running)
 			if(nightshift_lights && low_power_nightshift_lights)
 				low_power_nightshift_lights = FALSE
 				if(nightshift_disabled)

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -660,9 +660,9 @@
 			equipment = autoset(equipment, AUTOSET_ON)
 			lighting = autoset(lighting, AUTOSET_ON)
 			environ = autoset(environ, AUTOSET_ON)
-			//If nightlights are on, and we're recovering from low power/nightlight event, we'll remove it.
+			//If nightlights are on, and we're recovering from low power event, we'll remove it.
 			var/nightshift_disabled = !(locate(/datum/round_event/nightshift) in SSevents.running)
-			if(nightshift_lights && (nightshift_disabled || low_power_nightshift_lights))
+			if(nightshift_lights && low_power_nightshift_lights)
 				low_power_nightshift_lights = FALSE
 				if(nightshift_disabled)
 					INVOKE_ASYNC(src, PROC_REF(set_nightshift), FALSE)

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -660,15 +660,12 @@
 			equipment = autoset(equipment, AUTOSET_ON)
 			lighting = autoset(lighting, AUTOSET_ON)
 			environ = autoset(environ, AUTOSET_ON)
-			//If nightlights are on, and we're recovering from low power event, we'll remove it.
-			var/nightshift_disabled
-			if(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED)
-				nightshift_disabled = TRUE
-			else
-				nightshift_disabled = !(locate(/datum/round_event/nightshift) in SSevents.running)
+			//At this point the APC is fully powered. If we've swapped to night lights because of low power then
+			//that gets undone here. The night lights are disabled depending on nightshift or security level.
 			if(nightshift_lights && low_power_nightshift_lights)
 				low_power_nightshift_lights = FALSE
-				if(nightshift_disabled)
+				var/nightshift_disabled = !(locate(/datum/round_event/nightshift) in SSevents.running)
+				if(nightshift_disabled || SSsecurity_level.get_current_level_as_number >= SEC_LEVEL_RED)
 					INVOKE_ASYNC(src, PROC_REF(set_nightshift), FALSE)
 			if(cell_percent > APC_CHANNEL_ALARM_TRESHOLD)
 				alarm_manager.clear_alarm(ALARM_POWER)

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -665,7 +665,7 @@
 			if(nightshift_lights && low_power_nightshift_lights)
 				low_power_nightshift_lights = FALSE
 				var/nightshift_disabled = !(locate(/datum/round_event/nightshift) in SSevents.running)
-				if(nightshift_disabled || SSsecurity_level.get_current_level_as_number >= SEC_LEVEL_RED)
+				if(nightshift_disabled || SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED)
 					INVOKE_ASYNC(src, PROC_REF(set_nightshift), FALSE)
 			if(cell_percent > APC_CHANNEL_ALARM_TRESHOLD)
 				alarm_manager.clear_alarm(ALARM_POWER)


### PR DESCRIPTION

## About The Pull Request
The button which allows you to manually toggle night lighting on APCs is currently broken. When pressed outside of night shift, the APC will briefly swap to night lighting before immediately going back to standard. I suspect this might be caused by the changes to 'apc_main.dm' which occured during PR #95744. 

Additionally, the low power night light enabling introduced in #69374 doesn't seem to account for station security level when APCs get repowered. If a whole station loses power while on red alert during night shift (perhaps by a powersink) then the station will be entirely on night lighting when repowered.

I assume neither of these quirks are intentional and have attempted to fix them here.
## Why It's Good For The Game
Unless I've completely misunderstood something, this should (probably) fix a bug as per local testing.
## Changelog
:cl:
fix: Night shift lighting can be manually enabled through APCs again.
fix: Night lighting is no longer automatically reenabled during red alert night shifts when APCs are drained and recharged.
/:cl:
