### PR TITLE
Saves the AI's previous cam when tracking

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_camera.dm
+++ b/code/__DEFINES/dcs/signals/signals_camera.dm
@@ -1,4 +1,6 @@
 ///Signal sent when a /datum/trackable found a target: (mob/living/target)
 #define COMSIG_TRACKABLE_TRACKING_TARGET "comsig_trackable_tracking_target"
+///Signal sent when a /datum/trackable begins tracking a new target, before any eye movement: (mob/living/target)
+#define COMSIG_TRACKABLE_TRACKING_STARTED "comsig_trackable_tracking_started"
 ///Signal sent when the mob a /datum/trackable is actively following changes glide size: mob/living/target, new_glide_size)
 #define COMSIG_TRACKABLE_GLIDE_CHANGED "comsig_trackable_glide_changed"

--- a/code/game/machinery/camera/trackable.dm
+++ b/code/game/machinery/camera/trackable.dm
@@ -72,6 +72,7 @@
 		return
 	tracked_mob = track
 	if(tracked_mob)
+		SEND_SIGNAL(src, COMSIG_TRACKABLE_TRACKING_STARTED, tracked_mob)
 		RegisterSignal(tracked_mob, COMSIG_QDELETING, PROC_REF(target_deleted))
 		RegisterSignal(tracked_mob, COMSIG_MOVABLE_MOVED, PROC_REF(target_moved))
 		RegisterSignal(tracked_mob, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, PROC_REF(glide_size_changed))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -91,6 +91,7 @@
 	RegisterSignal(alert_control.listener, COMSIG_ALARM_LISTENER_CLEARED, PROC_REF(alarm_cleared))
 
 	ai_tracking_tool = new(src)
+	RegisterSignal(ai_tracking_tool, COMSIG_TRACKABLE_TRACKING_STARTED, PROC_REF(on_track_started))
 	RegisterSignal(ai_tracking_tool, COMSIG_TRACKABLE_TRACKING_TARGET, PROC_REF(on_track_target))
 	RegisterSignal(ai_tracking_tool, COMSIG_TRACKABLE_GLIDE_CHANGED, PROC_REF(tracked_glidesize_changed))
 
@@ -330,6 +331,12 @@ GAME_VERB_DESC(/mob/living/silicon/ai, pick_status_display, "Set AI Status Displ
 GAME_VERB_HIDDEN(/mob/living/silicon/ai, ai_camera_track, "track") //Don't display it on the verb lists. This verb exists purely so you can type "track Oldman Robustin" and follow his ass
 
 	ai_tracking_tool.track_input(src)
+
+///Called when an AI starts tracking a new target, before the eye moves. Saves the return point for the "last camera" hotkey.
+/mob/living/silicon/ai/proc/on_track_started(datum/trackable/source, mob/living/target)
+	SIGNAL_HANDLER
+	if(eyeobj)
+		cam_prev = get_turf(eyeobj)
 
 ///Called when an AI finds their tracking target.
 /mob/living/silicon/ai/proc/on_track_target(datum/trackable/source, mob/living/target)


### PR DESCRIPTION
## About The Pull Request

The AI currently saves `cam_prev` whenever you jump to a cam with a hotkey, so you can press 0 to instantly jump back to where you were looking before. 
This PR also sets `cam_prev` when tracking a mob.

## Why It's Good For The Game

Huge QOL for the role. Whenever a human asks you to open a door, you can click their name, open their stupid door, press 0 and be right back looking at what you were before.

## Changelog


:cl: PapaMichael
qol: AIs save their "previous camera" (accessed by pressing the '0' key) when tracking a mob.
/:cl: