### PR TITLE
Cyberhearts now use blood regeneration multiplier

### DIFF
--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -10,7 +10,6 @@
 	beat_noise = "an astonishing <b>BZZZ</b> of immense electrical power"
 	bleed_prevention = TRUE
 	toxification_probability = 0
-	blood_regeneration_multiplier = 1
 
 	COOLDOWN_DECLARE(survival_cooldown)
 	custom_materials = list(/datum/material/titanium = SHEET_MATERIAL_AMOUNT * 5, /datum/material/diamond = SHEET_MATERIAL_AMOUNT, /datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT)

--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -10,7 +10,7 @@
 	beat_noise = "an astonishing <b>BZZZ</b> of immense electrical power"
 	bleed_prevention = TRUE
 	toxification_probability = 0
-	blood_regeneration_multiplier = 9
+	blood_regeneration_multiplier = 1
 
 	COOLDOWN_DECLARE(survival_cooldown)
 	custom_materials = list(/datum/material/titanium = SHEET_MATERIAL_AMOUNT * 5, /datum/material/diamond = SHEET_MATERIAL_AMOUNT, /datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT)
@@ -189,6 +189,7 @@
 	. = ..()
 	core = new /obj/item/assembly/signaler/anomaly/flux(src)
 	add_organ_trait(TRAIT_SHOCKIMMUNE)
+	blood_regeneration_multiplier = 21
 	update_icon_state()
 
 /datum/status_effect/voltaic_overdrive

--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -10,6 +10,7 @@
 	beat_noise = "an astonishing <b>BZZZ</b> of immense electrical power"
 	bleed_prevention = TRUE
 	toxification_probability = 0
+	blood_regeneration_multiplier = 9
 
 	COOLDOWN_DECLARE(survival_cooldown)
 	custom_materials = list(/datum/material/titanium = SHEET_MATERIAL_AMOUNT * 5, /datum/material/diamond = SHEET_MATERIAL_AMOUNT, /datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT)
@@ -111,8 +112,6 @@
 	if(!core)
 		return
 
-	owner.adjust_blood_volume(5 * seconds_per_tick, maximum = BLOOD_VOLUME_NORMAL)
-
 	if(owner.health <= owner.crit_threshold)
 		activate_survival(owner)
 
@@ -158,6 +157,7 @@
 	balloon_alert(user, "core installed")
 	playsound(src, 'sound/machines/click.ogg', 30, TRUE)
 	add_organ_trait(TRAIT_SHOCKIMMUNE)
+	blood_regeneration_multiplier = 21
 	update_icon_state()
 	return ITEM_INTERACT_SUCCESS
 


### PR DESCRIPTION
## About The Pull Request

#96129 forgot to change cyberhearts, probably since they're in a different file. This makes them use the same code as everything else.

## Why It's Good For The Game

bugfix

## Changelog

:cl:
fix: cyberheart blood regeneration properly scales with heart damage
/:cl: