### PR TITLE
[NO GBP] fixes hand teleporter being unable to close portals

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -70,8 +70,9 @@
 	return TRUE
 
 /obj/effect/portal/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	if(!Adjacent(user))
+	if(!Adjacent(user) || istype(tool, /obj/item/hand_tele))
 		return ..()
+
 	teleport(user)
 	return ITEM_INTERACT_SUCCESS
 


### PR DESCRIPTION

## About The Pull Request

`item_interaction()` before `interact_with_atom()`, my bad. Wasn't able to test this one because hand teleporters weren't working at all at the time. 

## Why It's Good For The Game

fixes #96775

## Changelog

:cl:

fix: hand teleporters can now close portals

/:cl:
