### PR TITLE
Fix for vent taping and hierophant kill not granting style points multiplier

### DIFF
--- a/code/datums/components/style/style.dm
+++ b/code/datums/components/style/style.dm
@@ -444,7 +444,7 @@
 	if(died == parent)
 		change_points(-500, use_multiplier = FALSE)
 		return
-	else if(mob_parent.faction_check_atom(died) || !died.has_faction(FACTION_MINING) || (died.z != mob_parent.z) || !(died in view(mob_parent.client?.view, get_turf(mob_parent))))
+	else if(mob_parent.faction_check_atom(died) || !ismining(died) || (died.z != mob_parent.z) || !(died in view(mob_parent.client?.view, get_turf(mob_parent))))
 		return
 
 	if(ismegafauna(died))

--- a/code/datums/components/style/style_meter.dm
+++ b/code/datums/components/style/style_meter.dm
@@ -145,7 +145,7 @@
 		return
 	// If we have an active style meter, we're on someone's face. Use them to check if the dead megafauna could be credited to them...
 	var/mob/mob_parent = style_meter.parent
-	if(mob_parent.faction_check_atom(died) || !died.has_faction(FACTION_MINING) || (died.z != mob_parent.z) || !(died in view(mob_parent.client?.view, get_turf(mob_parent))))
+	if(mob_parent.faction_check_atom(died) || !ismining(died) || (died.z != mob_parent.z) || !(died in view(mob_parent.client?.view, get_turf(mob_parent))))
 		return
 
 	if(ismegafauna(died))

--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -354,6 +354,7 @@
 		return
 
 	for(var/mob/living/miner in range(7, src)) //Give the miners who are near the vent points and xp.
+		SEND_SIGNAL(miner, COMSIG_LIVING_ON_VENT_WIN, src)
 		var/obj/item/card/id/user_id_card = miner.get_idcard(TRUE)
 		if(miner.stat <= SOFT_CRIT)
 			miner.mind?.adjust_experience(/datum/skill/mining, MINING_SKILL_BOULDER_SIZE_XP * boulder_size)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -48,7 +48,6 @@ Difficulty: Hard
 	friendly_verb_continuous = "stares down"
 	friendly_verb_simple = "stare down"
 	icon = 'icons/mob/simple/lavaland/hierophant_new.dmi'
-	faction = list(FACTION_BOSS) //asteroid mobs? get that shit out of my beautiful square house
 	speak_emote = list("preaches")
 	armour_penetration = 50
 	melee_damage_lower = 15

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -48,6 +48,7 @@ Difficulty: Hard
 	friendly_verb_continuous = "stares down"
 	friendly_verb_simple = "stare down"
 	icon = 'icons/mob/simple/lavaland/hierophant_new.dmi'
+	faction = list(FACTION_BOSS) //asteroid mobs? get that shit out of my beautiful square house
 	speak_emote = list("preaches")
 	armour_penetration = 50
 	melee_damage_lower = 15


### PR DESCRIPTION

## About The Pull Request
Vent tapping supposed to send a signal, but apparently that line of code was lost during some silly merge skew

as of Hiero, it had wrong faction set on it, and signal handler on style component ignored it altogether

<img width="257" height="145" alt="изображение" src="https://github.com/user-attachments/assets/8a97a812-565d-4cda-bac3-25889727509e" />
<img width="283" height="193" alt="изображение" src="https://github.com/user-attachments/assets/3edf4bae-7f44-426f-92c6-ea8694dbb515" />

## Why It's Good For The Game
always good when code works as intended

## Changelog
:cl:
fix: Defeating Hiero now gives style point multiplier
fix: Successfully tapping a vent will grant a style point multiplication too, as it was supposed to
/:cl:
