### PR TITLE
Fixes some looping sounds treating start and end sound as lists.

### DIFF
--- a/code/datums/looping_sounds/item_sounds.dm
+++ b/code/datums/looping_sounds/item_sounds.dm
@@ -18,7 +18,7 @@
 
 /datum/looping_sound/tape_recorder_hiss
 	mid_sounds = list('sound/items/taperecorder/taperecorder_hiss_mid.ogg' = 1)
-	start_sound = list('sound/items/taperecorder/taperecorder_hiss_start.ogg' = 1)
+	start_sound = 'sound/items/taperecorder/taperecorder_hiss_start.ogg'
 	volume = 10
 
 /datum/looping_sound/heartbeat
@@ -35,11 +35,11 @@
 	use_sound_tokens = TRUE
 
 /datum/looping_sound/chainsaw
-	start_sound = list('sound/items/weapons/chainsaw_start.ogg' = 1)
+	start_sound = 'sound/items/weapons/chainsaw_start.ogg'
 	start_length = 0.85 SECONDS
 	mid_sounds = list('sound/items/weapons/chainsaw_loop.ogg' = 1)
 	mid_length = 0.85 SECONDS
-	end_sound = list('sound/items/weapons/chainsaw_stop.ogg' = 1)
+	end_sound = 'sound/items/weapons/chainsaw_stop.ogg'
 	end_volume = 35
 	volume = 40
 	ignore_walls = FALSE
@@ -54,13 +54,13 @@
 	volume = 5
 
 /datum/looping_sound/tesla_cannon
-	start_sound = list('sound/items/weapons/gun/tesla/tesla_start.ogg' = 1)
+	start_sound = 'sound/items/weapons/gun/tesla/tesla_start.ogg'
 	start_volume = 100
 	start_length = 200 MILLISECONDS
 	mid_sounds = list('sound/items/weapons/gun/tesla/tesla_loop.ogg' = 1)
 	mid_length = 3.8 SECONDS
 	volume = 100
-	end_sound = list('sound/items/weapons/gun/tesla/power_breaker_fan.ogg' = 1)
+	end_sound = 'sound/items/weapons/gun/tesla/power_breaker_fan.ogg'
 	end_volume = 15
 	ignore_walls = FALSE
 	reserve_random_channel = TRUE


### PR DESCRIPTION
## About The Pull Request

Some looping sounds thought start and end sounds were lists.

While this is technically supported by DM, looping sounds and more specifically rustg-sound-length does not, and will runtime if given a list.

## Why It's Good For The Game
bug fix good
## Changelog
:cl:
fix: Some looping sounds no longer runtime when stopping/starting
/:cl: