### PR TITLE
Refactor and fix power cell code drain

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -174,7 +174,7 @@
 		var/datum/gas_mixture/turf_gasmix = turf.return_air()
 		turf_gasmix.temperature += delta_energy / turf_gasmix.heat_capacity()
 		air_update_turf(FALSE, FALSE)
-	cell.use((required_energy * length(turfs)) / efficiency, force = TRUE)
+	cell.use((required_energy * length(turfs)) / efficiency)
 
 /obj/machinery/space_heater/RefreshParts()
 	. = ..()
@@ -401,7 +401,7 @@
 
 		beaker.reagents.adjust_thermal_energy(delta_energy)
 		beaker.reagents.handle_reactions()
-		cell.use(required_energy / efficiency, force = TRUE)
+		cell.use(required_energy / efficiency)
 	update_appearance()
 
 /obj/machinery/space_heater/improvised_chem_heater/ui_data()

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -178,7 +178,7 @@
 
 /obj/machinery/power/singularity_beacon/syndicate/no_escape/process()
 	if(cell.charge())
-		cell.use(energy_used, force = TRUE)
+		cell.use(energy_used)
 
 		if(!no_escape_event)
 			var/area/escape_shuttle_area = get_area(src)

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -171,7 +171,7 @@
 		if(istype(terminal.master, /obj/machinery/power/apc))
 			var/obj/machinery/power/apc/apc = terminal.master
 			if(apc.operating && apc.cell)
-				drained += 0.001 * apc.cell.use(0.1 * STANDARD_BATTERY_CHARGE, force = TRUE)
+				drained += 0.001 * apc.cell.use(0.1 * STANDARD_BATTERY_CHARGE)
 	internal_heat += drained
 
 /obj/item/powersink/process()

--- a/code/game/objects/items/robot/items/generic.dm
+++ b/code/game/objects/items/robot/items/generic.dm
@@ -185,7 +185,7 @@
 						span_danger("You shock [attacked_mob] to no effect."),
 					)
 			playsound(loc, 'sound/effects/sparks/sparks2.ogg', 50, TRUE, -1)
-			user.cell.use(0.5 * STANDARD_CELL_CHARGE, force = TRUE)
+			user.cell.use(0.5 * STANDARD_CELL_CHARGE)
 			COOLDOWN_START(src, shock_cooldown, HUG_SHOCK_COOLDOWN)
 		if(HUG_MODE_CRUSH)
 			if (!COOLDOWN_FINISHED(src, crush_cooldown))
@@ -202,7 +202,7 @@
 				)
 			playsound(loc, 'sound/items/weapons/smash.ogg', 50, TRUE, -1)
 			attacked_mob.adjust_brute_loss(15)
-			user.cell.use(0.3 * STANDARD_CELL_CHARGE, force = TRUE)
+			user.cell.use(0.3 * STANDARD_CELL_CHARGE)
 			COOLDOWN_START(src, crush_cooldown, HUG_CRUSH_COOLDOWN)
 
 /obj/item/borg/cyborghug/peacekeeper

--- a/code/game/objects/structures/water_structures/sink.dm
+++ b/code/game/objects/structures/water_structures/sink.dm
@@ -197,7 +197,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 		playsound(src, 'sound/machines/sink-faucet.ogg', 50)
 
 		var/obj/item/melee/baton/security/baton = tool
-		if(istype(baton) && baton.active && baton.cell?.use(baton.cell_hit_cost, force = TRUE))
+		if(istype(baton) && baton.active && baton.cell?.use(baton.cell_hit_cost))
 			flick("baton_active", src)
 			user.Paralyze(baton.knockdown_time)
 			user.set_stutter(baton.knockdown_time)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -21,7 +21,7 @@
 		if(cell.charge <= 0.01 * STANDARD_CELL_CHARGE)
 			drop_all_held_items()
 		var/energy_consumption = max(lamp_power_consumption * lamp_enabled * lamp_intensity * seconds_per_tick, BORG_MINIMUM_POWER_CONSUMPTION * seconds_per_tick) //Lamp will use a max of 5 * [BORG_LAMP_POWER_CONSUMPTION], depending on brightness of lamp. If lamp is off, borg systems consume [BORG_MINIMUM_POWER_CONSUMPTION], or the rest of the cell if it's lower than that.
-		cell.use(energy_consumption, force = TRUE)
+		cell.use(energy_consumption)
 	else
 		drop_all_held_items()
 		low_power_mode = TRUE

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -569,6 +569,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 			return ..()
 		playsound(src, 'sound/vehicles/mecha/mech_shield_deflect.ogg', 100, TRUE)
 		balloon_alert(borg, "absorbed!")
-		borg.cell.use(damage * (STANDARD_CELL_CHARGE / 15), force = TRUE)
+		borg.cell.use(damage * (STANDARD_CELL_CHARGE / 15))
 		damage *= 0.5
 	return ..()

--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -161,7 +161,7 @@
 	var/obj/item/stock_parts/power_store/charge_source = charge_source()
 	if(isnull(charge_source))
 		return FALSE
-	. = charge_source.use(amount, TRUE)
+	. = charge_source.use(amount)
 	if(.)
 		mod.update_charge_alert()
 	return .

--- a/code/modules/mod/mod_link.dm
+++ b/code/modules/mod/mod_link.dm
@@ -203,7 +203,7 @@
 /obj/item/clothing/neck/link_scryer/process(seconds_per_tick)
 	if(!mod_link.link_call)
 		return
-	cell.use(0.02 * STANDARD_CELL_RATE * seconds_per_tick, force = TRUE)
+	cell.use(0.02 * STANDARD_CELL_RATE * seconds_per_tick)
 
 /obj/item/clothing/neck/link_scryer/attackby(obj/item/attacked_by, mob/user, list/modifiers, list/attack_modifiers)
 	. = ..()

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -63,7 +63,7 @@
 		var/stomach_used_charge = stomach_cell.used_charge()
 		var/potential_charge = min(our_available_charge, stomach_used_charge)
 		var/to_drain = min(ETHEREAL_APC_POWER_GAIN, potential_charge)
-		var/energy_drained = cell.use(to_drain, force = TRUE)
+		var/energy_drained = cell.use(to_drain)
 		used_stomach.adjust_charge(energy_drained)
 
 		if(stomach_cell.used_charge() <= 0)

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -579,7 +579,7 @@
 		var/grid_used = min(terminal?.surplus(), total_static_energy_usage)
 		terminal?.add_load(grid_used)
 		if(total_static_energy_usage > grid_used && !QDELETED(cell))
-			cell.use(total_static_energy_usage - grid_used, force = TRUE)
+			cell.use(total_static_energy_usage - grid_used)
 
 /obj/machinery/power/apc/proc/late_process(seconds_per_tick)
 	if(icon_update_needed)

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -88,5 +88,5 @@
 	chargerate = INFINITY
 	ratingdesc = FALSE
 
-/obj/item/stock_parts/power_store/battery/infinite/use(used, force = FALSE)
+/obj/item/stock_parts/power_store/battery/infinite/use(used)
 	return used

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -166,7 +166,7 @@
 	chargerate = INFINITY
 	ratingdesc = FALSE
 
-/obj/item/stock_parts/power_store/cell/infinite/use(used, force = FALSE)
+/obj/item/stock_parts/power_store/cell/infinite/use(used)
 	return used
 
 /obj/item/stock_parts/power_store/cell/infinite/abductor

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -175,7 +175,7 @@
 	var/grid_used = min(surplus, amount)
 	var/apc_used = 0
 	if((amount > grid_used) && !ignore_apc && !QDELETED(local_apc.cell)) // Use from the APC's cell if there isn't enough energy from the grid.
-		apc_used = local_apc.cell.use(amount - grid_used, force = force)
+		apc_used = local_apc.cell.use(amount - grid_used)
 
 	if(!force && (amount > grid_used + apc_used)) // If we aren't forcing it and there isn't enough energy to supply demand, return nothing.
 		return FALSE
@@ -204,7 +204,7 @@
 	var/obj/machinery/power/apc/my_apc = my_area.apc
 	if(isnull(my_apc) || !my_apc.operating || QDELETED(my_apc.cell))
 		return FALSE
-	return my_apc.cell.use(amount, force = force)
+	return my_apc.cell.use(amount)
 
 /**
  * Attempts to draw power directly from the APC's Powernet rather than the APC's battery. For high-draw machines, like the cell charger

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -155,20 +155,20 @@
 /// - used: Amount of power in joules to use.
 /// Returns: The power used from the cell in joules.
 /obj/item/stock_parts/power_store/use(used)
-    var/power_used = min(used, charge)
+	var/power_used = min(used, charge)
 
-    if(power_used <= 0) // The cell is already empty or no power was used
-        return 0
+	if(power_used <= 0) // The cell is already empty or no power was used
+		return 0
 
-    if(try_explode()) // The cell decided to explode so we won't be able to use it
-        return 0
+	if(try_explode()) // The cell decided to explode so we won't be able to use it
+		return 0
 
-    charge -= power_used
+	charge -= power_used
 
-    if(!istype(loc, /obj/machinery/power/apc))
-        SSblackbox.record_feedback("tally", "cell_used", 1, type)
+	if(!istype(loc, /obj/machinery/power/apc))
+		SSblackbox.record_feedback("tally", "cell_used", 1, type)
 
-    return power_used
+	return power_used
 
 /// Recharge the cell.
 /// Args:
@@ -241,7 +241,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	use((STANDARD_CELL_CHARGE /severity) * emp_damage_modifier , force = TRUE)
+	use((STANDARD_CELL_CHARGE /severity) * emp_damage_modifier)
 
 /obj/item/stock_parts/power_store/ex_act(severity, target)
 	. = ..()
@@ -325,7 +325,7 @@
 		var/scaled_stomach_used_charge = stomach_cell.used_charge() / ETHEREAL_CELL_POWER_GAIN_FACTOR
 		var/potential_charge = min(our_charge, scaled_stomach_used_charge)
 		var/to_drain = min(ETHEREAL_CELL_POWER_DRAIN, potential_charge)
-		var/energy_drained = use(to_drain, force = TRUE)
+		var/energy_drained = use(to_drain)
 		used_stomach.adjust_charge(energy_drained * ETHEREAL_CELL_POWER_GAIN_FACTOR)
 		update_appearance(UPDATE_OVERLAYS)
 

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -153,19 +153,22 @@
 /// Use power from the cell.
 /// Args:
 /// - used: Amount of power in joules to use.
-/// - force: If true, uses the remaining power from the cell if there isn't enough power to supply the demand.
 /// Returns: The power used from the cell in joules.
-/obj/item/stock_parts/power_store/use(used, force = FALSE)
-	var/power_used = min(used, charge)
-	if(power_used > 0 && try_explode())
-		return 0 // The cell decided to explode so we won't be able to use it.
+/obj/item/stock_parts/power_store/use(used)
+    var/power_used = min(used, charge)
 
-	charge -= power_used
-	if(!force && charge < used)
-		return 0
-	if(!istype(loc, /obj/machinery/power/apc))
-		SSblackbox.record_feedback("tally", "cell_used", 1, type)
-	return power_used
+    if(power_used <= 0) // The cell is already empty or no power was used
+        return 0
+
+    if(try_explode()) // The cell decided to explode so we won't be able to use it
+        return 0
+
+    charge -= power_used
+
+    if(!istype(loc, /obj/machinery/power/apc))
+        SSblackbox.record_feedback("tally", "cell_used", 1, type)
+
+    return power_used
 
 /// Recharge the cell.
 /// Args:

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -159,9 +159,10 @@
 	var/power_used = min(used, charge)
 	if(power_used > 0 && try_explode())
 		return 0 // The cell decided to explode so we won't be able to use it.
+
+	charge -= power_used
 	if(!force && charge < used)
 		return 0
-	charge -= power_used
 	if(!istype(loc, /obj/machinery/power/apc))
 		SSblackbox.record_feedback("tally", "cell_used", 1, type)
 	return power_used

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -179,7 +179,7 @@
 		if(give)
 			amount_adjusted = power_cell.give(charge_adjust)
 		else
-			amount_adjusted = power_cell.use(charge_adjust, TRUE)
+			amount_adjusted = power_cell.use(charge_adjust)
 
 		. += amount_adjusted
 		charge_adjust -= amount_adjusted

--- a/code/modules/power/smes_portable.dm
+++ b/code/modules/power/smes_portable.dm
@@ -295,7 +295,7 @@
 	///Drain the charge
 	var/charge_adjust = STANDARD_BATTERY_CHARGE / severity
 	for(var/obj/item/stock_parts/power_store/power_cell in component_parts)
-		charge_adjust -= power_cell.use(charge_adjust, TRUE)
+		charge_adjust -= power_cell.use(charge_adjust)
 		if(!charge_adjust)
 			break
 

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -133,7 +133,7 @@
 		return
 	ammo_pack.overheat++
 	if(ammo_pack.battery)
-		var/transferred = ammo_pack.battery.use(cell.maxcharge - cell.charge, force = TRUE)
+		var/transferred = ammo_pack.battery.use(cell.maxcharge - cell.charge)
 		cell.give(transferred)
 
 

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -357,7 +357,7 @@
 		if(cell)
 			WR.crowbar_salvage += cell
 			cell.forceMove(WR)
-			cell.use(rand(0, cell.charge), TRUE)
+			cell.use(rand(0, cell.charge))
 			cell = null
 	return ..()
 

--- a/code/modules/wiremod/shell/assembly.dm
+++ b/code/modules/wiremod/shell/assembly.dm
@@ -80,7 +80,7 @@
 			return COMPONENT_OVERRIDE_POWER_USAGE
 	if(iscyborg(power_use_proxy))
 		var/mob/living/silicon/robot/borg = power_use_proxy
-		if(borg.cell?.use(power_to_use, force = TRUE))
+		if(borg.cell?.use(power_to_use))
 			return COMPONENT_OVERRIDE_POWER_USAGE
 
 /obj/item/assembly/wiremod/examine(mob/user)

--- a/code/modules/wiremod/shell/gun.dm
+++ b/code/modules/wiremod/shell/gun.dm
@@ -74,7 +74,7 @@
 			return
 		var/transferred = src.cell.give(min(0.1 * STANDARD_CELL_CHARGE, circuit.cell.charge))
 		if (transferred)
-			circuit.cell.use(transferred, force=TRUE)
+			circuit.cell.use(transferred)
 
 /**
  * Called when the shell item shoots something
@@ -98,4 +98,4 @@
 	var/obj/item/gun/energy/fired_gun = source
 	var/transferred = fired_gun.cell.give(min(0.1 * STANDARD_CELL_CHARGE, parent.cell.charge))
 	if(transferred)
-		parent.cell.use(transferred, force = TRUE)
+		parent.cell.use(transferred)


### PR DESCRIPTION

## About The Pull Request
Drops the `force` argument from `use()` in power cells to resolve bugs.

The old code had a broken order of operations that modified the cell's charge before checking if it actually had enough power to meet the demand. Because of this, power cells were quietly deleting energy or returning `0` even when they had enough charge for a full use.

This reminds me of when we had `BIO` armor values that did nothing, but because people were c/p'ing code everywhere, nobody noticed and assumed it had a purpose. 

## Why It's Good For The Game
Cleaner code that is not broken.

## Changelog
:cl:
refactor: Refactor how power cells drain power.
fix: Fix power cells not accurately draining power and returning the correct values. 
/:cl:
