### PR TITLE
Fixes accessories still looking like they're equipped once they're removed

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -386,6 +386,7 @@
 	// Remove it from the list before detaching
 	LAZYREMOVE(attached_accessories, removed)
 	removed.detach(src, update)
+	update_appearance()
 
 /// Get a list of all accessory overlays
 /obj/item/clothing/under/proc/get_accessory_overlays()


### PR DESCRIPTION

## About The Pull Request
When removing an accessory (e.g. medals, pins, etc) we need to `update_appearance()` otherwise it still looks like we have it attached.

## Why It's Good For The Game
Fix a bug

## Changelog
:cl: PapaMichael
fix: It no longer looks like you have accessories attached after you've removed them.
/:cl:
