### PR TITLE
Custom materials of turfs and walls are no longer lost on shuttle move.

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -25,6 +25,8 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		copy_to_turf.icon_state = icon_state
 	if(copy_to_turf.icon != icon)
 		copy_to_turf.icon = icon
+	if(length(custom_materials))
+		copy_to_turf.set_custom_materials(custom_materials)
 	if(LAZYLEN(atom_colours))
 		copy_to_turf.atom_colours = atom_colours.Copy()
 		copy_to_turf.update_atom_colour()


### PR DESCRIPTION
## About The Pull Request
No more pizza walls from my funny dimensional theme bombs no longer being pizza when the escape shuttle departs the station or arrives CC

## Why It's Good For The Game
Fixes an issue that has been around ever since custom materials were added.

## Changelog

:cl:
fix: Custom material floors and walls of a shuttle are no longer lost on departure or arrival.
/:cl:
