### PR TITLE
adds missing plant nutriments to the botanical dispenser

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -755,6 +755,8 @@
 		/datum/reagent/plantnutriment/eznutriment,
 		/datum/reagent/plantnutriment/left4zednutriment,
 		/datum/reagent/plantnutriment/robustharvestnutriment,
+		/datum/reagent/plantnutriment/endurogrow,
+		/datum/reagent/plantnutriment/liquidearthquake,
 		/datum/reagent/water,
 		/datum/reagent/toxin/plantbgone,
 		/datum/reagent/toxin/plantbgone/weedkiller,


### PR DESCRIPTION
## About The Pull Request
Adds Enduro Grow and Liquid Earthquake to the botanical chemical dispenser found in the lifebringer ship/conveniently admin-spawnable for botany-related stuff/etc.

## Why It's Good For The Game
While the lifebringer ship already has a biogenerator that lets you make these reagents, it always felt a little weird that the dispenser that dispensed basically everything else... didn't have these. For completion's sake, we might as well give it to them.

## Changelog

:cl:
qol: The botanical chemical dispenser (as seen on the lifebringer ship) is now also capable of dispensing Enduro Grow and Liquid Earthquake.
/:cl: