### PR TITLE
Move Loader MOD outside the QM's office in Delta Station

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -33548,11 +33548,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "ilx" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/suit_storage_unit/industrial/loader,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "ilG" = (
@@ -77416,6 +77415,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "tbJ" = (


### PR DESCRIPTION

## About The Pull Request
Moves the Loader MOD outside of the QM's office in Delta Station, and replaces the vacant space with a plant.
<img alt="image" src="https://github.com/user-attachments/assets/edc75c16-d318-4016-a0f8-aced05f84505" /><img  alt="image" src="https://github.com/user-attachments/assets/a6e49088-ec0d-42de-ab26-f468f9c1677d" />
## Why It's Good For The Game
Makes Delta consistent with every other map, such as Meta, where the Loader MOD is accessible to ordinary Cargo Techs
<img alt="image" src="https://github.com/user-attachments/assets/cbcd6a80-c0d6-4429-9723-e67eda83e7e3" />
## Changelog
:cl:
map: Moved Loader MODsuit outside of QM's office in DeltaStation
/:cl:
