### PR TITLE
Makes broken mirrors deconstruct properly

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -108,9 +108,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 		return ITEM_INTERACT_SUCCESS
 	return ITEM_INTERACT_BLOCKING
 
-/obj/structure/mirror/atom_deconstruct()
-	new /obj/item/wallframe/mirror(loc, 1)
-
 /obj/structure/mirror/proc/display_radial_menu(mob/living/carbon/human/user)
 	if(!can_use_mirror(user))
 		return
@@ -295,8 +292,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 	. = ..()
 	if(broken || . <= 0) // breaking a mirror truly gets you bad luck!
 		return
-	to_chat(user, span_warning("A chill runs down your spine as [src] shatters..."))
-	user.AddComponent(/datum/component/omen, incidents_left = 7)
+
+	. = ..()
+	if(broken)
+		to_chat(user, span_warning("A chill runs down your spine as [src] shatters..."))
+		user.AddComponent(/datum/component/omen, incidents_left = 7)
 
 /obj/structure/mirror/bullet_act(obj/projectile/proj)
 	if(broken || !isliving(proj.firer) || !proj.damage)
@@ -321,6 +321,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 /obj/structure/mirror/atom_deconstruct(disassembled = TRUE)
 	if(!disassembled)
 		new /obj/item/shard(loc)
+	else if(broken)
+		new /obj/item/wallframe/mirror/broken(loc)
 	else
 		new /obj/item/wallframe/mirror(loc)
 
@@ -353,12 +355,18 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 
 /obj/item/wallframe/mirror
 	name = "mirror"
-	desc = "An unmounted mirror. Attach it to a wall to use."
+	desc = "An unmounted mirror. Attach it to a wall for use."
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "mirror"
 	custom_materials = list(/datum/material/glass = SHEET_MATERIAL_AMOUNT * 5, /datum/material/silver = SHEET_MATERIAL_AMOUNT * 2)
 	result_path = /obj/structure/mirror
 	pixel_shift = 28
+
+/obj/item/wallframe/mirror/broken
+	name = "broken mirror"
+	desc = "An unmounted and broken mirror. Attach it to a wall for decor."
+	icon_state = "mirror_broke"
+	result_path = /obj/structure/mirror/broken
 
 /obj/structure/mirror/magic
 	name = "magic mirror"

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -292,11 +292,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 	. = ..()
 	if(broken || . <= 0) // breaking a mirror truly gets you bad luck!
 		return
-
-	. = ..()
-	if(broken)
-		to_chat(user, span_warning("A chill runs down your spine as [src] shatters..."))
-		user.AddComponent(/datum/component/omen, incidents_left = 7)
+	to_chat(user, span_warning("A chill runs down your spine as [src] shatters..."))
+	user.AddComponent(/datum/component/omen, incidents_left = 7)
 
 /obj/structure/mirror/bullet_act(obj/projectile/proj)
 	if(broken || !isliving(proj.firer) || !proj.damage)


### PR DESCRIPTION

## About The Pull Request
This PR makes broken mirrors deconstruct to broken mirror wallframes. A stray and seemingly duplicate definition for `atom_deconstruct()` has also been removed. 
## Why It's Good For The Game
Broken mirrors currently deconstruct to intact mirror wallframes. This seems like an oversight.
## Changelog
:cl:
fix: Broken mirrors no longer produce an intact mirror upon deconstruction.
/:cl:
