### PR TITLE
Clearly I own an air fryer: optimizes some really hot atmos procs

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -345,10 +345,8 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 /datum/gas_mixture/proc/copy_from_ratio(datum/gas_mixture/sample, partial = 1)
 	var/list/cached_moles = moles //accessing datum vars is slower than proc vars
 	var/list/sample_cached_moles = sample.moles
-
-	//remove all gases not in the sample
-	cached_moles &= sample_cached_moles
-
+	// Remove all gases (sample overrides our values anyways)
+	cached_moles.Cut()
 	temperature = sample.temperature
 	for(var/gas_id, amount in sample_cached_moles)
 		cached_moles[gas_id] = amount * partial

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -139,8 +139,8 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 	var/list/cached_moles_archive = moles_archive
 
 	temperature_archived = temperature
-	for(var/gas_id in cached_moles)
-		cached_moles_archive[gas_id] = cached_moles[gas_id]
+	for(var/gas_id, value in cached_moles)
+		cached_moles_archive[gas_id] = value
 
 	return TRUE
 
@@ -160,8 +160,8 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 	var/list/cached_moles = moles //accessing datum vars is slower than proc vars
 	var/list/cached_giver_moles = giver.moles
 	//gas transfer
-	for(var/gas_id in cached_giver_moles)
-		cached_moles[gas_id] += cached_giver_moles[gas_id]
+	for(var/gas_id, value in cached_giver_moles)
+		cached_moles[gas_id] += value
 
 	SEND_SIGNAL(src, COMSIG_GASMIX_MERGED)
 	return TRUE
@@ -184,8 +184,8 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 ///gases_moles is an associative list of gas species to their amount to be added
 /datum/gas_mixture/proc/adjust_multiple_gases(list/gases_moles)
 	var/cached_moles = moles
-	for(var/gas_id in gases_moles)
-		cached_moles[gas_id] += gases_moles[gas_id]
+	for(var/gas_id, value in gases_moles)
+		cached_moles[gas_id] += value
 	garbage_collect()
 
 
@@ -315,8 +315,8 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 	var/list/copy_cached_moles_archive = copy.moles_archive
 
 	copy.temperature = temperature
-	for(var/gas_id in cached_moles)
-		copy_cached_moles[gas_id] = cached_moles[gas_id]
+	for(var/gas_id, value in cached_moles)
+		copy_cached_moles[gas_id] = value
 		copy_cached_moles_archive[gas_id] = 0
 
 	return copy
@@ -334,8 +334,8 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 	cached_moles_archive.Cut()
 
 	temperature = sample.temperature
-	for(var/gas_id in sample_cached_moles)
-		cached_moles[gas_id] = sample_cached_moles[gas_id]
+	for(var/gas_id, value in sample_cached_moles)
+		cached_moles[gas_id] = value
 		cached_moles_archive[gas_id] = 0
 
 	return TRUE
@@ -350,9 +350,8 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 	cached_moles &= sample_cached_moles
 
 	temperature = sample.temperature
-	for(var/gas_id in sample_cached_moles)
-		cached_moles[gas_id] = sample_cached_moles[gas_id] * partial
-
+	for(var/gas_id, amount in sample_cached_moles)
+		cached_moles[gas_id] = amount * partial
 	return TRUE
 
 /// Performs air sharing calculations between two gas_mixtures

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -213,8 +213,8 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 	var/list/cached_removed_moles = removed.moles //accessing datum vars is slower than proc vars
 
 	removed.temperature = temperature
-	for(var/id in cached_moles)
-		cached_removed_moles[id] = QUANTIZE(cached_moles[id] * ratio)
+	for(var/id, value in cached_moles)
+		cached_removed_moles[id] = QUANTIZE(value * ratio)
 		cached_moles[id] -= cached_removed_moles[id]
 
 	garbage_collect()
@@ -235,8 +235,8 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 	var/list/cached_removed_moles = removed.moles //accessing datum vars is slower than proc vars
 
 	removed.temperature = temperature
-	for(var/id in cached_moles)
-		cached_removed_moles[id] = QUANTIZE(cached_moles[id] * ratio)
+	for(var/id, value in cached_moles)
+		cached_removed_moles[id] = QUANTIZE(value * ratio)
 		cached_moles[id] -= cached_removed_moles[id]
 
 	garbage_collect()
@@ -537,10 +537,10 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 			if((reqs["MIN_TEMP"] && temp < reqs["MIN_TEMP"]) || (reqs["MAX_TEMP"] && temp > reqs["MAX_TEMP"]))
 				continue
 
-			for(var/id in reqs)
+			for(var/id, value in reqs)
 				if (id == "MIN_TEMP" || id == "MAX_TEMP")
 					continue
-				if(cached_moles[id] < reqs[id])
+				if(cached_moles[id] < value)
 					continue reaction_loop
 
 			//at this point, all requirements for the reaction are satisfied. we can now react()
@@ -796,8 +796,7 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 
 	var/list/gases_to_check = acceptable_gas_bounds.Copy() // thank you spaceman
 	var/list/cached_moles = moles
-	for(var/id in cached_moles)
-		var/gas_moles = cached_moles[id]
+	for(var/id, gas_moles in cached_moles)
 		if(!(id in gases_to_check))
 			if(gas_moles > extraneous_gas_limit)
 				return FALSE

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -6,17 +6,16 @@
 	var/list/gas_types = subtypesof(/datum/gas)
 	ASSERT(GAS_TYPE_COUNT == length(gas_types),\
 		"GAS_TYPE_COUNT != length(subtypesof(gas_types)), if you added new gas please increment GAS_TYPE_COUNT")
-	for(var/gas_path in gas_types)
-		var/datum/gas/gas = gas_path
-		gas_info[META_GAS_SPECIFIC_HEAT][gas_path] = initial(gas.specific_heat)
-		gas_info[META_GAS_NAME][gas_path] = initial(gas.name)
-		gas_info[META_GAS_MOLES_VISIBLE][gas_path] = initial(gas.moles_visible)
+	for(var/datum/gas/gas_path as anything in gas_types)
+		gas_info[META_GAS_SPECIFIC_HEAT][gas_path] = initial(gas_path.specific_heat)
+		gas_info[META_GAS_NAME][gas_path] = initial(gas_path.name)
+		gas_info[META_GAS_MOLES_VISIBLE][gas_path] = initial(gas_path.moles_visible)
 		if (gas_info[META_GAS_MOLES_VISIBLE][gas_path])
-			gas_info[META_GAS_OVERLAY][gas_path] += generate_gas_overlays(0, SSmapping.max_plane_offset, gas)
-		gas_info[META_GAS_FUSION_POWER][gas_path] = initial(gas.fusion_power)
-		gas_info[META_GAS_DANGER][gas_path] = initial(gas.dangerous)
-		gas_info[META_GAS_ID][gas_path] = initial(gas.id)
-		gas_info[META_GAS_DESC][gas_path] = initial(gas.desc)
+			gas_info[META_GAS_OVERLAY][gas_path] += generate_gas_overlays(0, SSmapping.max_plane_offset, gas_path)
+		gas_info[META_GAS_FUSION_POWER][gas_path] = initial(gas_path.fusion_power)
+		gas_info[META_GAS_DANGER][gas_path] = initial(gas_path.dangerous)
+		gas_info[META_GAS_ID][gas_path] = initial(gas_path.id)
+		gas_info[META_GAS_DESC][gas_path] = initial(gas_path.desc)
 
 	/datum/gas_mixture::gas_meta = gas_info // save the reference to the list
 	return gas_info
@@ -35,8 +34,8 @@
 	var/list/meta_gas_id = GLOB.meta_gas_info[META_GAS_ID]
 	if(id in meta_gas_id)
 		return id
-	for(var/path in meta_gas_id)
-		if(meta_gas_id[path] == id)
+	for(var/path, meta_id in meta_gas_id)
+		if(meta_id == id)
 			return path
 	return ""
 

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -75,11 +75,11 @@
 		temperature = initial_temperature
 		gas -= "TEMP"
 	mix.Cut()
-	for(var/id in gas)
+	for(var/id, value in gas)
 		var/path = id
 		if(!ispath(path))
 			path = gas_id2path(path) //a lot of these strings can't have embedded expressions (especially for mappers), so support for IDs needs to stick around
-		mix[path] = text2num(gas[id])
+		mix[path] = text2num(value)
 
 	var/list/cached_moles = moles
 	var/list/cached_moles_archive = moles_archive

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -83,7 +83,7 @@
 
 	var/list/cached_moles = moles
 	var/list/cached_moles_archive = moles_archive
-	for(var/gas_id in mix)
-		cached_moles[gas_id] = cached_moles_archive[gas_id] = mix[gas_id]
+	for(var/gas_id, value in mix)
+		cached_moles[gas_id] = cached_moles_archive[gas_id] = value
 
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -1222,13 +1222,13 @@
 	if(total_not_antinoblium_moles < MINIMUM_MOLE_COUNT) // Clear up the remaining gases if this condition is met.
 		. = NO_REACTION
 		reaction_rate = total_not_antinoblium_moles
-	for(var/gas_id in cached_moles)
+	for(var/gas_id, value in cached_moles)
 		if(gas_id == /datum/gas/antinoblium)
 			continue
 		if(. == NO_REACTION) // Let the gases get properly cleared while avoiding potential division by 0.
 			cached_moles[gas_id] = 0
 			continue
-		cached_moles[gas_id] -= reaction_rate * cached_moles[gas_id] / total_not_antinoblium_moles
+		cached_moles[gas_id] -= reaction_rate * value / total_not_antinoblium_moles
 	cached_moles[/datum/gas/antinoblium] += reaction_rate
 
 	SET_REACTION_RESULTS(reaction_rate)

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -91,14 +91,14 @@
 	var/removal_ratio =  min(1, volume_rate / environment.volume)
 
 	var/total_moles_to_remove = 0
-	for(var/gas_id in cached_moles & scrubbing)
-		total_moles_to_remove += cached_moles[gas_id]
+	for(var/gas_id, value in cached_moles & scrubbing)
+		total_moles_to_remove += value
 
 	if(!total_moles_to_remove)//no gases to remove
 		return FALSE
 
-	for(var/gas_id in cached_moles & scrubbing)
-		var/transferred_moles = max(QUANTIZE(cached_moles[gas_id] * removal_ratio * (cached_moles[gas_id] / total_moles_to_remove)), min(MOLAR_ACCURACY*1000, cached_moles[gas_id]))
+	for(var/gas_id, value in cached_moles & scrubbing)
+		var/transferred_moles = max(QUANTIZE(value * removal_ratio * (value / total_moles_to_remove)), min(MOLAR_ACCURACY*1000, value))
 
 		filtered_out.moles[gas_id] += transferred_moles
 		cached_moles[gas_id] -= transferred_moles


### PR DESCRIPTION

## About The Pull Request

Replaces index iteration and list access to index-value iteration in hot (and not so hot) atmos procs, see #92926 for details and profiling comparison of access vs index-value iteration.
Should be especially noticeable in ``archive()``, some gains in ``copy()``/``copy_from()``/``copy_from_ratio()``, everything else has more costlier ops going on.
``copy_from_ratio()`` also did a useless ``&=`` on cached_moles, as all cached_sample_moles values would be assigned to it anyways, so we can just ``.Cut()`` it instead (Cut() is noticeably faster even on smaller lists)

## Changelog
:cl:
code: Optimized some hot atmos procs
/:cl:
