### PR TITLE
Blood Brothers Have a 10% chance of allowing a group of 3 again

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -218,6 +218,7 @@
 	if (!new_member.has_antag_datum(/datum/antagonist/brother))
 		add_brother(new_member.current)
 	else
+		// the only place a joining member spends a conversion slot; converts get here via add_brother()
 		set_brothers_left(brothers_left - 1)
 
 /datum/team/brother_team/remove_member(datum/mind/member)
@@ -244,16 +245,17 @@
 		return FALSE
 #endif
 
-	set_brothers_left(brothers_left - 1)
+	// this spends a conversion slot via add_member()
+	if (isnull(new_brother.mind.add_antag_datum(/datum/antagonist/brother, src)))
+		return FALSE
+
 	for (var/datum/mind/brother_mind as anything in members)
 		if (brother_mind == new_brother.mind)
 			continue
 
 		to_chat(brother_mind, span_notice("[span_bold("[new_brother.real_name]")] has been converted to aid you as your brother!"))
-		if (brothers_left == 0)
+		if (brothers_left <= 0)
 			to_chat(brother_mind, span_notice("You cannot recruit any more brothers."))
-
-	new_brother.mind.add_antag_datum(/datum/antagonist/brother, src)
 
 	return TRUE
 

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -246,8 +246,7 @@
 #endif
 
 	// this spends a conversion slot via add_member()
-	if (isnull(new_brother.mind.add_antag_datum(/datum/antagonist/brother, src)))
-		return FALSE
+	new_brother.mind.add_antag_datum(/datum/antagonist/brother, src)
 
 	for (var/datum/mind/brother_mind as anything in members)
 		if (brother_mind == new_brother.mind)


### PR DESCRIPTION

## About The Pull Request
Apropos of a deadchat convo debating whether bloodbrother trios were actually possible.
Yeah, they weren't. https://github.com/tgstation/tgstation/pull/92107 fixed *always* blood brother trios but double-decremented blood brother joiners, making the 10% chance of having a blood brother trio team impossible

## Why It's Good For The Game

Bugs are bad

## Changelog

:cl: PapaMichael
fix: Blood brothers once again have a 10% chance of being able to recruit a team of 3.
/:cl:
