### PR TITLE
[NO GBP] Change ref for GBP and auto changelog checkout

### DIFF
--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Generate App Token
         id: app-token-generation

--- a/.github/workflows/gbp.yml
+++ b/.github/workflows/gbp.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.event.repository.default_branch }}
       - name: Run Auto Labeler
         uses: actions/github-script@v9
         with:
@@ -44,7 +44,7 @@ jobs:
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.event.repository.default_branch }}
       - name: Setup git
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         run: |


### PR DESCRIPTION

## About The Pull Request

Opening #96750 made me realize that using `github.base_ref` will fail if the targeted branch doesn't contain the files referenced later in the workflow (the `gbp-balances` repo is missing all the scripts invoked by those workflows), change the steps to instead check out the default branch of the repo because that makes more sense in the context of what the workflows are doing

## Why It's Good For The Game

Workflows will still work even if the PR targets a branch that doesn't have the scripts

## Changelog

N/A
