### PR TITLE
Fixes some procs that sleep inside SHOULD_NOT_SLEEP procs

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -240,7 +240,7 @@
 	if(duration + bonus_time >= exhaustion_limit)
 		duration = exhaustion_limit
 		to_chat(new_owner, span_userdanger("Your muscles are exhausted! Might be a good idea to sleep..."))
-		new_owner.emote("scream")
+		INVOKE_ASYNC(new_owner, TYPE_PROC_REF(/mob, emote), "scream")
 		return // exhaustion_limit
 
 	return bonus_time

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -944,7 +944,7 @@
 			if(!prob(1)) // 99%
 				to_chat(victim, span_userdanger("You're covered in MORE ants!"))
 			else // 1%
-				victim.say("AAHH! THIS SITUATION HAS ONLY BEEN MADE WORSE WITH THE ADDITION OF YET MORE ANTS!!", forced = /datum/status_effect/ants)
+				INVOKE_ASYNC(victim, TYPE_PROC_REF(/mob, say), "AAHH! THIS SITUATION HAS ONLY BEEN MADE WORSE WITH THE ADDITION OF YET MORE ANTS!!", forced = /datum/status_effect/ants)
 		ants_remaining += amount_left
 	. = ..()
 

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -944,7 +944,7 @@
 			if(!prob(1)) // 99%
 				to_chat(victim, span_userdanger("You're covered in MORE ants!"))
 			else // 1%
-				INVOKE_ASYNC(victim, TYPE_PROC_REF(/mob, say), "AAHH! THIS SITUATION HAS ONLY BEEN MADE WORSE WITH THE ADDITION OF YET MORE ANTS!!", forced = /datum/status_effect/ants)
+				INVOKE_ASYNC(victim, TYPE_PROC_REF(/atom/movable, say), "AAHH! THIS SITUATION HAS ONLY BEEN MADE WORSE WITH THE ADDITION OF YET MORE ANTS!!", forced = /datum/status_effect/ants)
 		ants_remaining += amount_left
 	. = ..()
 

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -107,7 +107,7 @@
 	. = ..()
 	if (calibrating)
 		calibrating += world.time
-		say("Calibrating... Estimated wait time: [rand(3, 9)] minutes.")
+		INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, say), "Calibrating... Estimated wait time: [rand(3, 9)] minutes.")
 		pda_msgs += new /datum/data_tablet_msg("System Administrator", "system", "This is an automated message. System calibration started at [server_timestamp(ic_time = TRUE)] (PT: [round_timestamp()]).")
 	else
 		pda_msgs += new /datum/data_tablet_msg("System Administrator", "system", MESSAGE_SERVER_FUNCTIONING_MESSAGE)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -155,6 +155,7 @@
  * force - TRUE if we should ignore buckled_mob.can_buckle_to
  */
 /atom/movable/proc/unbuckle_mob(mob/living/buckled_mob, force = FALSE, can_fall = TRUE)
+
 	if(!isliving(buckled_mob))
 		CRASH("Non-living [buckled_mob] thing called unbuckle_mob() for source.")
 	if(buckled_mob.buckled != src)
@@ -203,7 +204,7 @@
 	if(!has_buckled_mobs())
 		return
 	for(var/m in buckled_mobs)
-		unbuckle_mob(m, force)
+		INVOKE_ASYNC(src, PROC_REF(unbuckle_mob), m, force)
 
 //Handle any extras after buckling
 //Called on buckle_mob()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -259,7 +259,7 @@
 
 	// Handle adding item associated actions
 	for(var/path in actions_types)
-		add_item_action(path)
+		INVOKE_ASYNC(src, PROC_REF(add_item_action), path)
 	actions_types = null
 
 	if(force_string)

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -426,7 +426,7 @@
 		return
 	var/obj/item/toy/plush/narplush/P = locate() in range(1, src)
 	if(P && istype(P.loc, /turf/open) && !P.clashing)
-		clash_of_the_plushies(P)
+		INVOKE_ASYNC(src, PROC_REF(clash_of_the_plushies), P)
 
 /obj/item/toy/plush/ratplush/proc/clash_of_the_plushies(obj/item/toy/plush/narplush/P)
 	clash_target = P
@@ -511,7 +511,7 @@
 	. = ..()
 	var/obj/item/toy/plush/ratplush/P = locate() in range(1, src)
 	if(P && istype(P.loc, /turf/open) && !P.clash_target && !clashing)
-		P.clash_of_the_plushies(src)
+		INVOKE_ASYNC(P, TYPE_PROC_REF(/obj/item/toy/plush/ratplush, clash_of_the_plushies), src)
 
 /obj/item/toy/plush/lizard_plushie
 	name = "lizard plushie"

--- a/code/modules/mob/living/basic/slime/feeding.dm
+++ b/code/modules/mob/living/basic/slime/feeding.dm
@@ -91,6 +91,6 @@
 		balloon_alert(src, "feeding stopped")
 	remove_offsets(FEEDING_OFFSET)
 	layer = initial(layer)
-	buckled.unbuckle_mob(src,force=TRUE)
+	INVOKE_ASYNC(buckled, TYPE_PROC_REF(/atom/movable, unbuckle_mob), src, force=TRUE)
 
 #undef FEEDING_OFFSET

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -97,7 +97,7 @@
 		role_name_text = "alien larva",
 		chat_text_border_icon = /mob/living/carbon/alien/larva,
 	)
-	on_poll_concluded(gib_on_success, chosen_one)
+	INVOKE_ASYNC(src, PROC_REF(on_poll_concluded), gib_on_success, chosen_one)
 
 /// Poll has concluded with a suitor
 /obj/item/organ/body_egg/alien_embryo/proc/on_poll_concluded(gib_on_success, mob/dead/observer/ghost)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -23,7 +23,7 @@
 	else
 		to_chat(finder, span_notice("It's grown quite large, and writhes slightly as you look at it."))
 		if(prob(10))
-			attempt_grow(gib_on_success = FALSE)
+			INVOKE_ASYNC(src, PROC_REF(attempt_grow), gib_on_success = FALSE)
 
 /obj/item/organ/body_egg/alien_embryo/on_life(seconds_per_tick)
 	. = ..()
@@ -78,7 +78,7 @@
 /obj/item/organ/body_egg/alien_embryo/egg_process()
 	if(stage == 6 && prob(50))
 		// If we are mid surgery we won't gib the mob, isn't that neat?
-		attempt_grow(gib_on_success = !LIMB_HAS_SURGERY_STATE(bodypart_owner, SURGERY_SKIN_OPEN|SURGERY_BONE_SAWED))
+		INVOKE_ASYNC(src, PROC_REF(attempt_grow), gib_on_success = !LIMB_HAS_SURGERY_STATE(bodypart_owner, SURGERY_SKIN_OPEN|SURGERY_BONE_SAWED))
 
 /// Attempt to burst an alien outside of the host, getting a ghost to play as the xeno.
 /obj/item/organ/body_egg/alien_embryo/proc/attempt_grow(gib_on_success = TRUE)
@@ -97,7 +97,7 @@
 		role_name_text = "alien larva",
 		chat_text_border_icon = /mob/living/carbon/alien/larva,
 	)
-	INVOKE_ASYNC(src, PROC_REF(on_poll_concluded), gib_on_success, chosen_one)
+	on_poll_concluded(gib_on_success, chosen_one)
 
 /// Poll has concluded with a suitor
 /obj/item/organ/body_egg/alien_embryo/proc/on_poll_concluded(gib_on_success, mob/dead/observer/ghost)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -442,7 +442,7 @@ Difficulty: Hard
 	blinking = TRUE //we do a fancy animation, release a huge burst(), and leave our staff.
 	visible_message(span_hierophant("\"Mrmxmexmrk wipj-hiwxvygx wiuyirgi...\""))
 	visible_message(span_hierophant_warning("[src] shrinks, releasing a massive burst of energy!"))
-	hierophant_burst(null, get_turf(src), 10)
+	INVOKE_ASYNC(src, PROC_REF(hierophant_burst), null, get_turf(src), 10)
 	set_stat(CONSCIOUS) // deathgasp won't run if dead, stupid
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1374,7 +1374,7 @@
 
 /datum/reagent/toxin/bonehurtingjuice/on_mob_add(mob/living/carbon/affected_mob)
 	. = ..()
-	affected_mob.say("oof ouch my bones", forced = /datum/reagent/toxin/bonehurtingjuice)
+	INVOKE_ASYNC(affected_mob, TYPE_PROC_REF(/atom/movable, say), "oof ouch my bones", forced = /datum/reagent/toxin/bonehurtingjuice)
 
 /datum/reagent/toxin/bonehurtingjuice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

I fixed should_not_sleep() locally as it wasn't catching all cases. I PR'd this but want to do some damage control before its merged so our linters dont fail on master

This revealed some procs that are sleeping but could run in SHOULD_NOT_SLEEP procs.

I'll probably keep doing more of these.

## Why It's Good For The Game

prevents procs that shouldnt nap from napping

## Changelog

:cl:
fix: Fixed some sleeping procs that could run in procs that arent allowed to sleep
/:cl:
