### PR TITLE
Doubles the time admins have to cancel random events

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -1,4 +1,4 @@
-#define RANDOM_EVENT_ADMIN_INTERVENTION_TIME (10 SECONDS)
+#define RANDOM_EVENT_ADMIN_INTERVENTION_TIME (20 SECONDS)
 
 //this singleton datum is used by the events controller to dictate how it selects events
 /datum/round_event_control


### PR DESCRIPTION

## About The Pull Request

Doubles the time an admin has to click the 'cancel event' button after dynamic triggers it from 10 seconds to 20

## Why It's Good For The Game

It's very very easy to miss the prompt that a random event is even happening as an admin, let alone deliberate on canceling it and then click it within the ten second window to cancel it. Ten seconds to intervene is a bit unreasonable, twenty gives you a bit more breathing room.

## Changelog
:cl:
admin: Event intervention time is now 20 seconds from 10
/:cl:
