### PR TITLE
QoL: Now you can place raptor eggs in lava without 4-degree burns and painful death. 

### DIFF
--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_egg.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_egg.dm
@@ -17,6 +17,7 @@
 
 /obj/item/food/egg/raptor_egg/Initialize(mapload)
 	. = ..()
+	AddElement(/datum/element/floor_placeable)
 	START_PROCESSING(SSobj, src)
 
 /obj/item/food/egg/raptor_egg/Destroy()


### PR DESCRIPTION
## About The Pull Request

Just add tag floor_placeable for raptor eggs so you can place them in any tile and even lava.

<img width="364" height="283" alt="dreamseeker_rABJuW1rmv" src="https://github.com/user-attachments/assets/8f87c719-f3d7-470d-a9b0-b1a506225f18" />

## Why It's Good For The Game

Code literally says you need to submerge raptor eggs in lava to speed up their grown rate. So why not. 

## Changelog
:cl:
qol: Raptor eggs now floor placeable (even in lava). It's now easier to immerse them in lava to accelerate their growth.

/:cl:
