### PR TITLE
Slight optimizations (no content changes, trust)

### DIFF
--- a/code/modules/deathmatch/deathmatch_controller.dm
+++ b/code/modules/deathmatch/deathmatch_controller.dm
@@ -18,6 +18,7 @@
 	for (var/datum/lazy_template/deathmatch/template as anything in subtypesof(/datum/lazy_template/deathmatch))
 		var/map_name = initial(template.name)
 		maps[map_name] = new template
+	maps = sort_list(maps)
 	loadouts = subtypesof(/datum/outfit/deathmatch_loadout)
 	modifiers = sortTim(init_subtypes_w_path_keys(/datum/deathmatch_modifier), GLOBAL_PROC_REF(cmp_deathmatch_mods), associative = TRUE)
 

--- a/code/modules/deathmatch/deathmatch_controller.dm
+++ b/code/modules/deathmatch/deathmatch_controller.dm
@@ -1,7 +1,7 @@
 /datum/deathmatch_controller
 	/// Assoc list of all lobbies (ckey = lobby)
 	var/list/datum/deathmatch_lobby/lobbies = list()
-	/// All deathmatch map templates
+	/// All deathmatch map templates (map_name = map_ref), sorted alphabetically
 	var/list/datum/lazy_template/deathmatch/maps = list()
 	/// All loadouts
 	var/list/datum/outfit/loadouts

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -360,8 +360,6 @@
 	.["maps"] = list()
 	for (var/map_key in GLOB.deathmatch_game.maps)
 		.["maps"] += map_key
-	.["maps"] = sort_list(.["maps"])
-
 
 /datum/deathmatch_lobby/ui_data(mob/user)
 	var/list/data = list()

--- a/code/modules/meteors/meteor_types.dm
+++ b/code/modules/meteors/meteor_types.dm
@@ -400,10 +400,12 @@
 	signature = "culinary material"
 
 /obj/effect/meteor/meaty/Initialize(mapload)
-	if(type == /obj/effect/meteor/meaty)
-		meteordrop += pick(subtypesof(/obj/item/food/meat/slab/human/mutant))
-		meteordrop += pick(typesof(/obj/item/organ/tongue))
+	setup_extra_drops()
 	return ..()
+
+/obj/effect/meteor/meaty/proc/setup_extra_drops()
+	meteordrop += pick(subtypesof(/obj/item/food/meat/slab/human/mutant))
+	meteordrop += pick(typesof(/obj/item/organ/tongue))
 
 /obj/effect/meteor/meaty/make_debris()
 	..()
@@ -424,9 +426,8 @@
 	meteorgibs = /obj/effect/gibspawner/xeno
 	signature = "exotic culinary material"
 
-/obj/effect/meteor/meaty/xeno/Initialize(mapload)
+/obj/effect/meteor/meaty/xeno/setup_extra_drops()
 	meteordrop += subtypesof(/obj/item/organ/alien)
-	return ..()
 
 /obj/effect/meteor/meaty/xeno/ram_turf(turf/T)
 	if(!isspaceturf(T))

--- a/code/modules/meteors/meteor_types.dm
+++ b/code/modules/meteors/meteor_types.dm
@@ -42,6 +42,7 @@
 	SSaugury.register_doom(src, threat)
 	SpinAnimation()
 	chase_target(target)
+	setup_extra_drops()
 	AddComponent(
 		/datum/component/meteor_combat, \
 		CALLBACK(src, PROC_REF(redirect)), \
@@ -87,6 +88,9 @@
 	var/datum/move_loop/new_loop = GLOB.move_manager.move_towards(src, chasing, delay, home, lifetime)
 	if(new_loop)
 		RegisterSignal(new_loop, COMSIG_MOVELOOP_STOP, PROC_REF(on_loop_stopped))
+
+/obj/effect/meteor/proc/setup_extra_drops()
+	return
 
 /obj/effect/meteor/proc/on_loop_stopped(datum/source)
 	SIGNAL_HANDLER
@@ -399,11 +403,7 @@
 	threat = 2
 	signature = "culinary material"
 
-/obj/effect/meteor/meaty/Initialize(mapload)
-	setup_extra_drops()
-	return ..()
-
-/obj/effect/meteor/meaty/proc/setup_extra_drops()
+/obj/effect/meteor/meaty/setup_extra_drops()
 	meteordrop += pick(subtypesof(/obj/item/food/meat/slab/human/mutant))
 	meteordrop += pick(typesof(/obj/item/organ/tongue))
 

--- a/code/modules/meteors/meteor_types.dm
+++ b/code/modules/meteors/meteor_types.dm
@@ -394,27 +394,20 @@
 	hits = 2
 	heavy = TRUE
 	meteorsound = 'sound/effects/blob/blobattack.ogg'
-	meteordrop = list(/obj/item/food/meat/slab/human, /obj/item/food/meat/slab/human/mutant, /obj/item/organ/heart, /obj/item/organ/lungs, /obj/item/organ/tongue, /obj/item/organ/appendix/)
+	meteordrop = list(/obj/item/food/meat/slab/human, /obj/item/organ/heart, /obj/item/organ/lungs, /obj/item/organ/appendix)
 	var/meteorgibs = /obj/effect/gibspawner/generic
 	threat = 2
 	signature = "culinary material"
 
 /obj/effect/meteor/meaty/Initialize(mapload)
-	for(var/path in meteordrop)
-		if(path == /obj/item/food/meat/slab/human/mutant)
-			meteordrop -= path
-			meteordrop += pick(subtypesof(path))
-
-	for(var/path in meteordrop)
-		if(path == /obj/item/organ/tongue)
-			meteordrop -= path
-			meteordrop += pick(typesof(path))
+	if(type == /obj/effect/meteor/meaty)
+		meteordrop += pick(subtypesof(/obj/item/food/meat/slab/human/mutant))
+		meteordrop += pick(typesof(/obj/item/organ/tongue))
 	return ..()
 
 /obj/effect/meteor/meaty/make_debris()
 	..()
 	new meteorgibs(get_turf(src))
-
 
 /obj/effect/meteor/meaty/ram_turf(turf/T)
 	if(!isspaceturf(T))


### PR DESCRIPTION

## About The Pull Request

- Makes it so we sort the deathmatch map names after creating them instead of every single time someone opens the deathmatch lobby menu
- Removes the evil trailing `/` symbol on appendix at the end of the meaty ores list
- Turns meatyores 11 + subtypesof(/obj/item/food/meat/slab/human/mutant) `if()` checks into a proc
- Above also turns xenomorph meatyores (2 + subtypesof(/obj/item/organ/alien) * 2) `if()` checks into a proc override

## Why It's Good For The Game

> Makes it so we sort the deathmatch map names after creating them instead of every single time someone opens the deathmatch lobby menu
- No reason to keep repeating work we already did
> Removes the evil trailing `/` symbol on appendix at the end of the meaty ores list
> Turns meatyores 11 + subtypesof(/obj/item/food/meat/slab/human/mutant) `if()` checks into 1 type check
> Above also turns xenomorph meatyores (2 + subtypesof(/obj/item/organ/alien) * 2) `if()` checks into 1 type check
- Those for() loops physically hurt me

Also have some screenshots because i forgot TG doesn't have testing screenshots be required and did them

<img width="230" height="268" alt="image" src="https://github.com/user-attachments/assets/40e089f6-b4e1-42ce-bf75-ab93cf0c590f" />

<img width="1600" height="853" alt="image" src="https://github.com/user-attachments/assets/17cc676e-6759-47c6-8bc2-e1a45f92fe5a" />

## Changelog

:cl:
code: optimized deathmatch lobbies and meaty ores a tiny bit
/:cl:
