### PR TITLE
Makes miner callouts compatible with pet commands, they start off by default

### DIFF
--- a/code/datums/components/callouts.dm
+++ b/code/datums/components/callouts.dm
@@ -20,13 +20,14 @@
 	/// Cooldown for callouts
 	COOLDOWN_DECLARE(callout_cooldown)
 
-/datum/component/callouts/Initialize(item_slot = null, voiceline = FALSE, radio_prefix = null, examine_text = null)
+/datum/component/callouts/Initialize(item_slot = null, voiceline = FALSE, radio_prefix = null, examine_text = null, active = TRUE)
 	if (!isitem(parent) && !ismob(parent))
 		return COMPONENT_INCOMPATIBLE
 	src.item_slot = item_slot
 	src.voiceline = voiceline
 	src.radio_prefix = radio_prefix
 	src.examine_text = examine_text
+	src.active = active
 
 	if (ismob(parent))
 		cur_user = parent
@@ -122,27 +123,24 @@
 		return
 
 	COOLDOWN_START(src, callout_cooldown, CALLOUT_COOLDOWN)
-	new /obj/effect/temp_visual/callout(get_turf(user), user, selection, clicked_atom)
+	var/obj/effect/temp_visual/point/callout/callout = user.point_at(clicked_atom, TRUE, /obj/effect/temp_visual/point/callout)
+	callout.set_callout(user, selection)
 	SEND_SIGNAL(user, COMSIG_MOB_CREATED_CALLOUT, selection, clicked_atom)
 	if (voiceline)
 		user.say((!isnull(radio_prefix) ? radio_prefix : "") + selection::voiceline, forced = src)
 
-/obj/effect/temp_visual/callout
+/obj/effect/temp_visual/point/callout
 	name = "callout"
 	icon = 'icons/effects/callouts.dmi'
 	icon_state = "point"
-	plane = ABOVE_LIGHTING_PLANE
 	duration = CALLOUT_TIME
 
-/obj/effect/temp_visual/callout/Initialize(mapload, mob/creator, datum/callout_option/callout, atom/target)
-	. = ..()
+/obj/effect/temp_visual/point/callout/proc/set_callout(mob/creator, datum/callout_option/callout)
 	if (isnull(creator))
 		return
 	icon_state = callout::icon_state
 	color = colorize_string(creator.get_voice(), 2, 0.9)
 	update_appearance()
-	var/turf/target_loc = get_turf(target)
-	animate(src, pixel_x = (target_loc.x - loc.x) * ICON_SIZE_X + target.pixel_x, pixel_y = (target_loc.y - loc.y) * ICON_SIZE_Y + target.pixel_y, time = 0.2 SECONDS, easing = SINE_EASING|EASE_OUT)
 
 /datum/callout_option
 	var/name = "ERROR"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -351,7 +351,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/headset/headset_cargo/mining/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/callouts, ITEM_SLOT_EARS, examine_text = span_info("Use ctrl-click to enable or disable callouts."))
+	AddComponent(/datum/component/callouts, ITEM_SLOT_EARS, examine_text = span_info("Use ctrl-click to enable or disable callouts."), active = FALSE)
 
 /obj/item/radio/headset/headset_cargo/mining/equipped(mob/living/carbon/human/user, slot)
 	. = ..()

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -7,7 +7,7 @@
  *
  * Not intended as a replacement for the mob verb
  */
-/atom/movable/proc/point_at(atom/pointed_atom, intentional = FALSE)
+/atom/movable/proc/point_at(atom/pointed_atom, intentional = FALSE, pointer_type = /obj/effect/temp_visual/point)
 	if(!isturf(loc))
 		return FALSE
 
@@ -20,12 +20,12 @@
 		return FALSE
 
 	var/turf/our_tile = get_turf(src)
-	var/obj/visual = new /obj/effect/temp_visual/point(our_tile, invisibility)
+	var/obj/visual = new pointer_type(our_tile, invisibility)
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_POINTED, pointed_atom, visual, intentional)
 
 	animate(visual, pixel_x = (tile.x - our_tile.x) * ICON_SIZE_X + pointed_atom.pixel_x, pixel_y = (tile.y - our_tile.y) * ICON_SIZE_Y + pointed_atom.pixel_y, time = 1.7, easing = EASE_OUT)
-	return TRUE
+	return visual
 
 /mob/point_at(atom/pointed_atom, intentional = FALSE)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Closes #87571

Callouts now use an override of pointing code rather than an entirely separate visual, which means that they can trigger pet commands now.
Also, they start off by default.

## Why It's Good For The Game

Callouts are only useful if you're mining with a buddy, so leaving them off by default is a sensible choice since most of the time that's not the case.

## Changelog
:cl:
qol: Miner callouts are now off by default
fix: Miner callouts can now be used to command pets like regular pointing
/:cl:
