### PR TITLE
Fixes f5 bluescreen with character prefs menu

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -85,8 +85,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	/// Used to avoid expensive READ_FILE every time a preference is retrieved.
 	var/value_cache = list()
 
-	/// If set to TRUE, will update character_profiles on the next ui_data tick.
+	/// If set to TRUE, will update cached_character_profiles on the next ui_data tick.
 	var/tainted_character_profiles = FALSE
+	/// The character profiles, saved so we can cheaply recompute them in ui_data only when necessary, without having to use expensive update_static_data calls.
+	var/list/cached_character_profiles
 
 /datum/preferences/Destroy(force)
 	QDEL_NULL(character_preview_view)
@@ -164,9 +166,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/ui_data(mob/user)
 	var/list/data = list()
 
-	if (tainted_character_profiles)
-		data["character_profiles"] = create_character_profiles()
+	if (tainted_character_profiles || isnull(cached_character_profiles))
+		cached_character_profiles = create_character_profiles()
 		tainted_character_profiles = FALSE
+
+	data["character_profiles"] = cached_character_profiles
 
 	data["character_preferences"] = compile_character_preferences(user)
 
@@ -281,6 +285,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	save_character()
 	save_preferences()
 	QDEL_NULL(character_preview_view)
+	cached_character_profiles = null
 
 /datum/preferences/Topic(href, list/href_list)
 	. = ..()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -340,6 +340,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 /datum/preferences/proc/load_character(slot = default_slot)
 	SHOULD_NOT_SLEEP(TRUE)
 	slot = sanitize_integer(slot, 1, max_save_slots, initial(default_slot))
+	var/original_default_slot = default_slot
+	if(slot != default_slot)
+		default_slot = slot
+		savefile.set_entry("default_slot", slot)
 
 	var/tree_key = "character[slot]"
 	var/list/save_data = savefile.get_entry(tree_key)
@@ -352,11 +356,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	var/data_validity_integer = check_savedata_version(save_data)
 	if(IS_DATA_OBSOLETE(data_validity_integer)) //fatal, can't load any data
+		default_slot = original_default_slot
 		return FALSE
-
-	if(slot != default_slot)
-		default_slot = slot
-		savefile.set_entry("default_slot", slot)
 
 	// Read everything into cache
 	// Uses priority order as some values may rely on others for creating default values

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -357,6 +357,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	var/data_validity_integer = check_savedata_version(save_data)
 	if(IS_DATA_OBSOLETE(data_validity_integer)) //fatal, can't load any data
 		default_slot = original_default_slot
+		savefile.set_entry("default_slot", original_default_slot)
 		return FALSE
 
 	// Read everything into cache

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -347,8 +347,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	var/tree_key = "character[slot]"
 	var/list/save_data = savefile.get_entry(tree_key)
-	if(isnull(save_data))
-		for (var/datum/preference/preference as anything in get_preferences_in_priority_order())
+	if(isnull(save_data)) // This is the case where we have a new character slot being switched to
+		for (var/datum/preference/preference as anything in get_preferences_in_priority_order()) // clear the cache in this case
 			if (preference.savefile_identifier != PREFERENCE_CHARACTER)
 				continue
 			value_cache -= preference.type

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -352,8 +352,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			if (preference.savefile_identifier != PREFERENCE_CHARACTER)
 				continue
 			value_cache -= preference.type
-		default_slot = original_default_slot
-		savefile.set_entry("default_slot", original_default_slot)
 		return FALSE
 
 	var/data_validity_integer = check_savedata_version(save_data)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -352,6 +352,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			if (preference.savefile_identifier != PREFERENCE_CHARACTER)
 				continue
 			value_cache -= preference.type
+		default_slot = original_default_slot
+		savefile.set_entry("default_slot", original_default_slot)
 		return FALSE
 
 	var/data_validity_integer = check_savedata_version(save_data)


### PR DESCRIPTION
## About The Pull Request

It was caused by `tainted_character_profiles` not being reset upon `send_full_update()`. To get around this issue, since `ui_data()` has no way of knowing whether it's a full update or not we will just keep the list of profiles in memory in the event that tgui gets its copy cleared.

No other functional difference, everything still works the same. It's just a little more reliable now.

<details><summary>Working as intended</summary>

<img width="1109" height="1054" alt="dreamseeker_2zhIL6owdE" src="https://github.com/user-attachments/assets/bfb9f7b9-5963-47b9-b726-cc9185e531a8" />

</details>

## Changelog

:cl:
fix: fixes an issue that would cause the character preferences menu to bluescreen if you press f5 to reload or used the Refresh-Tgui verb while it was open
fix: fixes an issue that was preventing a selected new slot from updating properly
/:cl:

