### PR TITLE
Makes tendril special mob

### DIFF
--- a/code/modules/mob/living/basic/lavaland/tendril/tendril.dm
+++ b/code/modules/mob/living/basic/lavaland/tendril/tendril.dm
@@ -13,7 +13,7 @@ GLOBAL_LIST_INIT(tendrils, list())
 	pixel_w = -8
 	base_pixel_w = -8
 	status_flags = NONE
-	mob_biotypes = MOB_ORGANIC | MOB_SKELETAL | MOB_MINING
+	mob_biotypes = MOB_ORGANIC | MOB_SKELETAL | MOB_MINING | MOB_SPECIAL
 	basic_mob_flags = DEL_ON_DEATH | IMMUNE_TO_FISTS
 	mob_size = MOB_SIZE_HUGE
 	maxHealth = 800


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

to prevent shit like making infinite necropolis chests with black regenerative extract from xenobio and possibly other wacky interactions

## Changelog

:cl:
fix: Fixed players being able to turn into tendril/dupe necrochests from it by turning it into MOB_SPECIAL biotype.
/:cl: