### PR TITLE
[FIX] arm delimbing no longer prevents you from using your good arm

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2581,7 +2581,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 /mob/living/perform_hand_swap(held_index)
 	//safeguard for one-handed mobs lol
-	if(num_hands == 1)
+	if(length(held_items) == 1)
 		held_index = 1
 
 	return ..()


### PR DESCRIPTION

## About The Pull Request

Change in https://github.com/tgstation/tgstation/pull/96637 made it so if you loose one arm and you have the wrong one selected, you can no longer switch to your good remaining arm. This change fixes that and tracks the actual number of serviceable hands in your mob currently.
## Why It's Good For The Game

Bugfix
## Changelog
:cl:
fix: People with missing limb can again use the remaining good one.
/:cl:
