### PR TITLE
Allow Skittish to Intercept Bump

### DIFF
--- a/code/datums/elements/skittish.dm
+++ b/code/datums/elements/skittish.dm
@@ -59,3 +59,5 @@
 	closet_turf.visible_message(span_warning("[scooby] dives into [closet]!"))
 	// If you run into a locker, you don't want to run out immediately
 	scooby.Immobilize(0.5 SECONDS)
+
+	return COMPONENT_INTERCEPT_BUMPED

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -950,7 +950,7 @@
 	if(!bumped_atom)
 		CRASH("Bump was called with no argument.")
 	if(SEND_SIGNAL(src, COMSIG_MOVABLE_BUMP, bumped_atom) & COMPONENT_INTERCEPT_BUMPED)
-		return
+		return TRUE
 	. = ..()
 	if(!QDELETED(throwing))
 		throwing.finalize(hit = TRUE, target = bumped_atom)


### PR DESCRIPTION

## About The Pull Request

resolves: https://github.com/tgstation/tgstation/issues/56396

Modifies `atoms_movable.dm` and `skittish.md`, as a subscriber to the `COMSIG_MOVABLE_BUMP` signal, to allow the latter to bubble up an intercept flag to `living.dm`, so that it can cancel a shove and function properly.

I looked at every other registered `COMSIG_MOVABLE_BUMP` signal receiver and found that only one ever possibly returns non-zero, and that is `/obj/item/clothing/gloves/gauntlets/proc/rocksmash`. However, when `rocksmash` is called via a bump signal, it will return `NONE` because the `proximity` parameter will not be set. Therefore, unless I missed something, there should be no collateral damage from this change.
## Why It's Good For The Game

Skittish has been broken seemingly since its addition to the game. This fixes that.

<img width="640" height="480" alt="crate" src="https://github.com/user-attachments/assets/0ce01c07-0e44-498b-aac0-02c448a6d379" />
<img width="640" height="480" alt="locker" src="https://github.com/user-attachments/assets/6fc946fb-e953-43d0-9bd3-9d958a3d9744" />

## Changelog
:cl:
fix: Fixed Skittish behaving strangely with lockers not against a wall, and crates in general.
/:cl:
