### PR TITLE
Removes a no good bad reference from a bounty description

### DIFF
--- a/code/modules/cargo/bounties/atmos.dm
+++ b/code/modules/cargo/bounties/atmos.dm
@@ -29,7 +29,7 @@
 
 /datum/bounty/item/atmospherics/nitrium_tank
 	name = "Full Tank of Nitrium"
-	description = "The non-human staff of Station 88 has been volunteered to test performance enhancing drugs. Ship them a tank full of Nitrium so they can get started. (20 Moles)"
+	description = "The prisoners of MegaStation 62 has been volunteered to test performance enhancing drugs. Ship them a tank full of Nitrium so they can get started. (20 Moles)"
 	gas_type = /datum/gas/nitrium
 
 /datum/bounty/item/atmospherics/freon_tank

--- a/code/modules/cargo/bounties/atmos.dm
+++ b/code/modules/cargo/bounties/atmos.dm
@@ -29,7 +29,7 @@
 
 /datum/bounty/item/atmospherics/nitrium_tank
 	name = "Full Tank of Nitrium"
-	description = "The prisoners of MegaStation 62 has been volunteered to test performance enhancing drugs. Ship them a tank full of Nitrium so they can get started. (20 Moles)"
+	description = "The prisoners of MegaStation 62 have been volunteered to test performance enhancing drugs. Ship them a tank full of Nitrium so they can get started. (20 Moles)"
 	gas_type = /datum/gas/nitrium
 
 /datum/bounty/item/atmospherics/freon_tank


### PR DESCRIPTION

## About The Pull Request

Station 88 in a description about sending gas is pretty close to actual nazism. Let's not.

## Why It's Good For The Game
Nazis are...bad!

## Changelog
:cl:
spellcheck: Dogwhistle has been removed from a bounty description.
/:cl:
