### PR TITLE
Fixes icewing watcher butcher results.

### DIFF
--- a/code/modules/mob/living/basic/lavaland/watcher/watcher.dm
+++ b/code/modules/mob/living/basic/lavaland/watcher/watcher.dm
@@ -107,7 +107,6 @@
 	health = 130
 	projectile_type = /obj/projectile/temp/watcher/ice_wing
 	gaze_attack = /datum/action/cooldown/mob_cooldown/watcher_gaze/ice
-	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/bone = 1)
 	butcher_results = list(
 		/obj/item/stack/sheet/bone = 1,
 		/obj/item/stack/ore/diamond = 5,


### PR DESCRIPTION
## About The Pull Request

Randomly noticed in the other PR, Icewing watchers for some reason have two sets of butcher results. That is an issue if I've seen one.

## Why It's Good For The Game

Just code cleanup. I am pretty sure the latter, correct line overwrites the former anyway. If it doesn't, then it makes icewing sinew obtainable again.

## Changelog
N/A
