### PR TITLE
Fixes an eye-related runtime

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -532,6 +532,8 @@
 			animate(time = wait_time)
 
 /obj/item/organ/eyes/proc/blink(duration = BLINK_DURATION, restart_animation = TRUE)
+	if(!blink_animation)
+		return
 	var/left_delayed = prob(50)
 	// Storing blink delay so mistimed blinks of lizards don't get cut short
 	var/sync_blinking = synchronized_blinking && (owner.get_organ_loss(ORGAN_SLOT_BRAIN) < BRAIN_DAMAGE_ASYNC_BLINKING)


### PR DESCRIPTION
## About The Pull Request
 
`code/modules/surgery/organs/internal/eyes/_eyes.dm, line 570: invalid object type 0:0
proc name: blink (/obj/item/organ/eyes/proc/blink)` -Bug eyes can have blink_animation = FALSE which is supposed to prevent blinking, and it does for some sources. But a number of things call `blink()` without first checking this var (like the emote for instance). Just put a guard in the proc itself, it's super cheap.

## Why It's Good For The Game

Just fixes an oversight

## Changelog

Not player-facing because even bugged it ultimately results in not blinking, just more quietly with this fix.