### PR TITLE
Optimizes revenant abilities

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
@@ -95,6 +95,9 @@
 	var/unreveal_time = 0
 	/// How many perfect, regen-cap increasing souls the revenant has. //TODO, add objective for getting a perfect soul(s?)
 	var/perfectsouls = 0
+	/// Are our abilities blocked from being inside a wall? Separate, as we set this back to null after running update in update_ability_status()
+	/// Used to avoid running turf checks more than once
+	var/ability_density_locked = null
 
 /mob/living/basic/revenant/Initialize(mapload)
 	. = ..()
@@ -157,14 +160,14 @@
 	if(essence_regenerating && !HAS_TRAIT(src, TRAIT_REVENANT_INHIBITED) && essence < max_essence) //While inhibited, essence will not regenerate
 		var/change_in_time = DELTA_WORLD_TIME(SSmobs)
 		essence = min(essence + (essence_regen_amount * change_in_time), max_essence)
-		update_mob_action_buttons() //because we update something required by our spells in life, we need to update our buttons
+		update_ability_status() //because we update something required by our spells in life, we need to update our buttons
 
 	update_health_hud()
 
 /mob/living/basic/revenant/proc/update_revenant_appearance()
 	SIGNAL_HANDLER
 	update_appearance(UPDATE_ICON)
-	update_mob_action_buttons()
+	update_ability_status()
 
 /mob/living/basic/revenant/AltClickOn(atom/target)
 	if(CAN_I_SEE(target))
@@ -326,7 +329,7 @@
 		return
 	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REVENANT_STUNNED_TRAIT)
 	dormant = TRUE
-	update_mob_action_buttons()
+	update_ability_status()
 
 	visible_message(
 		span_warning("[src] lets out a waning screech as violet mist swirls around its dissolving body!"),
@@ -413,22 +416,20 @@
 
 	return TRUE
 
+/mob/living/basic/revenant/proc/update_ability_status()
+	// Perform a shared check for all of our abilities
+	ability_density_locked = turf_density_check(silent = TRUE)
+	update_mob_action_buttons(UPDATE_BUTTON_STATUS)
+	ability_density_locked = null
+
 /mob/living/basic/revenant/proc/cast_check(essence_cost, deduct_essence = TRUE, silent = FALSE)
 	if(QDELETED(src))
-		return
-
-	var/turf/current = get_turf(src)
-
-	if(isclosedturf(current))
-		if(!silent)
-			to_chat(src, span_revenwarning("You cannot use abilities from inside of a wall."))
 		return FALSE
 
-	for(var/obj/thing in current)
-		if(!thing.density || thing.CanPass(src, get_dir(current, src)))
-			continue
+	essence_cost = abs(essence_cost) * -1
+	if(-essence_cost > essence)
 		if(!silent)
-			to_chat(src, span_revenwarning("You cannot use abilities inside of a dense object."))
+			to_chat(src, span_revenwarning("You lack the essence to use that ability!"))
 		return FALSE
 
 	if(dormant)
@@ -441,20 +442,37 @@
 			to_chat(src, span_revenwarning("Your powers have been suppressed by a nullifying energy!"))
 		return FALSE
 
-	essence_cost = abs(essence_cost) * -1
-	var/has_essence = deduct_essence ? change_essence_amount(essence_cost, silent = TRUE) : (essence + essence_cost >= 0)
-	if(!has_essence)
-		if(!silent)
-			to_chat(src, span_revenwarning("You lack the essence to use that ability!"))
+	if(ability_density_locked)
 		return FALSE
 
+	// Don't run turf checks more than once if checking from a forced update
+	if(isnull(ability_density_locked) && turf_density_check(silent))
+		return FALSE
+
+	if(deduct_essence)
+		change_essence_amount(essence_cost, silent = TRUE)
 	return TRUE
+
+/mob/living/basic/revenant/proc/turf_density_check(silent = FALSE)
+	var/turf/current = get_turf(src)
+	if(isclosedturf(current))
+		if(!silent)
+			to_chat(src, span_revenwarning("You cannot use abilities from inside of a wall."))
+		return TRUE
+
+	for(var/obj/thing in current)
+		if(!thing.density || thing.CanPass(src, get_dir(current, src)))
+			continue
+		if(!silent)
+			to_chat(src, span_revenwarning("You cannot use abilities inside of a dense object."))
+		return TRUE
+	return FALSE
 
 /mob/living/basic/revenant/proc/unlock(essence_cost)
 	if(essence_excess < essence_cost)
 		return FALSE
 	essence_excess -= essence_cost
-	update_mob_action_buttons()
+	update_ability_status()
 	return TRUE
 
 /mob/living/basic/revenant/proc/death_reset()
@@ -469,7 +487,7 @@
 	incorporeal_move = INCORPOREAL_MOVE_JAUNT
 	RemoveInvisibility(type)
 	alpha = 255
-	update_mob_action_buttons()
+	update_ability_status()
 
 /mob/living/basic/revenant/proc/change_essence_amount(essence_to_change_by, silent = FALSE, source = null)
 	if(QDELETED(src))
@@ -485,7 +503,7 @@
 		essence_accumulated = max(0, essence_accumulated + essence_to_change_by)
 		essence_excess = max(0, essence_excess + essence_to_change_by)
 
-	update_mob_action_buttons()
+	update_ability_status()
 	if(!silent)
 		if(essence_to_change_by > 0)
 			to_chat(src, span_revennotice("Gained [essence_to_change_by]E [source ? "from [source]":""]."))
@@ -500,11 +518,11 @@
 	. = ..()
 	if(vname == NAMEOF(src, essence) || vname == NAMEOF(src, max_essence) || vname == NAMEOF(src, essence_excess))
 		update_health_hud()
-		update_mob_action_buttons()
+		update_ability_status()
 
 /mob/living/basic/revenant/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
 	. = ..()
-	update_mob_action_buttons()
+	update_ability_status()
 
 /mob/living/basic/revenant/proc/on_reflect(datum/source, atom/movable/reflecting_in, obj/effect/abstract/reflection)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request

Revenant movement costs as much as all other client inputs in a tick combined due to them updating all of their abilities every time they move. In practice they don't need to update anything except said ability's color, and we can run the density check once rather than separately for each ability and share the result when checking for castability from a forced update (nor do we need to do said checks if any other check, like cost, fails to pass).

## Changelog
:cl:
code: Optimized revenant abilities
/:cl:
