### PR TITLE
adds a limb grower to chemistry

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -1876,13 +1876,16 @@
 	dir = 1
 	},
 /obj/structure/table,
+/obj/structure/sign/poster/official/periodic_table/directional/east,
 /obj/item/stack/sheet/mineral/plasma{
-	pixel_y = 5
+	pixel_x = -3
 	},
 /obj/item/stack/sheet/mineral/plasma{
 	pixel_x = 2
 	},
-/obj/structure/sign/poster/official/periodic_table/directional/east,
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/pharmacy)
 "azt" = (
@@ -48681,12 +48684,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname/directional/south,
-/obj/structure/table,
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/obj/item/clothing/glasses/science,
+/obj/machinery/limbgrower,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "mUt" = (
@@ -65695,6 +65693,7 @@
 	pixel_y = 7
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/pharmacy)
 "rxy" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -60270,20 +60270,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "oVd" = (
-/obj/structure/table,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/plunger,
-/obj/item/plunger,
 /obj/effect/turf_decal/siding/yellow,
 /obj/structure/sign/poster/official/periodic_table/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/limbgrower,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "oVp" = (
@@ -85117,6 +85107,16 @@
 /obj/effect/turf_decal/siding/yellow,
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/plunger,
+/obj/item/plunger,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "uUg" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -43465,21 +43465,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/table/reinforced,
-/obj/item/plunger{
-	pixel_x = 3
-	},
-/obj/item/plunger{
-	pixel_x = -3
-	},
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
+/obj/machinery/limbgrower,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "msu" = (
@@ -66737,6 +66723,20 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light/directional/east,
+/obj/item/stack/ducts/fifty,
+/obj/item/plunger{
+	pixel_x = 3
+	},
+/obj/item/plunger{
+	pixel_x = -3
+	},
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -15435,6 +15435,12 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/item/assembly/igniter,
+/obj/item/assembly/timer{
+	desc = "Used to time things. Works well with contraptions which has to count down. Tick tock. But slightly shifted to the left.";
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
 "fcv" = (
@@ -32265,32 +32271,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "kji" = (
-/obj/structure/table/glass,
-/obj/item/assembly/timer{
-	desc = "Used to time things. Works well with contraptions which has to count down. Tick tock. But slightly shifted to the left.";
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/assembly/timer{
-	desc = "Used to time things. Works well with contraptions which has to count down. Tick tock. But slightly shifted to the left.";
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/assembly/timer{
-	desc = "Used to time things. Works well with contraptions which has to count down. Tick tock. But slightly shifted to the left.";
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/screwdriver{
-	pixel_y = 5
-	},
-/obj/item/stack/cable_coil,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/limbgrower,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "kjl" = (
@@ -54304,6 +54288,22 @@
 /obj/item/reagent_containers/syringe,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
+	},
+/obj/item/stack/cable_coil,
+/obj/item/assembly/igniter,
+/obj/item/assembly/igniter,
+/obj/item/assembly/timer{
+	desc = "Used to time things. Works well with contraptions which has to count down. Tick tock. But slightly shifted to the left.";
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/assembly/timer{
+	desc = "Used to time things. Works well with contraptions which has to count down. Tick tock. But slightly shifted to the left.";
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/screwdriver{
+	pixel_y = 5
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -27705,6 +27705,16 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/plunger,
+/obj/item/plunger,
+/obj/item/stack/ducts/fifty,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "jxM" = (
@@ -69168,20 +69178,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "xyA" = (
-/obj/structure/table,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/plunger,
-/obj/item/plunger,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/limbgrower,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "xyC" = (

--- a/_maps/map_files/NebulaStation/NebulaStation.dmm
+++ b/_maps/map_files/NebulaStation/NebulaStation.dmm
@@ -58658,16 +58658,8 @@
 /area/station/maintenance/department/bridge)
 "iFC" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = -9;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/cup/beaker{
-	pixel_x = 8;
-	pixel_y = 8
-	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/limbgrower,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/medical/chemistry)
 "iFH" = (
@@ -115629,6 +115621,14 @@
 /obj/structure/table/glass,
 /obj/item/reagent_containers/syringe,
 /obj/machinery/door/firedoor/border_only,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = -9;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 8;
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/medical/chemistry)
 "rbO" = (

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1251,6 +1251,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"ns" = (
+/obj/machinery/limbgrower,
+/turf/open/floor/iron,
+/area/station/medical/chemistry)
 "nT" = (
 /obj/structure/table,
 /obj/machinery/light/directional/south,
@@ -7540,7 +7544,7 @@ sT
 IV
 IV
 Ce
-Ce
+ns
 qH
 QV
 bE

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -5695,19 +5695,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/book/manual/wiki/plumbing{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/plunger,
-/obj/item/plunger,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "aQO" = (
@@ -18389,6 +18382,17 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/construction/plumbing,
 /obj/item/construction/plumbing,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/book/manual/wiki/plumbing{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/plunger,
+/obj/item/plunger,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "foS" = (
@@ -23180,15 +23184,11 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "hdM" = (
-/obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/reagentgrinder,
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_y = 10
-	},
 /obj/structure/cable,
+/obj/machinery/limbgrower,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "hdT" = (


### PR DESCRIPTION
## About The Pull Request

Adds a limb grower to chemistry so you can grow limbs and organs. I didn't add it to medical storage because medical storage is full on most maps, there isn't much room for a new machine. Plus it's now exclusive job content to chemists and doesn't buff body purist too much or whatever
## Why It's Good For The Game

Building machines as a meddoc is a pain since you don't have tool access as part of your job and the limb grower is not very hard to research.

## Changelog

:cl:
add: Added a limb grower to chemistry in maps that have a chem dispenser.
/:cl: