### PR TITLE
Makes corpse spawners set species on init rather than after

### DIFF
--- a/code/datums/dna/dna.dm
+++ b/code/datums/dna/dna.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	///The blood type datum, usually a singleton
 	var/datum/blood_type/blood_type
 	///The type of mutant race the player is if applicable (i.e. potato-man)
-	var/datum/species/species = new /datum/species/human
+	var/datum/species/species = /datum/species/human
 	/// Assoc list of feature keys to their value
 	/// Note if you set these manually, and do not update [unique_features] afterwards, it will likely be reset.
 	var/list/features = list(FEATURE_MUTANT_COLOR = COLOR_WHITE)
@@ -57,9 +57,12 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	/// Weighted list of lethal meltdowns
 	var/static/list/fatal_meltdowns = list()
 
-/datum/dna/New(mob/living/new_holder)
+/datum/dna/New(mob/living/new_holder, datum/species/mob_species)
 	if(istype(new_holder))
 		holder = new_holder
+	if(mob_species)
+		species = mob_species
+	species = new species
 
 /datum/dna/Destroy()
 	if (iscarbon(holder))
@@ -470,8 +473,8 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 			if(allowed_sources)
 				dna.add_mutation(mutation, allowed_sources)
 
-/mob/living/carbon/proc/create_dna()
-	dna = new /datum/dna(src)
+/mob/living/carbon/proc/create_dna(datum/species/species)
+	dna = new /datum/dna(src, species)
 	if(!dna.species)
 		var/rando_race = pick(get_selectable_species())
 		dna.species = new rando_race()

--- a/code/datums/dna/dna.dm
+++ b/code/datums/dna/dna.dm
@@ -475,9 +475,6 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 
 /mob/living/carbon/proc/create_dna(datum/species/species)
 	dna = new /datum/dna(src, species)
-	if(!dna.species)
-		var/rando_race = pick(get_selectable_species())
-		dna.species = new rando_race()
 
 //proc used to update the mob's appearance after its dna UI has been changed
 //2025: Im unsure if dna is meant to be living, carbon, or human level.. there's contradicting stuff and bugfixes going back 8 years

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -7,7 +7,7 @@
 
 INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 
-/mob/living/carbon/human/dummy/Initialize(mapload)
+/mob/living/carbon/human/dummy/Initialize(mapload, datum/species/species)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_GODMODE, INNATE_TRAIT)
 	ADD_TRAIT(src, TRAIT_PREVENT_BLINKING, INNATE_TRAIT)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/human/Initialize(mapload)
+/mob/living/carbon/human/Initialize(mapload, datum/species/species)
 	ASSIGN_GAME_VERB(src, /mob/living, mob_sleep)
 	add_verb(src, /mob/living/proc/toggle_resting)
 
@@ -10,7 +10,8 @@
 	// Physiology needs to be created before species, as some species modify physiology
 	setup_physiology()
 
-	create_dna()
+
+	create_dna(species)
 	dna.species.create_fresh_body(src)
 	setup_human_dna()
 
@@ -1037,10 +1038,8 @@
 	var/race = null
 	var/use_random_name = TRUE
 
-/mob/living/carbon/human/species/create_dna()
-	dna = new /datum/dna(src)
-	if (!isnull(race))
-		dna.species = new race
+/mob/living/carbon/human/species/create_dna(datum/species/species)
+	..(race) //Kind of shit but I'm brainfarting how to do this better right now.
 
 /mob/living/carbon/human/species/set_species(datum/species/mrace, icon_update, pref_load, replace_missing)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -3,7 +3,7 @@
 	race = /datum/species/monkey
 	ai_controller = /datum/ai_controller/monkey
 
-/mob/living/carbon/human/species/monkey/Initialize(mapload, cubespawned = FALSE)
+/mob/living/carbon/human/species/monkey/Initialize(mapload, datum/species/species, cubespawned = FALSE)
 	ADD_TRAIT(src, TRAIT_BORN_MONKEY, INNATE_TRAIT)
 	if (cubespawned)
 		SSmobs.cubemonkeys += src
@@ -16,7 +16,7 @@
 /mob/living/carbon/human/species/monkey/angry
 	ai_controller = /datum/ai_controller/monkey/angry
 
-/mob/living/carbon/human/species/monkey/angry/Initialize(mapload, cubespawned = FALSE)
+/mob/living/carbon/human/species/monkey/angry/Initialize(mapload, datum/species/species, cubespawned = FALSE)
 	. = ..()
 	if(prob(10))
 		INVOKE_ASYNC(src, PROC_REF(give_ape_escape_helmet))
@@ -42,7 +42,7 @@ GLOBAL_DATUM(the_one_and_only_punpun, /mob/living/carbon/human/species/monkey/pu
 	var/relic_mask
 	var/memory_saved = FALSE
 
-/mob/living/carbon/human/species/monkey/punpun/Initialize(mapload)
+/mob/living/carbon/human/species/monkey/punpun/Initialize(mapload, datum/species/species)
 	. = ..()
 
 	REGISTER_REQUIRED_MAP_ITEM(1, 1) // pun pun is required on maps.

--- a/code/modules/mob_spawn/corpses/mining_corpses.dm
+++ b/code/modules/mob_spawn/corpses/mining_corpses.dm
@@ -34,6 +34,24 @@
 	outfit = select_outfit()
 	return ..()
 
+/obj/effect/mob_spawn/corpse/human/legioninfested/get_mob_species(mob/mob_possessor, apply_prefs)
+	if(ispath(outfit, /datum/outfit/consumed_miner))
+		return pick_weight(list(
+			/datum/species/human = 70,
+			/datum/species/lizard = 26,
+			/datum/species/fly = 2,
+			/datum/species/plasmaman = 2,
+		))
+	if(ispath(outfit, /datum/outfit/consumed_ashwalker))
+		return /datum/species/lizard/ashwalker
+	if(ispath(outfit, /datum/outfit/consumed_golem))
+		return /datum/species/golem
+	if(ispath(outfit, /datum/outfit/consumed_shadowperson))
+		return /datum/species/shadow
+	if(ispath(outfit, /datum/outfit/consumed_heremoth))
+		return /datum/species/moth
+	return ..()
+
 /obj/effect/mob_spawn/corpse/human/legioninfested/special(mob/living/carbon/human/spawned_human, mob/mob_possessor, apply_prefs)
 	. = ..()
 	var/obj/item/organ/legion_tumour/cancer = new()
@@ -151,13 +169,7 @@
 	if(visuals_only)
 		regular_uniform = TRUE //assume human
 	else
-		var/new_species_type = pick_weight(list(
-			/datum/species/human = 70,
-			/datum/species/lizard = 26,
-			/datum/species/fly = 2,
-			/datum/species/plasmaman = 2,
-		))
-		miner.set_species(new_species_type)
+		var/new_species_type = miner.dna.species.type
 		if(new_species_type != /datum/species/plasmaman)
 			regular_uniform = TRUE
 		else
@@ -207,8 +219,6 @@
 	uniform = /obj/item/clothing/under/costume/gladiator/ash_walker
 
 /datum/outfit/consumed_ashwalker/pre_equip(mob/living/carbon/human/ashwalker, visuals_only = FALSE)
-	if(!visuals_only)
-		ashwalker.set_species(/datum/species/lizard/ashwalker)
 	if(prob(95))
 		head = /obj/item/clothing/head/helmet/gladiator
 	else
@@ -281,8 +291,6 @@
 	//Oops! All randomized!
 
 /datum/outfit/consumed_golem/pre_equip(mob/living/carbon/human/golem, visuals_only = FALSE)
-	if(!visuals_only)
-		golem.set_species(/datum/species/golem)
 	if(prob(30))
 		glasses = pick_weight(list(
 			/obj/item/clothing/glasses/hud/diagnostic = 2,
@@ -367,11 +375,6 @@
 
 	accessory = /obj/item/clothing/accessory/medal/plasma/nobel_science
 
-/datum/outfit/consumed_shadowperson/pre_equip(mob/living/carbon/human/shadowperson, visuals_only = FALSE)
-	if(visuals_only)
-		return
-	shadowperson.set_species(/datum/species/shadow)
-
 /datum/outfit/consumed_cultist
 	name = "Legion-Consumed Cultist"
 	uniform = /obj/item/clothing/under/costume/roman
@@ -392,8 +395,6 @@
 	head = /obj/item/clothing/head/helmet/chaplain/heretic
 
 /datum/outfit/consumed_heremoth/pre_equip(mob/living/carbon/human/moth, visuals_only = FALSE)
-	if(!visuals_only)
-		moth.set_species(/datum/species/moth)
 	if(prob(70))
 		glasses = /obj/item/clothing/glasses/blindfold
 	if(prob(90))

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -198,8 +198,7 @@
 /obj/structure/ash_walker_eggshell/Destroy()
 	if(!egg)
 		return ..()
-	var/mob/living/carbon/human/yolk = new(get_turf(src))
-	yolk.set_species(/datum/species/lizard/ashwalker)
+	var/mob/living/carbon/human/yolk = new(get_turf(src), /datum/species/lizard/ashwalker)
 	yolk.fully_replace_character_name(null, yolk.generate_random_mob_name(TRUE))
 	yolk.underwear = "Nude"
 	yolk.equipOutfit(/datum/outfit/ashwalker)//this is an authentic mess we're making

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -60,12 +60,20 @@
 /obj/effect/mob_spawn/proc/create(mob/mob_possessor, newname, apply_prefs)
 	SHOULD_NOT_SLEEP(TRUE)
 
-	var/mob/living/spawned_mob = new mob_type(get_turf(src)) //living mobs only
+	var/mob/living/spawned_mob
+	if(ispath(mob_type, /mob/living/carbon/human))
+		spawned_mob = new mob_type(get_turf(src), get_mob_species(mob_possessor, apply_prefs))
+	else
+		spawned_mob = new mob_type(get_turf(src)) //living mobs only
 	special(spawned_mob, mob_possessor, apply_prefs)
 	name_mob(spawned_mob, newname)
 	equip(spawned_mob)
 	spawned_mob_ref = WEAKREF(spawned_mob)
 	return spawned_mob
+
+/// Returns the species typepath a human spawned by this spawner should be initialized with.
+/obj/effect/mob_spawn/proc/get_mob_species(mob/mob_possessor, apply_prefs)
+	return mob_species
 
 /**
  * Any special behavior that needs to be done to the mob after it's created but before it's equipped.
@@ -80,8 +88,6 @@
 		spawned_mob.set_faction(faction)
 	if(ishuman(spawned_mob))
 		var/mob/living/carbon/human/spawned_human = spawned_mob
-		if(mob_species)
-			spawned_human.set_species(mob_species)
 		spawned_human.dna.species.give_important_for_life(spawned_human) // for preventing plasmamen from combusting immediately upon spawning
 		spawned_human.underwear = "Nude"
 		spawned_human.undershirt = "Nude"
@@ -270,6 +276,11 @@
 
 	return ..()
 
+/obj/effect/mob_spawn/ghost_role/get_mob_species(mob/mob_possessor, apply_prefs)
+	if(mob_possessor?.client && apply_prefs && (allow_custom_character & GHOSTROLE_TAKE_PREFS_SPECIES))
+		return mob_possessor.client.prefs.read_preference(/datum/preference/choiced/species)
+	return ..()
+
 /obj/effect/mob_spawn/ghost_role/special(mob/living/spawned_mob, mob/mob_possessor, apply_prefs)
 	. = ..()
 	if(mob_possessor)
@@ -278,7 +289,6 @@
 			if(allow_custom_character & GHOSTROLE_TAKE_PREFS_APPEARANCE)
 				mob_possessor.client.prefs.apply_prefs_to(spawned_human, icon_updates = TRUE, do_not_apply = typesof(/datum/preference/name, /datum/preference/choiced/species))
 			if(allow_custom_character & GHOSTROLE_TAKE_PREFS_SPECIES)
-				spawned_human.set_species(mob_possessor.client.prefs.read_preference(/datum/preference/choiced/species))
 				spawned_human.fully_replace_character_name(spawned_human.real_name, spawned_human.generate_random_mob_name())
 		if(mob_possessor.mind)
 			mob_possessor.mind.transfer_to(spawned_mob, force_key_move = TRUE)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -671,7 +671,7 @@
 		var/monkey_cap = CONFIG_GET(number/monkeycap)
 		for(var/_ in 1 to created_volume)
 			if (LAZYLEN(SSmobs.cubemonkeys) < monkey_cap)
-				new /mob/living/carbon/human/species/monkey(location, TRUE)
+				new /mob/living/carbon/human/species/monkey(location, null, TRUE)
 
 /datum/chemical_reaction/angry_monkey
 	required_reagents = list(/datum/reagent/monkey_powder = 50, /datum/reagent/inverse/bath_salts = 10)
@@ -692,7 +692,7 @@
 		var/monkey_cap = CONFIG_GET(number/monkeycap)
 		for(var/_ in 1 to created_volume)
 			if (LAZYLEN(SSmobs.cubemonkeys) < monkey_cap)
-				new /mob/living/carbon/human/species/monkey/angry(location, TRUE)
+				new /mob/living/carbon/human/species/monkey/angry(location, null, TRUE)
 
 
 //water electrolysis

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -272,7 +272,7 @@
 		to_chat(user, span_warning("Bluespace harmonics prevent the creation of more than [cap] monkeys on the station at one time!"))
 		return
 
-	var/mob/living/carbon/human/species/monkey/food = new /mob/living/carbon/human/species/monkey(target_turf, TRUE)
+	var/mob/living/carbon/human/species/monkey/food = new /mob/living/carbon/human/species/monkey(target_turf, null, TRUE)
 	if (QDELETED(food))
 		return
 


### PR DESCRIPTION


## About The Pull Request

I noticed legion infested corpses ate up a lot of ms trying to spawn corpses. I noticed they were setting species 3 times because they were:
1. setting it when spawning the human
2. Setting it in the mob spawner object 
3. Setting it in the outfit

All of these would replace body parts which is expensive

## Why It's Good For The Game

less overtime when killing legions (and spawning corpses)

## Changelog


:cl:
code: Improved performance of corpse spawners
/:cl: