### PR TITLE
Fix Kilo engineering camera

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -9587,6 +9587,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/structure/cable,
+/obj/machinery/camera/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dgu" = (
@@ -67861,17 +67862,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
-"vzQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Supermatter Engine";
-	name = "supermatter camera";
-	network = list("engine")
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "vzV" = (
 /obj/structure/sign/poster/official/anniversary_vintage_reprint/directional/north,
 /obj/machinery/camera/directional/north{
@@ -111822,7 +111812,7 @@ tkO
 okp
 uvG
 piZ
-vzQ
+uvG
 lOX
 hqW
 jbZ

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -9587,7 +9587,11 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/structure/cable,
-/obj/machinery/camera/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Supermatter Engine";
+	name = "supermatter camera";
+	network = list("engine")
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dgu" = (


### PR DESCRIPTION

## About The Pull Request
This moves around a camera in the Kilo Engineering so that the SM chamber input/output atmos pumps are visible. 

## Why It's Good For The Game
AI can now properly set up the SM solo if needed.

## Changelog
:cl:
map: Fix Kilo engineering camera
/:cl:
