### PR TITLE
Makes toggle_icon component more respectful of base_icon_state

### DIFF
--- a/code/datums/components/toggle_suit.dm
+++ b/code/datums/components/toggle_suit.dm
@@ -5,8 +5,8 @@
 /datum/component/toggle_icon
 	/// Whether the icon is toggled
 	var/toggled = FALSE
-	/// The base icon state we do operations on.
-	var/base_icon_state
+	/// The inferred base icon state we do operations on, in case the atom doesn't have one set or if it becomes null or something.
+	var/inferred_base_icon_state
 	/// The noun of what was "toggled" displayed to the user. EX: "Toggled the item's [buttons]"
 	var/toggle_noun
 
@@ -18,7 +18,7 @@
 	atom_parent.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
 
 	src.toggle_noun = toggle_noun
-	src.base_icon_state = atom_parent.base_icon_state || atom_parent.post_init_icon_state || atom_parent.icon_state
+	src.inferred_base_icon_state = atom_parent.base_icon_state || atom_parent.post_init_icon_state || atom_parent.icon_state
 
 /datum/component/toggle_icon/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_CLICK_ALT, PROC_REF(on_click_alt))
@@ -88,10 +88,12 @@
 	source.balloon_alert(user, "toggled [toggle_noun]")
 
 	toggled = !toggled
+
+	var/icon_state_to_use = source.base_icon_state || inferred_base_icon_state
 	if(toggled)
-		source.icon_state = "[base_icon_state]_t"
+		source.icon_state = "[icon_state_to_use]_t"
 	else
-		source.icon_state = base_icon_state
+		source.icon_state = icon_state_to_use
 
 	if(isitem(source))
 		var/obj/item/item_source = source

--- a/code/datums/components/toggle_suit.dm
+++ b/code/datums/components/toggle_suit.dm
@@ -18,7 +18,7 @@
 	atom_parent.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
 
 	src.toggle_noun = toggle_noun
-	src.inferred_base_icon_state = atom_parent.base_icon_state || atom_parent.post_init_icon_state || atom_parent.icon_state
+	src.inferred_base_icon_state = atom_parent.post_init_icon_state || atom_parent.icon_state
 
 /datum/component/toggle_icon/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_CLICK_ALT, PROC_REF(on_click_alt))


### PR DESCRIPTION
## About The Pull Request

`/datum/component/toggle_icon component` keeps its own local `base_icon_state` var inferred from the `atom_parent`'s vars, I presume as qol to make it so that you do not have to to set `base_icon_state` explicitly for each atom. Which is fine.

But some things, such as reskins, can deliberately modify `base_icon_state` after this component gets added, which makes the `base_icon_state` that it saves stale. This can result in invisible or broken icons.

This PR just makes it always respect the parent atoms *current* `base_icon_state` to avoid these issues, by always prioritizing it over the one stored on the component.

## Why It's Good For The Game

Fixes an oversight

## Changelog

:cl:
fix: fixes an issue that can under certain conditions cause reskinnable items with the toggle component (such as jackets) to have invisible icons upon using the toggle
/:cl: