### PR TITLE
Shot in the dark screen alert hard delete

### DIFF
--- a/code/_onclick/hud/screen_objects/alert.dm
+++ b/code/_onclick/hud/screen_objects/alert.dm
@@ -86,6 +86,8 @@
 	alerts -= category
 	if(client && hud_used)
 		hud_used.reorganize_alerts()
+		for(var/mob/viewer as anything in observers)
+			viewer.client?.screen -= alert
 		client.screen -= alert
 	qdel(alert)
 


### PR DESCRIPTION
## About The Pull Request

This seems to be happening with some consistency - my only guess is that we never remove alerts from observer screens, only the mob's screen. 

<img width="405" height="163" alt="image" src="https://github.com/user-attachments/assets/87cfa0ff-955a-4f4b-93ca-a3f822848cc7" />

<img width="384" height="324" alt="image" src="https://github.com/user-attachments/assets/04955fac-635c-47ce-9220-aee9507abb14" />
