### PR TITLE
Fixes bot all access, and throwing medbots, and unit test

### DIFF
--- a/code/modules/mob/living/basic/bots/_bots.dm
+++ b/code/modules/mob/living/basic/bots/_bots.dm
@@ -114,7 +114,7 @@ GLOBAL_LIST_INIT(command_strings, list(
 /mob/living/basic/bot/Initialize(mapload)
 	. = ..()
 
-	add_traits(list(TRAIT_SILICON_ACCESS, TRAIT_REAGENT_SCANNER, TRAIT_UNOBSERVANT), INNATE_TRAIT)
+	add_traits(list(TRAIT_REAGENT_SCANNER, TRAIT_UNOBSERVANT), INNATE_TRAIT)
 	AddElement(/datum/element/ai_retaliate)
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(handle_loop_movement))
 	RegisterSignal(src, COMSIG_ATOM_WAS_ATTACKED, PROC_REF(after_attacked))

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
@@ -349,3 +349,13 @@
 	name = "Scrubs, MD"
 	req_one_access = list(ACCESS_ROBOTICS, ACCESS_JANITOR, ACCESS_MEDICAL)
 	bot_mode_flags = ~(BOT_MODE_ON | BOT_MODE_REMOTE_ENABLED)
+	additional_access = /datum/id_trim/job/janitor/medical_cleanbot
+
+/datum/id_trim/job/janitor/medical_cleanbot
+	minimal_access = list(
+		ACCESS_JANITOR,
+		ACCESS_MAINT_TUNNELS,
+		ACCESS_MINERAL_STOREROOM,
+		ACCESS_SERVICE,
+		ACCESS_MEDICAL,
+	)

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -12,7 +12,7 @@
 	light_power = 0.8
 	light_color = "#99ccff"
 	pass_flags = PASSMOB | PASSFLAPS
-	status_flags = (CANPUSH | CANSTUN)
+	status_flags = CANSTUN
 	ai_controller = /datum/ai_controller/basic_controller/bot/medbot
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 6.3, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 2.5)
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -127,6 +127,7 @@
 #include "blood_volume_procs.dm"
 #include "bloody_footprints.dm"
 #include "borg_tools.dm"
+#include "bot_access.dm"
 #include "boulder_processing.dm"
 #include "breath.dm"
 #include "buckle.dm"

--- a/code/modules/unit_tests/bot_access.dm
+++ b/code/modules/unit_tests/bot_access.dm
@@ -2,7 +2,6 @@
 /datum/unit_test/bot_access
 
 /datum/unit_test/bot_access/Run()
-	var/list/throwable_bots = list()
 	var/list/access_bypassing_bots = list()
 	var/obj/machinery/door/airlock/instant/impassable_door = allocate(/obj/machinery/door/airlock/instant, get_step(run_loc_floor_bottom_left, EAST))
 
@@ -11,15 +10,9 @@
 	var/mob/living/basic/bot/bot_to_check
 	for(var/bot_type in valid_subtypesof(/mob/living/basic/bot))
 		bot_to_check = allocate(bot_type, run_loc_floor_bottom_left)
-		if(bot_to_check.status_flags & CANPUSH)
-			throwable_bots += bot_to_check.type
 		bot_to_check.Bump(impassable_door)
 		if(!impassable_door.density)
 			access_bypassing_bots += bot_to_check.type
 			impassable_door.close(TRUE)
 
-	if(throwable_bots.len)
-		TEST_FAIL("The following bots are throwable: [english_list(throwable_bots)]")
-
 	TEST_ASSERT(!access_bypassing_bots.len, "The following bots bypass access requirements: [english_list(access_bypassing_bots)]")
-

--- a/code/modules/unit_tests/bot_access.dm
+++ b/code/modules/unit_tests/bot_access.dm
@@ -1,0 +1,25 @@
+/// Tests whether bots have been made able to bypass access, as well as whether they've been made throwable. None should be at the moment, and if they should be, make an exception
+/datum/unit_test/bot_access
+
+/datum/unit_test/bot_access/Run()
+	var/list/throwable_bots = list()
+	var/list/access_bypassing_bots = list()
+	var/obj/machinery/door/airlock/instant/impassable_door = allocate(/obj/machinery/door/airlock/instant, get_step(run_loc_floor_bottom_left, EAST))
+
+	impassable_door.req_access = list("access nothing has")
+
+	var/mob/living/basic/bot/bot_to_check
+	for(var/bot_type in valid_subtypesof(/mob/living/basic/bot))
+		bot_to_check = allocate(bot_type, run_loc_floor_bottom_left)
+		if(bot_to_check.status_flags & CANPUSH)
+			throwable_bots += bot_to_check.type
+		bot_to_check.Bump(impassable_door)
+		if(!impassable_door.density)
+			access_bypassing_bots += bot_to_check.type
+			impassable_door.close(TRUE)
+
+	if(throwable_bots.len)
+		TEST_FAIL("The following bots are throwable: [english_list(throwable_bots)]")
+
+	TEST_ASSERT(!access_bypassing_bots.len, "The following bots bypass access requirements: [english_list(access_bypassing_bots)]")
+


### PR DESCRIPTION

## About The Pull Request

This was originally just about being able to use them as a walking ID card by throwing them, again, but apparently they're not supposed to have all access in the first place(#82678), unless I've missed a pr in the interim. No wonder they have those id cards, those were supposed to actually be restricting access. Who knew!

The unit test checks whether all valid `/bot/` subtypes can be thrown, and whether they bypass door access requirements.

Also, gives Scrubs MD medbay access so that he can escape from his birthplace

## Why It's Good For The Game

fixes #95966

## Changelog
:cl:
fix: medbots can no longer be thrown, all bots no longer have AA
/:cl:
