### PR TITLE
Removes unnecessary click delay from window placement

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -264,7 +264,7 @@
 			return ITEM_INTERACT_BLOCKING
 
 		to_chat(user, span_notice("You start placing the window..."))
-		if(!do_after(user,20, target = src))
+		if(!do_after(user, 2 SECONDS, target = src))
 			return ITEM_INTERACT_BLOCKING
 
 		if(!src.loc || !anchored) //Grille broken or unanchored while waiting

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -232,7 +232,6 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/grille/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	user.changeNext_move(CLICK_CD_MELEE)
 	if(istype(tool, /obj/item/stack/rods) && broken)
 		if(!do_after(user, 1 SECONDS, target = src))
 			return ITEM_INTERACT_BLOCKING


### PR DESCRIPTION

## About The Pull Request

Lets players place multiple windows at once again.
Closes #97058
Handled in the click chain proper, technically not a bug but construction is a slog and we are all for making it convenient. 

## Changelog
:cl:
fix: Removed unnecessary click delay from window placement
/:cl:
