### PR TITLE
Fix EMPs to work on PDA power cells

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -429,6 +429,7 @@
 
 	if(internal_cell)
 		internal_cell.emp_act(severity)
+		handle_power(1 SECONDS)
 
 /obj/item/modular_computer/emag_act(mob/user, obj/item/card/emag/emag_card, forced)
 	if(!enabled && !forced)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -422,6 +422,14 @@
 		if(response == "Yes")
 			turn_on(user)
 
+/obj/item/modular_computer/emp_act(severity)
+	. = ..()
+	if (. & EMP_PROTECT_CONTENTS)
+		return
+
+	if(internal_cell)
+		internal_cell.emp_act(severity)
+
 /obj/item/modular_computer/emag_act(mob/user, obj/item/card/emag/emag_card, forced)
 	if(!enabled && !forced)
 		balloon_alert(user, "turn it on first!")


### PR DESCRIPTION

## About The Pull Request
EMPs normally drain power cells for objects and machinery. I was surprised to learn during my testing that PDAs were completely immune despite having a power cell stored inside. It's an electric item, so it should be suffering from power drain.

## Why It's Good For The Game
Consistency.

## Changelog
:cl:
fix: Fix EMPs to work on PDA power cells
/:cl:
