### PR TITLE
Corrects two instances where neckerchief was misspelled.

### DIFF
--- a/code/modules/clothing/masks/bandana.dm
+++ b/code/modules/clothing/masks/bandana.dm
@@ -80,7 +80,7 @@
 	slot_flags = initial(slot_flags)
 	worn_y_offset = initial(worn_y_offset)
 	transform = initial(transform)
-	user.visible_message(span_notice("[user] unties the neckercheif."), span_notice("You untie the neckercheif."))
+	user.visible_message(span_notice("[user] unties the neckerchief."), span_notice("You untie the neckerchief."))
 	flags_inv = initial(flags_inv)
 	flags_cover = initial(flags_cover)
 	return CLICK_ACTION_SUCCESS


### PR DESCRIPTION

## About The Pull Request

This corrects two instances, namely in neckerchief untying, where the object in question was misspelled as "neckerch**ei**f" instead of "neckerch**ie**f".

## Why It's Good For The Game

Things should be spelled correctly.

## Changelog
:cl:
spellcheck: When untying a neckerchief, the item in question will no longer be misspelled as "neckercheif".
/:cl:
