### PR TITLE
Photo Album Mapping Consistency

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -1810,11 +1810,14 @@
 /area/station/maintenance/starboard/upper)
 "ayR" = (
 /obj/structure/table,
+/obj/machinery/airalarm/directional/west,
 /obj/item/storage/crayons{
 	pixel_x = -3;
 	pixel_y = 1
 	},
-/obj/machinery/airalarm/directional/west,
+/obj/item/storage/photo_album/library{
+	pixel_x = 16
+	},
 /turf/open/floor/wood,
 /area/station/service/library/printer)
 "ayU" = (
@@ -9452,6 +9455,7 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/item/storage/photo_album/bar,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "cwe" = (
@@ -62854,7 +62858,6 @@
 "qKC" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/table/reinforced,
-/obj/item/storage/photo_album/qm,
 /turf/open/openspace,
 /area/station/cargo/storage)
 "qKG" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -537,7 +537,12 @@
 "agc" = (
 /obj/structure/table/wood,
 /obj/structure/cable,
-/obj/item/pen/fountain,
+/obj/item/pen/fountain{
+	pixel_x = 4
+	},
+/obj/item/storage/photo_album/chapel{
+	pixel_x = -16
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
@@ -12327,6 +12332,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
+/obj/item/storage/photo_album/bar,
 /turf/open/floor/iron/dark,
 /area/station/service/bar/backroom)
 "dZk" = (
@@ -73622,7 +73628,7 @@
 /area/station/security/prison)
 "xkP" = (
 /obj/structure/table/wood,
-/obj/item/storage/photo_album{
+/obj/item/storage/photo_album/library{
 	pixel_x = -4;
 	pixel_y = 4
 	},

--- a/_maps/map_files/NebulaStation/NebulaStation.dmm
+++ b/_maps/map_files/NebulaStation/NebulaStation.dmm
@@ -49251,7 +49251,6 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
 	},
-/obj/item/storage/photo_album/captain,
 /obj/item/camera,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/heads_quarters/captain)
@@ -107860,6 +107859,7 @@
 	dir = 1
 	},
 /obj/machinery/light/warm/directional/north,
+/obj/item/storage/photo_album/bar,
 /turf/open/floor/iron/dark/small,
 /area/station/service/bar/backroom)
 "pRK" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -67475,6 +67475,7 @@
 /obj/item/stack/spacecash/c100,
 /obj/machinery/airalarm/directional/north,
 /obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/item/storage/photo_album/bar,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "wwj" = (

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -14,7 +14,6 @@
 	new /obj/item/universal_scanner(src)
 	new /obj/item/door_remote/quartermaster(src)
 	new /obj/item/circuitboard/machine/techfab/department/cargo(src)
-	new /obj/item/storage/photo_album/qm(src)
 	new /obj/item/circuitboard/machine/ore_silo(src)
 	new /obj/item/storage/bag/garment/quartermaster(src)
 
@@ -23,3 +22,5 @@
 
 	// Traitor steal objective
 	new /obj/item/card/id/departmental_budget/car(src)
+
+	new /obj/item/storage/photo_album/qm(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -16,7 +16,6 @@
 	new /obj/item/storage/lockbox/medal/engineering(src)
 	new /obj/item/circuitboard/machine/techfab/department/engineering(src)
 	new /obj/item/extinguisher/advanced(src)
-	new /obj/item/storage/photo_album/ce(src)
 	new /obj/item/storage/box/skillchips/engineering(src)
 	new /obj/item/storage/box/stickers/chief_engineer(src)
 
@@ -26,6 +25,8 @@
 	// Traitor steal objective
 	new /obj/item/blueprints(src)
 	new /obj/item/pipe_dispenser(src)
+
+	new /obj/item/storage/photo_album/ce(src)
 
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -89,7 +89,6 @@
 	new /obj/item/clothing/neck/petcollar(src)
 	new /obj/item/pet_carrier(src)
 	new /obj/item/circuitboard/machine/techfab/department/medical(src)
-	new /obj/item/storage/photo_album/cmo(src)
 	new /obj/item/storage/lockbox/medal/med(src)
 
 /obj/structure/closet/secure_closet/chief_medical/populate_contents_immediate()
@@ -98,6 +97,8 @@
 	// Traitor steal objective
 	new /obj/item/reagent_containers/hypospray/cmo(src)
 	new /obj/item/defibrillator/compact/loaded/cmo(src)
+
+	new /obj/item/storage/photo_album/cmo(src)
 
 /obj/structure/closet/secure_closet/animal
 	name = "animal control locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -16,7 +16,6 @@
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/door_remote/research_director(src)
 	new /obj/item/circuitboard/machine/techfab/department/science(src)
-	new /obj/item/storage/photo_album/rd(src)
 	new /obj/item/storage/box/skillchips/science(src)
 
 /obj/structure/closet/secure_closet/research_director/populate_contents_immediate()
@@ -25,6 +24,8 @@
 	// Traitor steal objectives
 	new /obj/item/clothing/suit/armor/reactive/teleport(src)
 	new /obj/item/laser_pointer(src)
+
+	new /obj/item/storage/photo_album/rd(src)
 
 /obj/structure/closet/secure_closet/cytology
 	name = "cytology equipment locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -12,12 +12,13 @@
 	new /obj/item/radio/headset/heads/captain/alt(src)
 	new /obj/item/radio/headset/heads/captain(src)
 	new /obj/item/door_remote/captain(src)
-	new /obj/item/storage/photo_album/captain(src)
 	new /obj/item/megaphone/command(src)
 
 /obj/structure/closet/secure_closet/captains/populate_contents_immediate()
 	new /obj/item/gun/energy/e_gun(src)
 	new /obj/item/storage/belt/sheath/sabre(src)
+
+	new /obj/item/storage/photo_album/captain(src)
 
 /obj/structure/closet/secure_closet/hop
 	name = "head of personnel's locker"
@@ -39,12 +40,13 @@
 	new /obj/item/pet_carrier(src)
 	new /obj/item/door_remote/head_of_personnel(src)
 	new /obj/item/circuitboard/machine/techfab/department/service(src)
-	new /obj/item/storage/photo_album/hop(src)
 	new /obj/item/storage/lockbox/medal/hop(src)
 	new /obj/item/storage/box/stamps(src)
 
 /obj/structure/closet/secure_closet/hop/populate_contents_immediate()
 	new /obj/item/gun/energy/e_gun(src)
+
+	new /obj/item/storage/photo_album/hop(src)
 
 /obj/structure/closet/secure_closet/hos
 	name = "head of security's locker"
@@ -66,7 +68,6 @@
 	new /obj/item/shield/riot/tele(src)
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/circuitboard/machine/techfab/department/security(src)
-	new /obj/item/storage/photo_album/hos(src)
 
 /obj/structure/closet/secure_closet/hos/populate_contents_immediate()
 	. = ..()
@@ -74,6 +75,8 @@
 	// Traitor steal objectives
 	new /obj/item/gun/energy/e_gun/hos(src)
 	new /obj/item/pinpointer/nuke(src)
+
+	new /obj/item/storage/photo_album/hos(src)
 
 /obj/structure/closet/secure_closet/warden
 	name = "warden's locker"

--- a/code/modules/photography/photos/album.dm
+++ b/code/modules/photography/photos/album.dm
@@ -85,40 +85,72 @@
 	icon_state = "album_blue"
 	persistence_id = "HoS"
 
+/obj/item/storage/photo_album/hos/Initialize(mapload)
+	. = ..()
+	REGISTER_REQUIRED_MAP_ITEM(0, 0)
+
 /obj/item/storage/photo_album/rd
 	name = "photo album (Research Director)"
 	icon_state = "album_blue"
 	persistence_id = "RD"
+
+/obj/item/storage/photo_album/rd/Initialize(mapload)
+	. = ..()
+	REGISTER_REQUIRED_MAP_ITEM(0, 0)
 
 /obj/item/storage/photo_album/hop
 	name = "photo album (Head of Personnel)"
 	icon_state = "album_blue"
 	persistence_id = "HoP"
 
+/obj/item/storage/photo_album/hop/Initialize(mapload)
+	. = ..()
+	REGISTER_REQUIRED_MAP_ITEM(0, 0)
+
 /obj/item/storage/photo_album/captain
 	name = "photo album (Captain)"
 	icon_state = "album_blue"
 	persistence_id = "Captain"
+
+/obj/item/storage/photo_album/captain/Initialize(mapload)
+	. = ..()
+	REGISTER_REQUIRED_MAP_ITEM(0, 0)
 
 /obj/item/storage/photo_album/cmo
 	name = "photo album (Chief Medical Officer)"
 	icon_state = "album_blue"
 	persistence_id = "CMO"
 
+/obj/item/storage/photo_album/cmo/Initialize(mapload)
+	. = ..()
+	REGISTER_REQUIRED_MAP_ITEM(0, 0)
+
 /obj/item/storage/photo_album/qm
 	name = "photo album (Quartermaster)"
 	icon_state = "album_blue"
 	persistence_id = "QM"
+
+/obj/item/storage/photo_album/qm/Initialize(mapload)
+	. = ..()
+	REGISTER_REQUIRED_MAP_ITEM(0, 0)
 
 /obj/item/storage/photo_album/ce
 	name = "photo album (Chief Engineer)"
 	icon_state = "album_blue"
 	persistence_id = "CE"
 
+/obj/item/storage/photo_album/ce/Initialize(mapload)
+	. = ..()
+	REGISTER_REQUIRED_MAP_ITEM(0, 0)
+
 /obj/item/storage/photo_album/bar
 	name = "photo album (Bar)"
 	icon_state = "album_blue"
 	persistence_id = "bar"
+
+/obj/item/storage/photo_album/bar/Initialize(mapload)
+	. = ..()
+	REGISTER_REQUIRED_MAP_ITEM(1, 1)
 
 /obj/item/storage/photo_album/syndicate
 	name = "photo album (Syndicate)"
@@ -130,10 +162,18 @@
 	icon_state = "album_blue"
 	persistence_id = "library"
 
+/obj/item/storage/photo_album/library/Initialize(mapload)
+	. = ..()
+	REGISTER_REQUIRED_MAP_ITEM(1, 1)
+
 /obj/item/storage/photo_album/chapel
 	name = "photo album (Chapel)"
 	icon_state = "album_blue"
 	persistence_id = "chapel"
+
+/obj/item/storage/photo_album/chapel/Initialize(mapload)
+	. = ..()
+	REGISTER_REQUIRED_MAP_ITEM(1, 1)
 
 /obj/item/storage/photo_album/listeningstation
 	name = "photo album (Listening Station)"
@@ -149,6 +189,10 @@
 	name = "photo album (Prison)"
 	icon_state = "album_blue"
 	persistence_id = "prison"
+
+/obj/item/storage/photo_album/prison/Initialize(mapload)
+	. = ..()
+	REGISTER_REQUIRED_MAP_ITEM(1, 1)
 
 /obj/item/storage/photo_album/personal
 	icon_state = "album_green"

--- a/code/modules/photography/photos/album.dm
+++ b/code/modules/photography/photos/album.dm
@@ -87,7 +87,7 @@
 
 /obj/item/storage/photo_album/hos/Initialize(mapload)
 	. = ..()
-	REGISTER_REQUIRED_MAP_ITEM(0, 0)
+	REGISTER_REQUIRED_MAP_ITEM(1, 1)
 
 /obj/item/storage/photo_album/rd
 	name = "photo album (Research Director)"
@@ -96,7 +96,7 @@
 
 /obj/item/storage/photo_album/rd/Initialize(mapload)
 	. = ..()
-	REGISTER_REQUIRED_MAP_ITEM(0, 0)
+	REGISTER_REQUIRED_MAP_ITEM(1, 1)
 
 /obj/item/storage/photo_album/hop
 	name = "photo album (Head of Personnel)"
@@ -105,7 +105,7 @@
 
 /obj/item/storage/photo_album/hop/Initialize(mapload)
 	. = ..()
-	REGISTER_REQUIRED_MAP_ITEM(0, 0)
+	REGISTER_REQUIRED_MAP_ITEM(1, 1)
 
 /obj/item/storage/photo_album/captain
 	name = "photo album (Captain)"
@@ -114,7 +114,7 @@
 
 /obj/item/storage/photo_album/captain/Initialize(mapload)
 	. = ..()
-	REGISTER_REQUIRED_MAP_ITEM(0, 0)
+	REGISTER_REQUIRED_MAP_ITEM(1, 1)
 
 /obj/item/storage/photo_album/cmo
 	name = "photo album (Chief Medical Officer)"
@@ -123,7 +123,7 @@
 
 /obj/item/storage/photo_album/cmo/Initialize(mapload)
 	. = ..()
-	REGISTER_REQUIRED_MAP_ITEM(0, 0)
+	REGISTER_REQUIRED_MAP_ITEM(1, 1)
 
 /obj/item/storage/photo_album/qm
 	name = "photo album (Quartermaster)"
@@ -132,7 +132,7 @@
 
 /obj/item/storage/photo_album/qm/Initialize(mapload)
 	. = ..()
-	REGISTER_REQUIRED_MAP_ITEM(0, 0)
+	REGISTER_REQUIRED_MAP_ITEM(1, 1)
 
 /obj/item/storage/photo_album/ce
 	name = "photo album (Chief Engineer)"
@@ -141,7 +141,7 @@
 
 /obj/item/storage/photo_album/ce/Initialize(mapload)
 	. = ..()
-	REGISTER_REQUIRED_MAP_ITEM(0, 0)
+	REGISTER_REQUIRED_MAP_ITEM(1, 1)
 
 /obj/item/storage/photo_album/bar
 	name = "photo album (Bar)"

--- a/code/modules/unit_tests/required_map_items.dm
+++ b/code/modules/unit_tests/required_map_items.dm
@@ -4,11 +4,17 @@
  * How to add an item to this test:
  * - Add the typepath(s) to setup_expected_types
  * - In the type's initialize, REGISTER_REQUIRED_MAP_ITEM() a minimum and maximum
+ *
+ * How to ban an item from being mapped in:
+ * - Add the typepath(s) to setup_banned_types
+ * - In the type's initialize, REGISTER_REQUIRED_MAP_ITEM(0, 0)
  */
 /datum/unit_test/maptest_required_map_items
 	test_flags = UNIT_TEST_MAP_TEST
 	/// A list of all typepaths that we expect to be in the required items list
 	var/list/expected_types = list()
+	/// A list of all typepaths that should never be mapped in
+	var/list/banned_types = list()
 
 /// Used to fill the expected types list with all the types we look for on the map.
 /// This list will just be full of typepaths that we expect.
@@ -25,8 +31,27 @@
 	expected_types += /obj/machinery/drone_dispenser
 	expected_types += /obj/item/piggy_bank/vault
 
+	// each map should probably have all of them
+	expected_types += /obj/item/storage/photo_album/bar
+	expected_types += /obj/item/storage/photo_album/chapel
+	expected_types += /obj/item/storage/photo_album/library
+	expected_types += /obj/item/storage/photo_album/prison
+
+/// Types that must never be mapped in.
+/// Anything listed here is expected to be spawned by code instead.
+/datum/unit_test/maptest_required_map_items/proc/setup_banned_types()
+	// head albums come out of their locker, mapping one in makes a second album with the same save
+	banned_types += /obj/item/storage/photo_album/captain
+	banned_types += /obj/item/storage/photo_album/ce
+	banned_types += /obj/item/storage/photo_album/cmo
+	banned_types += /obj/item/storage/photo_album/hop
+	banned_types += /obj/item/storage/photo_album/hos
+	banned_types += /obj/item/storage/photo_album/qm
+	banned_types += /obj/item/storage/photo_album/rd
+
 /datum/unit_test/maptest_required_map_items/Run()
 	setup_expected_types()
+	setup_banned_types()
 
 	var/list/required_map_items = GLOB.required_map_items.Copy()
 	for(var/got_type in expected_types)
@@ -44,6 +69,12 @@
 		if(items_found > item.maximum_amount)
 			TEST_FAIL("Item [got_type] should have at most [item.maximum_amount] mapped in but had [items_found] on mapload!")
 			continue
+
+	for(var/banned_type in banned_types)
+		var/datum/required_item/item = required_map_items[banned_type]
+		required_map_items -= banned_type
+		if(item)
+			TEST_FAIL("Item [banned_type] should never be mapped in, but [item.total_amount] were found on mapload!")
 
 	// This primarily serves as a reminder to include the typepath in the expected types list above.
 	// However we can easily delete this line in the future if it runs into false positives.

--- a/code/modules/unit_tests/required_map_items.dm
+++ b/code/modules/unit_tests/required_map_items.dm
@@ -37,17 +37,19 @@
 	expected_types += /obj/item/storage/photo_album/library
 	expected_types += /obj/item/storage/photo_album/prison
 
+	expected_types += /obj/item/storage/photo_album/captain
+	expected_types += /obj/item/storage/photo_album/ce
+	expected_types += /obj/item/storage/photo_album/cmo
+	expected_types += /obj/item/storage/photo_album/hop
+	expected_types += /obj/item/storage/photo_album/hos
+	expected_types += /obj/item/storage/photo_album/qm
+	expected_types += /obj/item/storage/photo_album/rd
+
 /// Types that must never be mapped in.
 /// Anything listed here is expected to be spawned by code instead.
 /datum/unit_test/maptest_required_map_items/proc/setup_banned_types()
-	// head albums come out of their locker, mapping one in makes a second album with the same save
-	banned_types += /obj/item/storage/photo_album/captain
-	banned_types += /obj/item/storage/photo_album/ce
-	banned_types += /obj/item/storage/photo_album/cmo
-	banned_types += /obj/item/storage/photo_album/hop
-	banned_types += /obj/item/storage/photo_album/hos
-	banned_types += /obj/item/storage/photo_album/qm
-	banned_types += /obj/item/storage/photo_album/rd
+// Your typepaths here!
+	return
 
 /datum/unit_test/maptest_required_map_items/Run()
 	setup_expected_types()


### PR DESCRIPTION

## About The Pull Request
Companion to https://github.com/tgstation/tgstation/pull/97167

Nebula, Tram, Catwalk, and Kilo were all missing some combination of the Bar, Library and/or Chapel photo albums

Additionally, Nebula and Catwalk duplicated their Captain and QM albums, respectively (one spawns in the locker and one was mapped in)


## Why It's Good For The Game
Feels like it's just an oversight that all maps didn't have all of them and the duplicate albums are an actual bug
## Changelog
:cl: PapaMichael
fix: Bar, Library, and Chapel photo albums can now be found on all stations
fix: Removed duplicate photo albums from Catwalk and Nebula
/:cl:
