### PR TITLE
Fix scrubbers not updating turfs

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -203,14 +203,16 @@
 	var/turf/open/us = loc
 	if(!istype(us))
 		return
-	scrub(us)
+	if(scrub(us))
+		us.air_update_turf(FALSE, FALSE)
 	if(widenet)
 		if(COOLDOWN_FINISHED(src, check_turfs_cooldown))
 			check_turfs()
 			COOLDOWN_START(src, check_turfs_cooldown, 2 SECONDS)
 
 		for(var/turf/tile in adjacent_turfs)
-			scrub(tile)
+			if (scrub(tile))
+				tile.air_update_turf(FALSE, FALSE)
 	return TRUE
 
 ///filtered gases at or below this amount automatically get removed from the mix

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -66,19 +66,22 @@
 
 	var/turf/epicentre = get_turf(src)
 	if(isopenturf(epicentre))
-		scrub(epicentre.return_air())
+		if(scrub(epicentre.return_air()))
+			epicentre.air_update_turf(FALSE, FALSE)
 	for(var/turf/open/openturf as anything in epicentre.get_atmos_adjacent_turfs(alldir = TRUE))
-		scrub(openturf.return_air())
+		if(scrub(openturf.return_air()))
+			openturf.air_update_turf(FALSE, FALSE)
 	return ..()
 
 /**
  * Called in process_atmos(), handles the scrubbing of the given gas_mixture
  * Arguments:
  * * mixture: the gas mixture to be scrubbed
+ * Returns: TRUE if anything was scrubbed, FALSE otherwise
  */
 /obj/machinery/portable_atmospherics/scrubber/proc/scrub(datum/gas_mixture/environment)
 	if(air_contents.return_pressure() >= overpressure_m * ONE_ATMOSPHERE)
-		return
+		return FALSE
 
 	var/list/cached_moles = environment.moles
 
@@ -106,6 +109,7 @@
 	environment.garbage_collect()
 	//Remix the resulting gases
 	air_contents.merge(filtered_out)
+	return TRUE
 
 /obj/machinery/portable_atmospherics/scrubber/emp_act(severity)
 	. = ..()
@@ -230,7 +234,8 @@
 	if(!holding)
 		var/turf/T = get_turf(src)
 		for(var/turf/AT in T.get_atmos_adjacent_turfs(alldir = TRUE))
-			scrub(AT.return_air())
+			if(scrub(AT.return_air()))
+				AT.air_update_turf(FALSE, FALSE)
 
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

This PR fixes following issue:
Portable scrubber does not update air around it. Overlays are not updating, gas does not move. See figure 1 for my testing setup. As you can see, there is no plasma in the air on the floor (2), but overlay is not updated. Also, on floor (1) there is pressure that is not moving towards (2).
By the means of `git bisect` i have found PR #84412 that broke scrubbers. The problem is that scrubber does not call `air_update_turf` on turfs that were scrubbed.

<img width="554" height="358" alt="Image" src="https://github.com/user-attachments/assets/20f2df4a-c156-451b-b081-e7a3f774dbd2" />
<br><sup>Figure 1. Scrubber not updating air.</sup><br>

Also fixes stationary scrubbers having similar issue. Fixes #70074.

## Changelog
:cl:
fix: Fix scrubber not updating turfs
/:cl:
