### PR TITLE
Fix `get_bodyshape_icon` mangling `greyscale_colors`

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -452,7 +452,7 @@ There are several things that need to be remembered:
 	return icon(female_clothing_icon)
 
 /// Modifies a sprite to conform to custom body shapes
-/obj/item/proc/get_bodyshape_icon(icon/base_icon, key, bodyshape)
+/obj/item/proc/get_bodyshape_icon(icon/base_icon, key, greyscale_colors, bodyshape)
 	ASSERT(istext(key), "get_bodyshape_icon: no key passed")
 	if((bodyshape & BODYSHAPE_DIGITIGRADE) && (supports_variations_flags & CLOTHING_DIGITIGRADE_MASK))
 		if(isnull(greyscale_colors) || length(SSgreyscale.ParseColorString(greyscale_colors)) > 1)
@@ -608,6 +608,7 @@ generate/load female uniform sprites matching all previously decided variables
 		building_icon = get_bodyshape_icon(
 			base_icon = building_icon || icon(file2use, t_state),
 			key = "[t_state]-[file2use]-[female_uniform]",
+			greyscale_colors = greyscale_colors,
 			bodyshape = bodyshape,
 		)
 	if(building_icon)


### PR DESCRIPTION

## About The Pull Request

When this was refactored the `greyscale_colors` argument was removed from the proc which was a bad idea because now it's overwriting the object's `greyscale_colors` with the results of `get_general_color`. In items that have multiple greyscale colors this will cause rust-g panics if anything calls `update_greyscale` on it because there's now less colors than expected

## Why It's Good For The Game

Fix oversight

## Changelog

N/A
