### PR TITLE
Mute newscaster notices no longer play an animation 

### DIFF
--- a/code/game/machinery/newscaster/newscaster_data.dm
+++ b/code/game/machinery/newscaster/newscaster_data.dm
@@ -234,8 +234,9 @@ GLOBAL_LIST_EMPTY(request_list)
 		)
 		send2otherserver(html_decode(station_name()), channel_name, "create_news_article", additional_data = payload)
 
-	for(var/obj/machinery/newscaster/caster in GLOB.allCasters)
-		caster.news_alert(channel_name, update_alert)
+	if(update_alert)
+		for(var/obj/machinery/newscaster/caster as anything in GLOB.allCasters)
+			caster.news_alert(channel_name)
 	return new_article
 
 ///Submits a comment on the news network
@@ -259,9 +260,8 @@ GLOBAL_LIST_EMPTY(request_list)
 		wanted_issue.img = picture.picture_image
 		wanted_issue.photo_file = save_photo(picture.picture_image)
 	if(newMessage)
-		for(var/obj/machinery/newscaster/N in GLOB.allCasters)
+		for(var/obj/machinery/newscaster/N as anything in GLOB.allCasters)
 			N.news_alert()
-			N.update_appearance()
 
 /datum/feed_network/proc/delete_wanted()
 	wanted_issue.active = FALSE
@@ -269,7 +269,7 @@ GLOBAL_LIST_EMPTY(request_list)
 	wanted_issue.body = null
 	wanted_issue.scanned_user = null
 	wanted_issue.img = null
-	for(var/obj/machinery/newscaster/updated_newscaster in GLOB.allCasters)
+	for(var/obj/machinery/newscaster/updated_newscaster as anything in GLOB.allCasters)
 		updated_newscaster.update_appearance()
 
 /datum/feed_network/proc/save_photo(icon/photo)

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -637,12 +637,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 /obj/machinery/newscaster/proc/news_alert(channel)
 	if(channel)
 		alert = TRUE
+		say("Breaking news from [channel]!")
+		playsound(src, 'sound/machines/beep/twobeep_high.ogg', 75, TRUE)
 		update_appearance()
 		addtimer(CALLBACK(src, PROC_REF(remove_alert)), ALERT_DELAY, TIMER_UNIQUE|TIMER_OVERRIDE)
 
 	else
 		say("Attention! Wanted issue distributed!")
-		playsound(loc, 'sound/machines/warning-buzzer.ogg', 75, TRUE)
+		playsound(src, 'sound/machines/warning-buzzer.ogg', 75, TRUE)
 
 /**
  * Performs a series of sanity checks before giving the user confirmation to create a new feed_channel using channel_name, and channel_desc.

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -442,7 +442,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 
 		if("clearWantedIssue")
 			clear_wanted_issue(user)
-			for(var/obj/machinery/newscaster/other_newscaster in GLOB.allCasters)
+			for(var/obj/machinery/newscaster/other_newscaster as anything in GLOB.allCasters)
 				other_newscaster.update_appearance()
 				return TRUE
 
@@ -634,14 +634,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 /**
  * When a new feed message is made that will alert all newscasters, this causes the newscasters to sent out a spoken message as well as create a sound.
  */
-/obj/machinery/newscaster/proc/news_alert(channel, update_alert = TRUE)
+/obj/machinery/newscaster/proc/news_alert(channel)
 	if(channel)
 		alert = TRUE
-		if(update_alert)
-			say("Breaking news from [channel]!")
-			playsound(loc, 'sound/machines/beep/twobeep_high.ogg', 75, TRUE)
-			update_appearance()
-			addtimer(CALLBACK(src, PROC_REF(remove_alert)), ALERT_DELAY, TIMER_UNIQUE|TIMER_OVERRIDE)
+		update_appearance()
+		addtimer(CALLBACK(src, PROC_REF(remove_alert)), ALERT_DELAY, TIMER_UNIQUE|TIMER_OVERRIDE)
 
 	else if(!channel && update_alert)
 		say("Attention! Wanted issue distributed!")

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -640,7 +640,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 		update_appearance()
 		addtimer(CALLBACK(src, PROC_REF(remove_alert)), ALERT_DELAY, TIMER_UNIQUE|TIMER_OVERRIDE)
 
-	else if(!channel && update_alert)
+	else
 		say("Attention! Wanted issue distributed!")
 		playsound(loc, 'sound/machines/warning-buzzer.ogg', 75, TRUE)
 

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -636,12 +636,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
  */
 /obj/machinery/newscaster/proc/news_alert(channel, update_alert = TRUE)
 	if(channel)
+		alert = TRUE
 		if(update_alert)
 			say("Breaking news from [channel]!")
 			playsound(loc, 'sound/machines/beep/twobeep_high.ogg', 75, TRUE)
-		alert = TRUE
-		update_appearance()
-		addtimer(CALLBACK(src, PROC_REF(remove_alert)), ALERT_DELAY, TIMER_UNIQUE|TIMER_OVERRIDE)
+			update_appearance()
+			addtimer(CALLBACK(src, PROC_REF(remove_alert)), ALERT_DELAY, TIMER_UNIQUE|TIMER_OVERRIDE)
 
 	else if(!channel && update_alert)
 		say("Attention! Wanted issue distributed!")


### PR DESCRIPTION
## About The Pull Request

Right now if you send a news alert with `update_alert = FALSE` it'll skip the "new alert posted" speech / sfx but still update the newscasters appearance with a tiny 2x2 blinking light

Now it won't show the blinking light animation - I don't think many people noticed it regardless 

## Why It's Good For The Game

Updating newscasters is quite expensive 

<img width="827" height="337" alt="image" src="https://github.com/user-attachments/assets/f93c0ce6-f2b8-42da-a1f3-362abf43acae" />

## Changelog

:cl: Melbert
del: Newscasters no longer have tiny 2x2 pixel animation upon receiving a muted alert
/:cl:
