### PR TITLE
Medical doctors and CMOs can get virologist bounties

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -60,7 +60,7 @@
 #define CIV_JOB_SEC 4
 #define CIV_JOB_DRINK 5
 #define CIV_JOB_CHEM 6
-#define CIV_JOB_VIRO 7
+#define CIV_JOB_MED_VIRO 7
 #define CIV_JOB_SCI 8
 #define CIV_JOB_ENG 9
 #define CIV_JOB_MINE 10

--- a/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
+++ b/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
@@ -69,7 +69,7 @@
 			if(prob(50))
 				return /datum/bounty/reagent/chemical_simple
 			return /datum/bounty/reagent/chemical_complex
-		if(CIV_JOB_VIRO)
+		if(CIV_JOB_MED_VIRO)
 			if(prob(75))
 				return pick(subtypesof(/datum/bounty/item/medical))
 			return pick(subtypesof(/datum/bounty/virus))

--- a/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
+++ b/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
@@ -70,6 +70,8 @@
 				return /datum/bounty/reagent/chemical_simple
 			return /datum/bounty/reagent/chemical_complex
 		if(CIV_JOB_VIRO)
+			if(prob(70))
+				return pick(subtypesof(/datum/bounty/item/medical))
 			return pick(subtypesof(/datum/bounty/virus))
 		if(CIV_JOB_SCI)
 			if(prob(50))

--- a/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
+++ b/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
@@ -70,7 +70,7 @@
 				return /datum/bounty/reagent/chemical_simple
 			return /datum/bounty/reagent/chemical_complex
 		if(CIV_JOB_VIRO)
-			if(prob(70))
+			if(prob(75))
 				return pick(subtypesof(/datum/bounty/item/medical))
 			return pick(subtypesof(/datum/bounty/virus))
 		if(CIV_JOB_SCI)

--- a/code/modules/cargo/bounties/virus.dm
+++ b/code/modules/cargo/bounties/virus.dm
@@ -60,7 +60,7 @@
 	return virus.totalStealth() == stat_value
 
 /datum/bounty/virus/transmit
-	stat_name = "transmissible"
+	stat_name = "transmission"
 
 /datum/bounty/virus/transmit/accepts_virus(datum/disease/advance/virus)
 	return virus.totalTransmittable() == stat_value

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_EMPTY(shared_crew_bounties)
 				else
 					chosen_type = /datum/bounty/reagent/chemical_complex
 			if(CIV_JOB_VIRO)
-				if(prob(70))
+				if(prob(75))
 					chosen_type = pick(subtypesof(/datum/bounty/item/medical))
 				else
 					chosen_type = pick(subtypesof(/datum/bounty/virus))

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -105,7 +105,7 @@ GLOBAL_LIST_EMPTY(shared_crew_bounties)
 					chosen_type = /datum/bounty/reagent/chemical_simple
 				else
 					chosen_type = /datum/bounty/reagent/chemical_complex
-			if(CIV_JOB_VIRO)
+			if(CIV_JOB_MED_VIRO)
 				if(prob(75))
 					chosen_type = pick(subtypesof(/datum/bounty/item/medical))
 				else

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -106,7 +106,10 @@ GLOBAL_LIST_EMPTY(shared_crew_bounties)
 				else
 					chosen_type = /datum/bounty/reagent/chemical_complex
 			if(CIV_JOB_VIRO)
-				chosen_type = pick(subtypesof(/datum/bounty/virus))
+				if(prob(70))
+					chosen_type = pick(subtypesof(/datum/bounty/item/medical))
+				else
+					chosen_type = pick(subtypesof(/datum/bounty/virus))
 			if(CIV_JOB_SCI)
 				if(prob(50))
 					chosen_type = pick(subtypesof(/datum/bounty/item/science))

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -31,7 +31,7 @@
 	liver_traits = list(TRAIT_MEDICAL_METABOLISM, TRAIT_ROYAL_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_CHIEF_MEDICAL_OFFICER
-	bounty_types = CIV_JOB_VIRO
+	bounty_types = CIV_JOB_MED_VIRO
 
 	mail_goodies = list(
 		/obj/effect/spawner/random/medical/organs = 10,

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -31,7 +31,7 @@
 	liver_traits = list(TRAIT_MEDICAL_METABOLISM, TRAIT_ROYAL_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_CHIEF_MEDICAL_OFFICER
-	bounty_types = CIV_JOB_MED
+	bounty_types = CIV_JOB_VIRO
 
 	mail_goodies = list(
 		/obj/effect/spawner/random/medical/organs = 10,

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -19,7 +19,7 @@
 	liver_traits = list(TRAIT_MEDICAL_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_MEDICAL_DOCTOR
-	bounty_types = CIV_JOB_VIRO
+	bounty_types = CIV_JOB_MED_VIRO
 	departments_list = list(
 		/datum/job_department/medical,
 		)

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -19,7 +19,7 @@
 	liver_traits = list(TRAIT_MEDICAL_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_MEDICAL_DOCTOR
-	bounty_types = CIV_JOB_MED
+	bounty_types = CIV_JOB_VIRO
 	departments_list = list(
 		/datum/job_department/medical,
 		)


### PR DESCRIPTION
## About The Pull Request

Virologist bounties are currently unobtainable, probably from when virologist was removed. This PR gives medical doctors and CMOs a 25% chance to get a virologist bounty instead of a regular bounty.

## Why It's Good For The Game

Content

## Changelog

:cl:
add: Medical doctors and CMOs can get old virologist bounties
spellcheck: Changed "transmissible" to "transmission" in virologist bounties
/:cl:
