### PR TITLE
Allow more than one station lobby button to be shown at any time.

### DIFF
--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -75,7 +75,7 @@
 #define HUD_HUMAN_TOGGLE_INVENTORY "human_toggle_inventory"
 
 #define HUD_NEW_PLAYER_START_NOW "new_player_start_now"
-#define HUD_NEW_PLAYER_SIGN_UP "newp_layer_sign_up"
+#define HUD_NEW_PLAYER_LOBBY_BUTTON(type) "new_player_lobby_button:[type]"
 #define HUD_KEY_NEW_PLAYER(slot) "newplayer_hud:[slot]"
 
 #define HUD_SILICON_TAKE_IMAGE "silicon_camera"

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -426,11 +426,6 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	var/mob/screenmob = viewmob || mymob
 	inventory_update(screenmob)
 
-/datum/hud/new_player/show_hud(version = 0, mob/viewmob)
-	. = ..()
-	if(.)
-		show_station_trait_buttons()
-
 /datum/hud/proc/inventory_update(mob/viewer)
 	if (isnull(mymob))
 		return

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -33,6 +33,11 @@
 	start_button.RegisterSignal(src, COMSIG_HUD_LOBBY_COLLAPSED, TYPE_PROC_REF(/atom/movable/screen/lobby, collapse_button))
 	start_button.RegisterSignal(src, COMSIG_HUD_LOBBY_EXPANDED, TYPE_PROC_REF(/atom/movable/screen/lobby, expand_button))
 
+/datum/hud/new_player/show_hud(version = 0, mob/viewmob)
+	. = ..()
+	if(.)
+		show_station_trait_buttons()
+
 /datum/hud/new_player/on_viewdata_update()
 	. = ..()
 	place_station_trait_buttons()
@@ -47,7 +52,7 @@
 			continue
 		if(LAZYACCESS(shown_station_trait_buttons, trait))
 			continue
-		var/atom/movable/screen/lobby/button/sign_up/sign_up_button = add_screen_object(/atom/movable/screen/lobby/button/sign_up, HUD_NEW_PLAYER_SIGN_UP)
+		var/atom/movable/screen/lobby/button/sign_up/sign_up_button = add_screen_object(/atom/movable/screen/lobby/button/sign_up, HUD_NEW_PLAYER_LOBBY_BUTTON(trait.type))
 		trait.setup_lobby_button(sign_up_button)
 		LAZYSET(shown_station_trait_buttons, trait, sign_up_button)
 		RegisterSignal(trait, COMSIG_QDELETING, PROC_REF(remove_station_trait_button))


### PR DESCRIPTION

## About The Pull Request
This was broken by https://github.com/tgstation/tgstation/pull/95119 over two months ago, cuz add_screen_object() crashes if it finds out there's already a button on the same key slot, and all lobby trait buttons use the exact same key, so no wonders only one button would show up even if I decided to have fun enabling every job trait possible...
## Why It's Good For The Game
Fixing the above. Also moving a proc override from hud/hud.dm to hud/new_player.dm because that's where it belongs.
## Changelog
:cl:
fix: Fixed the lobby interface NOT being able to show more than ONE button related to station traits like special jobs and the skub trait.
/:cl:
