### PR TITLE
Fix screentip for shoes not showing

### DIFF
--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -30,6 +30,10 @@
 	var/datum/weakref/our_alert_ref
 	var/footprint_sprite = FOOTPRINT_SPRITE_SHOES
 
+/obj/item/clothing/shoes/Initialize(mapload)
+	. = ..()
+	register_context()
+
 /obj/item/clothing/shoes/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 	context[SCREENTIP_CONTEXT_ALT_RMB] = "Toggle shoes under uniforms"


### PR DESCRIPTION

## About The Pull Request

`register_context()` wasn't being called

## Why It's Good For The Game

Fixes #96743 

## Changelog
:cl:
fix: fixed screentip for shoes not showing
/:cl:
