### PR TITLE
Add Tombstone Escape Shuttle

### DIFF
--- a/_maps/shuttles/emergency/emergency_tombstone.dmm
+++ b/_maps/shuttles/emergency/emergency_tombstone.dmm
@@ -5,7 +5,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "as" = (
 /obj/docking_port/mobile/emergency{
 	dir = 2;
@@ -15,26 +15,26 @@
 	name = "Cemetery"
 	},
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "aI" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 8
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating/airless,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "aS" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "aX" = (
 /obj/item/statuebust,
 /obj/structure/table/wood,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "bG" = (
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 4
@@ -42,13 +42,13 @@
 /turf/open/floor/iron/freezer/edge{
 	dir = 4
 	},
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "bR" = (
 /obj/structure/closet/crate/grave/filled,
 /obj/effect/spawner/random/exotic/grave,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/misc/dirt/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "cb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -66,14 +66,14 @@
 	},
 /obj/structure/sign/poster/official/cleanliness/directional/west,
 /turf/open/floor/iron/freezer/corner,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "cu" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "cV" = (
 /obj/structure/table,
 /obj/item/storage/box/gloves,
@@ -83,10 +83,10 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "dd" = (
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "dh" = (
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 8
@@ -95,7 +95,7 @@
 /turf/open/floor/iron/freezer/edge{
 	dir = 8
 	},
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "dr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -112,35 +112,35 @@
 	},
 /obj/item/flashlight/flare/torch,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "dF" = (
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "eq" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/surgery_tray/full/morgue,
 /turf/open/floor/iron/freezer,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "et" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/sign/warning/vacuum/directional/south,
 /turf/open/floor/catwalk_floor,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "eW" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "fm" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "fx" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -148,13 +148,13 @@
 /obj/effect/turf_decal/weather/dirt,
 /obj/item/storage/fancy/candle_box,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "fS" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 9
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "gm" = (
 /obj/structure/mirror/directional/north,
 /obj/structure/sink/directional/south,
@@ -164,26 +164,26 @@
 /turf/open/floor/iron/freezer/edge{
 	dir = 1
 	},
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "it" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
 /mob/living/basic/mouse,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "iz" = (
 /obj/effect/spawner/random/trash/hobo_squat{
 	spawn_loot_chance = 50
 	},
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "iN" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 6
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "jl" = (
 /obj/effect/turf_decal/tile/dark_green/anticorner{
 	dir = 8
@@ -192,7 +192,7 @@
 /turf/open/floor/iron/freezer/corner{
 	dir = 4
 	},
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "jS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -211,7 +211,7 @@
 	name = "Cemetery"
 	},
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "kR" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -219,33 +219,33 @@
 	},
 /obj/item/storage/fancy/candle_box,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "la" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "ly" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
 /obj/item/flashlight/lantern,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "lV" = (
 /obj/effect/spawner/random/trash/graffiti{
 	spawn_loot_chance = 50
 	},
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "mc" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "mm" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/bot,
@@ -258,7 +258,7 @@
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "mt" = (
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 1
@@ -266,7 +266,7 @@
 /turf/open/floor/iron/freezer/edge{
 	dir = 1
 	},
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "mx" = (
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 10
@@ -277,7 +277,7 @@
 "mz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "mZ" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -288,7 +288,7 @@
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "nx" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -297,27 +297,27 @@
 	pixel_x = 19
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "ok" = (
 /obj/item/flashlight/flare/torch,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "px" = (
 /obj/item/flashlight/flare/torch,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "qn" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "qr" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -327,64 +327,64 @@
 "qx" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "qM" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "rz" = (
 /obj/machinery/computer/operating{
 	dir = 8
 	},
 /turf/open/floor/iron/freezer,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "rH" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/misc/dirt/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "rK" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/closet/l3closet,
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "rP" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "si" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "so" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "sP" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue"
 	},
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "th" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "vD" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "vK" = (
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "vL" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 1
@@ -393,7 +393,7 @@
 	name = "morgue"
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "vP" = (
 /obj/effect/spawner/random/trash/garbage{
 	spawn_scatter_radius = 1;
@@ -401,13 +401,13 @@
 	spawn_loot_chance = 50
 	},
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "vT" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "vZ" = (
 /obj/structure/bodycontainer/crematorium{
 	id = "graveyard_shuttle_crematorium"
@@ -419,45 +419,45 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/structure/sign/departments/maint/directional/north,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "wb" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "we" = (
 /obj/structure/table/optable,
 /turf/open/floor/iron/freezer,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "wu" = (
 /obj/item/flashlight/flare/torch,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "wX" = (
 /obj/machinery/vending/wardrobe/coroner_wardrobe,
 /turf/open/floor/iron/dark/smooth_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "wZ" = (
 /obj/effect/spawner/costume/plaguedoctor,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "xc" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "xt" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "yj" = (
 /obj/structure/closet/crate/grave/filled,
 /obj/effect/spawner/random/exotic/grave,
 /turf/open/misc/dirt/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "ym" = (
 /obj/effect/turf_decal/tile/dark_green/anticorner{
 	dir = 4
@@ -465,47 +465,47 @@
 /turf/open/floor/iron/freezer/corner{
 	dir = 8
 	},
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "yo" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "yJ" = (
 /obj/machinery/computer/emergency_shuttle{
 	dir = 8
 	},
 /obj/machinery/light/small/dim/directional/east,
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "zA" = (
 /obj/machinery/portable_atmospherics/canister/miasma,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/sign/warning/biohazard/directional/south,
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Ab" = (
 /obj/structure/bodycontainer/morgue/beeper_off{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Ah" = (
 /obj/structure/bodycontainer/morgue/beeper_off{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Aw" = (
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "AA" = (
 /obj/item/flashlight/flare/torch,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "AS" = (
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 5
@@ -523,50 +523,50 @@
 	},
 /obj/structure/sign/clock/directional/west,
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "DO" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/structure/bodycontainer/morgue/beeper_off{
 	name = "morgue"
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Ei" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Fi" = (
 /obj/machinery/light/small/dim/directional/west,
 /obj/structure/bodycontainer/morgue/beeper_off{
 	name = "morgue"
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "FJ" = (
 /obj/structure/mineral_door{
 	name = "Crypt"
 	},
 /obj/structure/barricade/wooden/crude,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "FZ" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/remains/human/smokey/maintenance,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Gf" = (
 /mob/living/basic/spider/maintenance,
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Gs" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "GU" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/weather/dirt{
@@ -574,14 +574,14 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Hy" = (
 /obj/item/flashlight/flare/torch,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "HZ" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/turf_decal/trimline/dark_red/warning{
@@ -595,13 +595,13 @@
 /turf/open/floor/iron/freezer/corner{
 	dir = 1
 	},
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Ih" = (
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "JE" = (
 /obj/effect/spawner/random/trash/garbage{
 	spawn_scatter_radius = 1;
@@ -610,7 +610,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Lv" = (
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 4
@@ -619,31 +619,31 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "MS" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Crematorium"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "MT" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Nw" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 10
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Ny" = (
 /obj/item/clothing/head/helmet/skull,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "NU" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -655,7 +655,7 @@
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/dark_green/half,
 /turf/open/floor/iron/freezer/edge,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Oa" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/bot,
@@ -668,15 +668,15 @@
 /obj/structure/table/wood,
 /obj/item/shovel,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Pi" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "PM" = (
 /turf/open/floor/catwalk_floor,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "PP" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/structure/bodycontainer/morgue/beeper_off{
@@ -684,11 +684,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Qd" = (
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark/smooth_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Ru" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -697,13 +697,13 @@
 	pixel_y = 44
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "RZ" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue"
 	},
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Ty" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -711,14 +711,14 @@
 /obj/effect/turf_decal/weather/dirt,
 /obj/item/flashlight/flare/torch,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Uu" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "UA" = (
 /obj/effect/turf_decal/tile/dark_green/half,
 /turf/open/floor/iron/freezer/edge,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "UM" = (
 /obj/structure/closet/crate/grave/fresh,
 /obj/structure/sign/painting/library{
@@ -728,7 +728,7 @@
 /obj/effect/spawner/random/exotic/grave,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/misc/dirt/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Vl" = (
 /obj/structure/closet/crate/grave/fresh,
 /obj/structure/sign/painting/library{
@@ -736,13 +736,13 @@
 	},
 /obj/effect/spawner/random/exotic/grave,
 /turf/open/misc/dirt/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "VQ" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "VW" = (
 /obj/structure/rack,
 /obj/item/storage/box/bodybags{
@@ -755,13 +755,13 @@
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Wp" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Ws" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 1
@@ -771,14 +771,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "WE" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Xg" = (
 /obj/structure/closet/crate/grave/fresh,
 /obj/structure/sign/painting/library{
@@ -787,7 +787,7 @@
 	},
 /obj/effect/spawner/random/exotic/grave,
 /turf/open/misc/dirt/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Xl" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -804,7 +804,7 @@
 	},
 /obj/item/shovel,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Yp" = (
 /obj/machinery/light/small/dim/directional/east,
 /obj/structure/bodycontainer/morgue/beeper_off{
@@ -812,20 +812,20 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Yt" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "YF" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Secure Morgue"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "YN" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/weather/dirt{
@@ -833,7 +833,7 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "YS" = (
 /obj/structure/closet/crate/grave/filled,
 /obj/structure/sign/painting/library{
@@ -841,7 +841,7 @@
 	},
 /obj/effect/spawner/random/exotic/grave,
 /turf/open/misc/dirt/station,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 "Zj" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 1
@@ -850,7 +850,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/area/shuttle/escape/tombstone)
 
 (1,1,1) = {"
 Bj

--- a/_maps/shuttles/emergency/emergency_tombstone.dmm
+++ b/_maps/shuttles/emergency/emergency_tombstone.dmm
@@ -1,0 +1,1233 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aj" = (
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"as" = (
+/obj/docking_port/mobile/emergency{
+	dir = 2;
+	name = "Tombstone shuttle"
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Cemetery"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"aI" = (
+/obj/machinery/power/shuttle_engine/heater{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"aS" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/shuttle/escape)
+"aX" = (
+/obj/item/statuebust,
+/obj/structure/table/wood,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"bG" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/rack,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"bR" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"cb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/button/crematorium{
+	id = "graveyard_shuttle_crematorium";
+	dir = 4;
+	pixel_y = 25
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"ct" = (
+/obj/effect/turf_decal/trimline/blue,
+/obj/structure/mirror/directional/west,
+/obj/structure/sink/directional/east,
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"cu" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"cV" = (
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/dead_body_placer,
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"dd" = (
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"dh" = (
+/obj/effect/turf_decal/trimline/neutral/warning,
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"dr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"dy" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/item/flashlight/flare/torch,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"et" = (
+/obj/machinery/portable_atmospherics/canister/miasma,
+/obj/structure/sign/warning/biohazard/directional/north,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"eW" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"fm" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"fx" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt,
+/obj/item/storage/fancy/candle_box,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"fS" = (
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"gm" = (
+/obj/machinery/smartfridge/organ,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"it" = (
+/obj/structure/closet/jcloset,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"iz" = (
+/obj/effect/spawner/random/trash/hobo_squat{
+	spawn_loot_chance = 50
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"iN" = (
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"jl" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/obj/machinery/light/small/dim/directional/south,
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"jS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"kz" = (
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 6
+	},
+/obj/structure/closet/crate/coffin,
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape/brig)
+"kM" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Cemetery"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"kR" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/item/storage/fancy/candle_box,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"la" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"ly" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/item/flashlight/lantern,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"lV" = (
+/obj/effect/spawner/random/trash/graffiti{
+	spawn_loot_chance = 50
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"mc" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"mm" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"mr" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
+/area/shuttle/escape)
+"mt" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/surgery_tray/full/morgue,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"mx" = (
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 10
+	},
+/obj/structure/closet/crate/coffin,
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape/brig)
+"mz" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"mZ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"ni" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"nx" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/item/bouquet/poppy{
+	pixel_x = 19
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"ok" = (
+/obj/item/flashlight/flare/torch,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"px" = (
+/obj/item/flashlight/flare/torch,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"qf" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"qn" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"qr" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"qx" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"qM" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"rH" = (
+/obj/structure/closet/crate/coffin,
+/turf/open/misc/dirt/station,
+/area/shuttle/escape)
+"si" = (
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"so" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"th" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"vD" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"vK" = (
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"vL" = (
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 1
+	},
+/obj/structure/bodycontainer/morgue/beeper_off{
+	name = "morgue"
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"vP" = (
+/obj/effect/spawner/random/trash/garbage{
+	spawn_scatter_radius = 1;
+	spawn_loot_count = 2;
+	spawn_loot_chance = 50
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"vT" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"vZ" = (
+/obj/structure/bodycontainer/crematorium{
+	id = "graveyard_shuttle_crematorium"
+	},
+/obj/structure/sign/warning/hot_temp/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/shuttle/escape/brig)
+"we" = (
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	name = "Coroner's Office";
+	req_access = list("morgue_secure")
+	},
+/obj/effect/turf_decal/trimline/neutral/warning,
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"wu" = (
+/obj/item/flashlight/flare/torch,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"wX" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/rack,
+/obj/item/storage/box/bodybags{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/bodybags,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"xc" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"xt" = (
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"yo" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"yJ" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 8
+	},
+/obj/machinery/light/small/dim/directional/east,
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"Ab" = (
+/obj/structure/bodycontainer/morgue/beeper_off{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"Aw" = (
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"AA" = (
+/obj/item/flashlight/flare/torch,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"AS" = (
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 5
+	},
+/obj/structure/closet/crate/coffin,
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape/brig)
+"Bj" = (
+/turf/template_noop,
+/area/template_noop)
+"Cz" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"DO" = (
+/obj/effect/turf_decal/trimline/neutral/warning,
+/obj/structure/bodycontainer/morgue/beeper_off{
+	name = "morgue"
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"Ei" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Fi" = (
+/obj/machinery/light/small/dim/directional/west,
+/obj/structure/bodycontainer/morgue/beeper_off{
+	name = "morgue"
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"FJ" = (
+/obj/structure/mineral_door{
+	name = "Crypt"
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"FZ" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/item/clothing/head/helmet/skull,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"Gf" = (
+/obj/effect/spawner/random/trash/garbage{
+	spawn_scatter_radius = 1;
+	spawn_loot_count = 2;
+	spawn_loot_chance = 50
+	},
+/obj/machinery/light/small/dim/directional/west,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Gs" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/box/gloves,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"GU" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"Hy" = (
+/obj/item/flashlight/flare/torch,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"HZ" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape/brig)
+"Ih" = (
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"Lv" = (
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"MS" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Crematorium"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape)
+"MT" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Nw" = (
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"Ny" = (
+/obj/item/clothing/head/helmet/skull,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"NU" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"NV" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"Oa" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/light/small/dim/directional/east,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"Ow" = (
+/obj/structure/table/wood,
+/obj/item/shovel,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"PM" = (
+/obj/structure/sign/warning/vacuum/directional/south,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/catwalk_floor,
+/area/shuttle/escape)
+"PP" = (
+/obj/effect/turf_decal/trimline/neutral/warning,
+/obj/structure/bodycontainer/morgue/beeper_off{
+	name = "morgue";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"Ru" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/item/bouquet/sunflower{
+	pixel_y = 44
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"RZ" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue"
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Sn" = (
+/obj/effect/spawner/costume/plaguedoctor,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Ty" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt,
+/obj/item/flashlight/flare/torch,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"Uu" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"UA" = (
+/obj/structure/table/optable,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"Vl" = (
+/obj/structure/closet/crate/grave/fresh,
+/obj/structure/sign/painting/library{
+	pixel_x = 32
+	},
+/obj/effect/spawner/random/exotic/grave,
+/turf/open/misc/dirt/station,
+/area/shuttle/escape)
+"VQ" = (
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"Wp" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Ws" = (
+/obj/effect/turf_decal/trimline/neutral/warning{
+	dir = 1
+	},
+/obj/structure/bodycontainer/morgue/beeper_off{
+	name = "morgue";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"Xg" = (
+/obj/structure/closet/crate/grave/fresh,
+/obj/structure/sign/painting/library{
+	pixel_y = 33;
+	dir = 1
+	},
+/obj/effect/spawner/random/exotic/grave,
+/turf/open/misc/dirt/station,
+/area/shuttle/escape)
+"Xl" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"Xv" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/item/shovel,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"Yp" = (
+/obj/machinery/light/small/dim/directional/east,
+/obj/structure/bodycontainer/morgue/beeper_off{
+	name = "morgue";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"Yt" = (
+/obj/machinery/door/morgue{
+	name = "Occult Study"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"YF" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Secure Morgue"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"YN" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"YS" = (
+/obj/structure/closet/crate/grave/filled,
+/obj/structure/sign/painting/library{
+	pixel_x = 32
+	},
+/obj/effect/spawner/random/exotic/grave,
+/turf/open/misc/dirt/station,
+/area/shuttle/escape)
+"Zj" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+Ih
+Ih
+Bj
+Ih
+Ih
+Bj
+Bj
+Bj
+Bj
+Bj
+"}
+(2,1,1) = {"
+Bj
+Bj
+Ih
+Ih
+Bj
+aI
+aI
+iz
+aI
+aI
+Bj
+Ih
+Ih
+Bj
+Bj
+"}
+(3,1,1) = {"
+Bj
+Bj
+aI
+aI
+Bj
+Uu
+Uu
+Uu
+Uu
+Uu
+Bj
+aI
+aI
+Bj
+Bj
+"}
+(4,1,1) = {"
+Uu
+Uu
+Uu
+Uu
+Bj
+Uu
+et
+Gf
+bR
+Uu
+Bj
+Uu
+Uu
+aS
+Uu
+"}
+(5,1,1) = {"
+Uu
+Aw
+it
+Uu
+lV
+Uu
+Uu
+Yt
+Uu
+Uu
+vP
+Uu
+Cz
+PM
+Uu
+"}
+(6,1,1) = {"
+Uu
+MT
+Uu
+Uu
+Uu
+Uu
+ct
+dh
+jl
+Uu
+Uu
+Uu
+Uu
+mr
+Uu
+"}
+(7,1,1) = {"
+Uu
+qx
+vL
+Fi
+DO
+wX
+mt
+dh
+UA
+bG
+vL
+Fi
+DO
+qn
+Uu
+"}
+(8,1,1) = {"
+Uu
+qx
+xt
+si
+iN
+la
+gm
+we
+NV
+la
+xt
+si
+iN
+qn
+Uu
+"}
+(9,1,1) = {"
+mz
+Wp
+mc
+mc
+mc
+Zj
+mc
+mc
+mc
+Zj
+mc
+mc
+mc
+Ei
+mz
+"}
+(10,1,1) = {"
+mz
+eW
+qM
+qM
+qM
+cu
+qM
+qM
+qM
+cu
+qM
+qM
+qM
+yo
+mz
+"}
+(11,1,1) = {"
+Uu
+qx
+fS
+VQ
+Nw
+la
+fS
+cV
+Nw
+la
+fS
+VQ
+Nw
+qn
+Uu
+"}
+(12,1,1) = {"
+qf
+qx
+Ws
+Yp
+PP
+la
+Ws
+Yp
+PP
+la
+Ws
+Yp
+PP
+Gs
+Uu
+"}
+(13,1,1) = {"
+Uu
+Uu
+Uu
+Uu
+Uu
+RZ
+Uu
+xc
+Uu
+RZ
+Uu
+Uu
+Uu
+Uu
+Uu
+"}
+(14,1,1) = {"
+kM
+ok
+vT
+vT
+vT
+vK
+vT
+vT
+vT
+vK
+vT
+vT
+vT
+px
+Uu
+"}
+(15,1,1) = {"
+Uu
+fm
+vK
+th
+th
+vK
+th
+th
+th
+vK
+th
+th
+vK
+ni
+Uu
+"}
+(16,1,1) = {"
+mz
+so
+vD
+rH
+rH
+Ty
+rH
+rH
+rH
+dy
+rH
+rH
+so
+vD
+mz
+"}
+(17,1,1) = {"
+mz
+Ny
+vD
+rH
+rH
+fx
+rH
+xc
+rH
+kR
+rH
+rH
+so
+FZ
+mz
+"}
+(18,1,1) = {"
+mz
+so
+vD
+rH
+rH
+Ty
+rH
+rH
+rH
+dy
+rH
+rH
+so
+vD
+mz
+"}
+(19,1,1) = {"
+Uu
+fm
+vK
+vT
+vT
+vK
+vT
+vT
+vT
+vK
+vT
+vT
+vK
+ni
+Uu
+"}
+(20,1,1) = {"
+as
+wu
+th
+th
+th
+th
+vK
+vK
+vK
+th
+th
+vK
+th
+Hy
+Uu
+"}
+(21,1,1) = {"
+Uu
+Uu
+mz
+mz
+Uu
+Uu
+so
+vK
+vD
+Uu
+Uu
+FJ
+Uu
+Uu
+Uu
+"}
+(22,1,1) = {"
+MS
+jS
+Xl
+AS
+kz
+mz
+so
+vK
+vD
+Uu
+Xg
+Ru
+Ow
+aX
+Uu
+"}
+(23,1,1) = {"
+Uu
+vZ
+dr
+mZ
+mZ
+MS
+vK
+AA
+vD
+Uu
+Xg
+so
+vK
+vK
+mz
+"}
+(24,1,1) = {"
+Uu
+cb
+NU
+qr
+qr
+mz
+YN
+vK
+GU
+Uu
+Xv
+th
+ly
+nx
+mz
+"}
+(25,1,1) = {"
+Uu
+mm
+Oa
+HZ
+mx
+Uu
+Uu
+YF
+Uu
+Uu
+YS
+Vl
+YS
+YS
+Uu
+"}
+(26,1,1) = {"
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+dd
+Sn
+dd
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+"}
+(27,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+Uu
+aj
+Lv
+aj
+Uu
+Bj
+Bj
+Bj
+Bj
+Bj
+"}
+(28,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+mz
+Ab
+yJ
+Ab
+mz
+Bj
+Bj
+Bj
+Bj
+Bj
+"}
+(29,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+mz
+mz
+xc
+mz
+mz
+Bj
+Bj
+Bj
+Bj
+Bj
+"}

--- a/_maps/shuttles/emergency/emergency_tombstone.dmm
+++ b/_maps/shuttles/emergency/emergency_tombstone.dmm
@@ -284,12 +284,6 @@
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
-"qf" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Morgue"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "qn" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -311,6 +305,12 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"qS" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue"
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "rH" = (
 /obj/structure/closet/crate/coffin,
@@ -373,8 +373,7 @@
 /area/shuttle/escape/brig)
 "we" = (
 /obj/machinery/door/window/brigdoor/left/directional/east{
-	name = "Coroner's Office";
-	req_access = list("morgue_secure")
+	name = "Coroner's Office"
 	},
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/effect/turf_decal/trimline/neutral/warning{
@@ -480,7 +479,7 @@
 /area/shuttle/escape)
 "FZ" = (
 /obj/effect/turf_decal/weather/dirt,
-/obj/item/clothing/head/helmet/skull,
+/obj/effect/decal/remains/human/smokey/maintenance,
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
 "Gf" = (
@@ -546,7 +545,6 @@
 /area/shuttle/escape)
 "MT" = (
 /obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Nw" = (
@@ -613,10 +611,6 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue"
 	},
-/turf/open/floor/iron/dark,
-/area/shuttle/escape)
-"Sn" = (
-/obj/effect/spawner/costume/plaguedoctor,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Ty" = (
@@ -691,6 +685,10 @@
 /obj/item/shovel,
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
+"Yk" = (
+/obj/effect/spawner/costume/plaguedoctor,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
 "Yp" = (
 /obj/machinery/light/small/dim/directional/east,
 /obj/structure/bodycontainer/morgue/beeper_off{
@@ -703,7 +701,6 @@
 /obj/machinery/door/morgue{
 	name = "Occult Study"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "YF" = (
@@ -926,7 +923,7 @@ qn
 Uu
 "}
 (12,1,1) = {"
-qf
+qS
 qx
 Ws
 Yp
@@ -1171,7 +1168,7 @@ Uu
 Uu
 Uu
 dd
-Sn
+Yk
 dd
 Uu
 Uu

--- a/_maps/shuttles/emergency/emergency_tombstone.dmm
+++ b/_maps/shuttles/emergency/emergency_tombstone.dmm
@@ -36,14 +36,13 @@
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
 "bG" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/structure/table,
-/obj/item/storage/box/gloves,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/iron/dark,
+/obj/machinery/light/small/dim/directional/west,
+/turf/open/floor/iron/freezer/edge{
+	dir = 8
+	},
 /area/shuttle/escape)
 "bR" = (
 /obj/structure/closet/crate/grave/filled,
@@ -63,11 +62,11 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "ct" = (
-/obj/effect/turf_decal/trimline/blue,
-/obj/structure/mirror/directional/west,
-/obj/structure/sink/directional/east,
-/obj/structure/sign/poster/official/cleanliness/directional/north,
-/turf/open/floor/iron/dark/textured_half,
+/obj/effect/turf_decal/tile/dark_green/anticorner{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/cleanliness/directional/west,
+/turf/open/floor/iron/freezer/corner,
 /area/shuttle/escape)
 "cu" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -87,11 +86,10 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "dh" = (
-/obj/effect/turf_decal/trimline/neutral/warning,
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 1
+/obj/machinery/computer/operating{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/textured_half,
+/turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "dr" = (
 /obj/effect/turf_decal/stripes/line{
@@ -148,10 +146,18 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
 "gm" = (
+/obj/structure/mirror/directional/north,
+/obj/structure/sink/directional/south,
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 1
+	},
+/turf/open/floor/iron/freezer/edge{
+	dir = 1
+	},
+/area/shuttle/escape)
+"hM" = (
 /obj/machinery/smartfridge/organ,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/iron/dark/textured_half,
+/turf/open/floor/iron/dark/smooth_half,
 /area/shuttle/escape)
 "it" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -173,12 +179,13 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
 "jl" = (
-/obj/machinery/computer/operating{
-	dir = 1
+/obj/effect/turf_decal/tile/dark_green/anticorner{
+	dir = 8
 	},
-/obj/machinery/light/small/dim/directional/south,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark/textured_half,
+/obj/structure/sign/poster/official/cleanliness/directional/west,
+/turf/open/floor/iron/freezer/corner{
+	dir = 4
+	},
 /area/shuttle/escape)
 "jS" = (
 /obj/effect/turf_decal/stripes/line{
@@ -247,10 +254,12 @@
 /turf/open/floor/catwalk_floor,
 /area/shuttle/escape)
 "mt" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/surgery_tray/full/morgue,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/iron/dark/textured_half,
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 1
+	},
+/turf/open/floor/iron/freezer/edge{
+	dir = 1
+	},
 /area/shuttle/escape)
 "mx" = (
 /obj/effect/turf_decal/trimline/dark_red/warning{
@@ -260,8 +269,12 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape/brig)
 "mz" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer/edge{
+	dir = 4
+	},
 /area/shuttle/escape)
 "mZ" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -297,6 +310,14 @@
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
+"pz" = (
+/obj/effect/turf_decal/tile/dark_green/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer/corner{
+	dir = 8
+	},
+/area/shuttle/escape)
 "qn" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -320,20 +341,16 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "rz" = (
-/obj/structure/closet/jcloset,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/surgery_tray/full/morgue,
+/turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "rH" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/misc/dirt/station,
 /area/shuttle/escape)
 "rK" = (
-/obj/machinery/portable_atmospherics/canister/miasma,
-/obj/effect/turf_decal/delivery,
-/obj/structure/sign/warning/biohazard/directional/west,
-/turf/open/floor/plating,
+/turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "si" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
@@ -402,18 +419,18 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "wb" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"we" = (
-/obj/machinery/door/window/brigdoor/left/directional/east{
-	name = "Coroner's Office"
-	},
-/obj/effect/turf_decal/trimline/neutral/warning,
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/structure/table,
+/obj/item/storage/box/gloves,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured_half,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"we" = (
+/obj/structure/table/optable,
+/turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "wu" = (
 /obj/item/flashlight/flare/torch,
@@ -423,17 +440,8 @@
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
 "wX" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/structure/rack,
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/bodybags,
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
+/turf/open/floor/iron/dark/smooth_half,
 /area/shuttle/escape)
 "wZ" = (
 /obj/effect/spawner/costume/plaguedoctor,
@@ -504,6 +512,19 @@
 	},
 /obj/structure/sign/clock/directional/west,
 /turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"CA" = (
+/obj/structure/rack,
+/obj/item/storage/box/bodybags{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/bodybags,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "DO" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
@@ -606,6 +627,10 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"Nt" = (
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
 "Nw" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 10
@@ -619,6 +644,12 @@
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
+"NE" = (
+/obj/effect/turf_decal/tile/dark_green/anticorner,
+/turf/open/floor/iron/freezer/corner{
+	dir = 1
+	},
+/area/shuttle/escape)
 "NU" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -627,10 +658,9 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "NV" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/vending/wardrobe/coroner_wardrobe,
-/turf/open/floor/iron/dark/textured_half,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/dark_green/half,
+/turf/open/floor/iron/freezer/edge,
 /area/shuttle/escape)
 "Oa" = (
 /obj/structure/kitchenspike,
@@ -670,6 +700,10 @@
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
+"RG" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
 "RZ" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue"
@@ -685,12 +719,12 @@
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
 "Uu" = (
-/turf/closed/wall/mineral/titanium,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "UA" = (
-/obj/structure/table/optable,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/iron/dark/textured_half,
+/obj/effect/turf_decal/tile/dark_green/half,
+/turf/open/floor/iron/freezer/edge,
 /area/shuttle/escape)
 "UM" = (
 /obj/structure/closet/crate/grave/fresh,
@@ -709,6 +743,13 @@
 	},
 /obj/effect/spawner/random/exotic/grave,
 /turf/open/misc/dirt/station,
+/area/shuttle/escape)
+"VB" = (
+/obj/machinery/portable_atmospherics/canister/miasma,
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/sign/warning/biohazard/directional/south,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "VQ" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
@@ -802,6 +843,12 @@
 /obj/effect/spawner/random/exotic/grave,
 /turf/open/misc/dirt/station,
 /area/shuttle/escape)
+"Zh" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/closet/l3closet,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "Zj" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 1
@@ -847,27 +894,27 @@ Bj
 Bj
 "}
 (3,1,1) = {"
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-aS
-Uu
+Bj
+Bj
+rK
+rK
+rK
+rK
+rK
+rK
+rK
+rK
+rK
+rK
+rK
+Bj
+Bj
 "}
 (4,1,1) = {"
-Uu
-rz
+Bj
+Bj
 rK
-Uu
+Aw
 Aw
 lV
 Aw
@@ -875,81 +922,115 @@ Gf
 vP
 Aw
 Aw
-Uu
-Yt
-et
-Uu
+VB
+rK
+Bj
+Bj
 "}
 (5,1,1) = {"
-Uu
+rK
+rK
+rK
+Aw
+rK
+rK
+rK
+RG
+rK
+rK
+Aw
+rK
+rK
+aS
+rK
+"}
+(6,1,1) = {"
+rK
+Zh
+rK
+Aw
+rK
+hM
+ct
+bG
+jl
+MT
+Aw
+rK
+Yt
+et
+rK
+"}
+(7,1,1) = {"
+rK
 Aw
 vP
 Aw
-Aw
-Uu
-Uu
-xc
-Uu
-Uu
-JE
-MT
-Aw
-PM
-Uu
-"}
-(6,1,1) = {"
-Uu
-MT
-Uu
-Uu
-Uu
-Uu
-ct
-dh
-jl
-Uu
-Uu
-Uu
-Uu
-mr
-Uu
-"}
-(7,1,1) = {"
-Uu
-wa
-vL
-Cz
-DO
+rK
 wX
 mt
 dh
 UA
-bG
+rK
+JE
+MT
+Aw
+PM
+rK
+"}
+(8,1,1) = {"
+rK
+MT
+rK
+rK
+rK
+rK
+gm
+we
+NV
+rK
+rK
+rK
+rK
+mr
+rK
+"}
+(9,1,1) = {"
+rK
+wa
+vL
+Cz
+DO
+wb
+mt
+rz
+UA
+CA
 vL
 Fi
 DO
 qn
-Uu
+rK
 "}
-(8,1,1) = {"
-Uu
+(10,1,1) = {"
+rK
 qx
 xt
 si
 iN
 la
-gm
-we
-NV
+pz
+mz
+NE
 la
 xt
 si
 iN
 qn
-Uu
+rK
 "}
-(9,1,1) = {"
-mz
+(11,1,1) = {"
+Uu
 Wp
 mc
 mc
@@ -963,10 +1044,10 @@ mc
 mc
 mc
 Ei
-mz
+Uu
 "}
-(10,1,1) = {"
-mz
+(12,1,1) = {"
+Uu
 eW
 qM
 qM
@@ -980,10 +1061,10 @@ qM
 qM
 qM
 yo
-mz
-"}
-(11,1,1) = {"
 Uu
+"}
+(13,1,1) = {"
+rK
 qx
 fS
 VQ
@@ -997,9 +1078,9 @@ fS
 VQ
 Nw
 qn
-Uu
+rK
 "}
-(12,1,1) = {"
+(14,1,1) = {"
 sP
 qx
 Ws
@@ -1014,26 +1095,26 @@ Ws
 Yp
 PP
 Gs
-Uu
+rK
 "}
-(13,1,1) = {"
-Uu
-Uu
-Uu
-wb
-Uu
+(15,1,1) = {"
+rK
+rK
+rK
+Nt
+rK
 RZ
-Uu
-xc
-Uu
+rK
+RG
+rK
 RZ
-Uu
-Uu
-Uu
-Uu
-Uu
+rK
+rK
+rK
+rK
+rK
 "}
-(14,1,1) = {"
+(16,1,1) = {"
 kM
 ok
 vT
@@ -1048,10 +1129,10 @@ vT
 vT
 vT
 px
-Uu
+rK
 "}
-(15,1,1) = {"
-Uu
+(17,1,1) = {"
+rK
 fm
 vK
 th
@@ -1065,10 +1146,10 @@ th
 th
 vK
 ni
-Uu
+rK
 "}
-(16,1,1) = {"
-mz
+(18,1,1) = {"
+Uu
 so
 vD
 rH
@@ -1082,10 +1163,10 @@ rH
 rH
 so
 vD
-mz
+Uu
 "}
-(17,1,1) = {"
-mz
+(19,1,1) = {"
+Uu
 Ny
 vD
 rH
@@ -1099,10 +1180,10 @@ rH
 rH
 so
 FZ
-mz
+Uu
 "}
-(18,1,1) = {"
-mz
+(20,1,1) = {"
+Uu
 so
 vD
 rH
@@ -1116,10 +1197,10 @@ rH
 rH
 so
 vD
-mz
-"}
-(19,1,1) = {"
 Uu
+"}
+(21,1,1) = {"
+rK
 fm
 vK
 vT
@@ -1133,9 +1214,9 @@ vT
 vT
 vK
 ni
-Uu
+rK
 "}
-(20,1,1) = {"
+(22,1,1) = {"
 as
 wu
 th
@@ -1150,44 +1231,44 @@ th
 vK
 th
 Hy
-Uu
+rK
 "}
-(21,1,1) = {"
+(23,1,1) = {"
+rK
+rK
 Uu
 Uu
-mz
-mz
-Uu
-Uu
+rK
+rK
 WE
 vK
 Pi
-Uu
-Uu
+rK
+rK
 FJ
-Uu
-Uu
-Uu
+rK
+rK
+rK
 "}
-(22,1,1) = {"
+(24,1,1) = {"
 MS
 jS
 Xl
 AS
 kz
-mz
+Uu
 so
 vK
 vD
-Uu
+rK
 UM
 Ru
 Ow
 aX
-Uu
+rK
 "}
-(23,1,1) = {"
-Uu
+(25,1,1) = {"
+rK
 vZ
 dr
 mZ
@@ -1196,97 +1277,63 @@ MS
 vK
 AA
 vD
-Uu
+rK
 Xg
 so
 vK
 vK
-mz
-"}
-(24,1,1) = {"
 Uu
+"}
+(26,1,1) = {"
+rK
 cb
 NU
 qr
 qr
-mz
+Uu
 YN
 vK
 GU
-Uu
+rK
 Xv
 th
 ly
 nx
-mz
-"}
-(25,1,1) = {"
 Uu
+"}
+(27,1,1) = {"
+rK
 mm
 Oa
 HZ
 mx
-Uu
-Uu
+rK
+rK
 YF
-Uu
-Uu
+rK
+rK
 bR
 Vl
 YS
 yj
-Uu
+rK
 "}
-(26,1,1) = {"
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
+(28,1,1) = {"
+rK
+rK
+rK
+rK
+rK
+rK
 dd
 wZ
 dd
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-"}
-(27,1,1) = {"
-Bj
-Bj
-Bj
-Bj
-Bj
-Uu
-aj
-Lv
-dF
-Uu
-Bj
-Bj
-Bj
-Bj
-Bj
-"}
-(28,1,1) = {"
-Bj
-Bj
-Bj
-Bj
-Bj
-mz
-Ah
-yJ
-Ab
-mz
-Bj
-Bj
-Bj
-Bj
-Bj
+rK
+rK
+rK
+rK
+rK
+rK
 "}
 (29,1,1) = {"
 Bj
@@ -1294,11 +1341,45 @@ Bj
 Bj
 Bj
 Bj
-mz
-mz
-xc
-mz
-mz
+rK
+aj
+Lv
+dF
+rK
+Bj
+Bj
+Bj
+Bj
+Bj
+"}
+(30,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+Uu
+Ah
+yJ
+Ab
+Uu
+Bj
+Bj
+Bj
+Bj
+Bj
+"}
+(31,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+Uu
+Uu
+RG
+Uu
+Uu
 Bj
 Bj
 Bj

--- a/_maps/shuttles/emergency/emergency_tombstone.dmm
+++ b/_maps/shuttles/emergency/emergency_tombstone.dmm
@@ -16,6 +16,10 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"ay" = (
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/iron/dark/smooth_half,
+/area/shuttle/escape)
 "aI" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 8
@@ -36,13 +40,7 @@
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
 "bG" = (
-/obj/effect/turf_decal/tile/dark_green/half{
-	dir = 8
-	},
-/obj/machinery/light/small/dim/directional/west,
-/turf/open/floor/iron/freezer/edge{
-	dir = 8
-	},
+/turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "bR" = (
 /obj/structure/closet/crate/grave/filled,
@@ -86,9 +84,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "dh" = (
-/obj/machinery/computer/operating{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/obj/effect/spawner/surgery_tray/full/morgue,
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "dr" = (
@@ -154,10 +151,6 @@
 /turf/open/floor/iron/freezer/edge{
 	dir = 1
 	},
-/area/shuttle/escape)
-"hM" = (
-/obj/machinery/smartfridge/organ,
-/turf/open/floor/iron/dark/smooth_half,
 /area/shuttle/escape)
 "it" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -269,12 +262,14 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape/brig)
 "mz" = (
-/obj/effect/turf_decal/tile/dark_green/half{
-	dir = 4
+/obj/structure/table,
+/obj/item/storage/box/gloves,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
 	},
-/turf/open/floor/iron/freezer/edge{
-	dir = 4
-	},
+/turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "mZ" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -282,6 +277,15 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
+"na" = (
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 8
+	},
+/obj/machinery/light/small/dim/directional/west,
+/turf/open/floor/iron/freezer/edge{
+	dir = 8
+	},
+/area/shuttle/escape)
 "ni" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/weather/dirt,
@@ -310,12 +314,10 @@
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
-"pz" = (
-/obj/effect/turf_decal/tile/dark_green/anticorner{
-	dir = 4
-	},
+"pF" = (
+/obj/effect/turf_decal/tile/dark_green/anticorner,
 /turf/open/floor/iron/freezer/corner{
-	dir = 8
+	dir = 1
 	},
 /area/shuttle/escape)
 "qn" = (
@@ -341,15 +343,19 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "rz" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/surgery_tray/full/morgue,
-/turf/open/floor/iron/freezer,
+/obj/effect/turf_decal/tile/dark_green/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer/corner{
+	dir = 8
+	},
 /area/shuttle/escape)
 "rH" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/misc/dirt/station,
 /area/shuttle/escape)
 "rK" = (
+/obj/structure/extinguisher_cabinet,
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "si" = (
@@ -406,6 +412,12 @@
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
+"vW" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/shuttle/escape)
 "vZ" = (
 /obj/structure/bodycontainer/crematorium{
 	id = "graveyard_shuttle_crematorium"
@@ -419,14 +431,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "wb" = (
-/obj/structure/table,
-/obj/item/storage/box/gloves,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/status_display/evac,
+/turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "we" = (
 /obj/structure/table/optable,
@@ -457,6 +463,19 @@
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
+"xP" = (
+/obj/structure/rack,
+/obj/item/storage/box/bodybags{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/bodybags,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
 "yj" = (
 /obj/structure/closet/crate/grave/filled,
 /obj/effect/spawner/random/exotic/grave,
@@ -474,6 +493,12 @@
 	},
 /obj/machinery/light/small/dim/directional/east,
 /turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"zw" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/closet/l3closet,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Ab" = (
 /obj/structure/bodycontainer/morgue/beeper_off{
@@ -512,19 +537,6 @@
 	},
 /obj/structure/sign/clock/directional/west,
 /turf/open/floor/iron/dark/textured_half,
-/area/shuttle/escape)
-"CA" = (
-/obj/structure/rack,
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/bodybags,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "DO" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
@@ -577,6 +589,14 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
+"GX" = (
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer/edge{
+	dir = 4
+	},
+/area/shuttle/escape)
 "Hy" = (
 /obj/item/flashlight/flare/torch,
 /obj/effect/turf_decal/weather/dirt{
@@ -627,9 +647,12 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"Nt" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/plastitanium,
+"Na" = (
+/obj/machinery/portable_atmospherics/canister/miasma,
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/sign/warning/biohazard/directional/south,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Nw" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
@@ -643,12 +666,6 @@
 	dir = 1
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
-/area/shuttle/escape)
-"NE" = (
-/obj/effect/turf_decal/tile/dark_green/anticorner,
-/turf/open/floor/iron/freezer/corner{
-	dir = 1
-	},
 /area/shuttle/escape)
 "NU" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
@@ -700,10 +717,6 @@
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
-"RG" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/escape)
 "RZ" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue"
@@ -743,13 +756,6 @@
 	},
 /obj/effect/spawner/random/exotic/grave,
 /turf/open/misc/dirt/station,
-/area/shuttle/escape)
-"VB" = (
-/obj/machinery/portable_atmospherics/canister/miasma,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/warning/biohazard/directional/south,
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "VQ" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
@@ -843,12 +849,6 @@
 /obj/effect/spawner/random/exotic/grave,
 /turf/open/misc/dirt/station,
 /area/shuttle/escape)
-"Zh" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/closet/l3closet,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "Zj" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 1
@@ -896,24 +896,24 @@ Bj
 (3,1,1) = {"
 Bj
 Bj
-rK
-rK
-rK
-rK
-rK
-rK
-rK
-rK
-rK
-rK
-rK
+bG
+bG
+bG
+bG
+bG
+bG
+bG
+bG
+bG
+bG
+bG
 Bj
 Bj
 "}
 (4,1,1) = {"
 Bj
 Bj
-rK
+bG
 Aw
 Aw
 lV
@@ -922,112 +922,112 @@ Gf
 vP
 Aw
 Aw
-VB
-rK
+Na
+bG
 Bj
 Bj
 "}
 (5,1,1) = {"
-rK
-rK
-rK
+bG
+bG
+bG
 Aw
-rK
-rK
-rK
-RG
-rK
-rK
+bG
+bG
+bG
+wb
+bG
+bG
 Aw
-rK
-rK
+bG
+bG
 aS
-rK
+bG
 "}
 (6,1,1) = {"
-rK
-Zh
-rK
-Aw
-rK
-hM
-ct
 bG
+zw
+bG
+Aw
+bG
+ay
+ct
+na
 jl
 MT
 Aw
-rK
+bG
 Yt
 et
-rK
+bG
 "}
 (7,1,1) = {"
-rK
+bG
 Aw
 vP
 Aw
-rK
+bG
 wX
 mt
 dh
 UA
-rK
+bG
 JE
 MT
 Aw
 PM
-rK
+bG
 "}
 (8,1,1) = {"
-rK
+bG
 MT
-rK
-rK
-rK
-rK
+bG
+bG
+bG
+bG
 gm
 we
 NV
-rK
-rK
-rK
-rK
+bG
+bG
+bG
+bG
 mr
-rK
+bG
 "}
 (9,1,1) = {"
-rK
+bG
 wa
 vL
 Cz
 DO
-wb
+mz
 mt
-rz
+vW
 UA
-CA
+xP
 vL
 Fi
 DO
 qn
-rK
+bG
 "}
 (10,1,1) = {"
-rK
+bG
 qx
 xt
 si
 iN
 la
-pz
-mz
-NE
+rz
+GX
+pF
 la
 xt
 si
 iN
 qn
-rK
+bG
 "}
 (11,1,1) = {"
 Uu
@@ -1064,7 +1064,7 @@ yo
 Uu
 "}
 (13,1,1) = {"
-rK
+bG
 qx
 fS
 VQ
@@ -1078,7 +1078,7 @@ fS
 VQ
 Nw
 qn
-rK
+bG
 "}
 (14,1,1) = {"
 sP
@@ -1095,24 +1095,24 @@ Ws
 Yp
 PP
 Gs
-rK
+bG
 "}
 (15,1,1) = {"
+bG
+bG
+bG
 rK
-rK
-rK
-Nt
-rK
+bG
 RZ
-rK
-RG
-rK
+bG
+wb
+bG
 RZ
-rK
-rK
-rK
-rK
-rK
+bG
+bG
+bG
+bG
+bG
 "}
 (16,1,1) = {"
 kM
@@ -1129,10 +1129,10 @@ vT
 vT
 vT
 px
-rK
+bG
 "}
 (17,1,1) = {"
-rK
+bG
 fm
 vK
 th
@@ -1146,7 +1146,7 @@ th
 th
 vK
 ni
-rK
+bG
 "}
 (18,1,1) = {"
 Uu
@@ -1200,7 +1200,7 @@ vD
 Uu
 "}
 (21,1,1) = {"
-rK
+bG
 fm
 vK
 vT
@@ -1214,7 +1214,7 @@ vT
 vT
 vK
 ni
-rK
+bG
 "}
 (22,1,1) = {"
 as
@@ -1231,24 +1231,24 @@ th
 vK
 th
 Hy
-rK
+bG
 "}
 (23,1,1) = {"
-rK
-rK
+bG
+bG
 Uu
 Uu
-rK
-rK
+bG
+bG
 WE
 vK
 Pi
-rK
-rK
+bG
+bG
 FJ
-rK
-rK
-rK
+bG
+bG
+bG
 "}
 (24,1,1) = {"
 MS
@@ -1260,15 +1260,15 @@ Uu
 so
 vK
 vD
-rK
+bG
 UM
 Ru
 Ow
 aX
-rK
+bG
 "}
 (25,1,1) = {"
-rK
+bG
 vZ
 dr
 mZ
@@ -1277,7 +1277,7 @@ MS
 vK
 AA
 vD
-rK
+bG
 Xg
 so
 vK
@@ -1285,7 +1285,7 @@ vK
 Uu
 "}
 (26,1,1) = {"
-rK
+bG
 cb
 NU
 qr
@@ -1294,7 +1294,7 @@ Uu
 YN
 vK
 GU
-rK
+bG
 Xv
 th
 ly
@@ -1302,38 +1302,38 @@ nx
 Uu
 "}
 (27,1,1) = {"
-rK
+bG
 mm
 Oa
 HZ
 mx
-rK
-rK
+bG
+bG
 YF
-rK
-rK
+bG
+bG
 bR
 Vl
 YS
 yj
-rK
+bG
 "}
 (28,1,1) = {"
-rK
-rK
-rK
-rK
-rK
-rK
+bG
+bG
+bG
+bG
+bG
+bG
 dd
 wZ
 dd
-rK
-rK
-rK
-rK
-rK
-rK
+bG
+bG
+bG
+bG
+bG
+bG
 "}
 (29,1,1) = {"
 Bj
@@ -1341,11 +1341,11 @@ Bj
 Bj
 Bj
 Bj
-rK
+bG
 aj
 Lv
 dF
-rK
+bG
 Bj
 Bj
 Bj
@@ -1377,7 +1377,7 @@ Bj
 Bj
 Uu
 Uu
-RG
+wb
 Uu
 Uu
 Bj

--- a/_maps/shuttles/emergency/emergency_tombstone.dmm
+++ b/_maps/shuttles/emergency/emergency_tombstone.dmm
@@ -16,10 +16,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"ay" = (
-/obj/machinery/smartfridge/organ,
-/turf/open/floor/iron/dark/smooth_half,
-/area/shuttle/escape)
 "aI" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 8
@@ -40,7 +36,12 @@
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
 "bG" = (
-/turf/closed/wall/mineral/plastitanium,
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer/edge{
+	dir = 4
+	},
 /area/shuttle/escape)
 "bR" = (
 /obj/structure/closet/crate/grave/filled,
@@ -74,19 +75,26 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "cV" = (
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 8
+/obj/structure/table,
+/obj/item/storage/box/gloves,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/dead_body_placer,
-/turf/open/floor/iron/dark/textured_half,
+/turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "dd" = (
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "dh" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/surgery_tray/full/morgue,
-/turf/open/floor/iron/freezer,
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 8
+	},
+/obj/machinery/light/small/dim/directional/west,
+/turf/open/floor/iron/freezer/edge{
+	dir = 8
+	},
 /area/shuttle/escape)
 "dr" = (
 /obj/effect/turf_decal/stripes/line{
@@ -111,6 +119,11 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"eq" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/surgery_tray/full/morgue,
+/turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "et" = (
 /obj/machinery/light/small/directional/south,
@@ -262,14 +275,8 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape/brig)
 "mz" = (
-/obj/structure/table,
-/obj/item/storage/box/gloves,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "mZ" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -277,15 +284,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
-"na" = (
-/obj/effect/turf_decal/tile/dark_green/half{
-	dir = 8
-	},
-/obj/machinery/light/small/dim/directional/west,
-/turf/open/floor/iron/freezer/edge{
-	dir = 8
-	},
-/area/shuttle/escape)
 "ni" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/weather/dirt,
@@ -314,12 +312,6 @@
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
-"pF" = (
-/obj/effect/turf_decal/tile/dark_green/anticorner,
-/turf/open/floor/iron/freezer/corner{
-	dir = 1
-	},
-/area/shuttle/escape)
 "qn" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -343,19 +335,23 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "rz" = (
-/obj/effect/turf_decal/tile/dark_green/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer/corner{
+/obj/machinery/computer/operating{
 	dir = 8
 	},
+/turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "rH" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/misc/dirt/station,
 /area/shuttle/escape)
 "rK" = (
-/obj/structure/extinguisher_cabinet,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/closet/l3closet,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"rP" = (
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "si" = (
@@ -412,12 +408,6 @@
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
-"vW" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/turf/open/floor/iron/freezer,
-/area/shuttle/escape)
 "vZ" = (
 /obj/structure/bodycontainer/crematorium{
 	id = "graveyard_shuttle_crematorium"
@@ -431,7 +421,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "wb" = (
-/obj/machinery/status_display/evac,
+/obj/structure/extinguisher_cabinet,
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "we" = (
@@ -463,23 +453,18 @@
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
-"xP" = (
-/obj/structure/rack,
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/bodybags,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron/dark,
-/area/shuttle/escape)
 "yj" = (
 /obj/structure/closet/crate/grave/filled,
 /obj/effect/spawner/random/exotic/grave,
 /turf/open/misc/dirt/station,
+/area/shuttle/escape)
+"ym" = (
+/obj/effect/turf_decal/tile/dark_green/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer/corner{
+	dir = 8
+	},
 /area/shuttle/escape)
 "yo" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -494,10 +479,11 @@
 /obj/machinery/light/small/dim/directional/east,
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
-"zw" = (
-/obj/effect/turf_decal/bot,
+"zA" = (
+/obj/machinery/portable_atmospherics/canister/miasma,
+/obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/cobweb,
-/obj/structure/closet/l3closet,
+/obj/structure/sign/warning/biohazard/directional/south,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Ab" = (
@@ -589,14 +575,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
-"GX" = (
-/obj/effect/turf_decal/tile/dark_green/half{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer/edge{
-	dir = 4
-	},
-/area/shuttle/escape)
 "Hy" = (
 /obj/item/flashlight/flare/torch,
 /obj/effect/turf_decal/weather/dirt{
@@ -612,6 +590,12 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape/brig)
+"If" = (
+/obj/effect/turf_decal/tile/dark_green/anticorner,
+/turf/open/floor/iron/freezer/corner{
+	dir = 1
+	},
+/area/shuttle/escape)
 "Ih" = (
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 8
@@ -645,13 +629,6 @@
 /area/shuttle/escape)
 "MT" = (
 /obj/machinery/door/airlock/maintenance_hatch,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Na" = (
-/obj/machinery/portable_atmospherics/canister/miasma,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/warning/biohazard/directional/south,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Nw" = (
@@ -708,6 +685,10 @@
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
+"Qd" = (
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/iron/dark/smooth_half,
+/area/shuttle/escape)
 "Ru" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -732,8 +713,7 @@
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
 "Uu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "UA" = (
 /obj/effect/turf_decal/tile/dark_green/half,
@@ -762,6 +742,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"VW" = (
+/obj/structure/rack,
+/obj/item/storage/box/bodybags{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/bodybags,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Wp" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -896,24 +889,24 @@ Bj
 (3,1,1) = {"
 Bj
 Bj
-bG
-bG
-bG
-bG
-bG
-bG
-bG
-bG
-bG
-bG
-bG
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
 Bj
 Bj
 "}
 (4,1,1) = {"
 Bj
 Bj
-bG
+Uu
 Aw
 Aw
 lV
@@ -922,115 +915,115 @@ Gf
 vP
 Aw
 Aw
-Na
-bG
+zA
+Uu
 Bj
 Bj
 "}
 (5,1,1) = {"
-bG
-bG
-bG
+Uu
+Uu
+Uu
 Aw
-bG
-bG
-bG
-wb
-bG
-bG
+Uu
+Uu
+Uu
+rP
+Uu
+Uu
 Aw
-bG
-bG
+Uu
+Uu
 aS
-bG
+Uu
 "}
 (6,1,1) = {"
-bG
-zw
-bG
+Uu
+rK
+Uu
 Aw
-bG
-ay
+Uu
+Qd
 ct
-na
+dh
 jl
 MT
 Aw
-bG
+Uu
 Yt
 et
-bG
+Uu
 "}
 (7,1,1) = {"
-bG
+Uu
 Aw
 vP
 Aw
-bG
+Uu
 wX
 mt
-dh
+eq
 UA
-bG
+Uu
 JE
 MT
 Aw
 PM
-bG
+Uu
 "}
 (8,1,1) = {"
-bG
+Uu
 MT
-bG
-bG
-bG
-bG
+Uu
+Uu
+Uu
+Uu
 gm
 we
 NV
-bG
-bG
-bG
-bG
+Uu
+Uu
+Uu
+Uu
 mr
-bG
+Uu
 "}
 (9,1,1) = {"
-bG
+Uu
 wa
 vL
 Cz
 DO
-mz
+cV
 mt
-vW
+rz
 UA
-xP
+VW
 vL
 Fi
 DO
 qn
-bG
+Uu
 "}
 (10,1,1) = {"
-bG
+Uu
 qx
 xt
 si
 iN
 la
-rz
-GX
-pF
+ym
+bG
+If
 la
 xt
 si
 iN
 qn
-bG
+Uu
 "}
 (11,1,1) = {"
-Uu
+mz
 Wp
 mc
 mc
@@ -1044,10 +1037,10 @@ mc
 mc
 mc
 Ei
-Uu
+mz
 "}
 (12,1,1) = {"
-Uu
+mz
 eW
 qM
 qM
@@ -1061,24 +1054,24 @@ qM
 qM
 qM
 yo
-Uu
+mz
 "}
 (13,1,1) = {"
-bG
+Uu
 qx
 fS
 VQ
 Nw
 la
 fS
-cV
+VQ
 Nw
 la
 fS
 VQ
 Nw
 qn
-bG
+Uu
 "}
 (14,1,1) = {"
 sP
@@ -1095,24 +1088,24 @@ Ws
 Yp
 PP
 Gs
-bG
+Uu
 "}
 (15,1,1) = {"
-bG
-bG
-bG
-rK
-bG
-RZ
-bG
+Uu
+Uu
+Uu
 wb
-bG
+Uu
 RZ
-bG
-bG
-bG
-bG
-bG
+Uu
+rP
+Uu
+RZ
+Uu
+Uu
+Uu
+Uu
+Uu
 "}
 (16,1,1) = {"
 kM
@@ -1129,10 +1122,10 @@ vT
 vT
 vT
 px
-bG
+Uu
 "}
 (17,1,1) = {"
-bG
+Uu
 fm
 vK
 th
@@ -1146,10 +1139,10 @@ th
 th
 vK
 ni
-bG
+Uu
 "}
 (18,1,1) = {"
-Uu
+mz
 so
 vD
 rH
@@ -1163,10 +1156,10 @@ rH
 rH
 so
 vD
-Uu
+mz
 "}
 (19,1,1) = {"
-Uu
+mz
 Ny
 vD
 rH
@@ -1180,10 +1173,10 @@ rH
 rH
 so
 FZ
-Uu
+mz
 "}
 (20,1,1) = {"
-Uu
+mz
 so
 vD
 rH
@@ -1197,10 +1190,10 @@ rH
 rH
 so
 vD
-Uu
+mz
 "}
 (21,1,1) = {"
-bG
+Uu
 fm
 vK
 vT
@@ -1214,7 +1207,7 @@ vT
 vT
 vK
 ni
-bG
+Uu
 "}
 (22,1,1) = {"
 as
@@ -1231,24 +1224,24 @@ th
 vK
 th
 Hy
-bG
+Uu
 "}
 (23,1,1) = {"
-bG
-bG
 Uu
 Uu
-bG
-bG
+mz
+mz
+Uu
+Uu
 WE
 vK
 Pi
-bG
-bG
+Uu
+Uu
 FJ
-bG
-bG
-bG
+Uu
+Uu
+Uu
 "}
 (24,1,1) = {"
 MS
@@ -1256,19 +1249,19 @@ jS
 Xl
 AS
 kz
-Uu
+mz
 so
 vK
 vD
-bG
+Uu
 UM
 Ru
 Ow
 aX
-bG
+Uu
 "}
 (25,1,1) = {"
-bG
+Uu
 vZ
 dr
 mZ
@@ -1277,63 +1270,63 @@ MS
 vK
 AA
 vD
-bG
+Uu
 Xg
 so
 vK
 vK
-Uu
+mz
 "}
 (26,1,1) = {"
-bG
+Uu
 cb
 NU
 qr
 qr
-Uu
+mz
 YN
 vK
 GU
-bG
+Uu
 Xv
 th
 ly
 nx
-Uu
+mz
 "}
 (27,1,1) = {"
-bG
+Uu
 mm
 Oa
 HZ
 mx
-bG
-bG
+Uu
+Uu
 YF
-bG
-bG
+Uu
+Uu
 bR
 Vl
 YS
 yj
-bG
+Uu
 "}
 (28,1,1) = {"
-bG
-bG
-bG
-bG
-bG
-bG
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
 dd
 wZ
 dd
-bG
-bG
-bG
-bG
-bG
-bG
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
 "}
 (29,1,1) = {"
 Bj
@@ -1341,11 +1334,11 @@ Bj
 Bj
 Bj
 Bj
-bG
+Uu
 aj
 Lv
 dF
-bG
+Uu
 Bj
 Bj
 Bj
@@ -1358,11 +1351,11 @@ Bj
 Bj
 Bj
 Bj
-Uu
+mz
 Ah
 yJ
 Ab
-Uu
+mz
 Bj
 Bj
 Bj
@@ -1375,11 +1368,11 @@ Bj
 Bj
 Bj
 Bj
-Uu
-Uu
-wb
-Uu
-Uu
+mz
+mz
+rP
+mz
+mz
 Bj
 Bj
 Bj

--- a/_maps/shuttles/emergency/emergency_tombstone.dmm
+++ b/_maps/shuttles/emergency/emergency_tombstone.dmm
@@ -3,6 +3,7 @@
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "as" = (
@@ -39,17 +40,16 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
-/obj/structure/rack,
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
-	},
+/obj/structure/table,
+/obj/item/storage/box/gloves,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "bR" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/plating,
+/obj/structure/closet/crate/grave/filled,
+/obj/effect/spawner/random/exotic/grave,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/misc/dirt/station,
 /area/shuttle/escape)
 "cb" = (
 /obj/effect/turf_decal/stripes/line{
@@ -66,6 +66,7 @@
 /obj/effect/turf_decal/trimline/blue,
 /obj/structure/mirror/directional/west,
 /obj/structure/sink/directional/east,
+/obj/structure/sign/poster/official/cleanliness/directional/north,
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
 "cu" = (
@@ -109,10 +110,17 @@
 /obj/item/flashlight/flare/torch,
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
+"dF" = (
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
 "et" = (
-/obj/machinery/portable_atmospherics/canister/miasma,
-/obj/structure/sign/warning/biohazard/directional/north,
-/turf/open/floor/plating,
+/obj/machinery/light/small/directional/south,
+/obj/structure/sign/warning/vacuum/directional/south,
+/turf/open/floor/catwalk_floor,
 /area/shuttle/escape)
 "eW" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
@@ -146,8 +154,11 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
 "it" = (
-/obj/structure/closet/jcloset,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/mob/living/basic/mouse,
+/turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "iz" = (
 /obj/effect/spawner/random/trash/hobo_squat{
@@ -166,6 +177,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small/dim/directional/south,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
 "jS" = (
@@ -224,6 +236,7 @@
 "mm" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "mr" = (
@@ -306,15 +319,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
-"qS" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Morgue"
-	},
+"rz" = (
+/obj/structure/closet/jcloset,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "rH" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/misc/dirt/station,
+/area/shuttle/escape)
+"rK" = (
+/obj/machinery/portable_atmospherics/canister/miasma,
+/obj/effect/turf_decal/delivery,
+/obj/structure/sign/warning/biohazard/directional/west,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "si" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
@@ -327,6 +346,12 @@
 	dir = 1
 	},
 /turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
+"sP" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue"
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "th" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -371,6 +396,15 @@
 /obj/structure/sign/warning/hot_temp/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/escape/brig)
+"wa" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/sign/departments/maint/directional/north,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"wb" = (
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
 "we" = (
 /obj/machinery/door/window/brigdoor/left/directional/east{
 	name = "Coroner's Office"
@@ -401,6 +435,10 @@
 /obj/item/storage/box/bodybags,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
+"wZ" = (
+/obj/effect/spawner/costume/plaguedoctor,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
 "xc" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
@@ -410,6 +448,11 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
+"yj" = (
+/obj/structure/closet/crate/grave/filled,
+/obj/effect/spawner/random/exotic/grave,
+/turf/open/misc/dirt/station,
 /area/shuttle/escape)
 "yo" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -430,6 +473,13 @@
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
+"Ah" = (
+/obj/structure/bodycontainer/morgue/beeper_off{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron/dark/textured_half,
+/area/shuttle/escape)
 "Aw" = (
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -448,8 +498,12 @@
 /turf/template_noop,
 /area/template_noop)
 "Cz" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plating,
+/obj/machinery/light/small/dim/directional/west,
+/obj/structure/bodycontainer/morgue/beeper_off{
+	name = "morgue"
+	},
+/obj/structure/sign/clock/directional/west,
+/turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
 "DO" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
@@ -475,6 +529,7 @@
 /obj/structure/mineral_door{
 	name = "Crypt"
 	},
+/obj/structure/barricade/wooden/crude,
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
 "FZ" = (
@@ -483,21 +538,14 @@
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
 "Gf" = (
-/obj/effect/spawner/random/trash/garbage{
-	spawn_scatter_radius = 1;
-	spawn_loot_count = 2;
-	spawn_loot_chance = 50
-	},
-/obj/machinery/light/small/dim/directional/west,
+/mob/living/basic/spider/maintenance,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Gs" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/storage/box/gloves,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "GU" = (
@@ -505,6 +553,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
 "Hy" = (
@@ -519,6 +568,7 @@
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 9
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape/brig)
 "Ih" = (
@@ -526,6 +576,15 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"JE" = (
+/obj/effect/spawner/random/trash/garbage{
+	spawn_scatter_radius = 1;
+	spawn_loot_count = 2;
+	spawn_loot_chance = 50
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Lv" = (
 /obj/effect/turf_decal/siding/dark_blue{
@@ -578,6 +637,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/machinery/light/small/dim/directional/east,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "Ow" = (
@@ -585,9 +645,12 @@
 /obj/item/shovel,
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
+"Pi" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
 "PM" = (
-/obj/structure/sign/warning/vacuum/directional/south,
-/obj/machinery/light/small/directional/south,
 /turf/open/floor/catwalk_floor,
 /area/shuttle/escape)
 "PP" = (
@@ -629,6 +692,16 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
+"UM" = (
+/obj/structure/closet/crate/grave/fresh,
+/obj/structure/sign/painting/library{
+	pixel_y = 33;
+	dir = 1
+	},
+/obj/effect/spawner/random/exotic/grave,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/misc/dirt/station,
+/area/shuttle/escape)
 "Vl" = (
 /obj/structure/closet/crate/grave/fresh,
 /obj/structure/sign/painting/library{
@@ -659,6 +732,13 @@
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
+"WE" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/misc/asteroid/basalt/wasteland/station,
+/area/shuttle/escape)
 "Xg" = (
 /obj/structure/closet/crate/grave/fresh,
 /obj/structure/sign/painting/library{
@@ -685,10 +765,6 @@
 /obj/item/shovel,
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
-"Yk" = (
-/obj/effect/spawner/costume/plaguedoctor,
-/turf/open/floor/iron/dark,
-/area/shuttle/escape)
 "Yp" = (
 /obj/machinery/light/small/dim/directional/east,
 /obj/structure/bodycontainer/morgue/beeper_off{
@@ -698,9 +774,9 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/shuttle/escape)
 "Yt" = (
-/obj/machinery/door/morgue{
-	name = "Occult Study"
-	},
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "YF" = (
@@ -715,6 +791,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/misc/asteroid/basalt/wasteland/station,
 /area/shuttle/escape)
 "YS" = (
@@ -738,85 +815,85 @@
 (1,1,1) = {"
 Bj
 Bj
-Bj
-Bj
-Bj
 Ih
 Ih
 Bj
 Ih
 Ih
 Bj
+Ih
+Ih
 Bj
-Bj
+Ih
+Ih
 Bj
 Bj
 "}
 (2,1,1) = {"
 Bj
 Bj
-Ih
-Ih
-Bj
+aI
+aI
+lV
 aI
 aI
 iz
 aI
 aI
-Bj
-Ih
-Ih
+vP
+aI
+aI
 Bj
 Bj
 "}
 (3,1,1) = {"
-Bj
-Bj
-aI
-aI
-Bj
 Uu
 Uu
 Uu
 Uu
 Uu
-Bj
-aI
-aI
-Bj
-Bj
-"}
-(4,1,1) = {"
 Uu
 Uu
 Uu
 Uu
-Bj
 Uu
-et
-Gf
-bR
 Uu
-Bj
 Uu
 Uu
 aS
 Uu
 "}
+(4,1,1) = {"
+Uu
+rz
+rK
+Uu
+Aw
+lV
+Aw
+Gf
+vP
+Aw
+Aw
+Uu
+Yt
+et
+Uu
+"}
 (5,1,1) = {"
 Uu
 Aw
-it
-Uu
-lV
-Uu
-Uu
-Yt
-Uu
-Uu
 vP
+Aw
+Aw
 Uu
-Cz
+Uu
+xc
+Uu
+Uu
+JE
+MT
+Aw
 PM
 Uu
 "}
@@ -839,9 +916,9 @@ Uu
 "}
 (7,1,1) = {"
 Uu
-qx
+wa
 vL
-Fi
+Cz
 DO
 wX
 mt
@@ -896,7 +973,7 @@ qM
 qM
 cu
 qM
-qM
+it
 qM
 cu
 qM
@@ -923,7 +1000,7 @@ qn
 Uu
 "}
 (12,1,1) = {"
-qS
+sP
 qx
 Ws
 Yp
@@ -943,7 +1020,7 @@ Uu
 Uu
 Uu
 Uu
-Uu
+wb
 Uu
 RZ
 Uu
@@ -1082,9 +1159,9 @@ mz
 mz
 Uu
 Uu
-so
+WE
 vK
-vD
+Pi
 Uu
 Uu
 FJ
@@ -1103,7 +1180,7 @@ so
 vK
 vD
 Uu
-Xg
+UM
 Ru
 Ow
 aX
@@ -1154,10 +1231,10 @@ Uu
 YF
 Uu
 Uu
-YS
+bR
 Vl
 YS
-YS
+yj
 Uu
 "}
 (26,1,1) = {"
@@ -1168,7 +1245,7 @@ Uu
 Uu
 Uu
 dd
-Yk
+wZ
 dd
 Uu
 Uu
@@ -1186,7 +1263,7 @@ Bj
 Uu
 aj
 Lv
-aj
+dF
 Uu
 Bj
 Bj
@@ -1201,7 +1278,7 @@ Bj
 Bj
 Bj
 mz
-Ab
+Ah
 yJ
 Ab
 mz

--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -112,6 +112,8 @@
 #define SHUTTLE_UNLOCK_WABBAJACK "wabbajack"
 // Needs cargo budget to be almost empty to be purchasable.
 #define SHUTTLE_UNLOCK_SCRAPHEAP "scrapheap"
+// Needs biohazard to be triggered - Blob, Zombies, or a Severe Disease
+#define SHUTTLE_UNLOCK_TOMBSTONE "tombstone"
 
 //Shuttle Events
 

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -83,6 +83,9 @@
 	var/turf/source_turf = get_turf(infectee)
 	log_virus("[key_name(infectee)] was infected by virus: [src.admin_details()] at [loc_name(source_turf)]")
 
+	if(severity >= DISEASE_SEVERITY_BIOHAZARD)
+		SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_TOMBSTONE] = TRUE
+
 /// Updates the spread flags set, ensuring signals are updated as necessary
 /datum/disease/proc/update_spread_flags(new_flags)
 	if(spread_flags == new_flags)

--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -523,4 +523,16 @@
 /datum/map_template/shuttle/emergency/zeta/prerequisites_met()
 	return SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_ALIENTECH]
 
+/datum/map_template/shuttle/emergency/tombstone
+	suffix = "tombstone"
+	name = "The NTSS Tombstone"
+	description = "Specifically commissioned for cleanups involving bio hazards, zombie outbreaks, or flesh-eating plagues. Features burial plots, reinforced morgue trays, and a crematorium. It's safe, airtight, and ensures you won't bite your coworkers during transit!"
+	admin_notes = "The aft of the ship has a miasma tank behind the curator room. May get released by crew. There are also random spawners in the crypt graves that has a chance to spawn a one use spectral musical instrument."
+	credit_cost = CARGO_CRATE_VALUE * 15
+	occupancy_limit = "40"
+	prerequisites = "This shuttle requires a biohazard outbreak to occur before it can be purchased."
+
+/datum/map_template/shuttle/emergency/tombstone/prerequisites_met()
+	return SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_TOMBSTONE]
+
 #undef EMAG_LOCKED_SHUTTLE_COST

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -193,6 +193,9 @@
 /area/shuttle/escape/engine
 	name = "Escape Shuttle Engine"
 
+/area/shuttle/escape/tombstone
+	ambience_index = AMBIENCE_SPOOKY
+
 /area/shuttle/transport
 	name = "Transport Shuttle"
 

--- a/code/game/objects/effects/spawners/random/exotic.dm
+++ b/code/game/objects/effects/spawners/random/exotic.dm
@@ -144,7 +144,7 @@
 	icon_state = "loot"
 	spawn_loot_chance = 50
 	loot = list(
-		/obj/effect/mob_spawn/corpse/human/skeleton = 22,
+		/obj/effect/mob_spawn/corpse/human/skeleton = 27,
 		/obj/item/instrument/trumpet/spectral/one_doot = 1,
 		/obj/item/instrument/saxophone/spectral/one_doot = 1,
 		/obj/item/instrument/trombone/spectral/one_doot = 1,

--- a/code/game/objects/effects/spawners/random/exotic.dm
+++ b/code/game/objects/effects/spawners/random/exotic.dm
@@ -144,7 +144,7 @@
 	icon_state = "loot"
 	spawn_loot_chance = 50
 	loot = list(
-		/obj/effect/mob_spawn/corpse/human/skeleton = 9,
+		/obj/effect/mob_spawn/corpse/human/skeleton = 22,
 		/obj/item/instrument/trumpet/spectral/one_doot = 1,
 		/obj/item/instrument/saxophone/spectral/one_doot = 1,
 		/obj/item/instrument/trombone/spectral/one_doot = 1,

--- a/code/game/objects/effects/spawners/random/exotic.dm
+++ b/code/game/objects/effects/spawners/random/exotic.dm
@@ -138,3 +138,14 @@
 		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/pathfinder,
 	)
+
+/obj/effect/spawner/random/exotic/grave
+	name = "grave spawner"
+	icon_state = "loot"
+	spawn_loot_chance = 50
+	loot = list(
+		/obj/effect/mob_spawn/corpse/human/skeleton = 9,
+		/obj/item/instrument/trumpet/spectral/one_doot = 1,
+		/obj/item/instrument/saxophone/spectral/one_doot = 1,
+		/obj/item/instrument/trombone/spectral/one_doot = 1,
+	)

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -174,6 +174,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 	if(announcement_time && (world.time >= announcement_time || blobs_legit.len >= announcement_size) && !has_announced)
 		priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", ANNOUNCER_OUTBREAK5)
+		SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_TOMBSTONE] = TRUE
 
 		// Set status displays to biohazard alert
 		send_status_display_biohazard_alert()

--- a/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -83,6 +83,9 @@
 	else
 		new /obj/item/stack/sheet/bone(src)
 
+/turf/open/misc/asteroid/basalt/wasteland/station
+	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+
 //***Oil well puddles.
 /obj/structure/sink/oil_well //You're not going to enjoy bathing in this...
 	name = "oil well"

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -112,6 +112,7 @@
 		after_assumed_control = CALLBACK(src, PROC_REF(after_ghost_control)), \
 		joinable_mobs_title = "Zombies", \
 	))
+	SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_TOMBSTONE] = TRUE
 
 /obj/item/organ/zombie_infection/proc/check_ghost_control_eligibility(mob/candidate)
 	if(QDELETED(src) || QDELETED(owner))


### PR DESCRIPTION

## About The Pull Request
This adds a morgue transport shuttle filled with morgue trays, coffins, and a graveyard. It can only be unlocked if a severe disease has successfully caused an infection, a zombie outbreak happens, or a blob biohazard is triggered.

The shuttle features:
- 15 morgue trays in back
- 2 secure morgue trays in the command area
- 1 mortician workspace (miasma canister in secret room behind their area)
- 20 coffins in the main cemetery
- Crematorium (Brig) area has 4 coffins, 2 meatspikes, and 1 crematorium)
- Crypt area has 6 graves with a random spawner for corpses and a small chance to spawn a one-use spectral instrument

I deliberately made it so that the only seating available is the pilot's chair since this is supposed to be a transport ship for dead bodies. Regular crew can get around this by climbing into morgue trays or coffins to avoid the knockdown from shuttle departure. To get a spooky/creepy vibe, I went ahead and made it so there is very little natural lighting. To offset this, I provided candles and torches on the ground that the crew can use as light sources.

## Why It's Good For The Game

<img width="992" height="480" alt="StrongDMM-2026-07-09 22 12 49" src="https://github.com/user-attachments/assets/1cc7c5c9-e0ca-4d80-8dd9-b9cfb76e917f" />

## Changelog
:cl:
add: Add Tombstone Escape Shuttle that can be unlocked via a biohazard event. (Blob, zombies, or a severe enough disease)
map: Add Tombstone Escape Shuttle that can be unlocked via a biohazard event. (Blob, zombies, or a severe enough disease)
/:cl:
