### PR TITLE
Adds defines for standard lung temperature limits

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -287,7 +287,7 @@
 #define COLD_GAS_DAMAGE_LEVEL_2 1.5 //Amount of damage applied when the current breath's temperature passes the 200K point
 #define COLD_GAS_DAMAGE_LEVEL_3 3 //Amount of damage applied when the current breath's temperature passes the 120K point
 
-/// Theses are for the default lungs
+/// These are for the default lungs
 #define COLD_LEVEL_1_THRESHOLD 260
 #define COLD_LEVEL_2_THRESHOLD 200
 #define COLD_LEVEL_3_THRESHOLD 120

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -269,6 +269,7 @@
 /// Combined brute and burn damage states on a human's head after which they become disfigured
 #define HUMAN_DISFIGURATION_HEAD_DAMAGE_STATES 3
 
+/// Lung temperature defines
 #define HEAT_DAMAGE_LEVEL_1 1 //Amount of damage applied when your body temperature just passes the 360.15k safety point
 #define HEAT_DAMAGE_LEVEL_2 1.5 //Amount of damage applied when your body temperature passes the 400K point
 #define HEAT_DAMAGE_LEVEL_3 4 //Amount of damage applied when your body temperature passes the 460K point and you are on fire
@@ -285,6 +286,14 @@
 #define COLD_GAS_DAMAGE_LEVEL_1 0.5 //Amount of damage applied when the current breath's temperature just passes the 260.15k safety point
 #define COLD_GAS_DAMAGE_LEVEL_2 1.5 //Amount of damage applied when the current breath's temperature passes the 200K point
 #define COLD_GAS_DAMAGE_LEVEL_3 3 //Amount of damage applied when the current breath's temperature passes the 120K point
+
+/// Theses are for the default lungs
+#define COLD_LEVEL_1_THRESHOLD 260
+#define COLD_LEVEL_2_THRESHOLD 200
+#define COLD_LEVEL_3_THRESHOLD 120
+#define HEAT_LEVEL_1_THRESHOLD 360
+#define HEAT_LEVEL_2_THRESHOLD 400
+#define HEAT_LEVEL_3_THRESHOLD 1000
 
 //Brain Damage defines
 #define BRAIN_DAMAGE_MILD 20

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -94,18 +94,18 @@
 	var/tritium_irradiation_probability_max = 60
 
 	var/cold_message = "your face freezing and an icicle forming"
-	var/cold_level_1_threshold = 260
-	var/cold_level_2_threshold = 200
-	var/cold_level_3_threshold = 120
+	var/cold_level_1_threshold = COLD_LEVEL_1_THRESHOLD
+	var/cold_level_2_threshold = COLD_LEVEL_2_THRESHOLD
+	var/cold_level_3_threshold = COLD_LEVEL_3_THRESHOLD
 	var/cold_level_1_damage = COLD_GAS_DAMAGE_LEVEL_1 //Keep in mind with gas damage levels, you can set these to be negative, if you want someone to heal, instead.
 	var/cold_level_2_damage = COLD_GAS_DAMAGE_LEVEL_2
 	var/cold_level_3_damage = COLD_GAS_DAMAGE_LEVEL_3
 	var/cold_damage_type = BURN
 
 	var/hot_message = "your face burning and a searing heat"
-	var/heat_level_1_threshold = 360
-	var/heat_level_2_threshold = 400
-	var/heat_level_3_threshold = 1000
+	var/heat_level_1_threshold = HEAT_LEVEL_1_THRESHOLD
+	var/heat_level_2_threshold = HEAT_LEVEL_2_THRESHOLD
+	var/heat_level_3_threshold = HEAT_LEVEL_3_THRESHOLD
 	var/heat_level_1_damage = HEAT_GAS_DAMAGE_LEVEL_1
 	var/heat_level_2_damage = HEAT_GAS_DAMAGE_LEVEL_2
 	var/heat_level_3_damage = HEAT_GAS_DAMAGE_LEVEL_3
@@ -990,9 +990,9 @@
 	safe_oxygen_min = 13
 	emp_vulnerability = 20
 
-	cold_level_1_threshold = 200
-	cold_level_2_threshold = 140
-	cold_level_3_threshold = 100
+	cold_level_1_threshold = COLD_LEVEL_1_THRESHOLD - 60
+	cold_level_2_threshold = COLD_LEVEL_2_THRESHOLD - 60
+	cold_level_3_threshold = COLD_LEVEL_3_THRESHOLD - 20
 
 /obj/item/organ/lungs/cybernetic/surplus
 	name = "surplus prosthetic lungs"
@@ -1117,8 +1117,8 @@
 	icon_state = "lungs_ethereal"
 	breath_noise = "a low fluorescent hum"
 	heat_level_1_threshold = FIRE_MINIMUM_TEMPERATURE_TO_SPREAD // 150C or 433k, in line with ethereal max safe body temperature
-	heat_level_2_threshold = 473
-	heat_level_3_threshold = 1073
+	heat_level_2_threshold = HEAT_LEVEL_2_THRESHOLD + 73
+	heat_level_3_threshold = HEAT_LEVEL_3_THRESHOLD + 73
 
 /obj/item/organ/lungs/ethereal/ethereal_smoker
 	name = "smoker aeration reticulum"


### PR DESCRIPTION
## About The Pull Request

Lung temperature limits now have #defines and the two lungs that have varying temperature limits now have them written as offsets of the default. Nothing changes in terms of gameplay.

## Why It's Good For The Game

It's easier to read and consistent with how the rest of the code is, like with max health of organs being written as regular max hp * 1.5 instead of 150. 

Yes, I could've just done away with the whole level 1 2 and 3 thing and made it so that lungs just had a heat limit multiplier or something to make it even simpler but that would be a balance change.

## Changelog
