### PR TITLE
Fix TTS runtime spam

### DIFF
--- a/code/controllers/subsystem/tts.dm
+++ b/code/controllers/subsystem/tts.dm
@@ -147,7 +147,6 @@ SUBSYSTEM_DEF(tts)
 		else
 			hearer_atom = hearer
 		if(!hearer_atom || QDELING(hearer_atom))
-			stack_trace("TTS tried to play a sound to a deleted mob.")
 			continue
 		if(!ismob(hearer_atom))
 			continue

--- a/code/datums/3d_sounds/_3d_sound.dm
+++ b/code/datums/3d_sounds/_3d_sound.dm
@@ -119,7 +119,7 @@
 	PROTECTED_PROC(TRUE)
 
 	if(!(new_listener in listeners))
-		// If the listener is the sound's parent, COMSIG_QDELETING/COMSIG_MOVABLE_MOVED are already registeredin New()
+		// If the listener is the sound's parent, COMSIG_QDELETING/COMSIG_MOVABLE_MOVED are already registered in New()
 		if(new_listener != parent)
 			RegisterSignal(new_listener, COMSIG_QDELETING, PROC_REF(listener_deleted))
 

--- a/code/datums/3d_sounds/_3d_sound.dm
+++ b/code/datums/3d_sounds/_3d_sound.dm
@@ -119,14 +119,19 @@
 	PROTECTED_PROC(TRUE)
 
 	if(!(new_listener in listeners))
-		RegisterSignal(new_listener, COMSIG_QDELETING, PROC_REF(listener_deleted))
+		// If the listener is the sound's parent, COMSIG_QDELETING/COMSIG_MOVABLE_MOVED are already registeredin New()
+		if(new_listener != parent)
+			RegisterSignal(new_listener, COMSIG_QDELETING, PROC_REF(listener_deleted))
 
 		if(isnull(new_listener.client))
 			RegisterSignal(new_listener, COMSIG_MOB_LOGIN, PROC_REF(listener_login))
 			return
 		if(preference_signal)
-			RegisterSignals(new_listener, list(COMSIG_MOVABLE_MOVED, preference_signal), PROC_REF(listener_moved))
-		else
+			if(new_listener == parent)
+				RegisterSignal(new_listener, preference_signal, PROC_REF(listener_moved))
+			else
+				RegisterSignals(new_listener, list(COMSIG_MOVABLE_MOVED, preference_signal), PROC_REF(listener_moved))
+		else if(new_listener != parent)
 			RegisterSignal(new_listener, COMSIG_MOVABLE_MOVED, PROC_REF(listener_moved))
 
 		RegisterSignals(new_listener, list(SIGNAL_ADDTRAIT(TRAIT_DEAF), SIGNAL_REMOVETRAIT(TRAIT_DEAF)), PROC_REF(listener_deaf))
@@ -195,23 +200,17 @@
 
 	listeners -= no_longer_listening
 	no_longer_listening.stop_sound_channel(our_channel)
+	// COMSIG_QDELETING/COMSIG_MOVABLE_MOVED are registered in New(), so leave them registered
+	var/list/unregister_signals = list(
+		COMSIG_MOB_LOGIN,
+		SIGNAL_ADDTRAIT(TRAIT_DEAF),
+		SIGNAL_REMOVETRAIT(TRAIT_DEAF),
+	)
+	if(no_longer_listening != parent)
+		unregister_signals += list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED)
 	if(preference_signal)
-		UnregisterSignal(no_longer_listening, list(
-			COMSIG_MOB_LOGIN,
-			COMSIG_QDELETING,
-			COMSIG_MOVABLE_MOVED,
-			preference_signal,
-			SIGNAL_ADDTRAIT(TRAIT_DEAF),
-			SIGNAL_REMOVETRAIT(TRAIT_DEAF),
-		))
-	else
-		UnregisterSignal(no_longer_listening, list(
-			COMSIG_MOB_LOGIN,
-			COMSIG_QDELETING,
-			COMSIG_MOVABLE_MOVED,
-			SIGNAL_ADDTRAIT(TRAIT_DEAF),
-			SIGNAL_REMOVETRAIT(TRAIT_DEAF),
-		))
+		unregister_signals += preference_signal
+	UnregisterSignal(no_longer_listening, unregister_signals)
 
 /datum/threed_sound/proc/update_listener(mob/listener)
 	PROTECTED_PROC(TRUE)

--- a/code/datums/3d_sounds/_3d_sound.dm
+++ b/code/datums/3d_sounds/_3d_sound.dm
@@ -200,13 +200,12 @@
 
 	listeners -= no_longer_listening
 	no_longer_listening.stop_sound_channel(our_channel)
-	// COMSIG_QDELETING/COMSIG_MOVABLE_MOVED are registered in New(), so leave them registered
 	var/list/unregister_signals = list(
 		COMSIG_MOB_LOGIN,
 		SIGNAL_ADDTRAIT(TRAIT_DEAF),
 		SIGNAL_REMOVETRAIT(TRAIT_DEAF),
 	)
-	if(no_longer_listening != parent)
+	if(no_longer_listening != parent) // COMSIG_QDELETING/COMSIG_MOVABLE_MOVED are registered in New(), leave them registered
 		unregister_signals += list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED)
 	if(preference_signal)
 		unregister_signals += preference_signal

--- a/code/datums/3d_sounds/_3d_sound.dm
+++ b/code/datums/3d_sounds/_3d_sound.dm
@@ -127,11 +127,8 @@
 			RegisterSignal(new_listener, COMSIG_MOB_LOGIN, PROC_REF(listener_login))
 			return
 		if(preference_signal)
-			if(new_listener == parent)
-				RegisterSignal(new_listener, preference_signal, PROC_REF(listener_moved))
-			else
-				RegisterSignals(new_listener, list(COMSIG_MOVABLE_MOVED, preference_signal), PROC_REF(listener_moved))
-		else if(new_listener != parent)
+			RegisterSignal(new_listener, preference_signal, PROC_REF(listener_moved))
+		if(new_listener != parent)
 			RegisterSignal(new_listener, COMSIG_MOVABLE_MOVED, PROC_REF(listener_moved))
 
 		RegisterSignals(new_listener, list(SIGNAL_ADDTRAIT(TRAIT_DEAF), SIGNAL_REMOVETRAIT(TRAIT_DEAF)), PROC_REF(listener_deaf))


### PR DESCRIPTION
## About The Pull Request

When a mob hears its own TTS speech, it's both the sound's parent and one of its listeners.

`register_listener()` was registering `COMSIG_MOVABLE_MOVED`/`COMSIG_QDELETING`, which would be overridden by New()'s separate on_moved/parent_delete registrations for the same target. 

Fixed by skipping those and letting them get handled by the New()'s registrations.

Also removes a stack trace that was reporting a legitimate case (if a mob logs off within the lifecycle of an async operation we skip them, correctly, and it doesn't need to be reported as if it were bug).

## Why It's Good For The Game

If a client logs in while self-hearing it will permanently unregister the parent's parent_delete/on_moved hooks, which isn't really something that we want.

Gets rid of 1000's of lines of runtime noise over the course of a round.

## Changelog

This is not really noticeable player-facing so I'll leave this blank