### PR TITLE
Fixes organ exports.

### DIFF
--- a/code/modules/cargo/exports/organs.dm
+++ b/code/modules/cargo/exports/organs.dm
@@ -8,7 +8,10 @@
 /datum/export/organ/get_base_cost(obj/exported_item)
 	// Multiply value for organs that started in a player
 	// Unaffected by price elasticity as there's a limited amount of these in play
-	return round(..() * HAS_TRAIT(exported_item, TRAIT_CLIENT_STARTING_ORGAN) ? CLIENT_ORGAN_MULT : 1)
+	var/multiplier = 1
+	if(HAS_TRAIT(exported_item, TRAIT_CLIENT_STARTING_ORGAN))
+		multiplier = CLIENT_ORGAN_MULT
+	return round(..() * multiplier)
 
 /datum/export/organ/heart
 	cost = CARGO_CRATE_VALUE * 0.2 //For the man who has everything and nothing.


### PR DESCRIPTION
## About The Pull Request
 Organ exports were designed so that human organs were meant to sell for amounts like 40-20 credits when they come from human sources, like monkeys.  On live, however, organs are selling for 1 credits. They also have a mechanic that multiplies the value of the exported organ if it's sold and it originally belonged to a roundstart human.

This didn't work! It may have never worked, or it stopped working at some point. Now it properly grabs the value of the organ, against the roundstart value of the organ. This means that on the high end, a roundstart heart is worth 400 credits. Roundstart, regular human organs are also worth about 200 credits each.

Now, this has a knock on effect with the other organs in this folder. I don't think we considered that when it was originally implemented, as lizard tails, cat tails, and cat ears are subtypes with this same behavior. Do with this what you will. I'm leaving it alone because I think it'd be fucking hilarious.

## Why It's Good For The Game

Technically fixes an issue that everyone knew existed, but nobody wanted to resolve for some unknown reason.

## Changelog

:cl:
fix: Selling organs in cargo once again works properly. As a reminder, Normal human organs sell for 20 credits. The organs of a roundstart human are worth 10x as much, however.
/:cl:
