### PR TITLE
Fix Ghost Menu "Extra View Distance" showing 0 instead of the current view distance

### DIFF
--- a/code/modules/mob/dead/observer/ghost_menu.dm
+++ b/code/modules/mob/dead/observer/ghost_menu.dm
@@ -103,6 +103,9 @@ GLOBAL_DATUM_INIT(ghost_menu, /datum/ghost_menu, new)
 			"desc" = GLOB.poll_ignore_desc[key],
 		))
 
+	var/current_width = user.client?.view_size?.width || 0
+	data["current_extra_view"] = current_width > 0 ? (current_width - 1) / 2 : 0
+
 	data["hud_info"] = list(
 		list(
 			"name" = "Data HUDs",

--- a/tgui/packages/tgui/interfaces/GhostMenu.tsx
+++ b/tgui/packages/tgui/interfaces/GhostMenu.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
   Button,
   Dropdown,
@@ -19,6 +18,7 @@ type Data = {
   lag_switch_on: BooleanLike;
   notification_data: NotificationData[];
   max_extra_view: number;
+  current_extra_view: number;
   body_name: string;
   current_darkness: string;
   darkness_levels: string[];
@@ -166,10 +166,14 @@ const HudSection = (props) => {
 };
 
 const GhostSettingsSection = (props) => {
-  const [viewNumber, setviewNumber] = useState<number>(0);
   const { act, data } = useBackend<Data>();
-  const { current_darkness, darkness_levels, max_extra_view, lag_switch_on } =
-    data;
+  const {
+    current_darkness,
+    darkness_levels,
+    max_extra_view,
+    current_extra_view,
+    lag_switch_on,
+  } = data;
   return (
     <Stack vertical>
       <Stack.Item>
@@ -198,15 +202,14 @@ const GhostSettingsSection = (props) => {
           <NumberInput
             width="30px"
             step={1}
-            value={viewNumber}
+            value={current_extra_view}
             minValue={0}
             maxValue={max_extra_view}
-            onChange={(new_range) => {
-              setviewNumber(new_range);
+            onChange={(new_range) =>
               act('view_range', {
                 new_view_range: new_range,
-              });
-            }}
+              })
+            }
           />
         </Stack.Item>
       )}


### PR DESCRIPTION

## About The Pull Request

Does anyone but me even use this feature?

Anyway, whenever you opened the Ghost Menu, "Extra View Distance" showed "0" instead of your current extra view distance (meaning, if you moved it off of zero and wanted it back on zero, you'd have to do this awkward "move off of zero and then back on to zero" dance)

## Why It's Good For The Game

Fix a bug

## Changelog
:cl: PapaMichael
fix: The Ghost Menu's Extra View Distance field now remembers your current extra view distance between openings
/:cl:
