### PR TITLE
Hopefully fixes Arena Shuttle by adding automatic guillotines.

### DIFF
--- a/_maps/templates/the_arena.dmm
+++ b/_maps/templates/the_arena.dmm
@@ -127,6 +127,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
 /area/shuttle/shuttle_arena)
+"wv" = (
+/obj/structure/guillotine/automatic,
+/turf/open/indestructible/necropolis/air,
+/area/shuttle/shuttle_arena)
 "xA" = (
 /obj/effect/forcefield/arena_shuttle,
 /turf/open/indestructible/necropolis/air,
@@ -245,6 +249,11 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
+/area/shuttle/shuttle_arena)
+"Qz" = (
+/obj/effect/landmark/shuttle_arena_entrance,
+/obj/structure/guillotine/automatic,
+/turf/open/indestructible/necropolis/air,
 /area/shuttle/shuttle_arena)
 "QZ" = (
 /obj/structure/stone_tile/block{
@@ -678,7 +687,7 @@ ar
 qp
 dz
 bE
-dz
+Qz
 qp
 ar
 ar
@@ -980,7 +989,7 @@ ar
 ar
 ar
 ar
-ar
+wv
 ar
 ar
 ar
@@ -1290,7 +1299,7 @@ yX
 yX
 rX
 rX
-ar
+wv
 ar
 ar
 ar
@@ -1324,7 +1333,7 @@ ar
 ar
 ar
 ar
-ar
+wv
 rX
 ar
 ar
@@ -1352,7 +1361,7 @@ UN
 UN
 iH
 ar
-ar
+wv
 ar
 ar
 ar
@@ -1460,7 +1469,7 @@ ar
 ar
 ar
 ar
-ar
+wv
 ar
 ar
 ar
@@ -1741,7 +1750,7 @@ LY
 IT
 Kb
 Kb
-ar
+wv
 ar
 ar
 ar
@@ -1964,7 +1973,7 @@ LY
 ar
 ar
 ar
-ar
+wv
 ar
 LY
 LY
@@ -2406,7 +2415,7 @@ ar
 ar
 ar
 ar
-ar
+wv
 ar
 ar
 rX
@@ -2516,7 +2525,7 @@ dz
 ar
 rX
 rX
-ar
+wv
 ar
 ar
 ar
@@ -2736,7 +2745,7 @@ yX
 rX
 rX
 rX
-ar
+wv
 ar
 ar
 rX
@@ -2939,7 +2948,7 @@ ar
 ar
 ar
 ar
-ar
+wv
 ar
 ar
 ar
@@ -3048,7 +3057,7 @@ rX
 rX
 ar
 ar
-ar
+wv
 rX
 yX
 yX

--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -285,6 +285,37 @@
 	current_action = GUILLOTINE_ACTION_IDLE
 	return FALSE
 
+/obj/structure/guillotine/automatic
+	name = "automatic guillotine"
+	desc = "A large structure that can and will remove heads of whomever falls under its blade."
+	resistance_flags = INDESTRUCTIBLE
+
+/obj/structure/guillotine/automatic/post_buckle_mob(mob/living/potential_victim)
+	if (!ishuman(potential_victim))
+		return
+
+	var/mob/living/carbon/human/victim = potential_victim
+
+	if (victim.dna)
+		if (victim.dna.species)
+			var/datum/species/S = victim.dna.species
+
+			if (istype(S))
+				victim.render_only_head()
+				victim.remove_overlay(BODY_ADJ_LAYER)
+				victim.pixel_y += -GUILLOTINE_HEAD_OFFSET // Offset their body so it looks like they're in the guillotine
+				victim.layer += GUILLOTINE_LAYER_DIFF
+				drop_blade(victim)
+				raise_blade()
+			else
+				unbuckle_all_mobs()
+		else
+			unbuckle_all_mobs()
+	else
+		unbuckle_all_mobs()
+
+	..()
+
 #undef GUILLOTINE_BLADE_MAX_SHARP
 #undef GUILLOTINE_DECAP_MIN_SHARP
 #undef GUILLOTINE_ANIMATION_LENGTH


### PR DESCRIPTION

## About The Pull Request

Arena shuttle requires you to claim skulls to exit.
You can't decapitate people anymore.
Arena shuttle doesn't work.
Proposed solution: Add guillotines which instantly behead anyone you buckle into them.
Now, maybe, hopefully it will work?

## Why It's Good For The Game

I get that the fight is kinda the whole thing of arena shuttle, but it's nice for the fight to actually have some reason, you know?

## Changelog

:cl:
map: Added several (13) automatic guillotines to the arena shuttle.
/:cl:
