### PR TITLE
remove biomeTarget only when

### DIFF
--- a/tools/build/build.ts
+++ b/tools/build/build.ts
@@ -297,9 +297,6 @@ export const BunTarget = new Juke.Target({
 export const BiomeInstallTarget = new Juke.Target({
   dependsOn: [BunTarget],
   inputs: ['package.json', 'bun.lock'],
-  onlyWhen: () => {
-    return Juke.glob('node_modules/@biomejs/**').length === 0;
-  },
   executes: () => {
     return bun('.', 'install');
   },


### PR DESCRIPTION

## About The Pull Request
Removes the onlyWhen condition for biome install. If the lockfile changes, this prevents the dependencies from being updated, so people need to manually update them as it only ever gets installed when it's fully missing.

It slightly increases the toolchain time, but at most it's 0.x to 3 seconds, because it checks if the biome version in the lockfile has changed. 
## Why It's Good For The Game
## Changelog
:cl:
fix: biome install being skipped after a dependency update
/:cl:
