### PR TITLE
Fixes rain overlay rendering (only) with particle weather enabled

### DIFF
--- a/code/datums/weather/weather_types/rain_storm.dm
+++ b/code/datums/weather/weather_types/rain_storm.dm
@@ -17,7 +17,7 @@
 	end_duration = 30 SECONDS
 
 	// Don't display overlays when using particle weather
-	weather_alpha = 0
+	overlay_planes = list(WEATHER_PLANE)
 
 	weather_duration_lower = 3 MINUTES
 	weather_duration_upper = 5 MINUTES


### PR DESCRIPTION

## About The Pull Request

This achieved opposite of the desired effect, making the overlay render only with the particle weather pref ON, not OFF

## Changelog
:cl:
fix: Fixed rain overlay rendering (only) with particle weather enabled
/:cl:
