### PR TITLE
Revert "Fix paramedic power crowbar in medical belt" (#96723)

### DIFF
--- a/code/datums/storage/subtypes/belts.dm
+++ b/code/datums/storage/subtypes/belts.dm
@@ -14,7 +14,6 @@
 ///Medical belt
 /datum/storage/medical_belt
 	max_total_storage = 21
-	exception_max = 1
 
 /datum/storage/medical_belt/New(atom/parent, max_slots, max_specific_storage, max_total_storage, rustle_sound, remove_rustle_sound)
 	. = ..()

--- a/code/datums/storage/subtypes/belts.dm
+++ b/code/datums/storage/subtypes/belts.dm
@@ -76,9 +76,6 @@
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tourniquet,
 		/obj/item/wrench/medical,
-	),
-	exception_hold_list = list(
-		/obj/item/crowbar/power/paramedic,
 	))
 
 ///Security belt


### PR DESCRIPTION
## About The Pull Request

I don't think they're supposed to fit in medical belts

## Changelog

:cl: Melbert
del: Fixed jaws of recovery being able to be stored in the paramedic EMT belt
/:cl:
