### PR TITLE
Replaces bespoke holy whip-vampire interaction with silver material interaction

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -91,7 +91,7 @@
 		MATERIAL_ELECTRICAL = 9,
 		MATERIAL_THERMAL = 4,
 		MATERIAL_CHEMICAL = 4,
-		MATERIAL_VAMPIRES_BANE = 5,
+		MATERIAL_VAMPIRES_BANE = 8,
 	)
 	sheet_type = /obj/item/stack/sheet/mineral/silver
 	ore_type = /obj/item/stack/ore/silver

--- a/code/datums/materials/properties/optional.dm
+++ b/code/datums/materials/properties/optional.dm
@@ -153,7 +153,7 @@
 	if(!skin_contact && !source.get_property(MATERIAL_PENETRATING))
 		armor_block = target.run_armor_check(def_zone, WOUND, armour_penetration = object.armour_penetration, silent = TRUE, weak_against_armor = TRUE)
 
-	if(armor_block > 66)
+	if(armor_block > 50)
 		return
 
 	to_chat(target, span_userdanger("Contact with [object] sears your undead flesh!"))

--- a/code/datums/materials/properties/optional.dm
+++ b/code/datums/materials/properties/optional.dm
@@ -120,7 +120,7 @@
 	if (isliving(target))
 		target.adjust_fire_stacks(source.get_property(id))
 
-/// Deals additional burn damage to vampires, property value determines damage
+/// Deals additional burn damage to vampires, property value times material volume determines damage
 /datum/material_property/vampires_bane
 	name = "Vampires' Bane"
 	id = MATERIAL_VAMPIRES_BANE
@@ -129,7 +129,7 @@
 	return "vampires' bane"
 
 /datum/material_property/vampires_bane/get_tooltip(value)
-	return "Deals [value] additional burn damage to vampires on contact"
+	return "Deals [value * 0.5] to [value * 2] additional burn damage to vampires on contact (based on material volume)"
 
 /datum/material_property/vampires_bane/attach_to(datum/material/material)
 	. = ..()
@@ -149,7 +149,8 @@
 		return
 
 	to_chat(target, span_userdanger("Contact with [object] sears your undead flesh!"))
-	target.apply_damage(source.get_property(id), BURN, def_zone, wound_bonus = 10, wound_clothing = FALSE)
+	playsound(target, SFX_SIZZLE, 33, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	target.apply_damage(source.get_property(id) * clamp((object.custom_materials[source] / (2 * SHEET_MATERIAL_AMOUNT)), 0.5, 2), BURN, def_zone, wound_bonus = 10, wound_clothing = FALSE)
 
 /// Teleports targets who come into active contact with the material around, property value determines teleport radius and damage taken per teleport
 /datum/material_property/teleporting

--- a/code/datums/materials/properties/optional.dm
+++ b/code/datums/materials/properties/optional.dm
@@ -151,7 +151,7 @@
 	var/burn_damage = source.get_property(id) * clamp((object.custom_materials[source] / (2 * SHEET_MATERIAL_AMOUNT)), 0.5, 2)
 	var/armor_block = 0
 	if(!skin_contact && !source.get_property(MATERIAL_PENETRATING))
-		armor_block = target.run_armor_check(def_zone, WOUND, armour_penetration = object.armour_penetration, silent = TRUE, weak_against_armor = TRUE)
+		armor_block = target.run_armor_check(def_zone, WOUND, armour_penetration = astype(object, /obj/item)?.armour_penetration || 0, silent = TRUE, weak_against_armour = TRUE)
 
 	if(armor_block > 50)
 		return

--- a/code/datums/materials/properties/optional.dm
+++ b/code/datums/materials/properties/optional.dm
@@ -145,12 +145,20 @@
 /datum/material_property/vampires_bane/proc/on_contact(datum/material/source, atom/object, mob/living/target, mob/living/user, def_zone, skin_contact)
 	SIGNAL_HANDLER
 
-	if (!isvampire(target) || (!skin_contact && !source.get_property(MATERIAL_PENETRATING)))
+	if (!isvampire(target))
+		return
+
+	var/burn_damage = source.get_property(id) * clamp((object.custom_materials[source] / (2 * SHEET_MATERIAL_AMOUNT)), 0.5, 2)
+	var/armor_block = 0
+	if(!skin_contact && !source.get_property(MATERIAL_PENETRATING))
+		armor_block = target.run_armor_check(def_zone, WOUND, armour_penetration = object.armour_penetration, silent = TRUE, weak_against_armor = TRUE)
+
+	if(armor_block > 66)
 		return
 
 	to_chat(target, span_userdanger("Contact with [object] sears your undead flesh!"))
 	playsound(target, SFX_SIZZLE, 33, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-	target.apply_damage(source.get_property(id) * clamp((object.custom_materials[source] / (2 * SHEET_MATERIAL_AMOUNT)), 0.5, 2), BURN, def_zone, wound_bonus = 10, wound_clothing = FALSE)
+	target.apply_damage(burn_damage, BURN, def_zone, armor_block, wound_bonus = 10, attacking_item = object, attack_direction = get_dir(user, target), wound_clothing = FALSE)
 
 /// Teleports targets who come into active contact with the material around, property value determines teleport radius and damage taken per teleport
 /datum/material_property/teleporting

--- a/code/game/objects/items/storage/toolboxes/_toolbox.dm
+++ b/code/game/objects/items/storage/toolboxes/_toolbox.dm
@@ -13,7 +13,7 @@
 	throw_range = 7
 	demolition_mod = 1.25
 	w_class = WEIGHT_CLASS_BULKY
-	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*5)
+	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 0.5)
 	attack_verb_continuous = list("robusts")
 	attack_verb_simple = list("robust")
 	hitsound = 'sound/items/weapons/smash.ogg'

--- a/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
@@ -523,7 +523,10 @@ GLOBAL_LIST_INIT(nullrod_variants, init_nullrod_variants())
 	attack_verb_continuous = list("whips", "lashes")
 	attack_verb_simple = list("whip", "lash")
 	hitsound = 'sound/items/weapons/chainhit.ogg'
-	menu_description = "A whip. Deals extra damage to vampires. Fits in pockets. Can be worn on the belt."
+	menu_description = "A whip forged from silver. Deals extra damage to vampires. Fits in pockets. Can be worn on the belt."
+	material_flags = MATERIAL_EFFECTS
+	custom_materials = list(/datum/material/silver = SHEET_MATERIAL_AMOUNT * 3, /datum/material/iron = SHEET_MATERIAL_AMOUNT)
+	material_slots = list(/datum/material_slot/weapon_head = /datum/material/silver, /datum/material_slot/handle = /datum/material/iron)
 
 // Atheist's Fedora - Wear it on your head. No melee damage, massive throw force.
 

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -31,7 +31,6 @@
 	. = ..()
 	to_chat(new_vampire, "[info_text]")
 	new_vampire.skin_tone = "albino"
-	RegisterSignal(new_vampire, COMSIG_ATOM_ATTACKBY, PROC_REF(on_attackby))
 	RegisterSignal(new_vampire, COMSIG_MOB_HUD_CREATED, PROC_REF(on_hud_created))
 	RegisterSignal(new_vampire, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 	if(new_vampire.hud_used)
@@ -40,7 +39,6 @@
 /datum/species/human/vampire/on_species_loss(mob/living/carbon/human/old_vampire, datum/species/new_species, pref_load)
 	. = ..()
 	UnregisterSignal(old_vampire, list(
-		COMSIG_ATOM_ATTACKBY,
 		COMSIG_MOB_HUD_CREATED,
 		COMSIG_LIVING_LIFE,
 	))
@@ -72,12 +70,6 @@
 /datum/species/human/vampire/proc/on_hud_created(mob/source)
 	SIGNAL_HANDLER
 	source.hud_used.add_screen_object(/atom/movable/screen/blood_level, HUD_MOB_BLOOD_LEVEL, HUD_GROUP_INFO, update_screen = TRUE)
-
-/datum/species/human/vampire/proc/on_attackby(mob/living/source, obj/item/attacking_item, mob/living/attacker, list/modifiers, list/attack_modifiers)
-	SIGNAL_HANDLER
-
-	if(istype(attacking_item, /obj/item/nullrod/whip))
-		MODIFY_ATTACK_FORCE_MULTIPLIER(attack_modifiers, 2)
 
 /datum/species/human/vampire/get_physical_attributes()
 	return "Vampires are afflicted with the Thirst, needing to sate it by draining the blood out of another living creature. However, they do not need to breathe or eat normally. \


### PR DESCRIPTION
## About The Pull Request

The holy whip no longer arbitrarily does 2x damage to vampires

The holy whip is now made out of silver, and thus applies bonus burn damage when hitting vampires

The damage amount has gone down slightly (36 brute -> 18 brute + 12 burn) but it's slightly offset by the fact that the silver burn damage is calculated against different armor

Silver itself now does more damage on average (from 5 flat to 4-16 based on material volume) and is no longer completely blocked by any form of clothing, instead blocked by wound armor

## Why It's Good For The Game

Tying these hardcoded debuffs to more broad game systems is more sandboxy, which I think is more fun. It establishes consistent rules that players can follow without needing niche code knowledge or extra examine tooltips

Yeah it's a bit weaker in practice... but the balance doesn't really matter anyways since it's a niche Halloween interaction 

## Changelog

:cl: Melbert
balance: "Holy whip" null rod no longer arbitrarily does 2x brute damage to vampires
balance: "Holy whip" null rod is now made of silver, which does bonus burn damage to vampires (~1.67x damage now)
balance: Silver material weapons deal more burn damage to vampires on average now (from 5 flat to 4-16, depending on volume of silver in the weapon) 
balance: Silver material weapons are no longer completely blocked by any form of clothing, instead now reduced / blocked by wound armor 
/:cl:
