### PR TITLE
Fixes particle weather bleeding through z-levels when different weathers are present

### DIFF
--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -85,17 +85,32 @@
 	// We can actually do this just fine as we do not render anything onto ourselves but our particles
 	add_filter("weather_mask", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(WEATHER_MASK_RENDER_TARGET, offset)))
 
+/atom/movable/screen/plane_master/rendering_plate/particle_weather/Destroy()
+	SSweather.particle_planemasters -= src
+	return ..()
+
 /atom/movable/screen/plane_master/rendering_plate/particle_weather/set_home(datum/plane_master_group/home)
 	. = ..()
 	if(!.)
 		return
 	home.AddComponent(/datum/component/hide_weather_planes, src)
 	RegisterSignal(home, COMSIG_GROUP_HUD_CHANGED, PROC_REF(hud_changed))
+	if (home.our_hud)
+		attach_hud(home.our_hud)
 	update_state(home.our_hud?.mymob)
 
 /atom/movable/screen/plane_master/rendering_plate/particle_weather/proc/hud_changed(datum/source, datum/hud/old_hud, datum/hud/new_hud)
 	SIGNAL_HANDLER
+	if (old_hud)
+		UnregisterSignal(old_hud, COMSIG_HUD_Z_CHANGED)
+	attach_hud(new_hud)
 	update_state(new_hud?.mymob)
+
+/atom/movable/screen/plane_master/rendering_plate/particle_weather/proc/attach_hud(datum/hud/new_hud)
+	RegisterSignal(new_hud, COMSIG_HUD_Z_CHANGED, PROC_REF(z_changed))
+	var/mob/eye = new_hud?.mymob?.client?.eye
+	var/turf/eye_location = get_turf(eye)
+	z_changed(new_hud, eye_location?.z)
 
 /// Updates ourselves based on our mob's preferences state
 /atom/movable/screen/plane_master/rendering_plate/particle_weather/proc/update_state(mob/mymob)
@@ -106,15 +121,35 @@
 		return
 
 	SSweather.particle_planemasters += src
+
+	// Lobby HUDs, we don't care about weather during init anyways
+	if(!SSmapping.initialized)
+		return
+
+	var/list/stack_levels = SSmapping.get_connected_levels(get_turf(mymob.client?.eye || mymob))
 	// And add all ongoing weather to ourselves
 	for (var/holder_offset, holder_list in SSweather.particle_holders)
 		for (var/obj/effect/abstract/weather_holder/holder as anything in holder_list)
-			if (holder.plane == plane)
+			// Only display particles from the same Z-stack as our mob's
+			if (holder.plane == plane && length(holder_list[holder] & stack_levels))
 				vis_contents += holder
 
-/atom/movable/screen/plane_master/rendering_plate/particle_weather/Destroy()
-	SSweather.particle_planemasters -= src
-	return ..()
+/atom/movable/screen/plane_master/rendering_plate/particle_weather/proc/z_changed(datum/source, new_z)
+	SIGNAL_HANDLER
+
+	if(!SSmapping.initialized)
+		return
+
+	var/list/stack_levels = SSmapping.get_connected_levels(new_z)
+	for (var/holder_offset, holder_list in SSweather.particle_holders)
+		for (var/obj/effect/abstract/weather_holder/holder as anything in holder_list)
+			if (holder.plane != plane)
+				continue
+
+			if (length(holder_list[holder] & stack_levels))
+				vis_contents |= holder
+			else
+				vis_contents -= holder
 
 /atom/movable/screen/plane_master/rendering_plate/particle_weather/emissive
 	name = "Emissive Particle Weather Holder Plate"

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -12,7 +12,7 @@ SUBSYSTEM_DEF(weather)
 	var/list/eligible_zlevels = list()
 	/// Used by barometers to know when the next storm is coming
 	var/list/next_hit_by_zlevel = list()
-	/// Alist of all particle holders per Z-stack offset for particle weather to be shown to clients
+	/// Alist of all particle holders per Z-stack offset for particle weather, each particle holder associated with z-levels it should be displayed on, to be shown to clients
 	var/alist/particle_holders = alist()
 	/// List of all RENDER_PLANE_PARTICLE_WEATHER and RENDER_PLANE_EMISSIVE_PARTICLE_WEATHER planes
 	var/list/particle_planemasters = list()
@@ -103,9 +103,19 @@ SUBSYSTEM_DEF(weather)
 		// We add it to vis_contents of planemasters rather than client screen as planemasters already
 		// manage their own visibility based on owner's z level
 		for (var/atom/movable/screen/plane_master/plane_master as anything in particle_planemasters)
+			var/mob/owner = plane_master.home.our_hud?.mymob
+			if (!owner) // Vibecheck
+				continue
+			// Could be caching these per-mob but its basically just a list lookup wrapper
+			var/list/stack_levels = SSmapping.get_connected_levels(get_turf(owner.client?.eye || owner))
 			for (var/obj/effect/abstract/weather_holder/holder as anything in holder_list)
-				if (holder.plane == plane_master.plane)
-					plane_master.vis_contents |= holder
+				if (holder.plane != plane_master.plane)
+					continue
+
+				if (!length(holder_list[holder] & stack_levels))
+					continue
+
+				plane_master.vis_contents |= holder
 
 /datum/controller/subsystem/weather/proc/remove_weather_objects(list/old_holders)
 	for (var/offset in 1 to length(old_holders))

--- a/code/datums/weather/particle_weather.dm
+++ b/code/datums/weather/particle_weather.dm
@@ -28,7 +28,7 @@
 	/// Direction of our wind
 	var/wind_sign = 0
 
-/datum/weather/particle/New(z_levels, list/weather_data)
+/datum/weather/particle/New(list/z_levels, list/weather_data)
 	. = ..()
 	if (isnull(particle_type) && isnull(emissive_type))
 		CRASH("[src] ([type]) attempted to initialize without normal or emissive particle types!")
@@ -39,13 +39,13 @@
 			var/obj/effect/abstract/weather_holder/holder = new()
 			SET_PLANE_W_SCALAR(holder, RENDER_PLANE_PARTICLE_WEATHER, offset)
 			holder.particles = new particle_type()
-			object_list += holder
+			object_list[holder] = impacted_z_levels
 
 		if (emissive_type)
 			var/obj/effect/abstract/weather_holder/holder = new()
 			holder.particles = new emissive_type()
 			SET_PLANE_W_SCALAR(holder, RENDER_PLANE_EMISSIVE_PARTICLE_WEATHER, offset)
-			object_list += holder
+			object_list[holder] = impacted_z_levels
 
 		weather_objects += list(object_list)
 

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -70,7 +70,7 @@
 	/// Areas that are protected and excluded from the affected areas.
 	var/list/protected_areas = list()
 	/// The list of z-levels that this weather is actively affecting
-	VAR_FINAL/impacted_z_levels
+	VAR_FINAL/list/impacted_z_levels
 	/// A weighted list of z-levels impacted by weather, where weights reflect the total turf count on each level
 	VAR_FINAL/list/impacted_z_levels_weighted = list()
 
@@ -137,10 +137,9 @@
 	/// The actual atom that holds our reagents that is held in nullspace
 	var/obj/effect/abstract/weather_reagent_holder
 
-/datum/weather/New(z_levels, list/weather_data)
+/datum/weather/New(list/z_levels, list/weather_data)
 	..()
-
-	impacted_z_levels = z_levels
+	impacted_z_levels = z_levels.Copy()
 	weather_flags = isnull(weather_data?[WEATHER_FORCED_FLAGS]) ? weather_flags : weather_data?[WEATHER_FORCED_FLAGS]
 	turf_thunder_chance = isnull(weather_data?[WEATHER_FORCED_THUNDER]) ? turf_thunder_chance : weather_data?[WEATHER_FORCED_THUNDER]
 	telegraph_duration = isnull(weather_data?[WEATHER_FORCED_TELEGRAPH]) ? telegraph_duration : weather_data?[WEATHER_FORCED_TELEGRAPH]


### PR DESCRIPTION

## About The Pull Request

The original implementation was flawed as it added all particle holders to vis_contents and displayed/masked all of them at once if the z-level had any weather present. This caused "bleed-through" if two z-levels with the same z-stack offset had particle weather running at the same time (such as ash storm on lavaland and a weather anomaly rain on station's first z-level) causing particles from both z-stacks to display on both z-levels. By tracking holder's assigned z-levels we can filter holders not affecting any levels in the current plane z-stack, which solves this issue. There's still the problem of multiple particle weathers running on the same z-level, but this is so insanely rare (and also some other code would break anyways) I don't think its worth currently bothering with as it would require some insane code to resolve.

## Changelog
:cl:
fix: Fixed particle weather bleeding through z-levels when different weathers are present
/:cl:
