### PR TITLE
fix important oversight in death commando names

### DIFF
--- a/strings/names/death_commando.txt
+++ b/strings/names/death_commando.txt
@@ -43,7 +43,7 @@ Killiam Shakespeare
 Killing McKillingalot
 Lance Killiam
 Leonardo Da Viking
-Lump Beefrock
+Lump Beefbroth
 Lunge Crushheel
 Max Pain
 Maximilian Murderface


### PR DESCRIPTION

## About The Pull Request
Corrects a mistake in a death commando name.
## Why It's Good For The Game
Death commando names are derived from https://www.youtube.com/watch?v=RFHlJ2voJHY
It can clearly be heard (at 0:58) that the name said is "Lump Beefbroth" not "Lump Beefrock". This is an oversight in a very important part of the codebase.
## Changelog
:cl:
fix: Fixed mistake in death commando names.
/:cl:
