### PR TITLE
Fix for blood decal hard deletes take 2

### DIFF
--- a/code/game/objects/effects/decals/cleanable/blood.dm
+++ b/code/game/objects/effects/decals/cleanable/blood.dm
@@ -8,6 +8,10 @@
 	clean_type = CLEAN_TYPE_BLOOD
 	color = BLOOD_COLOR_RED
 
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_ENTERED = PROC_REF(on_entered)
+	)
+
 	/// Amount of blood, in units, in this decal
 	/// Spent when drying or making footprints
 	var/bloodiness = BLOOD_AMOUNT_PER_DECAL
@@ -64,16 +68,15 @@
 		total_dry_time = drying_time
 		START_PROCESSING(SSblood_drying, src)
 
-	var/static/list/loc_connections = list(
-		COMSIG_ATOM_ENTERED = PROC_REF(on_entered)
-	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
 	if (bloodiness || GET_ATOM_BLOOD_DECAL_LENGTH(src))
 		update_appearance()
 
-/obj/effect/decal/cleanable/blood/Destroy()
+/obj/effect/decal/cleanable/blood/Destroy(force)
 	STOP_PROCESSING(SSblood_drying, src)
+	// connect_loc only unregisters via COMSIG_MOVABLE_MOVED, which never fires when the turf we're on gets replaced by ChangeTurf()
+	RemoveElement(/datum/element/connect_loc, loc_connections)
 	return ..()
 
 /// Returns the default blood type for this decal for maploaded decals

--- a/code/game/objects/effects/decals/cleanable/food.dm
+++ b/code/game/objects/effects/decals/cleanable/food.dm
@@ -33,13 +33,18 @@
 	desc = "A sizable pile of table salt. Someone must be upset."
 	icon_state = "salt_pile"
 	var/safepasses = 3 //how many times can this salt pile be passed before dissipating
-
-/obj/effect/decal/cleanable/food/salt/Initialize(mapload, list/datum/disease/diseases)
-	. = ..()
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered)
 	)
+
+/obj/effect/decal/cleanable/food/salt/Initialize(mapload, list/datum/disease/diseases)
+	. = ..()
 	AddElement(/datum/element/connect_loc, loc_connections)
+
+/obj/effect/decal/cleanable/food/salt/Destroy(force)
+	// connect_loc only unregisters via COMSIG_MOVABLE_MOVED, which never fires when the turf we're on gets replaced by ChangeTurf()
+	RemoveElement(/datum/element/connect_loc, loc_connections)
+	return ..()
 
 /obj/effect/decal/cleanable/food/salt/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

They're still hard deleting. The only thing I can imagine would be left causing this, is changeTurf() shenanigans. 
Let's see if this fixes the issue maybe? Also found a similar source of issue in the salt decal.

Fixes https://github.com/tgstation/tgstation/issues/96310
Fixes https://github.com/tgstation/tgstation/issues/96288
Fixes https://github.com/tgstation/tgstation/issues/96190
Fixes https://github.com/tgstation/tgstation/issues/96310

## Changelog

Not player-facing