### PR TITLE
Refactors ruin load order to make sure they spawn after map generation

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_homestead.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_homestead.dmm
@@ -321,7 +321,7 @@
 	},
 /area/ruin/powered/shuttle)
 "Sv" = (
-/turf/open/genturf,
+/turf/template_noop,
 /area/icemoon/underground/unexplored/rivers)
 "SJ" = (
 /obj/structure/railing{

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
@@ -1523,7 +1523,7 @@
 /turf/open/floor/iron/edge,
 /area/ruin/plasma_facility/commons)
 "AG" = (
-/turf/open/genturf,
+/turf/template_noop,
 /area/icemoon/underground/unexplored/rivers)
 "AT" = (
 /obj/structure/lattice/catwalk,

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_comms_agent.dmm
@@ -657,9 +657,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/parquet,
 /area/ruin/comms_agent)
-"KQ" = (
-/turf/open/genturf,
-/area/template_noop)
 "KR" = (
 /obj/effect/baseturf_helper/asteroid/snow,
 /turf/closed/wall,
@@ -2875,7 +2872,7 @@ MH
 MH
 MH
 MH
-KQ
+OM
 tl
 YX
 YX
@@ -2931,8 +2928,8 @@ MH
 MH
 MH
 MH
-KQ
-KQ
+OM
+OM
 tl
 tl
 MH
@@ -2988,9 +2985,9 @@ MH
 MH
 MH
 MH
-KQ
-KQ
-KQ
+OM
+OM
+OM
 tl
 tl
 MH
@@ -3046,8 +3043,8 @@ PC
 MH
 MH
 MH
-KQ
-KQ
+OM
+OM
 tl
 MH
 MH
@@ -3104,7 +3101,7 @@ sB
 MH
 MH
 MH
-KQ
+OM
 MH
 MH
 OM

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_frozen_comms.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_frozen_comms.dmm
@@ -4,7 +4,7 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "aU" = (
-/turf/open/genturf,
+/turf/template_noop,
 /area/icemoon/underground/unexplored/rivers)
 "bh" = (
 /mob/living/basic/mining/wolf,

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -163,10 +163,10 @@ SUBSYSTEM_DEF(mapping)
 
 	// Run map generation after ruin space is reserved, since this space is used for the cave gen.
 	run_map_terrain_generation()
-	// Now that terrain generation is done, actually load the ruin maps in.
-	load_reserved_ruins()
 	// Generate our rivers, we do this here so the map doesn't load on top of them
 	setup_rivers()
+	// Now that terrain generation is done, actually load the ruin maps in.
+	load_reserved_ruins()
 	// now that the terrain is generated, including rivers, we can safely populate it with objects and mobs
 	run_map_terrain_population()
 	// Add the first transit level

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -20,6 +20,9 @@ SUBSYSTEM_DEF(mapping)
 	///Assoc list of all ruins spawned, key center of ruin spawn -> value ruin instance
 	var/list/active_ruins = alist()
 
+	///Ordered list of ruins that have been reserved. Each entry is list(ruin template, central turf, clear_below). Populated by seedRuins(), consumed by load_reserved_ruins().
+	var/list/reserved_ruins = list()
+
 	///List of ruins, separated by their theme
 	var/list/themed_ruins = list()
 
@@ -161,8 +164,10 @@ SUBSYSTEM_DEF(mapping)
 	loading_ruins = FALSE
 #endif
 
-	// Run map generation after ruin generation to prevent issues
+	// Run map generation after ruin space is reserved, since this space is used for the cave gen.
 	run_map_terrain_generation()
+	// Now that terrain generation is done, actually load the ruin maps in.
+	load_reserved_ruins()
 	// Generate our rivers, we do this here so the map doesn't load on top of them
 	setup_rivers()
 	// now that the terrain is generated, including rivers, we can safely populate it with objects and mobs
@@ -275,6 +280,15 @@ SUBSYSTEM_DEF(mapping)
 		// Create a proportional budget by multiplying the amount of space ruin levels in the current map over the default amount
 		var/proportional_budget = round(CONFIG_GET(number/space_budget) * (space_ruins.len / DEFAULT_SPACE_RUIN_LEVELS))
 		seedRuins(space_ruins, proportional_budget, list(/area/space), themed_ruins[ZTRAIT_SPACE_RUINS], mineral_budget = 0, ruins_type = ZTRAIT_SPACE_RUINS)
+
+///loads all of the ruins we previously reserved space for
+/datum/controller/subsystem/mapping/proc/load_reserved_ruins()
+	for(var/list/reservation in reserved_ruins)
+		var/datum/map_template/ruin/reserved_ruin = reservation[1]
+		var/turf/central_turf = reservation[2]
+		var/clear_below = reservation[3]
+		reserved_ruin.load_reserved(central_turf, clear_below)
+	reserved_ruins.Cut()
 
 /// Sets up rivers, and things that behave like rivers. So lava/plasma rivers, and chasms
 /// It is important that this happens AFTER generating mineral walls and such, since we rely on them for river logic

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -58,7 +58,6 @@ SUBSYSTEM_DEF(mapping)
 	/// The largest plane offset we've generated so far
 	var/max_plane_offset = 0
 
-	var/loading_ruins = FALSE
 	var/list/turf/unused_turfs = list() //Not actually unused turfs they're unused but reserved for use for whatever requests them. "[zlevel_of_turf]" = list(turfs)
 	var/list/datum/turf_reservations //list of turf reservations
 	var/list/used_turfs = list() //list of turf = datum/turf_reservation
@@ -159,9 +158,7 @@ SUBSYSTEM_DEF(mapping)
 	else if (SSmapping.current_map.load_all_away_missions) // we're likely in a local testing environment, so punch it.
 		load_all_away_missions()
 
-	loading_ruins = TRUE
 	setup_ruins()
-	loading_ruins = FALSE
 #endif
 
 	// Run map generation after ruin space is reserved, since this space is used for the cave gen.

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -287,8 +287,19 @@ SUBSYSTEM_DEF(mapping)
 		var/datum/map_template/ruin/reserved_ruin = reservation[1]
 		var/turf/central_turf = reservation[2]
 		var/clear_below = reservation[3]
-		reserved_ruin.load_reserved(central_turf, clear_below)
+		load_ruin_now(reserved_ruin, central_turf, clear_below)
 	reserved_ruins.Cut()
+
+/**
+ * Immediately loads a single reserved ruin's map, and runs terrain generation for any
+ * of the areas, since they get spawned AFTER normal terrain gen runs its pass
+ */
+/datum/controller/subsystem/mapping/proc/load_ruin_now(datum/map_template/ruin/reserved_ruin, turf/central_turf, clear_below)
+	var/starting_area_count = GLOB.areas.len
+	reserved_ruin.load_reserved(central_turf, clear_below)
+	for(var/i in starting_area_count + 1 to GLOB.areas.len)
+		var/area/ruin_area = GLOB.areas[i]
+		ruin_area.RunTerrainGeneration()
 
 /// Sets up rivers, and things that behave like rivers. So lava/plasma rivers, and chasms
 /// It is important that this happens AFTER generating mineral walls and such, since we rely on them for river logic

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -629,7 +629,7 @@ ADMIN_VERB(place_ruin, R_DEBUG, "Spawn Ruin", "Attempt to randomly place a speci
 			return
 
 	var/len = GLOB.ruin_landmarks.len
-	seedRuins(SSmapping.levels_by_trait(data[2]), max(1, template.cost), data[3], list(ruinname = template))
+	seedRuins(SSmapping.levels_by_trait(data[2]), max(1, template.cost), data[3], list(ruinname = template), immediate_load = TRUE)
 	if (GLOB.ruin_landmarks.len > len)
 		var/obj/effect/landmark/ruin/landmark = GLOB.ruin_landmarks[GLOB.ruin_landmarks.len]
 		log_admin("[key_name(user)] randomly spawned ruin [ruinname] at [COORD(landmark)].")

--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -224,7 +224,7 @@
 			SSmapping.active_ruins[locate(bottom_left_x, bottom_left_y, placed_turf.z)] = current_pick
 
 			if(immediate_load)
-				current_pick.load_reserved(placed_turf, clear_below)
+				SSmapping.load_ruin_now(current_pick, placed_turf, clear_below)
 			else
 				///Queue up the actual map load for after terrain generation, so cave/biome gen doesn't overwrite the ruin
 				SSmapping.reserved_ruins += list(list(current_pick, placed_turf, clear_below))

--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/proc/try_to_place(z, list/allowed_areas_typecache, turf/forced_turf, clear_below)
 	var/sanity = forced_turf ? 1 : PLACEMENT_TRIES
 	if(SSmapping.level_trait(z,ZTRAIT_ISOLATED_RUINS))
-		return place_on_isolated_level(z)
+		return reserve_isolated_level(z)
 	while(sanity > 0)
 		sanity--
 		var/width_border = TRANSITIONEDGE + SPACERUIN_MAP_EDGE_PAD + round(width / 2)
@@ -28,40 +28,42 @@
 		if(!valid)
 			continue
 
-		testing("Ruin \"[name]\" placed at ([central_turf.x], [central_turf.y], [central_turf.z])")
-
-		if(clear_below)
-			var/static/list/clear_below_typecache = typecacheof(list(
-				/obj/structure/spawner,
-				/mob/living/simple_animal,
-				/obj/structure/flora
-			))
-			for(var/turf/T as anything in affected_turfs)
-				for(var/atom/thing as anything in T)
-					if(clear_below_typecache[thing.type])
-						qdel(thing)
-
-		load(central_turf,centered = TRUE)
-		loaded++
+		testing("Ruin \"[name]\" reserved at ([central_turf.x], [central_turf.y], [central_turf.z])")
 
 		for(var/turf/T in affected_turfs)
 			T.turf_flags |= NO_RUINS
 
-		new /obj/effect/landmark/ruin(central_turf, src)
 		return central_turf
 
-/datum/map_template/ruin/proc/place_on_isolated_level(z)
+/datum/map_template/ruin/proc/reserve_isolated_level(z)
 	var/datum/turf_reservation/reservation = SSmapping.request_turf_block_reservation(width, height, 1, z) //Make the new level creation work with different traits.
 	if(!reservation)
 		return
 	var/turf/placement = reservation.bottom_left_turfs[1]
-	load(placement)
-	loaded++
 	for(var/turf/T in get_affected_turfs(placement))
 		T.turf_flags |= NO_RUINS
 	var/turf/center = locate(placement.x + round(width/2),placement.y + round(height/2),placement.z)
-	new /obj/effect/landmark/ruin(center, src)
 	return center
+
+///Loads a specified ruin that was previously reserved.
+/datum/map_template/ruin/proc/load_reserved(turf/central_turf, clear_below)
+	var/list/affected_turfs = get_affected_turfs(central_turf, 1)
+
+	if(clear_below)
+		var/static/list/clear_below_typecache = typecacheof(list(
+			/obj/structure/spawner,
+			/mob/living/simple_animal,
+			/obj/structure/flora
+		))
+		for(var/turf/T as anything in affected_turfs)
+			for(var/atom/thing as anything in T)
+				if(clear_below_typecache[thing.type])
+					qdel(thing)
+
+	load(central_turf, centered = TRUE)
+	loaded++
+
+	new /obj/effect/landmark/ruin(central_turf, src)
 
 /**
  * Loads the ruins for a given z level.
@@ -73,8 +75,9 @@
  * @param mineral_budget The budget to spend on ruins that spawn ore vents. Map templates with vents have that defined by mineral_cost.
  * @param mineral_budget_update What type of ore distribution should spawn from ruins picked by this cave generator? This list is copied from ores_spawned.dm into SSore_generation.ore_vent_minerals.
  * @param ruin_type The type of ruins that are spawning (ZTRAIT_SPACE_RUINS, ZTRAIT_ICE_RUINS, ZTRAIT_LAVA_RUINS, etc.)
+ * @param immediate_load If TRUE, loads the placed ruins' maps in right away instead of leaving them queued in SSmapping.reserved_ruins for terrain generation to run first. Only safe to use outside of the roundstart mapping init sequence, once terrain generation has already finished.
  */
-/proc/seedRuins(list/z_levels = null, budget = 0, whitelist = list(/area/space), list/potentialRuins, clear_below = FALSE, mineral_budget = 15, mineral_budget_update, ruins_type = ZTRAIT_STATION)
+/proc/seedRuins(list/z_levels = null, budget = 0, whitelist = list(/area/space), list/potentialRuins, clear_below = FALSE, mineral_budget = 15, mineral_budget_update, ruins_type = ZTRAIT_STATION, immediate_load = FALSE)
 #if defined(CIBUILDING) && !defined(OPENDREAM)
 	if(SSmapping.current_map.is_unit_test_map && PERFORM_ALL_TESTS(maptest_log_mapping) )
 		return log_mapping("Skipping ruin seeding due to running on unit test map in workflow enviorment.")
@@ -219,6 +222,12 @@
 
 			///Keep track of the active ruins so we can take it in account for map generation. Using bottom lef turf as key
 			SSmapping.active_ruins[locate(bottom_left_x, bottom_left_y, placed_turf.z)] = current_pick
+
+			if(immediate_load)
+				current_pick.load_reserved(placed_turf, clear_below)
+			else
+				///Queue up the actual map load for after terrain generation, so cave/biome gen doesn't overwrite the ruin
+				SSmapping.reserved_ruins += list(list(current_pick, placed_turf, clear_below))
 
 		//Update the available list
 		for(var/datum/map_template/ruin/R in ruins_available)


### PR DESCRIPTION

## About The Pull Request

Currently, we generate ruins, then do terrain generation. This means ruins get placed on top of genturf and if not set up correctly that can cause genturfs to pop up

Since ruins have some input on terrain gen nowadays, it made some sense. But we only really care about the map template, we dont need the actual map to be loaded in yet, so now we seed the ruins, then do terrain gen, then actually load the ruins on the map gen. I also removed an unused var.

terrain gen in ruins still work, as they call any areas they spawn their terrain gen manually.

## Why It's Good For The Game

hopefully less unit test fails and bugs

## Changelog
:cl:
refactor: Ruin loading should now be more robust and should spawn less orphaned genturfs
/:cl:
