### PR TITLE
Removes advanced robotic limbs

### DIFF
--- a/code/__DEFINES/bodyparts.dm
+++ b/code/__DEFINES/bodyparts.dm
@@ -7,7 +7,7 @@
 /// Used by the max_damage var.
 #define LIMB_MAX_HP_PROSTHESIS 20 //Used by surplus prosthesis limbs.
 #define LIMB_MAX_HP_DEFAULT 50 //Used by most all limbs by default.
-#define LIMB_MAX_HP_ADVANCED 75 //Used by advanced robotic limbs.
+#define LIMB_MAX_HP_CYBERNETIC 75 //Used by robotic limbs.
 #define LIMB_MAX_HP_CORE 200 //Only use this for heads and torsos.
 
 /// Xenomorph Limbs
@@ -20,7 +20,7 @@
 /// A multiplication of the burn and brute damage that the limb's stored damage contributes to its attached mob's overall wellbeing.
 /// For instance, if a limb has 50 damage, and has a coefficient of 50%, the human is considered to have suffered 25 damage to their total health.
 
-#define LIMB_BODY_DAMAGE_COEFFICIENT_ADVANCED 0.5 //Used by advanced robotic limbs.
+#define LIMB_BODY_DAMAGE_COEFFICIENT_CYBERNETIC 0.5 //Used by robotic limbs.
 #define LIMB_BODY_DAMAGE_COEFFICIENT_DEFAULT 0.75 //Used by all limbs by default.
 #define LIMB_BODY_DAMAGE_COEFFICIENT_TOTAL 1 //Used by heads and torsos
 #define LIMB_BODY_DAMAGE_COEFFICIENT_PROSTHESIS 2.5 //Used by surplus prosthesis limbs

--- a/code/__DEFINES/research/research_categories.dm
+++ b/code/__DEFINES/research/research_categories.dm
@@ -196,7 +196,6 @@
 #define RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY "/Cybernetic Utility Implants"
 #define RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_MISC "/Cybernetic Miscellaneous Implants"
 #define RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_SECURITY "/Cybernetic Security Implants"
-#define RND_SUBCATEGORY_CYBERNETICS_ADVANCED_LIMBS "/Cybernetic Advanced Limbs"
 
 // Limb Categories
 #define RND_CATEGORY_LIMBS_DIGITIGRADE "digitigrade"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -76,67 +76,6 @@
 		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CHASSIS
 	)
 
-//Advanced Robotic Limbs
-
-/datum/design/advanced_l_arm
-	name = "Advanced Left Arm"
-	id = "advanced_l_arm"
-	build_type = MECHFAB
-	build_path = /obj/item/bodypart/arm/left/robot/advanced
-	materials = list(
-		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
-		/datum/material/titanium=SHEET_MATERIAL_AMOUNT*3,
-		/datum/material/gold=SHEET_MATERIAL_AMOUNT*3,
-	)
-	construction_time = 20 SECONDS
-	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ADVANCED_LIMBS
-	)
-
-/datum/design/advanced_r_arm
-	name = "Advanced Right Arm"
-	id = "advanced_r_arm"
-	build_type = MECHFAB
-	build_path = /obj/item/bodypart/arm/right/robot/advanced
-	materials = list(
-		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
-		/datum/material/titanium=SHEET_MATERIAL_AMOUNT*3,
-		/datum/material/gold=SHEET_MATERIAL_AMOUNT*3,
-	)
-	construction_time = 20 SECONDS
-	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ADVANCED_LIMBS
-	)
-
-/datum/design/advanced_l_leg
-	name = "Advanced Left Leg"
-	id = "advanced_l_leg"
-	build_type = MECHFAB
-	build_path = /obj/item/bodypart/leg/left/robot/advanced
-	materials = list(
-		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
-		/datum/material/titanium=SHEET_MATERIAL_AMOUNT*3,
-		/datum/material/gold=SHEET_MATERIAL_AMOUNT*3,
-	)
-	construction_time = 20 SECONDS
-	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ADVANCED_LIMBS
-	)
-
-/datum/design/advanced_r_leg
-	name = "Advanced Right Leg"
-	id = "advanced_r_leg"
-	build_type = MECHFAB
-	build_path = /obj/item/bodypart/leg/right/robot/advanced
-	materials = list(
-		/datum/material/iron=SHEET_MATERIAL_AMOUNT*10,
-		/datum/material/titanium=SHEET_MATERIAL_AMOUNT*3,
-		/datum/material/gold=SHEET_MATERIAL_AMOUNT*3,
-	)
-	construction_time = 20 SECONDS
-	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ADVANCED_LIMBS
-	)
 
 //Ripley
 /datum/design/ripley_chassis

--- a/code/modules/research/techweb/nodes/cyborg_nodes.dm
+++ b/code/modules/research/techweb/nodes/cyborg_nodes.dm
@@ -37,10 +37,6 @@
 		"mmi_posi",
 		"mmi",
 		"mmi_m",
-		"advanced_l_arm",
-		"advanced_r_arm",
-		"advanced_l_leg",
-		"advanced_r_leg",
 		"borg_upgrade_rename",
 		"borg_upgrade_restart",
 	)

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -31,6 +31,11 @@
 
 	brute_modifier = 0.8
 	burn_modifier = 0.8
+	unarmed_damage_low = 5
+	unarmed_damage_high = 13
+	unarmed_effectiveness = 20
+	max_damage = LIMB_MAX_HP_CYBERNETIC
+	body_damage_coeff = LIMB_BODY_DAMAGE_COEFFICIENT_CYBERNETIC
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
 	medium_brute_msg = ROBOTIC_MEDIUM_BRUTE_MSG
@@ -72,6 +77,11 @@
 
 	brute_modifier = 0.8
 	burn_modifier = 0.8
+	unarmed_damage_low = 5
+	unarmed_damage_high = 13
+	unarmed_effectiveness = 20
+	max_damage = LIMB_MAX_HP_CYBERNETIC
+	body_damage_coeff = LIMB_BODY_DAMAGE_COEFFICIENT_CYBERNETIC
 
 	disabling_threshold_percentage = 1
 
@@ -114,6 +124,11 @@
 
 	brute_modifier = 0.8
 	burn_modifier = 0.8
+	unarmed_damage_low = 7
+	unarmed_damage_high = 17
+	unarmed_effectiveness = 20
+	max_damage = LIMB_MAX_HP_CYBERNETIC
+	body_damage_coeff = LIMB_BODY_DAMAGE_COEFFICIENT_CYBERNETIC
 
 	disabling_threshold_percentage = 1
 
@@ -170,6 +185,11 @@
 
 	brute_modifier = 0.8
 	burn_modifier = 0.8
+	unarmed_damage_low = 7
+	unarmed_damage_high = 17
+	unarmed_effectiveness = 20
+	max_damage = LIMB_MAX_HP_CYBERNETIC
+	body_damage_coeff = LIMB_BODY_DAMAGE_COEFFICIENT_CYBERNETIC
 
 	disabling_threshold_percentage = 1
 
@@ -583,59 +603,6 @@
 
 	biological_state = (BIO_METAL|BIO_JOINTED)
 
-// Advanced Limbs: More durable, high punching force
-
-/obj/item/bodypart/arm/left/robot/advanced
-	name = "advanced robotic left arm"
-	desc = "An advanced cybernetic arm, capable of greater feats of strength and durability."
-	icon_static = 'icons/mob/augmentation/advanced_augments.dmi'
-	icon = 'icons/mob/augmentation/advanced_augments.dmi'
-	unarmed_damage_low = 5
-	unarmed_damage_high = 13
-	unarmed_effectiveness = 20
-	max_damage = LIMB_MAX_HP_ADVANCED
-	body_damage_coeff = LIMB_BODY_DAMAGE_COEFFICIENT_ADVANCED
-	is_emissive = TRUE
-	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 10, /datum/material/titanium = SHEET_MATERIAL_AMOUNT * 3, /datum/material/gold = SHEET_MATERIAL_AMOUNT * 3)
-
-/obj/item/bodypart/arm/right/robot/advanced
-	name = "advanced robotic right arm"
-	desc = "An advanced cybernetic arm, capable of greater feats of strength and durability."
-	icon_static = 'icons/mob/augmentation/advanced_augments.dmi'
-	icon = 'icons/mob/augmentation/advanced_augments.dmi'
-	unarmed_damage_low = 5
-	unarmed_damage_high = 13
-	unarmed_effectiveness = 20
-	max_damage = LIMB_MAX_HP_ADVANCED
-	body_damage_coeff = LIMB_BODY_DAMAGE_COEFFICIENT_ADVANCED
-	is_emissive = TRUE
-	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 10, /datum/material/titanium = SHEET_MATERIAL_AMOUNT * 3, /datum/material/gold = SHEET_MATERIAL_AMOUNT * 3)
-
-/obj/item/bodypart/leg/left/robot/advanced
-	name = "advanced robotic left leg"
-	desc = "An advanced cybernetic leg, capable of greater feats of strength and durability."
-	icon_static = 'icons/mob/augmentation/advanced_augments.dmi'
-	icon = 'icons/mob/augmentation/advanced_augments.dmi'
-	unarmed_damage_low = 7
-	unarmed_damage_high = 17
-	unarmed_effectiveness = 20
-	max_damage = LIMB_MAX_HP_ADVANCED
-	body_damage_coeff = LIMB_BODY_DAMAGE_COEFFICIENT_ADVANCED
-	is_emissive = TRUE
-	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 10, /datum/material/titanium = SHEET_MATERIAL_AMOUNT * 3, /datum/material/gold = SHEET_MATERIAL_AMOUNT * 3)
-
-/obj/item/bodypart/leg/right/robot/advanced
-	name = "advanced robotic right leg"
-	desc = "An advanced cybernetic leg, capable of greater feats of strength and durability."
-	icon_static = 'icons/mob/augmentation/advanced_augments.dmi'
-	icon = 'icons/mob/augmentation/advanced_augments.dmi'
-	unarmed_damage_low = 7
-	unarmed_damage_high = 17
-	unarmed_effectiveness = 20
-	max_damage = LIMB_MAX_HP_ADVANCED
-	body_damage_coeff = LIMB_BODY_DAMAGE_COEFFICIENT_ADVANCED
-	is_emissive = TRUE
-	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 10, /datum/material/titanium = SHEET_MATERIAL_AMOUNT * 3, /datum/material/gold = SHEET_MATERIAL_AMOUNT * 3)
 
 #undef ROBOTIC_LIGHT_BRUTE_MSG
 #undef ROBOTIC_MEDIUM_BRUTE_MSG


### PR DESCRIPTION
## About The Pull Request

Advanced robotic limbs are kill, regular robotic limbs get advanced stats

## Why It's Good For The Game

Advanced robotic limbs are kind of in a weird spot. They're available very very early on in the round, when posis and MMIs are researched. They're also printed by science, which means anyone who can get an advanced robotic limb has the means to spend 40 points to research them. Compared to normal limbs, they have 50% more health and more unarmed damage, and the major obstacle to getting them is surgery, which is the same as that of regular robotic limbs. You do need titanium and gold, but outside of rare situations people aren't really coming in for surgery before mining makes a single return trip and if they do they'll just wait so they don't have to use the regular limbs.

It all begs the question, why do these things exist? I like their emissive bits, but they just don't really have a place in the game. If they were to be later in the tech tree, people would just _not get cybernetics_ until they're researched. As it stands, all they do is powercreep the regular limbs.

## Changelog
:cl:
del: removes advanced cybernetic limbs
balance: regular cybernetic limbs have advanced cybernetic stats
/:cl:
