### PR TITLE
fixes master not compiling lmao

### DIFF
--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -61,8 +61,7 @@
 	if(neutered)
 		return FALSE
 	if(name in advanced_disease.affected_mob.symptom_resistances)
-		symptom_delay_min *= 1.75
-		symptom_delay_max *= 1.75
+		symptom_delay *= 1.75
 	return TRUE
 
 ///Called when the advance disease is going to be deleted or when the advance disease stops processing.


### PR DESCRIPTION
so https://github.com/tgstation/tgstation/pull/97014 got rid of the `symptom_delay_min` and `symptom_delay_max` vars

https://github.com/tgstation/tgstation/pull/96968 has code that used those vars

these were both merged in succession.

master is now broken :(
```
code/datums/diseases/advance/symptoms/symptoms.dm:64:error: symptom_delay_min: undefined var
code/datums/diseases/advance/symptoms/symptoms.dm:65:error: symptom_delay_max: undefined var
```

this fixes it, simple enough.