### PR TITLE
Fixes TGUI crash when renaming ports on circuit modules and the proc call component

### DIFF
--- a/tgui/packages/tgui/interfaces/CircuitModule.jsx
+++ b/tgui/packages/tgui/interfaces/CircuitModule.jsx
@@ -41,7 +41,7 @@ export const CircuitModule = (props) => {
                             port_type: type,
                           })
                         }
-                        onEnter={(e, value) =>
+                        onEnter={(value) =>
                           act('set_port_name', {
                             port_id: index + 1,
                             is_input: true,
@@ -83,7 +83,7 @@ export const CircuitModule = (props) => {
                             port_type: type,
                           })
                         }
-                        onEnter={(e, value) =>
+                        onEnter={(value) =>
                           act('set_port_name', {
                             port_id: index + 1,
                             is_input: false,

--- a/tgui/packages/tgui/interfaces/ProcCallMenu.tsx
+++ b/tgui/packages/tgui/interfaces/ProcCallMenu.tsx
@@ -93,7 +93,7 @@ export const ProcCallMenu = (props) => {
                         datatype: type,
                       })
                     }
-                    onEnter={(e, value) =>
+                    onEnter={(value) =>
                       act('rename_argument', {
                         index: index + 1,
                         name: value,


### PR DESCRIPTION

## About The Pull Request

Editing the name of a port in the circuit module editor, or of an argument on the Proc Call component, crashes TGUI:

```
TypeError: Converting circular structure to JSON
--> starting at object with constructor 'HTMLInputElement'
|     property '__reactFiber$4lsrel5o8w4' -> object with constructor 'rt'
--- property 'stateNode' closes the circle
at JSON.stringify (<anonymous>)
at onEnter
...
```

Both `CircuitModule.jsx` and `ProcCallMenu.tsx` define a local `PortEntry` component that renders the name field as `<Input onChange={onEnter} />`. The `onEnter` prop name is vestigial: it is wired to the `Input`'s `onChange`, so it fires on any edit, not just on Enter.

The handlers those files pass in are bound to the old tgui `Input` callback signature, `(event, value)`. tgui-core's `Input` passes the value as the **first** argument, so the handler was reading argument two (the change event) and forwarding it as the
port name. `JSON.stringify` then walks from the event to its target `<input>` element, which holds a `__reactFiber$…` back-reference whose `stateNode` points back at the element, and throws on the cycle. That is the loop shown in the trace above.

This is the same root cause as #95865 (and its duplicates #95944 / #95889), which surfaced more visibly in the general circuit component text fields. That was fixed in #95946 by correcting the `onChange` binding in `IntegratedCircuit/FundamentalTypes.jsx`. These three call sites reach the same prop on the same component through the misleadingly-named passthrough, and were missed.

Fixed by reading the value from the first argument, matching every other `Input` handler in the codebase.

After this change, no `Input` handler in `tgui/packages/tgui/interfaces/` uses the old signature. The remaining `(e, value)` handlers in that directory are all on `Slider` (16) and `Knob` (5), which still take the event first and are unaffected.

**Testing:** Rebuilt and tested locally. Circuit module input and output ports can be renamed without a crash. On the Proc Call component, added two arguments, renamed both, and set their datatypes. No crash occurred, and the names and types persist correctly.
## Why It's Good For The Game

Fixes a TGUI crash that makes it impossible to rename ports on circuit modules, or arguments on the Proc Call component.
## Changelog
:cl:
fix: Renaming input/output ports on a circuit module no longer crashes the UI.
admin: Renaming an argument on the Proc Call circuit component no longer crashes the UI.
/:cl:
