### PR TITLE
Fixes weird banding on mineral turfs adjacent to space (on the bottom z level)

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -204,6 +204,17 @@
 	scan_state_overlay.pixel_y = 224
 	scan_overlay.add_overlay(scan_state_overlay)
 
+/turf/closed/mineral/set_smoothed_icon_state(new_junction)
+	var/old_junction = smoothing_junction
+	. = ..()
+	if(new_junction != ALL_SMOOTHING_JUNCTIONS || (!isnull(old_junction) && old_junction != new_junction))
+		update_appearance(UPDATE_OVERLAYS)
+
+/turf/closed/mineral/update_overlays()
+	. = ..()
+	if(smoothing_junction != ALL_SMOOTHING_JUNCTIONS)
+		. += fast_emissive_blocker(src)
+
 /turf/closed/mineral/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	if(turf_type)
 		underlay_appearance.icon = initial(turf_type.icon)


### PR DESCRIPTION

## About The Pull Request

You need to block emissives for starlight to color you, and this turf isn't well, doing that.

So we should do that.

This is hot code, which is why I have guard checks like I do. It's about 0.2-0.3 seconds of init on my machine, somewhere in there at least.

## Why It's Good For The Game

This bugs me a lot

## Changelog
:cl:
fix: Starlight will light rock walls adjacent to space... better.
/:cl:
