### PR TITLE
You can't see out of a perceptomatrix without a core

### DIFF
--- a/code/modules/clothing/head/perceptomatrix.dm
+++ b/code/modules/clothing/head/perceptomatrix.dm
@@ -22,6 +22,7 @@
 	flags_cover = HEADCOVERSEYES|EARS_COVERED
 	flags_inv = HIDEHAIR|HIDEFACE
 	flash_protect = FLASH_PROTECTION_WELDER_SENSITIVE
+	tint = INFINITY
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	equip_sound = 'sound/items/handling/helmet/helmet_equip1.ogg'
 	pickup_sound = 'sound/items/handling/helmet/helmet_pickup1.ogg'
@@ -102,10 +103,12 @@
 		detach_clothing_traits(additional_clothing_traits)
 		QDEL_LIST(active_components)
 		RemoveElement(/datum/element/wearable_client_colour, /datum/client_colour/perceptomatrix, ITEM_SLOT_HEAD, HELMET_TRAIT, forced = TRUE)
+		tint = INFINITY
 		return
 
 	clothing_flags = PERCEPTOMATRIX_ACTIVE_FLAGS
 	attach_clothing_traits(additional_clothing_traits)
+	tint = 0
 
 	// When someone makes TRAIT_DEAF an element, or status effect, or whatever, give this item a way to bypass said deafness.
 	// just blocking future instances of deafness isn't what the item is meant to do but there's no proper way to do it otherwise at the moment.

--- a/code/modules/clothing/head/perceptomatrix.dm
+++ b/code/modules/clothing/head/perceptomatrix.dm
@@ -104,11 +104,13 @@
 		QDEL_LIST(active_components)
 		RemoveElement(/datum/element/wearable_client_colour, /datum/client_colour/perceptomatrix, ITEM_SLOT_HEAD, HELMET_TRAIT, forced = TRUE)
 		tint = INFINITY
+		astype(loc, /mob/living/carbon)?.update_tint()
 		return
 
 	clothing_flags = PERCEPTOMATRIX_ACTIVE_FLAGS
 	attach_clothing_traits(additional_clothing_traits)
 	tint = 0
+	astype(loc, /mob/living/carbon)?.update_tint()
 
 	// When someone makes TRAIT_DEAF an element, or status effect, or whatever, give this item a way to bypass said deafness.
 	// just blocking future instances of deafness isn't what the item is meant to do but there's no proper way to do it otherwise at the moment.


### PR DESCRIPTION

## About The Pull Request

Perceptomatrixes effectively act as a slightly better blindfold when without a core(better flash resist than a blindfold).

## Why It's Good For The Game

Some people started using these for mass printable armored sunglasses a few rounds in a row some time ago and no-downside flash protection is supposed to be limited supply. Also, how would you see out of it? It doesn't have any viewport. It's just a hunk of metal on your head.

## Changelog
:cl:

balance: You can't see out of a perceptomatrix without a core

/:cl:
