### PR TITLE
Surplus crate items shows up in roundend report (again?)

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -151,10 +151,14 @@
 	var/atom/spawned_item = spawn_item(item, user, uplink_handler, source)
 	log_uplink("[key_name(user)] purchased [src] for [cost] telecrystals from [source]'s uplink")
 	user.playsound_local(get_turf(user), 'sound/effects/kaching.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
-	if(purchase_log_vis && uplink_handler.purchase_log)
-		uplink_handler.purchase_log.LogPurchase(spawned_item, src, cost)
+	if(uplink_handler.purchase_log)
+		log_purchase(spawned_item, uplink_handler)
 	if(lock_other_purchases)
 		uplink_handler.shop_locked = TRUE
+	return spawned_item
+
+/datum/uplink_item/proc/log_purchase(atom/spawned_item, datum/uplink_handler/uplink_handler)
+	uplink_handler.purchase_log.log_purchase(spawned_item, src, cost)
 
 /// Spawns an item in the world
 /datum/uplink_item/proc/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)

--- a/code/modules/uplink/uplink_items/bundle.dm
+++ b/code/modules/uplink/uplink_items/bundle.dm
@@ -37,10 +37,12 @@
 	desc = "A telecrystal in its rawest and purest form; can be utilized on active uplinks to increase their telecrystal count."
 	item = /obj/item/stack/telecrystal
 	cost = 1
-	// Don't add telecrystals to the purchase_log since
-	// it's just used to buy more items (including itself!)
-	purchase_log_vis = FALSE
 	purchasable_from = NONE
+
+// Don't add telecrystals to the purchase_log since
+// it's just used to buy more items (including itself!)
+/datum/uplink_item/bundles_tc/telecrystal/log_purchase(atom/spawned_item, datum/uplink_handler/uplink_handler)
+	return
 
 /datum/uplink_item/bundles_tc/bundle_a
 	name = "Syndi-kit Tactical"
@@ -132,7 +134,28 @@
 		"style" = /datum/pod_style/syndicate,
 		"spawn" = surplus_crate,
 	))
-	return source //For log icon
+	return surplus_crate //For log icon
+
+/datum/uplink_item/bundles_tc/surplus/log_purchase(atom/spawned_item, datum/uplink_handler/uplink_handler)
+	. = ..()
+	var/list/entries = list()
+	for(var/obj/item/loot in spawned_item)
+		if(entries[loot.type])
+			var/datum/uplink_purchase_entry/existing_entry = entries[loot.type]
+			existing_entry.amount_purchased += 1
+			continue
+
+		var/datum/uplink_purchase_entry/custom_entry = new()
+		custom_entry.set_item(loot)
+		custom_entry.base_cost = 0
+		custom_entry.spent_cost = 0
+		custom_entry.amount_purchased = 1
+		custom_entry.name = "Surplus Item: [format_text(loot.name)]"
+		custom_entry.desc = "Obtained via surplus crate."
+		entries[loot.type] = custom_entry
+
+	for(var/entry_type, entry_datum in entries)
+		uplink_handler.purchase_log.log_purchase_custom(entry_datum)
 
 /datum/uplink_item/bundles_tc/surplus/united
 	name = "United Surplus Crate"

--- a/code/modules/uplink/uplink_purchase_log.dm
+++ b/code/modules/uplink/uplink_purchase_log.dm
@@ -39,29 +39,36 @@ GLOBAL_LIST(uplink_purchase_logs_by_key) //assoc key = /datum/uplink_purchase_lo
 /datum/uplink_purchase_log/proc/TotalTelecrystalsSpent()
 	. = total_spent
 
+#define FORMAT_COST(uplink_entry) (uplink_entry.spent_cost ? "[uplink_entry.spent_cost] TC" : (uplink_entry.base_cost ? "Free" : "Surplus"))
+
 /datum/uplink_purchase_log/proc/generate_render(show_key = TRUE)
 	. = ""
 	for(var/hash in purchase_log)
 		var/datum/uplink_purchase_entry/UPE = purchase_log[hash]
