### PR TITLE
Fixes an immerse runtime

### DIFF
--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -254,6 +254,10 @@
 	. = ..()
 	if(!(flags_1 & INITIALIZED_1))
 		return
+	// If arrived hasn't finished its own Initialize() yet (e.g. during its own creation during mapload), on_atom_inited() will call enter_hot_spring() for it once
+	// Calling it here too would register dip_in/dip_out twice on the same movable.
+	if(!(arrived.flags_1 & INITIALIZED_1))
+		return
 	enter_hot_spring(arrived)
 
 /turf/open/water/hot_spring/on_atom_inited(datum/source, atom/movable/movable)

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -254,9 +254,7 @@
 	. = ..()
 	if(!(flags_1 & INITIALIZED_1))
 		return
-	// If arrived hasn't finished its own Initialize() yet (e.g. during its own creation during mapload), on_atom_inited() will call enter_hot_spring() for it once
-	// Calling it here too would register dip_in/dip_out twice on the same movable.
-	if(!(arrived.flags_1 & INITIALIZED_1))
+	if(!(arrived.flags_1 & INITIALIZED_1)) // If arrived hasn't finished its own Initialize() yet (e.g. during its own creation during mapload), on_atom_inited() will already call enter_hot_spring() for it once
 		return
 	enter_hot_spring(arrived)
 


### PR DESCRIPTION
## About The Pull Request

```
usr: someone)
usr.loc: (start area (8,248,1))
src: null
call stack:
stack trace("addtrait immersed overridden. ...", "code/datums/signals.dm", 43)
the hot spring (243,186,6) (/turf/open/water/hot_spring): RegisterSignal(the fence (/obj/structure/fence), "addtrait immersed", "dip_in", 0)
the hot spring (243,186,6) (/turf/open/water/hot_spring): enter hot spring(the fence (/obj/structure/fence))
the hot spring (243,186,6) (/turf/open/water/hot_spring): on atom inited(the hot spring (243,186,6) (/turf/open/water/hot_spring), the fence (/obj/structure/fence), 1)
the hot spring (243,186,6) (/turf/open/water/hot_spring): SendSignal("atom_init_success_on", /list (/list))
Atoms (/datum/controller/subsystem/atoms): InitAtom(the fence (/obj/structure/fence), 1, /list (/list))
Atoms (/datum/controller/subsystem/atoms): CreateAtoms(/list (/list), null, "subsystem init 60")
Atoms (/datum/controller/subsystem/atoms): InitializeAtoms(/list (/list), null)
Away Mission (/datum/map_template): initTemplateBounds(/list (/list))
Away Mission (/datum/map_template): load new z(0)
Load Away Mission (/datum/admin_verb/load_away_mission): avd do verb(someone (/client))
Admin Verbs (/datum/controller/subsystem/admin_verbs): dynamic invoke verb(someone (/client), /datum/admin_verb/load_away_mi... (/datum/admin_verb/load_away_mission))
Darkinite (/client): Load Away Mission()

```

## Changelog

Not player facing, just removes a lot of runtime spam
