### PR TITLE
[NO GBP] Remove redundant custom_materials definition for .38 speedloaders

### DIFF
--- a/code/modules/projectiles/boxes_magazines/speedloaders.dm
+++ b/code/modules/projectiles/boxes_magazines/speedloaders.dm
@@ -46,7 +46,6 @@
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 6
 	caliber = CALIBER_38
-	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT)
 	ammo_band_icon = "+38_ammo_band"
 	ammo_band_color = null
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 3)


### PR DESCRIPTION

## About The Pull Request
Title. It was overridden a few lines below anyway.
## Why It's Good For The Game
Well, that line is useless now.
## Changelog
N/A