### PR TITLE
Fixes atmos diffs and incorrect atmos in lavaland hermit ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -10,10 +10,10 @@
 /area/ruin/powered)
 "e" = (
 /obj/item/clothing/suit/space/orange,
-/turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace,
+/turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace/normal_atmos,
 /area/ruin/powered)
 "f" = (
-/turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace,
+/turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace/normal_atmos,
 /area/ruin/powered)
 "g" = (
 /turf/open/misc/asteroid{
@@ -57,7 +57,7 @@
 /obj/item/seeds/plump,
 /obj/item/food/grown/mushroom/glowshroom,
 /obj/item/seeds/tower,
-/turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace,
+/turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace/normal_atmos,
 /area/ruin/powered)
 "n" = (
 /obj/machinery/hydroponics/soil,
@@ -71,7 +71,7 @@
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/storage/bag/ore,
 /obj/item/storage/medkit/regular,
-/turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace,
+/turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace/normal_atmos,
 /area/ruin/powered)
 "q" = (
 /obj/structure/glowshroom/single,
@@ -81,7 +81,7 @@
 /obj/structure/rack,
 /obj/item/pickaxe/emergency,
 /obj/item/tank/internals/oxygen,
-/turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace,
+/turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace/normal_atmos,
 /area/ruin/powered)
 "s" = (
 /turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace,
@@ -174,7 +174,7 @@
 /area/ruin/powered)
 "M" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace,
+/turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace/normal_atmos,
 /area/ruin/powered)
 "P" = (
 /turf/template_noop,

--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -217,6 +217,10 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 	if(cur_flags & NO_RUINS)
 		new_turf.turf_flags |= NO_RUINS
 
+/turf/open/misc/asteroid/basalt/lava_land_surface/biome_replace/normal_atmos
+	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+	planetary_atmos = FALSE
+
 /turf/open/misc/asteroid/lowpressure
 	initial_gas_mix = OPENTURF_LOW_PRESSURE
 	baseturfs = /turf/open/misc/asteroid/lowpressure


### PR DESCRIPTION

## About The Pull Request
Caused by #95955, solved by adding a subtype of biome replace turf that has standard atmos

## Changelog
:cl:
fix: Fixed atmos diffs and incorrect atmos in lavaland hermit ruin
/:cl:
