### PR TITLE
Pipeguns are more lethal. Good luck.

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/junk.dm
+++ b/code/modules/projectiles/ammunition/ballistic/junk.dm
@@ -19,6 +19,7 @@
 		/obj/item/ammo_casing/junk/incendiary = 20,
 		/obj/item/ammo_casing/junk/shock = 20,
 		/obj/item/ammo_casing/junk/hunter = 20,
+		/obj/item/ammo_casing/junk/ants = 20,
 		/obj/item/ammo_casing/junk/phasic = 5,
 		/obj/item/ammo_casing/junk/ripper = 5,
 		/obj/item/ammo_casing/junk/reaper = 1,
@@ -26,6 +27,9 @@
 
 /obj/item/ammo_casing/junk/incendiary
 	projectile_type = /obj/projectile/bullet/incendiary/fire/junk
+
+/obj/item/ammo_casing/junk/ants
+	projectile_type = /obj/projectile/bullet/dart/ants
 
 /obj/item/ammo_casing/junk/phasic
 	projectile_type = /obj/projectile/bullet/junk/phasic

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -301,8 +301,8 @@
 	fire_sound = 'sound/items/weapons/gun/sniper/shot.ogg'
 	custom_materials = list(/datum/material/wood = SHEET_MATERIAL_AMOUNT * 8, /datum/material/iron = SHEET_MATERIAL_AMOUNT * 8, /datum/material/cardboard = SHEET_MATERIAL_AMOUNT)
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun
-
-	projectile_damage_multiplier = 1.35
+	projectile_damage_multiplier = 1.75
+	projectile_speed_multiplier = 1.6
 	obj_flags = UNIQUE_RENAME
 	can_be_sawn_off = FALSE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
@@ -340,7 +340,8 @@
 	worn_icon_state = "gun"
 	custom_materials = list(/datum/material/wood = SHEET_MATERIAL_AMOUNT * 4, /datum/material/iron = SHEET_MATERIAL_AMOUNT * 7, /datum/material/cardboard = SHEET_MATERIAL_AMOUNT)
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun/pistol
-	projectile_damage_multiplier = 0.50
+	projectile_damage_multiplier = 0.625
+	projectile_speed_multiplier = 1
 	spread = 15 //kinda inaccurate
 	burst_size = 3 //but it empties the entire magazine when it fires
 	burst_delay = 0.3 // and by empties, I mean it does it all at once
@@ -362,7 +363,7 @@
 	inhand_icon_state = "regal_pipegun"
 	worn_icon_state = "regal_pipegun"
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun/prime
-	projectile_damage_multiplier = 2
+	projectile_damage_multiplier = 3
 	custom_materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 9.15,
 		/datum/material/wood = SHEET_MATERIAL_AMOUNT *8,

--- a/code/modules/projectiles/projectile/bullets/junk.dm
+++ b/code/modules/projectiles/projectile/bullets/junk.dm
@@ -45,6 +45,16 @@
 	fire_stacks = 5
 	suppressed = SUPPRESSED_NONE
 
+/obj/projectile/bullet/dart/ants
+	name = "a ball of ants"
+	icon_state = "trashball"
+	damage = 40 // Fuck your life.
+	inject_flags = INJECT_CHECK_PENETRATE_THICK // Fuck your modsuit.
+
+/obj/projectile/bullet/dart/ants/Initialize(mapload)
+	. = ..()
+	reagents.add_reagent(/datum/reagent/ants, damage) // Get fucked, asshole. Ants.
+
 /obj/projectile/bullet/junk/phasic
 	name = "junk phasic bullet"
 	icon_state = "gaussphase"

--- a/code/modules/projectiles/projectile/bullets/junk.dm
+++ b/code/modules/projectiles/projectile/bullets/junk.dm
@@ -3,7 +3,7 @@
 /obj/projectile/bullet/junk
 	name = "junk bullet"
 	icon_state = "trashball"
-	damage = 30
+	damage = 40
 	embed_type = /datum/embedding/bullet/junk
 	/// What biotype does our junk projectile especially harm?
 	var/extra_damage_mob_biotypes = MOB_ROBOTIC
@@ -29,7 +29,7 @@
 			living_target.apply_damage(finalized_damage, damagetype = extra_damage_type, def_zone = BODY_ZONE_CHEST, wound_bonus = wound_bonus)
 
 /datum/embedding/bullet/junk
-	embed_chance = 15
+	embed_chance = 30
 	fall_chance = 3
 	jostle_chance = 4
 	ignore_throwspeed_threshold = TRUE
@@ -41,7 +41,7 @@
 
 /obj/projectile/bullet/incendiary/fire/junk
 	name = "burning oil"
-	damage = 30
+	damage = 40
 	fire_stacks = 5
 	suppressed = SUPPRESSED_NONE
 
@@ -53,7 +53,7 @@
 /obj/projectile/bullet/junk/shock
 	name = "bundle of live electrical parts"
 	icon_state = "tesla_projectile"
-	damage = 15
+	damage = 20
 	embed_type = null
 	shrapnel_type = null
 	extra_damage_added_damage = 30
@@ -70,14 +70,14 @@
 	icon_state = "gauss"
 	extra_damage_mob_biotypes = MOB_ROBOTIC | MOB_BEAST | MOB_SPECIAL | MOB_MINING
 	extra_damage_multiplier = 0
-	extra_damage_added_damage = 50
+	extra_damage_added_damage = 80
 
 /obj/projectile/bullet/junk/ripper
 	name = "junk ripper bullet"
 	icon_state = "redtrac"
-	damage = 10
+	damage = 20
 	embed_type = /datum/embedding/bullet/junk/ripper
-	wound_bonus = 10
+	wound_bonus = 20
 	exposed_wound_bonus = 30
 
 /datum/embedding/bullet/junk/ripper


### PR DESCRIPTION

## About The Pull Request

Pipegun: 40 -> 70
Pipegun Prime : 80 -> 120
Pipe Pistol: 15 x 3 -> 25 x 3
Pipe Pistol Prime: LOL-> LMAO

The junk round types have additional adjustments accordingly.

New Junk Round type: Ants

It shoots ants at you. Go fuck yourself.

## Why It's Good For The Game
People are still telling me that the pipegun/pipe pistol is still not worth crafting despite various attempts to improve the means of doing so. Killing people too slowly, it often leaves plenty of time for victims to reverse the attack or simply escape, leaving the intended hit and run playstyle it wishes to encourage too ineffectual.

Therefore, to make it actually an appreciable attack, we have boosted the damage to 'oh God I'm fucking dying RIGHT NOW' tier.

You're welcome.

Ants.

## Changelog
:cl:
balance: The pipegun types now deal more damage. Good luck.
balance: New Junk Round: Sometimes, your pipegun will fire an entire ant colony into your enemies bloodstream. Die, asshole. Ants.
/:cl:
