### PR TITLE
Hilberts hotel will properly kick people out who are peeking when the room is deleted & related bugfixes

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -376,7 +376,7 @@
 	stoplag(1) // allow the door to process any allow/deny responses first
 	var/do_after_time = rand(delayed_unres_time_lower, delayed_unres_time_upper)
 	ADD_TRAIT(opener, TRAIT_UNRESTRICTED_AIRLOCK_OPENING, REF(src))
-	RegisterSignal(opener, COMSIG_ATOM_PRE_PRESSURE_PUSH, PROC_REF(stop_pressure_during_unres_open))
+	RegisterSignal(opener, COMSIG_ATOM_PRE_PRESSURE_PUSH, PROC_REF(stop_pressure_during_unres_open), override = TRUE)
 	addtimer(CALLBACK(src, PROC_REF(deregister_pressure_push_signal), opener), do_after_time + 0.5 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE) // extra half-second to be safe, else this is just a guarantee we remove the signal.
 
 	SSblackbox.record_feedback("tally", "unrestricted_airlock_usage", 1, "open attempt ([type])") // statcollecting on how often people try to use this.

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -199,8 +199,8 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 
 /obj/item/hilbertshotel/proc/ejectRooms()
 	if(length(activeRooms))
-		for(var/room in activeRooms)
-			var/datum/turf_reservation/room = activeRooms[room]
+		for(var/active_room, turf_reservation in activeRooms)
+			var/datum/turf_reservation/room = active_room
 			var/turf/room_bottom_left = room.bottom_left_turfs[1]
 			for(var/i in 0 to hotelRoomTemp.width-1)
 				for(var/j in 0 to hotelRoomTemp.height-1)

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -142,10 +142,10 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 							room_turf.y + y,
 							room_turf.z,
 						))
-						if(storageObj && (atom in storageObj.wallmounted_contents))
+						if(storage_obj && (atom in storage_obj.wallmounted_contents))
 							var/obj/stored_in = atom
 							if(istype(stored_in))
-								storedIn.find_and_mount_on_atom()
+								stored_in.find_and_mount_on_atom()
 				turfNumber++
 		qdel(storage_obj)
 		storedRooms -= "[roomNumber]"
@@ -206,7 +206,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 				for(var/j in 0 to hotelRoomTemp.height-1)
 					for(var/atom/movable/atom in locate(room_bottom_left.x + i, room_bottom_left.y + j, room_bottom_left.z))
 						if(ismob(atom))
-							var/mob/mob_atom = mob_atom
+							var/mob/mob_atom = atom
 							if(mob_atom.mind)
 								to_chat(mob_atom, span_warning("As the sphere breaks apart, you're suddenly ejected into the depths of space!"))
 						var/max = world.maxx-TRANSITIONEDGE
@@ -220,7 +220,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 						var/_x = rand(min,max)
 						var/_y = rand(min,max)
 						var/turf/turf_to_place_at = locate(_x, _y, _z)
-						atom.forceMove(T)
+						atom.forceMove(turf_to_place_at)
 			qdel(room)
 
 	if(length(storedRooms))
@@ -488,7 +488,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 			var/list/current_living_mobs = get_all_contents_type(/mob/living) //Got to catch anyone hiding in anything
 			for(var/mob/living/living_mob as anything in current_living_mobs) //Check to see if theres any sentient mobs left.
 				if(living_mob.mind)
-					stillPopulated = TRUE
+					still_populated = TRUE
 					break
 			if(!still_populated)
 				storeRoom()
@@ -509,7 +509,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		for(var/y in 0 to parentSphere.hotelRoomTemp.height-1)
 			var/list/turfContents = list()
 			for(var/atom/movable/atom in locate(room_bottom_left.x + x, room_bottom_left.y + y, room_bottom_left.z))
-				if(ismob(atom) && !isliving(A))
+				if(ismob(atom) && !isliving(atom))
 					continue //Don't want to store ghosts
 				turfContents += atom
 				if(HAS_TRAIT(atom, TRAIT_WALLMOUNTED))

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -301,15 +301,37 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	icon_state = "hoteldoor"
 	explosive_resistance = INFINITY
 	var/obj/item/hilbertshotel/parentSphere
+	/// Mobs currently peeking through this door - needs cleanup if this turf changes type while they're still registered to it.
+	var/list/mob/peeking_users
 
 /turf/closed/indestructible/hoteldoor/Initialize(mapload)
 	. = ..()
 	register_context()
 
+/turf/closed/indestructible/hoteldoor/Destroy(force)
+	LAZYNULL(peeking_users)
+	return ..()
+
 /turf/closed/indestructible/hoteldoor/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 	context[SCREENTIP_CONTEXT_ALT_LMB] = "Peek through"
 	return CONTEXTUAL_SCREENTIP_SET
+
+// Cancel the peeking of anyone peeking out of this door when the turf changes
+/turf/closed/indestructible/hoteldoor/ChangeTurf(path, list/new_baseturfs, flags)
+	for(var/mob/user in peeking_users)
+		cancel_peek(user)
+	return ..()
+
+/// Cancel the peeking of anyone peeking out of this door while they are deleted
+/turf/closed/indestructible/hoteldoor/proc/on_peeker_qdeleted(datum/source, force)
+	SIGNAL_HANDLER
+	LAZYREMOVE(peeking_users, source)
+
+/// Cancels a user's peeking
+/turf/closed/indestructible/hoteldoor/proc/cancel_peek(mob/user)
+	for(var/datum/action/peephole_cancel/cancel_action in user.actions)
+		INVOKE_ASYNC(cancel_action, TYPE_PROC_REF(/datum/action/peephole_cancel, Trigger))
 
 /turf/closed/indestructible/hoteldoor/proc/promptExit(mob/living/user)
 	if(!isliving(user))
@@ -361,22 +383,27 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	to_chat(user, span_notice("You peek through the door's bluespace peephole..."))
 	user.reset_perspective(parentSphere)
 	var/datum/action/peephole_cancel/PHC = new
+	PHC.door = src
 	user.overlay_fullscreen("remote_view", /atom/movable/screen/fullscreen/impaired, 1)
 	PHC.Grant(user)
+	LAZYADD(peeking_users, user)
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(check_eye))
+	RegisterSignal(user, COMSIG_QDELETING, PROC_REF(on_peeker_qdeleted))
 	return CLICK_ACTION_SUCCESS
 
 /turf/closed/indestructible/hoteldoor/proc/check_eye(mob/user, atom/oldloc, direction)
 	SIGNAL_HANDLER
 	if(get_dist(get_turf(src), get_turf(user)) < 2)
 		return
-	for(var/datum/action/peephole_cancel/PHC in user.actions)
-		INVOKE_ASYNC(PHC, TYPE_PROC_REF(/datum/action/peephole_cancel, Trigger))
+	cancel_peek(user)
+	UnregisterSignal(user, COMSIG_QDELETING)
 
 /datum/action/peephole_cancel
 	name = "Cancel View"
 	desc = "Stop looking through the bluespace peephole."
 	button_icon_state = "cancel_peephole"
+	/// The door this peephole view is looking through
+	var/turf/closed/indestructible/hoteldoor/door
 
 /datum/action/peephole_cancel/Trigger(mob/clicker, trigger_flags)
 	. = ..()
@@ -385,8 +412,13 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	to_chat(owner, span_warning("You move away from the peephole."))
 	owner.reset_perspective()
 	owner.clear_fullscreen("remote_view", 0)
-	UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
+	door?.UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
+	LAZYREMOVE(door?.peeking_users, owner)
 	qdel(src)
+
+/datum/action/peephole_cancel/Destroy(force)
+	door = null
+	return ..()
 
 // Despite using the ruins.dmi, hilbertshotel is not a ruin
 /area/misc/hilbertshotel

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -520,7 +520,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 			turfNumber++
 	parentSphere.storedRooms["[roomnumber]"] = storage
 	parentSphere.activeRooms -= "[roomnumber]"
-	qdel(reservation)
+	QDEL_NULL(reservation)
 
 /area/misc/hilbertshotelstorage
 	name = "Hilbert's Hotel Storage Room"

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -127,6 +127,11 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		var/datum/turf_reservation/roomReservation = SSmapping.request_turf_block_reservation(hotelRoomTemp.width, hotelRoomTemp.height, 1)
 		var/turf/room_turf = roomReservation.bottom_left_turfs[1]
 		hotelRoomTempEmpty.load(room_turf)
+		var/obj/item/abstracthotelstorage/storageObj
+		for(var/obj/item/abstracthotelstorage/S in storageTurf)
+			if((S.roomNumber == roomNumber) && (S.parentSphere == src))
+				storageObj = S
+				break
 		var/turfNumber = 1
 		for(var/x in 0 to hotelRoomTemp.width-1)
 			for(var/y in 0 to hotelRoomTemp.height-1)
@@ -137,10 +142,12 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 							room_turf.y + y,
 							room_turf.z,
 						))
+						if(storageObj && (A in storageObj.wallmounted_contents))
+							var/obj/storedIn = A
+							if(istype(storedIn))
+								storedIn.find_and_mount_on_atom()
 				turfNumber++
-		for(var/obj/item/abstracthotelstorage/S in storageTurf)
-			if((S.roomNumber == roomNumber) && (S.parentSphere == src))
-				qdel(S)
+		qdel(storageObj)
 		storedRooms -= "[roomNumber]"
 		activeRooms["[roomNumber]"] = roomReservation
 		linkTurfs(roomReservation, roomNumber)
@@ -505,6 +512,9 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 				if(ismob(A) && !isliving(A))
 					continue //Don't want to store ghosts
 				turfContents += A
+				if(HAS_TRAIT(A, TRAIT_WALLMOUNTED))
+					LAZYADD(storageObj.wallmounted_contents, A)
+					qdel(A.GetComponent(/datum/component/atom_mounted))
 				A.forceMove(storageObj)
 			storage[turfNumber] = turfContents
 			turfNumber++
@@ -528,6 +538,8 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	item_flags = ABSTRACT
 	var/roomNumber
 	var/obj/item/hilbertshotel/parentSphere
+	/// Movables that had their atom_mounted component stripped so they wouldn't deconstruct while stored - remounted when the room is restored.
+	var/list/wallmounted_contents
 
 /obj/item/abstracthotelstorage/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	if(istype(arrived, /obj/machinery/light))
@@ -537,6 +549,10 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	if(ismob(arrived))
 		var/mob/target = arrived
 		ADD_TRAIT(target, TRAIT_NO_TRANSFORM, REF(src))
+
+/obj/item/abstracthotelstorage/Destroy(force)
+	LAZYNULL(wallmounted_contents)
+	return ..()
 
 /obj/item/abstracthotelstorage/Exited(atom/movable/gone, direction)
 	. = ..()

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -214,7 +214,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 						var/list/possible_transtitons = list()
 						for(var/z_level in SSmapping.z_list)
 							var/datum/space_level/space_level = z_level
-							if (D.linkage == CROSSLINKED)
+							if (space_level.linkage == CROSSLINKED)
 								possible_transtitons += space_level.z_value
 						var/_z = pick(possible_transtitons)
 						var/_x = rand(min,max)

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -200,7 +200,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 /obj/item/hilbertshotel/proc/ejectRooms()
 	if(length(activeRooms))
 		for(var/active_room, turf_reservation in activeRooms)
-			var/datum/turf_reservation/room = active_room
+			var/datum/turf_reservation/room = turf_reservation
 			var/turf/room_bottom_left = room.bottom_left_turfs[1]
 			for(var/i in 0 to hotelRoomTemp.width-1)
 				for(var/j in 0 to hotelRoomTemp.height-1)

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -127,27 +127,27 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		var/datum/turf_reservation/roomReservation = SSmapping.request_turf_block_reservation(hotelRoomTemp.width, hotelRoomTemp.height, 1)
 		var/turf/room_turf = roomReservation.bottom_left_turfs[1]
 		hotelRoomTempEmpty.load(room_turf)
-		var/obj/item/abstracthotelstorage/storageObj
-		for(var/obj/item/abstracthotelstorage/S in storageTurf)
-			if((S.roomNumber == roomNumber) && (S.parentSphere == src))
-				storageObj = S
+		var/obj/item/abstracthotelstorage/storage_obj
+		for(var/obj/item/abstracthotelstorage/hotel_storage in storageTurf)
+			if((hotel_storage.roomNumber == roomNumber) && (hotel_storage.parentSphere == src))
+				storage_obj = hotel_storage
 				break
 		var/turfNumber = 1
 		for(var/x in 0 to hotelRoomTemp.width-1)
 			for(var/y in 0 to hotelRoomTemp.height-1)
-				for(var/atom/movable/A in storedRooms["[roomNumber]"][turfNumber])
-					if(istype(A.loc, /obj/item/abstracthotelstorage))//Don't want to recall something thats been moved
-						A.forceMove(locate(
+				for(var/atom/movable/atom in storedRooms["[roomNumber]"][turfNumber])
+					if(istype(atom.loc, /obj/item/abstracthotelstorage))//Don't want to recall something thats been moved
+						atom.forceMove(locate(
 							room_turf.x + x,
 							room_turf.y + y,
 							room_turf.z,
 						))
-						if(storageObj && (A in storageObj.wallmounted_contents))
-							var/obj/storedIn = A
-							if(istype(storedIn))
+						if(storageObj && (atom in storageObj.wallmounted_contents))
+							var/obj/stored_in = atom
+							if(istype(stored_in))
 								storedIn.find_and_mount_on_atom()
 				turfNumber++
-		qdel(storageObj)
+		qdel(storage_obj)
 		storedRooms -= "[roomNumber]"
 		activeRooms["[roomNumber]"] = roomReservation
 		linkTurfs(roomReservation, roomNumber)
@@ -198,47 +198,47 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		BSturf.parentSphere = src
 
 /obj/item/hilbertshotel/proc/ejectRooms()
-	if(activeRooms.len)
-		for(var/x in activeRooms)
-			var/datum/turf_reservation/room = activeRooms[x]
+	if(length(activeRooms))
+		for(var/room in activeRooms)
+			var/datum/turf_reservation/room = activeRooms[room]
 			var/turf/room_bottom_left = room.bottom_left_turfs[1]
 			for(var/i in 0 to hotelRoomTemp.width-1)
 				for(var/j in 0 to hotelRoomTemp.height-1)
-					for(var/atom/movable/A in locate(room_bottom_left.x + i, room_bottom_left.y + j, room_bottom_left.z))
-						if(ismob(A))
-							var/mob/M = A
-							if(M.mind)
-								to_chat(M, span_warning("As the sphere breaks apart, you're suddenly ejected into the depths of space!"))
+					for(var/atom/movable/atom in locate(room_bottom_left.x + i, room_bottom_left.y + j, room_bottom_left.z))
+						if(ismob(atom))
+							var/mob/mob_atom = mob_atom
+							if(mob_atom.mind)
+								to_chat(mob_atom, span_warning("As the sphere breaks apart, you're suddenly ejected into the depths of space!"))
 						var/max = world.maxx-TRANSITIONEDGE
 						var/min = 1+TRANSITIONEDGE
 						var/list/possible_transtitons = list()
-						for(var/AZ in SSmapping.z_list)
-							var/datum/space_level/D = AZ
+						for(var/z_level in SSmapping.z_list)
+							var/datum/space_level/space_level = z_level
 							if (D.linkage == CROSSLINKED)
-								possible_transtitons += D.z_value
+								possible_transtitons += space_level.z_value
 						var/_z = pick(possible_transtitons)
 						var/_x = rand(min,max)
 						var/_y = rand(min,max)
-						var/turf/T = locate(_x, _y, _z)
-						A.forceMove(T)
+						var/turf/turf_to_place_at = locate(_x, _y, _z)
+						atom.forceMove(T)
 			qdel(room)
 
-	if(storedRooms.len)
-		for(var/x in storedRooms)
-			var/list/atomList = storedRooms[x]
-			for(var/atom/movable/A in atomList)
+	if(length(storedRooms))
+		for(var/room in storedRooms)
+			var/list/atom_list = storedRooms[room]
+			for(var/atom/movable/atom in atom_list)
 				var/max = world.maxx-TRANSITIONEDGE
 				var/min = 1+TRANSITIONEDGE
 				var/list/possible_transtitons = list()
-				for(var/AZ in SSmapping.z_list)
-					var/datum/space_level/D = AZ
-					if (D.linkage == CROSSLINKED)
-						possible_transtitons += D.z_value
+				for(var/z_level in SSmapping.z_list)
+					var/datum/space_level/space_level = z_level
+					if (space_level.linkage == CROSSLINKED)
+						possible_transtitons += space_level.z_value
 				var/_z = pick(possible_transtitons)
 				var/_x = rand(min,max)
 				var/_y = rand(min,max)
-				var/turf/T = locate(_x, _y, _z)
-				A.forceMove(T)
+				var/turf/turf_to_place_at = locate(_x, _y, _z)
+				atom.forceMove(turf_to_place_at)
 
 //Template Stuff
 /datum/map_template/hilbertshotel
@@ -389,10 +389,10 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 
 	to_chat(user, span_notice("You peek through the door's bluespace peephole..."))
 	user.reset_perspective(parentSphere)
-	var/datum/action/peephole_cancel/PHC = new
-	PHC.door = src
+	var/datum/action/peephole_cancel/peephole_cancel_action = new
+	peephole_cancel_action.door = src
 	user.overlay_fullscreen("remote_view", /atom/movable/screen/fullscreen/impaired, 1)
-	PHC.Grant(user)
+	peephole_cancel_action.Grant(user)
 	LAZYADD(peeking_users, user)
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(check_eye))
 	RegisterSignal(user, COMSIG_QDELETING, PROC_REF(on_peeker_qdeleted))
@@ -448,49 +448,49 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	if(istype(arrived, /obj/item/hilbertshotel))
 		relocate(arrived)
 	var/list/obj/item/hilbertshotel/hotels = arrived.get_all_contents_type(/obj/item/hilbertshotel)
-	for(var/obj/item/hilbertshotel/H in hotels)
-		if(parentSphere == H)
-			relocate(H)
+	for(var/obj/item/hilbertshotel/hotel_item in hotels)
+		if(parentSphere == hotel_item)
+			relocate(hotel_item)
 
-/area/misc/hilbertshotel/proc/relocate(obj/item/hilbertshotel/H)
+/area/misc/hilbertshotel/proc/relocate(obj/item/hilbertshotel/hotel_item)
 	if(prob(0.135685)) //Because screw you
-		qdel(H)
+		qdel(hotel_item)
 		return
 
 	// Prepare for...
-	var/mob/living/unforeseen_consequences = get_atom_on_turf(H, /mob/living)
+	var/mob/living/unforeseen_consequences = get_atom_on_turf(hotel_item, /mob/living)
 
 	// Turns out giving anyone who grabs a Hilbert's Hotel a free, complementary warp whistle is probably bad.
 	// Let's gib the last person to have selected a room number in it.
 	if(unforeseen_consequences)
-		to_chat(unforeseen_consequences, span_warning("\The [H] starts to resonate. Forcing it to enter itself induces a bluespace paradox, violently tearing your body apart."))
-		unforeseen_consequences.investigate_log("has been gibbed by using [H] while inside of it.", INVESTIGATE_DEATHS)
+		to_chat(unforeseen_consequences, span_warning("\The [hotel_item] starts to resonate. Forcing it to enter itself induces a bluespace paradox, violently tearing your body apart."))
+		unforeseen_consequences.investigate_log("has been gibbed by using [hotel_item] while inside of it.", INVESTIGATE_DEATHS)
 		unforeseen_consequences.gib(DROP_ALL_REMAINS)
 
 	var/turf/targetturf = find_safe_turf()
 	if(!targetturf)
-		if(GLOB.blobstart.len > 0)
+		if(length(GLOB.blobstart) > 0)
 			targetturf = get_turf(pick(GLOB.blobstart))
 		else
 			CRASH("Unable to find a blobstart landmark")
 
-	log_game("[H] entered itself. Moving it to [loc_name(targetturf)].")
-	message_admins("[H] entered itself. Moving it to [ADMIN_VERBOSEJMP(targetturf)].")
-	H.visible_message(span_danger("[H] almost implodes in upon itself, but quickly rebounds, shooting off into a random point in space!"))
-	H.forceMove(targetturf)
+	log_game("[hotel_item] entered itself. Moving it to [loc_name(targetturf)].")
+	message_admins("[hotel_item] entered itself. Moving it to [ADMIN_VERBOSEJMP(targetturf)].")
+	hotel_item.visible_message(span_danger("[hotel_item] almost implodes in upon itself, but quickly rebounds, shooting off into a random point in space!"))
+	hotel_item.forceMove(targetturf)
 
 /area/misc/hilbertshotel/Exited(atom/movable/gone, direction)
 	. = ..()
 	if(ismob(gone))
-		var/mob/M = gone
-		if(M.mind)
-			var/stillPopulated = FALSE
-			var/list/currentLivingMobs = get_all_contents_type(/mob/living) //Got to catch anyone hiding in anything
-			for(var/mob/living/L in currentLivingMobs) //Check to see if theres any sentient mobs left.
-				if(L.mind)
+		var/mob/gone_mob = gone
+		if(gone_mob.mind)
+			var/still_populated = FALSE
+			var/list/current_living_mobs = get_all_contents_type(/mob/living) //Got to catch anyone hiding in anything
+			for(var/mob/living/living_mob as anything in current_living_mobs) //Check to see if theres any sentient mobs left.
+				if(living_mob.mind)
 					stillPopulated = TRUE
 					break
-			if(!stillPopulated)
+			if(!still_populated)
 				storeRoom()
 
 /area/misc/hilbertshotel/proc/storeRoom()
@@ -508,14 +508,14 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	for(var/x in 0 to parentSphere.hotelRoomTemp.width-1)
 		for(var/y in 0 to parentSphere.hotelRoomTemp.height-1)
 			var/list/turfContents = list()
-			for(var/atom/movable/A in locate(room_bottom_left.x + x, room_bottom_left.y + y, room_bottom_left.z))
-				if(ismob(A) && !isliving(A))
+			for(var/atom/movable/atom in locate(room_bottom_left.x + x, room_bottom_left.y + y, room_bottom_left.z))
+				if(ismob(atom) && !isliving(A))
 					continue //Don't want to store ghosts
-				turfContents += A
-				if(HAS_TRAIT(A, TRAIT_WALLMOUNTED))
-					LAZYADD(storageObj.wallmounted_contents, A)
-					qdel(A.GetComponent(/datum/component/atom_mounted))
-				A.forceMove(storageObj)
+				turfContents += atom
+				if(HAS_TRAIT(atom, TRAIT_WALLMOUNTED))
+					LAZYADD(storageObj.wallmounted_contents, atom)
+					qdel(atom.GetComponent(/datum/component/atom_mounted))
+				atom.forceMove(storageObj)
 			storage[turfNumber] = turfContents
 			turfNumber++
 	parentSphere.storedRooms["[roomnumber]"] = storage
@@ -583,7 +583,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		to_chat(user, span_warning("It's to far away to scan!"))
 		return ITEM_INTERACT_BLOCKING
 	var/obj/item/hilbertshotel/sphere = interacting_with
-	if(sphere.activeRooms.len)
+	if(length(sphere.activeRooms))
 		to_chat(user, "Currently Occupied Rooms:")
 		for(var/roomnumber in sphere.activeRooms)
 			to_chat(user, roomnumber)

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -502,13 +502,13 @@
 // if a light is turned off, it won't activate emergency power
 /obj/machinery/light/proc/turned_off()
 	var/area/local_area = get_room_area()
-	return !local_area.lightswitch && local_area.power_light || flickering
+	return (local_area && !local_area.lightswitch && local_area.power_light) || flickering
 
 // returns whether this light has power
 // true if area has power and lightswitch is on
 /obj/machinery/light/proc/has_power()
 	var/area/local_area = get_room_area()
-	return local_area.lightswitch && local_area.power_light
+	return local_area && local_area.lightswitch && local_area.power_light
 
 // returns whether this light has emergency power
 // can also return if it has access to a certain amount of that power


### PR DESCRIPTION
## About The Pull Request

<img width="559" height="299" alt="image" src="https://github.com/user-attachments/assets/6c66838c-c9a6-43b3-8367-4e3b8813d3de" />

If a room gets deleted while someone is looking at (or the user) things don't get cleaned up properly. This PR just fixes that

Fixes some other associated runtime log spams. (one adding an override to a signal that should be an override, another fixing the lights starting turned off if you reload the same room, caused by the wallmount changes and needing some special consideration)

## Why It's Good For The Game

Bugfix

## Changelog

:cl:
fix: peeking into a hilberts hotel room while it gets deleted will now kick you out properly
fix: fixed an issue where the lights would stay dark after reloading the same hilberts hotel room
/:cl:
