### PR TITLE
Fix flaky hard delete on hearts 

### DIFF
--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -47,7 +47,7 @@
 
 /obj/item/organ/heart/Remove(mob/living/carbon/heartless, special, movement_flags)
 	. = ..()
-	if(!special)
+	if(!special && !QDELETED(src))
 		addtimer(CALLBACK(src, PROC_REF(stop_if_unowned)), 12 SECONDS, TIMER_DELETE_ME)
 	beat = BEAT_NONE
 	owner?.stop_sound_channel(CHANNEL_HEARTBEAT)


### PR DESCRIPTION

## About The Pull Request

#96409 correctly identified the source of the problem, but failed to resolve it because the timer is actually added during qdel, as part of Destroy related organ movement. That means it's already past the point where a delete_me timer would get removed.

## Why It's Good For The Game

Fixes #96458

## Changelog

N/A
