### PR TITLE
Fixes the random modifiers deathmatch modifier not randomifying your modifiers

### DIFF
--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -530,7 +530,7 @@
 		var/datum/deathmatch_modifier/modifier = GLOB.deathmatch_game.modifiers[pick_n_take(modifiers_pool)]
 		modifier.on_select(lobby)
 		modifier.on_start_game(lobby)
-		lobby += modifier.type
+		lobby.modifiers += modifier.type
 		modifiers_pool -= modifier.blacklisted_modifiers
 		if(!length(modifiers_pool))
 			return


### PR DESCRIPTION

## About The Pull Request

we were adding the modifier to the lobby instead of its modifiers, it'd runtime and you wouldn't get random modifiers
now we du

## Why It's Good For The Game

Random modifiers working is nice

<img width="1600" height="829" alt="image" src="https://github.com/user-attachments/assets/9c26d999-8688-4dff-b839-3b83788077c8" />

Just look at that parapalegic getting rolled.

## Changelog

:cl:
fix: fixed random modifiers not working in deathmatch
/:cl:
