### PR TITLE
One-line portable gravity generator sprite fix

### DIFF
--- a/code/game/machinery/portagrav.dm
+++ b/code/game/machinery/portagrav.dm
@@ -88,7 +88,7 @@
 
 /obj/machinery/power/portagrav/update_icon_state()
 	. = ..()
-	icon_state = panel_open ? "[base_icon_state]-o" : base_icon_state
+	icon_state = panel_open ? "[base_icon_state]_o" : base_icon_state
 
 /obj/machinery/power/portagrav/screwdriver_act(mob/living/user, obj/item/tool)
 	return default_deconstruction_screwdriver(user, tool)


### PR DESCRIPTION

## About The Pull Request
An underscore seems to have been accidentally changed to a hyphen in #95408. This broke the portable gravgen screwed open sprite state.
## Why It's Good For The Game
This fixes #96906
## Changelog
:cl:
fix: Portable gravity generators will no longer become invisible when screwed open.
/:cl:
