### PR TITLE
Adds Pharaoh costumes to DeusVend

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -587,6 +587,9 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	premium = list(
 		/obj/item/clothing/head/chaplain/bishopmitre = 1,
 		/obj/item/clothing/suit/chaplainsuit/bishoprobe = 1,
+		/obj/item/clothing/head/costume/pharaoh = 1,
+		/obj/item/clothing/head/costume/nemes = 1,
+		/obj/item/clothing/suit/costume/nemes = 1,
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/chap_wardrobe
 	payment_department = ACCOUNT_SRV


### PR DESCRIPTION

## About The Pull Request

Curse of Ra is back. Now you can buy Pharaoh Hat, Nemes Hat and Pharaoh Tunic in DeusVend (premium)
<img width="201" height="141" alt="dreamseeker_rt14sBNYyO" src="https://github.com/user-attachments/assets/08b01765-3371-46cd-9adb-4852a2a3fcc7" />


<img width="431" height="635" alt="N2GbZpuGpx" src="https://github.com/user-attachments/assets/0c73de5c-7345-4174-81cb-72b49babd990" />

## Why It's Good For The Game

Unused (for years) content is bad. Cool costplay is good. 

## Changelog
:cl:
add: Curse of Ra is back. Now you can buy some pharaon costumes in DeusVend (premium)
/:cl: