### PR TITLE
Some quirks menu backends improvements

### DIFF
--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -39,6 +39,7 @@
 		return
 
 	tainted = TRUE
+	previous_species_value = value
 	preferences.validate_quirks()
 
 /datum/preference_middleware/quirks/proc/get_species_compatibility()

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -1,6 +1,11 @@
 /// Middleware to handle quirks
 /datum/preference_middleware/quirks
-	var/tainted = FALSE
+	/// Used to track whether or not we need to update changes in ui_data
+	var/tainted = TRUE
+	/// The current selected quirks, saved so we can cheaply resend them in ui_data only when necessary, without having to use expensive update_static_data() calls
+	var/list/cached_selected_quirks
+	/// The current species compatibility, saved so we can cheaply resend them in ui_data only when necessary, without having to use expensive update_static_data() calls
+	var/list/cached_species_compatibility
 
 	action_delegations = list(
 		"give_quirk" = PROC_REF(give_quirk),
@@ -47,19 +52,20 @@
 
 	var/list/data = list()
 
-	data["selected_quirks"] = get_selected_quirks()
 	data["default_quirk_balance"] = SSquirks.default_quirk_points
-	data["species_disallowed_quirks"] = get_species_compatibility()
 
 	return data
 
 /datum/preference_middleware/quirks/get_ui_data(mob/user)
 	var/list/data = list()
 
-	if (tainted)
+	if (tainted || isnull(cached_selected_quirks)) // if one of these is null, both are null
 		tainted = FALSE
-		data["selected_quirks"] = get_selected_quirks()
-		data["species_disallowed_quirks"] = get_species_compatibility()
+		cached_selected_quirks = get_selected_quirks()
+		cached_species_compatibility = get_species_compatibility()
+
+	data["selected_quirks"] = cached_selected_quirks
+	data["species_disallowed_quirks"] = cached_species_compatibility
 
 	return data
 
@@ -96,7 +102,6 @@
 
 /datum/preference_middleware/quirks/on_new_character(mob/user)
 	tainted = TRUE
-	preferences.update_static_data(user, always_instant = TRUE)
 
 /datum/preference_middleware/quirks/proc/give_quirk(list/params, mob/user)
 	var/quirk_name = params["quirk"]
@@ -107,12 +112,13 @@
 		// If the client is sending an invalid give_quirk, that means that
 		// something went wrong with the client prediction, so we should
 		// catch it back up to speed.
+		tainted = TRUE
 		preferences.update_static_data(user, always_instant = TRUE)
 		return TRUE
 
 	preferences.all_quirks = new_quirks
+	tainted = TRUE
 	preferences.character_preview_view?.update_body()
-	preferences.update_static_data(user, always_instant = TRUE)
 
 	return TRUE
 
@@ -127,12 +133,13 @@
 		// If the client is sending an invalid remove_quirk, that means that
 		// something went wrong with the client prediction, so we should
 		// catch it back up to speed.
+		tainted = TRUE
 		preferences.update_static_data(user, always_instant = TRUE)
 		return TRUE
 
 	preferences.all_quirks = new_quirks
+	tainted = TRUE
 	preferences.character_preview_view?.update_body()
-	preferences.update_static_data(user, always_instant = TRUE)
 
 	return TRUE
 

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -2,6 +2,8 @@
 /datum/preference_middleware/quirks
 	/// Used to track whether or not we need to update changes in ui_data
 	var/tainted = TRUE
+	/// Remember what the last species we chose was, to avoid having to validate quirks again
+	var/previous_species_value
 	/// The current selected quirks, saved so we can cheaply resend them in ui_data only when necessary, without having to use expensive update_static_data() calls
 	var/list/cached_selected_quirks
 	/// The current species compatibility, saved so we can cheaply resend them in ui_data only when necessary, without having to use expensive update_static_data() calls
@@ -33,8 +35,9 @@
 		return TRUE
 
 /datum/preference_middleware/quirks/post_set_preference(mob/user, preference, value)
-	if(preference != "species")
+	if(preference != "species" || value == previous_species_value)
 		return
+
 	tainted = TRUE
 	preferences.validate_quirks()
 
@@ -102,6 +105,7 @@
 
 /datum/preference_middleware/quirks/on_new_character(mob/user)
 	tainted = TRUE
+	previous_species_value = null
 
 /datum/preference_middleware/quirks/proc/give_quirk(list/params, mob/user)
 	var/quirk_name = params["quirk"]

--- a/code/modules/client/preferences/species.dm
+++ b/code/modules/client/preferences/species.dm
@@ -27,6 +27,9 @@
 	return values
 
 /datum/preference/choiced/species/apply_to_human(mob/living/carbon/human/target, value)
+	if(value == target.dna.species.type) // we're already this species
+		return
+
 	target.set_species(value, icon_update = FALSE, pref_load = TRUE)
 
 /datum/preference/choiced/species/compile_constant_data()


### PR DESCRIPTION
## About The Pull Request

I noticed a similar pattern of silliness here as with https://github.com/tgstation/tgstation/pull/96808 where there was a `tainted` var to limit updates in `ui_data()` _in addition to_ the same data being passed through `ui_static_data()`.

Having two identical data keys being sent in both `ui_data()` and `ui_static_data()` like this causes issues and doesn't really make sense.

This PR takes full advantage of the state var that was being half-used and removes the need for a bunch of `update_static_data()`, calls which is great because those full updates were laggy as they were unneeded.

Thanks to the `tainted` var it will only update the data when: 

-a new character is swapped to
-a quirk is added or removed
-a species is changed
-rare invalid give/remove quirk error condition


## Why It's Good For The Game

Faster UI that actually works properly!

<details><summary>Works</summary>

<img width="920" height="770" alt="cCtZayEptp" src="https://github.com/user-attachments/assets/bd405ea1-e752-4dfc-a0df-afa31689b25a" />

</details>

<details><summary>Limitations update right away like they're supposed to (the nearsightedness is temp modified to test)</summary>

<img width="920" height="770" alt="2ewt2r4kiy" src="https://github.com/user-attachments/assets/c916c650-deea-4666-92c8-fcebcc2b0f27" />

</details>

## Changelog

:cl:
fix: species quirk incompatibilities will now update immediately without the need to add/remove a quirk to force a ui update
code: quirks backend improved, it will no longer send full updates constantly and be faster
/:cl:
