### PR TITLE
Fixes experiment scanners being unable to scan the DNA Infuser

### DIFF
--- a/code/game/machinery/dna_infuser/dna_infuser.dm
+++ b/code/game/machinery/dna_infuser/dna_infuser.dm
@@ -172,7 +172,7 @@
 		return NONE
 	// if the machine already has a infusion target, or the target is not valid then no adding.
 	if(!is_valid_infusion(tool, user))
-		return ITEM_INTERACT_BLOCKING
+		return ..() //research scanning is so back
 	if(!user.transferItemToLoc(tool, src))
 		to_chat(user, span_warning("[tool] is stuck to your hand!"))
 		return ITEM_INTERACT_BLOCKING


### PR DESCRIPTION

## About The Pull Request
Replaces one instance of `return ITEM_INTERACT_BLOCKING` with `return ..()` for the DNA Infuser, allowing the attack chain to continue if you use a non-mob.
## Why It's Good For The Game
I was doing the upgrade parts experiment and I couldn't scan the infuser after upgrading. I found this to be dumb.
## Changelog
:cl:
fix: You can now use experiment scanners on DNA Infusers correctly. 
/:cl:
