### PR TITLE
Successful stamping closes paper UI

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -694,6 +694,7 @@ GAME_VERB_SRC(/obj/item/paper, rename, usr, "Rename paper", null)
 
 			update_appearance()
 			update_static_data_for_all_viewers()
+			ui.close()
 			return TRUE
 		if("add_text")
 			var/paper_input = params["text"]

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -693,8 +693,8 @@ GAME_VERB_SRC(/obj/item/paper, rename, usr, "Rename paper", null)
 			playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
 
 			update_appearance()
-			update_static_data_for_all_viewers()
 			ui.close()
+			update_static_data_for_all_viewers()
 			return TRUE
 		if("add_text")
 			var/paper_input = params["text"]


### PR DESCRIPTION
## About The Pull Request

Automatically closes the paper UI when you successfully apply a stamp.

## Why It's Good For The Game

QOL not having to manually close each paper's window as you're stamping manifests, forms, etc.

## Changelog

:cl: LT3
qol: Stamping a paper now automatically closes the paper UI
/:cl: