### PR TITLE
Stops race blood decal race condition + hard delete

### DIFF
--- a/code/game/objects/effects/decals/cleanable/blood.dm
+++ b/code/game/objects/effects/decals/cleanable/blood.dm
@@ -50,6 +50,8 @@
 				can_hold_viruses = TRUE
 				break
 	. = ..(diseases = can_hold_viruses ? diseases : null)
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	if(islist(blood_or_dna))
 		add_blood_DNA(blood_or_dna)
 	else if(istype(blood_or_dna, /datum/blood_type))

--- a/code/game/objects/effects/decals/cleanable/mess.dm
+++ b/code/game/objects/effects/decals/cleanable/mess.dm
@@ -41,6 +41,8 @@
 
 /obj/effect/decal/cleanable/glass/Initialize(mapload)
 	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	setDir(pick(GLOB.cardinals))
 
 /obj/effect/decal/cleanable/glass/ex_act()
@@ -142,6 +144,8 @@
 
 /obj/effect/decal/cleanable/greenglow/radioactive/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	AddComponent(
 		/datum/component/radioactive_emitter, \
 		cooldown_time = 5 SECONDS, \

--- a/code/game/objects/effects/decals/cleanable/mess.dm
+++ b/code/game/objects/effects/decals/cleanable/mess.dm
@@ -77,6 +77,8 @@
 
 /obj/effect/decal/cleanable/dirt/Initialize(mapload)
 	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	icon_state = pick("dirt-flat-0","dirt-flat-1","dirt-flat-2","dirt-flat-3")
 	var/obj/structure/broken_flooring/broken_flooring = locate(/obj/structure/broken_flooring) in loc
 	if(!isnull(broken_flooring))

--- a/code/game/objects/effects/decals/cleanable/mess.dm
+++ b/code/game/objects/effects/decals/cleanable/mess.dm
@@ -230,6 +230,8 @@ GLOBAL_LIST_EMPTY(nebula_vomits)
 
 /obj/effect/decal/cleanable/vomit/nebula/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	update_appearance(UPDATE_OVERLAYS)
 	GLOB.nebula_vomits += src
 
@@ -247,6 +249,8 @@ GLOBAL_LIST_EMPTY(nebula_vomits)
 
 /obj/effect/decal/cleanable/vomit/nebula/worms/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	for (var/i in 1 to rand(2, 3))
 		new /mob/living/basic/hivelord_brood(loc)
 
@@ -256,6 +260,8 @@ GLOBAL_LIST_EMPTY(nebula_vomits)
 
 /obj/effect/decal/cleanable/vomit/old/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	icon_state += "-old"
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_SLUDGE, CELL_VIRUS_TABLE_GENERIC, rand(2,4), 10)
 
@@ -304,6 +310,8 @@ GLOBAL_LIST_EMPTY(nebula_vomits)
 
 /obj/effect/decal/cleanable/glitter/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	add_overlay(mutable_appearance('icons/effects/glitter.dmi', "glitter_sparkle[rand(1,9)]", appearance_flags = EMISSIVE_APPEARANCE_FLAGS))
 
 /obj/effect/decal/cleanable/plasma
@@ -366,6 +374,8 @@ GLOBAL_LIST_EMPTY(nebula_vomits)
 
 /obj/effect/decal/cleanable/garbage/Initialize(mapload)
 	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_SLUDGE, CELL_VIRUS_TABLE_GENERIC, rand(2,4), 15)
 
 /obj/effect/decal/cleanable/rubble
@@ -382,6 +392,8 @@ GLOBAL_LIST_EMPTY(nebula_vomits)
 
 /obj/effect/decal/cleanable/rubble/Initialize(mapload)
 	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	flick("rubble_bounce", src)
 	icon_state = "rubble"
 	update_appearance(UPDATE_ICON_STATE)


### PR DESCRIPTION
## About The Pull Request

<img width="1534" height="357" alt="firefox_fHp7w5Ycwe" src="https://github.com/user-attachments/assets/eb6c20f5-f7f2-4e17-acdd-36a143a0ec58" />

Blood decals have a merging mechanic in the parent call which can result in queuing it for deletion. So we need an early return here to match the one in the parent or we will hang refs.

## Why It's Good For The Game

Fixes a hard delete

## Changelog

Not player-facing