### PR TITLE
Fixes broken DreamSeeker debug launch option

### DIFF
--- a/code/controllers/subsystem/verbs.dm
+++ b/code/controllers/subsystem/verbs.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(verbs)
 /datum/controller/subsystem/verbs/Initialize()
 	if (!length(verbs_by_type))
 		initialize_verb_types()
+	initialized = TRUE
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/verbs/proc/initialize_verb_types()
@@ -23,7 +24,7 @@ SUBSYSTEM_DEF(verbs)
 /datum/controller/subsystem/verbs/proc/assign_verb(target, datum/verb_metadata/verb_type)
 	// When launching via dreamseeker and not dreamdaemon, client is created first before any of the subsystems init
 	// This can only happen in dev environments so its not a big deal
-	if (!length(verbs_by_type))
+	if (!initialized)
 		initialize_verb_types()
 	var/datum/verb_metadata/meta = verbs_by_type[verb_type]
 	if(isnull(meta))

--- a/code/controllers/subsystem/verbs.dm
+++ b/code/controllers/subsystem/verbs.dm
@@ -5,9 +5,13 @@ SUBSYSTEM_DEF(verbs)
 	var/list/datum/verb_metadata/verbs_by_type = list()
 
 /datum/controller/subsystem/verbs/Initialize()
+	if (!length(verbs_by_type))
+		initialize_verb_types()
+	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/verbs/proc/initialize_verb_types()
 	for(var/datum/verb_metadata/verb_type as anything in subtypesof(/datum/verb_metadata))
 		verbs_by_type[verb_type] = new verb_type
-	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/verbs/proc/invoke(target, datum/verb_metadata/verb_type, ...)
 	var/datum/verb_metadata/meta = verbs_by_type[verb_type]
@@ -17,6 +21,10 @@ SUBSYSTEM_DEF(verbs)
 	call(target, meta.body_path)(arglist(invoke_args))
 
 /datum/controller/subsystem/verbs/proc/assign_verb(target, datum/verb_metadata/verb_type)
+	// When launching via dreamseeker and not dreamdaemon, client is created first before any of the subsystems init
+	// This can only happen in dev environments so its not a big deal
+	if (!length(verbs_by_type))
+		initialize_verb_types()
 	var/datum/verb_metadata/meta = verbs_by_type[verb_type]
 	if(isnull(meta))
 		CRASH("Attempted to assign unknown verb '[verb_type]'.")


### PR DESCRIPTION

Verb PR broke the dreamseeker debug launch option and will spew runtimes until the debugger chokes and crashes. A lot of our devs use this option so this is pretty high prio.
