### PR TITLE
Heparin increases the power of nosebleeds

### DIFF
--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -206,7 +206,8 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 /datum/voice_of_god_command/bleed/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
 	for(var/mob/living/carbon/human/target in listeners)
 		var/obj/item/bodypart/chosen_part = pick(target.get_bodyparts())
-		chosen_part.adjustBleedStacks(5)
+		var/add_stacks = HAS_TRAIT(target, TRAIT_BLOOD_FOUNTAIN) ? 7 : 5
+		chosen_part.adjustBleedStacks(add_stacks)
 
 /// This command sets the listeners ablaze.
 /datum/voice_of_god_command/burn

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1349,7 +1349,8 @@
 	if(!can_bleed())
 		to_chat(src, span_notice("You get a headache."))
 		return
-	head.adjustBleedStacks(5)
+	var/add_stacks = HAS_TRAIT(src, TRAIT_BLOOD_FOUNTAIN) ? 7 : 5
+	head.adjustBleedStacks(add_stacks)
 	visible_message(span_notice("[src] gets a nosebleed."), span_warning("You get a nosebleed."))
 
 /mob/living/carbon/check_hit_limb_zone_name(hit_zone)


### PR DESCRIPTION
## About The Pull Request

The trait "blood fountain" applied by Leparin and Nitrous Oxide now also makes you bleed slightly more when you get an ominous nosebleed, or when a really authoritative guy yells at you that you need to bleed right now.

(You get an Ominous Nosebleed when a Dark Matter Singularity or Bioscrambler pick you as their target)

## Why It's Good For The Game

Someone asked if it worked this way in tg-general and it did not, but I thought it was a funny idea.
I'll be honest I suspect these values on the Ominous Nosebleed are not likely to be noticed unless you're juggling aggro back and forth with someone else but that's fine.

## Changelog

:cl:
balance: Heparin and Nitrous Oxide now make nosebleeds worse, and also make you bleed more if someone very convincing tells you to start doing it.
/:cl:
