### PR TITLE
Optimizes get_bodypart(s)

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -16,7 +16,7 @@
 	. = ..()
 
 	living_flags |= STOP_OVERLAY_UPDATE_BODY_PARTS
-
+	real_bodypart_cache.Cut()
 	QDEL_LIST(hand_bodyparts)
 	QDEL_LIST(organs)
 	QDEL_LIST(bodyparts)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -883,6 +883,8 @@
 
 	new_bodypart.on_adding(src)
 	bodyparts += new_bodypart
+	if(!IS_STUMP(new_bodypart))
+		real_bodypart_cache[new_bodypart.body_zone] = new_bodypart
 	new_bodypart.update_owner(src)
 
 	// Apply a bodypart effect or merge with an existing one, for stuff like plant limbs regenning in light
@@ -921,6 +923,7 @@
 
 	old_bodypart.on_removal(src)
 	bodyparts -= old_bodypart
+	real_bodypart_cache -= old_bodypart
 
 	switch(old_bodypart.body_part)
 		if(LEG_LEFT, LEG_RIGHT)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -923,7 +923,7 @@
 
 	old_bodypart.on_removal(src)
 	bodyparts -= old_bodypart
-	real_bodypart_cache -= old_bodypart
+	real_bodypart_cache -= old_bodypart.body_zone
 
 	switch(old_bodypart.body_part)
 		if(LEG_LEFT, LEG_RIGHT)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -64,6 +64,8 @@
 		/obj/item/bodypart/leg/right,
 		/obj/item/bodypart/leg/left,
 	)
+	/// Alist of (non-stump) bodyparts by their bodyzone for quick get_bodypart access
+	var/alist/real_bodypart_cache = alist()
 
 	/// A collection of arms (or actually whatever the fug /bodyparts you monsters use to wreck my systems)
 	var/list/hand_bodyparts = list()

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -13,13 +13,12 @@
 
 /mob/living/carbon/get_bodypart(zone = BODY_ZONE_CHEST, include_stumps = FALSE)
 	RETURN_TYPE(/obj/item/bodypart)
+	if (!include_stumps)
+		return real_bodypart_cache[zone]
 
 	for(var/obj/item/bodypart/bodypart as anything in bodyparts)
-		if(!include_stumps && IS_STUMP(bodypart))
-			continue
-		if(bodypart.body_zone != zone)
-			continue
-		return bodypart
+		if(bodypart.body_zone == zone)
+			return bodypart
 
 /**
  * Returns all bodyparts this mob has, optionally including stumps.
@@ -35,7 +34,14 @@
 		var/obj/item/bodypart/bodypart = get_bodypart(zone, include_stumps)
 		if(bodypart)
 			parts += bodypart
+	return parts
 
+/mob/living/carbon/get_bodyparts(include_stumps = FALSE)
+	if (include_stumps)
+		return bodyparts.Copy()
+	var/list/parts = list()
+	for (var/key, limb in real_bodypart_cache)
+		parts += limb
 	return parts
 
 /**
@@ -50,15 +56,6 @@
 	for(var/zone in get_all_limbs())
 		parts[zone] = get_bodypart(zone)
 	return parts
-
-///Returns TRUE/FALSE on whether the mob should have a limb in a given zone, used for species-restrictions.
-/mob/living/carbon/proc/should_have_limb(zone)
-	if(!zone || !dna)
-		return TRUE
-	var/datum/species/carbon_species = dna.species
-	if(zone in carbon_species.bodypart_overrides)
-		return TRUE
-	return FALSE
 
 /// Replaces a single limb and deletes the old one if there was one
 /mob/living/carbon/proc/del_and_replace_bodypart(obj/item/bodypart/new_limb, special)


### PR DESCRIPTION

## About The Pull Request

get_bodypart is one of the hottest procs in the codebase (top 20 in total time), and the hottest mob proc we have. Moving it to an alist lookup from a for loop should greatly speed up things. Also improved get_bodyparts for carbons and removed an unused proc while at it.

<img width="948" height="31" alt="image" src="https://github.com/user-attachments/assets/b89b60bb-1965-4a4b-8706-1529244f7a21" />

## Changelog
:cl:
code: Optimized bodypart code
/:cl:
