### PR TITLE
Adds an emp protection stat

### DIFF
--- a/code/__DEFINES/bodyparts.dm
+++ b/code/__DEFINES/bodyparts.dm
@@ -37,13 +37,13 @@
 #define AUGGED_LIMB_EMP_PARALYZE_TIME 3 SECONDS
 
 /// When hit by an EMP, the time an augged leg will be knocked down for.
-#define AUGGED_LEG_EMP_KNOCKDOWN_TIME 3 SECONDS
+#define AUGGED_LEG_EMP_KNOCKDOWN_TIME 5 SECONDS
 /// When hit by an EMP, the time a augged chest will cause a hardstun for if its above the damage threshold.
 #define AUGGED_CHEST_EMP_STUN_TIME 3 SECONDS
-/// When hit by an EMP, the time an augged chest will cause the mob to shake() for.
-#define AUGGED_CHEST_EMP_SHAKE_TIME 5 SECONDS
+/// When hit by an EMP, the time an augged chest will cause the mob to jitter for.
+#define AUGGED_CHEST_EMP_SHAKE_TIME 6 SECONDS
 /// When hit by an EMP, the time an augged head will make vision fucky for.
-#define AUGGED_HEAD_EMP_GLITCH_DURATION 6 SECONDS
+#define AUGGED_HEAD_EMP_GLITCH_DURATION 3.5 SECONDS
 
 // Color priorities for bodyparts
 /// Abductor team recoloring priority

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -549,9 +549,9 @@
  * EMP protection
  * These values are additive to determine your overall emp protection
  */
- #define EMP_PROTECTION_NONE 0
- #define EMP_PROTECTION_MODERATE 1
- #define EMP_PROTECTION_HIGH 2
+#define EMP_PROTECTION_NONE 0
+#define EMP_PROTECTION_MODERATE 1
+#define EMP_PROTECTION_HIGH 2
 
 /**
  * Soundbang defines

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -546,6 +546,14 @@
 #define EAR_PROTECTION_FULL INFINITY
 
 /**
+ * EMP protection
+ * These values are additive to determine your overall emp protection
+ */
+ #define EMP_PROTECTION_NONE 0
+ #define EMP_PROTECTION_MODERATE 1
+ #define EMP_PROTECTION_HIGH 2
+
+/**
  * Soundbang defines
  * These values are used as argument to determine the strength of the soundbang_act call
  */

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -23,6 +23,8 @@
 	var/toggle_message
 	///chat message when the visor is toggled up.
 	var/alt_toggle_message
+	/// What level of emp protection item has
+	var/emp_protection = 0
 
 	var/clothing_flags = NONE
 	///List of items that can be equipped in the suit storage slot while we're worn.
@@ -396,6 +398,8 @@
 		.["sterile"] = "Increases the speed at which reagents are administered to others by [round((1/NITRILE_GLOVES_MULTIPLIER-1)*100, 1)]%."
 	if(TRAIT_FAST_CUFFING in clothing_traits)
 		.["secure"] = "Increases the speed at which you apply restraints."
+	if(emp_protection >= 0)
+		.["emp resistant"] = "Reduces the effects of incoming electromagnetic pulses on the wearer."
 
 /obj/item/clothing/examine_descriptor(mob/user)
 	return "clothing"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -24,7 +24,7 @@
 	///chat message when the visor is toggled up.
 	var/alt_toggle_message
 	/// What level of emp protection item has
-	var/emp_protection = 0
+	var/emp_protection = EMP_PROTECTION_NONE
 
 	var/clothing_flags = NONE
 	///List of items that can be equipped in the suit storage slot while we're worn.
@@ -398,7 +398,7 @@
 		.["sterile"] = "Increases the speed at which reagents are administered to others by [round((1/NITRILE_GLOVES_MULTIPLIER-1)*100, 1)]%."
 	if(TRAIT_FAST_CUFFING in clothing_traits)
 		.["secure"] = "Increases the speed at which you apply restraints."
-	if(emp_protection >= 0)
+	if(emp_protection >= EMP_PROTECTION_NONE)
 		.["emp resistant"] = "Reduces the effects of incoming electromagnetic pulses on the wearer."
 
 /obj/item/clothing/examine_descriptor(mob/user)

--- a/code/modules/clothing/head/tinfoilhat.dm
+++ b/code/modules/clothing/head/tinfoilhat.dm
@@ -11,6 +11,7 @@
 	var/datum/brain_trauma/mild/phobia/conspiracies/paranoia
 	var/warped = FALSE
 	interaction_flags_mouse_drop = NEED_HANDS
+	emp_protection = 1
 
 /datum/armor/costume_foilhat
 	laser = -5

--- a/code/modules/clothing/head/tinfoilhat.dm
+++ b/code/modules/clothing/head/tinfoilhat.dm
@@ -11,7 +11,7 @@
 	var/datum/brain_trauma/mild/phobia/conspiracies/paranoia
 	var/warped = FALSE
 	interaction_flags_mouse_drop = NEED_HANDS
-	emp_protection = 1
+	emp_protection = EMP_PROTECTION_MODERATE
 
 /datum/armor/costume_foilhat
 	laser = -5

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -233,7 +233,7 @@
 	cooldown_message = span_danger("The tesla capacitors on the reactive tesla armor are still recharging! The armor merely emits some sparks.")
 	emp_message = span_warning("The tesla capacitors beep ominously for a moment.")
 	clothing_traits = list(TRAIT_TESLA_SHOCKIMMUNE)
-	emp_protection = 1
+	emp_protection = EMP_PROTECTION_MODERATE
 	/// How strong are the zaps we give off?
 	var/zap_power = 2.5e4
 	/// How far to the zaps we give off go?

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -233,6 +233,7 @@
 	cooldown_message = span_danger("The tesla capacitors on the reactive tesla armor are still recharging! The armor merely emits some sparks.")
 	emp_message = span_warning("The tesla capacitors beep ominously for a moment.")
 	clothing_traits = list(TRAIT_TESLA_SHOCKIMMUNE)
+	emp_protection = 1
 	/// How strong are the zaps we give off?
 	var/zap_power = 2.5e4
 	/// How far to the zaps we give off go?

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -758,3 +758,8 @@
 	. = ..()
 	for (var/obj/item/clothing/clothing in get_equipped_items())
 		. += clothing.flash_protect
+
+/mob/living/carbon/human/get_emp_protection()
+	. = ..()
+	for(var/obj/item/clothing/each_clothing in get_equipped_items())
+		. += each_clothing.emp_protection

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -35,6 +35,10 @@
 /mob/living/proc/get_eye_protection()
 	return 0
 
+//this returns a number is subtracted from the severity of incoming emps against this mob.
+/mob/living/proc/get_emp_protection()
+	return emp_protection
+
 ///A easy to use proc to apply both organ damage and temporary deafness at once, so you don't have to get the ears everytime.
 /mob/living/proc/sound_damage(damage, deafen)
 	return
@@ -615,6 +619,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_CONTENTS)
 		return
+	severity += get_emp_protection()
 	for(var/obj/inside in contents)
 		inside.emp_act(severity)
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -31,19 +31,19 @@
 /mob/living/proc/getarmor(def_zone, type)
 	return 0
 
-//this returns the mob's protection against eye damage (number between -1 and 2) from bright lights
+/// This returns the mob's protection against eye damage (number between -1 and 2) from bright lights
 /mob/living/proc/get_eye_protection()
 	return 0
 
-//this returns a number is subtracted from the severity of incoming emps against this mob.
+/// This returns a number is subtracted from the severity of incoming emps against this mob.
 /mob/living/proc/get_emp_protection()
 	return emp_protection
 
-///A easy to use proc to apply both organ damage and temporary deafness at once, so you don't have to get the ears everytime.
+/// An easy to use proc to apply both organ damage and temporary deafness at once, so you don't have to get the ears everytime.
 /mob/living/proc/sound_damage(damage, deafen)
 	return
 
-//this returns the mob's protection against ear damage (0:no protection; 1: some ear protection; 2: has no ears)
+/// This returns the mob's protection against ear damage (0:no protection; 1: some ear protection; 2: has no ears)
 /mob/living/proc/get_ear_protection(ignore_deafness = FALSE)
 	if(!ignore_deafness && HAS_TRAIT(src, TRAIT_DEAF))
 		return INFINITY //For all my homies that can not hear in the world

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -268,4 +268,4 @@
 	VAR_FINAL/image/unconscious_appearance
 
 	/// Reduces the effects of EMPs, does NOT negate them even at very high numbers
-	var/emp_protection = 0
+	var/emp_protection = EMP_PROTECTION_NONE

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -266,3 +266,6 @@
 
 	/// Reference to the unconscious appearance image that appears in place of the mob to other knocked out mobs
 	VAR_FINAL/image/unconscious_appearance
+
+	/// Reduces the effects of EMPs, does NOT negate them even at very high numbers
+	var/emp_protection = 0

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -382,14 +382,22 @@
 	incompatible_modules = list(/obj/item/mod/module/emp_shield)
 	required_slots = list(ITEM_SLOT_BACK|ITEM_SLOT_BELT)
 	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 5, /datum/material/plasma = SMALL_MATERIAL_AMOUNT * 5)
+	//How much emp protection this module grants to its wearer when fully extended.
+	var/protection_factor = 1
 
 /obj/item/mod/module/emp_shield/on_install()
 	. = ..()
 	mod.AddElement(/datum/element/empprotection, EMP_PROTECT_ALL)
+	var/list/all_parts = mod.get_parts()
+	for(var/obj/item/clothing/mod_part as anything in all_parts)
+		mod_part.emp_protection += protection_factor/all_parts.len
 
 /obj/item/mod/module/emp_shield/on_uninstall(deleting = FALSE)
 	. = ..()
 	mod.RemoveElement(/datum/element/empprotection, EMP_PROTECT_ALL)
+	var/list/all_parts = mod.get_parts()
+	for(var/obj/item/clothing/mod_part as anything in all_parts)
+		mod_part.emp_protection -= protection_factor/all_parts.len
 
 /obj/item/mod/module/emp_shield/advanced
 	name = "MOD advanced EMP shield module"

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -383,7 +383,7 @@
 	required_slots = list(ITEM_SLOT_BACK|ITEM_SLOT_BELT)
 	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 5, /datum/material/plasma = SMALL_MATERIAL_AMOUNT * 5)
 	//How much emp protection this module grants to its wearer when fully extended.
-	var/protection_factor = 1
+	var/protection_factor = EMP_PROTECTION_MODERATE
 
 /obj/item/mod/module/emp_shield/on_install()
 	. = ..()

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -382,7 +382,7 @@
 	incompatible_modules = list(/obj/item/mod/module/emp_shield)
 	required_slots = list(ITEM_SLOT_BACK|ITEM_SLOT_BELT)
 	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 5, /datum/material/plasma = SMALL_MATERIAL_AMOUNT * 5)
-	//How much emp protection this module grants to its wearer when fully extended.
+	/// How much emp protection this module grants to its wearer when fully extended.
 	var/protection_factor = EMP_PROTECTION_MODERATE
 
 /obj/item/mod/module/emp_shield/on_install()

--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -129,6 +129,7 @@ Slimecrossing Armor
 	flags_inv = NONE
 	item_flags = IMMUTABLE_SLOW
 	slowdown = 4
+	emp_protection = 1
 	var/hit_reflect_chance = 40
 
 /obj/item/clothing/suit/armor/heavy/adamantine/Initialize(mapload)

--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -129,7 +129,7 @@ Slimecrossing Armor
 	flags_inv = NONE
 	item_flags = IMMUTABLE_SLOW
 	slowdown = 4
-	emp_protection = 1
+	emp_protection = EMP_PROTECTION_MODERATE
 	var/hit_reflect_chance = 40
 
 /obj/item/clothing/suit/armor/heavy/adamantine/Initialize(mapload)

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -140,15 +140,15 @@
 	. = ..()
 	if(!. || isnull(owner))
 		return
-
-	var/knockdown_time = AUGGED_LEG_EMP_KNOCKDOWN_TIME
-	if (severity == EMP_HEAVY)
-		knockdown_time *= 2
-	owner.Knockdown(knockdown_time)
-	if(INCAPACITATED_IGNORING(owner, INCAPABLE_RESTRAINTS|INCAPABLE_GRAB)) // So the message isn't duplicated. If they were stunned beforehand by something else, then the message not showing makes more sense anyways.
-		return
-	to_chat(owner, span_danger("As your [plaintext_zone] unexpectedly malfunctions, it causes you to fall to the ground!"))
-	return
+	if(prob(80 / severity))
+		if(owner.body_position == LYING_DOWN) // So the message isn't duplicated. If they were stunned beforehand by something else, then the message not showing makes more sense anyways.
+			to_chat(owner, span_danger("Your [plaintext_zone] suddenly malfunctions!"))
+		else
+			to_chat(owner, span_danger("As your [plaintext_zone] suddenly malfunctions, it causes you to fall to the ground!"))
+		owner.Knockdown(AUGGED_LEG_EMP_KNOCKDOWN_TIME)
+	owner.adjust_staggered(STAGGERED_SLOWDOWN_LENGTH * 3 / severity)
+	owner.client?.move_delay = max(owner.client?.move_delay, world.time)
+	owner.client?.move_delay += 0.6 SECONDS / severity
 
 /obj/item/bodypart/leg/right/robot
 	name = "cyborg right leg"
@@ -196,15 +196,15 @@
 	. = ..()
 	if(!. || isnull(owner))
 		return
-
-	var/knockdown_time = AUGGED_LEG_EMP_KNOCKDOWN_TIME
-	if (severity == EMP_HEAVY)
-		knockdown_time *= 2
-	owner.Knockdown(knockdown_time)
-	if(INCAPACITATED_IGNORING(owner, INCAPABLE_RESTRAINTS|INCAPABLE_GRAB)) // So the message isn't duplicated. If they were stunned beforehand by something else, then the message not showing makes more sense anyways.
-		return
-	to_chat(owner, span_danger("As your [plaintext_zone] unexpectedly malfunctions, it causes you to fall to the ground!"))
-	return
+	if(prob(80 / severity))
+		if(owner.body_position == LYING_DOWN) // So the message isn't duplicated. If they were stunned beforehand by something else, then the message not showing makes more sense anyways.
+			to_chat(owner, span_danger("Your [plaintext_zone] suddenly malfunctions!"))
+		else
+			to_chat(owner, span_danger("As your [plaintext_zone] suddenly malfunctions, it causes you to fall to the ground!"))
+		owner.Knockdown(AUGGED_LEG_EMP_KNOCKDOWN_TIME)
+	owner.adjust_staggered(STAGGERED_SLOWDOWN_LENGTH * 3 / severity)
+	owner.client?.move_delay = max(owner.client?.move_delay, world.time)
+	owner.client?.move_delay += 0.6 SECONDS / severity
 
 /obj/item/bodypart/chest/robot
 	name = "cyborg torso"
@@ -258,24 +258,11 @@
 	. = ..()
 	if(!. || isnull(owner))
 		return
-
-	var/stun_time = 0
-	var/shift_x = 3
-	var/shift_y = 0
-	var/shake_duration = AUGGED_CHEST_EMP_SHAKE_TIME
-
-	if(severity == EMP_HEAVY)
-		stun_time = AUGGED_CHEST_EMP_STUN_TIME
-
-		shift_x = 5
-		shift_y = 2
-
 	var/damage_percent_to_max = (get_damage() / max_damage)
-	if (stun_time && (damage_percent_to_max >= robotic_emp_paralyze_damage_percent_threshold))
+	if(damage_percent_to_max >= robotic_emp_paralyze_damage_percent_threshold)
 		to_chat(owner, span_danger("Your [plaintext_zone]'s logic boards temporarily become unresponsive!"))
-		owner.Stun(stun_time)
-	owner.Shake(pixelshiftx = shift_x, pixelshifty = shift_y, duration = shake_duration)
-	return
+		owner.Stun(AUGGED_CHEST_EMP_STUN_TIME / severity)
+	owner.adjust_jitter(AUGGED_CHEST_EMP_SHAKE_TIME / severity)
 
 /obj/item/bodypart/chest/robot/get_cell()
 	return cell
@@ -436,22 +423,14 @@
 	if(limb_id == BODYPART_ID_ROBOTIC)
 		. += should_draw_greyscale ? icon_greyscale : icon_static
 
-#define EMP_GLITCH "EMP_GLITCH"
 
 /obj/item/bodypart/head/robot/emp_effect(severity, protection)
 	. = ..()
 	if(!. || isnull(owner))
 		return
-
-	to_chat(owner, span_danger("Your [plaintext_zone]'s optical transponders glitch out and malfunction!"))
-
-	var/glitch_duration = AUGGED_HEAD_EMP_GLITCH_DURATION
-	if (severity == EMP_HEAVY)
-		glitch_duration *= 2
-
-	QDEL_IN(owner.add_client_colour(/datum/client_colour/malfunction, HEAD_TRAIT), glitch_duration)
-
-#undef EMP_GLITCH
+	to_chat(owner, span_danger("Your [plaintext_zone] hurts..."))
+	QDEL_IN(owner.add_client_colour(/datum/client_colour/malfunction, HEAD_TRAIT), (AUGGED_HEAD_EMP_GLITCH_DURATION / severity))
+	owner.adjust_confusion(AUGGED_HEAD_EMP_GLITCH_DURATION / severity)
 
 /obj/item/bodypart/head/robot/Exited(atom/movable/gone, direction)
 	. = ..()

--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -160,16 +160,16 @@
 		return
 
 	if(reviving)
-		revive_cost += 200
+		revive_cost += 200 / severity
 	else
-		reviver_cooldown += 20 SECONDS
+		reviver_cooldown += 20 SECONDS / severity
 
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_owner = owner
 		if(human_owner.stat != DEAD && prob(50 / severity) && human_owner.can_heartattack())
 			human_owner.set_heartattack(TRUE)
 			to_chat(human_owner, span_userdanger("You feel a horrible agony in your chest!"))
-			addtimer(CALLBACK(src, PROC_REF(undo_heart_attack)), 600 / severity)
+			addtimer(CALLBACK(src, PROC_REF(undo_heart_attack)), 50 SECONDS / severity)
 
 /obj/item/organ/cyberimp/chest/reviver/proc/undo_heart_attack()
 	var/mob/living/carbon/human/human_owner = owner

--- a/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
@@ -135,7 +135,7 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
-	var/range = severity ? 10 : 5
+	var/range = 10 / severity
 	var/atom/throw_target
 	if(active)
 		release_items()
@@ -240,7 +240,7 @@
 	if((organ_flags & ORGAN_FAILING) || . & EMP_PROTECT_SELF)
 		return
 	organ_flags |= ORGAN_FAILING
-	addtimer(CALLBACK(src, PROC_REF(reboot)), 90 / severity)
+	addtimer(CALLBACK(src, PROC_REF(reboot)), 9 SECONDS / severity)
 
 /obj/item/organ/cyberimp/brain/anti_stun/proc/reboot()
 	organ_flags &= ~ORGAN_FAILING

--- a/code/modules/surgery/organs/internal/eyes/eyes_augments.dm
+++ b/code/modules/surgery/organs/internal/eyes/eyes_augments.dm
@@ -12,7 +12,7 @@
 	. = ..()
 	if((. & EMP_PROTECT_SELF) || !owner)
 		return
-	if(prob(10 * severity))
+	if(prob(100 / severity))
 		return
 	to_chat(owner, span_warning("Static obfuscates your vision!"))
 	owner.flash_act(visual = 1)

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -231,14 +231,14 @@
 	var/owner_needs_us = owner?.needs_heart()
 
 	if(owner_needs_us && !COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
-		owner.set_dizzy_if_lower(20 SECONDS)
+		owner.set_dizzy_if_lower(15 SECONDS / severity)
 		owner.losebreath += 10
-		COOLDOWN_START(src, severe_cooldown, 20 SECONDS)
+		COOLDOWN_START(src, severe_cooldown, 15 SECONDS)
 
 	if(prob(emp_vulnerability/severity)) //Chance of permanent effects
 		organ_flags |= ORGAN_EMP //Starts organ faliure - gonna need replacing soon.
 		Stop()
-		addtimer(CALLBACK(src, PROC_REF(Restart)), 10 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(Restart)), 10 SECONDS / severity)
 		if(owner_needs_us)
 			owner.visible_message(
 				span_danger("[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!"),

--- a/code/modules/surgery/organs/internal/liver/_liver.dm
+++ b/code/modules/surgery/organs/internal/liver/_liver.dm
@@ -254,7 +254,7 @@
 	if(. & EMP_PROTECT_SELF)
 		return
 	if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
-		owner.adjust_tox_loss(10)
+		owner.adjust_tox_loss(10 / severity)
 		COOLDOWN_START(src, severe_cooldown, 10 SECONDS)
 	if(prob(emp_vulnerability/severity)) //Chance of permanent effects
 		organ_flags |= ORGAN_EMP //Starts organ faliure - gonna need replacing soon.

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -951,7 +951,7 @@
 	if(. & EMP_PROTECT_SELF)
 		return
 	if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
-		owner.losebreath += 20
+		owner.losebreath += (20 / severity)
 		COOLDOWN_START(src, severe_cooldown, 30 SECONDS)
 	if(prob(emp_vulnerability/severity)) //Chance of permanent effects
 		organ_flags |= ORGAN_EMP //Starts organ faliure - gonna need replacing soon.

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -511,7 +511,8 @@
 	if(. & EMP_PROTECT_SELF)
 		return
 	if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
-		owner.vomit(vomit_flags = (MOB_VOMIT_MESSAGE | MOB_VOMIT_HARM))
+		if(prob(100/severity))
+			owner.vomit(vomit_flags = (MOB_VOMIT_MESSAGE | MOB_VOMIT_HARM))
 		COOLDOWN_START(src, severe_cooldown, 10 SECONDS)
 	if(prob(emp_vulnerability/severity)) //Chance of permanent effects
 		organ_flags |= ORGAN_EMP //Starts organ faliure - gonna need replacing soon.


### PR DESCRIPTION
## About The Pull Request

EMP effects against specifically only robotic bodyparts and cybernetic organs get weaker if their severity is weaker. In general, a lower severity leads to a lower duration or a lower intensity in the case of taking damage. If the effect is strong even at low durations (like how any duration of knockdown makes you drop items) then it was moved to a scaling probability of occuring as well.

Also adds emp_protection, like flash_protection but with a slightly hackier implementation. It adds to the severity (higher severity value = weaker emp). Regular mod emp shield module has 1 emp_protection, so does adamantine armor because it's like, several inches of metal I bet, and tesla has 1 as well.

Also something to note is that suit sensors only break when hit by heavy EMPs, so with any amount of emp_protection those won't break.

## Why It's Good For The Game

Something something flux heart bad and EMPs are too binary, I think making more use out of severity is a good idea.

## Changelog

:cl:
balance: robotic limbs, organs, and cybernetic implants have their emp effects scale more closely with emp severity.
balance: reactive tesla armor, adamantine armor, the mod emp shield module, and tinfoil hats slightly lower the severity of incoming EMPs.
/:cl:
