### PR TITLE
Fixes material tiles spawned by disposals underneath the floor

### DIFF
--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -123,8 +123,7 @@
 
 	if(isfloorturf(T) && T.overfloor_placed) // pop the tile if present
 		floorturf = T
-		if(floorturf.floor_tile)
-			new floorturf.floor_tile(T)
+		floorturf.spawn_tile()
 		floorturf.make_plating(TRUE)
 
 	if(direction) // direction is specified


### PR DESCRIPTION
## About The Pull Request

Material tiles spawned by disposal pipe under the floor were generating white material tiles. This PR fixes that bug.

:cl:
fix: Fixes material tiles spawned by disposals underneath the floor
/:cl: