### PR TITLE
No seeds for abstract food, unit test for edible food only checks valid types

### DIFF
--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -6,7 +6,6 @@
 	abstract_type = /obj/item/food/grown/citrus
 	foodtypes = FRUIT
 	wine_power = 30
-	seed = /obj/item/seeds/lime
 
 // Lime
 /obj/item/seeds/lime

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -1,5 +1,4 @@
 /obj/item/food/grown/melonlike
-	seed = /obj/item/seeds/watermelon
 	name = "melon?"
 	desc = "You felt like this was a melon, but it definitely isn't. You should tell somebody about this."
 	icon_state = "watermelon"

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -1,5 +1,4 @@
 /obj/item/food/grown/carrotlike
-	seed = /obj/item/seeds/carrot
 	name = "carrot?"
 	desc = "What is this? It's not a carrot, that's for sure. You should tell someone about this."
 	icon_state = "carrot"

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -241,22 +241,26 @@
 //SNACKS
 
 /obj/item/food/grown/ash_flora
-	name = "mushroom shavings"
-	desc = "Some shavings from a tall mushroom. With enough, might serve as a bowl."
+	name = "unidentified bits of a wierd plant"
+	desc = "What's this? An intruder, is what it is. Tell somebody about this."
 	icon = 'icons/obj/mining_zones/ash_flora.dmi'
 	icon_state = "mushroom_shavings"
 	abstract_type = /obj/item/food/grown/ash_flora
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
-	seed = /obj/item/seeds/lavaland/polypore
-	wine_power = 20
 	foodtypes = VEGETABLES
 
 /obj/item/food/grown/ash_flora/Initialize(mapload)
 	. = ..()
 	pixel_x = base_pixel_x + rand(-4, 4)
 	pixel_y = base_pixel_y + rand(-4, 4)
+
+/obj/item/food/grown/ash_flora/shavings
+	name = "mushroom shavings"
+	desc = "Some shavings from a tall mushroom. With enough, might serve as a bowl."
+	seed = /obj/item/seeds/lavaland/polypore
+	wine_power = 20
 
 /obj/item/food/grown/ash_flora/shavings/grind_results()
 	return list(/datum/reagent/toxin/mushroom_powder = 5)

--- a/code/modules/unit_tests/food_edibility_check.dm
+++ b/code/modules/unit_tests/food_edibility_check.dm
@@ -3,13 +3,10 @@
 
 /datum/unit_test/food_edibility_check/Run()
 	var/list/not_food = list(
-		/obj/item/food/grown,
-		/obj/item/food/grown/mushroom,
 		/obj/item/food/clothing,
-		/obj/item/food/meat/slab/human/mutant,
 	)
 
-	var/list/food_paths = subtypesof(/obj/item/food) - not_food
+	var/list/food_paths = valid_subtypesof(/obj/item/food) - not_food
 
 	for(var/food_path in food_paths)
 		var/obj/item/food/spawned_food = allocate(food_path)


### PR DESCRIPTION

## About The Pull Request

in #96984 Ghommie spoke of how there's not supposed to be seeds in abstract plants, but when you take out the seed it runtimes in the edible food unit test because they're not removing abstract types. This is the same reason that I snuck by seeds in abstract melons and carrots. This pr removes seeds in already-existing abstract plants, and makes the unit test only check `valid_typesof()`. 

## Why It's Good For The Game

Damned if you do, damned if you don't. 

## Changelog
:cl:
code: Edible food unit test doesn't check abstract type food, abstract type food doesn't have seeds.
/:cl:
