### PR TITLE
bumps minimum compiler version to 516.1659 (and CI version to 516.1685)

### DIFF
--- a/.github/actions/restore_or_install_byond/action.yml
+++ b/.github/actions/restore_or_install_byond/action.yml
@@ -29,6 +29,13 @@ runs:
         echo "BYOND_MAJOR=$BYOND_MAJOR" >> $GITHUB_ENV
         echo "BYOND_MINOR=$BYOND_MINOR" >> $GITHUB_ENV
 
+    - name: Install 32-bit libcurl
+      shell: bash
+      run: |
+        sudo dpkg --add-architecture i386
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends libcurl4t64:i386
+
     # The use of `actions/cache/restore` and `actions/cache/save` here is deliberate, as we want to
     # save the BYOND install to a cache as early as possible. If we used just `actions/cache`, it
     # would only attempt to save the cache at the end of a job. This ensures that if a workflow run

--- a/.github/alternate_byond_versions.txt
+++ b/.github/alternate_byond_versions.txt
@@ -7,4 +7,4 @@
 # 500.1337: runtimestation
 # 516.1638: runtimestation;516
 # Lowest supported version
-516.1648: runtimestation
+516.1659: runtimestation

--- a/.tgs.yml
+++ b/.tgs.yml
@@ -3,7 +3,7 @@
 version: 1
 # The BYOND version to use (kept in sync with dependencies.sh by the "TGS Test Suite" CI job)
 # Must be interpreted as a string, keep quoted
-byond: "516.1659"
+byond: "516.1685"
 # Folders to create in "<instance_path>/Configuration/GameStaticFiles/"
 static_files:
   # Config directory should be static

--- a/code/__HELPERS/stack_trace.dm
+++ b/code/__HELPERS/stack_trace.dm
@@ -3,16 +3,10 @@
 /proc/_stack_trace(message, file, line)
 	CRASH("[message][WORKAROUND_IDENTIFIER][json_encode(list(file, line))][WORKAROUND_IDENTIFIER]")
 
-
-#if (DM_BUILD > 1667)
-#warn if this is ci please remove my Note: comment below, thanks, love you!
-#endif
 #define STACK_DEPTH_SEARCH_LIMIT 2000
-/// Returns an ordered list of all our parent procs, highest to deepest
-/// Note: This will frequently cause erorrs and have seemingly infinitely repeating procs on the current good byond version
-/// It'll be fixed when we can update to latest for dev but you likely can't do that right now (since debugging hasn't been fixed yet)
-/// BIGGER, MORE IMPORTANT NOTE: Should not be used on master maybe ever, introspection like this is mostly useful for debugging
-/// if you have another use I suspect you are just creating god's strongest footgun and should rethink things
+/// Returns an ordered list of all our parent procs, highest to deepest.
+///
+/// introspection like this is mostly useful for debugging, if you have another use I suspect you are just creating god's strongest footgun and should rethink things
 /proc/dump_stack(max_depth = STACK_DEPTH_SEARCH_LIMIT)
 	var/list/proc_paths = list()
 	var/crashed = FALSE

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -2,11 +2,11 @@
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 516
-#define MIN_COMPILER_BUILD 1648
+#define MIN_COMPILER_BUILD 1659
 #if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM) && !defined(OPENDREAM)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 516.1648 or higher
+#error You need version 516.1659 or higher
 #endif
 
 // 516.1660 broke (x in vars), which breaks a lot of things.

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,7 +5,7 @@
 
 # byond version. Also must be updated in .tgs.yml
 export BYOND_MAJOR=516
-export BYOND_MINOR=1659
+export BYOND_MINOR=1685
 
 #rust_g git tag
 export RUST_G_VERSION=6.2.0


### PR DESCRIPTION

## About The Pull Request

this bumps the minimum byond compile version to 516.1659, and the main ci version to 516.1685 (the current latest)

1659 specifically bc it has this fix - and im pretty sure the bug it fixed is the one that's causing monkey business to segfault CI only on alternate tests:
> Calling alist() without arguments could cause crashes in some uncommon situations. (Lummox JR)

## Why It's Good For The Game

the red x from alists crashing old byond version annoy me

## Changelog

literally no user-facing changes, this only affects server hosts and devs