### PR TITLE
Adds a new type of check to turf_peel to confirm reachability

### DIFF
--- a/code/__DEFINES/_helpers.dm
+++ b/code/__DEFINES/_helpers.dm
@@ -52,3 +52,10 @@
 
 /// Abstraction over using mob.client to just check if there's a connected player.
 #define HAS_CONNECTED_PLAYER(mob) (mob.client)
+
+/// uses circle_range_turfs(), turfs are picked purely by distance
+#define TURF_PEEL_RANGE 0
+/// uses circle_view_turfs(), turfs must be within line of sight (blocked by opacity)
+#define TURF_PEEL_VIEW 1
+/// uses circle_reachable_turfs(), turfs must be reachable by movement (blocked by density)
+#define TURF_PEEL_REACHABLE 2

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -362,6 +362,28 @@
 			turfs += checked_turf
 	return turfs
 
+///Returns a list of turfs around a center that can be reached from said center (blocked by density) using a breadth-first flood fill
+/proc/circle_reachable_turfs(turf/center, radius = 3)
+	var/list/turfs = list()
+	var/list/checked = alist(center = TRUE)
+	var/list/current_ring = list(center)
+	for(var/step in 1 to radius)
+		var/list/next_ring = list()
+		for(var/turf/checking as anything in current_ring)
+			for(var/direction in GLOB.alldirs)
+				var/turf/neighbor = get_step(checking, direction)
+				if(!neighbor || checked[neighbor])
+					continue
+				checked[neighbor] = TRUE
+				if(neighbor.is_blocked_turf(exclude_mobs = TRUE))
+					continue
+				next_ring += neighbor
+				turfs += neighbor
+		if(!length(next_ring))
+			break
+		current_ring = next_ring
+	return turfs
+
 ///Returns the list of turfs around the outside of a center based on RANGE_TURFS()
 /proc/border_diamond_range_turfs(atom/center = usr, radius = 3)
 	var/turf/center_turf = get_turf(center)
@@ -513,20 +535,25 @@
  * @params outer_range - The outer range of the cicle to pull from.
  * @params inner_range - The inner range of the circle to NOT pull from.
  * @params center - The center of the circle to pull from, can be an atom (we'll apply get_turf() to it within circle_x_turfs procs.)
- * @params view_based - If TRUE, we'll use circle_view_turfs instead of circle_range_turfs procs.
+ * @params mode - One of TURF_PEEL_RANGE (plain distance, the default), TURF_PEEL_VIEW (blocked by opacity,
+ * via circle_view_turfs), or TURF_PEEL_REACHABLE (blocked by density, via circle_reachable_turfs).
  */
-/proc/turf_peel(outer_range, inner_range, center, view_based = FALSE)
+/proc/turf_peel(outer_range, inner_range, center, mode = TURF_PEEL_RANGE)
 	if(inner_range > outer_range) // If the inner range is larger than the outer range, you're using this wrong.
 		CRASH("Turf peel inner range is larger than outer range!")
 	var/list/peel = list()
 	var/list/outer
 	var/list/inner
-	if(view_based)
-		outer = circle_view_turfs(center, outer_range)
-		inner = circle_view_turfs(center, inner_range)
-	else
-		outer = circle_range_turfs(center, outer_range)
-		inner = circle_range_turfs(center, inner_range)
+	switch(mode)
+		if(TURF_PEEL_VIEW)
+			outer = circle_view_turfs(center, outer_range)
+			inner = circle_view_turfs(center, inner_range)
+		if(TURF_PEEL_REACHABLE)
+			outer = circle_reachable_turfs(get_turf(center), outer_range)
+			inner = circle_reachable_turfs(get_turf(center), inner_range)
+		else
+			outer = circle_range_turfs(center, outer_range)
+			inner = circle_range_turfs(center, inner_range)
 	for(var/turf/possible_spawn as anything in outer)
 		if(possible_spawn in inner)
 			continue

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -362,12 +362,17 @@
 			turfs += checked_turf
 	return turfs
 
-///Returns a list of turfs around a center that can be reached from said center (blocked by density) using a breadth-first flood fill
-/proc/circle_reachable_turfs(turf/center, radius = 3)
+///Returns a list of turfs around a center that can be reached from said center (blocked by density and directional obstacles like windows/windoors) using a breadth-first flood fill.
+///Turfs are matched against the same circular radius used by circle_range_turfs()/circle_view_turfs(), rather than merely the number of steps taken to reach them,
+///since a path detouring around an obstacle can need more steps than a straight line of length radius to reach a turf that is still within the circle.
+/proc/circle_reachable_turfs(turf/center, radius = 3, datum/can_pass_info/pass_info)
 	var/list/turfs = list()
 	var/list/checked = alist(center = TRUE)
 	var/list/current_ring = list(center)
-	for(var/step in 1 to radius)
+	var/rsq = radius * (radius + 0.5)
+	if(!pass_info)
+		pass_info = new(no_id = TRUE)
+	for(var/step in 1 to radius * 2) //extra slack steps allow detouring around obstacles while still bounding the search
 		var/list/next_ring = list()
 		for(var/turf/checking as anything in current_ring)
 			for(var/direction in GLOB.alldirs)
@@ -375,10 +380,13 @@
 				if(!neighbor || checked[neighbor])
 					continue
 				checked[neighbor] = TRUE
-				if(neighbor.is_blocked_turf(exclude_mobs = TRUE))
+				if(neighbor.density || checking.LinkBlockedWithAccess(neighbor, pass_info))
 					continue
 				next_ring += neighbor
-				turfs += neighbor
+				var/dx = neighbor.x - center.x
+				var/dy = neighbor.y - center.y
+				if(dx * dx + dy * dy <= rsq)
+					turfs += neighbor
 		if(!length(next_ring))
 			break
 		current_ring = next_ring

--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -75,7 +75,7 @@
 		if(spawn_distance == 1)
 			created = new chosen_mob_type(spawner.loc)
 		else if(spawn_distance >= 1 && spawn_distance_exclude >= 1)
-			picked_spot = pick(turf_peel(spawn_distance, spawn_distance_exclude, spawner.loc, view_based = TRUE))
+			picked_spot = pick(turf_peel(spawn_distance, spawn_distance_exclude, spawner.loc, mode = TURF_PEEL_REACHABLE))
 			if(!picked_spot)
 				picked_spot = pick(circle_range_turfs(spawner.loc, spawn_distance))
 			if(picked_spot == spawner.loc)


### PR DESCRIPTION

## About The Pull Request

Adds a flood-fill check to turf_peel so instead of just being able to check visibility or distance you can also check whether a path is available (only accounting for density, so not taking in account proper access etc).

## Why It's Good For The Game

Fixes #94870 

## Changelog

:cl:
code: Adds ability to check reachability when using turf_peel
fix: Fixes being able to cheese ore vents
/:cl:
