### PR TITLE
Minor adjustment to tree felling

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -287,6 +287,9 @@
  *********/
 //Can *you* speak their language?
 
+/// The amount of extra range (in tiles) given to trees upon falling.
+#define TREE_FALL_EXTRARANGE 5
+
 /obj/structure/flora/tree
 	name = "tree"
 	desc = "A large tree."
@@ -321,13 +324,15 @@
 /obj/structure/flora/tree/harvest(mob/living/user, product_amount_multiplier)
 	. = ..()
 	var/turf/my_turf = get_turf(src)
-	playsound(my_turf, 'sound/effects/meteorimpact.ogg', 100 , FALSE, FALSE)
+	if(has_gravity(my_turf)) // If a tree falls in the forest, it makes a sound unless it doesn't have gravity.
+		playsound(my_turf, 'sound/effects/meteorimpact.ogg', 100 , FALSE, extrarange = TREE_FALL_EXTRARANGE, ignore_walls = TRUE)
 	var/obj/structure/flora/tree/stump/new_stump = new(my_turf)
 	new_stump.name = "[name] stump"
 
 /obj/structure/flora/tree/uproot(mob/living/user)
 	..()
-	playsound(get_turf(src), 'sound/effects/meteorimpact.ogg', 100 , FALSE, FALSE)
+	if(has_gravity(get_turf(src)))
+		playsound(get_turf(src), 'sound/effects/meteorimpact.ogg', 100 , FALSE, extrarange = TREE_FALL_EXTRARANGE, ignore_walls = TRUE)
 
 /obj/structure/flora/tree/stump
 	name = "stump"
@@ -540,6 +545,8 @@
 	. = ..()
 	icon_state = "palm[rand(1,2)]"
 	update_appearance()
+
+#undef TREE_FALL_EXTRARANGE
 
 /*********
  * Grass *

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -325,14 +325,14 @@
 	. = ..()
 	var/turf/my_turf = get_turf(src)
 	if(has_gravity(my_turf)) // If a tree falls in the forest, it makes a sound unless it doesn't have gravity.
-		playsound(my_turf, 'sound/effects/meteorimpact.ogg', 100 , FALSE, extrarange = TREE_FALL_EXTRARANGE, ignore_walls = TRUE)
+		playsound(my_turf, 'sound/effects/meteorimpact.ogg', 100 , FALSE, extrarange = TREE_FALL_EXTRARANGE)
 	var/obj/structure/flora/tree/stump/new_stump = new(my_turf)
 	new_stump.name = "[name] stump"
 
 /obj/structure/flora/tree/uproot(mob/living/user)
 	..()
 	if(has_gravity(get_turf(src)))
-		playsound(get_turf(src), 'sound/effects/meteorimpact.ogg', 100 , FALSE, extrarange = TREE_FALL_EXTRARANGE, ignore_walls = TRUE)
+		playsound(get_turf(src), 'sound/effects/meteorimpact.ogg', 100 , FALSE, extrarange = TREE_FALL_EXTRARANGE)
 
 /obj/structure/flora/tree/stump
 	name = "stump"


### PR DESCRIPTION

## About The Pull Request
This PR ~~sets `ignore_walls` to `TRUE` on tree felling sounds~~ gives tree felling sounds five tiles of extra range and makes them _not_ occur in zero gravity.
## Why It's Good For The Game
I think this increases generic verisimilitude. Trees are large and (if influenced by gravity such that they may fall) loud.
## Changelog
:cl:
fix: If a tree "falls" in zero gravity, it doesn't make a sound.
balance: The sound of tree felling has a bit more range.
/:cl:
