### PR TITLE
Raptor eggs no longer hatch into fully grown raptors

### DIFF
--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_egg.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_egg.dm
@@ -47,6 +47,6 @@
 		return
 
 	visible_message(span_notice("[src] hatches with a quiet cracking sound."))
-	new /mob/living/basic/raptor(loc, child_color, inherited_stats)
+	new /mob/living/basic/raptor/baby(loc, child_color, inherited_stats)
 	inherited_stats = null
 	qdel(src)


### PR DESCRIPTION

## About The Pull Request

Closes #94485 

## Changelog
:cl:
fix: Raptor eggs no longer hatch into fully grown raptors
/:cl:
