### PR TITLE
Reduces the effect of RNG in diseases

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -157,7 +157,7 @@
 		if(half_stage)
 			half_stage = FALSE
 			update_stage(min(stage + 1, max_stages))
-		else
+		else if(stage <= max_stages)
 			half_stage = TRUE
 
 	if(!(disease_flags & CHRONIC) && disease_flags & CURABLE && bypasses_immunity != TRUE)

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -57,6 +57,7 @@
 	var/infectable_biotypes = MOB_ORGANIC //if the disease can spread on organics, synthetics, or undead
 	var/process_dead = FALSE //if this ticks while the host is dead
 	var/copy_type = null //if this is null, copies will use the type of the instance being copied
+	var/half_stage = FALSE // Acts as a counter for half stages
 
 /datum/disease/Destroy()
 	. = ..()
@@ -152,8 +153,12 @@
 	if(stage == max_stages && stage_peaked != TRUE) //mostly a sanity check in case we manually set a virus to max stages
 		stage_peaked = TRUE
 
-	if(SPT_PROB(stage_prob * slowdown * bad_immune, seconds_per_tick))
-		update_stage(min(stage + 1, max_stages))
+	if(SPT_PROB(stage_prob * slowdown * bad_immune * 2, seconds_per_tick))
+		if(half_stage)
+			half_stage = FALSE
+			update_stage(min(stage + 1, max_stages))
+		else
+			half_stage = TRUE
 
 	if(!(disease_flags & CHRONIC) && disease_flags & CURABLE && bypasses_immunity != TRUE)
 		switch(severity)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -87,7 +87,7 @@
 		for(var/s in symptoms)
 			var/datum/symptom/symptom_datum = s
 			if(symptom_datum.Start(src)) //this will return FALSE if the symptom is neutered
-				symptom_datum.next_activation = world.time + (rand(symptom_datum.symptom_delay_min SECONDS, symptom_datum.symptom_delay_max SECONDS) * DISEASE_SYMPTOM_FREQUENCY_MODIFIER)
+				symptom_datum.next_activation = world.time + (rand(symptom_datum.symptom_delay * (1 - symptom_datum.delay_variation) SECONDS, symptom_datum.symptom_delay * (1 + symptom_datum.delay_variation) SECONDS) * DISEASE_SYMPTOM_FREQUENCY_MODIFIER)
 			symptom_datum.on_stage_change(src)
 
 	for(var/s in symptoms)

--- a/code/datums/diseases/advance/symptoms/beard.dm
+++ b/code/datums/diseases/advance/symptoms/beard.dm
@@ -17,8 +17,7 @@
 	transmittable = 1
 	level = 4
 	severity = 1
-	symptom_delay_min = 18
-	symptom_delay_max = 36
+	symptom_delay = 27
 	symptom_cure = /datum/reagent/medicine/mannitol
 	var/list/beard_order = list("Beard (Jensen)", "Beard (Full)", "Beard (Dwarf)", "Beard (Very Long)")
 

--- a/code/datums/diseases/advance/symptoms/chills.dm
+++ b/code/datums/diseases/advance/symptoms/chills.dm
@@ -18,8 +18,7 @@
 	transmittable = 2
 	level = 2
 	severity = 2
-	symptom_delay_min = 10
-	symptom_delay_max = 30
+	symptom_delay = 20
 	symptom_cure = /datum/reagent/medicine/leporazine
 	threshold_descs = list(
 		"Stage Speed 5" = "Increases the intensity of the cooling; the host can fall below safe temperature levels.",

--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -18,8 +18,7 @@
 	level = 3
 	severity = 3
 	base_message_chance = 15
-	symptom_delay_min = 10
-	symptom_delay_max = 30
+	symptom_delay = 20
 	required_organ = ORGAN_SLOT_LUNGS
 	symptom_cure = /datum/reagent/medicine/c2/tirimol
 	cure_color = "orange"
@@ -33,8 +32,7 @@
 	if(!.)
 		return
 	if(A.totalStageSpeed() >= 8)
-		symptom_delay_min = 7
-		symptom_delay_max = 24
+		symptom_delay = 15.5
 	if(A.totalStealth() >= 4)
 		suppress_warning = TRUE
 
@@ -97,8 +95,7 @@ Bonus
 	level = 7
 	severity = 6
 	base_message_chance = 15
-	symptom_delay_min = 14
-	symptom_delay_max = 30
+	symptom_delay = 22
 	required_organ = ORGAN_SLOT_LUNGS
 	symptom_cure = /datum/reagent/toxin/bonehurtingjuice // It'll be funny I swear
 	cure_color = "orange" // The only level 7 symptom without a red color

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -17,8 +17,7 @@
 	level = 4
 	severity = 2
 	base_message_chance = 25
-	symptom_delay_min = 10
-	symptom_delay_max = 30
+	symptom_delay = 20
 	symptom_cure = /datum/reagent/medicine/synaptizine
 	threshold_descs = list(
 		"Resistance 6" = "Causes brain damage over time.",

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -17,8 +17,7 @@
 	level = 1
 	severity = 1
 	base_message_chance = 15
-	symptom_delay_min = 2
-	symptom_delay_max = 15
+	symptom_delay = 8.5
 	required_organ = ORGAN_SLOT_LUNGS
 	threshold_descs = list(
 		"Resistance 11" = "The host will drop small items when coughing.",

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -45,7 +45,7 @@
 	if(active_disease.totalResistance() >= 15) //strong enough to stun (occasionally)
 		power = 2
 	if(active_disease.totalStageSpeed() >= 6) //cough more often
-		symptom_delay_max = 10
+		symptom_delay = 6
 
 /datum/symptom/cough/Activate(datum/disease/advance/active_disease)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -17,8 +17,7 @@
 	level = 4
 	severity = 4
 	base_message_chance = 100
-	symptom_delay_min = 25
-	symptom_delay_max = 80
+	symptom_delay = 52.5
 	required_organ = ORGAN_SLOT_EARS
 	symptom_cure = /datum/reagent/medicine/psicodine
 	threshold_descs = list(

--- a/code/datums/diseases/advance/symptoms/disfiguration.dm
+++ b/code/datums/diseases/advance/symptoms/disfiguration.dm
@@ -16,8 +16,7 @@
 	transmittable = 1
 	level = 5
 	severity = 1
-	symptom_delay_min = 25
-	symptom_delay_max = 75
+	symptom_delay = 50
 	symptom_cure = /datum/reagent/consumable/milk
 
 /datum/symptom/disfiguration/Activate(datum/disease/advance/disease)

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -18,8 +18,7 @@
 	level = 4
 	severity = 2
 	base_message_chance = 50
-	symptom_delay_min = 15
-	symptom_delay_max = 30
+	symptom_delay = 22.5
 	symptom_cure = /datum/reagent/medicine/haloperidol
 	cure_color = "yellow"
 	threshold_descs = list(

--- a/code/datums/diseases/advance/symptoms/fever.dm
+++ b/code/datums/diseases/advance/symptoms/fever.dm
@@ -19,8 +19,7 @@
 	level = 2
 	severity = 2
 	base_message_chance = 20
-	symptom_delay_min = 10
-	symptom_delay_max = 30
+	symptom_delay = 20
 	symptom_cure = /datum/reagent/medicine/leporazine
 	threshold_descs = list(
 		"Resistance 5" = "Increases fever intensity, fever can overheat and harm the host.",

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -18,8 +18,7 @@
 	level = 6
 	severity = 5
 	base_message_chance = 20
-	symptom_delay_min = 20
-	symptom_delay_max = 75
+	symptom_delay = 47.5
 	symptom_cure = /datum/reagent/medicine/leporazine // See, this one's tricky. You gotta convince them you don't have fever or chills in the same virus.
 	var/infective = FALSE
 	threshold_descs = list(
@@ -101,8 +100,7 @@ Bonus
 	level = 7
 	severity = 6
 	base_message_chance = 100
-	symptom_delay_min = 30
-	symptom_delay_max = 90
+	symptom_delay = 60
 	symptom_cure = /datum/reagent/consumable/frostoil
 	cure_color = "red"
 	var/chems = FALSE
@@ -119,8 +117,7 @@ Bonus
 		return
 	if(A.totalResistance() >= 9) //intense but sporadic effect
 		power = 2
-		symptom_delay_min = 50
-		symptom_delay_max = 140
+		symptom_delay = 95
 	if(A.totalStageSpeed() >= 8) //serious boom when wet
 		explosion_power = 2
 	if(A.totalTransmittable() >= 8) //extra chemicals

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -19,8 +19,7 @@ Bonus
 	level = 6
 	severity = 5
 	base_message_chance = 50
-	symptom_delay_min = 15
-	symptom_delay_max = 60
+	symptom_delay = 37.5
 	symptom_cure = /datum/reagent/medicine/omnizine
 	cure_color = "orange"
 	threshold_descs = list(
@@ -93,8 +92,7 @@ Bonus
 	level = 7
 	severity = 6
 	base_message_chance = 50
-	symptom_delay_min = 3
-	symptom_delay_max = 6
+	symptom_delay = 4.5
 	symptom_cure = /datum/reagent/medicine/earthsblood // Good luck finding THAT.
 	cure_color = "red"
 	var/chems = FALSE

--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -18,8 +18,7 @@
 	level = 6
 	severity = 4
 	base_message_chance = 50
-	symptom_delay_min = 30
-	symptom_delay_max = 60
+	symptom_delay = 45
 	symptom_cure = /datum/reagent/acetaldehyde
 	cure_color = "orange"
 	var/excludemuts = NONE
@@ -39,8 +38,7 @@
 	if(A.totalStealth() >= 5) //only give them bad mutations
 		excludemuts = POSITIVE
 	if(A.totalStageSpeed() >= 10) //activate dormant mutations more often at around 1.5x the pace
-		symptom_delay_min = 20
-		symptom_delay_max = 40
+		symptom_delay = 30
 	if(A.totalResistance() >= 8) //mutadone won't save you now
 		mutadone_proof = (NEGATIVE | MINOR_NEGATIVE)
 	if(A.totalResistance() >= 14) //one does not simply escape Nurgle's grasp

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -18,8 +18,7 @@
 	level = 5
 	severity = 2
 	base_message_chance = 25
-	symptom_delay_min = 25
-	symptom_delay_max = 90
+	symptom_delay = 57.5
 	symptom_cure = /datum/reagent/medicine/psicodine
 	cure_color = "yellow"
 	threshold_descs = list(

--- a/code/datums/diseases/advance/symptoms/headache.dm
+++ b/code/datums/diseases/advance/symptoms/headache.dm
@@ -17,8 +17,7 @@
 	level = 1
 	severity = 1
 	base_message_chance = 100
-	symptom_delay_min = 15
-	symptom_delay_max = 30
+	symptom_delay = 22.5
 	symptom_cure = /datum/reagent/drug/space_drugs
 	threshold_descs = list(
 		"Stage Speed 6" = "Headaches will cause severe pain, that weakens the host.",
@@ -35,8 +34,7 @@
 	if(A.totalStageSpeed() >= 6) //severe pain
 		power = 2
 	if(A.totalStageSpeed() >= 9) //cluster headaches
-		symptom_delay_min = 30
-		symptom_delay_max = 60
+		symptom_delay = 45
 		power = 3
 
 /datum/symptom/headache/Activate(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -8,8 +8,8 @@
 	transmittable = 0
 	level = 0 //not obtainable
 	base_message_chance = 20 //here used for the overlays
-	symptom_delay_min = 1
-	symptom_delay_max = 1
+	symptom_delay = 1
+	delay_variation = 0
 	var/passive_message = "" //random message to infected but not actively healing people
 	var/healable_bodytypes = BODYTYPE_ORGANIC // What types of body parts we can heal
 
@@ -575,8 +575,6 @@
 	stage_speed = 2
 	transmittable = -3
 	level = 6
-	symptom_delay_min = 1
-	symptom_delay_max = 1
 	passive_message = span_notice("Your skin glows faintly for a moment.")
 	threshold_descs = list(
 		"Resistance 7" = "Increases healing speed.",
@@ -617,8 +615,6 @@
 	transmittable = -1
 	level = 4
 	base_message_chance = 0
-	symptom_delay_min = 1
-	symptom_delay_max = 1
 	symptom_cure = null
 	power = 2
 

--- a/code/datums/diseases/advance/symptoms/itching.dm
+++ b/code/datums/diseases/advance/symptoms/itching.dm
@@ -16,8 +16,7 @@
 	transmittable = 1
 	level = 1
 	severity = 1
-	symptom_delay_min = 5
-	symptom_delay_max = 25
+	symptom_delay = 15
 	var/scratch = FALSE
 	threshold_descs = list(
 		"Transmission 6" = "Increases frequency of itching.",
@@ -33,8 +32,7 @@
 	if(!.)
 		return
 	if(active_disease.totalTransmittable() >= 6) //itch more often
-		symptom_delay_min = 1
-		symptom_delay_max = 4
+		symptom_delay = 2.5
 	if(active_disease.totalStageSpeed() >= 7) //scratch
 		scratch = TRUE
 

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -15,8 +15,7 @@
 	stage_speed = -2
 	transmittable = 0
 	level = 6
-	symptom_delay_min = 30
-	symptom_delay_max = 85
+	symptom_delay = 57.5
 	severity = 4
 	symptom_cure = /datum/reagent/medicine/ondansetron
 	cure_color = "yellow"
@@ -33,8 +32,7 @@
 	if(A.totalTransmittable() >= 4) //yawning (mostly just some copy+pasted code from sneezing, with a few tweaks)
 		yawning = TRUE
 	if(A.totalStageSpeed() >= 10) //act more often
-		symptom_delay_min = 20
-		symptom_delay_max = 45
+		symptom_delay = 32.5
 
 /datum/symptom/narcolepsy/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -15,8 +15,8 @@
 	transmittable = -4
 	level = 6
 	base_message_chance = 3
-	symptom_delay_min = 1
-	symptom_delay_max = 1
+	symptom_delay = 1
+	delay_variation = 0
 	required_organ = ORGAN_SLOT_LUNGS
 	threshold_descs = list(
 		"Resistance 8" = "Additionally regenerates lost blood."

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -13,8 +13,7 @@
 	stage_speed = 1
 	transmittable = -3
 	level = 5
-	symptom_delay_min = 5
-	symptom_delay_max = 10
+	symptom_delay = 7.5
 	var/purge_alcohol = FALSE
 	var/trauma_heal_mild = FALSE
 	var/trauma_heal_severe = FALSE
@@ -84,8 +83,8 @@
 	transmittable = 2
 	level = 4
 	base_message_chance = 7
-	symptom_delay_min = 1
-	symptom_delay_max = 1
+	symptom_delay = 1
+	delay_variation = 0
 
 /datum/symptom/sensory_restoration/Activate(datum/disease/advance/advanced_disease)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/shedding.dm
+++ b/code/datums/diseases/advance/symptoms/shedding.dm
@@ -19,8 +19,7 @@
 	symptom_cure = /datum/reagent/barbers_aid
 	cure_color = "yellow"
 	base_message_chance = 50
-	symptom_delay_min = 45
-	symptom_delay_max = 90
+	symptom_delay = 67.5
 
 /datum/symptom/shedding/Activate(datum/disease/advance/disease)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -16,8 +16,7 @@
 	transmittable = 2
 	level = 5
 	severity = 1
-	symptom_delay_min = 7
-	symptom_delay_max = 14
+	symptom_delay = 10.5
 	symptom_cure = /datum/reagent/water/salt
 
 /datum/symptom/polyvitiligo/Activate(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -16,8 +16,8 @@
 	transmittable = 4
 	level = 1
 	severity = 1
-	symptom_delay_min = 5
-	symptom_delay_max = 35
+	symptom_delay = 20
+	delay_variation = 0.4
 	required_organ = ORGAN_SLOT_LUNGS
 	threshold_descs = list(
 		"Transmission 9" = "Increases sneezing range, spreading the virus over 6 meter cone instead of over a 4 meter cone.",

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -28,8 +28,8 @@
 	var/suppress_warning = FALSE
 	///Ticks between each activation
 	var/next_activation = 0
-	var/symptom_delay_min = 1
-	var/symptom_delay_max = 1
+	var/symptom_delay = 1 // Measured in seconds, not ticks or life ticks
+	var/delay_variation = 0.25 // Anywhere from -25% to +25%
 	///Can be used to multiply virus effects
 	var/power = 1
 	///A neutered symptom has no effect, and only affects statistics.
@@ -80,7 +80,7 @@
 	if(world.time < next_activation)
 		return FALSE
 	else
-		next_activation = world.time + rand(symptom_delay_min * 10, symptom_delay_max * 10)
+		next_activation = world.time + rand(symptom_delay * (1 - delay_variation) SECONDS, symptom_delay * (1 + delay_variation) SECONDS) * DISEASE_SYMPTOM_FREQUENCY_MODIFIER
 		return TRUE
 
 /datum/symptom/proc/on_stage_change(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -17,8 +17,7 @@
 	level = 5
 	severity = 5
 	base_message_chance = 50
-	symptom_delay_min = 25
-	symptom_delay_max = 80
+	symptom_delay = 52.5
 	required_organ = ORGAN_SLOT_EYES
 	symptom_cure = /datum/reagent/medicine/oculine
 	cure_color = "yellow"

--- a/code/datums/diseases/advance/symptoms/voice_change.dm
+++ b/code/datums/diseases/advance/symptoms/voice_change.dm
@@ -18,8 +18,7 @@
 	level = 6
 	severity = 2
 	base_message_chance = 100
-	symptom_delay_min = 60
-	symptom_delay_max = 120
+	symptom_delay = 90
 	required_organ = ORGAN_SLOT_TONGUE
 	symptom_cure = /datum/reagent/inverse/healing/convermol
 	threshold_descs = list(
@@ -38,8 +37,8 @@
 		suppress_warning = TRUE
 	if(A.totalStageSpeed() >= 7) //faster change of voice
 		base_message_chance = 25
-		symptom_delay_min = 25
-		symptom_delay_max = 85
+		symptom_delay = 55
+		delay_variation = 0.35
 	if(A.totalTransmittable() >= 14) //random language
 		scramble_language = TRUE
 

--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -18,8 +18,7 @@ and your disease can spread via people walking on vomit.
 	level = 3
 	severity = 3
 	base_message_chance = 100
-	symptom_delay_min = 25
-	symptom_delay_max = 80
+	symptom_delay = 52.5
 	required_organ = ORGAN_SLOT_STOMACH
 	symptom_cure = /datum/reagent/medicine/ondansetron
 	cure_color = "yellow"

--- a/code/datums/diseases/advance/symptoms/weight.dm
+++ b/code/datums/diseases/advance/symptoms/weight.dm
@@ -16,8 +16,7 @@
 	level = 3
 	severity = 3
 	base_message_chance = 100
-	symptom_delay_min = 15
-	symptom_delay_max = 45
+	symptom_delay = 30
 	required_organ = ORGAN_SLOT_STOMACH
 	symptom_cure = /datum/reagent/medicine/diphenhydramine // It's good with terrible stats, it should be harder to cure
 	cure_color = "orange"

--- a/code/datums/diseases/advance/symptoms/youth.dm
+++ b/code/datums/diseases/advance/symptoms/youth.dm
@@ -17,8 +17,7 @@
 	transmittable = -4
 	level = 5
 	base_message_chance = 100
-	symptom_delay_min = 25
-	symptom_delay_max = 50
+	symptom_delay = 37.5
 	symptom_cure = null
 
 /datum/symptom/youth/Activate(datum/disease/advance/A)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -437,7 +437,7 @@
 	properties["transmittable"] = rand(4,7)
 	spreading_modifier = max(CEILING(0.4 * properties["transmittable"], 1), 1)
 	cure_chance = clamp(10 * (0.94 ** properties["resistance"]), 3.5, 12)
-	stage_prob = max(0.4 * properties["stage_rate"], 1) // 33% faster than regular advanced diseases
+	stage_prob = max(0.4 * properties["stage_rate"], 1) // Faster than regular advanced diseases
 	set_severity(properties["severity"])
 
 	//If we have an advanced (high stage) disease, add it to the name.


### PR DESCRIPTION
## About The Pull Request

This PR cuts down on the unpredictability of diseases by requiring diseases to advance twice to advance once, and standardizing the range of advanced disease symptoms. 

All diseases, including simple ones, had their chance of advancing in stage doubled but only actually move up a stage every other advance. This means that virology is now weighted more heavily towards the middle "bell curve" in terms of effectiveness. The worst and best luck are equally less likely.

Secondly, advanced diseases also have had their symptom delays standardized from a min value and a max value into a single average value and another that determines the range. Most symptoms had a range of around +33% to -33%, with some going as far as +75% to -75% delay. After this change, viruses have a range of +25% to -25%, with some exceptions (the super variable symptoms had their delays set to 35% and 40%, for example). This makes dying from a disease more of a straight line instead of a roller coaster.

## Why It's Good For The Game

RNG is very important to bad diseases, but it's at the point where the same disease can cause wildly different results because of the massive amount of interacting randomized effects. Viruses have a chance to advance forwards each tick, a chance to advance backwards each tick, and each symptom has a randomize delay between activations in order to deal a randomized amount of damage to the host. This makes them a headache to test and I can't imagine they're much fairer in an actual round.

## Changelog

:cl:
balance: Disease stage speed and advanced disease symptom delay RNG has been reduced
/:cl:
