### PR TITLE
Fix mousetrap beaker assemblies not activating when container is opened

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -355,6 +355,11 @@
 	update_appearance()
 	return TRUE
 
+/obj/item/reagent_containers/cup/on_found(mob/finder)
+	. = ..()
+	if(lid_assembly)
+		lid_assembly.on_found(finder)
+
 /obj/item/reagent_containers/cup/Exited(atom/movable/gone, direction)
 	. = ..()
 	if (gone == lid_assembly)

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -357,8 +357,7 @@
 
 /obj/item/reagent_containers/cup/on_found(mob/finder)
 	. = ..()
-	if(lid_assembly)
-		lid_assembly.on_found(finder)
+	lid_assembly?.on_found(finder)
 
 /obj/item/reagent_containers/cup/Exited(atom/movable/gone, direction)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Beaker needs to pass `on_found` down to the assembly

## Why It's Good For The Game

Fixes #95826 

## Changelog
:cl:
fix: fixed mousetrap beaker assemblies not triggering when container is opened
/:cl:
