### PR TITLE
Born, real monkeys retain their primitive brains when turned into humans.

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -572,7 +572,8 @@
 		brain.zone = initial(brain.zone)
 		brain.Insert(owner, special = TRUE, movement_flags = NO_ID_TRANSFER)
 
-	owner.dna.species.regenerate_organs(owner, replace_current = FALSE, excluded_zones = list(BODY_ZONE_CHEST)) //replace_current needs to be FALSE to prevent weird adding and removing mutation healing
+	var/list/excluded_zones = GLOB.all_body_zones - BODY_ZONE_HEAD
+	owner.dna.species.regenerate_organs(owner, replace_current = FALSE, excluded_zones = excluded_zones) //replace_current needs to be FALSE to prevent weird adding and removing mutation healing
 	owner.apply_damage(damage = 50, damagetype = BRUTE, def_zone = BODY_ZONE_HEAD) //and this to DISCOURAGE organ farming, or at least not make it free.
 	owner.visible_message(span_warning("[owner]'s head returns with a sickening crunch!"), span_warning("Your head regrows with a sickening crack! Ouch."))
 	new /obj/effect/gibspawner/generic(get_turf(owner), owner)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -291,11 +291,13 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		var/obj/item/organ/new_organ = get_mutant_organ_type_for_slot(slot)
 		var/old_organ_type = old_species?.get_mutant_organ_type_for_slot(slot)
 
-		if(existing_organ)
-			if(!existing_organ.get_replaceability(new_organ, old_organ_type, old_species, replace_current))
-				continue
+		if(existing_organ && !existing_organ.get_replaceability(new_organ, old_organ_type, old_species, replace_current))
+			continue
 		// if we have an extra organ that before changing that the species didnt have, remove it
 		else if(!new_organ)
+			if(existing_organ)
+				existing_organ.Remove(organ_holder)
+				qdel(existing_organ)
 			continue
 
 		if(visual_only && (!initial(new_organ.bodypart_overlay) && !initial(new_organ.visual)))

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -291,21 +291,12 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		var/obj/item/organ/new_organ = get_mutant_organ_type_for_slot(slot)
 		var/old_organ_type = old_species?.get_mutant_organ_type_for_slot(slot)
 
-		// if we have an extra organ that before changing that the species didnt have, remove it
-		if(!new_organ)
-			if(existing_organ && (old_organ_type == existing_organ.type || replace_current))
-				existing_organ.Remove(organ_holder)
-				qdel(existing_organ)
-			continue
-
 		if(existing_organ)
-			// we dont want to remove organs that were not from the old species (such as from freak surgery or prosthetics)
-			if(existing_organ.type != old_organ_type && !replace_current)
+			if(!existing_organ.get_replaceability(new_organ, old_organ_type, old_species, replace_current))
 				continue
-
-			// we don't want to remove organs that are the same as the new one
-			if(existing_organ.type == new_organ)
-				continue
+		// if we have an extra organ that before changing that the species didnt have, remove it
+		else if(!new_organ)
+			continue
 
 		if(visual_only && (!initial(new_organ.bodypart_overlay) && !initial(new_organ.visual)))
 			continue

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -123,6 +123,12 @@
 	/// Will this monkey stumble if they are crossed by a simple mob or a carbon in combat mode? Toggable by monkeys with clients, and is messed automatically set to true by monkey AI.
 	var/tripping = TRUE
 
+/obj/item/organ/brain/primate/get_replaceability(obj/item/organ/new_organ_type, obj/item/organ/expected_organ_type, datum/species/old_species, replace_current = TRUE)
+	///Real monkeys retain their ape brains when humanized (further species change can override it). If old_species is null,
+	if(HAS_TRAIT(owner, TRAIT_BORN_MONKEY) && (!old_species || istype(old_species, /datum/species/monkey)))
+		return FALSE
+	return ..()
+
 /datum/action/item_action/organ_action/toggle_trip
 	name = "Toggle Tripping"
 	button_icon = 'icons/mob/actions/actions_changeling.dmi'

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -441,12 +441,12 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
  * * replace_current - boolean, *generally* force the organ to be deleted whether or not they pass the species' ability to keep that organ.
  */
 /obj/item/organ/proc/get_replaceability(obj/item/organ/new_organ_type, obj/item/organ/expected_organ_type, datum/species/old_species, replace_current = TRUE)
-	// we dont want to remove organs that were not from the old species (such as from freak surgery or prosthetics)
-	if(replace_current || type == expected_organ_type)
-		return TRUE
-
 	// we don't want to remove organs that are the same as the new one
 	if(type == new_organ_type)
+		return FALSE
+
+	// we dont want to remove organs that were not from the old species (such as from freak surgery or prosthetics)
+	if(replace_current || type == expected_organ_type)
 		return TRUE
 
 	return FALSE

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -431,6 +431,26 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 /obj/item/organ/proc/get_availability(datum/species/owner_species, mob/living/owner_mob)
 	return TRUE
 
+/**
+ * Perform a series of get to see if this organ is elegible to be replaced by regenerate_orgas. While get_availability is for the new_organ
+ * this one is, conversely, for the old organ.
+ *
+ * * new_organ_type - the type of the new organ we ought to replace this with.
+ * * expected_organ_type - the old organ for this slot that the old species is supposed to have, which may or may not match what the mob currently has.
+ * * species - the old species datum, present if the regenerate_organs proc has been called as a result of a species change.
+ * * replace_current - boolean, *generally* force the organ to be deleted whether or not they pass the species' ability to keep that organ.
+ */
+/obj/item/organ/proc/get_replaceability(obj/item/organ/new_organ_type, obj/item/organ/expected_organ_type, datum/species/old_species, replace_current = TRUE)
+	// we dont want to remove organs that were not from the old species (such as from freak surgery or prosthetics)
+	if(replace_current || type == expected_organ_type)
+		return FALSE
+
+	// we don't want to remove organs that are the same as the new one
+	if(type == new_organ_type)
+		return FALSE
+
+	return TRUE
+
 /// Called before organs are replaced in regenerate_organs with new ones
 /obj/item/organ/proc/before_organ_replacement(obj/item/organ/replacement)
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -443,13 +443,13 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 /obj/item/organ/proc/get_replaceability(obj/item/organ/new_organ_type, obj/item/organ/expected_organ_type, datum/species/old_species, replace_current = TRUE)
 	// we dont want to remove organs that were not from the old species (such as from freak surgery or prosthetics)
 	if(replace_current || type == expected_organ_type)
-		return FALSE
+		return TRUE
 
 	// we don't want to remove organs that are the same as the new one
 	if(type == new_organ_type)
-		return FALSE
+		return TRUE
 
-	return TRUE
+	return FALSE
 
 /// Called before organs are replaced in regenerate_organs with new ones
 /obj/item/organ/proc/before_organ_replacement(obj/item/organ/replacement)


### PR DESCRIPTION
## About The Pull Request
Yeah, suddenly a monkey that has spent its entirely life being a primate with the general intellect of a child becomes a relatively intelligent spaceman capable of using plenty of tools and computers as soon as they get their innate monkey genes deactivated, especially when we have the clever trait which is supposed to be the one handling that.

This PR also deals with `/datum/mutation/headless/on_losing()` possibly regenerating organs in other zones of the body that are neither the head (eyes and tongue) or the torso, like a removed appendix.

## Why It's Good For The Game
@CabinetOnFire asked me if I could do this, as he says that humanized monkeys losing their primitive brains is causing him some issues as the now human monkeys can perform advanced tool interactions when it really shouldn't fit their nature.

## Changelog

:cl:
balance: humanized monkeys (that were born as monkeys) should have their primitive ape brain untouched (not an advanced tool user unless they have the clever trait).
/:cl:
