### PR TITLE
Don't show unconscious and blind huds to non-player characters (and more)

### DIFF
--- a/code/datums/status_effects/_status_effect.dm
+++ b/code/datums/status_effects/_status_effect.dm
@@ -66,26 +66,14 @@
 		update_shown_duration()
 
 	if(duration != STATUS_EFFECT_PERMANENT || tick_interval != STATUS_EFFECT_NO_TICK) //don't process if we don't care
-		switch(processing_speed)
-			if(STATUS_EFFECT_FAST_PROCESS)
-				START_PROCESSING(SSfastprocess, src)
-			if(STATUS_EFFECT_NORMAL_PROCESS)
-				START_PROCESSING(SSprocessing, src)
-			if(STATUS_EFFECT_PRIORITY)
-				START_PROCESSING(SSpriority_effects, src)
+		start_processing()
 
 	update_particles()
 	SEND_SIGNAL(owner, COMSIG_LIVING_STATUS_APPLIED, src)
 	return TRUE
 
 /datum/status_effect/Destroy()
-	switch(processing_speed)
-		if(STATUS_EFFECT_FAST_PROCESS)
-			STOP_PROCESSING(SSfastprocess, src)
-		if(STATUS_EFFECT_NORMAL_PROCESS)
-			STOP_PROCESSING(SSprocessing, src)
-		if(STATUS_EFFECT_PRIORITY)
-			STOP_PROCESSING(SSpriority_effects, src)
+	stop_processing()
 	if(owner)
 		linked_alert = null
 		owner.clear_alert(id)
@@ -238,6 +226,46 @@
 
 	if(var_name == NAMEOF(src, show_duration))
 		update_shown_duration()
+
+/// Stops ticking. Entirely stops processing if the effect is permanent.
+/datum/status_effect/proc/stop_ticking()
+	// If we have a set duration, we can't stop processing as duration is also handled in process
+	if(duration != STATUS_EFFECT_PERMANENT)
+		time_until_next_tick = STATUS_EFFECT_NO_TICK
+		return
+
+	// But if we have are permanent, there is no reason to keep processing if we don't tick
+	stop_processing()
+
+/// Stops processing, removing it from relevant subsystems
+/datum/status_effect/proc/stop_processing()
+	switch(processing_speed)
+		if(STATUS_EFFECT_FAST_PROCESS)
+			STOP_PROCESSING(SSfastprocess, src)
+		if(STATUS_EFFECT_NORMAL_PROCESS)
+			STOP_PROCESSING(SSprocessing, src)
+		if(STATUS_EFFECT_PRIORITY)
+			STOP_PROCESSING(SSpriority_effects, src)
+
+/// (Re)starts ticking, also (re)starting processing if the effect is permanent
+/datum/status_effect/proc/start_ticking()
+	// If we have a set duration, we assume we're processing already, so just reset the timer
+	if(duration != STATUS_EFFECT_PERMANENT)
+		time_until_next_tick = tick_interval
+		return
+
+	// But if we are permanent, we probably need to start processing
+	start_processing()
+
+/// (Re)starts processing, adding it to relevant subsystems
+/datum/status_effect/proc/start_processing()
+	switch(processing_speed)
+		if(STATUS_EFFECT_FAST_PROCESS)
+			START_PROCESSING(SSfastprocess, src)
+		if(STATUS_EFFECT_NORMAL_PROCESS)
+			START_PROCESSING(SSprocessing, src)
+		if(STATUS_EFFECT_PRIORITY)
+			START_PROCESSING(SSpriority_effects, src)
 
 /// Alert base type for status effect alerts
 /atom/movable/screen/alert/status_effect

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -155,10 +155,8 @@
 	owner.apply_status_effect(/datum/status_effect/grouped/see_no_names, TRAIT_STATUS_EFFECT(id))
 	owner.add_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_BLOCK_SECHUD, TRAIT_BLOCK_MEDHUD, TRAIT_INCAPACITATED, TRAIT_FLOORED), TRAIT_STATUS_EFFECT(id))
 	owner.update_eyes() // updates eyelids
-
-	if(isnull(owner.client))
-		RegisterSignal(owner, COMSIG_MOB_LOGIN, PROC_REF(show_unconscious_hud))
-	else
+	RegisterSignal(owner, COMSIG_MOB_LOGIN, PROC_REF(show_unconscious_hud))
+	if(!isnull(owner.client))
 		show_unconscious_hud(owner)
 	return TRUE
 
@@ -167,10 +165,8 @@
 	owner.remove_status_effect(/datum/status_effect/grouped/see_no_names, TRAIT_STATUS_EFFECT(id))
 	owner.remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_BLOCK_SECHUD, TRAIT_BLOCK_MEDHUD, TRAIT_INCAPACITATED, TRAIT_FLOORED), TRAIT_STATUS_EFFECT(id))
 	owner.update_eyes() // updates eyelids
-
-	if(isnull(owner.client))
-		UnregisterSignal(owner, COMSIG_MOB_LOGIN)
-	else
+	UnregisterSignal(owner, COMSIG_MOB_LOGIN)
+	if(!isnull(owner.client))
 		hide_unconscious_hud(owner)
 
 /datum/status_effect/knocked_out/tick(seconds_between_ticks)
@@ -178,7 +174,6 @@
 
 /datum/status_effect/knocked_out/proc/show_unconscious_hud(mob/living/source)
 	SIGNAL_HANDLER
-	UnregisterSignal(owner, COMSIG_MOB_LOGIN)
 	for(var/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity/uncon_aa in GLOB.active_alternate_appearances)
 		if(uncon_aa.target == owner)
 			continue
@@ -186,7 +181,6 @@
 
 /datum/status_effect/knocked_out/proc/hide_unconscious_hud(mob/living/source)
 	SIGNAL_HANDLER
-	UnregisterSignal(owner, COMSIG_MOB_LOGIN)
 	for(var/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity/uncon_aa in GLOB.active_alternate_appearances)
 		uncon_aa.hide_from(owner, absolute = TRUE)
 

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -155,17 +155,25 @@
 	owner.apply_status_effect(/datum/status_effect/grouped/see_no_names, TRAIT_STATUS_EFFECT(id))
 	owner.add_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_BLOCK_SECHUD, TRAIT_BLOCK_MEDHUD, TRAIT_INCAPACITATED, TRAIT_FLOORED), TRAIT_STATUS_EFFECT(id))
 	owner.update_eyes() // updates eyelids
+	RegisterSignal(owner, COMSIG_MOB_STATCHANGE, PROC_REF(on_mob_statchange))
 	RegisterSignal(owner, COMSIG_MOB_CLIENT_LOGIN, PROC_REF(show_unconscious_hud))
-	if(GET_CLIENT(owner))
+	if(GET_CLIENT(owner)) // let's not waste time giving the hud to non-player characters
 		show_unconscious_hud(owner)
 	return TRUE
+
+/datum/status_effect/knocked_out/on_creation(mob/living/new_owner, ...)
+	. = ..()
+	if(!.)
+		return
+	if(owner.stat == DEAD)
+		stop_ticking()
 
 /datum/status_effect/knocked_out/on_remove()
 	owner.cure_blind(TRAIT_STATUS_EFFECT(id))
 	owner.remove_status_effect(/datum/status_effect/grouped/see_no_names, TRAIT_STATUS_EFFECT(id))
 	owner.remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_BLOCK_SECHUD, TRAIT_BLOCK_MEDHUD, TRAIT_INCAPACITATED, TRAIT_FLOORED), TRAIT_STATUS_EFFECT(id))
 	owner.update_eyes() // updates eyelids
-	UnregisterSignal(owner, COMSIG_MOB_CLIENT_LOGIN)
+	UnregisterSignal(owner, list(COMSIG_MOB_CLIENT_LOGIN, COMSIG_MOB_STATCHANGE))
 	if(GET_CLIENT(owner))
 		hide_unconscious_hud(owner)
 
@@ -184,6 +192,13 @@
 	for(var/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity/uncon_aa in GLOB.active_alternate_appearances)
 		uncon_aa.hide_from(owner, absolute = TRUE)
 
+/datum/status_effect/knocked_out/proc/on_mob_statchange(mob/living/source, ...)
+	SIGNAL_HANDLER
+	if(owner.stat == DEAD)
+		stop_ticking()
+	else
+		start_ticking()
+
 //SLEEPING
 /datum/status_effect/incapacitating/sleeping
 	id = "sleeping"
@@ -197,18 +212,21 @@
 	. = ..()
 	if(!.)
 		return
-	if(HAS_TRAIT(owner, TRAIT_SLEEPIMMUNE))
-		tick_interval = STATUS_EFFECT_NO_TICK
-	else
+	if(!HAS_TRAIT(owner, TRAIT_SLEEPIMMUNE))
 		ADD_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
 	RegisterSignal(owner, SIGNAL_ADDTRAIT(TRAIT_SLEEPIMMUNE), PROC_REF(on_owner_insomniac))
 	RegisterSignal(owner, SIGNAL_REMOVETRAIT(TRAIT_SLEEPIMMUNE), PROC_REF(on_owner_sleepy))
 
+/datum/status_effect/incapacitating/sleeping/on_creation(mob/living/new_owner, set_duration)
+	. = ..()
+	if(!.)
+		return
+	if(HAS_TRAIT(owner, TRAIT_SLEEPIMMUNE))
+		stop_ticking()
+
 /datum/status_effect/incapacitating/sleeping/on_remove()
 	UnregisterSignal(owner, list(SIGNAL_ADDTRAIT(TRAIT_SLEEPIMMUNE), SIGNAL_REMOVETRAIT(TRAIT_SLEEPIMMUNE)))
-	if(!HAS_TRAIT(owner, TRAIT_SLEEPIMMUNE))
-		REMOVE_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
-		tick_interval = initial(tick_interval)
+	REMOVE_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
 /datum/status_effect/incapacitating/sleeping/try_force_say()
@@ -219,13 +237,13 @@
 /datum/status_effect/incapacitating/sleeping/proc/on_owner_insomniac(mob/living/source)
 	SIGNAL_HANDLER
 	REMOVE_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
-	tick_interval = STATUS_EFFECT_NO_TICK
+	stop_ticking()
 
 ///If the mob has the TRAIT_SLEEPIMMUNE but somehow looses it we make him sleep and restart the tick()
 /datum/status_effect/incapacitating/sleeping/proc/on_owner_sleepy(mob/living/source)
 	SIGNAL_HANDLER
 	ADD_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
-	tick_interval = initial(tick_interval)
+	start_ticking()
 
 /datum/status_effect/incapacitating/sleeping/tick(seconds_between_ticks)
 	if(owner.maxHealth)

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -180,17 +180,18 @@
 /datum/status_effect/knocked_out/tick(seconds_between_ticks)
 	owner.adjust_stamina_loss(-3 * seconds_between_ticks)
 
+/// Global list of images that correspond to a mob's unconscious appearance
+GLOBAL_LIST_EMPTY(unconscious_appearances)
+
 /datum/status_effect/knocked_out/proc/show_unconscious_hud(mob/living/source)
 	SIGNAL_HANDLER
-	for(var/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity/uncon_aa in GLOB.active_alternate_appearances)
-		if(uncon_aa.target == owner)
-			continue
-		uncon_aa.show_to(owner)
+
+	source.client?.images += (GLOB.unconscious_appearances - source.unconscious_appearance)
 
 /datum/status_effect/knocked_out/proc/hide_unconscious_hud(mob/living/source)
 	SIGNAL_HANDLER
-	for(var/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity/uncon_aa in GLOB.active_alternate_appearances)
-		uncon_aa.hide_from(owner, absolute = TRUE)
+
+	source.client?.images -= GLOB.unconscious_appearances
 
 /datum/status_effect/knocked_out/proc/on_mob_statchange(mob/living/source, ...)
 	SIGNAL_HANDLER

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -156,7 +156,7 @@
 	owner.add_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_BLOCK_SECHUD, TRAIT_BLOCK_MEDHUD, TRAIT_INCAPACITATED, TRAIT_FLOORED), TRAIT_STATUS_EFFECT(id))
 	owner.update_eyes() // updates eyelids
 	RegisterSignal(owner, COMSIG_MOB_CLIENT_LOGIN, PROC_REF(show_unconscious_hud))
-	if(GET_CLIENT(owner.client))
+	if(GET_CLIENT(owner))
 		show_unconscious_hud(owner)
 	return TRUE
 
@@ -166,7 +166,7 @@
 	owner.remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_BLOCK_SECHUD, TRAIT_BLOCK_MEDHUD, TRAIT_INCAPACITATED, TRAIT_FLOORED), TRAIT_STATUS_EFFECT(id))
 	owner.update_eyes() // updates eyelids
 	UnregisterSignal(owner, COMSIG_MOB_CLIENT_LOGIN)
-	if(GET_CLIENT(owner.client))
+	if(GET_CLIENT(owner))
 		hide_unconscious_hud(owner)
 
 /datum/status_effect/knocked_out/tick(seconds_between_ticks)

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -155,7 +155,7 @@
 	owner.apply_status_effect(/datum/status_effect/grouped/see_no_names, TRAIT_STATUS_EFFECT(id))
 	owner.add_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_BLOCK_SECHUD, TRAIT_BLOCK_MEDHUD, TRAIT_INCAPACITATED, TRAIT_FLOORED), TRAIT_STATUS_EFFECT(id))
 	owner.update_eyes() // updates eyelids
-	RegisterSignal(owner, COMSIG_MOB_LOGIN, PROC_REF(show_unconscious_hud))
+	RegisterSignal(owner, COMSIG_MOB_CLIENT_LOGIN, PROC_REF(show_unconscious_hud))
 	if(!isnull(owner.client))
 		show_unconscious_hud(owner)
 	return TRUE
@@ -165,7 +165,7 @@
 	owner.remove_status_effect(/datum/status_effect/grouped/see_no_names, TRAIT_STATUS_EFFECT(id))
 	owner.remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_BLOCK_SECHUD, TRAIT_BLOCK_MEDHUD, TRAIT_INCAPACITATED, TRAIT_FLOORED), TRAIT_STATUS_EFFECT(id))
 	owner.update_eyes() // updates eyelids
-	UnregisterSignal(owner, COMSIG_MOB_LOGIN)
+	UnregisterSignal(owner, COMSIG_MOB_CLIENT_LOGIN)
 	if(!isnull(owner.client))
 		hide_unconscious_hud(owner)
 

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -156,7 +156,7 @@
 	owner.add_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_BLOCK_SECHUD, TRAIT_BLOCK_MEDHUD, TRAIT_INCAPACITATED, TRAIT_FLOORED), TRAIT_STATUS_EFFECT(id))
 	owner.update_eyes() // updates eyelids
 	RegisterSignal(owner, COMSIG_MOB_CLIENT_LOGIN, PROC_REF(show_unconscious_hud))
-	if(!isnull(owner.client))
+	if(GET_CLIENT(owner.client))
 		show_unconscious_hud(owner)
 	return TRUE
 
@@ -166,7 +166,7 @@
 	owner.remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_BLOCK_SECHUD, TRAIT_BLOCK_MEDHUD, TRAIT_INCAPACITATED, TRAIT_FLOORED), TRAIT_STATUS_EFFECT(id))
 	owner.update_eyes() // updates eyelids
 	UnregisterSignal(owner, COMSIG_MOB_CLIENT_LOGIN)
-	if(!isnull(owner.client))
+	if(GET_CLIENT(owner.client))
 		hide_unconscious_hud(owner)
 
 /datum/status_effect/knocked_out/tick(seconds_between_ticks)

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -155,10 +155,11 @@
 	owner.apply_status_effect(/datum/status_effect/grouped/see_no_names, TRAIT_STATUS_EFFECT(id))
 	owner.add_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_BLOCK_SECHUD, TRAIT_BLOCK_MEDHUD, TRAIT_INCAPACITATED, TRAIT_FLOORED), TRAIT_STATUS_EFFECT(id))
 	owner.update_eyes() // updates eyelids
-	for(var/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity/uncon_aa in GLOB.active_alternate_appearances)
-		if(uncon_aa.target == owner)
-			continue
-		uncon_aa.show_to(owner)
+
+	if(isnull(owner.client))
+		RegisterSignal(owner, COMSIG_MOB_LOGIN, PROC_REF(show_unconscious_hud))
+	else
+		show_unconscious_hud(owner)
 	return TRUE
 
 /datum/status_effect/knocked_out/on_remove()
@@ -166,11 +167,28 @@
 	owner.remove_status_effect(/datum/status_effect/grouped/see_no_names, TRAIT_STATUS_EFFECT(id))
 	owner.remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_BLOCK_SECHUD, TRAIT_BLOCK_MEDHUD, TRAIT_INCAPACITATED, TRAIT_FLOORED), TRAIT_STATUS_EFFECT(id))
 	owner.update_eyes() // updates eyelids
-	for(var/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity/uncon_aa in GLOB.active_alternate_appearances)
-		uncon_aa.hide_from(owner, absolute = TRUE)
+
+	if(isnull(owner.client))
+		UnregisterSignal(owner, COMSIG_MOB_LOGIN)
+	else
+		hide_unconscious_hud(owner)
 
 /datum/status_effect/knocked_out/tick(seconds_between_ticks)
 	owner.adjust_stamina_loss(-3 * seconds_between_ticks)
+
+/datum/status_effect/knocked_out/proc/show_unconscious_hud(mob/living/source)
+	SIGNAL_HANDLER
+	UnregisterSignal(owner, COMSIG_MOB_LOGIN)
+	for(var/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity/uncon_aa in GLOB.active_alternate_appearances)
+		if(uncon_aa.target == owner)
+			continue
+		uncon_aa.show_to(owner)
+
+/datum/status_effect/knocked_out/proc/hide_unconscious_hud(mob/living/source)
+	SIGNAL_HANDLER
+	UnregisterSignal(owner, COMSIG_MOB_LOGIN)
+	for(var/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity/uncon_aa in GLOB.active_alternate_appearances)
+		uncon_aa.hide_from(owner, absolute = TRUE)
 
 //SLEEPING
 /datum/status_effect/incapacitating/sleeping

--- a/code/datums/status_effects/debuffs/vision/blindness.dm
+++ b/code/datums/status_effects/debuffs/vision/blindness.dm
@@ -27,31 +27,29 @@
 	return ..()
 
 /datum/status_effect/grouped/blindness/source_added(source, ...)
-	update_blindness(source)
+	update_blindness()
 
 /datum/status_effect/grouped/blindness/source_removed(source, removing)
 	if (!removing)
-		update_blindness(source)
+		update_blindness()
 
-/datum/status_effect/grouped/blindness/proc/update_blindness(changed_source)
+/datum/status_effect/grouped/blindness/proc/update_blindness()
 	if (!CAN_BE_BLIND(owner)) // future proofing
 		qdel(src)
 		return
 
 	if (!HAS_TRAIT(owner, TRAIT_SIGHT_BYPASS))
-		make_blind(changed_source)
+		make_blind()
 		return
 
 	for (var/blocker in blocking_sources)
 		if (owner.is_blind_from(blocker))
-			make_blind(changed_source)
+			make_blind()
 			return
 
 	make_unblind()
 
-/datum/status_effect/grouped/blindness/proc/make_blind(changed_source)
-	SIGNAL_HANDLER
-
+/datum/status_effect/grouped/blindness/proc/make_blind()
 	if(!GET_CLIENT(owner))
 		RegisterSignal(owner, COMSIG_MOB_LOGIN, PROC_REF(make_blind_on_login), override = TRUE)
 		return
@@ -60,7 +58,7 @@
 	// by default we use the noflicker overlay
 	// but if our one and only source is from "temp blindness", use flicker overlay
 	var/overlay_to_use = /atom/movable/screen/fullscreen/blind/noflicker
-	if(changed_source == /datum/status_effect/temporary_blindness::id && length(sources) == 1)
+	if(sources[1] == /datum/status_effect/temporary_blindness::id && length(sources) == 1)
 		overlay_to_use = /atom/movable/screen/fullscreen/blind
 
 	owner.overlay_fullscreen(id, overlay_to_use)
@@ -69,10 +67,12 @@
 
 /datum/status_effect/grouped/blindness/proc/make_blind_on_login(mob/living/source)
 	SIGNAL_HANDLER
+
 	UnregisterSignal(owner, COMSIG_MOB_LOGIN)
-	make_blind(source)
+	make_blind()
 
 /datum/status_effect/grouped/blindness/proc/make_unblind()
+	UnregisterSignal(owner, COMSIG_MOB_LOGIN)
 	owner.clear_fullscreen(id)
 	owner.remove_client_colour(id)
 

--- a/code/datums/status_effects/debuffs/vision/blindness.dm
+++ b/code/datums/status_effects/debuffs/vision/blindness.dm
@@ -52,7 +52,7 @@
 /datum/status_effect/grouped/blindness/proc/make_blind(changed_source)
 	SIGNAL_HANDLER
 
-	if(isnull(owner.client))
+	if(!GET_CLIENT(owner))
 		RegisterSignal(owner, COMSIG_MOB_LOGIN, PROC_REF(make_blind_on_login), override = TRUE)
 		return
 

--- a/code/datums/status_effects/debuffs/vision/blindness.dm
+++ b/code/datums/status_effects/debuffs/vision/blindness.dm
@@ -50,23 +50,36 @@
 	make_unblind()
 
 /datum/status_effect/grouped/blindness/proc/make_blind(changed_source)
+	SIGNAL_HANDLER
+
+	if(isnull(owner.client))
+		RegisterSignal(owner, COMSIG_MOB_LOGIN, PROC_REF(make_blind_on_login), override = TRUE)
+		return
+
 	// have some extra logic to determine what overlay to use
 	// by default we use the noflicker overlay
 	// but if our one and only source is from "temp blindness", use flicker overlay
 	var/overlay_to_use = /atom/movable/screen/fullscreen/blind/noflicker
 	if(changed_source == /datum/status_effect/temporary_blindness::id && length(sources) == 1)
 		overlay_to_use = /atom/movable/screen/fullscreen/blind
-	owner.overlay_fullscreen(id, overlay_to_use )
+
+	owner.overlay_fullscreen(id, overlay_to_use)
 	// You are blind - at most, able to make out shapes near you
-	owner.add_client_colour(/datum/client_colour/blindness, REF(src))
+	owner.add_client_colour(/datum/client_colour/blindness, id)
+
+/datum/status_effect/grouped/blindness/proc/make_blind_on_login(mob/living/source)
+	SIGNAL_HANDLER
+	UnregisterSignal(owner, COMSIG_MOB_LOGIN)
+	make_blind(source)
 
 /datum/status_effect/grouped/blindness/proc/make_unblind()
 	owner.clear_fullscreen(id)
-	owner.remove_client_colour(REF(src))
+	owner.remove_client_colour(id)
 
 /datum/status_effect/grouped/blindness/on_remove()
 	make_unblind()
 	UnregisterSignal(owner, update_signals)
+	UnregisterSignal(owner, COMSIG_MOB_LOGIN)
 	return ..()
 
 /atom/movable/screen/alert/status_effect/blind

--- a/code/game/atom/alternate_appearance.dm
+++ b/code/game/atom/alternate_appearance.dm
@@ -233,17 +233,3 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 	if(IS_HERETIC_OR_MONSTER(viewer))
 		return TRUE
 	return FALSE
-
-/// Hud specifically used for mobs when unconscious to hide other humans
-/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity
-
-/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity/New(key, image/shown_image, options)
-	. = ..()
-	RegisterSignal(target, COMSIG_LIVING_POST_UPDATE_TRANSFORM, PROC_REF(turn_image))
-
-/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity/proc/turn_image(datum/source, ...)
-	SIGNAL_HANDLER
-	image.transform = target.transform
-
-/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity/mobShouldSee(mob/M)
-	return FALSE // this hud is managed manually, so don't show it generically

--- a/code/modules/mob/living/basic/revolutionary.dm
+++ b/code/modules/mob/living/basic/revolutionary.dm
@@ -107,8 +107,8 @@
 	shuffle_inplace(causes)
 	desc += span_notice("#[pick(causes)].")
 
-/mob/living/basic/revolutionary/init_unconscious_appearance()
-	add_generic_humanoid_static_appearance()
+/mob/living/basic/revolutionary/get_unconscious_appearance()
+	return get_generic_humanoid_static_appearance()
 
 /obj/effect/mob_spawn/corpse/human/revolutionary
 	name = "Revolutionary"

--- a/code/modules/mob/living/basic/ruin_defender/dark_wizard.dm
+++ b/code/modules/mob/living/basic/ruin_defender/dark_wizard.dm
@@ -53,8 +53,8 @@
 
 	new /obj/item/clothing/head/wizard/hood(src) // Having this hat in our contents allows us to cast wizard spells
 
-/mob/living/basic/paper_wizard/init_unconscious_appearance()
-	add_generic_humanoid_static_appearance()
+/mob/living/basic/paper_wizard/get_unconscious_appearance()
+	return get_generic_humanoid_static_appearance()
 
 /datum/ai_controller/basic_controller/dark_wizard
 	behavior_tree_json = "code/modules/mob/living/basic/ruin_defender/dark_wizard.bt.json"

--- a/code/modules/mob/living/basic/ruin_defender/skeleton.dm
+++ b/code/modules/mob/living/basic/ruin_defender/skeleton.dm
@@ -54,8 +54,8 @@
 	var/list/foods_list = good_drinks + bad_drinks
 	ai_controller?.set_blackboard_key(BB_BASIC_FOODS, typecacheof(foods_list))
 
-/mob/living/basic/skeleton/init_unconscious_appearance()
-	add_generic_humanoid_static_appearance()
+/mob/living/basic/skeleton/get_unconscious_appearance()
+	return get_generic_humanoid_static_appearance()
 
 /mob/living/basic/skeleton/settler
 	name = "undead settler"

--- a/code/modules/mob/living/basic/ruin_defender/wizard/wizard.dm
+++ b/code/modules/mob/living/basic/ruin_defender/wizard/wizard.dm
@@ -83,8 +83,8 @@
 	blink_spell.Grant(src)
 	ai_controller.set_blackboard_key(BB_WIZARD_BLINK_SPELL, blink_spell)
 
-/mob/living/basic/wizard/init_unconscious_appearance()
-	add_generic_humanoid_static_appearance()
+/mob/living/basic/wizard/get_unconscious_appearance()
+	return get_generic_humanoid_static_appearance()
 
 /// Uses the colors and loadout of the original wizard simplemob
 /mob/living/basic/wizard/classic

--- a/code/modules/mob/living/basic/ruin_defender/zombie.dm
+++ b/code/modules/mob/living/basic/ruin_defender/zombie.dm
@@ -33,8 +33,8 @@
 	apply_dynamic_human_appearance(src, outfit, /datum/species/zombie, bloody_slots = ITEM_SLOT_OCLOTHING)
 	AddElement(/datum/element/death_drops, /obj/effect/decal/remains/human)
 
-/mob/living/basic/zombie/init_unconscious_appearance()
-	add_generic_humanoid_static_appearance()
+/mob/living/basic/zombie/get_unconscious_appearance()
+	return get_generic_humanoid_static_appearance()
 
 /mob/living/basic/zombie/melee_attack(atom/target, list/modifiers, ignore_cooldown)
 	. = ..()

--- a/code/modules/mob/living/basic/space_fauna/cat_surgeon.dm
+++ b/code/modules/mob/living/basic/space_fauna/cat_surgeon.dm
@@ -44,8 +44,8 @@
 	AddElement(/datum/element/death_drops, drop_on_death)
 	RegisterSignal(src, COMSIG_HOSTILE_POST_ATTACKINGTARGET, PROC_REF(after_attack))
 
-/mob/living/basic/cat_butcherer/init_unconscious_appearance()
-	add_generic_humanoid_static_appearance()
+/mob/living/basic/cat_butcherer/get_unconscious_appearance()
+	return get_generic_humanoid_static_appearance()
 
 /mob/living/basic/cat_butcherer/proc/after_attack(mob/living/basic/attacker, atom/target)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/basic/space_fauna/paper_wizard/paper_wizard.dm
+++ b/code/modules/mob/living/basic/space_fauna/paper_wizard/paper_wizard.dm
@@ -35,8 +35,8 @@
 	grant_loot()
 	AddElement(/datum/element/effect_trail, /obj/effect/temp_visual/paper_scatter)
 
-/mob/living/basic/paper_wizard/init_unconscious_appearance()
-	add_generic_humanoid_static_appearance()
+/mob/living/basic/paper_wizard/get_unconscious_appearance()
+	return get_generic_humanoid_static_appearance()
 
 /mob/living/basic/paper_wizard/proc/grant_abilities()
 	var/static/list/innate_actions = list(

--- a/code/modules/mob/living/basic/trader/trader.dm
+++ b/code/modules/mob/living/basic/trader/trader.dm
@@ -58,8 +58,8 @@
 	setup_shop.Grant(src)
 	ai_controller.set_blackboard_key(BB_SETUP_SHOP, setup_shop)
 
-/mob/living/basic/trader/init_unconscious_appearance()
-	add_generic_humanoid_static_appearance()
+/mob/living/basic/trader/get_unconscious_appearance()
+	return get_generic_humanoid_static_appearance()
 
 /mob/living/basic/trader/mrbones
 	name = "Mr. Bones"

--- a/code/modules/mob/living/basic/trooper/trooper.dm
+++ b/code/modules/mob/living/basic/trooper/trooper.dm
@@ -38,5 +38,5 @@
 		AddElement(/datum/element/death_drops, loot)
 	AddElement(/datum/element/footstep, footstep_type = FOOTSTEP_MOB_SHOE)
 
-/mob/living/basic/trooper/init_unconscious_appearance()
-	add_generic_humanoid_static_appearance()
+/mob/living/basic/trooper/get_unconscious_appearance()
+	return get_generic_humanoid_static_appearance()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -42,16 +42,16 @@
 /mob/living/carbon/human/proc/setup_physiology()
 	physiology = new()
 
-/mob/living/carbon/human/init_unconscious_appearance()
-	add_generic_humanoid_static_appearance()
+/mob/living/carbon/human/get_unconscious_appearance()
+	return get_generic_humanoid_static_appearance()
 
 /mob/living/carbon/human/proc/setup_mood()
 	if (CONFIG_GET(flag/disable_human_mood))
 		return
 	mob_mood = new /datum/mood(src)
 
-/mob/living/carbon/human/dummy/init_unconscious_appearance()
-	return
+/mob/living/carbon/human/dummy/get_unconscious_appearance()
+	return null
 
 /mob/living/carbon/human/dummy/setup_mood()
 	return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -19,7 +19,9 @@
 	SSpoints_of_interest.make_point_of_interest(src)
 	update_fov()
 	gravity_setup()
-	init_unconscious_appearance()
+	unconscious_appearance = get_unconscious_appearance()
+	if(!isnull(unconscious_appearance))
+		GLOB.unconscious_appearances += unconscious_appearance
 
 /mob/living/prepare_huds()
 	..()
@@ -29,9 +31,9 @@
 	med_hud_set_health()
 	med_hud_set_status()
 
-/// Inits the unconscious alt appearance for when other mobs see us while unconscious
-/mob/living/proc/init_unconscious_appearance()
-	return
+/// Returns the appearance other mobs see instead of us while unconscious
+/mob/living/proc/get_unconscious_appearance()
+	return null
 
 /mob/living/Destroy()
 	for(var/datum/status_effect/effect as anything in status_effects)
@@ -53,6 +55,14 @@
 		QDEL_LIST(imaginary_group)
 	QDEL_LAZYLIST(diseases)
 	QDEL_LAZYLIST(quirks)
+
+	if(!isnull(unconscious_appearance))
+		// Not super necessary strictly speaking but just in case
+		for(var/client/player as anything in GLOB.clients)
+			player?.images -= unconscious_appearance
+		GLOB.unconscious_appearances -= unconscious_appearance
+		unconscious_appearance = null
+
 	return ..()
 
 /mob/living/onZImpact(turf/impacted_turf, levels, impact_flags = NONE)
@@ -3048,16 +3058,12 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	else
 		add_verb(src, /mob/living/verb/pulled)
 
-/// Generic helper to add a static-y humanoid appearance shown to other mobs when unconscious
-/mob/living/proc/add_generic_humanoid_static_appearance()
+/// Generic helper to return a static-y humanoid appearance shown to other mobs when unconscious
+/mob/living/proc/get_generic_humanoid_static_appearance()
 	SHOULD_NOT_OVERRIDE(TRUE)
 
 	var/image/static_image = image('icons/effects/effects.dmi', src, "static")
 	static_image.override = TRUE
 	static_image.name = "unknown humanoid"
-	add_alt_appearance(
-		/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity,
-		"[REF(src)]_unconscious",
-		static_image,
-		NONE,
-	)
+
+	return static_image

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -262,3 +262,6 @@
 	/// When less than or equal to  this distance (but not adjacent), this mob can hear parts of distant whispers, but not the entire message.
 	/// When greater than this distance, this mob cannot hear anything of a whisper.
 	var/eavesdrop_range = EAVESDROP_RANGE
+
+	/// Reference to the unconscious appearance image that appears in place of the mob to other knocked out mobs
+	VAR_FINAL/image/unconscious_appearance

--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -55,6 +55,7 @@
 	readjust_atom_huds(animate_time)
 
 	SEND_SIGNAL(src, COMSIG_LIVING_POST_UPDATE_TRANSFORM, resize, lying_angle, is_opposite_angle)
+	unconscious_appearance?.transform = ntransform
 	return TRUE
 
 /mob/living/proc/readjust_atom_huds(animate_time = null)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1102,7 +1102,7 @@ GAME_VERB_DESC(/mob/living/silicon/ai, deploy_to_shell, "Deploy to Shell", "Tran
 		return ai_voicechanger.say_name
 	return ..()
 
-/mob/living/silicon/ai/init_unconscious_appearance()
+/mob/living/silicon/ai/get_unconscious_appearance()
 	var/image/static_overlay = image('icons/effects/effects.dmi', null, "static_base")
 	static_overlay.blend_mode = BLEND_INSET_OVERLAY
 
@@ -1111,12 +1111,8 @@ GAME_VERB_DESC(/mob/living/silicon/ai, deploy_to_shell, "Deploy to Shell", "Tran
 	static_image.overlays += static_overlay
 	static_image.override = TRUE
 	static_image.name = "unknown AI"
-	add_alt_appearance(
-		/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity,
-		"[REF(src)]_unconscious",
-		static_image,
-		NONE,
-	)
+
+	return static_image
 
 /mob/living/silicon/ai/proc/set_control_disabled(control_disabled)
 	SEND_SIGNAL(src, COMSIG_SILICON_AI_SET_CONTROL_DISABLED, control_disabled)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1049,7 +1049,7 @@
 		unbuckle_mob(buckled_mob)
 	do_sparks(5, 0, src)
 
-/mob/living/silicon/robot/init_unconscious_appearance()
+/mob/living/silicon/robot/get_unconscious_appearance()
 	var/image/static_overlay = image('icons/effects/effects.dmi', null, "static_base")
 	static_overlay.blend_mode = BLEND_INSET_OVERLAY
 
@@ -1058,9 +1058,5 @@
 	static_image.overlays += static_overlay
 	static_image.override = TRUE
 	static_image.name = "unknown cyborg"
-	add_alt_appearance(
-		/datum/atom_hud/alternate_appearance/basic/unconscious_obscurity,
-		"[REF(src)]_unconscious",
-		static_image,
-		NONE,
-	)
+
+	return static_image

--- a/code/modules/unit_tests/blindness.dm
+++ b/code/modules/unit_tests/blindness.dm
@@ -12,6 +12,7 @@
 	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
 	var/obj/item/clothing/glasses/blindfold/blindfold = new(dummy.loc)
 	TEST_ASSERT(!dummy.is_blind(), "Dummy was blind on initialize, and shouldn't be.")
+	dummy.mock_client = new()
 
 	// Become blind
 	dummy.become_blind("unit_test")
@@ -70,6 +71,7 @@
 /datum/unit_test/nearsighted_quirk/Run()
 	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
 	var/obj/item/clothing/glasses/regular/glasses = allocate(/obj/item/clothing/glasses/regular)
+	dummy.mock_client = new()
 
 	// Become quirk nearsighted
 	// Have to do a transfer here so we don't get glasses
@@ -106,6 +108,7 @@
 /datum/unit_test/eye_damage/Run()
 	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
 	var/obj/item/organ/eyes/eyes = dummy.get_organ_slot(ORGAN_SLOT_EYES)
+	dummy.mock_client = new()
 	TEST_ASSERT_NOTNULL(eyes, "Eye damage unit test spawned a dummy without eyes!")
 
 	// Test blindness due to eye damage
@@ -154,6 +157,7 @@
 /datum/unit_test/nearsighted_effect/Run()
 	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
 	var/datum/status_effect/grouped/nearsighted/myopia
+	dummy.mock_client = new()
 
 	/* APPLICATION */
 	// Let's test regular nearsightedness first


### PR DESCRIPTION
## About The Pull Request

I noticed an init time regression from the unconscious huds that I didn't consider: 
When we spawened dead bodies at round start, it'd show the unconscious hud to them. While this *functions* fine, it's a little wasteful, since it's a purely visual effect. It's a lot faster if we just... don't add non-players to the unconscious huds until they have a client login. 

Reclaims ~0.5s of init time

A similar optimization can be made to blindness:
While the fullscreen overlay and client colors can be added to mobs and it *functions* fine, it's wasteful to add, delete, recreate these things when they're purely visual effects. 

Reclaims ~0.05s of init time 

Screen alerts can also benefit from something like this, but it'd be a bit more work to set that up.

Would reclaim ~0.05s of init time

Also changed: 
Don't tick `knocked_out` if the mob is dead, it doesn't do anything. Saves a fair bit of time over the course of the round
Iterating over alt appearances is pretty slow and I'm pretty sure it's faster if we just manually handle the images in a separate list.

## Changelog

:cl: Melbert
code: Slightly changed the logic for blindness and unconscious hud effects, report any oddities
/:cl:
