### PR TITLE
Fixes cube monkey cap runtimes

### DIFF
--- a/code/modules/food_and_drinks/food/monkeycube.dm
+++ b/code/modules/food_and_drinks/food/monkeycube.dm
@@ -33,7 +33,16 @@
 		holder.dropItemToGround(src)
 
 	var/mob/spammer = get_mob_by_key(fingerprintslast)
-	var/mob/living/bananas = new spawned_mob(drop_location(), TRUE, spammer) // funny that we pass monkey init args to non-monkey mobs, that's totally a future issue
+	var/mob/living/bananas = null
+	if (ispath(spawned_mob, /mob/living/carbon/human/species/monkey))
+		var/cap = CONFIG_GET(number/monkeycap)
+		if (LAZYLEN(SSmobs.cubemonkeys) < cap)
+			bananas = new spawned_mob(drop_location(), TRUE)
+		else if (spammer)
+			to_chat(spammer, span_warning("Bluespace harmonics prevent the creation of more than [cap] monkeys on the station at one time!"))
+	else
+		bananas = new(drop_location())
+
 	if (!QDELETED(bananas))
 		ADD_TRAIT(bananas, TRAIT_SPAWNED_MOB, INNATE_TRAIT)
 		SET_FACTION_AND_ALLIES_FROM(bananas, src)

--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -3,14 +3,9 @@
 	race = /datum/species/monkey
 	ai_controller = /datum/ai_controller/monkey
 
-/mob/living/carbon/human/species/monkey/Initialize(mapload, cubespawned = FALSE, mob/spawner)
+/mob/living/carbon/human/species/monkey/Initialize(mapload, cubespawned = FALSE)
 	ADD_TRAIT(src, TRAIT_BORN_MONKEY, INNATE_TRAIT)
 	if (cubespawned)
-		var/cap = CONFIG_GET(number/monkeycap)
-		if (LAZYLEN(SSmobs.cubemonkeys) > cap)
-			if (spawner)
-				to_chat(spawner, span_warning("Bluespace harmonics prevent the spawning of more than [cap] monkeys on the station at one time!"))
-			return INITIALIZE_HINT_QDEL
 		SSmobs.cubemonkeys += src
 	return ..()
 
@@ -21,7 +16,7 @@
 /mob/living/carbon/human/species/monkey/angry
 	ai_controller = /datum/ai_controller/monkey/angry
 
-/mob/living/carbon/human/species/monkey/angry/Initialize(mapload, cubespawned = FALSE, mob/spawner)
+/mob/living/carbon/human/species/monkey/angry/Initialize(mapload, cubespawned = FALSE)
 	. = ..()
 	if(prob(10))
 		INVOKE_ASYNC(src, PROC_REF(give_ape_escape_helmet))

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -658,7 +658,9 @@
 		else
 			maybe_monkey.vomit(VOMIT_CATEGORY_BLOOD)
 			to_chat(maybe_monkey, span_danger("You vomit out blood, making you feel grossly monkeyish."))
-	new /mob/living/carbon/human/species/monkey(location, TRUE)
+
+	if (LAZYLEN(SSmobs.cubemonkeys) < CONFIG_GET(number/monkeycap))
+		new /mob/living/carbon/human/species/monkey(location, TRUE)
 
 /datum/chemical_reaction/angry_monkey
 	required_reagents = list(/datum/reagent/monkey_powder = 50, /datum/reagent/inverse/bath_salts = 10)
@@ -675,7 +677,9 @@
 		else
 			maybe_monkey.vomit(VOMIT_CATEGORY_BLOOD)
 			to_chat(maybe_monkey, span_danger("You vomit out blood, making you feel grossly monkeyish."))
-	new /mob/living/carbon/human/species/monkey/angry(location, TRUE)
+
+	if (LAZYLEN(SSmobs.cubemonkeys) < CONFIG_GET(number/monkeycap))
+		new /mob/living/carbon/human/species/monkey/angry(location, TRUE)
 
 //water electrolysis
 /datum/chemical_reaction/electrolysis

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -266,7 +266,12 @@
 		target_turf.balloon_alert(user, "not enough monkeys")
 		return
 
-	var/mob/living/carbon/human/species/monkey/food = new /mob/living/carbon/human/species/monkey(target_turf, TRUE, user)
+	var/cap = CONFIG_GET(number/monkeycap)
+	if (LAZYLEN(SSmobs.cubemonkeys) < cap)
+		to_chat(user, span_warning("Bluespace harmonics prevent the creation of more than [cap] monkeys on the station at one time!"))
+		return
+
+	var/mob/living/carbon/human/species/monkey/food = new /mob/living/carbon/human/species/monkey(target_turf, TRUE)
 	if (QDELETED(food))
 		return
 


### PR DESCRIPTION

## About The Pull Request

Closes #96842
Could've moved INITIALIZE_HINT_QDEL to the very end but then we'd still be doing the expensive carbon initialization on monkeys about to be deleted, better to just move the check outside into relevant code.

## Changelog
:cl:
fix: Fixed cube monkey cap runtimes
/:cl:
