### PR TITLE
Fix Access Management app missing trim access options

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosCard.tsx
+++ b/tgui/packages/tgui/interfaces/NtosCard.tsx
@@ -123,7 +123,7 @@ export const NtosCardContent = (props) => {
                 selectedList={modified_card.access_on_card}
                 wildcardFlags={wildcard_flags}
                 wildcardSlots={modified_card.wildcard_slots}
-                trim_access={modified_card.trim_access}
+                trimAccess={modified_card.trim_access}
                 accessFlags={access_flags}
                 accessFlagNames={access_flag_names}
                 showBasic={!!show_basic}


### PR DESCRIPTION

## About The Pull Request

The component property is `trimAccess` not `trim_access`

## Why It's Good For The Game

Fixes #96603

## Changelog
:cl:
fix: fixed being unable to view/modify trim accesses in Access Management app
/:cl:
