### PR TITLE
Fix HOP ticket display showing wrong number when tickets are destroyed

### DIFF
--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -88,7 +88,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/ticket_machine, 32)
 		QDEL_NULL(current_ticket)
 	if(LAZYLEN(tickets))
 		current_ticket = tickets[1]
-		current_number++ //Increment the one we're serving.
+		current_number = current_ticket.number //Destroyed tickets are removed from the queue, so the next ticket's number may have skipped ahead.
 		playsound(src, 'sound/announcer/announcement/announce_dig.ogg', 50, FALSE)
 		say("Now serving [current_ticket]!")
 		if(!(obj_flags & EMAGGED))


### PR DESCRIPTION
## About The Pull Request

When HOP tickets are destroyed, the displayed number no longer gets out of sync with the current ticket number being called (the actual selecting the next ticket already worked fine, only the display got out of sync)

## Why It's Good For The Game

The number not actually being the number is a bug

## Changelog
:cl: PapaMichael
fix: The HOP ticket machine display now shows the correct number when tickets are destroyed
/:cl:
