### PR TITLE
Glorf tweaks (knockdowns no longer trigger glorf 100% of the time)

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -49,7 +49,7 @@
 
 	var/mob/living/carbon/human/human = owner
 	if(istype(human) && prob(force_say_chance) && (duration >= 6 SECONDS || (duration >= 2 SECONDS && prob(66))) )
-		human.force_say(alter_phrases, immediate = TRUE, major = (duration >= 1 MINUTES))
+		human.force_say(alter_phrases, immediate = TRUE, major = (duration >= 30 SECONDS))
 
 //STUN
 /datum/status_effect/incapacitating/stun

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -16,7 +16,7 @@
 	remove_on_fullheal = TRUE
 	heal_flag_necessary = HEAL_CC_STATUS
 	/// Chance of triggering a force_say
-	var/force_say_chance = 50
+	var/force_say_chance = 66
 	/// If TRUE we run update_stat on apply/remove
 	var/needs_update_stat = FALSE
 	/// Suffixes attached to the force_say when applied, uses the "hurt" suffixes by default

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -48,7 +48,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 
 	var/mob/living/carbon/human/human = owner
-	if(istype(human) && prob(force_say_chance) && (duration >= 6 SECONDS || (duration >= 3 SECONDS && prob(66))) )
+	if(istype(human) && prob(force_say_chance) && (duration >= 6 SECONDS || (duration >= 2 SECONDS && prob(66))) )
 		human.force_say(alter_phrases, immediate = TRUE, major = (duration >= 1 MINUTES))
 
 //STUN

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -15,6 +15,9 @@
 	processing_speed = STATUS_EFFECT_PRIORITY
 	remove_on_fullheal = TRUE
 	heal_flag_necessary = HEAL_CC_STATUS
+	/// Chance of triggering a force_say
+	var/force_say_chance = 50
+	/// If TRUE we run update_stat on apply/remove
 	var/needs_update_stat = FALSE
 	/// Suffixes attached to the force_say when applied, uses the "hurt" suffixes by default
 	var/list/alter_phrases
@@ -39,14 +42,14 @@
 	if(!.)
 		return
 
-	force_say()
+	try_force_say()
 
-/datum/status_effect/incapacitating/proc/force_say()
+/datum/status_effect/incapacitating/proc/try_force_say()
 	SHOULD_CALL_PARENT(TRUE)
 
 	var/mob/living/carbon/human/human = owner
-	if(istype(human))
-		human.force_say(alter_phrases, immediate = TRUE)
+	if(istype(human) && prob(force_say_chance) && (duration >= 6 SECONDS || (duration >= 3 SECONDS && prob(33))) )
+		human.force_say(alter_phrases, immediate = TRUE, major = (duration >= 1 MINUTES))
 
 //STUN
 /datum/status_effect/incapacitating/stun
@@ -80,6 +83,7 @@
 //IMMOBILIZED
 /datum/status_effect/incapacitating/immobilized
 	id = "immobilized"
+	force_say_chance = 0
 
 /datum/status_effect/incapacitating/immobilized/on_apply()
 	. = ..()
@@ -111,6 +115,7 @@
 /// This status effect represents anything that leaves a character unable to perform basic tasks (interrupting do-afters, for example), but doesn't incapacitate them further than that (no stuns etc..)
 /datum/status_effect/incapacitating/incapacitated
 	id = "incapacitated"
+	force_say_chance = 0
 
 // What happens when you get the incapacitated status. You get TRAIT_INCAPACITATED added to you for the duration of the status effect.
 /datum/status_effect/incapacitating/incapacitated/on_apply()
@@ -129,6 +134,7 @@
 /datum/status_effect/incapacitating/unconscious
 	id = "unconscious"
 	needs_update_stat = TRUE
+	force_say_chance = 100
 
 /datum/status_effect/incapacitating/unconscious/on_apply()
 	. = ..()
@@ -152,6 +158,7 @@
 	needs_update_stat = TRUE
 	tick_interval = 2 SECONDS
 	alter_phrases = list("Zzz...", "ZZz...", "ZZZ...", "zzZ...", "zZZ...", "ZzZ...", "zzz...", "zZz...", "mimimimimimi...")
+	force_say_chance = 100
 
 /datum/status_effect/incapacitating/sleeping/on_apply()
 	. = ..()
@@ -171,9 +178,9 @@
 		tick_interval = initial(tick_interval)
 	return ..()
 
-/datum/status_effect/incapacitating/sleeping/force_say()
+/datum/status_effect/incapacitating/sleeping/try_force_say()
 	if(!HAS_TRAIT(owner, TRAIT_SLEEPIMMUNE))
-		..()
+		return ..()
 
 ///If the mob is sleeping and gain the TRAIT_SLEEPIMMUNE we remove the TRAIT_KNOCKEDOUT and stop the tick() from happening
 /datum/status_effect/incapacitating/sleeping/proc/on_owner_insomniac(mob/living/source)

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -48,7 +48,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 
 	var/mob/living/carbon/human/human = owner
-	if(istype(human) && prob(force_say_chance) && (duration >= 6 SECONDS || (duration >= 3 SECONDS && prob(33))) )
+	if(istype(human) && prob(force_say_chance) && (duration >= 6 SECONDS || (duration >= 3 SECONDS && prob(66))) )
 		human.force_say(alter_phrases, immediate = TRUE, major = (duration >= 1 MINUTES))
 
 //STUN

--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -315,8 +315,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	QDEL_NULL(mob_smoke)
 	how_long_have_we_been_smokin = 0 SECONDS
 
-/obj/item/cigarette/proc/on_forcesay(mob/living/source)
+/obj/item/cigarette/proc/on_forcesay(mob/living/source, major)
 	SIGNAL_HANDLER
+
+	if(!major)
+		return
 	source.apply_status_effect(/datum/status_effect/choke, src, lit, choke_forever ? -1 : rand(25 SECONDS, choke_time_max))
 
 /obj/item/cigarette/proc/on_mob_dir_change(mob/living/source, old_dir, new_dir)

--- a/code/game/objects/items/weaponry/melee/baton.dm
+++ b/code/game/objects/items/weaponry/melee/baton.dm
@@ -33,8 +33,6 @@
 	var/stun_armour_penetration = 15 // pens very light / cosmetic armor
 	/// What armor does our stun attack check before delivering the attack?
 	var/armour_type_against_stun = MELEE
-	/// Chance of causing force_say() when stunning a human mob
-	var/force_say_chance = 33
 	/// Can we stun cyborgs?
 	var/affect_cyborg = FALSE
 	/// The path of the default sound to play when we stun something.
@@ -255,10 +253,6 @@
 		target.Paralyze((isnull(stun_override) ? stun_time_cyborg : stun_override) * (trait_check ? 0.1 : 1))
 		additional_effects_cyborg(target, user)
 	else
-		if(ishuman(target))
-			var/mob/living/carbon/human/human_target = target
-			if(prob(force_say_chance))
-				human_target.force_say()
 		var/armour_block = target.run_armor_check(BODY_ZONE_CHEST, armour_type_against_stun, null, null, stun_armour_penetration)
 		target.apply_damage(stamina_damage, STAMINA, blocked = armour_block)
 		if(!trait_check)
@@ -435,7 +429,6 @@
 	item_flags = NONE
 	force = 5
 	cooldown = 2.5 SECONDS
-	force_say_chance = 80 //very high force say chance because it's funny
 	stamina_damage = 85
 	stun_armour_penetration = 30 // strong enough to pen sec armor
 	clumsy_knockdown_time = 24 SECONDS
@@ -470,7 +463,6 @@
 	attack_verb_simple = list("beat")
 	armor_type = /datum/armor/baton_security
 	throwforce = 7
-	force_say_chance = 50
 	stamina_damage = 60
 	armour_type_against_stun = ENERGY
 	knockdown_time = 5 SECONDS

--- a/code/game/objects/items/weaponry/melee/baton.dm
+++ b/code/game/objects/items/weaponry/melee/baton.dm
@@ -33,6 +33,8 @@
 	var/stun_armour_penetration = 15 // pens very light / cosmetic armor
 	/// What armor does our stun attack check before delivering the attack?
 	var/armour_type_against_stun = MELEE
+	/// Chance of causing force_say() when stunning a human mob
+	var/force_say_chance = 33
 	/// Can we stun cyborgs?
 	var/affect_cyborg = FALSE
 	/// The path of the default sound to play when we stun something.
@@ -253,6 +255,10 @@
 		target.Paralyze((isnull(stun_override) ? stun_time_cyborg : stun_override) * (trait_check ? 0.1 : 1))
 		additional_effects_cyborg(target, user)
 	else
+		if(ishuman(target))
+			var/mob/living/carbon/human/human_target = target
+			if(prob(force_say_chance))
+				human_target.force_say()
 		var/armour_block = target.run_armor_check(BODY_ZONE_CHEST, armour_type_against_stun, null, null, stun_armour_penetration)
 		target.apply_damage(stamina_damage, STAMINA, blocked = armour_block)
 		if(!trait_check)
@@ -429,6 +435,7 @@
 	item_flags = NONE
 	force = 5
 	cooldown = 2.5 SECONDS
+	force_say_chance = 80 //very high force say chance because it's funny
 	stamina_damage = 85
 	stun_armour_penetration = 30 // strong enough to pen sec armor
 	clumsy_knockdown_time = 24 SECONDS
@@ -463,6 +470,7 @@
 	attack_verb_simple = list("beat")
 	armor_type = /datum/armor/baton_security
 	throwforce = 7
+	force_say_chance = 50
 	stamina_damage = 60
 	armour_type_against_stun = ENERGY
 	knockdown_time = 5 SECONDS

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -893,14 +893,14 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/kicking = (atk_effect == ATTACK_EFFECT_KICK)
 	var/final_armor_block = armor_block
 	if(kicking || grappled) //kicks and punches when grappling bypass armor slightly.
-		if(damage >= 9)
+		if(damage >= 12 || (damage >= 9 && prob(66)))
 			target.force_say()
 		log_combat(user, target, grappled ? "grapple punched" : "kicked")
 		final_armor_block -= limb_accuracy
 		target.apply_damage(damage, attack_type, affecting, final_armor_block, attack_direction = attack_direction, sharpness = limb_sharpness)
 	else // Normal attacks do not gain the benefit of armor penetration.
 		target.apply_damage(damage, attack_type, affecting, armor_block, attack_direction = attack_direction, sharpness = limb_sharpness)
-		if(damage >= 9)
+		if(damage >= 12 || (damage >= 9 && prob(66)))
 			target.force_say()
 		log_combat(user, target, "punched")
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_EMPTY(dead_players_during_shift)
 	human_heart?.beat = BEAT_NONE
 	human_heart?.Stop()
 
-	force_say(immediate = TRUE)
+	force_say(list(""), immediate = TRUE)
 
 	. = ..()
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -823,6 +823,9 @@
 				span_userdanger("You[knocked_down ? "'re knocked down" : " resist falling down"] from a shove by [name]!"), span_hear("You hear aggressive shuffling [knocked_down ? "followed by a loud thud!" : ""]"), COMBAT_MESSAGE_RANGE, src)
 			to_chat(src, span_danger("You shove [target.name][knocked_down ? ", knocking [target.p_them()] down" : ""]!"))
 			log_combat(src, target, "shoved", "[knocked_down ? "knocking them down[weapon ? " with [weapon]" : ""]" : ""]")
+			if(ishuman(target))
+				var/mob/living/carbon/human/human_target = target
+				human_target.force_say()
 			return
 
 	if(shove_flags & SHOVE_CAN_KICK_SIDE) //KICK HIM IN THE NUTS

--- a/code/modules/tgui_input/say_modal/modal.dm
+++ b/code/modules/tgui_input/say_modal/modal.dm
@@ -92,6 +92,7 @@
 	if(!payload?["channel"])
 		CRASH("No channel provided to an open TGUI-Say")
 	window_open = TRUE
+	saved_text = ""
 	if(payload["channel"] != OOC_CHANNEL && payload["channel"] != ADMIN_CHANNEL && payload["channel"] != PRAY_CHANNEL)
 		start_thinking()
 	if(!client.typing_indicators)

--- a/code/modules/tgui_input/say_modal/speech.dm
+++ b/code/modules/tgui_input/say_modal/speech.dm
@@ -87,10 +87,11 @@
 /**
  * Makes the player force say what's in their current input box.
  * Arguments:
- * 	alter_phrases - Optional list of alternate suffixes to blurt out
- * 	immediate - If [TRUE], the say must be invoked inline due to side effects that may cause the mob to be unable to speak
+ * * alter_phrases - Optional list of alternate suffixes to blurt out
+ * * immediate - If [TRUE], the say must be invoked inline due to side effects that may cause the mob to be unable to speak
+ * * major - If [TRUE], a "major action" triggered the force say, which may have additional side effects
  */
-/mob/living/carbon/human/proc/force_say(list/alter_phrases = null, immediate = FALSE)
+/mob/living/carbon/human/proc/force_say(list/alter_phrases = null, immediate = FALSE, major = TRUE)
 	if(stat != CONSCIOUS || !client?.tgui_say?.window_open)
 		return FALSE
 	client.tgui_say.force_say(alter_phrases, immediate)
@@ -98,7 +99,7 @@
 		log_speech_indicators("[key_name(client)] FORCED to stop typing, indicators enabled.")
 	else
 		log_speech_indicators("[key_name(client)] FORCED to stop typing, indicators DISABLED.")
-	SEND_SIGNAL(src, COMSIG_HUMAN_FORCESAY)
+	SEND_SIGNAL(src, COMSIG_HUMAN_FORCESAY, major)
 
 /**
  * Gets whatever text is currently in this mob's say box and returns it.


### PR DESCRIPTION
## About The Pull Request

- Knockdown, Stun, and Paralyze now have a 66% change to trigger glorf by default (down from 100%)
- Immobilize and Incapacitating now has a 0% chance to trigger glorf (down from 100%)
- Sleep and Unconscious still has a 100% chance to trigger glorf 
- A second roll is made depending on severity of the effect: >6 second stuns have a 100% chance, >2 second stuns have a 66% chance, <2 second stuns have a 0% chance
- Disarm knockdowns will always trigger a glorf (they are unaffected by the aforementioned changes)
- All forms of incapacitation induced glorfing will no longer cause cigarette choking unless the effect was of >30 second duration
- Modified chance to glorf on punched from 100% if above 9 force to 66% if above 9 force or 100% if above 12 force
- Fixed a bug where getting glorfed right after you open the chat window but before you type anything forces the last message to be repeated
- Changed the glorf effects on death to cut off abruptly rather than append something

<img width="365" height="37" alt="image" src="https://github.com/user-attachments/assets/85c963f4-72f0-4cf5-b919-e4570bfe159b" />

## Why It's Good For The Game

We use microstuns for temporary effects in many places (such as a 0.1 second immobilize on shuttle transition), which is cool and good, but these microstuns will constantly trigger glorfing (which is mildly annoying) and cigarette choking (which is literally lethal) 

As funny as it is the first time to die to choking on a cigarette because you smoked while a shuttle moved, it gets tiresome fast

Ultimately my changes here sought to make force say trigger a bit less consistently, to keep the jokes from being ran into the ground and make it a bit less unfun to play around

## Changelog

:cl: Melbert
balance: Knockdown, stun, and paralyze now have a 66% chance to interrupt speech (down from 100%)
balance: Immobilize and Incapacitate now has a 0% chance to trigger interrupt speech (down from 100%)
balance: Sleep and Unconscious still has a 100% chance to trigger interrupt speech
balance: Chance to interrupt speech from a stun makes a second roll based on stun severity: >6 second stuns have a 100% chance, >2 second stuns have a 66% chance, and <2 second stuns have a 0% chance
balance: Shove knockdown is unaffected by these changes, and always interrupts speech
balance: Having speech interrupted from stuns no longer causes you to choke on cigarettes unless the stun effect was high severity (>30 seconds)
balance: Chance of interrupting speech on punch was modified from 100% at 9 damage to 66% at 9 damage and 100% at 12 damage
fix: When your speech is interrupted from death, it now cuts off abruptly, rather than appending a generic interrupt indicator
fix: Fixed a bug where you repeat your last said line if your speech is interrupted after opening your say box, but before typing anything
/:cl:
