### PR TITLE
Fix (almost) all do afters cancelling if you did any cooldown based action

### DIFF
--- a/code/datums/timed_actions.dm
+++ b/code/datums/timed_actions.dm
@@ -77,7 +77,7 @@
 	if (!(timed_action_flags & IGNORE_INCAPACITATED))
 		RegisterSignal(user, SIGNAL_ADDTRAIT(TRAIT_INCAPACITATED), PROC_REF(on_user_incapacitated))
 
-	if (!(timed_action_flags & DO_AFTER_CHECK_NEXT_MOVE))
+	if (timed_action_flags & DO_AFTER_CHECK_NEXT_MOVE)
 		RegisterSignal(user, COMSIG_LIVING_CHANGENEXT_MOVE, PROC_REF(on_changenext_move))
 
 	if (!(timed_action_flags & IGNORE_HELD_ITEM))


### PR DESCRIPTION
## About The Pull Request

Fixes #97188

The check for this flag was inverted, meaning rather than only cancelling specific do afters if your nextmove was changed, we cancelled almost all doafters if your nextmove was changed.

## Changelog

:cl: Melbert
fix: Performing an action with an internal cooldown (like resisting) will no longer cancel timed actions
/:cl:
