### PR TITLE
Fix flaky hard delete with cleanbots

### DIFF
--- a/code/datums/ai/generic_behaviors/acquire_target.dm
+++ b/code/datums/ai/generic_behaviors/acquire_target.dm
@@ -176,6 +176,8 @@
 		if(controller.can_reach_target(candidate, reach_distance, minimum_distance))
 			target = candidate
 			break
+		if(!async_still_valid())
+			return
 		controller.note_unreachable_target(candidate)
 	// If finish_action fired while we were sleeping, bail without touching anything.
 	if(!async_still_valid())


### PR DESCRIPTION

## About The Pull Request

If a cleanbot gets deleted midway through this proc it'll still call `note_unreachable_target` which sets a callback and hangs refs

## Why It's Good For The Game

<img width="1464" height="242" alt="image" src="https://github.com/user-attachments/assets/d0c444b4-5516-4615-9f1c-5f1da1d56cc7" />
<img width="1441" height="233" alt="image" src="https://github.com/user-attachments/assets/0676ffca-c3b0-4fed-b38f-bab42a514752" />


## Changelog

N/A