### PR TITLE
Fixes `update_overlays()` being called by itself

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -113,7 +113,7 @@
 	if(multi_tile)
 		set_bounds()
 		set_filler()
-		update_overlays()
+		update_appearance(UPDATE_OVERLAYS)
 	air_update_turf(TRUE, TRUE)
 	register_context()
 	if(elevator_mode)

--- a/code/game/objects/items/tcg/tcg_machines.dm
+++ b/code/game/objects/items/tcg/tcg_machines.dm
@@ -176,7 +176,7 @@ GLOBAL_LIST_EMPTY(tcgcard_machine_radial_choices)
 	desc = template.desc
 	summon_power = template.power
 	summon_resolve = template.resolve
-	update_overlays()
+	update_appearance(UPDATE_OVERLAYS)
 
 /obj/structure/trading_card_summon/get_name_chaser(mob/user, list/name_chaser = list())
 	name_chaser += "Faction: [template.faction]"
@@ -240,7 +240,7 @@ GLOBAL_LIST_EMPTY(tcgcard_machine_radial_choices)
 		resolve_color = DEFAULT_RESOLVE_COLOR
 	else
 		resolve_color = modified_color
-	update_overlays()
+	update_appearance(UPDATE_OVERLAYS)
 
 /obj/structure/trading_card_summon/Destroy()
 	if(hologram)
@@ -263,7 +263,7 @@ GLOBAL_LIST_EMPTY(tcgcard_machine_radial_choices)
 	hologram.name = name
 	hologram.alpha = 170
 	hologram.add_atom_colour(team_color, FIXED_COLOUR_PRIORITY)
-	update_overlays()
+	update_appearance(UPDATE_OVERLAYS)
 
 /obj/structure/trading_card_summon/blank/get_name_chaser(mob/user, list/name_chaser)
 	name_chaser += "Power/Resolve: [summon_power]/[summon_resolve]"
@@ -272,7 +272,7 @@ GLOBAL_LIST_EMPTY(tcgcard_machine_radial_choices)
 /obj/structure/trading_card_summon/blank/modify_stats(mob/living/user)
 	summon_power = num2text(tgui_input_number(user, "Please input power value", "Stat Modification", text2num(summon_power), 25))
 	summon_resolve = num2text(tgui_input_number(user, "Please input resolve value", "Stat Modification", text2num(summon_resolve), 25))
-	update_overlays()
+	update_appearance(UPDATE_OVERLAYS)
 
 #undef STAT_Y
 #undef POWER_X

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -56,7 +56,7 @@
 /obj/structure/door_assembly/multi_tile/Initialize(mapload)
 	. = ..()
 	set_bounds()
-	update_overlays()
+	update_appearance(UPDATE_OVERLAYS)
 
 /obj/structure/door_assembly/multi_tile/Move()
 	. = ..()

--- a/code/modules/mob/living/basic/blob_minions/blobbernaut.dm
+++ b/code/modules/mob/living/basic/blob_minions/blobbernaut.dm
@@ -54,7 +54,7 @@
 /mob/living/basic/blob_minion/blobbernaut/death(gibbed)
 	flick("[icon_state]_death", src)
 	playsound(src, 'sound/mobs/non-humanoids/blobmob/blobbernaut_death.ogg', 100, TRUE)
-	update_overlays()
+	update_appearance(UPDATE_OVERLAYS)
 	return ..()
 
 /mob/living/basic/blob_minion/blobbernaut/create_mob_hud()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -533,7 +533,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/peppertank, 3
 		else
 			icon_state = "water_cooler"
 
-	update_overlays()
+	update_appearance(UPDATE_OVERLAYS)
 	update_appearance()
 
 ///Creates an empty jug inside of the cooler. Doesn't need to be filled bc it absorbs the cooler's reagent on eject.

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -377,7 +377,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/peppertank, 3
 	if(prob(2) && mapload)
 		reagents.convert_reagent(/datum/reagent/water, /datum/reagent/consumable/fruit_punch)
 	create_jug()
-	refresh_appearance()
+	update_appearance()
 
 /obj/structure/reagent_dispensers/water_cooler/Destroy()
 	. = ..()
@@ -403,7 +403,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/peppertank, 3
 		if(!do_after(user, 5 SECONDS, src))
 			return
 		tipped = FALSE
-		refresh_appearance()
+		update_appearance()
 		return
 
 
@@ -421,6 +421,16 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/peppertank, 3
 	var/obj/item/reagent_containers/cup/glass/sillycup/new_cup = new(get_turf(src))
 	user.put_in_hands(new_cup)
 	paper_cups--
+
+/obj/structure/reagent_dispensers/water_cooler/update_icon_state()
+	. = ..()
+	if(tipped)
+		icon_state = "water_cooler_disgraced"
+	else
+		if(!our_jug)
+			icon_state = "water_cooler_forlorn"
+		else
+			icon_state = "water_cooler"
 
 /obj/structure/reagent_dispensers/water_cooler/update_overlays()
 	. = ..()
@@ -511,7 +521,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/peppertank, 3
 	balloon_alert(user, "attached")
 	user.log_message("attached a [new_jug] to [src] at [AREACOORD(src)] containing ([new_jug.reagents.get_reagent_log_string()])", LOG_ATTACK)
 	add_fingerprint(user)
-	refresh_appearance()
+	update_appearance()
 	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/reagent_dispensers/water_cooler/boom()
@@ -523,18 +533,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/peppertank, 3
 	eject_jug(throw_away = TRUE)
 	playsound(src, 'sound/effects/glass/glassbash.ogg', 100)
 	tip_over()
-
-/obj/structure/reagent_dispensers/water_cooler/proc/refresh_appearance()
-	if(tipped)
-		icon_state = "water_cooler_disgraced"
-	else
-		if(!our_jug)
-			icon_state = "water_cooler_forlorn"
-		else
-			icon_state = "water_cooler"
-
-	update_appearance(UPDATE_OVERLAYS)
-	update_appearance()
 
 ///Creates an empty jug inside of the cooler. Doesn't need to be filled bc it absorbs the cooler's reagent on eject.
 /obj/structure/reagent_dispensers/water_cooler/proc/create_jug()
@@ -558,12 +556,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/peppertank, 3
 		reagents.trans_to(our_jug.reagents, tank_volume)
 
 	our_jug = null
-	refresh_appearance()
+	update_appearance()
 
 ///Handles the visual stuff related to the cooler itself tipping.
 /obj/structure/reagent_dispensers/water_cooler/proc/tip_over()
 	tipped = TRUE
-	refresh_appearance()
+	update_appearance()
 
 ///Pre-tipped version for mapping.
 /obj/structure/reagent_dispensers/water_cooler/fallen

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -256,6 +256,13 @@ if $grep 'var\/(turf|mob|obj|atom\/movable).+ as anything in o?(view|range|heare
 	st=1
 fi;
 
+part "update_overlays() called without using return value"
+if $grep '^\t+update_overlays\(\)$' "${code_files[@]}"; then
+	echo
+	echo -e "${RED}ERROR: update_overlays() is being called without using the return value. Use update_appearance(UPDATE_OVERLAYS) instead if you dont understand what this means.${NC}"
+	st=1
+fi;
+
 part "common spelling mistakes"
 if $grep -i 'centcomm' "${code_files[@]}"; then
 	echo


### PR DESCRIPTION

## About The Pull Request
calling this proc by itself SHOULD do literally nothing as all it does is builds and returns a list of icons

I wonder if this changes anything.
## Changelog
:cl:
code: Ensures some code actually updates overlays instead of return a list of them to nobody
/:cl:
