### PR TITLE
Clean up bottle smash code a little

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -27,7 +27,7 @@
 	if(ismob(thrower) && bartender_check(target, thrower) && throwingdatum)
 		return FALSE
 	var/splash_target = QDELETED(target) ? target.drop_location() : target
-	var/splash_thrower = ismob(thrower) ? thrower || throwingdatum?.get_thrower() : null
+	var/splash_thrower = ismob(thrower) ? thrower : null
 	splash_reagents(splash_target, splash_thrower, allow_closed_splash = TRUE)
 	var/obj/item/broken_bottle/broken = new (loc)
 	broken.mimic_broken(src, target, break_top)

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -17,22 +17,25 @@
 /obj/item/reagent_containers/cup/glass/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum, do_splash = TRUE)
 	. = ..()
 	if(!.) //if the bottle wasn't caught
-		var/mob/thrower = throwingdatum?.get_thrower()
-		if(!istype(thrower))
-			return
-		smash(hit_atom, thrower, throwingdatum)
+		smash(hit_atom, throwingdatum?.get_thrower(), throwingdatum)
 
-/obj/item/reagent_containers/cup/glass/proc/smash(atom/target, mob/thrower, datum/thrownthing/throwingdatum, break_top = FALSE)
+/obj/item/reagent_containers/cup/glass/proc/smash(atom/target, atom/thrower, datum/thrownthing/throwingdatum, break_top = FALSE)
 	if(!isGlass)
 		return
 	if(QDELING(src) || !target) //Invalid loc
 		return
-	if(bartender_check(target, thrower) && throwingdatum)
+	if(ismob(thrower) && bartender_check(target, thrower) && throwingdatum)
 		return
-	splash_reagents(QDELETED(target) ? target.drop_location() : target, thrower || throwingdatum?.get_thrower(), allow_closed_splash = TRUE)
-	var/obj/item/broken_bottle/B = new (loc)
-	B.mimic_broken(src, target, break_top)
+	var/splash_target = QDELETED(target) ? target.drop_location() : target
+	var/splash_thrower = ismob(thrower) ? thrower || throwingdatum?.get_thrower() : null
+	splash_reagents(splash_target, splash_thrower, allow_closed_splash = TRUE)
+	var/obj/item/broken_bottle/broken = new (loc)
+	broken.mimic_broken(src, target, break_top)
+	post_smash(target, thrower, throwingdatum, broken)
 	qdel(src)
+
+/obj/item/reagent_containers/cup/glass/proc/post_smash(atom/target, atom/thrower, datum/thrownthing/throwingdatum, obj/item/broken_bottle/broken)
+	return
 
 /obj/item/reagent_containers/cup/glass/bullet_act(obj/projectile/proj)
 	. = ..()
@@ -371,14 +374,6 @@
 		on_icon_reset = CALLBACK(src, PROC_REF(on_cup_reset)), \
 		base_container_type = /obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton, \
 	)
-
-/obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton/smash(atom/target, mob/thrower, datum/thrownthing/throwingdatum, break_top)
-	if(bartender_check(target, thrower) && throwingdatum)
-		return
-	splash_reagents(QDELETED(target) ? target.drop_location() : target, thrower || throwingdatum?.get_thrower(), allow_closed_splash = TRUE)
-	var/obj/item/broken_bottle/bottle_shard = new(drop_location())
-	bottle_shard.mimic_broken(src, target)
-	qdel(src)
 
 /obj/item/reagent_containers/cup/glass/colocup
 	name = "colo cup"

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -21,11 +21,11 @@
 
 /obj/item/reagent_containers/cup/glass/proc/smash(atom/target, atom/thrower, datum/thrownthing/throwingdatum, break_top = FALSE)
 	if(!isGlass)
-		return
+		return FALSE
 	if(QDELING(src) || !target) //Invalid loc
-		return
+		return FALSE
 	if(ismob(thrower) && bartender_check(target, thrower) && throwingdatum)
-		return
+		return FALSE
 	var/splash_target = QDELETED(target) ? target.drop_location() : target
 	var/splash_thrower = ismob(thrower) ? thrower || throwingdatum?.get_thrower() : null
 	splash_reagents(splash_target, splash_thrower, allow_closed_splash = TRUE)
@@ -33,6 +33,7 @@
 	broken.mimic_broken(src, target, break_top)
 	post_smash(target, thrower, throwingdatum, broken)
 	qdel(src)
+	return TRUE
 
 /obj/item/reagent_containers/cup/glass/proc/post_smash(atom/target, atom/thrower, datum/thrownthing/throwingdatum, obj/item/broken_bottle/broken)
 	return

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -161,7 +161,7 @@
 	else
 		user.visible_message(
 			span_warning("[user] smashes [src] [head_hitter ? "over [target]'s head" : "against [target]"]!"),
-			span_warning("[user] smashes [src] [head_hitter ? "over your head" : "against you"]!"),
+			span_warning("You smash [src] [head_hitter ? "over [target]'s head" : "against [target]"]!"),
 		)
 
 	// Finally, smash the bottle. This kills (del) the bottle and also does all the logging for us

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -125,20 +125,11 @@
 	volume = 50
 	custom_price = PAYCHECK_CREW * 0.9
 
-/obj/item/reagent_containers/cup/glass/bottle/smash(mob/living/target, mob/thrower, datum/thrownthing/throwingdatum, break_top)
-	if(bartender_check(target, thrower) && throwingdatum)
-		return FALSE
-	splash_reagents(target, thrower || throwingdatum?.get_thrower(), allow_closed_splash = TRUE)
-	var/obj/item/broken_bottle/broken = new(drop_location())
-	if(!throwingdatum && thrower)
-		thrower.put_in_hands(broken)
-	broken.mimic_broken(src, target, break_top)
+/obj/item/reagent_containers/cup/glass/bottle/post_smash(atom/target, atom/thrower, datum/thrownthing/throwingdatum, obj/item/broken_bottle/broken)
+	if(!throwingdatum && ismob(thrower))
+		astype(thrower, /mob).put_in_hands(broken)
 	broken.inhand_icon_state = broken_inhand_icon_state
-	if(message_in_a_bottle)
-		message_in_a_bottle.forceMove(drop_location())
-
-	qdel(src)
-	return TRUE
+	message_in_a_bottle?.forceMove(drop_location())
 
 /obj/item/reagent_containers/cup/glass/bottle/try_splash(mob/user, atom/target)
 	if(!isGlass)


### PR DESCRIPTION

## About The Pull Request

- Delete the `smash` override on `/obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton` because I have no idea why it exists, cartons of juice shouldn't be smashing into glass
- Remove the mob type check in `/obj/item/reagent_containers/cup/glass/throw_impact` because `smash` takes `atom` now
- Refactor `smash` to take `atom/thrower` and add an `ismob` check where needed
- Break the two args passed to `splash_reagents` into separate vars because the call was getting really long with the ternaries
- Add a `post_smash` proc called at the end of `smash` but before the `qdel`
- Change `/obj/item/reagent_containers/cup/glass/bottle` to use `post_smash` so it doesn't have to duplicate a bunch of code from `smash`

## Why It's Good For The Game

Glasses only smashing if a mob threw them (because of the type check in `throw_impact`) is stupid. Closes #97080 

## Changelog
:cl:
fix: Glasses will always smash when thrown around, not just if thrown by a mob
/:cl:
