### PR TITLE
Maybe fix sound token hard deletes

### DIFF
--- a/code/controllers/subsystem/sound_tokens.dm
+++ b/code/controllers/subsystem/sound_tokens.dm
@@ -15,10 +15,7 @@ SUBSYSTEM_DEF(sound_tokens)
 		var/client/client = currentrun[currentrun.len]
 		currentrun.len--
 		var/mob/owned_mob = client.mob
-		if(!owned_mob)
-			continue
-		for(var/datum/sound_token/token in client.sound_tokens)
+		for(var/datum/sound_token/token as anything in owned_mob?.sound_tokens)
 			token.update_listener(owned_mob)
 		if(MC_TICK_CHECK)
 			break
-

--- a/code/datums/sound_token.dm
+++ b/code/datums/sound_token.dm
@@ -108,7 +108,7 @@
 		return FALSE
 
 	listeners[listener_mob] = NONE
-	listener_mob.client.sound_tokens += src
+	LAZYOR(listener_mob.sound_tokens, src)
 	if(source != listener_mob) //this is possible...yea... :/
 		RegisterSignal(listener_mob, COMSIG_QDELETING, PROC_REF(listener_deleted))
 	RegisterSignals(listener_mob, list(SIGNAL_ADDTRAIT(TRAIT_DEAF), SIGNAL_REMOVETRAIT(TRAIT_DEAF)), PROC_REF(listener_deafness_update))
@@ -119,9 +119,7 @@
 /datum/sound_token/proc/remove_listener(mob/listener_mob)
 
 	listeners -= listener_mob
-
-	if(listener_mob.client)
-		listener_mob.client.sound_tokens -= src
+	LAZYREMOVE(listener_mob.sound_tokens, src)
 
 	UnregisterSignal(listener_mob, list(COMSIG_QDELETING, SIGNAL_ADDTRAIT(TRAIT_DEAF),SIGNAL_REMOVETRAIT(TRAIT_DEAF)))
 	SEND_SOUND(listener_mob, null_sound)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -75,13 +75,6 @@
 	///The visual delay to use for the current client.Move(), mostly used for making a client based move look like it came from some other slower source
 	var/visual_delay = 0
 
-		///////////////
-		//SOUND STUFF//
-		///////////////
-
-	/// Sound tokens currently playing for this client. Managed by /datum/sound_token and the soundtoken subsystem!! SOUND TOKENS 2026
-	var/list/datum/sound_token/sound_tokens = list()
-
 		////////////
 		//SECURITY//
 		////////////

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -640,8 +640,6 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 
 	QDEL_LIST_ASSOC_VAL(char_render_holders)
 
-	sound_tokens = null
-
 	SSambience.remove_ambience_client(src)
 	SSmouse_entered.hovers -= src
 	SSping.currentrun -= src
@@ -653,7 +651,6 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 	QDEL_NULL(loot_panel)
 	QDEL_NULL(parallax_rock)
 	seen_messages = null
-	sound_tokens = null
 	Master.UpdateTickRate()
 	..() //Even though we're going to be hard deleted there are still some things that want to know the destroy is happening
 	return QDEL_HINT_HARDDEL_NOW

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -216,3 +216,7 @@
 
 	/// A ref of the area we're taking our ambient loop from.
 	var/area/ambience_tracked_area
+
+	/// Sound tokens currently playing for this mob.
+	/// Managed by /datum/sound_token and the soundtoken subsystem
+	var/list/datum/sound_token/sound_tokens

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -578,5 +578,5 @@ GAME_VERB_HIDDEN_INSTANT(/client, toggle_walk_run, "toggle-walk-run")
 
 /mob/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
 	. = ..()
-	if(client?.sound_tokens.len)
+	if(client && LAZYLEN(sound_tokens))
 		SSsound_tokens.clients_needing_update[client] = TRUE


### PR DESCRIPTION
## About The Pull Request

`remove_listener` would fail on logout so instead I figure we could track the tokens on the mob, rather than the client

Functionally not much is changed - but if you go from ghost to mob it'll remove the token from the ghost and adds the token to the new mob, so it should fix the issue

There also doesn't need to be any code in `/mob/destroy` because we listen for `listener_deleted` and remove listeners on the token itself