### PR TITLE
Add screentips for beaker assemblies

### DIFF
--- a/code/modules/food_and_drinks/machinery/stove.dm
+++ b/code/modules/food_and_drinks/machinery/stove.dm
@@ -52,7 +52,6 @@
 	. = ..()
 	AddElement(/datum/element/cuffable_item)
 	RegisterSignal(src, COMSIG_ATOM_REAGENT_EXAMINE, PROC_REF(reagent_special_examine))
-	register_context()
 
 /obj/item/reagent_containers/cup/soup_pot/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	if(isnull(held_item))

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -53,19 +53,20 @@
 
 /obj/item/reagent_containers/cup/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
-	if(can_lid)
-		if(isnull(held_item))
-			context[SCREENTIP_CONTEXT_ALT_LMB] = lid_assembly ? "Detach assembly" : "Toggle lid"
-			return CONTEXTUAL_SCREENTIP_SET
-		if(isnull(lid_assembly) && istype(held_item, /obj/item/assembly_holder))
-			context[SCREENTIP_CONTEXT_LMB] = "Attach assembly"
-			return CONTEXTUAL_SCREENTIP_SET
-		if(isnull(attached_cell) && !isnull(lid_assembly) && istype(held_item, /obj/item/stock_parts/power_store/cell))
-			context[SCREENTIP_CONTEXT_LMB] = "Attach cell"
-			return CONTEXTUAL_SCREENTIP_SET
-
 	if(cell_wired && held_item.tool_behaviour == TOOL_WIRECUTTER)
 		context[SCREENTIP_CONTEXT_LMB] = "Cut wires"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(!can_lid)
+		return
+	if(isnull(held_item))
+		context[SCREENTIP_CONTEXT_ALT_LMB] = lid_assembly ? "Detach assembly" : "Toggle lid"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(isnull(lid_assembly) && istype(held_item, /obj/item/assembly_holder))
+		context[SCREENTIP_CONTEXT_LMB] = "Attach assembly"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(isnull(attached_cell) && !isnull(lid_assembly) && istype(held_item, /obj/item/stock_parts/power_store/cell))
+		context[SCREENTIP_CONTEXT_LMB] = "Attach cell"
 		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/reagent_containers/cup/examine(mob/user)

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -44,11 +44,29 @@
 	. = ..()
 	if(heatable)
 		AddElement(/datum/element/reagents_item_heatable)
+	register_context()
 
 /obj/item/reagent_containers/cup/Destroy(force)
 	QDEL_NULL(lid_assembly)
 	QDEL_NULL(attached_cell)
 	return ..()
+
+/obj/item/reagent_containers/cup/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(can_lid)
+		if(isnull(held_item))
+			context[SCREENTIP_CONTEXT_ALT_LMB] = lid_assembly ? "Detach assembly" : "Toggle lid"
+			return CONTEXTUAL_SCREENTIP_SET
+		if(isnull(lid_assembly) && istype(held_item, /obj/item/assembly_holder))
+			context[SCREENTIP_CONTEXT_LMB] = "Attach assembly"
+			return CONTEXTUAL_SCREENTIP_SET
+		if(isnull(attached_cell) && !isnull(lid_assembly) && istype(held_item, /obj/item/stock_parts/power_store/cell))
+			context[SCREENTIP_CONTEXT_LMB] = "Attach cell"
+			return CONTEXTUAL_SCREENTIP_SET
+
+	if(cell_wired && held_item.tool_behaviour == TOOL_WIRECUTTER)
+		context[SCREENTIP_CONTEXT_LMB] = "Cut wires"
+		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/reagent_containers/cup/examine(mob/user)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/cups/bottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/bottle.dm
@@ -521,7 +521,6 @@
 
 /obj/item/reagent_containers/cup/bottle/syrup_bottle/Initialize(mapload)
 	. = ..()
-	register_context()
 	// this is not done via initial_reagent_flags because it represents state
 	update_container_flags(SEALED_CONTAINER | TRANSPARENT)
 

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -128,10 +128,6 @@
 	list_reagents = null
 	lid_open = TRUE
 
-/obj/item/reagent_containers/cup/glass/coffee/Initialize(mapload)
-	. = ..()
-	register_context()
-
 /obj/item/reagent_containers/cup/glass/coffee/examine(mob/user)
 	. = ..()
 	. += span_notice("Alt-click to toggle cup lid.")
@@ -440,7 +436,6 @@
 
 /obj/item/reagent_containers/cup/glass/shaker/Initialize(mapload)
 	. = ..()
-	register_context()
 	if(prob(10))
 		name = "\improper Nanotrasen 20th Anniversary Shaker"
 		desc += " It has an emblazoned Nanotrasen logo on it."

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -34,7 +34,6 @@
 	. = ..()
 	var/static/list/recipes =  list(/datum/crafting_recipe/molotov)
 	AddElement(/datum/element/slapcrafting, recipes)
-	register_context()
 	register_item_context()
 
 /obj/item/reagent_containers/cup/glass/bottle/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)


### PR DESCRIPTION

## About The Pull Request

Add screentips for toggling the lid of a beaker and the different parts of building a beaker assembly

## Why It's Good For The Game

I didn't even know you could toggle a lid

## Changelog
:cl:
qol: added screentips for beaker assemblies
/:cl:
