### PR TITLE
Adds paper planes to the list of faxable items

### DIFF
--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -38,6 +38,7 @@ GLOBAL_VAR_INIT(fax_autoprinting, FALSE)
 		/obj/item/paper,
 		/obj/item/photo,
 		/obj/item/tcgcard,
+		/obj/item/paperplane,
 	)
 	/// List of types which should be allowed to be faxed if hacked
 	var/static/list/exotic_types = list(
@@ -54,7 +55,6 @@ GLOBAL_VAR_INIT(fax_autoprinting, FALSE)
 		/obj/item/holochip,
 		/obj/item/stack/spacecash,
 		/obj/item/throwing_star,
-		/obj/item/paperplane,
 	)
 	/// List with a fake-networks(not a fax actually), for request manager.
 	var/list/special_networks = list(

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -54,6 +54,7 @@ GLOBAL_VAR_INIT(fax_autoprinting, FALSE)
 		/obj/item/holochip,
 		/obj/item/stack/spacecash,
 		/obj/item/throwing_star,
+		/obj/item/paperplane,
 	)
 	/// List with a fake-networks(not a fax actually), for request manager.
 	var/list/special_networks = list(


### PR DESCRIPTION

## About The Pull Request
Paper planes will be faxable (they're paper too)
## Why It's Good For The Game
While not entirely useful if all you do is set up a fax machine and send the plane, if you manage to get to the fax machine you want to send it to, and hack its output servo so that it chucks items, it will send the paper plane flying (which is hilarious) Unless the fax machine is pointed towards a wall. This also means that you could attach an x4 charge to the paper airplane and turn every fax machine you touch into their own little bomb launcher.
## Changelog
:cl:
add: fax machines now accept paper airplanes
/:cl:
