### PR TITLE
Message monitor stall exploit fixes + off station message monitors can't change station passwords

### DIFF
--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -119,6 +119,20 @@
 			data["requests"] = request_list
 	return data
 
+/obj/machinery/computer/message_monitor/ui_static_data(mob/user)
+	var/list/data = list()
+	data["is_on_station"] = is_on_station()
+	return data
+
+/// Check if this console is on the station and in a valid area
+/obj/machinery/computer/message_monitor/proc/is_on_station()
+	if(!is_station_level(z))
+		return FALSE
+	var/area/station/area = get_area(src)
+	if(isnull(area) || !(area.area_flags & VALID_TERRITORY))
+		return FALSE
+	return TRUE
+
 /obj/machinery/computer/message_monitor/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
@@ -150,7 +164,11 @@
 				message_servers += message_server
 
 			if(length(message_servers) > 1)
-				set_linked_server(tgui_input_list(usr, "Please select a server", "Server Selection", message_servers))
+				var/selected_server = tgui_input_list(usr, "Please select a server", "Server Selection", message_servers)
+				if(QDELETED(src) || !is_operational || !usr.can_interact_with(src))
+					screen = MSG_MON_SCREEN_MAIN
+					return TRUE
+				set_linked_server(selected_server)
 				if(linked_server)
 					notice_message = "NOTICE: Server selected."
 			else if(length(message_servers) == 1)
@@ -182,10 +200,17 @@
 			notice_message = "NOTICE: Logs cleared."
 			return TRUE
 		if("set_key")
+			if(!is_on_station())
+				return TRUE
+
 			var/dkey = tgui_input_text(usr, "Please enter the decryption key", "Telecomms Decryption", max_length = 16)
+			if(QDELETED(src) || !is_operational || !usr.can_interact_with(src))
+				return TRUE
 			if(dkey && dkey != "")
 				if(linked_server.decryptkey == dkey)
 					var/newkey = tgui_input_text(usr, "Please enter the new key (3 - 16 characters max)", "New Key", max_length = 16)
+					if(QDELETED(src) || !is_operational || !usr.can_interact_with(src))
+						return TRUE
 					if(length(newkey) <= 3)
 						notice_message = "NOTICE: Decryption key too short!"
 					else if(newkey && newkey != "")
@@ -238,10 +263,12 @@
 
 			if(isnull(recipient))
 				notice_message = "NOTICE: No recipient selected!"
-				return attack_hand(usr)
+				return TRUE
 			if(isnull(message) || message == "")
 				notice_message = "NOTICE: No message entered!"
-				return attack_hand(usr)
+				return TRUE
+			if(QDELETED(src) || !is_operational || !usr.can_interact_with(src))
+				return TRUE
 
 			var/datum/signal/subspace/messaging/tablet_message/signal = new(src, list(
 				"fakename" = "[sender]",

--- a/tgui/packages/tgui/interfaces/MessageMonitor.tsx
+++ b/tgui/packages/tgui/interfaces/MessageMonitor.tsx
@@ -32,6 +32,7 @@ type Data = {
   notice_message: string;
   requests: Request[];
   messages: Message[];
+  is_on_station: BooleanLike;
 };
 
 type Request = {
@@ -170,7 +171,7 @@ const MainScreenAuth = (props: AuthScreenProps) => {
   const { auth_password, setPassword } = props;
 
   const { act, data } = useBackend<Data>();
-  const { status, is_malf } = data;
+  const { status, is_malf, is_on_station } = data;
 
   return (
     <>
@@ -245,12 +246,17 @@ const MainScreenAuth = (props: AuthScreenProps) => {
           </Table.Cell>
           <Table.Cell>Clears request console logs</Table.Cell>
         </Table.Row>
-        <Table.Row>
-          <Table.Cell>
-            <Button content={'Set Custom Key'} onClick={() => act('set_key')} />
-          </Table.Cell>
-          <Table.Cell>Changes decryption key</Table.Cell>
-        </Table.Row>
+        {!!is_on_station && (
+          <Table.Row>
+            <Table.Cell>
+              <Button
+                content={'Set Custom Key'}
+                onClick={() => act('set_key')}
+              />
+            </Table.Cell>
+            <Table.Cell>Changes decryption key</Table.Cell>
+          </Table.Row>
+        )}
         <Table.Row>
           <Table.Cell>
             <Button


### PR DESCRIPTION
## About The Pull Request

- Patches up potential input stalling exploits in message monitor input
- Off station message monitors can't change the password

## Why It's Good For The Game

- Patches some exploits
- Comms agent can just wake up and change the password and the station is (kinda) perma-owned which is a little goofy

## Changelog

:cl: Melbert
fix: Fixes a few potential exploits in the message monitor
balance: Message monitors located off station can no longer change the station's message monitor password
/:cl:
