### PR TITLE
Fix chainsaw beheading

### DIFF
--- a/code/game/objects/items/weaponry/melee/chainsaw.dm
+++ b/code/game/objects/items/weaponry/melee/chainsaw.dm
@@ -120,13 +120,6 @@
 	if (user.zone_selected != BODY_ZONE_HEAD)
 		return ..()
 
-	if (HAS_TRAIT(target_mob, TRAIT_NODISMEMBER))
-		return ..()
-
-	var/obj/item/bodypart/head = target_mob.get_bodypart(BODY_ZONE_HEAD)
-	if (head.bodypart_flags & BODYPART_UNREMOVABLE)
-		return ..()
-
 	playsound(src, 'sound/items/weapons/chainsawhit.ogg', vol = 100, vary = TRUE)
 
 	target_mob.balloon_alert(user, "cutting off head...")

--- a/code/game/objects/items/weaponry/melee/chainsaw.dm
+++ b/code/game/objects/items/weaponry/melee/chainsaw.dm
@@ -128,6 +128,8 @@
 		return TRUE
 
 	if (!head.dismember(silent = FALSE))
+		playsound(src, 'sound/items/weapons/chainsawhit.ogg', vol = 100, vary = TRUE)
+	else
 		user.visible_message(span_warning("[target_mob]'s head is attached too firmly to cut off!"))
 
 	return TRUE

--- a/code/game/objects/items/weaponry/melee/chainsaw.dm
+++ b/code/game/objects/items/weaponry/melee/chainsaw.dm
@@ -127,9 +127,7 @@
 	if (!do_after(user, behead_time, target_mob, extra_checks = CALLBACK(src, PROC_REF(has_same_head), target_mob, head)))
 		return TRUE
 
-	if (head.dismember(silent = FALSE))
-		playsound(user, 'sound/items/weapons/slice.ogg', vol = 80, vary = TRUE)
-	else
+	if (!head.dismember(silent = FALSE))
 		user.visible_message(span_warning("[target_mob]'s head is attached too firmly to cut off!"))
 
 	return TRUE

--- a/code/game/objects/items/weaponry/melee/chainsaw.dm
+++ b/code/game/objects/items/weaponry/melee/chainsaw.dm
@@ -121,6 +121,9 @@
 		return ..()
 
 	var/obj/item/bodypart/head = target_mob.get_bodypart(BODY_ZONE_HEAD)
+	if (!head)
+		return ..()
+
 	playsound(src, 'sound/items/weapons/chainsawhit.ogg', vol = 100, vary = TRUE)
 	target_mob.balloon_alert(user, "cutting off head...")
 
@@ -130,7 +133,7 @@
 	if (head.dismember(silent = FALSE))
 		playsound(src, 'sound/items/weapons/chainsawhit.ogg', vol = 100, vary = TRUE)
 	else
-		user.visible_message(span_warning("[target_mob]'s head is attached too firmly to cut off!"))
+		to_chat(user, span_warning("[target_mob]'s head is attached too firmly to cut off!"))
 
 	return TRUE
 

--- a/code/game/objects/items/weaponry/melee/chainsaw.dm
+++ b/code/game/objects/items/weaponry/melee/chainsaw.dm
@@ -127,7 +127,7 @@
 	if (!do_after(user, behead_time, target_mob, extra_checks = CALLBACK(src, PROC_REF(has_same_head), target_mob, head)))
 		return TRUE
 
-	if (!head.dismember(silent = FALSE))
+	if (head.dismember(silent = FALSE))
 		playsound(src, 'sound/items/weapons/chainsawhit.ogg', vol = 100, vary = TRUE)
 	else
 		user.visible_message(span_warning("[target_mob]'s head is attached too firmly to cut off!"))

--- a/code/game/objects/items/weaponry/melee/chainsaw.dm
+++ b/code/game/objects/items/weaponry/melee/chainsaw.dm
@@ -111,24 +111,32 @@
 	return BRUTELOSS
 
 /obj/item/chainsaw/attack(mob/living/target_mob, mob/living/user, list/modifiers, list/attack_modifiers)
+	if(!HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
+		return ..()
+
 	if (target_mob.stat != DEAD)
 		return ..()
 
 	if (user.zone_selected != BODY_ZONE_HEAD)
 		return ..()
 
-	var/obj/item/bodypart/head = target_mob.get_bodypart(BODY_ZONE_HEAD)
-	if (!head?.can_dismember())
+	if (HAS_TRAIT(target_mob, TRAIT_NODISMEMBER))
 		return ..()
 
-	playsound(user, 'sound/items/weapons/slice.ogg', vol = 80, vary = TRUE)
+	var/obj/item/bodypart/head = target_mob.get_bodypart(BODY_ZONE_HEAD)
+	if (head.bodypart_flags & BODYPART_UNREMOVABLE)
+		return ..()
+
+	playsound(src, 'sound/items/weapons/chainsawhit.ogg', vol = 100, vary = TRUE)
 
 	target_mob.balloon_alert(user, "cutting off head...")
 	if (!do_after(user, behead_time, target_mob, extra_checks = CALLBACK(src, PROC_REF(has_same_head), target_mob, head)))
 		return TRUE
 
 	if (head.dismember(silent = FALSE))
-		user.put_in_hands(head)
+		playsound(user, 'sound/items/weapons/slice.ogg', vol = 80, vary = TRUE)
+	else
+		user.visible_message(span_warning("[target_mob]'s head is attached too firmly to cut off!"))
 
 	return TRUE
 

--- a/code/game/objects/items/weaponry/melee/chainsaw.dm
+++ b/code/game/objects/items/weaponry/melee/chainsaw.dm
@@ -120,9 +120,10 @@
 	if (user.zone_selected != BODY_ZONE_HEAD)
 		return ..()
 
+	var/obj/item/bodypart/head = target_mob.get_bodypart(BODY_ZONE_HEAD)
 	playsound(src, 'sound/items/weapons/chainsawhit.ogg', vol = 100, vary = TRUE)
-
 	target_mob.balloon_alert(user, "cutting off head...")
+
 	if (!do_after(user, behead_time, target_mob, extra_checks = CALLBACK(src, PROC_REF(has_same_head), target_mob, head)))
 		return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Chainsaws are supposed to be able to be used to behead dead people, however they haven't been able to do this since I did a check wrong in #94808 and nobody complained about it to me until today, nor posted an issue report 

The bug was that I checked if the head was dismemberable before trying to cut it off and fell back to just attacking them if it failed
However `can_dismember()` on heads returns false on everything except zombie heads

Instead I elected to just remove the checks: You can try and cut anyone's head off for 15 seconds you just might fail (for instance if they are a golem)
Additionally I made it so that you can only cut people's heads off with a chainsaw while it's turned on, because that feels like it makes sense

Finally I removed the "put in hands" call after dismembering the head because... chainsaws take up both of your hands...

## Why It's Good For The Game

Fixes a bug
It's cool to be able to cut peoples' heads of sometimes

## Changelog

:cl:
fix: You can cut off the heads of corpses using a chainsaw
balance: You have to turn it on first
/:cl:
