### PR TITLE
Strongarm crate says "humanoid arms" instead of "human arms"

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -193,7 +193,7 @@
 
 /datum/supply_pack/medical/arm_implants
 	name = "Strong-Arm Implant Set"
-	desc = "A crate containing two implants, which can be surgically implanted to empower the strength of human arms. Warranty void if exposed to electromagnetic pulses."
+	desc = "A crate containing two implants, which can be surgically implanted to empower the strength of humanoid arms. Warranty void if exposed to electromagnetic pulses."
 	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/obj/item/organ/cyberimp/arm/strongarm = 2)
 	crate_name = "\improper Strong-Arm implant crate"


### PR DESCRIPTION
## About The Pull Request

Adds a single "oid" to the crate description

## Why It's Good For The Game

When I was a new player I thought they only worked in human arms, and not any other race nor robotic arms.

## Changelog

:cl:
spellcheck: Strongarms crate decription now mentions "humanoid" instead of "human" arms.
/:cl:
