### PR TITLE
crafted pipe guns/pistols and the regal condor come without ammo and magazine.

### DIFF
--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -189,7 +189,7 @@
 
 /datum/crafting_recipe/pipegun
 	name = "Pipegun"
-	result = /obj/item/gun/ballistic/rifle/boltaction/pipegun
+	result = /obj/item/gun/ballistic/rifle/boltaction/pipegun/empty
 	reqs = list(
 		/obj/item/weaponcrafting/receiver = 1,
 		/obj/item/pipe = 2,
@@ -203,7 +203,7 @@
 
 /datum/crafting_recipe/pipepistol
 	name = "Pipe Pistol"
-	result = /obj/item/gun/ballistic/rifle/boltaction/pipegun/pistol
+	result = /obj/item/gun/ballistic/rifle/boltaction/pipegun/pistol/empty
 	reqs = list(
 		/obj/item/weaponcrafting/receiver = 1,
 		/obj/item/pipe = 1,
@@ -249,7 +249,7 @@
 
 /datum/crafting_recipe/pipegun_prime
 	name = "Regal Pipegun"
-	result = /obj/item/gun/ballistic/rifle/boltaction/pipegun/prime
+	result = /obj/item/gun/ballistic/rifle/boltaction/pipegun/prime/empty
 	reqs = list(
 		/obj/item/gun/ballistic/rifle/boltaction/pipegun = 1,
 		/obj/item/food/deadmouse = 1,

--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -266,16 +266,14 @@
 
 /datum/crafting_recipe/deagle_prime //When you factor in the makarov (7 tc), the toolbox (1 tc), and the emag (3 tc), this comes to a total of 18 TC or thereabouts. Igorning the 20k pricetag, obviously.
 	name = "Regal Condor"
-	result = /obj/item/gun/ballistic/automatic/pistol/deagle/regal
+	result = /obj/item/gun/ballistic/automatic/pistol/deagle/regal/no_mag
 	reqs = list(
 		/obj/item/gun/ballistic/automatic/pistol = 1,
-		/obj/item/stack/sheet/mineral/gold = 25,
-		/obj/item/stack/sheet/mineral/silver = 25,
-		/obj/item/food/donkpocket = 1,
+		/obj/item/stack/sheet/mineral/gold = 15,
+		/obj/item/stack/sheet/mineral/silver = 15,
 		/obj/item/stack/telecrystal = 4,
 		/obj/item/clothing/head/costume/crown/fancy = 1, //the captain's crown
 		/obj/item/storage/toolbox/syndicate = 1,
-		/obj/item/stack/sheet/iron = 10,
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	tool_paths = list(
@@ -283,7 +281,7 @@
 		/obj/item/clothing/mask/gas/syndicate,
 		/obj/item/card/emag
 	)
-	time = 30 SECONDS
+	time = 25 SECONDS
 	category = CAT_WEAPON_RANGED
 	crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_MUST_BE_LEARNED
 

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -160,7 +160,7 @@
 ///puts a round into the magazine
 /obj/item/ammo_box/proc/give_round(obj/item/ammo_casing/new_round, replace_spent = 0)
 	// Boxes don't have a caliber type, magazines do. Not sure if it's intended or not, but if we fail to find a caliber, then we fall back to ammo_type.
-	if(!new_round || !(caliber ? (caliber == new_round.caliber) : (ammo_type == new_round.type)))
+	if(!is_compatible_round(new_round))
 		return FALSE
 
 	if (stored_ammo.len < max_ammo)
@@ -188,6 +188,11 @@
 		new_round.forceMove(src)
 		return TRUE
 	return FALSE
+
+/obj/item/ammo_box/proc/is_compatible_round(obj/item/ammo_casing/new_round)
+	if(!new_round || !(caliber ? (caliber == new_round.caliber) : (ammo_type == new_round.type)))
+		return FALSE
+	return TRUE
 
 ///Whether or not the box can be loaded, used in overrides
 /obj/item/ammo_box/proc/can_load(mob/user)

--- a/code/modules/projectiles/boxes_magazines/external/rechargable.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rechargable.dm
@@ -9,7 +9,7 @@
 
 /obj/item/ammo_box/magazine/recharge/update_desc()
 	. = ..()
-	desc = "[initial(desc)] It has [stored_ammo.len] shot\s left."
+	desc = "[initial(desc)] It has [length(stored_ammo)] shot\s left."
 
 /obj/item/ammo_box/magazine/recharge/update_icon_state()
 	. = ..()

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -17,14 +17,23 @@
 	ammo_type = /obj/item/ammo_casing/junk
 	max_ammo = 1
 
+/obj/item/ammo_box/magazine/internal/boltaction/pipegun/empty
+	start_empty = TRUE
+
 /obj/item/ammo_box/magazine/internal/boltaction/pipegun/pistol
 	name = "pipe pistol internal magazine"
 	max_ammo = 3
+
+/obj/item/ammo_box/magazine/internal/boltaction/pipegun/pistol/empty
+	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/internal/boltaction/pipegun/prime
 	name = "regal pipegun internal magazine"
 	max_ammo = 4
 	ammo_type = /obj/item/ammo_casing/junk/reaper
+
+/obj/item/ammo_box/magazine/internal/boltaction/pipegun/prime/empty
+	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/internal/boltaction/pipegun/pistol/prime
 	name = "regal pipe pistol internal magazine"

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -170,10 +170,49 @@
 	QDEL_NULL(suppressor)
 	return ..()
 
+/obj/item/gun/ballistic/on_craft_completion(list/components, datum/crafting_recipe/current_recipe, atom/crafter)
+	. = ..()
+	var/replace_chamber = TRUE
+	var/replace_magazine = !magazine || !(magazine.item_flags & ABSTRACT) //don't replace abstract magazines
+	for(var/obj/item/gun/ballistic/gun in components)
+		if(gun.magazine?.item_flags & ABSTRACT) //we cannot insert an internal magazine into the new gun, so we insert the individual casings instead.
+			for(var/i in 1 to length(gun.magazine.stored_ammo))
+				var/obj/item/ammo_casing/round = gun.magazine.get_round()
+				if(!magazine.give_round(round))
+					round.forceMove(drop_location())
+		else if(gun.magazine && istype(gun.magazine, accepted_magazine_type)) //insert the new magazine into the gun
+			var/obj/item/ammo_box/magazine/new_magazine = gun.magazine //hold onto the reference since magazine is set to null once ejected
+			qdel(magazine)
+			new_magazine.forceMove(src)
+			magazine = new_magazine
+			replace_magazine = FALSE
+		else if(gun.magazine) //the magazine cannot be replaced
+			gun.magazine.forceMove(drop_location()) //drop the magazine on the floor so it doesn't get deleted alongside the gun components.
+		else if(replace_magazine && istype(gun.accepted_magazine_type, accepted_magazine_type)) //the gun we used for crafting lacked a magazine so this one should as well
+			qdel(magazine)
+
+		if(!gun.chambered)
+			continue
+
+		var/obj/item/ammo_casing/round = gun.chambered //hold onto the reference since chambered is set to null once the casing is ejected
+		if(!magazine?.is_compatible_round(round) || !replace_chamber)
+			round.forceMove(drop_location())
+			continue
+		qdel(chambered) //nulled when moved to null
+		round.forceMove(src)
+		chambered = round
+		replace_chamber = FALSE
+
+	update_appearance()
+
 /obj/item/gun/ballistic/Exited(atom/movable/gone, direction)
 	. = ..()
 	if(gone == suppressor)
 		clear_suppressor()
+	if(gone == magazine)
+		magazine.update_appearance()
+		magazine = null
+		update_appearance()
 
 /obj/item/gun/ballistic/add_weapon_description()
 	AddElement(/datum/element/weapon_description, attached_proc = PROC_REF(add_notes_ballistic))
@@ -487,21 +526,16 @@
 		playsound(src, eject_sound, eject_sound_volume, eject_sound_vary)
 	else
 		playsound(src, eject_empty_sound, eject_sound_volume, eject_sound_vary)
-	magazine.forceMove(drop_location())
 	var/obj/item/ammo_box/magazine/old_mag = magazine
+	magazine.forceMove(drop_location())
 	if (tac_load)
 		if (insert_magazine(user, tac_load, FALSE))
 			balloon_alert(user, "[magazine_wording] swapped")
 		else
 			to_chat(user, span_warning("You dropped the old [magazine_wording], but the new one doesn't fit. How embarassing."))
-			magazine = null
-	else
-		magazine = null
 	user.put_in_hands(old_mag)
-	old_mag.update_appearance()
 	if (display_message)
 		balloon_alert(user, "[magazine_wording] unloaded")
-	update_appearance()
 
 /obj/item/gun/ballistic/can_shoot()
 	return chambered?.loaded_projectile
@@ -873,7 +907,6 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 	if(!internal_magazine && magazine) //if a magazine is attached to the weapon, we remove it and throw it aside
 		magazine.forceMove(drop_location())
 		magazine.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), 1, 1)
-		magazine = null
 		update_icon() //updating the sprite of weapons without a magazine
 	if(!isnull(chambered)) //if there is a cartridge in the chamber, we remove it
 		rack()

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -165,11 +165,6 @@
 	update_appearance()
 	RegisterSignal(src, COMSIG_ITEM_RECHARGED, PROC_REF(instant_reload))
 
-/obj/item/gun/ballistic/Destroy()
-	QDEL_NULL(magazine)
-	QDEL_NULL(suppressor)
-	return ..()
-
 /obj/item/gun/ballistic/on_craft_completion(list/components, datum/crafting_recipe/current_recipe, atom/crafter)
 	. = ..()
 	var/replace_chamber = TRUE
@@ -210,9 +205,11 @@
 	if(gone == suppressor)
 		clear_suppressor()
 	if(gone == magazine)
-		magazine.update_appearance()
+		if(!QDELETED(magazine))
+			magazine.update_appearance()
 		magazine = null
-		update_appearance()
+		if(!QDELETED(src))
+			update_appearance()
 
 /obj/item/gun/ballistic/add_weapon_description()
 	AddElement(/datum/element/weapon_description, attached_proc = PROC_REF(add_notes_ballistic))
@@ -645,8 +642,6 @@
 	update_appearance()
 
 /obj/item/gun/ballistic/clear_suppressor()
-	if(!can_unsuppress)
-		return
 	suppressed = SUPPRESSED_NONE
 	if(suppressor)
 		update_weight_class(w_class - suppressor.w_class)

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -216,7 +216,10 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/r45
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	obj_flags = UNIQUE_RENAME // if you did the sidequest, you get the customization
-	custom_materials = list(/datum/material/gold = SHEET_MATERIAL_AMOUNT * 30, /datum/material/silver = SHEET_MATERIAL_AMOUNT * 25, /datum/material/iron = SHEET_MATERIAL_AMOUNT * 11.5, /datum/material/telecrystal = SHEET_MATERIAL_AMOUNT * 4)
+	custom_materials = list(/datum/material/gold = SHEET_MATERIAL_AMOUNT * 20, /datum/material/silver = SHEET_MATERIAL_AMOUNT * 15, /datum/material/iron = SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/telecrystal = SHEET_MATERIAL_AMOUNT * 4)
+
+/obj/item/gun/ballistic/automatic/pistol/deagle/regal/no_mag
+	spawnwithmagazine = FALSE
 
 /obj/item/gun/ballistic/automatic/pistol/deagle/regal/add_deep_lore()
 	AddElement(/datum/element/examine_lore, \

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -339,6 +339,9 @@
 	. = ..()
 	do_sparks(1, TRUE, src)
 
+/obj/item/gun/ballistic/rifle/boltaction/pipegun/empty
+	spawn_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun/empty
+
 /obj/item/gun/ballistic/rifle/boltaction/pipegun/pistol
 	name = "pipe pistol"
 	desc = "It is foolish to think that anyone wearing the grey is incapable of hurting you, simply because they are not baring their teeth."
@@ -361,6 +364,9 @@
 /obj/item/gun/ballistic/rifle/boltaction/pipegun/pistol/add_bayonet_point()
 	return
 
+/obj/item/gun/ballistic/rifle/boltaction/pipegun/pistol/empty
+	spawn_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun/pistol/empty
+
 /obj/item/gun/ballistic/rifle/boltaction/pipegun/prime
 	name = "regal pipegun"
 	desc = "To call this 'regal' is a cruel irony. For the only noteworthy quality of nobility is in how it is wielded to kill. \
@@ -378,6 +384,9 @@
 		/datum/material/cardboard = SHEET_MATERIAL_AMOUNT,
 		/datum/material/plastic = SMALL_MATERIAL_AMOUNT * 3,
 	)
+
+/obj/item/gun/ballistic/rifle/boltaction/pipegun/prime/empty
+	spawn_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun/prime/empty
 
 /obj/item/gun/ballistic/rifle/boltaction/pipegun/pistol/prime
 	name = "regal pipe pistol"


### PR DESCRIPTION
## About The Pull Request
Crafted pipe guns and pistols no longer come with additional junk shells out of the blue. The junk shells have their own recipe, which requires different components than those guns! As for the regal condor, I've reduced the amount of items and time needed to craft the it.

This PR also introduces code to make it possible to transfer magazines and ammo over to the new crafted gun if one or more of the components used in the recipe are is a gun with compatible magazine/ammo. This means that any junk shell in the pipegun used to craft the regal variant will be transfered over to the new, better pipegun instead. As for the makarov used to make the regal condor, its magazine and chambered casing will be ejected on the floor in the process.

## Why It's Good For The Game
Consistency, however it's also required by #96833 (which is why I'm making the change to regal condors at all! It's the easiest solution!). I've made this into a separate PR because it's a bit of a balance change, especially for pipeguns.

## Changelog

:cl:
balance: Crafted pipe guns and pistols no longer come preloaded with junk shells out of the blue when crafted. As for the regal pipegun, it will instead inherit the junk shells present in the pipegun used to craft it.
balance: The regal condor no longer has a magazine when crafted. I've reduced the amount of items and time needed to craft it to make up for it.
/:cl:
