### PR TITLE
Spam pointing too much without speaking risks joint dislocation

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -39,6 +39,9 @@
 		emote.run_emote(src, param, type_override, intentional)
 		SEND_SIGNAL(src, COMSIG_MOB_EMOTE, emote, act, type_override, message, intentional)
 		SEND_SIGNAL(src, COMSIG_MOB_EMOTED(emote.key))
+		if(intentional && iscarbon(src))
+			var/mob/living/carbon/carbon_emoter = src
+			carbon_emoter.point_spam_count = 0
 		return TRUE
 	if(intentional && !silenced && !force_silence)
 		to_chat(src, span_notice("Unusable emote '[act]'. Say *help for a list."))

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -25,6 +25,11 @@
 	///Same as handcuffs but for legs. Bear traps use this.
 	var/obj/item/legcuffed = null
 
+	///How many times we've pointed without speaking or manually emoting, risks dislocating our arm if too high
+	var/point_spam_count = 0
+	///world.time at which the current point spam counting window expires
+	var/point_spam_window_end = 0
+
 	/// Measure of how disgusted we are. See DISGUST_LEVEL_GROSS and friends
 	var/disgust = 0
 	/// How disgusted we were LAST time we processed disgust. Helps prevent unneeded work

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -167,6 +167,10 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	if(!try_speak(original_message, ignore_spam, forced, filterproof))
 		return
 
+	if(iscarbon(src))
+		var/mob/living/carbon/carbon_speaker = src
+		carbon_speaker.point_spam_count = 0
+
 	language ||= message_mods[LANGUAGE_EXTENSION] || get_selected_language()
 
 	var/succumbed = FALSE

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -114,6 +114,10 @@
 #define POINT_SPAM_CHANCE_PER_POINT 10
 ///Point count at which we warn the pointer that their arm is starting to ache
 #define POINT_SPAM_ACHE_THRESHOLD 20
+///How long after the final warning before dislocation rolls can actually proc
+#define POINT_SPAM_GRACE_PERIOD (2 SECONDS)
+///Minimum time between points that count towards the spam counter, so mouse-speed bursts don't count as sustained spam
+#define POINT_SPAM_INCREMENT_COOLDOWN (0.5 SECONDS)
 
 GAME_VERB(/mob, pointed, "Point To", null, atom/A as mob|obj|turf in view(client.view, src))
 
@@ -146,30 +150,33 @@ GAME_VERB(/mob, pointed, "Point To", null, atom/A as mob|obj|turf in view(client
 		if(world.time > our_carbon.point_spam_window_end)
 			our_carbon.point_spam_count = 0
 			our_carbon.point_spam_window_end = world.time + POINT_SPAM_WINDOW
-		our_carbon.point_spam_count++
-		switch(our_carbon.point_spam_count)
-			if(POINT_SPAM_ACHE_THRESHOLD)
-				to_chat(our_carbon, span_warning("Your arm is starting to ache from all this pointing."))
-			if(POINT_SPAM_LIMIT)
-				to_chat(our_carbon, span_boldwarning("Your shoulder is throbbing painfully. Maybe you should say something instead."))
-		if(prob((our_carbon.point_spam_count - POINT_SPAM_LIMIT) * POINT_SPAM_CHANCE_PER_POINT))
-			var/obj/item/bodypart/pointing_arm = our_carbon.hand_bodyparts[our_carbon.active_hand_index]
-			pointing_arm ||= our_carbon.get_bodypart(BODY_ZONE_R_ARM) || our_carbon.get_bodypart(BODY_ZONE_L_ARM)
-			if(!isnull(pointing_arm))
-				var/datum/wound/blunt/bone/moderate/dislocation = new
-				dislocation.apply_wound(pointing_arm, silent = TRUE, wound_source = "pointing too much")
-				if(!QDELETED(dislocation))
-					our_carbon.point_spam_count = 0
-					our_carbon.visible_message(
-						span_danger("[our_carbon]'s [pointing_arm.plaintext_zone] pops out of its socket from all that pointing!"),
-						span_userdanger("Your [pointing_arm.plaintext_zone] pops out of its socket from all that pointing!"),
-					)
-					playsound(our_carbon, 'sound/effects/wounds/crack1.ogg', 70, TRUE)
-					INVOKE_ASYNC(our_carbon, TYPE_PROC_REF(/mob, emote), "scream")
-					if(pointing_arm.held_index)
-						var/obj/item/held_item = our_carbon.held_items[pointing_arm.held_index]
-						if(held_item)
-							our_carbon.dropItemToGround(held_item)
+		if(TIMER_COOLDOWN_FINISHED(our_carbon, "point_spam_increment"))
+			TIMER_COOLDOWN_START(our_carbon, "point_spam_increment", POINT_SPAM_INCREMENT_COOLDOWN)
+			our_carbon.point_spam_count++
+			switch(our_carbon.point_spam_count)
+				if(POINT_SPAM_ACHE_THRESHOLD)
+					to_chat(our_carbon, span_warning("Your arm is starting to ache from all this pointing."))
+				if(POINT_SPAM_LIMIT)
+					to_chat(our_carbon, span_boldwarning("Your shoulder is throbbing painfully. Maybe you should say something instead."))
+					TIMER_COOLDOWN_START(our_carbon, "point_spam_grace", POINT_SPAM_GRACE_PERIOD)
+			if(TIMER_COOLDOWN_FINISHED(our_carbon, "point_spam_grace") && prob((our_carbon.point_spam_count - POINT_SPAM_LIMIT) * POINT_SPAM_CHANCE_PER_POINT))
+				var/obj/item/bodypart/pointing_arm = our_carbon.hand_bodyparts[our_carbon.active_hand_index]
+				pointing_arm ||= our_carbon.get_bodypart(BODY_ZONE_R_ARM) || our_carbon.get_bodypart(BODY_ZONE_L_ARM)
+				if(!isnull(pointing_arm))
+					var/datum/wound/blunt/bone/moderate/dislocation = new
+					dislocation.apply_wound(pointing_arm, silent = TRUE, wound_source = "pointing too much")
+					if(!QDELETED(dislocation))
+						our_carbon.point_spam_count = 0
+						our_carbon.visible_message(
+							span_danger("[our_carbon]'s [pointing_arm.plaintext_zone] pops out of its socket from all that pointing!"),
+							span_userdanger("Your [pointing_arm.plaintext_zone] pops out of its socket from all that pointing!"),
+						)
+						playsound(our_carbon, 'sound/effects/wounds/crack1.ogg', 70, TRUE)
+						INVOKE_ASYNC(our_carbon, TYPE_PROC_REF(/mob, emote), "scream")
+						if(pointing_arm.held_index)
+							var/obj/item/held_item = our_carbon.held_items[pointing_arm.held_index]
+							if(held_item)
+								our_carbon.dropItemToGround(held_item)
 	point_at(pointing_at, TRUE)
 
 	return TRUE
@@ -178,3 +185,5 @@ GAME_VERB(/mob, pointed, "Point To", null, atom/A as mob|obj|turf in view(client
 #undef POINT_SPAM_WINDOW
 #undef POINT_SPAM_CHANCE_PER_POINT
 #undef POINT_SPAM_ACHE_THRESHOLD
+#undef POINT_SPAM_GRACE_PERIOD
+#undef POINT_SPAM_INCREMENT_COOLDOWN

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -106,6 +106,15 @@
  *
  * overridden here and in /mob/dead/observer for different point span classes and sanity checks
  */
+///How many times a carbon can point within one spam window before risking a dislocated arm
+#define POINT_SPAM_LIMIT 30
+///How long a point spam counting window lasts
+#define POINT_SPAM_WINDOW (30 SECONDS)
+///Additional chance to dislocate the pointing arm for each point past the limit
+#define POINT_SPAM_CHANCE_PER_POINT 10
+///Point count at which we warn the pointer that their arm is starting to ache
+#define POINT_SPAM_ACHE_THRESHOLD 20
+
 GAME_VERB(/mob, pointed, "Point To", null, atom/A as mob|obj|turf in view(client.view, src))
 
 	if(isnull(A) || istype(A, /obj/effect/temp_visual/point) || isarea(A))
@@ -133,6 +142,39 @@ GAME_VERB(/mob, pointed, "Point To", null, atom/A as mob|obj|turf in view(client
 			else
 				to_chat(src, span_warning("You need to wait before pointing again!"))
 				return FALSE
+		// pointing this much without saying anything is terrible for your rotator cuff
+		if(world.time > our_carbon.point_spam_window_end)
+			our_carbon.point_spam_count = 0
+			our_carbon.point_spam_window_end = world.time + POINT_SPAM_WINDOW
+		our_carbon.point_spam_count++
+		switch(our_carbon.point_spam_count)
+			if(POINT_SPAM_ACHE_THRESHOLD)
+				to_chat(our_carbon, span_warning("Your arm is starting to ache from all this pointing."))
+			if(POINT_SPAM_LIMIT)
+				to_chat(our_carbon, span_boldwarning("Your shoulder is throbbing painfully. Maybe you should say something instead."))
+		if(prob((our_carbon.point_spam_count - POINT_SPAM_LIMIT) * POINT_SPAM_CHANCE_PER_POINT))
+			var/obj/item/bodypart/pointing_arm = our_carbon.hand_bodyparts[our_carbon.active_hand_index]
+			pointing_arm ||= our_carbon.get_bodypart(BODY_ZONE_R_ARM) || our_carbon.get_bodypart(BODY_ZONE_L_ARM)
+			if(!isnull(pointing_arm))
+				var/datum/wound/blunt/bone/moderate/dislocation = new
+				dislocation.apply_wound(pointing_arm, silent = TRUE, wound_source = "pointing too much")
+				if(!QDELETED(dislocation))
+					our_carbon.point_spam_count = 0
+					our_carbon.visible_message(
+						span_danger("[our_carbon]'s [pointing_arm.plaintext_zone] pops out of its socket from all that pointing!"),
+						span_userdanger("Your [pointing_arm.plaintext_zone] pops out of its socket from all that pointing!"),
+					)
+					playsound(our_carbon, 'sound/effects/wounds/crack1.ogg', 70, TRUE)
+					INVOKE_ASYNC(our_carbon, TYPE_PROC_REF(/mob, emote), "scream")
+					if(pointing_arm.held_index)
+						var/obj/item/held_item = our_carbon.held_items[pointing_arm.held_index]
+						if(held_item)
+							our_carbon.dropItemToGround(held_item)
 	point_at(pointing_at, TRUE)
 
 	return TRUE
+
+#undef POINT_SPAM_LIMIT
+#undef POINT_SPAM_WINDOW
+#undef POINT_SPAM_CHANCE_PER_POINT
+#undef POINT_SPAM_ACHE_THRESHOLD


### PR DESCRIPTION
## About The Pull Request

Pointing for more than 15 seconds in a 30 second window, without speaking, has a scaling chance of making the arm you are pointing with dislocate. The player gets two chat message warnings as they approach the threshold.

## Why It's Good For The Game

Players who refuse to type a single word and faceplant an airlock while spam pointing at the autolathe should have something bad and funny happen to them and cmon its an arm dislocation it barely matters
## Changelog
:cl: PapaMichael
balance: Pointing too frequently without speaking risks a joint dislocation
/:cl:
