### PR TITLE
Removes UNIT_TEST_FOCUS from boulder processing and adds a warning message that alerts when CI has it.

### DIFF
--- a/code/modules/unit_tests/boulder_processing.dm
+++ b/code/modules/unit_tests/boulder_processing.dm
@@ -3,7 +3,6 @@
  */
 
 /datum/unit_test/boulder_processing
-	test_flags = UNIT_TEST_FOCUS
 
 /datum/unit_test/boulder_processing/Run()
 	var/turf/refinery_loc = get_step(run_loc_floor_bottom_left, EAST)

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -68,6 +68,8 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 		var/datum/map_template/unit_tests/template = new
 		reservation = template.load_new_z()
 
+	if(test_flags & UNIT_TEST_FOCUS)
+		warning("[src] has UNIT_TEST_FOCUS present inside var/test_flags.")
 	uncreatables ||= build_list_of_uncreatables()
 
 	allocated = list()


### PR DESCRIPTION

## About The Pull Request

Per title. Also this means right now, CI is only running this single test.

## Why It's Good For The Game

This is a really easy thing to miss if it's committed and not caught. Also CI should probably work.

## Changelog

not player facing.