-		. += "<span class='tooltip_container'>\[[UPE.icon_b64][show_key?"([owner])":""]<span class='tooltip_hover'><b>[UPE.name]</b><br>[UPE.spent_cost ? "[UPE.spent_cost] TC" : "[UPE.base_cost] TC<br>(Surplus)"]<br>[UPE.desc]</span>[(UPE.amount_purchased > 1) ? "x[UPE.amount_purchased]" : ""]\]</span>"
+		. += "<span class='tooltip_container'>\[[UPE.icon_b64][show_key ? "([owner])":""]<span class='tooltip_hover'><b>[UPE.name]</b><br>[FORMAT_COST(UPE)]<br>[UPE.desc]</span>[(UPE.amount_purchased > 1) ? "x[UPE.amount_purchased]" : ""]\]</span>"
 
-/datum/uplink_purchase_log/proc/LogPurchase(atom/A, datum/uplink_item/uplink_item, spent_cost)
-	var/datum/uplink_purchase_entry/UPE
+#undef FORMAT_COST
+
+/// Logs that an uplink item was purchased
+/datum/uplink_purchase_log/proc/log_purchase(atom/spawned_item, datum/uplink_item/uplink_item, spent_cost)
 	var/hash = hash_purchase(uplink_item, spent_cost)
-	if(purchase_log[hash])
-		UPE = purchase_log[hash]
-	else
-		UPE = new
-		purchase_log[hash] = UPE
-		UPE.path = A.type
-		UPE.icon_b64 = "[icon2base64html(A)]"
-		UPE.desc = uplink_item.desc
-		UPE.name = uplink_item.name
-		UPE.base_cost = initial(uplink_item.cost)
-		UPE.spent_cost = spent_cost
+	var/datum/uplink_purchase_entry/purchase_entry = purchase_log[hash]
+	if(isnull(purchase_entry))
+		purchase_entry = new()
+		purchase_entry.set_item(spawned_item)
+		purchase_entry.name = uplink_item.name
+		purchase_entry.desc = uplink_item.desc
+		purchase_entry.base_cost = initial(uplink_item.cost)
+		purchase_entry.spent_cost = spent_cost
+		purchase_log[hash] = purchase_entry
 
-	UPE.amount_purchased++
+	purchase_entry.amount_purchased += 1
 	total_spent += spent_cost
+
+/// Used to add custom items into the purchase log
+/datum/uplink_purchase_log/proc/log_purchase_custom(datum/uplink_purchase_entry/custom_entry)
+	purchase_log[REF(custom_entry)] = custom_entry
+	total_spent += custom_entry.spent_cost
 
 /datum/uplink_purchase_log/proc/hash_purchase(datum/uplink_item/uplink_item, spent_cost)
 	return "[uplink_item.type]|[uplink_item.name]|[uplink_item.cost]|[spent_cost]"
@@ -74,3 +81,7 @@ GLOBAL_LIST(uplink_purchase_logs_by_key) //assoc key = /datum/uplink_purchase_lo
 	var/base_cost
 	var/spent_cost
 	var/name
+
+/datum/uplink_purchase_entry/proc/set_item(obj/item/to_set)
+	path = to_set.type
+	icon_b64 = "[icon2base64html(to_set)]"


### PR DESCRIPTION
## About The Pull Request

Buying a surplus crate shows the items you got in it in the roundend report

<img width="823" height="58" alt="image" src="https://github.com/user-attachments/assets/54e08de6-066f-43f0-a3e8-eaf96694b15d" />

(Hovering over them says `Surplus item: [xyz]`)

## Why It's Good For The Game

I could've sworn it used to do this but I don't remember
It's nice to know where all the guy's loot came from though

## Changelog

:cl: Melbert
qol: Surplus crate items show up in roundend report
/:cl:
