### PR TITLE
Move Byond.sendMessage('visible') to Window instead of resume(), add support for refreshing page with ByondUi

### DIFF
--- a/tgui/packages/tgui/events/handlers/update.ts
+++ b/tgui/packages/tgui/events/handlers/update.ts
@@ -48,7 +48,6 @@ function resume(payload: UpdatePayload): void {
     Byond.winset(Byond.windowId, {
       'is-visible': true,
     });
-    Byond.sendMessage('visible');
     perf.mark('resume/finish');
 
     if (process.env.NODE_ENV !== 'production') {

--- a/tgui/packages/tgui/layouts/Window.tsx
+++ b/tgui/packages/tgui/layouts/Window.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react';
 import { type Box, KeyListener } from 'tgui-core/components';
 import { UI_DISABLED, UI_INTERACTIVE } from 'tgui-core/constants';
+import { globalEvents } from 'tgui-core/events';
 import { KEY_ALT } from 'tgui-core/keycodes';
 import { type BooleanLike, classes } from 'tgui-core/react';
 import { decodeHtmlEntities } from 'tgui-core/string';
@@ -88,6 +89,9 @@ export function Window(props: Props) {
         Byond.winset(Byond.windowId, {
           'is-visible': true,
         });
+        Byond.sendMessage('visible');
+        globalEvents.emit('window-geometry-finished');
+
         logger.log('set to visible');
       };
 


### PR DESCRIPTION

## About The Pull Request
This adds support for tgstation/tgui-core#274 and also moves `Byond.sendMessage("visible")` from resume to Window. This is because there's currently a race condition with how it's set up, with the following chain of events:

- browse() is called, window opens
- tgui init happens
- update kicks resume() in events/handlers/update.ts
  - is-visible is set to true
  - Byond.sendMessage("visible") is sent during a setTimeout, this sometimes works and sometimes doesn't
- Window's useLayoutEffect hook runs and causes is-visible=false
- The server processes "visible" and fires off the chain of COMSIG_TGUI_WINDOW_VISIBLE
- The race condition happens here: If the appearance update hits the client before useEffect runs, we get the small map bug
- Window's useEffect hook runs and causes is-visible=true

If this PR is merged before the tgui-core PR + release, nothing bad will happen, but you'll have to update tgui-core to see the refresh bug fixed later on.

## Why It's Good For The Game
It is mildly annoying to have to refresh a UI because the map view bugged out

## Changelog
:cl:
fix: ByondUi/TGUI Map elements should never have the small map bug again
fix: ByondUi/TGUI Map elements will no longer layout incorrectly if you refresh the page in some circumstances
/:cl:
