### PR TITLE
Unsilence `log_mapping` messages in unit tests that don't meet `/datum/unit_test/maptest_log_mapping` criteria

### DIFF
--- a/code/__HELPERS/logging/debug.dm
+++ b/code/__HELPERS/logging/debug.dm
@@ -26,8 +26,14 @@
 /// Logging for mapping errors
 /proc/log_mapping(text, skip_world_log)
 #ifdef UNIT_TESTS
-	GLOB.unit_test_mapping_logs += text
-	return
+	// Only add to fail list if AREACOORD was conveyed, and it's a station or mining z-level.
+	// This is due to mapping errors don't have coords being impossible to diagnose as a unit test,
+	// and various ruins frequently intentionally doing non-standard things.
+	if(GLOB.test_areacoord_regex.Find(text))
+		var/z = text2num(GLOB.test_areacoord_regex.group[1])
+		if(is_station_level(z) || is_mining_level(z))
+			GLOB.unit_test_mapping_logs += text
+			return
 #endif
 #ifdef MAP_TEST
 	message_admins("Mapping: [text]")

--- a/code/_globalvars/_regexes.dm
+++ b/code/_globalvars/_regexes.dm
@@ -21,3 +21,6 @@ GLOBAL_DATUM_INIT(html_tags, /regex, regex(@"<.*?>", "g"))
 GLOBAL_DATUM_INIT(filename_forbidden_chars, /regex, regex(@{""|[\\\n\t/?%*:|<>]|\.\."}, "g"))
 GLOBAL_PROTECT(filename_forbidden_chars)
 // had to use the OR operator for quotes instead of putting them in the character class because it breaks the syntax highlighting otherwise.
+
+//Find AREACOORD() in log_mapping messages
+GLOBAL_DATUM_INIT(test_areacoord_regex, /regex, regex(@"\(-?\d+,-?\d+,(-?\d+)\)"))

--- a/code/modules/unit_tests/mapping.dm
+++ b/code/modules/unit_tests/mapping.dm
@@ -5,16 +5,5 @@
 	priority = TEST_PRE
 
 /datum/unit_test/maptest_log_mapping/Run()
-	var/static/regex/test_areacoord_regex = regex(@"\(-?\d+,-?\d+,(-?\d+)\)")
-
 	for(var/log_entry in GLOB.unit_test_mapping_logs)
-		// Only fail if AREACOORD was conveyed, and it's a station or mining z-level.
-		// This is due to mapping errors don't have coords being impossible to diagnose as a unit test,
-		// and various ruins frequently intentionally doing non-standard things.
-		if(!test_areacoord_regex.Find(log_entry))
-			continue
-		var/z = text2num(test_areacoord_regex.group[1])
-		if(!is_station_level(z) && !is_mining_level(z))
-			continue
-
 		TEST_FAIL(log_entry)


### PR DESCRIPTION

## About The Pull Request

#94688 changed it so that during unit testing, `log_mapping` is silenced completely because the messages are added to the global list that `/datum/unit_test/maptest_log_mapping` later reads from. The problem with this is that the latter unit test has specific criteria for what it'll print out because anything it prints will be counted as a unit test failure (it'll only print if it has coordinates inserted by `AREACOORD` and those coordinates are on a station or mining z level).

That makes sense in the context of whether CI passes, but there's a fair amount of `log_mapping` calls that are either not errors or are errors but don't contain coordinates, and it's still important that we see these messages, just not count them as CI failing. This change ensures anything that will be printed by the unit test doesn't get printed twice, and anything that won't prints like before.

## Why It's Good For The Game

After making this change I immediately saw two mapping errors that were previously silent

## Changelog

N/A
