### PR TITLE
Bandaid on human mob biotypes.

### DIFF
--- a/code/datums/elements/organ_set_bonus.dm
+++ b/code/datums/elements/organ_set_bonus.dm
@@ -147,7 +147,7 @@
 	owner.update_body()
 
 ///We need to recalculate the mob biotypes, so first, remove the added biotypes from the mob before the new species changes the standard biotypes.
-/datum/status_effect/organ_set_bonus/proc/on_species_gain(mob/living/carbon/human, datum/species/new_species, datum/species/old_species)
+/datum/status_effect/organ_set_bonus/proc/on_species_loss(mob/living/carbon/human, datum/species/new_species, datum/species/old_species)
 	SIGNAL_HANDLER
 	human.mob_biotypes &= ~biotype_added
 	biotype_added = NONE

--- a/code/datums/elements/organ_set_bonus.dm
+++ b/code/datums/elements/organ_set_bonus.dm
@@ -57,10 +57,10 @@
 	var/required_biotype = MOB_ORGANIC
 	/// A list of traits added to the mob upon bonus activation, can be of any length.
 	var/list/bonus_traits = list()
-	/// Bonus biotype to add on bonus activation.
+	/// Bonus biotype(s) to add on bonus activation.
 	var/bonus_biotype
-	/// If the biotype was added - used to check if we should remove the biotype or not, on organ set loss.
-	var/biotype_added = FALSE
+	/// what biotype(s) was added - used to check if we should remove the biotype or not, on organ set loss.
+	var/biotype_added = NONE
 	/// Limb texture to apply upon activation
 	var/limb_texture
 	/// Color priority for limb limb_texture
@@ -89,10 +89,11 @@
 		owner.add_traits(bonus_traits, TRAIT_STATUS_EFFECT(id))
 
 	// Add biotype
-	if(owner.mob_biotypes & bonus_biotype)
-		biotype_added = FALSE
-	owner.mob_biotypes |= bonus_biotype
-	biotype_added = TRUE
+	if(bonus_biotype)
+		biotype_added = bonus_biotype & ~owner.mob_biotypes
+		owner.mob_biotypes |= biotype_added
+		RegisterSignal(owner, COMSIG_SPECIES_LOSS, PROC_REF(on_species_loss))
+		RegisterSignal(owner, COMSIG_SPECIES_GAIN, PROC_REF(on_species_gain))
 
 	if(bonus_activate_text)
 		to_chat(owner, bonus_activate_text)
@@ -123,7 +124,8 @@
 		owner.remove_traits(bonus_traits, TRAIT_STATUS_EFFECT(id))
 	// Remove biotype (if added)
 	if(biotype_added)
-		owner.mob_biotypes &= ~bonus_biotype
+		owner.mob_biotypes &= ~biotype_added
+		biotype_added = NONE
 
 	if(bonus_deactivate_text)
 		to_chat(owner, bonus_deactivate_text)
@@ -132,7 +134,7 @@
 	if(!limb_texture)
 		return
 
-	UnregisterSignal(owner, list(COMSIG_CARBON_ATTACH_LIMB, COMSIG_CARBON_REMOVE_LIMB))
+	UnregisterSignal(owner, list(COMSIG_CARBON_ATTACH_LIMB, COMSIG_CARBON_REMOVE_LIMB, COMSIG_SPECIES_LOSS, COMSIG_SPECIES_GAIN))
 
 	if(QDELETED(owner))
 		return
@@ -143,6 +145,18 @@
 			limb.remove_color_override(color_overlay_priority)
 
 	owner.update_body()
+
+///We need to recalculate the mob biotypes, so first, remove the added biotypes from the mob before the new species changes the standard biotypes.
+/datum/status_effect/organ_set_bonus/proc/on_species_gain(mob/living/carbon/human, datum/species/new_species, datum/species/old_species)
+	SIGNAL_HANDLER
+	human.mob_biotypes &= ~biotype_added
+	biotype_added = NONE
+
+///After the new species has added its biotypes to the mob, check if they already have or don't have the bonus biotype now.
+/datum/status_effect/organ_set_bonus/proc/on_species_gain(mob/living/carbon/human, datum/species/new_species, datum/species/old_species)
+	SIGNAL_HANDLER
+	biotype_added = bonus_biotype & ~owner.mob_biotypes
+	owner.mob_biotypes |= biotype_added
 
 /datum/status_effect/organ_set_bonus/proc/texture_limb(atom/source, obj/item/bodypart/limb)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -371,7 +371,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	human_who_gained_species.living_flags |= STOP_OVERLAY_UPDATE_BODY_PARTS //Don't call update_body_parts() for every single bodypart overlay added.
 
 	// Drop the items the new species can't wear
-	human_who_gained_species.mob_biotypes = inherent_biotypes
+	human_who_gained_species.mob_biotypes |= inherent_biotypes
 	human_who_gained_species.butcher_results = knife_butcher_results?.Copy()
 
 	//update body zones to match what they are supposed to have
@@ -446,6 +446,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	human.living_flags |= STOP_OVERLAY_UPDATE_BODY_PARTS //Don't call update_body_parts() for every single bodypart overlay removed.
 	human.butcher_results = null
+	human.mob_biotypes &= ~inherent_biotypes
 	for(var/trait in inherent_traits)
 		REMOVE_TRAIT(human, trait, SPECIES_TRAIT)
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -9,7 +9,7 @@
 	hud_type = /datum/hud/human
 	pressure_resistance = 25
 	buckle_lying = 0
-	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
+	mob_biotypes = NONE // The current mob biotypes of human mobs are dependent on the human species (and the organ set bonus)
 	can_be_shoved_into = TRUE
 	initial_language_holder = /datum/language_holder/empty // We get stuff from our species
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1


### PR DESCRIPTION
## About The Pull Request
inherent_biotypes no longer completely overrides the mob_biotypes var. This was causing the biotypes from the organ set bonus status effect (dna infusion stuff) to be lost upon species change. That shouldn't happen anymore. This PR also includes a bandaid to organ_set_bonus.dm so that it won't hypothetically remove the MOB_BUG biotype from mothpeople that get the roach infusion, for example.

## Why It's Good For The Game
Values being overridden like that is bad.

## Changelog

:cl:
fix: Bonus biotypes from dna infusions shouldn't be lost on species change as long as you have enough infused organs.
/:cl:
