### PR TITLE
Tiny buff to spacers

### DIFF
--- a/code/_globalvars/lists/quirks.dm
+++ b/code/_globalvars/lists/quirks.dm
@@ -127,6 +127,6 @@ GLOBAL_LIST_INIT(quirk_chipped_choice, list(
 
 ///Spacer quirk
 GLOBAL_LIST_INIT(spacer_height_choices, list(
-	"Average" = HUMAN_HEIGHT_MEDIUM,
-	"Tall" = HUMAN_HEIGHT_TALLEST,
+	"Tall" = HUMAN_HEIGHT_TALLER,
+	"Extra Tall" = HUMAN_HEIGHT_TALLEST,
 ))

--- a/code/_globalvars/lists/quirks.dm
+++ b/code/_globalvars/lists/quirks.dm
@@ -127,6 +127,6 @@ GLOBAL_LIST_INIT(quirk_chipped_choice, list(
 
 ///Spacer quirk
 GLOBAL_LIST_INIT(spacer_height_choices, list(
-	"Tall" = HUMAN_HEIGHT_TALLER,
 	"Extra Tall" = HUMAN_HEIGHT_TALLEST,
+	"Tall" = HUMAN_HEIGHT_TALLER,
 ))

--- a/code/_globalvars/lists/quirks.dm
+++ b/code/_globalvars/lists/quirks.dm
@@ -124,3 +124,9 @@ GLOBAL_LIST_INIT(quirk_chipped_choice, list(
 	"Mast-Angl-Er" = /obj/item/skillchip/master_angler,
 	"Kommand" = /obj/item/skillchip/big_pointer,
 ))
+
+///Spacer quirk
+GLOBAL_LIST_INIT(spacer_height_choices, list(
+	"Average" = HUMAN_HEIGHT_MEDIUM,
+	"Tall" = HUMAN_HEIGHT_TALLEST,
+))

--- a/code/datums/quirks/positive_quirks/spacer.dm
+++ b/code/datums/quirks/positive_quirks/spacer.dm
@@ -17,8 +17,6 @@
 		/obj/item/storage/pill_bottle/ondansetron,
 		/obj/item/reagent_containers/applicator/pill/gravitum,
 	)
-	/// How high spacers get bumped up to
-	var/modded_height = HUMAN_HEIGHT_TALLEST
 	/// How long on a planet before we get averse effects
 	var/planet_period = 3 MINUTES
 	/// TimerID for time spend on a planet
@@ -36,6 +34,10 @@
 	VAR_FINAL/drift_mod = 0.75
 
 /datum/quirk/spacer_born/add(client/client_source)
+	var/modded_height = GLOB.spacer_height_choices[client_source?.prefs?.read_preference(/datum/preference/choiced/spacer_height)]
+	if(isnull(modded_height))
+		modded_height = GLOB.spacer_height_choices[pick(GLOB.spacer_height_choices)]
+
 	if(isdummy(quirk_holder))
 		var/mob/living/carbon/human/dummy_quirker = quirk_holder
 		dummy_quirker.set_mob_height(modded_height)

--- a/code/modules/client/preferences/spacer_born.dm
+++ b/code/modules/client/preferences/spacer_born.dm
@@ -1,0 +1,20 @@
+/datum/preference/choiced/spacer_height
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "spacer_height"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/choiced/spacer_height/init_possible_values()
+	return assoc_to_keys(GLOB.spacer_height_choices)
+
+/datum/preference/choiced/spacer_height/is_accessible(datum/preferences/preferences)
+	return ..() && (/datum/quirk/spacer_born::name in preferences.all_quirks)
+
+/datum/preference/choiced/spacer_height/create_default_value()
+	return init_possible_values()[1]
+
+/datum/quirk_constant_data/spacer_height
+	associated_typepath = /datum/quirk/spacer_born
+	customization_options = list(/datum/preference/choiced/spacer_height)
+
+/datum/preference/choiced/spacer_height/apply_to_human(mob/living/carbon/human/target, value)
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4257,6 +4257,7 @@
 #include "code\modules\client\preferences\silicon_gender.dm"
 #include "code\modules\client\preferences\skin_tone.dm"
 #include "code\modules\client\preferences\sounds.dm"
+#include "code\modules\client\preferences\spacer_born.dm"
 #include "code\modules\client\preferences\species.dm"
 #include "code\modules\client\preferences\statpanel.dm"
 #include "code\modules\client\preferences\status_bar.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/spacer_born.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/spacer_born.tsx
@@ -1,0 +1,7 @@
+import type { FeatureChoiced } from '../base';
+import { FeatureDropdownInput } from '../dropdowns';
+
+export const spacer_height: FeatureChoiced = {
+  name: 'Character Height',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
## About The Pull Request

Modified version of [this PR](https://github.com/NovaSector/NovaSector/pull/7699) that I figured I might as well try pushing to tg even if it's unlikely to get merged. 

Basically, spacers can choose their height. Unlike the nova version, there is no "random" option and you can't pick any height option in between taller and tallest (tallest is the current spacer height, taller was the height when they were originally added).

## Why It's Good For The Game

Small buff to spacers, you don't stick out like a sore thumb quite as much. Technically this also makes your hitbox just a bit smaller but I'm labeling this as qol anyways.
## Changelog

:cl:
qol: Spacers can choose their height a little
/:cl: