### PR TITLE
Fix for material tiles not having material after prying and placing back

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -154,6 +154,11 @@
 		other_stack = find_other_stack(already_found, TRUE)
 	return TRUE
 
+/obj/item/stack/apply_material_effects(list/materials)
+	. = ..()
+	if(amount)
+		mats_per_unit = SSmaterials.get_material_set_cache(materials, 1/amount)
+
 /obj/item/stack/blend_requirements(atom/movable/grinder, mob/living/user)
 	if(!is_cyborg)
 		return TRUE


### PR DESCRIPTION
## About The Pull Request

Fixes bug with material tile having no materials after you pry it and place it back.

Bug was introduced in #92620, found by bisection. Proc `/obj/item/stack/apply_material_effects(list/materials)` was [deleted](https://github.com/tgstation/tgstation/pull/92620/changes#diff-0c7456c96a956e2de9c4962ab9dba27fda208421cc48f9aca97b7cad6dc9ed43L163-L167) in that PR by mistake or by oversight, so when you pry the tile, `mats_per_unit` is null.
This PR brings back that proc, fixing the bug.

## Changelog

:cl:
fix: Fixes material tiles not having material after prying and placing back.
/:cl: