### PR TITLE
Fix false walls being distinguisable via examine

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -33,9 +33,13 @@
 
 /obj/structure/falsewall/Initialize(mapload)
 	. = ..()
-	var/obj/item/stack/initialized_mineral = new mineral // Okay this kinda sucks.
-	set_custom_materials(initialized_mineral.mats_per_unit, mineral_amount)
-	qdel(initialized_mineral)
+	// minerals are only applied to fake mineral walls
+	// ...yes, real iron walls are not actually made of iron
+	if(ispath(walltype, /turf/closed/wall/mineral))
+		var/obj/item/stack/initialized_mineral = new mineral // Okay this kinda sucks.
+		set_custom_materials(initialized_mineral.mats_per_unit, mineral_amount)
+		qdel(initialized_mineral)
+
 	air_update_turf(TRUE, TRUE)
 	update_appearance()
 
@@ -145,9 +149,11 @@
 /obj/structure/falsewall/get_dumping_location()
 	return null
 
+/obj/structure/falsewall/examine_descriptor(mob/user)
+	return "wall"
+
 /obj/structure/falsewall/examine_status(mob/user) //So you can't detect falsewalls by examine.
-	to_chat(user, span_notice("The outer plating is <b>welded</b> firmly in place."))
-	return null
+	return span_notice("The outer plating is <b>welded</b> firmly in place.")
 
 /obj/structure/falsewall/mouse_drop_receive(mob/living/dropping, mob/user, params)
 	. = ..()
@@ -168,8 +174,7 @@
 	smoothing_flags = SMOOTH_BITMASK
 
 /obj/structure/falsewall/reinforced/examine_status(mob/user)
-	to_chat(user, span_notice("The outer <b>grille</b> is fully intact."))
-	return null
+	return span_notice("The outer <b>grille</b> is fully intact.")
 
 /obj/structure/falsewall/reinforced/attackby(obj/item/tool, mob/user)
 	..()


### PR DESCRIPTION
## About The Pull Request

None of this code got updated with all the examine changes so it stuck out
Now it looks proper again

<img width="426" height="351" alt="image" src="https://github.com/user-attachments/assets/9eaab1bc-7464-49b5-b161-4bde1b1051e4" />

## Changelog

:cl: Melbert
fix: Fix false walls being distinguisable via examine
/:cl:
