### PR TITLE
Fix compilation errors on BYOND 516.1685

### DIFF
--- a/code/game/objects/items/rcd/RWD.dm
+++ b/code/game/objects/items/rcd/RWD.dm
@@ -1,5 +1,6 @@
 //This represents the amount of materials (both iron and glass that the max_amount of cable would amount to
-#define MAX_CABLE_AMOUNT (SMALL_MATERIAL_AMOUNT * 0.1 * /obj/item/rwd/loaded::max_amount)
+#define RWD_MAX_CABLES_MATS (SMALL_MATERIAL_AMOUNT * 0.1 * RWD_MAX_CABLES)
+#define RWD_MAX_CABLES 210
 
 /obj/item/rwd
 	name = "rapid wiring device"
@@ -15,10 +16,13 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5 - MAX_CABLE_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT * 2.5 - MAX_CABLE_AMOUNT)
+	custom_materials = list(
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5 - RWD_MAX_CABLES_MATS,
+		/datum/material/glass = SHEET_MATERIAL_AMOUNT * 2.5 - RWD_MAX_CABLES_MATS,
+	)
 
 	/// maximum amount of cable this device can hold
-	var/max_amount = 210
+	var/max_amount = RWD_MAX_CABLES
 	/// current amount of cable in the machine
 	var/current_amount = 0
 	/// are we dual wielding this machine
@@ -32,7 +36,7 @@
 	/// radial menu to select cable layer
 	var/list/radial_menu = null
 
-#undef MAX_CABLE_AMOUNT
+#undef RWD_MAX_CABLES_MATS
 
 /obj/item/rwd/Initialize(mapload)
 	. = ..()
@@ -256,11 +260,11 @@
 
 /obj/item/rwd/loaded
 	icon_state = "rwd-30-layer2"
-	current_amount = 210
+	current_amount = RWD_MAX_CABLES
 
 /obj/item/rwd/admin
 	name = "admin RWD"
 	max_amount = INFINITY
 	current_amount = INFINITY
 
-
+#undef RWD_MAX_CABLES


### PR DESCRIPTION

## About The Pull Request

<img width="1223" height="157" alt="image" src="https://github.com/user-attachments/assets/37812955-1c19-42d8-9676-96eed71be8b1" />

Per Lummox, defining a variable based on a subtype's var is invalid, so using `/obj/item/rwd/loaded::max_amount` in `/obj/item/rwd/custom_materials` doesn't work. Adds a define for the actual `max_amount` number and uses that in the other macro, as well as the `max_amount` variable itself (and the loaded subtype's `current_amount` because it wasn't before)

## Why It's Good For The Game

Make the code compile on the latest BYOND

## Changelog

N/A
