### PR TITLE
Add the academy and heretic away mission paths to awaymissionconfig.txt for reference

### DIFF
--- a/config/awaymissionconfig.txt
+++ b/config/awaymissionconfig.txt
@@ -7,9 +7,11 @@
 #Do NOT tick the maps during compile -- the game uses this list to decide which map to load. Ticking the maps will result in them ALL being loaded at once.
 #DO tick the associated code file for the away mission you are enabling. Otherwise, the map will be trying to reference objects which do not exist, which will cause runtime errors!
 
+#_maps/RandomZLevels/Academy.dmm
 #_maps/RandomZLevels/TheBeach.dmm
 #_maps/RandomZLevels/moonoutpost19.dmm
 #_maps/RandomZLevels/undergroundoutpost45.dmm
 #_maps/RandomZLevels/research.dmm
 #_maps/RandomZLevels/SnowCabin.dmm
+#_maps/RandomZLevels/heretic.dmm
 #_maps/RandomZLevels/museum.dmm


### PR DESCRIPTION
## About The Pull Request
Add these two away missions to the default config txt file for reference.

## Why It's Good For The Game
Merely for reference, as the actual config files are stored along other server data and do not depend on changes done to the repository

## Changelog
N/A