### PR TITLE
fix wine cids causing `/client/New()` to return early

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -439,18 +439,17 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 		if (SSstickyban && (computer_id in SSstickyban.ignored_cids))
 			message_admins("<B>MULTIKEYING: </B></span><span class='notice'>[key_name_admin(src)] Connecting player joined with IGNORED CID [computer_id].")
 			log_admin_private("MULTIKEYING: [key_name(src)] Connecting player joined with IGNORED CID [computer_id].")
-			return
-
-		// If the CID is not ignored, notify the player with the pop-up.
-		var/dupe_login_message = "Your ComputerID has already logged in with another key this round, please log out of this one NOW or risk being banned!"
-		// Notify admins if the connecting player's CID is a duplicate of another player's CID
-		if (alert_admin_multikey)
-			dupe_login_message += "\nAdmins have been informed."
-			message_admins(span_danger("<B>MULTIKEYING: </B></span><span class='notice'>[key_name_admin(src)] has a matching CID+IP with another player and is clearly multikeying. They have been warned to leave the server or risk getting banned."))
-			log_admin_private("MULTIKEYING: [key_name(src)] has a matching CID+IP with another player and is clearly multikeying. They have been warned to leave the server or risk getting banned.")
-		spawn(0.5 SECONDS) //needs to run during world init, do not convert to add timer
-			alert(mob, dupe_login_message) //players get banned if they don't see this message, do not convert to tgui_alert (or even tg_alert) please.
-			to_chat_immediate(mob, span_danger(dupe_login_message))
+		else
+			// If the CID is not ignored, notify the player with the pop-up.
+			var/dupe_login_message = "Your ComputerID has already logged in with another key this round, please log out of this one NOW or risk being banned!"
+			// Notify admins if the connecting player's CID is a duplicate of another player's CID
+			if (alert_admin_multikey)
+				dupe_login_message += "\nAdmins have been informed."
+				message_admins(span_danger("<B>MULTIKEYING: </B></span><span class='notice'>[key_name_admin(src)] has a matching CID+IP with another player and is clearly multikeying. They have been warned to leave the server or risk getting banned."))
+				log_admin_private("MULTIKEYING: [key_name(src)] has a matching CID+IP with another player and is clearly multikeying. They have been warned to leave the server or risk getting banned.")
+			spawn(0.5 SECONDS) //needs to run during world init, do not convert to add timer
+				alert(mob, dupe_login_message) //players get banned if they don't see this message, do not convert to tgui_alert (or even tg_alert) please.
+				to_chat_immediate(mob, span_danger(dupe_login_message))
 
 
 	connection_time = world.time


### PR DESCRIPTION

## About The Pull Request

for some reason, the wine cid ignore pr made it so those cids caused `/client/New()` to early return, before a bunch of other important client init stuff happened.

thanks to @flleeppyy for pointing this out <3

## Changelog
:cl:
fix: Fixed potential issues when connecting via Wine.
/:cl:
