### PR TITLE
Fixes random black siderite/shale tiles appearing after ash storms

### DIFF
--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -234,6 +234,7 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 	floor_variance = 0
 	transform = MAP_SWITCH(TRANSLATE_MATRIX(-8, -8), matrix())
 	smooth_broken = TRUE
+	has_floor_variance = FALSE
 	/// DMI used by unsmoothed turfs for variance
 	var/variant_dmi = null
 	/// Amount of variants this turf has
@@ -259,6 +260,12 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 	if(!smoothing_flags)
 		return
 	underlay_appearance.transform = transform
+
+/turf/open/misc/asteroid/basalt/smooth/refill_dug()
+	dug = FALSE
+	broken = FALSE
+	set_smoothed_icon_state(smoothing_junction)
+	update_appearance()
 
 /turf/open/misc/asteroid/basalt/smooth/siderite
 	name = "siderite floor"


### PR DESCRIPTION

## About The Pull Request
Storms refilling dug siderite/shale floors would create black spots due to refilling assigning base_icon_state to the icon_state without accounting for smoothing that those variants use

<img width="741" height="674" alt="image" src="https://github.com/user-attachments/assets/ae997d8a-46bb-4851-b1c0-6637993fc47b" />

## Changelog
:cl:
fix: Fixed random black siderite/shale tiles appearing after ash storms
/:cl:
