### PR TITLE
Removes a stray disposals pipe on Catwalk Station

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -85072,7 +85072,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},


### PR DESCRIPTION

## About The Pull Request
This PR removes a singular stray disposals pipe on Catwalk Station.
## Why It's Good For The Game
This pipe overlaps another and anything flushed through gets shot out into a maintenance basketball court.
## Changelog
:cl:
fix: Removed a singular stray disposals pipe on Catwalk Station.
/:cl:
