### PR TITLE
Fixes golem hard delete

### DIFF
--- a/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
@@ -138,8 +138,9 @@
 	part.add_bodypart_overlay(src, update = FALSE)
 
 /datum/bodypart_overlay/simple/golem_overlay/Destroy(force)
-	var/obj/item/bodypart/referenced_bodypart = attached_bodypart.resolve()
-	referenced_bodypart?.remove_bodypart_overlay(src)
+	var/obj/item/bodypart/referenced_bodypart = attached_bodypart?.resolve()
+	if(referenced_bodypart)
+		referenced_bodypart.remove_bodypart_overlay(src)
 	return ..()
 
 /// Freezes hunger for the duration

--- a/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
@@ -139,8 +139,7 @@
 
 /datum/bodypart_overlay/simple/golem_overlay/Destroy(force)
 	var/obj/item/bodypart/referenced_bodypart = attached_bodypart?.resolve()
-	if(referenced_bodypart)
-		referenced_bodypart.remove_bodypart_overlay(src)
+	referenced_bodypart?.remove_bodypart_overlay(src)
 	return ..()
 
 /// Freezes hunger for the duration


### PR DESCRIPTION
## About The Pull Request

<img width="1021" height="662" alt="image" src="https://github.com/user-attachments/assets/51a98276-68bd-444a-8154-e9da2bdc5534" />

This occasionally can runtime in its `Destroy()`, which will cause hung refs

## Changelog

Not player-facing