### PR TITLE
Makes necropolis stone tiles un-hittable

### DIFF
--- a/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
@@ -255,6 +255,7 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 	layer = ABOVE_OPEN_TURF_LAYER
 	anchored = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	obj_flags = NONE
 	var/tile_key = "pristine_tile"
 	var/tile_random_sprite_max = 24
 


### PR DESCRIPTION

## About The Pull Request

Removes ``CAN_BE_HIT`` from necropolis stone tiles, preventing them from being attacked with items

## Why It's Good For The Game

They are completely indestructible and are meant to function as decals. Them being hittable results in accidental attacks during fights near/in ruins, which steals players' clicks and is generally very annoying to deal with.

## Changelog
:cl:
qol: Necropolis stone tiles can no longer be hit
/:cl:
