### PR TITLE
C4 is visible on the floor again

### DIFF
--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -146,6 +146,8 @@
 		thrown_weapon.get_embed()?.embed_chance = 0
 	else if(isliving(bomb_target))
 		plastic_overlay.layer = FLOAT_LAYER
+	else if(isopenturf(bomb_target)) //Render them above open turf layer if theyre open turf
+		plastic_overlay.layer = ABOVE_OPEN_TURF_LAYER
 
 	target.add_overlay(plastic_overlay)
 	to_chat(user, span_notice("You plant the bomb. Timer counting down from [det_time]."))


### PR DESCRIPTION
## About The Pull Request
fixes #95859

Due to planecube (?) we now render floor at layer 10.000

that means c4 was way below the floor and wouldnt show up if you attached it to floro.

I put it on ABOVE_OPEN_TURF_LAYER but there might be a better layer for it?

## Why It's Good For The Game

bro invisible c4 epic prank (caught in 4K) is over. Its probably for the best

## Changelog

:cl: 
fix: C4 no longer renders below floors when placed on floors
/:cl:

