### PR TITLE
[FIX] Item interaction with spawners

### DIFF
--- a/code/game/objects/structures/spawner.dm
+++ b/code/game/objects/structures/spawner.dm
@@ -40,9 +40,10 @@
 		. += span_notice("It looks like you could probably scan and tag it with a <b>[scanner_descriptor]</b>.")
 
 /obj/structure/spawner/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	if(!scanner_taggable || !is_type_in_list(tool, scanner_types))
+	if(scanner_taggable && is_type_in_list(tool, scanner_types))
 		gps_tag(user)
 		return ITEM_INTERACT_SUCCESS
+
 	return NONE
 
 /// Tag the spawner, prefixing its GPS entry with an identifier - or giving it one, if nonexistent.


### PR DESCRIPTION

## About The Pull Request

After #96739 logic was wrong, for example causing attacks with spear causing to try imprint an holotag on them. This fixes this behavior and restores the previous logic
## Why It's Good For The Game

Bugfix.
## Changelog
:cl:
fix: you should be able to hit cave spawners with melee items again
/:cl:
