### PR TITLE
Pirates prioritize spawning a leader

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -176,23 +176,31 @@
 	if(!ship.load(T))
 		CRASH("Loading pirate ship failed!")
 
+	//if the pirate has a "leader" type, fill that first
+	var/list/spawners = list()
 	for(var/turf/area_turf as anything in ship.get_affected_turfs(T))
 		for(var/obj/effect/mob_spawn/ghost_role/human/pirate/spawner in area_turf)
-			if(candidates.len > 0)
-				var/mob/our_candidate = candidates[1]
-				var/mob/spawned_mob = spawner.create_from_ghost(our_candidate)
-				candidates -= our_candidate
-				notify_ghosts(
-					"The [chosen_gang.ship_name] has an object of interest: [spawned_mob]!",
-					source = spawned_mob,
-					header = "Pirates!",
-				)
+			if(spawner.is_leader)
+				spawners.Insert(1, spawner)
 			else
-				notify_ghosts(
-					"The [chosen_gang.ship_name] has an object of interest: [spawner]!",
-					source = spawner,
-					header = "Pirate Spawn Here!",
-				)
+				spawners += spawner
+
+	for(var/obj/effect/mob_spawn/ghost_role/human/pirate/spawner as anything in spawners)
+		if(candidates.len > 0)
+			var/mob/our_candidate = candidates[1]
+			var/mob/spawned_mob = spawner.create_from_ghost(our_candidate)
+			candidates -= our_candidate
+			notify_ghosts(
+				"The [chosen_gang.ship_name] has an object of interest: [spawned_mob]!",
+				source = spawned_mob,
+				header = "Pirates!",
+			)
+		else
+			notify_ghosts(
+				"The [chosen_gang.ship_name] has an object of interest: [spawner]!",
+				source = spawner,
+				header = "Pirate Spawn Here!",
+			)
 
 	priority_announce(chosen_gang.arrival_announcement, sender_override = chosen_gang.ship_name)
 

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -92,7 +92,7 @@
 	config_tag = "Heavy Pirates"
 	midround_type = HEAVY_MIDROUND
 	jobban_flag = ROLE_TRAITOR
-	ruleset_flags = RULESET_INVADER
+	ruleset_flags = RULESET_INVADER|RULESET_ADMIN_CONFIGURABLE
 	weight = 3
 	min_pop = 25
 	min_antag_cap = 0 // ship will spawn if there are no ghosts around

--- a/code/modules/antagonists/pirate/pirate_roles.dm
+++ b/code/modules/antagonists/pirate/pirate_roles.dm
@@ -17,6 +17,8 @@
 	allow_custom_character = GHOSTROLE_TAKE_PREFS_APPEARANCE
 	///Rank of the pirate on the ship, it's used in generating pirate names!
 	var/rank = "Deserter"
+	///Leader spawners are filled before the rest of the crew.
+	var/is_leader = FALSE
 	///Path of the structure we spawn after creating a pirate.
 	var/fluff_spawn = /obj/structure/showcase/machinery/oldpod/used
 
@@ -44,6 +46,7 @@
 /obj/effect/mob_spawn/ghost_role/human/pirate/captain
 	rank = "Renegade Leader"
 	outfit = /datum/outfit/pirate/space/captain
+	is_leader = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/pirate/gunner
 	rank = "Rogue"
@@ -64,6 +67,7 @@
 /obj/effect/mob_spawn/ghost_role/human/pirate/skeleton/captain
 	rank = "Captain"
 	outfit = /datum/outfit/pirate/captain/skeleton
+	is_leader = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/pirate/skeleton/gunner
 	rank = "Gunner"
@@ -94,6 +98,7 @@
 /obj/effect/mob_spawn/ghost_role/human/pirate/silverscale/captain
 	rank = "Old-guard"
 	outfit = /datum/outfit/pirate/silverscale/captain
+	is_leader = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/pirate/silverscale/gunner
 	rank = "Top-drawer"
@@ -125,6 +130,7 @@
 /obj/effect/mob_spawn/ghost_role/human/pirate/interdyne/senior
 	rank = "Pharmacist Director"
 	outfit = /datum/outfit/pirate/interdyne/captain
+	is_leader = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/pirate/interdyne/junior
 	rank = "Pharmacist"
@@ -173,6 +179,7 @@
 /obj/effect/mob_spawn/ghost_role/human/pirate/irs/auditor
 	rank = "Head Auditor"
 	outfit = /datum/outfit/pirate/irs/auditor
+	is_leader = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/pirate/lustrous
 	name = "lustrous crystal"
@@ -192,6 +199,7 @@
 /obj/effect/mob_spawn/ghost_role/human/pirate/lustrous/captain
 	rank = "Radiant"
 	outfit = /datum/outfit/pirate/lustrous/captain
+	is_leader = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/pirate/lustrous/gunner
 	rank = "Coruscant"
@@ -220,6 +228,7 @@
 /obj/effect/mob_spawn/ghost_role/human/pirate/medieval/warlord
 	rank = "Warlord"
 	outfit = /datum/outfit/pirate/medieval/warlord
+	is_leader = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/pirate/medieval/warlord/special(mob/living/carbon/spawned_mob, mob/mob_possessor, apply_prefs)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
When pirates have a leader (all types of pirates besides greytiders), prioritize spawning the "leader" type from the ghost poll

Also makes Heavy Pirates admin-configurable (Light Pirates already were)
## Why It's Good For The Game

Pretty small cosmetic change (well except for the medieval pirates where the leader is a hulk) but idk it feels weird for the one labeled "leader" to wake up 30 minutes later and have to ask the crew what's going on
## Changelog
:cl: PapaMichael
balance: Pirates prioritize spawning their leaders
admin: Admins can configure Heavy Pirates
/:cl:
