### PR TITLE
Replica katana can now be printed on hacked autolathe and service fabricator

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -822,6 +822,8 @@
 	hitsound = 'sound/items/weapons/bladeslice.ogg'
 	var/list/alt_continuous = list("stabs", "pierces", "impales")
 	var/list/alt_simple = list("stab", "pierce", "impale")
+	custom_materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT)
+
 
 /obj/item/toy/katana/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -820,9 +820,9 @@
 	attack_verb_continuous = list("attacks", "slashes", "slices")
 	attack_verb_simple = list("attack", "slash", "slice")
 	hitsound = 'sound/items/weapons/bladeslice.ogg'
+	custom_materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT)
 	var/list/alt_continuous = list("stabs", "pierces", "impales")
 	var/list/alt_simple = list("stab", "pierce", "impale")
-	custom_materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT)
 
 /obj/item/toy/katana/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -824,7 +824,6 @@
 	var/list/alt_simple = list("stab", "pierce", "impale")
 	custom_materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT)
 
-
 /obj/item/toy/katana/Initialize(mapload)
 	. = ..()
 	alt_continuous = string_list(alt_continuous)

--- a/code/modules/research/designs/autolathe/service_designs.dm
+++ b/code/modules/research/designs/autolathe/service_designs.dm
@@ -422,7 +422,7 @@
 	name = "Plastic Katana"
 	id = "toy_katana"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/plastic =SHEET_MATERIAL_AMOUNT)
+	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/toy/katana
 	category = list(
 		RND_CATEGORY_HACKED,

--- a/code/modules/research/designs/autolathe/service_designs.dm
+++ b/code/modules/research/designs/autolathe/service_designs.dm
@@ -418,6 +418,18 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
 
+/datum/design/toy_katana
+	name = "Plastic Katana"
+	id = "toy_katana"
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/plastic =SHEET_MATERIAL_AMOUNT)
+	build_path = /obj/item/toy/katana
+	category = list(
+		RND_CATEGORY_HACKED,
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SERVICE,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
+
 /datum/design/plastic_tree
 	name = "Plastic Potted Plant"
 	id = "plastic_trees"

--- a/code/modules/research/techweb/nodes/security_nodes.dm
+++ b/code/modules/research/techweb/nodes/security_nodes.dm
@@ -5,6 +5,7 @@
 	description = "Ballistics can be unpredictable in space."
 	design_ids = list(
 		"toy_armblade",
+		"toy_katana",
 		"toygun",
 		"c38_rubber",
 		"c38_rubber_mag",


### PR DESCRIPTION

## About The Pull Request

Now you can print plastic Replica katanas (toy) in Service Fabricator (1 plastic sheet) and hacked autolathe (a little more expensive) similar to how foam armblades are printed
<img width="672" height="254" alt="dreamseeker_d7k3WfRLXU" src="https://github.com/user-attachments/assets/172c08ac-310e-42c9-9a37-55e02d956b18" />
<img width="639" height="323" alt="dreamseeker_HpcZDqsNfO" src="https://github.com/user-attachments/assets/bc529702-97af-47d7-995d-745afa0babba" />
<img width="670" height="600" alt="Cq7MZBNnYF" src="https://github.com/user-attachments/assets/1548d6e7-3323-40a4-bf9e-fbb9d2ec9702" />



## Why It's Good For The Game

Fake (plastic) armblades have been available for printing for quite some time now. Adding a printable Replica katana follows the same trend, and it fits perfectly with the current sheaths.

## Changelog

:cl:
add: Now you can print Replica Katana in Service Protolathe and Hacked AutoLathe

/:cl:


