### PR TITLE
Vending machines tilt after falling a z level

### DIFF
--- a/code/modules/vending/vendor/tilting.dm
+++ b/code/modules/vending/vendor/tilting.dm
@@ -310,3 +310,9 @@
 	var/matrix/to_turn = turn(transform, -tilted_rotation)
 	animate(src, transform = to_turn, 0.2 SECONDS)
 	tilted_rotation = 0
+
+/obj/machinery/vending/onZImpact(turf/impacted_turf, levels, impact_flags)
+	impact_flags |= ZIMPACT_NO_MESSAGE
+	if(fall_and_crush(impacted_turf, squish_damage, paralyze_time = 6 SECONDS, crush_dir = UP, rotation = pick(90, 270)) & SUCCESSFULLY_FELL_OVER)
+		impact_flags |= ZIMPACT_NO_SPIN
+	return ..()


### PR DESCRIPTION
## About The Pull Request

- [x] I tested this pr

After falling a z-level vending machines tilt on the tile they land on, potentially squishing people. They don't roll for crit meaning they can't outright kill you if you're unlucky.

## Why It's Good For The Game

They do NOTHING right now

## Changelog

:cl: Melbert
add: Vending machines tilt after falling a z level
/:cl:
