### PR TITLE
Voting admin display fix

### DIFF
--- a/code/datums/votes/_vote_datum.dm
+++ b/code/datums/votes/_vote_datum.dm
@@ -22,7 +22,9 @@
 	/// The method for selecting a winner.
 	var/winner_method = VOTE_WINNER_METHOD_SIMPLE
 	/// Should we show details about the number of votes submitted for each option?
-	var/display_statistics = TRUE
+	var/display_statistics = FALSE
+	/// only applicable if `display_statistics` is false, this will let the final vote tally be printed to chat even if it couldn't be seen during the vote
+	var/print_results = TRUE
 
 	// Internal values used when tracking ongoing votes.
 	// Don't mess with these, change the above values / override procs for subtypes.
@@ -193,7 +195,7 @@
 	if(total_votes <= 0)
 		return span_bold("Vote Result: Inconclusive - No Votes!")
 
-	if (display_statistics)
+	if (display_statistics || print_results)
 		returned_text += "\nResults:"
 		for(var/option in choices)
 			returned_text += "\n"

--- a/code/datums/votes/_vote_datum.dm
+++ b/code/datums/votes/_vote_datum.dm
@@ -22,7 +22,7 @@
 	/// The method for selecting a winner.
 	var/winner_method = VOTE_WINNER_METHOD_SIMPLE
 	/// Should we show details about the number of votes submitted for each option?
-	var/display_statistics = FALSE
+	var/display_statistics = TRUE
 	/// only applicable if `display_statistics` is false, this will let the final vote tally be printed to chat even if it couldn't be seen during the vote
 	var/print_results = TRUE
 

--- a/code/datums/votes/custom_vote.dm
+++ b/code/datums/votes/custom_vote.dm
@@ -79,17 +79,17 @@
 	display_statistics = display_stats == "Yes"
 
 	if (!display_statistics)
-		var/_print_result = tgui_alert(
+		var/set_print_result = tgui_alert(
 			vote_creator,
 			"Should the vote tally be public after the vote is concluded?",
 			"Print vote tally after vote?",
 			list("Yes", "No"),
 		)
 
-		if (isnull(_print_result))
+		if (isnull(set_print_result))
 			return FALSE
 
-		print_results = _print_result == "Yes"
+		print_results = set_print_result == "Yes"
 
 	override_question = tgui_input_text(vote_creator, "What is the vote for?", "Custom Vote")
 	if(!override_question)

--- a/code/datums/votes/custom_vote.dm
+++ b/code/datums/votes/custom_vote.dm
@@ -78,6 +78,19 @@
 		return FALSE
 	display_statistics = display_stats == "Yes"
 
+	if (!display_statistics)
+		var/_print_result = tgui_alert(
+			vote_creator,
+			"Should the vote tally be public after the vote is concluded?",
+			"Print vote tally after vote?",
+			list("Yes", "No"),
+		)
+
+		if (isnull(_print_result))
+			return FALSE
+
+		print_results = _print_result == "Yes"
+
 	override_question = tgui_input_text(vote_creator, "What is the vote for?", "Custom Vote")
 	if(!override_question)
 		return FALSE

--- a/tgui/packages/tgui/interfaces/VotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/VotePanel.tsx
@@ -248,7 +248,7 @@ const ChoicesPanel = (props) => {
                   choice.name === user.singleSelection && (
                     <Icon align="right" mr={2} color="green" name="vote-yea" />
                   )}
-                {currentVote.displayStatistics ? `${choice.votes} Votes` : null}
+                {(currentVote.displayStatistics || user.isLowerAdmin) ? `${choice.votes} Votes` : null}
               </LabeledList.Item>
               <LabeledList.Divider />
             </Box>


### PR DESCRIPTION
## About The Pull Request

For some reasons admins were barred from seeing the amount of people voting for each option during the vote when the `display_statistics` flag was set to false. This PR fixes this. It also adds a new functionality to votes, allowing the vote tallies to be secret DURING the vote, but public after the vote concludes.

## Why It's Good For The Game

Fixes a bug in the voting panel. Adds additional customization option for votes.

## Changelog

:cl: Swan
add: Added the ability for custom votes to display their results to the public only AFTER the vote is concluded
fix: Fixes admins not being able to see vote tallies during an active vote when the public vote statistics were disabled
/:cl: