### PR TITLE
Fix BSRPED potentially bricking reagent containers

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -291,3 +291,6 @@
 
 ///sent to radio TTS sounds when the volume preference is changed and applied
 #define COMSIG_MOB_TTS_RADIO_VOLUME_PREFERENCE_APPLIED "tts_radio_volume_preference_applied"
+
+///from base of [/datum/component/multiple_lives/proc/respawn]: (mob/respawned_mob, gibbed, lives_left)
+#define COMSIG_ON_MULTIPLE_LIVES_RESPAWN "on_multiple_lives_respawn"

--- a/code/__DEFINES/dcs/signals/signals_reagent.dm
+++ b/code/__DEFINES/dcs/signals/signals_reagent.dm
@@ -21,8 +21,10 @@
 ///from base of [/datum/reagent/proc/on_transfer_creation(reagent, target_holder, new_reagent)]: (datum/reagents/target_holder, datum/reagent/new_reagent)
 #define COMSIG_REAGENT_ON_TRANSFER "reagent_on_transfer"
 
-///from base of [/datum/component/multiple_lives/proc/respawn]: (mob/respawned_mob, gibbed, lives_left)
-#define COMSIG_ON_MULTIPLE_LIVES_RESPAWN "on_multiple_lives_respawn"
+///from base of [/datum/reagents/proc/add_reagent] - Sent before the reagent is added: (reagenttype, amount, reagtemp, data, no_react)
+#define COMSIG_REAGENTS_PRE_ADD_REAGENT "reagents_pre_add_reagent"
+	/// Prevents the reagent from being added.
+	#define COMPONENT_CANCEL_REAGENT_ADD (1<<0)
 
 ///from base of [/datum/reagents/proc/update_total()]
 #define COMSIG_REAGENTS_HOLDER_UPDATED "reagents_update_total"

--- a/code/modules/reagents/chemistry/holder/holder.dm
+++ b/code/modules/reagents/chemistry/holder/holder.dm
@@ -98,6 +98,9 @@
 		stack_trace("non finite amount passed to add reagent [amount] [reagent_type]")
 		return FALSE
 
+	if(SEND_SIGNAL(src, COMSIG_REAGENTS_PRE_ADD_REAGENT, reagent_type, amount, reagtemp, data, no_react) & COMPONENT_CANCEL_REAGENT_ADD)
+		return FALSE
+
 	var/datum/reagent/glob_reagent = GLOB.chemical_reagents_list[reagent_type]
 	if(!glob_reagent)
 		stack_trace("[my_atom] attempted to add a reagent called '[reagent_type]' which doesn't exist. ([usr])")

--- a/code/modules/research/part_replacer.dm
+++ b/code/modules/research/part_replacer.dm
@@ -102,7 +102,14 @@
 			target_holder.force_stop_reacting()
 			target_holder.clear_reagents()
 			to_chat(usr, span_notice("[src] churns as [inserted_component] has its reagents emptied into bluespace."))
-		target_holder.flags = target_holder.flags << 5 //masks all flags upto DUNKABLE(1<<5) i.e. removes all methods of transfering reagents to/from the object
+		RegisterSignal(target_holder, COMSIG_REAGENTS_PRE_ADD_REAGENT, PROC_REF(on_insered_component_reagent_pre_add))
+
+/// Hooks [COMSIG_REAGENTS_PRE_ADD_REAGENT] to block adding any form of reagent to component beakers inside the RPED
+/obj/item/storage/part_replacer/bluespace/proc/on_insered_component_reagent_pre_add(datum/source, reagent, amount, reagtemp, data, no_react)
+	SIGNAL_HANDLER
+
+	return COMPONENT_CANCEL_REAGENT_ADD
+
 /**
  * Signal handler for a part is removed from the BRPED.
  * Restores original reagents of the component part, if it has any.
@@ -112,7 +119,7 @@
 
 	var/datum/reagents/target_holder = removed_component.reagents
 	if(target_holder)
-		target_holder.flags = target_holder.flags >> 5 //restores all flags upto DUNKABLE(1<<5)
+		UnregisterSignal(target_holder, COMSIG_REAGENTS_PRE_ADD_REAGENT)
 
 //RPED with tiered contents
 /obj/item/storage/part_replacer/bluespace/tier1/PopulateContents()


### PR DESCRIPTION
## About The Pull Request

Fixes #96867
Reverts part of #88909

The PR removed the signal in favor of flipping off reagent flags on insert, and restoring flags on removal
This caused the linked issue: We didn't check if the thing we were restoring was a cell, so we'd just flip off a bunch of flags, leaving the cell's reagent container with `NONE` flags set

However in fixing this, I noticed a pretty core issue with the idea of flipping off flags, and that's "well what happens if something else messes with the reagent container's flags"? Sure enough, if you lid and unlid a beaker in an RPED, you completely bypass the exploit check and can bomb like days of old

So I reverted the flipping of flags back to a signal. It was the easiest way to handle the "flags" conflict without adding a bunch of traits or whatever.

## Changelog

:cl: Melbert
fix: Fix the BSRPED potentially bricking reagent containers on removal
fix: Fix a potential exploit with BSRPED and reagent containers
/:cl:
