### PR TITLE
Makes fermenting barrels plumbable

### DIFF
--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -31,6 +31,7 @@
 /obj/structure/fermenting_barrel/Initialize(mapload)
 	. = ..()
 	create_reagents(600, DRAINABLE)
+	AddComponent(/datum/component/plumbing/tank)
 	soundloop = new(src, fermenting)
 	soundloop.volume = sound_volume
 	register_context()

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -181,6 +181,7 @@
 #include "emp_flashlight.dm"
 #include "ethereal_revival.dm"
 #include "explosion_action.dm"
+#include "fermenting_barrel_plumbing.dm"
 #include "firedoor_regions.dm"
 #include "fish_unit_tests.dm"
 #include "flyperson.dm"

--- a/code/modules/unit_tests/fermenting_barrel_plumbing.dm
+++ b/code/modules/unit_tests/fermenting_barrel_plumbing.dm
@@ -1,0 +1,7 @@
+/datum/unit_test/fermenting_barrel_plumbing/Run()
+	var/obj/structure/fermenting_barrel/barrel = allocate(/obj/structure/fermenting_barrel, run_loc_floor_bottom_left)
+	var/list/plumbing_components = barrel.GetComponents(/datum/component/plumbing/tank)
+	var/datum/component/plumbing/tank/barrel_plumbing = length(plumbing_components) ? plumbing_components[1] : null
+
+	TEST_ASSERT_NOTNULL(barrel_plumbing, "Fermenting barrel did not initialize with a plumbing tank component.")
+	TEST_ASSERT_EQUAL(barrel_plumbing.recipient_reagents_holder(), barrel.reagents, "Fermenting barrel plumbing component did not use the barrel's reagent holder.")


### PR DESCRIPTION
## About The Pull Request

Makes wooden fermenting barrels connectable to plumbing networks by adding the existing bidirectional plumbing tank component after their reagent holder is initialized. This provides reagent input and output while preserving the barrel's existing capacity and behavior.

Adds a unit test confirming that the barrel initializes with the plumbing component and that the component uses the barrel's reagent holder.

Fixes #97081

## Why It's Good For The Game

Wooden fermenting barrels behave like other reagent storage equipment, so allowing them to connect to plumbing makes their interactions consistent and enables automated brewing setups.

## Changelog

:cl:
qol: Wooden fermenting barrels can now connect to plumbing networks for reagent input and output.
/:cl:
