### PR TITLE
Fix departmental photo albums not saving

### DIFF
--- a/code/modules/photography/photos/album.dm
+++ b/code/modules/photography/photos/album.dm
@@ -19,6 +19,9 @@
 	. = ..()
 	if (!SSpersistence.initialized)
 		LAZYADD(SSpersistence.queued_photo_albums, src)
+	else if (!isnull(persistence_id))
+		// Albums might spawn after roundstart (e.g. locker lazyload)
+		persistence_load()
 
 /obj/item/storage/photo_album/Destroy()
 	LAZYREMOVE(SSpersistence.queued_photo_albums, src)


### PR DESCRIPTION

## About The Pull Request

Lockers lazyload their contents so any album in a locker didn't load persistence
## Why It's Good For The Game

Fix a bug that's been in the game for years now

## Changelog
:cl: PapaMichael
fix: Departmental photo albums now properly save their photos between rounds
/:cl:
