### PR TITLE
Character setup prefs for jobs sorts the same as Latejoin

### DIFF
--- a/code/modules/client/preferences/middleware/jobs.dm
+++ b/code/modules/client/preferences/middleware/jobs.dm
@@ -30,6 +30,7 @@
 
 	var/list/departments = list()
 	var/list/jobs = list()
+	var/list/jobs_sorted = list()
 
 	for (var/datum/job/job as anything in SSjob.joinable_occupations)
 		if (job.job_flags & JOB_LATEJOIN_ONLY)
@@ -51,6 +52,9 @@
 				"head" = department_head_type && initial(department_head_type.title),
 			)
 
+		// Use the built in sorting of the main occupation list to keep it sorted how we want instead of asc
+		jobs_sorted += job.title
+
 		jobs[job.title] = list(
 			"description" = job.description,
 			"department" = department_name,
@@ -58,6 +62,7 @@
 
 	data["departments"] = departments
 	data["jobs"] = jobs
+	data["jobs_sorted"] = jobs_sorted
 
 	return data
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/JobsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/JobsPage.tsx
@@ -342,6 +342,11 @@ function JoblessRoleDropdown(props) {
 }
 
 export function JobsPage() {
+  const departmentColumns = [
+    ['Engineering', 'Science', 'Silicon', 'Assistant'],
+    ['Captain', 'Service', 'Cargo'],
+    ['Security', 'Medical'],
+  ];
   return (
     <>
       <JoblessRoleDropdown />
@@ -349,27 +354,20 @@ export function JobsPage() {
         <Stack.Item mt={15}>
           <Stack fill g={1} className="PreferencesMenu__Jobs">
             <Stack.Item>
-              <Stack vertical>
-                <PriorityHeaders />
-                <Department department="Engineering" />
-                <Department department="Science" />
-                <Department department="Silicon" />
-                <Department department="Assistant" />
-              </Stack>
-            </Stack.Item>
-            <Stack.Item mt={-5.9}>
-              <Stack vertical>
-                <PriorityHeaders />
-                <Department department="Captain" />
-                <Department department="Service" />
-                <Department department="Cargo" />
-              </Stack>
-            </Stack.Item>
-            <Stack.Item>
-              <Stack vertical>
-                <PriorityHeaders />
-                <Department department="Security" />
-                <Department department="Medical" />
+              <Stack>
+                {departmentColumns.map((column, columnIndex) => (
+                  <Stack.Item
+                    key={columnIndex}
+                    mt={columnIndex === 1 ? -5.9 : undefined}
+                  >
+                    <Stack vertical>
+                      <PriorityHeaders />
+                      {column.map((department) => (
+                        <Department key={department} department={department} />
+                      ))}
+                    </Stack>
+                  </Stack.Item>
+                ))}
               </Stack>
             </Stack.Item>
           </Stack>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/JobsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/JobsPage.tsx
@@ -13,13 +13,6 @@ import {
 } from '../types';
 import { useServerPrefs } from '../useServerPrefs';
 
-function sortJobs(entries: [string, Job][], head?: string) {
-  return sortBy(entries, [
-    ([key, _]) => (key === head ? -1 : 1),
-    ([key, _]) => key,
-  ]);
-}
-
 const PRIORITY_BUTTON_SIZE = '18px';
 
 type PriorityButtonProps = {
@@ -267,7 +260,7 @@ function Department(props: DepartmentProps) {
   const data = useServerPrefs();
   if (!data) return;
 
-  const { departments, jobs } = data.jobs;
+  const { departments, jobs, jobs_sorted} = data.jobs;
   const department = departments[name];
 
   // This isn't necessarily a bug, it's like this
@@ -278,10 +271,9 @@ function Department(props: DepartmentProps) {
     return null;
   }
 
-  const jobsForDepartment = sortJobs(
-    Object.entries(jobs).filter(([_, job]) => job.department === name),
-    department.head,
-  );
+  const jobsForDepartment = jobs_sorted
+    .map((jobName) => [jobName, jobs[jobName]] as const)
+    .filter(([, job]) => job.department === name);
 
   return (
     <Box>
@@ -342,11 +334,6 @@ function JoblessRoleDropdown(props) {
 }
 
 export function JobsPage() {
-  const departmentColumns = [
-    ['Engineering', 'Science', 'Silicon', 'Assistant'],
-    ['Captain', 'Service', 'Cargo'],
-    ['Security', 'Medical'],
-  ];
   return (
     <>
       <JoblessRoleDropdown />
@@ -354,20 +341,27 @@ export function JobsPage() {
         <Stack.Item mt={15}>
           <Stack fill g={1} className="PreferencesMenu__Jobs">
             <Stack.Item>
-              <Stack>
-                {departmentColumns.map((column, columnIndex) => (
-                  <Stack.Item
-                    key={columnIndex}
-                    mt={columnIndex === 1 ? -5.9 : undefined}
-                  >
-                    <Stack vertical>
-                      <PriorityHeaders />
-                      {column.map((department) => (
-                        <Department key={department} department={department} />
-                      ))}
-                    </Stack>
-                  </Stack.Item>
-                ))}
+              <Stack vertical>
+                <PriorityHeaders />
+                <Department department="Engineering" />
+                <Department department="Science" />
+                <Department department="Silicon" />
+                <Department department="Assistant" />
+              </Stack>
+            </Stack.Item>
+            <Stack.Item mt={-5.9}>
+              <Stack vertical>
+                <PriorityHeaders />
+                <Department department="Captain" />
+                <Department department="Service" />
+                <Department department="Cargo" />
+              </Stack>
+            </Stack.Item>
+            <Stack.Item>
+              <Stack vertical>
+                <PriorityHeaders />
+                <Department department="Security" />
+                <Department department="Medical" />
               </Stack>
             </Stack.Item>
           </Stack>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
@@ -208,6 +208,7 @@ export type ServerData = {
   jobs: {
     departments: Record<string, Department>;
     jobs: Record<string, Job>;
+    jobs_sorted: string[];
   };
   names: {
     types: Record<string, Name>;


### PR DESCRIPTION

## About The Pull Request
This:
<img width="796" height="530" alt="image" src="https://github.com/user-attachments/assets/c9af7f3e-0f5f-48e1-8b25-90e4dcd62e79" />\
To this:
<img width="913" height="481" alt="image" src="https://github.com/user-attachments/assets/0a296c58-1ed0-4711-afaa-580198b27312" />

I didn't sort the departments programmatically as well because I dont know how i want to structure the code because rn its hard-coded and i dont know if i want to keep it like that or not..  I could totally just replicate the late-join menu for this if its desired tho.
<img width="505" height="537" alt="image" src="https://github.com/user-attachments/assets/53606ac2-223d-4bb5-a0b9-47687311720f" />
## Why It's Good For The Game
Stuff like the atmos tech appearing above the engineer- or the food roles or clown+mime not being group- is bad.
## Changelog
:cl:
qol: per department sorting for character setup matches latejoin menu
/:cl:
