### PR TITLE
Allows gorillas to kill themselves with items

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -155,7 +155,7 @@
 #define COMSIG_MONKEY_HUMANIZE "monkey_humanize"
 
 ///From mob/living/carbon/human/suicide()
-#define COMSIG_HUMAN_SUICIDE_ACT "human_suicide_act"
+#define COMSIG_LIVING_SUICIDE_ACT "human_suicide_act"
 
 ///from base of /mob/living/carbon/regenerate_limbs(): (excluded_limbs)
 #define COMSIG_CARBON_REGENERATE_LIMBS "living_regen_limbs"

--- a/code/datums/actions/items/stealth_box.dm
+++ b/code/datums/actions/items/stealth_box.dm
@@ -35,11 +35,11 @@
 /datum/action/item_action/agent_box/Grant(mob/grant_to)
 	. = ..()
 	if(owner)
-		RegisterSignal(owner, COMSIG_HUMAN_SUICIDE_ACT, PROC_REF(suicide_act))
+		RegisterSignal(owner, COMSIG_LIVING_SUICIDE_ACT, PROC_REF(suicide_act))
 
 /datum/action/item_action/agent_box/Remove(mob/M)
 	if(owner)
-		UnregisterSignal(owner, COMSIG_HUMAN_SUICIDE_ACT)
+		UnregisterSignal(owner, COMSIG_LIVING_SUICIDE_ACT)
 	return ..()
 
 /datum/action/item_action/agent_box/proc/suicide_act(datum/source)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -35,7 +35,7 @@
 	///What is our honorific name/title combo to be displayed?
 	var/honorific_title
 
-/obj/item/card/suicide_act(mob/living/carbon/user)
+/obj/item/card/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins to swipe [user.p_their()] neck with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 

--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -198,10 +198,11 @@
 	pickup_sound = SFX_GENERIC_DEVICE_PICKUP
 	drop_sound = SFX_GENERIC_DEVICE_DROP
 
-/obj/item/razor/suicide_act(mob/living/carbon/user)
+/obj/item/razor/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins shaving [user.p_them()]self without the razor guard! It looks like [user.p_theyre()] trying to commit suicide!"))
-	shave(user, BODY_ZONE_PRECISE_MOUTH)
-	shave(user, BODY_ZONE_HEAD)//doesn't need to be BODY_ZONE_HEAD specifically, but whatever
+	if (ishuman(user))
+		shave(user, BODY_ZONE_PRECISE_MOUTH)
+		shave(user, BODY_ZONE_HEAD) //doesn't need to be BODY_ZONE_HEAD specifically, but whatever
 	return BRUTELOSS
 
 /obj/item/razor/proc/shave(mob/living/carbon/human/skinhead, location = BODY_ZONE_PRECISE_MOUTH)

--- a/code/game/objects/items/dehy_carp.dm
+++ b/code/game/objects/items/dehy_carp.dm
@@ -33,7 +33,7 @@
 	//Wait for animation to end
 	addtimer(CALLBACK(src, PROC_REF(spawn_carp)), 0.6 SECONDS)
 
-/obj/item/toy/plush/carpplushie/dehy_carp/suicide_act(mob/living/carbon/human/user)
+/obj/item/toy/plush/carpplushie/dehy_carp/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] starts eating [src]. It looks like [user.p_theyre()] trying to commit suicide!"))
 	playsound(src, 'sound/items/eatfood.ogg', 50, TRUE)
 	if(!istype(user))

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -115,7 +115,7 @@
 	attack_self(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-/obj/item/flashlight/suicide_act(mob/living/carbon/human/user)
+/obj/item/flashlight/suicide_act(mob/living/user)
 	if (user.is_blind())
 		user.visible_message(span_suicide("[user] is putting [src] close to [user.p_their()] eyes and turning it on... but [user.p_theyre()] blind!"))
 		return SHAME
@@ -1012,7 +1012,7 @@
 		user.visible_message(span_notice("[user] cracks and shakes [src]."), span_notice("You crack and shake [src], turning it on!"))
 		turn_on()
 
-/obj/item/flashlight/glowstick/suicide_act(mob/living/carbon/human/user)
+/obj/item/flashlight/glowstick/suicide_act(mob/living/user)
 	if(!get_fuel())
 		user.visible_message(span_suicide("[user] is trying to squirt [src]'s fluids into [user.p_their()] eyes... but it's empty!"))
 		return SHAME

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -11,7 +11,7 @@
 	var/spamcheck = 0
 	var/list/voicespan = list(SPAN_COMMAND)
 
-/obj/item/megaphone/suicide_act(mob/living/carbon/user)
+/obj/item/megaphone/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is uttering [user.p_their()] last words into \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	spamcheck = 0//so they dont have to worry about recharging
 	user.say("AAAAAAAAAAAARGHHHHH", forced="megaphone suicide")//he must have died while coding this

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -118,7 +118,7 @@
 	if (!QDELETED(our_hud))
 		INVOKE_ASYNC(our_hud, TYPE_PROC_REF(/datum/hud, show_hud), our_hud.hud_version)
 
-/obj/item/multitool/suicide_act(mob/living/carbon/user)
+/obj/item/multitool/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] puts the [src] to [user.p_their()] chest. It looks like [user.p_theyre()] trying to pulse [user.p_their()] heart off!"))
 	return OXYLOSS//there's a reason it wasn't recommended by doctors
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -42,7 +42,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	overlay_mic_idle = null
 	overlay_mic_active = null
 
-/obj/item/radio/headset/suicide_act(mob/living/carbon/user)
+/obj/item/radio/headset/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins putting \the [src]'s antenna up [user.p_their()] nose! It looks like [user.p_theyre()] trying to give [user.p_them()]self cancer!"))
 	return TOXLOSS
 

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -59,7 +59,7 @@
 	. += span_notice("Right-click [src] to open the gas reference.")
 	. += span_notice("Alt-click [src] to activate the barometer function.")
 
-/obj/item/analyzer/suicide_act(mob/living/carbon/user)
+/obj/item/analyzer/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins to analyze [user.p_them()]self with [src]! The display shows that [user.p_theyre()] dead!"))
 	return BRUTELOSS
 

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -47,7 +47,7 @@
 	if(src.mode != SCANNER_NO_MODE)
 		. += span_notice("Alt-click [src] to toggle the limb damage readout. Ctrl-shift-click to print readout report.")
 
-/obj/item/healthanalyzer/suicide_act(mob/living/carbon/user)
+/obj/item/healthanalyzer/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins to analyze [user.p_them()]self with [src]! The display shows that [user.p_theyre()] dead!"))
 	return BRUTELOSS
 

--- a/code/game/objects/items/devices/scanners/t_scanner.dm
+++ b/code/game/objects/items/devices/scanners/t_scanner.dm
@@ -17,7 +17,7 @@
 	/// Is this T-Ray scanner currently on?
 	var/on = FALSE
 
-/obj/item/t_scanner/suicide_act(mob/living/carbon/user)
+/obj/item/t_scanner/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins to emit terahertz-rays into [user.p_their()] brain with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return TOXLOSS
 

--- a/code/game/objects/items/grenades/_grenade.dm
+++ b/code/game/objects/items/grenades/_grenade.dm
@@ -64,7 +64,7 @@
 	ADD_TRAIT(src, TRAIT_ODD_CUSTOMIZABLE_FOOD_INGREDIENT, type)
 	RegisterSignal(src, COMSIG_ITEM_USED_AS_INGREDIENT, PROC_REF(on_used_as_ingredient))
 
-/obj/item/grenade/suicide_act(mob/living/carbon/user)
+/obj/item/grenade/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] primes [src], then eats it! It looks like [user.p_theyre()] trying to commit suicide!"))
 	playsound(src, 'sound/items/eatfood.ogg', 50, TRUE)
 	arm_grenade(user, det_time)

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -14,7 +14,7 @@
 	dye_color = DYE_PRISONER
 	icon = 'icons/obj/weapons/restraints.dmi'
 
-/obj/item/restraints/suicide_act(mob/living/carbon/user)
+/obj/item/restraints/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is strangling [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return OXYLOSS
 

--- a/code/game/objects/items/lighter.dm
+++ b/code/game/objects/items/lighter.dm
@@ -93,7 +93,7 @@
 		return
 	set_lit(FALSE)
 
-/obj/item/lighter/suicide_act(mob/living/carbon/user)
+/obj/item/lighter/suicide_act(mob/living/user)
 	if (lit)
 		user.visible_message(span_suicide("[user] begins holding \the [src]'s flame up to [user.p_their()] face! It looks like [user.p_theyre()] trying to commit suicide!"))
 		playsound(src, 'sound/items/tools/welder.ogg', 50, TRUE)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -47,7 +47,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 /datum/embedding/rods
 	embed_chance = 50
 
-/obj/item/stack/rods/suicide_act(mob/living/carbon/user)
+/obj/item/stack/rods/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins to stuff \the [src] down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide!"))//it looks like theyre ur mum
 	return BRUTELOSS
 

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 	fire = 50
 	acid = 100
 
-/obj/item/stack/sheet/glass/suicide_act(mob/living/carbon/user)
+/obj/item/stack/sheet/glass/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins to slice [user.p_their()] neck with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 

--- a/code/game/objects/items/stacks/sheets/hot_ice.dm
+++ b/code/game/objects/items/stacks/sheets/hot_ice.dm
@@ -8,6 +8,6 @@
 	material_type = /datum/material/hot_ice
 	merge_type = /obj/item/stack/sheet/hot_ice
 
-/obj/item/stack/sheet/hot_ice/suicide_act(mob/living/carbon/user)
+/obj/item/stack/sheet/hot_ice/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins licking \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return FIRELOSS//dont you kids know that stuff is toxic?

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -178,7 +178,7 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 	material_type = /datum/material/plasma
 	walltype = /turf/closed/wall/mineral/plasma
 
-/obj/item/stack/sheet/mineral/plasma/suicide_act(mob/living/carbon/user)
+/obj/item/stack/sheet/mineral/plasma/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins licking \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return TOXLOSS//dont you kids know that stuff is toxic?
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -210,7 +210,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	. = ..()
 	. += GLOB.metal_recipes
 
-/obj/item/stack/sheet/iron/suicide_act(mob/living/carbon/user)
+/obj/item/stack/sheet/iron/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins whacking [user.p_them()]self over the head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -16,7 +16,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	var/content_overlays = FALSE //If this is true, the belt will gain overlays based on what it's holding
 
-/obj/item/storage/belt/suicide_act(mob/living/carbon/user)
+/obj/item/storage/belt/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins belting [user.p_them()]self with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 

--- a/code/game/objects/items/storage/boxes/_boxes.dm
+++ b/code/game/objects/items/storage/boxes/_boxes.dm
@@ -23,7 +23,7 @@
 		set_custom_materials(list(/datum/material/cardboard = SHEET_MATERIAL_AMOUNT))
 	update_appearance()
 
-/obj/item/storage/box/suicide_act(mob/living/carbon/user)
+/obj/item/storage/box/suicide_act(mob/living/user)
 	var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)
 	if(myhead)
 		user.visible_message(span_suicide("[user] puts [user.p_their()] head into \the [src] and begins closing it! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -35,7 +35,7 @@
 	icon_state = "medkit"
 	desc = "A first aid kit with the ability to heal common types of injuries."
 
-/obj/item/storage/medkit/regular/suicide_act(mob/living/carbon/user)
+/obj/item/storage/medkit/regular/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins giving [user.p_them()]self aids with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 
@@ -150,7 +150,7 @@
 /obj/item/storage/medkit/fire/get_medbot_skin()
 	return "burn"
 
-/obj/item/storage/medkit/fire/suicide_act(mob/living/carbon/user)
+/obj/item/storage/medkit/fire/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins rubbing \the [src] against [user.p_them()]self! It looks like [user.p_theyre()] trying to start a fire!"))
 	return FIRELOSS
 
@@ -174,7 +174,7 @@
 /obj/item/storage/medkit/toxin/get_medbot_skin()
 	return "tox"
 
-/obj/item/storage/medkit/toxin/suicide_act(mob/living/carbon/user)
+/obj/item/storage/medkit/toxin/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins licking the lead paint off \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return TOXLOSS
 
@@ -201,7 +201,7 @@
 /obj/item/storage/medkit/o2/get_medbot_skin()
 	return "oxy"
 
-/obj/item/storage/medkit/o2/suicide_act(mob/living/carbon/user)
+/obj/item/storage/medkit/o2/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins hitting [user.p_their()] neck with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return OXYLOSS
 
@@ -225,7 +225,7 @@
 /obj/item/storage/medkit/brute/get_medbot_skin()
 	return "brute"
 
-/obj/item/storage/medkit/brute/suicide_act(mob/living/carbon/user)
+/obj/item/storage/medkit/brute/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins beating [user.p_them()]self over the head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 
@@ -466,7 +466,7 @@
 		return ITEM_INTERACT_SUCCESS
 	return ..()
 
-/obj/item/storage/organbox/suicide_act(mob/living/carbon/user)
+/obj/item/storage/organbox/suicide_act(mob/living/user)
 	if(HAS_TRAIT(user, TRAIT_RESISTCOLD)) //if they're immune to cold, just do the box suicide
 		var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)
 		if(myhead)

--- a/code/game/objects/items/storage/sixpack.dm
+++ b/code/game/objects/items/storage/sixpack.dm
@@ -10,7 +10,7 @@
 	max_integrity = 500
 	storage_type = /datum/storage/sixcan
 
-/obj/item/storage/cans/suicide_act(mob/living/carbon/user)
+/obj/item/storage/cans/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins popping open a final cold one with the boys! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 

--- a/code/game/objects/items/tools/extinguisher.dm
+++ b/code/game/objects/items/tools/extinguisher.dm
@@ -211,7 +211,7 @@
 /obj/item/extinguisher/advanced/empty
 	starting_water = FALSE
 
-/obj/item/extinguisher/suicide_act(mob/living/carbon/user)
+/obj/item/extinguisher/suicide_act(mob/living/user)
 	if (!safety && (reagents.total_volume >= 1))
 		user.visible_message(span_suicide("[user] puts the nozzle to [user.p_their()] mouth. It looks like [user.p_theyre()] trying to extinguish the spark of life!"))
 		interact_with_atom(user, user)

--- a/code/game/objects/items/toy_mechs.dm
+++ b/code/game/objects/items/toy_mechs.dm
@@ -212,7 +212,7 @@
 /**
  * Starts a battle, toy mech vs player. Player... doesn't win.
  */
-/obj/item/toy/mecha/suicide_act(mob/living/carbon/user)
+/obj/item/toy/mecha/suicide_act(mob/living/user)
 	if(in_combat)
 		to_chat(user, span_notice("[src] is in battle, let it finish first."))
 		return

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -436,7 +436,11 @@
 	icon_state = "singularity_s1"
 	item_flags = NO_PIXEL_RANDOM_DROP
 
-/obj/item/toy/spinningtoy/suicide_act(mob/living/carbon/human/user)
+/obj/item/toy/spinningtoy/suicide_act(mob/living/user)
+	if (!iscarbon(user))
+		user.visible_message(span_suicide("[user] consumes [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+		user.spin(8 SECONDS, 1)
+		return BRUTELOSS
 	var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)
 	if(!myhead)
 		user.visible_message(span_suicide("[user] tries consuming [src]... but [user.p_they()] [user.p_have()] no mouth!")) // and i must scream

--- a/code/game/objects/items/weaponry/melee/chainsaw.dm
+++ b/code/game/objects/items/weaponry/melee/chainsaw.dm
@@ -85,10 +85,14 @@
 /obj/item/chainsaw/get_demolition_modifier(obj/target)
 	return HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE) ? demolition_mod : 0.8
 
-/obj/item/chainsaw/suicide_act(mob/living/carbon/user)
+/obj/item/chainsaw/suicide_act(mob/living/user)
 	if(!HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
 		user.visible_message(span_suicide("[user] smashes [src] into [user.p_their()] neck, destroying [user.p_their()] esophagus! It looks like [user.p_theyre()] trying to commit suicide!"))
 		playsound(src, 'sound/items/weapons/genhit1.ogg', 100, TRUE)
+		return BRUTELOSS
+
+	if (!iscarbon(user))
+		user.visible_message(span_suicide("[user] begins to shred [user.p_themselves()] with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 		return BRUTELOSS
 
 	user.visible_message(span_suicide("[user] begins to tear [user.p_their()] head off with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/game/objects/items/weaponry/melee/dualsaber.dm
+++ b/code/game/objects/items/weaponry/melee/dualsaber.dm
@@ -85,13 +85,15 @@
 	icon_state = inhand_icon_state = HAS_TRAIT(src, TRAIT_WIELDED) ? "dualsaber[saber_color][HAS_TRAIT(src, TRAIT_WIELDED)]" : "dualsaber0"
 	return ..()
 
-/obj/item/dualsaber/suicide_act(mob/living/carbon/user)
+/obj/item/dualsaber/suicide_act(mob/living/user)
 	if(HAS_TRAIT(src, TRAIT_WIELDED))
 		user.visible_message(span_suicide("[user] begins spinning way too fast! It looks like [user.p_theyre()] trying to commit suicide!"))
 
 		var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)//stole from chainsaw code
-		var/obj/item/organ/brain/B = user.get_organ_slot(ORGAN_SLOT_BRAIN)
-		B.organ_flags &= ~ORGAN_VITAL //this cant possibly be a good idea
+		var/obj/item/organ/brain/mybrain = user.get_organ_slot(ORGAN_SLOT_BRAIN)
+		if (mybrain)
+			mybrain.organ_flags &= ~ORGAN_VITAL //this cant possibly be a good idea
+
 		var/randdir
 		for(var/i in 1 to 24)//like a headless chicken!
 			if(user.is_holding(src))

--- a/code/game/objects/items/weaponry/melee/knives.dm
+++ b/code/game/objects/items/weaponry/melee/knives.dm
@@ -326,7 +326,7 @@
 	icon_angle = -45
 	custom_materials = null
 
-/obj/item/knife/shiv/carrot/suicide_act(mob/living/carbon/user)
+/obj/item/knife/shiv/carrot/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] forcefully drives \the [src] into [user.p_their()] eye! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 

--- a/code/game/objects/items/weaponry/melee/spear.dm
+++ b/code/game/objects/items/weaponry/melee/spear.dm
@@ -91,7 +91,7 @@
 		worn_icon_state = null
 	return ..()
 
-/obj/item/spear/suicide_act(mob/living/carbon/user)
+/obj/item/spear/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins to sword-swallow \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	if (!do_after(user, 4 SECONDS, target = src))
 		return SHAME
@@ -340,7 +340,7 @@
 		set_explosive(nade)
 	return ..()
 
-/obj/item/spear/explosive/suicide_act(mob/living/carbon/user)
+/obj/item/spear/explosive/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins to sword-swallow \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	user.say("[war_cry]", forced="spear warcry")
 	explosive.forceMove(user)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -418,7 +418,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	. = ..()
 	AddElement(/datum/element/cuffable_item)
 
-/obj/item/chair/suicide_act(mob/living/carbon/user)
+/obj/item/chair/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins hitting [user.p_them()]self with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	playsound(src,hitsound,50,TRUE)
 	return BRUTELOSS

--- a/code/game/objects/structures/water_structures/toilet.dm
+++ b/code/game/objects/structures/water_structures/toilet.dm
@@ -417,7 +417,7 @@
 	desc = "A horrendous mass of fused flesh resembling a standard-issue HT-451 model toilet. How it manages to function as one is beyond you. \
 	This one seems to be made out of the flesh of a devoted employee of the RnD department."
 
-/obj/structure/toilet/greyscale/flesh/Initialize(mapload, mob/living/carbon/suicide)
+/obj/structure/toilet/greyscale/flesh/Initialize(mapload, mob/living/suicide)
 	. = ..()
 	///The suicide victim's brain that will be placed inside the toilet's cistern
 	var/obj/item/organ/brain/toilet_brain
@@ -432,8 +432,9 @@
 		toilet_brain = new(drop_location())
 		set_custom_materials(list(/datum/material/meat = SHEET_MATERIAL_AMOUNT))
 
-	toilet_brain.forceMove(src)
-	add_cistern_item(toilet_brain)
+	if (toilet_brain)
+		toilet_brain.forceMove(src)
+		add_cistern_item(toilet_brain)
 
 //this also prevents the toilet from dropping meat sheets. if you want to cheese the meat exepriments, sacrifice more people
 /obj/structure/toilet/greyscale/flesh/atom_deconstruct(dissambled = TRUE)

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -14,7 +14,7 @@
 	pickup_sound = 'sound/items/handling/component_pickup.ogg'
 	assembly_flags = ASSEMBLY_NO_DUPLICATES
 
-/obj/item/assembly/igniter/suicide_act(mob/living/carbon/user)
+/obj/item/assembly/igniter/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is trying to ignite [user.p_them()]self with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	user.ignite_mob()
 	return FIRELOSS

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -29,7 +29,7 @@
 	/// Signal range, see /datum/radio_frequency/proc/post_signal
 	var/range = 0 //Everywhere
 
-/obj/item/assembly/signaler/suicide_act(mob/living/carbon/user)
+/obj/item/assembly/signaler/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] eats \the [src]! If it is signaled, [user.p_they()] will die!"))
 	playsound(src, 'sound/items/eatfood.ogg', 50, TRUE)
 	moveToNullspace()

--- a/code/modules/cards/cardhand.dm
+++ b/code/modules/cards/cardhand.dm
@@ -12,7 +12,7 @@
 	register_context()
 	update_appearance()
 
-/obj/item/toy/cards/cardhand/suicide_act(mob/living/carbon/user)
+/obj/item/toy/cards/cardhand/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is slitting [user.p_their()] wrists with \the [src]! It looks like [user.p_they()] [user.p_have()] a crummy hand!"))
 	playsound(src, 'sound/items/cards/cardshuffle.ogg', 50, TRUE)
 	return BRUTELOSS

--- a/code/modules/cards/deck/deck.dm
+++ b/code/modules/cards/deck/deck.dm
@@ -52,7 +52,7 @@
 		for(var/person in list("Jack", "Queen", "King"))
 			initial_cards += "[person] of [suit]"
 
-/obj/item/toy/cards/deck/suicide_act(mob/living/carbon/user)
+/obj/item/toy/cards/deck/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is slitting [user.p_their()] wrists with \the [src]! It looks like their luck ran out!"))
 	playsound(src, 'sound/items/cards/cardshuffle.ogg', 50, TRUE)
 	return BRUTELOSS

--- a/code/modules/cards/singlecard.dm
+++ b/code/modules/cards/singlecard.dm
@@ -101,7 +101,7 @@
 
 	return NONE
 
-/obj/item/toy/singlecard/suicide_act(mob/living/carbon/user)
+/obj/item/toy/singlecard/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is slitting [user.p_their()] wrists with \the [src]! It looks like [user.p_they()] [user.p_have()] an unlucky card!"))
 	playsound(src, 'sound/items/weapons/bladeslice.ogg', 50, TRUE)
 	return BRUTELOSS

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -8,11 +8,23 @@
 /// Actually handles the bare basics of the suicide process. Message type is the message we want to dispatch in the world regarding the suicide, using the defines in this file.
 /// Override this ENTIRELY if you want to add any special behavior to your suicide handling, if you fuck up the order of operations then shit will break.
 /mob/living/proc/handle_suicide()
-	SHOULD_CALL_PARENT(FALSE)
 	if(!suicide_alert())
 		return
 
 	set_suicide(TRUE)
+
+	var/obj/item/held_item = get_active_held_item()
+	var/damage_type = SEND_SIGNAL(src, COMSIG_LIVING_SUICIDE_ACT) || held_item?.suicide_act(src)
+
+	if(damage_type)
+		if(apply_suicide_damage(held_item, damage_type))
+			final_checkout(held_item, apply_damage = FALSE)
+		return
+
+	perform_basic_suicide()
+
+/// Kill yourself without any items
+/mob/living/proc/perform_basic_suicide()
 	send_applicable_messages()
 	final_checkout()
 
@@ -69,7 +81,7 @@
 	return FALSE
 
 /// Inserts in logging and death + mind dissociation when we're fully done with ending the life of our mob, as well as adjust the health. We will disallow re-entering the body when this is called.
-/// The suicide_tool variable is currently only used for humans in order to allow suicide log to properly put stuff in investigate log.
+/// The suicide_tool variable is used in order to allow suicide log to properly put stuff in investigate log.
 /// Set apply_damage to FALSE in order to not do damage (in case it's handled elsewhere in the verb or another proc that the suicide tree calls). Will dissociate client from mind and ghost the player regardless.
 /mob/living/proc/final_checkout(obj/item/suicide_tool, apply_damage = TRUE)
 	if(apply_damage) // enough to really drive home the point that they are DEAD.
@@ -101,8 +113,31 @@
 /// The actual proc that will apply the damage to the suiciding mob. damage_type is the actual type of damage we want to deal, if that matters.
 /// Return TRUE if we actually apply any real damage, FALSE otherwise.
 /mob/living/proc/apply_suicide_damage(obj/item/suicide_tool, damage_type = NONE)
-	adjust_oxy_loss(max(maxHealth * 2 - get_tox_loss() - get_fire_loss() - get_brute_loss() - get_oxy_loss(), 0))
-	return TRUE
+	if (damage_type == NONE)
+		adjust_oxy_loss(max(maxHealth * 2 - get_tox_loss() - get_fire_loss() - get_brute_loss() - get_oxy_loss(), 0))
+		return TRUE
+
+	if(damage_type & SHAME)
+		adjust_stamina_loss(max_stamina)
+		if (!has_status_effect(/datum/status_effect/incapacitating/stamcrit))
+			Paralyze(10 SECONDS, ignore_canstun = TRUE) // No will to go on, for 10 seconds
+		set_suicide(FALSE)
+		add_mood_event("shameful_suicide", /datum/mood_event/shameful_suicide)
+		return FALSE
+
+	if(damage_type & MANUAL_SUICIDE_NONLETHAL)
+		set_suicide(FALSE)
+		return FALSE
+
+	if(damage_type & MANUAL_SUICIDE) // Assume that the suicide tool will handle the death.
+		suicide_log(suicide_tool)
+		return FALSE
+
+	if(damage_type & (BRUTELOSS | FIRELOSS | OXYLOSS | TOXLOSS))
+		handle_suicide_damage_spread(damage_type)
+		return TRUE
+
+	return FALSE
 
 /// If we want to apply multiple types of damage to a carbon mob based on the way they suicide, this is the proc that handles that.
 /// Currently only compatible with Brute, Burn, Toxin, and Suffocation Damage. damage_type is the bitflag that carries the information.

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -6,8 +6,9 @@
 	handle_suicide()
 
 /// Actually handles the bare basics of the suicide process. Message type is the message we want to dispatch in the world regarding the suicide, using the defines in this file.
-/// Override this ENTIRELY if you want to add any special behavior to your suicide handling, if you fuck up the order of operations then shit will break.
+/// The order of operations here is important, if you want to make specific behaviour for a kind of mob killing itself you likely want to override perform_basic_suicide()
 /mob/living/proc/handle_suicide()
+	SHOULD_NOT_OVERRIDE(TRUE)
 	if(!suicide_alert())
 		return
 

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -37,7 +37,7 @@
 	if(glass_colour_type)
 		AddElement(/datum/element/wearable_client_colour, glass_colour_type, ITEM_SLOT_EYES, GLASSES_TRAIT, forced = forced_glass_color, comsig_toggle = COMSIG_CLICK_ALT_SECONDARY)
 
-/obj/item/clothing/glasses/suicide_act(mob/living/carbon/user)
+/obj/item/clothing/glasses/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is stabbing \the [src] into [user.p_their()] eyes! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 
@@ -89,7 +89,7 @@
 	drop_sound = SFX_GOGGLES_DROP
 	equip_sound = SFX_GOGGLES_EQUIP
 
-/obj/item/clothing/glasses/meson/suicide_act(mob/living/carbon/user)
+/obj/item/clothing/glasses/meson/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is putting \the [src] to [user.p_their()] eyes and overloading the brightness! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 
@@ -140,7 +140,7 @@
 	fire = 80
 	acid = 100
 
-/obj/item/clothing/glasses/science/suicide_act(mob/living/carbon/user)
+/obj/item/clothing/glasses/science/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is tightening \the [src]'s straps around [user.p_their()] neck! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return OXYLOSS
 

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -40,7 +40,7 @@
 		transfer_blood = 0
 		. |= COMPONENT_CLEANED|COMPONENT_CLEANED_GAIN_XP
 
-/obj/item/clothing/gloves/suicide_act(mob/living/carbon/user)
+/obj/item/clothing/gloves/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("\the [src] are forcing [user]'s hands around [user.p_their()] neck! It looks like the gloves are possessed!"))
 	return OXYLOSS
 

--- a/code/modules/clothing/head/tinfoilhat.dm
+++ b/code/modules/clothing/head/tinfoilhat.dm
@@ -39,7 +39,7 @@
 		QDEL_NULL(paranoia)
 	paranoia = new()
 
-	RegisterSignal(user, COMSIG_HUMAN_SUICIDE_ACT, PROC_REF(call_suicide))
+	RegisterSignal(user, COMSIG_LIVING_SUICIDE_ACT, PROC_REF(call_suicide))
 
 	user.gain_trauma(paranoia, TRAUMA_RESILIENCE_MAGIC)
 	to_chat(user, span_warning("As you don the foiled hat, an entire world of conspiracy theories and seemingly insane ideas suddenly rush into your mind. What you once thought unbelievable suddenly seems.. undeniable. Everything is connected and nothing happens just by accident. You know too much and now they're out to get you. "))
@@ -57,7 +57,7 @@
 	. = ..()
 	if(paranoia)
 		QDEL_NULL(paranoia)
-	UnregisterSignal(user, COMSIG_HUMAN_SUICIDE_ACT)
+	UnregisterSignal(user, COMSIG_LIVING_SUICIDE_ACT)
 
 /// When the foilhat is drained an anti-magic charge.
 /obj/item/clothing/head/costume/foilhat/proc/drain_antimagic(mob/user)
@@ -71,7 +71,7 @@
 	if(!isliving(loc) || !paranoia)
 		return
 	var/mob/living/target = loc
-	UnregisterSignal(target, COMSIG_HUMAN_SUICIDE_ACT)
+	UnregisterSignal(target, COMSIG_LIVING_SUICIDE_ACT)
 	if(target.get_item_by_slot(ITEM_SLOT_HEAD) != src)
 		return
 	QDEL_NULL(paranoia)

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -19,7 +19,7 @@
 /datum/armor/mask_breath
 	bio = 50
 
-/obj/item/clothing/mask/breath/suicide_act(mob/living/carbon/user)
+/obj/item/clothing/mask/breath/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is wrapping \the [src]'s tube around [user.p_their()] neck! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return OXYLOSS
 

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -240,7 +240,7 @@
 	. = ..()
 	AddElement(/datum/element/adjust_fishing_difficulty, -3) //FISH DOCTOR?!
 
-/obj/item/clothing/neck/stethoscope/suicide_act(mob/living/carbon/user)
+/obj/item/clothing/neck/stethoscope/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] puts \the [src] to [user.p_their()] chest! It looks like [user.p_they()] won't hear much!"))
 	return OXYLOSS
 

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -45,7 +45,7 @@
 /datum/armor/clothing_shoes
 	bio = 50
 
-/obj/item/clothing/shoes/suicide_act(mob/living/carbon/user)
+/obj/item/clothing/shoes/suicide_act(mob/living/user)
 	if(prob(50))
 		user.visible_message(span_suicide("[user] begins fastening \the [src] up waaay too tightly! It looks like [user.p_theyre()] trying to commit suicide!"))
 		var/obj/item/bodypart/leg/left = user.get_bodypart(BODY_ZONE_L_LEG)

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -371,7 +371,7 @@
 	if(cell)
 		cell.emp_act(severity)
 
-/obj/item/clothing/head/helmet/space/suicide_act(mob/living/carbon/user)
+/obj/item/clothing/head/helmet/space/suicide_act(mob/living/user)
 	var/datum/gas_mixture/environment = user.loc.return_air()
 	if(HAS_TRAIT(user, TRAIT_RESISTCOLD) || !environment || environment.return_temperature() >= user.get_body_temp_cold_damage_limit())
 		user.visible_message(span_suicide("[user] is beating [user.p_them()]self with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/experisci/handheld_scanner.dm
+++ b/code/modules/experisci/handheld_scanner.dm
@@ -32,7 +32,7 @@
 		experiment_signals = handheld_signals, \
 	)
 
-/obj/item/experi_scanner/suicide_act(mob/living/carbon/user)
+/obj/item/experi_scanner/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is giving in to the Great Toilet Beyond! It looks like [user.p_theyre()] trying to commit suicide!"))
 
 	forceMove(drop_location())
@@ -48,7 +48,7 @@
 	addtimer(CALLBACK(src, PROC_REF(make_meat_toilet), user), 5 SECONDS)
 	return MANUAL_SUICIDE
 
-/obj/item/experi_scanner/proc/make_meat_toilet(mob/living/carbon/user)
+/obj/item/experi_scanner/proc/make_meat_toilet(mob/living/user)
 	///The toilet we're about to unleash unto this cursed plane of existence
 	new /obj/structure/toilet/greyscale/flesh (drop_location(), user) //the toilet's Initialize proc will handle the rest from here.
 

--- a/code/modules/fishing/fish/types/holographic.dm
+++ b/code/modules/fishing/fish/types/holographic.dm
@@ -111,7 +111,7 @@
 	sprite_height = 3
 	beauty = FISH_BEAUTY_NULL
 
-/obj/item/fish/holo/checkered/suicide_act(mob/living/carbon/user)
+/obj/item/fish/holo/checkered/suicide_act(mob/living/user)
 	if(!iscarbon(user))
 		return ..()
 

--- a/code/modules/fishing/fish/types/ruins.dm
+++ b/code/modules/fishing/fish/types/ruins.dm
@@ -156,23 +156,26 @@
 /obj/item/fish/skin_crab/get_fish_taste_cooked()
 	return list("cooked crab" = 2)
 
-/obj/item/fish/skin_crab/suicide_act(mob/living/carbon/human/user)
+/obj/item/fish/skin_crab/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] puts [user.p_their()] hand on [src] and focuses intently! It looks like [user.p_theyre()] trying to transfer [user.p_their()] skin to [src]!"))
-	if(!ishuman(user) || HAS_TRAIT(user, TRAIT_UNHUSKABLE))
+	if(HAS_TRAIT(user, TRAIT_UNHUSKABLE))
 		user.visible_message(span_suicide("[user] has no skin! How embarrassing!"))
 		return SHAME
-
+	if(!ishuman(user))
+		user.visible_message(span_suicide("[src] doesn't want [user]'s skin! How embarrassing!"))
+		return SHAME
 	if(status == FISH_DEAD)
 		user.visible_message(span_suicide("[src] is dead! [user] just looks like a doofus!"))
 		return SHAME
 
+	var/mob/living/carbon/skin_haver = user
 	var/skin_tone
 	for(var/obj/item/bodypart/to_wound as anything in user.get_bodyparts())
 		if(to_wound == user.get_bodypart(BODY_ZONE_CHEST))
 			skin_tone = to_wound.species_color || skintone2hex(to_wound.skin_tone)
-		user.cause_wound_of_type_and_severity(WOUND_SLASH, to_wound, WOUND_SEVERITY_CRITICAL, WOUND_SEVERITY_CRITICAL)
-		user.cause_wound_of_type_and_severity(WOUND_PIERCE, to_wound, WOUND_SEVERITY_CRITICAL, WOUND_SEVERITY_CRITICAL)
-		user.cause_wound_of_type_and_severity(WOUND_BLUNT, to_wound, WOUND_SEVERITY_CRITICAL, WOUND_SEVERITY_CRITICAL)
+		skin_haver.cause_wound_of_type_and_severity(WOUND_SLASH, to_wound, WOUND_SEVERITY_CRITICAL, WOUND_SEVERITY_CRITICAL)
+		skin_haver.cause_wound_of_type_and_severity(WOUND_PIERCE, to_wound, WOUND_SEVERITY_CRITICAL, WOUND_SEVERITY_CRITICAL)
+		skin_haver.cause_wound_of_type_and_severity(WOUND_BLUNT, to_wound, WOUND_SEVERITY_CRITICAL, WOUND_SEVERITY_CRITICAL)
 		user.become_husk(REF(src))
 		to_wound.skin_tone = COLOR_RED // skin is gone. (if they somehow get revived, don't worry - death from loss of skin takes longer than dehydration, so it's still realistic)
 

--- a/code/modules/fishing/fish/types/syndicate.dm
+++ b/code/modules/fishing/fish/types/syndicate.dm
@@ -201,7 +201,7 @@
 	toolspeed -= bonus_malus * 0.1
 
 // you suicide like a real chainsaw
-/obj/item/fish/chainsawfish/suicide_act(mob/living/carbon/user)
+/obj/item/fish/chainsawfish/suicide_act(mob/living/user)
 	if(status == FISH_DEAD)
 		user.visible_message(span_suicide("[user] smashes [src] into [user.p_their()] neck, destroying [user.p_their()] esophagus! It looks like [user.p_theyre()] trying to commit suicide!"))
 		playsound(src, 'sound/items/weapons/genhit1.ogg', 100, TRUE)

--- a/code/modules/food_and_drinks/equipment/kitchen_utensils.dm
+++ b/code/modules/food_and_drinks/equipment/kitchen_utensils.dm
@@ -51,7 +51,7 @@
 	. = ..()
 	AddElement(/datum/element/eyestab)
 
-/obj/item/kitchen/fork/suicide_act(mob/living/carbon/user)
+/obj/item/kitchen/fork/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] stabs \the [src] into [user.p_their()] chest! It looks like [user.p_theyre()] trying to take a bite out of [user.p_them()]self!"))
 	playsound(src, 'sound/items/eatfood.ogg', 50, TRUE)
 	return BRUTELOSS
@@ -190,7 +190,7 @@
 	custom_price = PAYCHECK_CREW * 2
 	exposed_wound_bonus = 14
 
-/obj/item/kitchen/rollingpin/suicide_act(mob/living/carbon/user)
+/obj/item/kitchen/rollingpin/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins flattening [user.p_their()] head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 /* Trays  moved to /obj/item/storage/bag */

--- a/code/modules/mining/equipment/kheiral_cuffs.dm
+++ b/code/modules/mining/equipment/kheiral_cuffs.dm
@@ -109,9 +109,10 @@
 	. = ..()
 	. += emissive_appearance(icon, "strand_light", src, alpha = src.alpha)
 
-/obj/item/clothing/accessory/kheiral_cuffs/suicide_act(mob/living/carbon/user)
+/obj/item/clothing/accessory/kheiral_cuffs/suicide_act(mob/living/user)
 	if(!ishuman(user))
-		return
+		user.visible_message(span_suicide("[user] locks [src] around their neck, wrinkles forming across their face. It looks like [user.p_theyre()] trying to commit suicide!"))
+		return OXYLOSS
 
 	var/mob/living/carbon/human/victim = user
 	victim.visible_message(span_suicide("[user] locks [src] around their neck, wrinkles forming across their face. It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/mob/living/carbon/human/human_suicide.dm
+++ b/code/modules/mob/living/carbon/human/human_suicide.dm
@@ -4,20 +4,7 @@
 #define HUMAN_COMBAT_MODE_SUICIDE_MESSAGE "combat mode message"
 #define HUMAN_DEFAULT_MODE_SUICIDE_MESSAGE "default mode message"
 
-/mob/living/carbon/human/handle_suicide()
-	if(!suicide_alert())
-		return
-
-	set_suicide(TRUE) //need to be called before calling suicide_act as fuck knows what suicide_act will do with your suicide
-
-	var/obj/item/held_item = get_active_held_item()
-	var/damage_type = SEND_SIGNAL(src, COMSIG_HUMAN_SUICIDE_ACT) || held_item?.suicide_act(src)
-
-	if(damage_type)
-		if(apply_suicide_damage(held_item, damage_type))
-			final_checkout(held_item, apply_damage = FALSE)
-		return
-
+/mob/living/carbon/human/perform_basic_suicide()
 	// if no specific item or damage type we want to deal, default to doing the deed with our own bare hands.
 	if(combat_mode)
 		send_applicable_messages(HUMAN_COMBAT_MODE_SUICIDE_MESSAGE)
@@ -28,32 +15,7 @@
 		else
 			send_applicable_messages(HUMAN_DEFAULT_MODE_SUICIDE_MESSAGE)
 
-	final_checkout(held_item, apply_damage = TRUE)
-
-/mob/living/carbon/human/apply_suicide_damage(obj/item/suicide_tool, damage_type = NONE)
-	// if we don't have any damage_type passed in, default to parent.
-	if(damage_type == NONE)
-		return ..()
-
-	if(damage_type & SHAME)
-		adjust_stamina_loss(200)
-		set_suicide(FALSE)
-		add_mood_event("shameful_suicide", /datum/mood_event/shameful_suicide)
-		return FALSE
-
-	if(damage_type & MANUAL_SUICIDE_NONLETHAL)
-		set_suicide(FALSE)
-		return FALSE
-
-	if(damage_type & MANUAL_SUICIDE) // Assume that the suicide tool will handle the death.
-		suicide_log(suicide_tool)
-		return FALSE
-
-	if(damage_type & (BRUTELOSS | FIRELOSS | OXYLOSS | TOXLOSS))
-		handle_suicide_damage_spread(damage_type)
-		return TRUE
-
-	return ..() //if all else fails, hope parent accounts for it or just do whatever damage that parent prescribes.
+	final_checkout()
 
 /// Any "special" suicide messages are handled by the related item that the mob uses to kill itself. This is just messages for when it's done with the bare hands.
 /mob/living/carbon/human/send_applicable_messages(message_type)

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -44,7 +44,7 @@
 	 */
 	var/obj/item/paper/top_paper
 
-/obj/item/clipboard/suicide_act(mob/living/carbon/user)
+/obj/item/clipboard/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins putting [user.p_their()] head into the clip of \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS //The clipboard's clip is very strong. Industrial duty. Can kill a man easily.
 

--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -68,12 +68,9 @@
 		icon = I
 	return ..()
 
-/obj/item/photo/suicide_act(mob/living/carbon/human/user)
+/obj/item/photo/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is taking one last look at \the [src]! It looks like [user.p_theyre()] giving in to death!"))//when you wanna look at photo of waifu one last time before you die...
-	if (!ishuman(user) || user.physique == MALE)
-		playsound(user, 'sound/mobs/humanoids/human/laugh/manlaugh1.ogg', 50, TRUE)//EVERY TIME I DO IT MAKES ME LAUGH
-	else
-		playsound(user, 'sound/mobs/humanoids/human/laugh/womanlaugh.ogg', 50, TRUE)
+	user.emote("laugh", intentional = FALSE, forced = TRUE) // EVERY TIME I DO IT MAKES ME LAUGH
 	return OXYLOSS
 
 /obj/item/photo/attack_self(mob/user)

--- a/code/modules/power/lighting/light_items.dm
+++ b/code/modules/power/lighting/light_items.dm
@@ -43,7 +43,7 @@
 /obj/item/light/proc/is_intact()
 	return status == LIGHT_OK
 
-/obj/item/light/suicide_act(mob/living/carbon/user)
+/obj/item/light/suicide_act(mob/living/user)
 	if (status == LIGHT_BROKEN)
 		user.visible_message(span_suicide("[user] begins to stab [user.p_them()]self with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	else

--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -36,7 +36,7 @@
 		icon_state = icon_empty
 	return ..()
 
-/obj/item/reagent_containers/condiment/suicide_act(mob/living/carbon/user)
+/obj/item/reagent_containers/condiment/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is trying to eat the entire [src]! It looks like [user.p_they()] forgot how food works!"))
 	return OXYLOSS
 

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -40,35 +40,39 @@
 	new T(loc)
 	return INITIALIZE_HINT_QDEL
 
-/obj/item/reagent_containers/cup/soda_cans/suicide_act(mob/living/carbon/human/H)
+/obj/item/reagent_containers/cup/soda_cans/suicide_act(mob/living/user)
 	if(!reagents.total_volume)
-		H.visible_message(span_warning("[H] is trying to take a big sip from [src]... The can is empty!"))
+		user.visible_message(span_warning("[user] is trying to take a big sip from [src]... The can is empty!"))
 		return SHAME
 	if(!is_drainable())
-		open_soda(H)
+		open_soda(user)
 		sleep(1 SECONDS)
-	H.visible_message(span_suicide("[H] takes a big sip from [src]! It looks like [H.p_theyre()] trying to commit suicide!"))
-	playsound(H,'sound/items/drink.ogg', 80, TRUE)
-	reagents.trans_to(H, src.reagents.total_volume, transferred_by = H) //a big sip
+	user.visible_message(span_suicide("[user] takes a big sip from [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+	playsound(user,'sound/items/drink.ogg', 80, TRUE)
+	reagents.trans_to(user, src.reagents.total_volume, transferred_by = user) //a big sip
 	sleep(0.5 SECONDS)
-	H.say(pick(
+	user.say(pick(
 		"Now, Outbomb Cuban Pete, THAT was a game.",
 		"All these new fangled arcade games are too slow. I prefer the classics.",
 		"They don't make 'em like Orion Trail anymore.",
 		"You know what they say. Worst day of spess carp fishing is better than the best day at work.",
 		"They don't make 'em like good old-fashioned singularity engines anymore.",
 	))
-	if(H.age >= 30)
-		H.Stun(50)
-		sleep(5 SECONDS)
-		playsound(H,'sound/items/drink.ogg', 80, TRUE)
-		H.say(pick(
-			"Another day, another dollar.",
-			"I wonder if I should hold?",
-			"Diversifying is for young'ns.",
-			"Yeap, times were good back then.",
-		))
-		return MANUAL_SUICIDE_NONLETHAL
+
+	if(ishuman(user))
+		var/mob/living/carbon/human/drinker = user
+		if (drinker.age >= 30)
+			drinker.Stun(50)
+			sleep(5 SECONDS)
+			playsound(drinker,'sound/items/drink.ogg', 80, TRUE)
+			drinker.say(pick(
+				"Another day, another dollar.",
+				"I wonder if I should hold?",
+				"Diversifying is for young'ns.",
+				"Yeap, times were good back then.",
+			))
+			return MANUAL_SUICIDE_NONLETHAL
+
 	sleep(2 SECONDS) //dramatic pause
 	return TOXLOSS
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -158,7 +158,7 @@
 	var/label_examine = TRUE
 	var/label_text
 
-/obj/item/reagent_containers/hypospray/medipen/suicide_act(mob/living/carbon/user)
+/obj/item/reagent_containers/hypospray/medipen/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins to choke on \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return OXYLOSS//ironic. he could save others from oxyloss, but not himself.
 

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -231,7 +231,7 @@
 /obj/item/reagent_containers/spray/pepper/empty //for protolathe printing
 	list_reagents = null
 
-/obj/item/reagent_containers/spray/pepper/suicide_act(mob/living/carbon/user)
+/obj/item/reagent_containers/spray/pepper/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins huffing \the [src]! It looks like [user.p_theyre()] getting a dirty high!"))
 	return OXYLOSS
 

--- a/code/modules/surgery/surgery_tools.dm
+++ b/code/modules/surgery/surgery_tools.dm
@@ -589,7 +589,7 @@
 	if(HAS_MIND_TRAIT(user, TRAIT_MORBID)) //Freak
 		user.add_mood_event("morbid_dismemberment", /datum/mood_event/morbid_dismemberment)
 
-/obj/item/shears/suicide_act(mob/living/carbon/user)
+/obj/item/shears/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is pinching [user.p_them()]self with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	var/timer = 1 SECONDS
 	for(var/obj/item/bodypart/thing in user.get_bodyparts())

--- a/code/modules/vehicles/vehicle_key.dm
+++ b/code/modules/vehicles/vehicle_key.dm
@@ -13,7 +13,7 @@
 	desc = "A keyring with a small steel key, and a rubber stun baton accessory."
 	icon_state = "keysec"
 
-/obj/item/key/security/suicide_act(mob/living/carbon/user)
+/obj/item/key/security/suicide_act(mob/living/user)
 	if(!user.emote("spin")) //In the off chance that someone attempts this suicide while under the effects of mime's bane they deserve the silliness.
 		user.visible_message(span_suicide("[user] is putting \the [src] in [user.p_their()] ear and starts [user.p_their()] motor! It looks like [user.p_theyre()] trying to commit suicide... But [user.p_they()] sputters and stalls out! "))
 		playsound(src, 'sound/misc/sadtrombone.ogg', 50, TRUE, -1)
@@ -43,12 +43,8 @@
 	embed_chance = 30
 	fall_chance = 70
 
-/obj/item/key/janitor/suicide_act(mob/living/carbon/user)
+/obj/item/key/janitor/suicide_act(mob/living/user)
 	switch(user.mind?.get_skill_level(/datum/skill/cleaning))
-		if(SKILL_LEVEL_NONE to SKILL_LEVEL_NOVICE) //Their mind is too weak to ascend as a janny
-			user.visible_message(span_suicide("[user] is putting \the [src] in [user.p_their()] mouth and is trying to become one with the janicart, but has no idea where to start! It looks like [user.p_theyre()] trying to commit suicide!"))
-			user.gib(DROP_ALL_REMAINS)
-			return MANUAL_SUICIDE
 		if(SKILL_LEVEL_APPRENTICE to SKILL_LEVEL_JOURNEYMAN) //At least they tried
 			user.visible_message(span_suicide("[user] is putting \the [src] in [user.p_their()] mouth and has inefficiently become one with the janicart! It looks like [user.p_theyre()] trying to commit suicide!"))
 			user.AddElement(/datum/element/cleaning)
@@ -70,6 +66,11 @@
 				addtimer(CALLBACK(user, TYPE_PROC_REF(/atom, add_atom_colour), (i % 2)? "#a245bb" : "#7a7d82", ADMIN_COLOUR_PRIORITY), i)
 			addtimer(CALLBACK(src, PROC_REF(manual_suicide), user), 151)
 			return MANUAL_SUICIDE
+
+	//Their mind is too weak to ascend as a janny
+	user.visible_message(span_suicide("[user] is putting \the [src] in [user.p_their()] mouth and is trying to become one with the janicart, but has no idea where to start! It looks like [user.p_theyre()] trying to commit suicide!"))
+	user.gib(DROP_ALL_REMAINS)
+	return MANUAL_SUICIDE
 
 /obj/item/key/proc/manual_suicide(mob/living/user)
 	if(user)


### PR DESCRIPTION
## About The Pull Request

This PR moves most of the code for using an item to commit suicide from `human` to `living`, so that anything with hands can use what it is holding to commit suicide.
This was surprisingly painless, as most `suicide_act` procs were already written without the assumption that the person killing themselves was a human even though they couldn't be anything else.

This might occasionally mean that in some cases (like drones) it may reference anatomy that they don't have (like necks) but I think that's not a big deal and don't worry about it.

## Why It's Good For The Game

It's funny.

## Changelog

:cl:
balance: Anything with hands can now use the things it is holding to commit suicide
/:cl:
