### PR TITLE
Attempts to fix mass pickup CI failure

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -783,7 +783,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	INVOKE_ASYNC(src, PROC_REF(collect_on_turf_loop), thing.loc, user, progress, rejections, collection_mode == COLLECT_SAME ? thing.type : null, success)
 
 /datum/storage/proc/collect_on_turf_loop(atom/holder, mob/user, datum/progressbar/progress, list/rejections, pick_up_type, list/success)
-	if (do_after(user, 1 SECONDS, parent, NONE, FALSE, CALLBACK(src, PROC_REF(handle_mass_pickuip), user, pick_up_type, holder, rejections, progress, success)))
+	if (do_after(user, 1 SECONDS, parent, NONE, FALSE, CALLBACK(src, PROC_REF(handle_mass_pickup), user, pick_up_type, holder, rejections, progress, success)))
 		INVOKE_ASYNC(src, PROC_REF(collect_on_turf_loop), holder, user, progress, rejections, pick_up_type, success)
 		return
 

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -536,15 +536,15 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
  *
  * Arguments
  * * mob/user - the user who is inserting the items
- * * list/things - the list of items to insert
+ * * list/pick_up_type - type to filter items by
  * * atom/thing_loc - the location of the items (used to make sure an item hasn't moved during pickup)
  * * list/rejections - a list used to make sure we only complain once about an invalid insertion
  * * datum/progressbar/progress - the progressbar used to show the progress of the insertion
+ * * list/success - list with a single element to use as a tracker for the amount of things we picked up
  */
-/datum/storage/proc/handle_mass_pickup(mob/user, list/things, atom/thing_loc, list/rejections, datum/progressbar/progress)
-	for(var/obj/item/thing in things)
-		things -= thing
-		if(thing.loc != thing_loc)
+/datum/storage/proc/handle_mass_pickup(mob/user, pick_up_type, atom/thing_loc, list/rejections, datum/progressbar/progress, list/success)
+	for(var/obj/item/thing in thing_loc)
+		if(!isnull(pick_up_type) && !istype(thing, pick_up_type))
 			continue
 		if(thing.type in rejections) // To limit bag spamming: any given type only complains once
 			continue
@@ -553,12 +553,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 				break
 			rejections += thing.type // therefore full bags are still a little spammy
 			continue
-
+		success[1] += 1
 		if (TICK_CHECK)
-			progress.update(progress.goal - things.len)
+			progress.update(success[1])
 			return TRUE
-
-	progress.update(progress.goal - things.len)
+	progress.update(success[1])
 	return FALSE
 
 /**
@@ -780,16 +779,17 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	var/datum/progressbar/progress = new(user, amount, thing.loc)
 	var/list/rejections = list()
+	var/list/success = list(0)
+	INVOKE_ASYNC(src, PROC_REF(collect_on_turf_loop), thing.loc, user, progress, rejections, collection_mode == COLLECT_SAME ? thing.type : null, success)
 
-	while(do_after(user, 1 SECONDS, parent, NONE, FALSE, CALLBACK(src, PROC_REF(handle_mass_pickup), user, pick_up.Copy(), thing.loc, rejections, progress)))
-		stoplag(1)
+/datum/storage/proc/collect_on_turf_loop(atom/holder, mob/user, datum/progressbar/progress, list/rejections, pick_up_type, list/success)
+	if (do_after(user, 1 SECONDS, parent, NONE, FALSE, CALLBACK(src, PROC_REF(handle_mass_pickuip), user, pick_up_type, holder, rejections, progress, success)))
+		INVOKE_ASYNC(src, PROC_REF(collect_on_turf_loop), holder, user, progress, rejections, pick_up_type, success)
+		return
 
 	progress.end_progress()
-	// If nothing was actually removed, don't send the pickup message
-	var/list/current_contents = holder.contents.Copy()
-	if(length(pick_up | current_contents) == length(current_contents))
-		return
-	parent.balloon_alert(user, "picked up")
+	if(success[1])
+		parent.balloon_alert(user, "picked up")
 
 /// Signal handler for whenever we drag the storage somewhere.
 /datum/storage/proc/on_mousedrop_onto(datum/source, atom/over_object, mob/user)


### PR DESCRIPTION

## About The Pull Request

Maybe? fixes the flaky we're getting from monkeys messing around with RPEDs and such, or at least make it mildly more resilient? Pulling it out into a datum that tracks deletions and uses destructible timers rather than sleep would be the only totally harddel proof solution and I want to see if this helps first