### PR TITLE
fixes upgraded regular microwaves' PDA recharging

### DIFF
--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -854,7 +854,7 @@
 		pre_fail()
 		return
 
-	if(!vampire_charge_amount || !length(ingredients) || isnull(cell) || !cell.charge || vampire_charge_amount < 25)
+	if(!vampire_charge_amount || !length(ingredients) || vampire_charge_amount < 25 || (cell_powered && (isnull(cell) || !cell.charge)))
 		vampire_cell = null
 		charge_loop_finish(cooker)
 		return


### PR DESCRIPTION
## About The Pull Request

Makes regular microwaves able to recharge PDAs when upgraded with a better capacitor by making the cell check only checked when the microwave is cell-powered.

## Why It's Good For The Game

Please let me charge my PDA in the chef's microwave I promise I'll double-check it's on charge (I won't)

## Changelog

:cl:
fix: Nanotrasen Wave (tm) support on standard, non-portable microwaves has been reinstated after a firmware update addressed an erroneous check (Regular microwaves can be used to recharge PDAs if properly upgraded again).
/:cl: