### PR TITLE
Chemical reactions are no longer exothermic by default

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks/drinks_alcoholic.dm
+++ b/code/modules/food_and_drinks/recipes/drinks/drinks_alcoholic.dm
@@ -4,7 +4,6 @@
 	temp_exponent_factor = 1
 	optimal_ph_min = 2
 	optimal_ph_max = 10
-	thermic_constant = 0
 	H_ion_release = 0
 	rate_up_lim = 60
 	purity_min = 0

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -80,7 +80,6 @@
 	temp_exponent_factor = 1
 	optimal_ph_min = 2
 	optimal_ph_max = 10
-	thermic_constant = 0
 	H_ion_release = 0
 	reaction_tags = REACTION_TAG_FOOD | REACTION_TAG_EASY
 

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -45,7 +45,7 @@
 	/// How sharp the pH exponential curve is (to the power of value)
 	var/ph_exponent_factor = 2
 	/// How much the temperature changes per unit of chem used. without REACTION_HEAT_ARBITARY flag the rate of change depends on the holder heat capacity else results are more accurate
-	var/thermic_constant = 50
+	var/thermic_constant = 0
 	/// pH change per 1u reaction
 	var/H_ion_release = 0.01
 	/// Optimal/max rate possible if all conditions are perfect

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -2,6 +2,7 @@
 	results = list(/datum/reagent/drug/space_drugs = 3)
 	required_reagents = list(/datum/reagent/mercury = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/lithium = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG
+	thermic_constant = 50
 
 /datum/chemical_reaction/krokodil
 	results = list(/datum/reagent/drug/krokodil = 6)
@@ -9,6 +10,7 @@
 	mix_message = "The mixture dries into a pale blue powder."
 	required_temp = 380
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG
+	thermic_constant = 50
 
 /datum/chemical_reaction/methamphetamine
 	results = list(/datum/reagent/drug/methamphetamine = 4)
@@ -114,11 +116,13 @@
 	required_temp = 374
 	reaction_flags = REACTION_CLEAR_INVERSE
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG | REACTION_TAG_ORGAN | REACTION_TAG_DAMAGING
+	thermic_constant = 50
 
 /datum/chemical_reaction/aranesp
 	results = list(/datum/reagent/drug/aranesp = 3)
 	required_reagents = list(/datum/reagent/medicine/epinephrine = 1, /datum/reagent/medicine/atropine = 1, /datum/reagent/medicine/morphine = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG | REACTION_TAG_TOXIN | REACTION_TAG_DAMAGING
+	thermic_constant = 50
 
 /datum/chemical_reaction/happiness
 	results = list(/datum/reagent/drug/happiness = 4)
@@ -126,33 +130,39 @@
 	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
 	reaction_flags = REACTION_CLEAR_INVERSE
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG | REACTION_TAG_ORGAN | REACTION_TAG_DAMAGING
+	thermic_constant = 50
 
 /datum/chemical_reaction/pumpup
 	results = list(/datum/reagent/drug/pumpup = 5)
 	required_reagents = list(/datum/reagent/medicine/epinephrine = 2, /datum/reagent/consumable/coffee = 5)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG | REACTION_TAG_TOXIN | REACTION_TAG_DAMAGING
+	thermic_constant = 50
 
 /datum/chemical_reaction/maint_tar1
 	results = list(/datum/reagent/toxin/acid = 1 ,/datum/reagent/drug/maint/tar = 3)
 	required_reagents = list(/datum/reagent/consumable/tea = 1, /datum/reagent/yuck = 1 , /datum/reagent/fuel = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG | REACTION_TAG_TOXIN | REACTION_TAG_DAMAGING
+	thermic_constant = 50
 
 /datum/chemical_reaction/maint_tar2
 	results = list(/datum/reagent/toxin/acid = 1 ,/datum/reagent/drug/maint/tar = 3)
 	required_reagents = list(/datum/reagent/consumable/tea = 1, /datum/reagent/consumable/enzyme = 3 , /datum/reagent/fuel = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG | REACTION_TAG_TOXIN | REACTION_TAG_DAMAGING
+	thermic_constant = 50
 
 /datum/chemical_reaction/maint_sludge
 	results = list(/datum/reagent/drug/maint/sludge = 1)
 	required_reagents = list(/datum/reagent/drug/maint/tar = 3 , /datum/reagent/toxin/acid/fluacid = 1)
 	required_catalysts = list(/datum/reagent/hydrogen_peroxide = 5)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG | REACTION_TAG_TOXIN | REACTION_TAG_DAMAGING
+	thermic_constant = 50
 
 /datum/chemical_reaction/maint_powder
 	results = list(/datum/reagent/drug/maint/powder = 1)
 	required_reagents = list(/datum/reagent/drug/maint/sludge = 6 , /datum/reagent/toxin/acid/nitracid = 1 , /datum/reagent/consumable/enzyme = 1)
 	required_catalysts = list(/datum/reagent/acetone_oxide = 5)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG | REACTION_TAG_ORGAN | REACTION_TAG_DAMAGING
+	thermic_constant = 50
 
 //These drug item reactions should probably be converted to fermichem in the future.
 /datum/chemical_reaction/moon_rock //botany is real easy so it requires a lot of kronkus_extract, make it cheaper if it doesnt get made.

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -8,6 +8,7 @@
 	purity_min = 0.1
 	rate_up_lim = 35
 	reaction_tags = REACTION_TAG_HEALING | REACTION_TAG_EASY
+	thermic_constant = 50
 
 /datum/chemical_reaction/medicine/leporazine
 	results = list(/datum/reagent/medicine/leporazine = 2)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -3,11 +3,13 @@
 	results = list(/datum/reagent/space_cleaner/sterilizine = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/medicine/c2/multiver = 1, /datum/reagent/chlorine = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
+	thermic_constant = 50
 
 /datum/chemical_reaction/lube
 	results = list(/datum/reagent/lube = 4)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
+	thermic_constant = 50
 
 /datum/chemical_reaction/lube/superlube
 	results = list(/datum/reagent/lube/superlube = 3)
@@ -28,11 +30,13 @@
 	results = list(/datum/reagent/impedrezene = 2)
 	required_reagents = list(/datum/reagent/mercury = 1, /datum/reagent/oxygen = 1, /datum/reagent/consumable/sugar = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_ORGAN
+	thermic_constant = 50
 
 /datum/chemical_reaction/cryptobiolin
 	results = list(/datum/reagent/cryptobiolin = 3)
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/oxygen = 1, /datum/reagent/consumable/sugar = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
+	thermic_constant = 50
 
 /datum/chemical_reaction/glycerol
 	results = list(/datum/reagent/glycerol = 1)
@@ -43,6 +47,7 @@
 	results = list(/datum/reagent/consumable/salt = 2)
 	required_reagents = list(/datum/reagent/sodium = 1, /datum/reagent/chlorine = 1) // That's what I said! Sodium Chloride!
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_FOOD | REACTION_TAG_COMPONENT
+	thermic_constant = 50
 
 /datum/chemical_reaction/sodiumchloride/pre_reaction_other_checks(datum/reagents/holder)
 	. = ..()
@@ -172,6 +177,7 @@
 	results = list(/datum/reagent/mulligan = 1)
 	required_reagents = list(/datum/reagent/mutationtoxin/jelly = 1, /datum/reagent/toxin/mutagen = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE
+	thermic_constant = 50
 
 
 ////////////////////////////////// VIROLOGY //////////////////////////////////////////
@@ -194,12 +200,10 @@
 /datum/chemical_reaction/virus_food_plasma
 	results = list(/datum/reagent/toxin/plasma/plasmavirusfood = 1)
 	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/consumable/virus_food = 1)
-	thermic_constant = 20 // To avoid the plasma boiling
 
 /datum/chemical_reaction/virus_food_plasma_synaptizine
 	results = list(/datum/reagent/toxin/plasma/plasmavirusfood/weak = 2)
 	required_reagents = list(/datum/reagent/medicine/synaptizine = 1, /datum/reagent/toxin/plasma/plasmavirusfood = 1)
-	thermic_constant = 20 // To avoid the plasma boiling
 
 /datum/chemical_reaction/virus_food_mutagen_sugar
 	results = list(/datum/reagent/toxin/mutagen/mutagenvirusfood/sugar = 2)
@@ -341,6 +345,7 @@
 	required_reagents = list(/datum/reagent/fluorine = 2, /datum/reagent/carbon = 2, /datum/reagent/toxin/acid = 1)
 	reaction_flags = REACTION_INSTANT
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE
+	thermic_constant = 50
 
 /datum/chemical_reaction/foam
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water = 1)
@@ -425,11 +430,13 @@
 	optimal_ph_max = 12
 	H_ion_release = -0.02 //handmade is more neutral
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL | REACTION_TAG_PLANT | REACTION_TAG_COMPONENT
+	thermic_constant = 50
 
 /datum/chemical_reaction/diethylamine
 	results = list(/datum/reagent/diethylamine = 2)
 	required_reagents = list (/datum/reagent/ammonia = 1, /datum/reagent/consumable/ethanol = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL | REACTION_TAG_PLANT | REACTION_TAG_COMPONENT
+	thermic_constant = 50
 
 /datum/chemical_reaction/space_cleaner
 	results = list(/datum/reagent/space_cleaner = 2)
@@ -464,6 +471,7 @@
 	results = list(/datum/reagent/acetone = 3)
 	required_reagents = list(/datum/reagent/fuel/oil = 1, /datum/reagent/fuel = 1, /datum/reagent/oxygen = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL | REACTION_TAG_COMPONENT
+	thermic_constant = 50
 
 /datum/chemical_reaction/carpet
 	results = list(/datum/reagent/carpet = 2)
@@ -570,6 +578,7 @@
 	results = list(/datum/reagent/phenol = 3)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/chlorine = 1, /datum/reagent/fuel/oil = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL | REACTION_TAG_COMPONENT
+	thermic_constant = 50
 
 /datum/chemical_reaction/ash
 	results = list(/datum/reagent/ash = 1)
@@ -937,7 +946,6 @@
 	overheat_temp = 0
 	optimal_ph_min = 0
 	optimal_ph_max = 14
-	thermic_constant = 0
 	H_ion_release = 0
 	rate_up_lim = 50
 	purity_min = 0
@@ -953,7 +961,6 @@
 	overheat_temp = NO_OVERHEAT
 	optimal_ph_min = 0
 	optimal_ph_max = 14
-	thermic_constant = 0
 	H_ion_release = 0
 	rate_up_lim = 50
 	purity_min = 0
@@ -970,7 +977,6 @@
 	overheat_temp = NO_OVERHEAT
 	optimal_ph_min = 0
 	optimal_ph_max = 14
-	thermic_constant = 0
 	H_ion_release = 0
 	rate_up_lim = 50
 	purity_min = 0


### PR DESCRIPTION
## About The Pull Request

This might break some stuff.

I originally was trying to fix accidentally boiling plasma when trying to make virus plasma, but then I realized that the reason it happens in the first place is because every reaction in the game is exothermic. Like, every reaction. I tried mixing water and saltwater and the mixture heat up by 50 kelvin. That's a little wack, so this PR makes them stop heating up. 

Medicines remain exothermic, and food/drinks already had their own thermic_constant set. I also manually added 50 thermic_constant to things like acetone or phenol that are used in chemistry. The only things affected by this change are miscellaneous chemicals like mixing salt water, ice melting into water, and other stuff that I might've forgotten about. Since temperature doesn't affect purity and the reactions that care about temperature set their own thermic_constants, this shouldn't do too much. 

## Why It's Good For The Game

Literally every chemical reaction being exothermic by default is a little ridiculous. 

## Changelog

:cl:
fix: Many chemical reactions are no longer exothermic.
/:cl:
