### PR TITLE
Cleans up some unnecessary bodyshape flags

### DIFF
--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -661,7 +661,6 @@
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	bodyshapes_with_variations = NONE
 
 /obj/item/clothing/suit/costume/soviet
 	name = "soviet armored coat"
@@ -684,7 +683,6 @@
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	bodyshapes_with_variations = NONE
 
 /obj/item/clothing/suit/costume/pg
 	name = "powder ganger jacket"
@@ -693,7 +691,6 @@
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	bodyshapes_with_variations = NONE
 
 /obj/item/clothing/suit/costume/irs
 	name = "internal revenue service jacket"
@@ -702,7 +699,6 @@
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	bodyshapes_with_variations = NONE
 
 /obj/item/clothing/suit/costume/bear_suit
 	name = "bear suit"

--- a/code/modules/clothing/suits/lasertag.dm
+++ b/code/modules/clothing/suits/lasertag.dm
@@ -10,7 +10,6 @@
 	allowed = list (/obj/item/gun/energy/laser/bluetag)
 	resistance_flags = NONE
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	bodyshapes_with_variations = NONE
 
 /obj/item/clothing/suit/bluetag/equipped(mob/equipper, slot)
 	. = ..()
@@ -35,7 +34,6 @@
 	allowed = list (/obj/item/gun/energy/laser/redtag)
 	resistance_flags = NONE
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	bodyshapes_with_variations = NONE
 
 /obj/item/clothing/suit/redtag/equipped(mob/equipper, slot)
 	. = ..()

--- a/code/modules/clothing/suits/moth.dm
+++ b/code/modules/clothing/suits/moth.dm
@@ -35,4 +35,3 @@
 	cold_protection = CHEST|GROIN|ARMS|LEGS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	bodyshapes_with_variations = NONE

--- a/code/modules/clothing/under/jobs/civilian/curator.dm
+++ b/code/modules/clothing/under/jobs/civilian/curator.dm
@@ -19,6 +19,7 @@
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+	bodyshapes_with_variations = NONE
 
 /obj/item/clothing/under/rank/civilian/curator/treasure_hunter
 	name = "treasure hunter uniform"

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -116,7 +116,6 @@
 	alternate_worn_layer = NECK_LAYER
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	bodyshapes_with_variations = NONE
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	heat_protection = CHEST|GROIN|LEGS|ARMS


### PR DESCRIPTION
## About The Pull Request

Was doing a little audit of these `bodyshapes_with_variations` flags, a couple weren't needed because they inherit `NONE` from their parent, and in one case there was a skirt that was missing it (which only has the effect of allowing it to enter `get_bodyshape_icon()`, which it doesn't need to be doing, but otherwise nothing anyone would notice.

## Why It's Good For The Game

Cleaner code

## Changelog

Not player-facing, this doesn't actually affect anything.