### PR TITLE
Adds a spare R.D.S.P.L.X. skill chip to the RD's locker.

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -303,6 +303,7 @@
 /obj/item/storage/box/skillchips/science/PopulateContents()
 	new/obj/item/skillchip/job/roboticist(src)
 	new/obj/item/skillchip/job/roboticist(src)
+	new/obj/item/skillchip/research_director(src)
 
 /obj/item/storage/box/skillchips/engineering
 	name = "box of engineering job skillchips"


### PR DESCRIPTION
## About The Pull Request

Adds a spare R.D.S.P.L.X. skill chip to the RD's locker.

## Why It's Good For The Game

All jobs should be replacable by promoting someone into the position and having them gear up from their job locker. This should include the Research Director, and currently until this PR you couldn't replace the RD's ability to suplex immovable rods. We added job skill chips explicitly so we could turn these innate job bonuses into gear that can be assigned to/stolen by crewmembers.

## Changelog

:cl:
qol: Adds a spare R.D.S.P.L.X. skill chip to the RD's locker.
/:cl:
