### PR TITLE
Make behavior tree compiler actually use bootstrap

### DIFF
--- a/tools/build/build.ts
+++ b/tools/build/build.ts
@@ -168,7 +168,8 @@ export const BehaviorTreeCompilerTarget = new Juke.Target({
     });
   },
   executes: async () => {
-    await Juke.exec('python', ['tools/build_bt.py']);
+    const suffix = process.platform == 'win32' ? '.bat' : '';
+    await Juke.exec(`tools/bootstrap/python${suffix}`, ['tools/build_bt.py']);
   },
 });
 


### PR DESCRIPTION

## About The Pull Request

#97040 only changed the vscode task not the actual call in Juke

## Why It's Good For The Game

We vendor python we should use vendored python

## Changelog

N/A
