### PR TITLE
Fixes some bugs with GetFlatIcon, improves performance of Select Equipment by a lot

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -553,8 +553,8 @@ world
 				)
 
 				flatX1 = addX1
-				flatX2 = addY1
-				flatY1 = addX2
+				flatX2 = addX2
+				flatY1 = addY1
 				flatY2 = addY2
 
 			// Blend the overlay into the flattened icon

--- a/code/modules/admin/verbs/selectequipment.dm
+++ b/code/modules/admin/verbs/selectequipment.dm
@@ -28,6 +28,10 @@ ADMIN_VERB_ONLY_CONTEXT_MENU(select_equipment, R_FUN, "Select Equipment", mob/ta
 	var/datum/outfit/selected_outfit = /datum/outfit
 	//serializable string for the UI to keep track of which outfit is selected
 	var/selected_identifier = "/datum/outfit"
+	/// Cached flat icon of the dummy wearing selected_outfit, so ui_data() doesn't redraw the sprite on every refresh when it doesn't need to
+	var/icon/cached_dummy_icon
+	/// The selected_identifier cached_dummy_icon was last rendered for.
+	var/cached_for_identifier
 
 /datum/select_equipment/New(_user, mob/target)
 	user = CLIENT_FROM_VAR(_user)
@@ -105,12 +109,16 @@ ADMIN_VERB_ONLY_CONTEXT_MENU(select_equipment, R_FUN, "Select Equipment", mob/ta
 	if(!dummy_key)
 		init_dummy()
 
-	var/icon/dummysprite = get_flat_human_icon(null,
-		dummy_key = dummy_key,
-		outfit_override = selected_outfit,
-		no_anim = TRUE,
-	)
-	data["icon64"] = icon2base64(dummysprite)
+	if(isnull(cached_dummy_icon) || cached_for_identifier != selected_identifier)
+		cached_dummy_icon = get_flat_human_icon(null,
+			dummy_key = dummy_key,
+			showDirs = list(SOUTH),
+			outfit_override = selected_outfit,
+			no_anim = TRUE,
+		)
+		cached_for_identifier = selected_identifier
+
+	data["icon64"] = icon2base64(cached_dummy_icon)
 	data["name"] = target_mob
 
 	var/datum/preferences/prefs = user?.client?.prefs

--- a/code/modules/asset_cache/spritesheet/batched/universal_icon.dm
+++ b/code/modules/asset_cache/spritesheet/batched/universal_icon.dm
@@ -579,8 +579,8 @@
 				)
 
 				flatX1 = addX1
-				flatX2 = addY1
-				flatY1 = addX2
+				flatX2 = addX2
+				flatY1 = addY1
 				flatY2 = addY2
 
 			// Blend the overlay into the flattened icon


### PR DESCRIPTION
## About The Pull Request

Fixes a bug that has apparently existed for five years now.

After resizing the canvas to fit an oversized overlay (like a wide tail sprite), the new bounds get reassigned with X and Y swapped.
This leads to bad icons being often being generated if they are larger than 32x32. For me it just showed one overlay of the mob's tail, with the rest of them yeeted off to who knows where.

This bug also applies to universal icon equivalent proc and has been fixed there as well.

Also does some optimization on select_equipment. This ui can create a noticeable amount of lag on the server if an admin is using it. I've stopped it from regenerating the icon if there's an unrelated ui update (like clicking on the favorite button or something).

I also made the previews one-direction instead of 4, which was the biggest gain because GetFlatIcon was the biggest lag contributor for this proc.

<details><summary>Before</summary>

<img width="1873" height="364" alt="image" src="https://github.com/user-attachments/assets/4fd5e6f0-f590-4da7-9d08-6ca3504f5b6a" />

<img width="650" height="415" alt="7K5japEGZe" src="https://github.com/user-attachments/assets/b20d3d72-11d6-4f4c-afa2-ece506b922df" />

</details>

<details><summary>After</summary>

<img width="1943" height="675" alt="tracy-profiler_QbM8LM1pGe" src="https://github.com/user-attachments/assets/37eb84eb-3352-441e-9c8e-fa692ea928fe" />

<img width="650" height="415" alt="8XBxy41sHW" src="https://github.com/user-attachments/assets/e2f9bfc1-1443-4280-92ef-9901774c6733" />

</details>

Note:

This was not a full refactor, and there is room for improvement. These were just the lowest hanging fruit for now. The rest would require touching the outfit equip procs and probably doing a refactor there to reduce the amount of `update_body()` calls are happening (there's quite a few happening needlessly).

## Why It's Good For The Game

Fixes a long-standing bug, and reduces lag.

## Changelog

:cl:
fix: fixed an issue that would cause preview icons to randomly become corrupt or invisible if they met certain criteria
admin: select equipment now just shows one direction of previews, greatly reducing lag
/:cl:

