### PR TITLE
Fixes tails/ears prefs changes not updating properly on the dummy

### DIFF
--- a/code/modules/client/preferences/species.dm
+++ b/code/modules/client/preferences/species.dm
@@ -27,9 +27,6 @@
 	return values
 
 /datum/preference/choiced/species/apply_to_human(mob/living/carbon/human/target, value)
-	if(value == target.dna.species.type) // we're already this species
-		return
-
 	target.set_species(value, icon_update = FALSE, pref_load = TRUE)
 
 /datum/preference/choiced/species/compile_constant_data()


### PR DESCRIPTION
## About The Pull Request

I introduced an error in https://github.com/tgstation/tgstation/pull/96999 . This PR is a partial revert.

We need to call `set_species()` even if our species is the same, because the tail pref exists.

Probably would be a good target to refactor someday so we can benefit from less needless dummy updates, but for now let's just revert this.

## Why It's Good For The Game

Fixes a slightly annoying bug

<details><summary>Works</summary>

<img width="683" height="541" alt="JPQ5cVtFEb" src="https://github.com/user-attachments/assets/6137c51e-61c9-4c65-9410-1438eaa324c4" />

</details>

## Changelog

:cl:
fix: fixed tails and ears not updating on your dummy when changing the pref until you change species or switch characters
/:cl:
