### PR TITLE
Makes decals unhittable in combat mode, reduces vent debris spawns

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -123,6 +123,14 @@
 		if (blood_type.reagent_type == /datum/reagent/blood)
 			return TRUE
 
+/obj/effect/decal/cleanable/attackby(obj/item/weapon, mob/user, list/modifiers, list/attack_modifiers)
+	if (!isliving(user))
+		return ..()
+	var/mob/living/as_living = user
+	if (as_living.combat_mode)
+		return TRUE
+	return ..()
+
 /// Creates a cleanable decal on a turf
 /// Use this if your decal is one of one, and thus we should not spawn it if it's there already
 /// Returns either the existing cleanable, the one we created, or null if we can't spawn on that turf

--- a/code/game/objects/items/devices/earthcracker.dm
+++ b/code/game/objects/items/devices/earthcracker.dm
@@ -151,15 +151,15 @@
 		for(var/turf/rock in oview(i)) // This collects a list of rings of turfs (in a growing radius of i) that we'll applying logic to "drill" below.
 
 			if(istype(rock, /turf/closed/mineral))
-				if(prob(50 + (i * 8)))
+				if(prob((i * 15) - 25))
 					continue
 				var/turf/closed/mineral/drillable = rock
 				drillable.gets_drilled(user)
-				if(prob(50))
+				if(prob(15))
 					new /obj/effect/decal/cleanable/rubble(rock)
 				continue
 
-			if(istype(rock, /turf/open/misc/asteroid) && prob(35))
+			if(istype(rock, /turf/open/misc/asteroid) && prob(10))
 				new /obj/effect/decal/cleanable/rubble(rock)
 				continue
 		sleep(0.6 SECONDS)

--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -252,20 +252,20 @@
 		for(var/turf/rock in oview(i))
 
 			if(istype(rock, /turf/closed/mineral)) //Solid wall checks: Mine out the wall, but start skipping more as we move farther away.
-				if(prob(50 + (i * 8)))
+				if(prob((i * 15) - 25))
 					continue
 				var/turf/closed/mineral/drillable = rock
 				drillable.gets_drilled(user)
-				if(prob(50))
+				if(prob(15))
 					new /obj/effect/decal/cleanable/rubble(rock) // Only throw rubble when we actually mine something, and not all the time.
 				continue //skip the rest of the checks
 
-			if(istype(rock, /turf/open/misc/asteroid) && prob(35)) // Open rock floors: make rubble decals occasionally.
+			if(istype(rock, /turf/open/misc/asteroid) && prob(10)) // Open rock floors: make rubble decals occasionally.
 				new /obj/effect/decal/cleanable/rubble(rock)
 				continue
 
 			if(istype(rock, /turf/open/lava)) // Lava turfs, skip as we get farther away, otherwise produce a boulder and make it a platform, lasting the whole wave.
-				if(prob(30 + (i * 8))) // We want to skip these less than the mining walls, since lava is more common to deal with.
+				if(prob((i * 15) - 35)) // We want to skip these less than the mining walls, since lava is more common to deal with.
 					continue
 
 				var/obj/item/boulder/produced = produce_boulder(FALSE)


### PR DESCRIPTION

## About The Pull Request
Cleanable decals, such as rubble, trash, glass shards, etc, can no longer be hit (not interacted with, but just offensively hit) in combat mode. 
Ore vents now more consistently clear rocks around them, and spawn noticeably less debris.

## Why It's Good For The Game

Suggested under my necropolis tile PR, some larger decals may steal your clicks in combat which I do not think offers any positive gameplay value. 
Ore vents just spawn too much debris, and as it only has one sprite, it just looks really bad. 

## Changelog
:cl:
qol: Ore vents spawn less rubble and are more consistent at excavating the surrounding area
balance: Cleanable decals can no longer be hit (not cleaned, just hit) if the user has combat mode on.
/:cl:
