### PR TITLE
Fixes goldgrubs leaving floating emissives after dying

### DIFF
--- a/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
+++ b/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
@@ -162,6 +162,11 @@
 	if(has_emissive)
 		. += emissive_appearance(icon, "[icon_state]_e", src)
 
+/mob/living/basic/mining/goldgrub/death(gibbed)
+	. = ..()
+	if (!QDELETED(src) && has_emissive)
+		update_appearance(UPDATE_OVERLAYS)
+
 /mob/living/basic/mining/goldgrub/baby
 	icon = 'icons/mob/simple/lavaland/lavaland_monsters.dmi'
 	name = "goldgrub baby"


### PR DESCRIPTION

## About The Pull Request

<img width="240" height="141" alt="dreamseeker_yU7zcN5nNC" src="https://github.com/user-attachments/assets/08957f26-6347-429b-97d5-dc24a8c3f486" />

## Changelog
:cl:
fix: Fixed goldgrubs leaving floating emissives after dying
/:cl:
