### PR TITLE
Bitrunning the Gradening

### DIFF
--- a/code/__DEFINES/bitrunning.dm
+++ b/code/__DEFINES/bitrunning.dm
@@ -4,6 +4,13 @@
 #define BITRUNNER_COST_HIGH 3
 #define BITRUNNER_COST_EXTREME 20
 
+#define BITRUNNING_GRADE_NONE "None"
+#define BITRUNNING_GRADE_D "D"
+#define BITRUNNING_GRADE_C "C"
+#define BITRUNNING_GRADE_B "B"
+#define BITRUNNING_GRADE_A "A"
+#define BITRUNNING_GRADE_S "S"
+
 /// Yay you did it
 #define BITRUNNER_REWARD_MIN 1
 /// You faced some decent odds

--- a/code/_globalvars/lists/bitrunning.dm
+++ b/code/_globalvars/lists/bitrunning.dm
@@ -1,0 +1,9 @@
+/// Assoc list of bitrunning grades in ascending order and their associated fontawesome icons.
+GLOBAL_LIST_INIT(bitrunning_grades, list(
+	BITRUNNING_GRADE_NONE = FA_ICON_MINUS,
+	BITRUNNING_GRADE_D = FA_ICON_D,
+	BITRUNNING_GRADE_C = FA_ICON_C,
+	BITRUNNING_GRADE_B = FA_ICON_B,
+	BITRUNNING_GRADE_A = FA_ICON_A,
+	BITRUNNING_GRADE_S = FA_ICON_S
+))

--- a/code/controllers/subsystem/networks/bitrunning.dm
+++ b/code/controllers/subsystem/networks/bitrunning.dm
@@ -24,6 +24,8 @@ SUBSYSTEM_DEF(bitrunning)
 		var/can_view = domain.can_view_name(scanner_tier, points)
 		var/can_view_reward = domain.can_view_reward(scanner_tier, points)
 
+		var/grade_symbol = GLOB.bitrunning_grades[domain.best_grade]
+
 		UNTYPED_LIST_ADD(levels, list(
 			"announce_ghosts" = domain.announce_to_ghosts,
 			"cost" = domain.cost,
@@ -34,6 +36,7 @@ SUBSYSTEM_DEF(bitrunning)
 			"has_secondary_objectives" = counterlist_sum(domain.secondary_loot) ? TRUE : FALSE,
 			"name" = can_view ? domain.name : REDACTED,
 			"reward" = can_view_reward ? domain.reward_points : REDACTED,
+			"grade_symbol" = grade_symbol,
 		))
 
 	return levels

--- a/code/modules/bitrunning/server/loot.dm
+++ b/code/modules/bitrunning/server/loot.dm
@@ -1,10 +1,3 @@
-#define GRADE_D "D"
-#define GRADE_C "C"
-#define GRADE_B "B"
-#define GRADE_A "A"
-#define GRADE_S "S"
-
-
 /// Handles calculating rewards based on number of players, parts, threats, etc
 /obj/machinery/quantum_server/proc/calculate_rewards()
 	var/rewards_base = 0.8
@@ -73,6 +66,8 @@
 	var/obj/structure/closet/crate/secure/bitrunning/decrypted/reward_cache = new(src, generated_domain, bonus)
 	reward_cache.manifest = WEAKREF(certificate)
 	reward_cache.update_appearance()
+
+	generated_domain.submit_grade(grade)
 
 	if(can_generate_tech_disk(grade))
 		SSblackbox.record_feedback("tally", "bitrunning_bepis_rewarded", 1, generated_domain.key)
@@ -159,7 +154,7 @@
 
 	var/static/list/passing_grades = list()
 	if(!passing_grades.len)
-		passing_grades = list(GRADE_A,GRADE_S)
+		passing_grades = list(BITRUNNING_GRADE_A,BITRUNNING_GRADE_S)
 
 	return  generated_domain.difficulty >= BITRUNNER_DIFFICULTY_MEDIUM && (grade in passing_grades)
 
@@ -190,18 +185,12 @@
 
 	switch(score)
 		if(1 to 4)
-			return GRADE_D
+			return BITRUNNING_GRADE_D
 		if(5 to 7)
-			return GRADE_C
+			return BITRUNNING_GRADE_C
 		if(8 to 10)
-			return GRADE_B
+			return BITRUNNING_GRADE_B
 		if(11 to 13)
-			return GRADE_A
+			return BITRUNNING_GRADE_A
 		else
-			return GRADE_S
-
-#undef GRADE_D
-#undef GRADE_C
-#undef GRADE_B
-#undef GRADE_A
-#undef GRADE_S
+			return BITRUNNING_GRADE_S

--- a/code/modules/bitrunning/virtual_domain/virtual_domain.dm
+++ b/code/modules/bitrunning/virtual_domain/virtual_domain.dm
@@ -91,6 +91,12 @@
 	/// The role that ghosts will get. Only used for poll text.
 	var/spawner_role = "Antagonist"
 
+	/**
+	 * Scorekeeping
+	 */
+
+	/// The highest score grade achieved so far
+	var/best_grade = "None"
 
 /datum/lazy_template/virtual_domain/proc/can_view_name(scanner_tier, server_points)
 	return difficulty < scanner_tier && cost <= server_points + 5
@@ -134,3 +140,7 @@
 /// Overridable proc to be called after the map is loaded.
 /datum/lazy_template/virtual_domain/proc/setup_domain(list/created_atoms)
 	return
+
+/datum/lazy_template/virtual_domain/proc/submit_grade(new_grade)
+	if(GLOB.bitrunning_grades.Find(new_grade) > GLOB.bitrunning_grades.Find(best_grade))
+		best_grade = new_grade

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -575,6 +575,7 @@
 #include "code\_globalvars\time_vars.dm"
 #include "code\_globalvars\lists\achievements.dm"
 #include "code\_globalvars\lists\ambience.dm"
+#include "code\_globalvars\lists\bitrunning.dm"
 #include "code\_globalvars\lists\canisters.dm"
 #include "code\_globalvars\lists\cargo.dm"
 #include "code\_globalvars\lists\client.dm"

--- a/tgui/packages/tgui/interfaces/QuantumConsole.tsx
+++ b/tgui/packages/tgui/interfaces/QuantumConsole.tsx
@@ -54,6 +54,7 @@ type Domain = {
   has_secondary_objectives: BooleanLike;
   name: string;
   reward: number | string;
+  grade_symbol: string;
 };
 
 type DomainEntryProps = {
@@ -261,6 +262,7 @@ function DomainEntry(props: DomainEntryProps) {
       has_secondary_objectives,
       name,
       reward,
+      grade_symbol,
     },
   } = props;
   const { act, data } = useBackend<Data>();
@@ -308,6 +310,7 @@ function DomainEntry(props: DomainEntryProps) {
           {!!announce_ghosts && canView && <Icon name="ghost" ml={1} />}
         </>
       }
+      sideIcon={grade_symbol}
     >
       <Stack height={5}>
         <Stack.Item color="label" grow={4}>


### PR DESCRIPTION

## About The Pull Request

Shows the best grade achieved for each domain in the quantum console.

<img width="517" height="518" alt="image" src="https://github.com/user-attachments/assets/026035f1-ba34-48a0-b71b-72a10419afe8" />

## Why It's Good For The Game

Allows bitrunners to see what domains they've already finished without going back through a stack of paper they may have already trashed or just remembering everything.

Also provides players with a sense of pride and accomplishment for scoring high on all the domains.

## Changelog
:cl:
add: The quantum console now tells bitrunners what grade they've reached on completed domains.
/:cl:
