### PR TITLE
Fixes revolvers runtiming when non-player mobs try to spin them

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -41,7 +41,7 @@
 	chamber_round()
 
 /obj/item/gun/ballistic/revolver/click_alt(mob/user)
-	spin()
+	spin_chamber(user)
 	return CLICK_ACTION_SUCCESS
 
 /obj/item/gun/ballistic/revolver/fire_sounds()
@@ -58,13 +58,15 @@
 			playsound(src, 'sound/items/weapons/gun/general/ballistic_click.ogg', fire_sound_volume, vary_fire_sound, frequency = click_frequency_to_use)
 
 GAME_VERB(/obj/item/gun/ballistic/revolver, spin, "Spin Chamber", null)
-	var/mob/user = usr
+	spin_chamber(usr)
 
-	if(user.stat || !in_range(user, src))
+/obj/item/gun/ballistic/revolver/verb/spin_chamber(mob/living/user)
+	if(!istype(user) || user.stat || !in_range(user, src))
 		return
 
 	if (recent_spin > world.time)
 		return
+
 	recent_spin = world.time + spin_delay
 
 	if(do_spin())
@@ -261,7 +263,7 @@ GAME_VERB(/obj/item/gun/ballistic/revolver, spin, "Spin Chamber", null)
 
 /obj/item/gun/ballistic/revolver/russian/attack_self(mob/user)
 	if(!spun)
-		spin()
+		spin_chamber(user)
 		return TRUE
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

Spotted in #96628's CI, spin() is a verb that is invoked in attack_self() which can be called outside of user input

## Changelog
:cl:
fix: Fixed revolvers runtiming when non-player mobs try to spin them
/:cl:
