### PR TITLE
Slightly optimizes ui_state

### DIFF
--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -111,14 +111,14 @@
 	// If the object is obscured or too far away, close it.
 	if (dist > 5 || (viewcheck && !(src_object in view(5, src))))
 		return UI_CLOSE
-	// Open and interact if 1-0 tiles away.
-	if(dist <= 1)
-		return UI_INTERACTIVE
-	// View only if 2-3 tiles away.
-	else if(dist <= 2)
+	// Disable if further than 2 tiles
+	if (dist > 2)
+		return UI_DISABLED
+	// Update but block interactions if further than a tile away
+	if (dist > 1)
 		return UI_UPDATE
-	// Disable if 5 tiles away.
-	return UI_DISABLED
+	// Open and interact if 1-0 tiles away.
+	return UI_INTERACTIVE
 
 /mob/living/carbon/human/shared_living_ui_distance(atom/movable/src_object, viewcheck = TRUE, allow_tk = TRUE)
 	if(allow_tk && dna.check_mutation(/datum/mutation/telekinesis) && tkMaxRangeCheck(src, src_object))

--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -106,10 +106,11 @@
 		var/obj/item/machine_remote/remote = item_in_hand
 		if(remote.controlling_machine_or_bot == src_object)
 			return UI_INTERACTIVE
-	// If the object is obscured, close it.
-	if(viewcheck && !(src_object in view(src)))
-		return UI_CLOSE
+
 	var/dist = get_dist(src_object, src)
+	// If the object is obscured or too far away, close it.
+	if (dist > 5 || (viewcheck && !(src_object in view(src, 5))))
+		return UI_CLOSE
 	// Open and interact if 1-0 tiles away.
 	if(dist <= 1)
 		return UI_INTERACTIVE
@@ -117,10 +118,7 @@
 	else if(dist <= 2)
 		return UI_UPDATE
 	// Disable if 5 tiles away.
-	else if(dist <= 5)
-		return UI_DISABLED
-	// Otherwise, we got nothing.
-	return UI_CLOSE
+	return UI_DISABLED
 
 /mob/living/carbon/human/shared_living_ui_distance(atom/movable/src_object, viewcheck = TRUE, allow_tk = TRUE)
 	if(allow_tk && dna.check_mutation(/datum/mutation/telekinesis) && tkMaxRangeCheck(src, src_object))

--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -109,7 +109,7 @@
 
 	var/dist = get_dist(src_object, src)
 	// If the object is obscured or too far away, close it.
-	if (dist > 5 || (viewcheck && !(src_object in view(src, 5))))
+	if (dist > 5 || (viewcheck && !(src_object in view(5, src))))
 		return UI_CLOSE
 	// Open and interact if 1-0 tiles away.
 	if(dist <= 1)


### PR DESCRIPTION

## About The Pull Request

A) We do not need to run the view() check if we're closing the UI due to distance anyways, 
B) We do not need to run the view() check beyond 5 tiles of distance as it defaults to our world's 15x15 view, which 7 tiles of distance
C) This code is pretty hot so reducing the view() check range should help a bit

## Changelog
:cl:
code: Optimized object TGUI code
/:cl:
