### PR TITLE
Implements the BT diffing tool built into BehaviorTreeG

### DIFF
--- a/.github/workflows/bt_diff.yml
+++ b/.github/workflows/bt_diff.yml
@@ -1,0 +1,28 @@
+# Renders the diffs and uploads them to filehouse
+name: Behavior tree diff
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  render:
+    name: Render behavior tree diffs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Render diffs
+        uses: CabinetOnFire/BehaviorTreeG2@main
+        with:
+          mode: render
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload rendered diffs
+        uses: actions/upload-artifact@v4
+        with:
+          name: bt-diff
+          path: bt-diff-out
+          if-no-files-found: ignore

--- a/.github/workflows/bt_diff.yml
+++ b/.github/workflows/bt_diff.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Render diffs
-        uses: tgstation/BehaviorTreeG2@main
+        uses: tgstation/BehaviorTreeG@main
         with:
           mode: render
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bt_diff.yml
+++ b/.github/workflows/bt_diff.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Render diffs
-        uses: CabinetOnFire/BehaviorTreeG2@main
+        uses: tgstation/BehaviorTreeG2@main
         with:
           mode: render
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bt_diff_comment.yml
+++ b/.github/workflows/bt_diff_comment.yml
@@ -26,7 +26,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload images and comment
-        uses: tgstation/BehaviorTreeG2@main
+        uses: tgstation/BehaviorTreeG@main
         with:
           mode: publish
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bt_diff_comment.yml
+++ b/.github/workflows/bt_diff_comment.yml
@@ -1,0 +1,33 @@
+# Uploads the rendered images and posts the PR comment. Runs on workflow_run.
+name: Behavior tree diff comment
+
+on:
+  workflow_run:
+    workflows: ["Behavior tree diff"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    name: Post behavior tree diff comment
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download rendered diffs
+        uses: actions/download-artifact@v4
+        with:
+          name: bt-diff
+          path: bt-diff-out
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload images and comment
+        uses: CabinetOnFire/BehaviorTreeG2@main
+        with:
+          mode: publish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          file-house-key: ${{ secrets.FILE_HOUSE_KEY }}

--- a/.github/workflows/bt_diff_comment.yml
+++ b/.github/workflows/bt_diff_comment.yml
@@ -26,7 +26,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload images and comment
-        uses: CabinetOnFire/BehaviorTreeG2@main
+        uses: tgstation/BehaviorTreeG2@main
         with:
           mode: publish
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

## About The Pull Request

Finished up a diff tool for the Behavior Tree editor which renders the tree into an SVG which we then send to file.house and then post via a comment, (Similar to screenshot tests)

It reports:

- Changes to values
- New nodes
- Removal of nodes

so in theory you should be able to see important changes. It's not perfect but should make it easier to catch big issues from the PR body.

<img width="1780" height="1634" alt="image" src="https://github.com/user-attachments/assets/0a2860c7-7403-47e6-a511-488f945eed8c" />

This is what the post appears like right now. You can double-click the images and get a nice zoomed in view.

<img width="914" height="852" alt="image" src="https://github.com/user-attachments/assets/e2db06bd-a072-465b-ac8e-0cec5c78bc22" />


## Why It's Good For The Game

Reading BT jsons is not really ideal, and noone is going to actually grab your branch and look at it via the extension, so this offers a nice solution.


