### PR TITLE
Fixes character slots not updating

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -146,6 +146,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
+		tainted_character_profiles = TRUE
 		character_preview_view = create_character_preview_view(user)
 		ui = new(user, src, "PreferencesMenu")
 		ui.set_autoupdate(FALSE)
@@ -178,8 +179,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 /datum/preferences/ui_static_data(mob/user)
 	var/list/data = list()
-
-	data["character_profiles"] = create_character_profiles()
 
 	data["character_preview_view"] = character_preview_view.assigned_map
 	data["overflow_role"] = SSjob.get_job_type(SSjob.overflow_role).title

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -96,6 +96,7 @@
 
 /datum/preference_middleware/quirks/on_new_character(mob/user)
 	tainted = TRUE
+	preferences.update_static_data(user, always_instant = TRUE)
 
 /datum/preference_middleware/quirks/proc/give_quirk(list/params, mob/user)
 	var/quirk_name = params["quirk"]

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -444,6 +444,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if (!load_character(new_slot))
 		tainted_character_profiles = TRUE
 		randomise_appearance_prefs()
+		all_quirks = list()
 		read_preference(/datum/preference/name/real_name)
 		recently_updated_keys |= /datum/preference/name/real_name
 		save_character()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -445,7 +445,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		tainted_character_profiles = TRUE
 		randomise_appearance_prefs()
 		all_quirks = list()
-		read_preference(/datum/preference/name/real_name)
 		recently_updated_keys |= /datum/preference/name/real_name
 		save_character()
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -348,6 +348,13 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	var/tree_key = "character[slot]"
 	var/list/save_data = savefile.get_entry(tree_key)
+	if(isnull(save_data))
+		for (var/datum/preference/preference as anything in get_preferences_in_priority_order())
+			if (preference.savefile_identifier != PREFERENCE_CHARACTER)
+				continue
+			value_cache -= preference.type
+		return FALSE
+
 	var/data_validity_integer = check_savedata_version(save_data)
 	if(IS_DATA_OBSOLETE(data_validity_integer)) //fatal, can't load any data
 		return FALSE
@@ -437,6 +444,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if (!load_character(new_slot))
 		tainted_character_profiles = TRUE
 		randomise_appearance_prefs()
+		read_preference(/datum/preference/name/real_name)
+		recently_updated_keys |= /datum/preference/name/real_name
 		save_character()
 
 	for (var/datum/preference_middleware/preference_middleware as anything in middleware)


### PR DESCRIPTION
## About The Pull Request

Moves `"character_profiles"` out of `ui_static_data()`. We already have the `tainted_character_profiles` to prevent unnecessary updates, and this data is not static.

<details><summary>Before, button doesn't update</summary>

<img width="661" height="629" alt="061mR8KEUA" src="https://github.com/user-attachments/assets/4fc362f5-25e8-42a3-a0f0-4e17418506fd" />

</details>

<details><summary>After</summary>

<img width="679" height="639" alt="dreamseeker_vpIRPDgDKp" src="https://github.com/user-attachments/assets/42f5457c-f471-468b-a391-87a8762d44bd" />

</details>

<details><summary>Deletion is functional and updates as well</summary>

<img width="568" height="559" alt="obZYCZ5A1K" src="https://github.com/user-attachments/assets/a5a375fe-84ca-4b52-99fb-095c149a9c4c" />

</details>

<details><summary>Quirks update when switching slots</summary>

<img width="920" height="770" alt="mJJGxYTvPj" src="https://github.com/user-attachments/assets/6260a862-e59d-4fc7-9ff8-3140e7122283" />


</details>


## Why It's Good For The Game

Fixes a bug/oversight

## Changelog

:cl:
fix: in prefs menu, changing your character name will now update your slot button correctly
fix: fixes an issue where switching slots would carry over the quirks of a previous slot until you add or remove a quirk
/:cl:

