### PR TITLE
Fixes point-based domain resetting

### DIFF
--- a/code/modules/bitrunning/server/map_handling.dm
+++ b/code/modules/bitrunning/server/map_handling.dm
@@ -237,6 +237,7 @@
 		qdel(creature)
 
 	generated_domain.secondary_loot_generated = 0
+	generated_domain.main_crate_points = 0
 
 	avatar_connection_refs.Cut()
 	exit_turfs = list()


### PR DESCRIPTION

## About The Pull Request

Resets the points tracker on virtual domains whenever they're cleared, as this is kept in the map template and previously wasn't ever reset leading to near instant completion when rerunning domains.

## Why It's Good For The Game

You're supposed to play these every time, not just the first.

## Changelog
:cl:
fix: Point-based bitrunning domains will no longer mysteriously complete themselves on reruns.
/:cl:
