### PR TITLE
Small Tweak for Checking Ghost Role Prefs

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -232,9 +232,14 @@
 	candidate.transfer_to(body, force_key_move = TRUE) // yoinks the candidate's client
 	if(ishuman(body))
 		var/mob/living/carbon/human/human_body = body
-		body.client?.prefs.safe_transfer_prefs_to(body)
+		if(should_transfer_prefs_to_body())
+			body.client?.prefs.safe_transfer_prefs_to(body)
 		human_body.dna.remove_all_mutations()
 		human_body.dna.update_dna_identity()
+
+///For when applying prefs to ghost roles will result in unexpected behavior, we can have this return false.
+/datum/dynamic_ruleset/midround/from_ghosts/proc/should_transfer_prefs_to_body()
+	return TRUE
 
 /**
  * Handles making the body for the candidate


### PR DESCRIPTION

## About The Pull Request

Small little proc to check to see if we should apply prefs to a new ghost role body.

## Why It's Good For The Game

Little more flexibility for pulling people into ghost roles, there might be times where applying client preferences could have unintended effects or we just don't want to do it for whatever reason. 


## Changelog
:cl:
code: added an extra check in ghost role prep for skipping preferences being loaded onto a new role's body.
/:cl:
