### PR TITLE
Allows you to make chili out of ghost chilis

### DIFF
--- a/code/modules/food_and_drinks/recipes/soup_guide.dm
+++ b/code/modules/food_and_drinks/recipes/soup_guide.dm
@@ -49,6 +49,7 @@
 /datum/crafting_recipe/food/reaction/soup/hotchili
 	name = "Chili Con Carne (Meat Chili)"
 	reaction = /datum/chemical_reaction/food/soup/hotchili
+	cuisine_category = CUISINE_MEXICAN
 
 /datum/crafting_recipe/food/reaction/soup/hotchili/ghost
 	name = "Ghost Chili Con Carne (Meat Chili)"
@@ -56,9 +57,11 @@
 
 /datum/crafting_recipe/food/reaction/soup/coldchili
 	reaction = /datum/chemical_reaction/food/soup/coldchili
+	cuisine_category = CUISINE_MEXICAN
 
 /datum/crafting_recipe/food/reaction/soup/clownchili
 	reaction = /datum/chemical_reaction/food/soup/clownchili
+	cuisine_category = CUISINE_MEXICAN
 
 /datum/crafting_recipe/food/reaction/soup/tomatosoup
 	reaction = /datum/chemical_reaction/food/soup/tomatosoup
@@ -140,6 +143,15 @@
 
 /datum/crafting_recipe/food/reaction/soup/corn_chowder
 	reaction = /datum/chemical_reaction/food/soup/corn_chowder
+
+/datum/crafting_recipe/food/reaction/soup/chili_sin_carne
+	name = "Chili Sin Carne (Vegetarian Chili)"
+	reaction = /datum/chemical_reaction/food/soup/chili_sin_carne
+	cuisine_category = CUISINE_MEXICAN
+
+/datum/crafting_recipe/food/reaction/soup/chili_sin_carne/ghost
+	name = "Ghost Chili Sin Carne (Vegetarian Chili)"
+	reaction = /datum/chemical_reaction/food/soup/chili_sin_carne/ghost
 
 // Other
 

--- a/code/modules/food_and_drinks/recipes/soup_guide.dm
+++ b/code/modules/food_and_drinks/recipes/soup_guide.dm
@@ -47,7 +47,12 @@
 	reaction = /datum/chemical_reaction/food/soup/wingfangchu
 
 /datum/crafting_recipe/food/reaction/soup/hotchili
+	name = "Chili Con Carne (Meat Chili)"
 	reaction = /datum/chemical_reaction/food/soup/hotchili
+
+/datum/crafting_recipe/food/reaction/soup/hotchili/ghost
+	name = "Ghost Chili Con Carne (Meat Chili)"
+	reaction = /datum/chemical_reaction/food/soup/hotchili/ghost
 
 /datum/crafting_recipe/food/reaction/soup/coldchili
 	reaction = /datum/chemical_reaction/food/soup/coldchili

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -486,8 +486,8 @@
 
 // Chili (Hot, not cold)
 /datum/reagent/consumable/nutriment/soup/hotchili
-	name = "Hot Chili"
-	description = "A five alarm Texan Chili!"
+	name = "Chili Con Carne"
+	description = "An extra spicy five alarm Texan Chili."
 	data = list("hot peppers" = 1)
 	glass_price = FOOD_PRICE_NORMAL
 	color = "#E23D12"
@@ -520,9 +520,29 @@
 	ingredient_reagent_multiplier = 0.33 // Chilis have a TON of capsaicin naturally
 	percentage_of_nutriment_converted = 0
 
+// Chili but hotter
+/datum/reagent/consumable/nutriment/soup/hotchili/ghost
+	name = "Ghost Chili Con Carne"
+	description = "An extra-extra <i>seven</i> alarm Texan Chili. Apparently, it goes that high."
+	data = list("extremely hot peppers" = 2)
+	glass_price = FOOD_PRICE_NORMAL
+	color = "#ff9479"
+
+/datum/glass_style/has_foodtype/soup/hotchili/ghost
+	required_drink_type = /datum/reagent/consumable/nutriment/soup/hotchili/ghost
+
+/datum/chemical_reaction/food/soup/hotchili/ghost
+
+/datum/chemical_reaction/food/soup/hotchili/ghost/New()
+	. = ..()
+	required_ingredients[/obj/item/food/grown/ghost_chili] = required_ingredients[/obj/item/food/grown/chili]
+	required_ingredients -= /obj/item/food/grown/chili
+	results[/datum/reagent/consumable/nutriment/soup/hotchili/ghost] = results[/datum/reagent/consumable/nutriment/soup/hotchili]
+	results -= /datum/reagent/consumable/nutriment/soup/hotchili
+
 // Chili (Cold)
 /datum/reagent/consumable/nutriment/soup/coldchili
-	name = "Cold Chili"
+	name = "Chili Frio"
 	description = "This slush is barely a liquid!"
 	data = list("tomato" = 1, "mint" = 1)
 	glass_price = FOOD_PRICE_NORMAL
@@ -608,6 +628,25 @@
 		/datum/reagent/consumable/nutriment/soup/chili_sin_carne = 30,
 		/datum/reagent/consumable/tomatojuice = 10,
 	)
+
+// Vegan Chili but hotter
+/datum/reagent/consumable/nutriment/soup/chili_sin_carne/ghost
+	name = "Ghost Chili Sin Carne"
+	description = "For the hombres who don't want carne, but do want to feel like their mouth is on fire."
+	data = list("extremely hot peppers" = 2)
+	color = "#ff9479"
+
+/datum/glass_style/has_foodtype/soup/chili_sin_carne/ghost
+	required_drink_type = /datum/reagent/consumable/nutriment/soup/chili_sin_carne/ghost
+
+/datum/chemical_reaction/food/soup/chili_sin_carne/ghost
+
+/datum/chemical_reaction/food/soup/chili_sin_carne/ghost/New()
+	. = ..()
+	required_ingredients[/obj/item/food/grown/ghost_chili] = required_ingredients[/obj/item/food/grown/chili]
+	required_ingredients -= /obj/item/food/grown/chili
+	results[/datum/reagent/consumable/nutriment/soup/chili_sin_carne/ghost] = results[/datum/reagent/consumable/nutriment/soup/chili_sin_carne]
+	results -= /datum/reagent/consumable/nutriment/soup/chili_sin_carne
 
 // Tomato soup
 /datum/reagent/consumable/nutriment/soup/tomato

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -537,6 +537,7 @@
 	. = ..()
 	required_ingredients[/obj/item/food/grown/ghost_chili] = required_ingredients[/obj/item/food/grown/chili]
 	required_ingredients -= /obj/item/food/grown/chili
+	results.Insert(1, /datum/reagent/consumable/nutriment/soup/hotchili/ghost)
 	results[/datum/reagent/consumable/nutriment/soup/hotchili/ghost] = results[/datum/reagent/consumable/nutriment/soup/hotchili]
 	results -= /datum/reagent/consumable/nutriment/soup/hotchili
 
@@ -645,6 +646,7 @@
 	. = ..()
 	required_ingredients[/obj/item/food/grown/ghost_chili] = required_ingredients[/obj/item/food/grown/chili]
 	required_ingredients -= /obj/item/food/grown/chili
+	results.Insert(1, /datum/reagent/consumable/nutriment/soup/chili_sin_carne/ghost)
 	results[/datum/reagent/consumable/nutriment/soup/chili_sin_carne/ghost] = results[/datum/reagent/consumable/nutriment/soup/chili_sin_carne]
 	results -= /datum/reagent/consumable/nutriment/soup/chili_sin_carne
 

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
@@ -452,3 +452,7 @@
 	name = "Chili Sin Carne (Vegetarian Chili)"
 	reaction = /datum/chemical_reaction/food/soup/chili_sin_carne
 	cuisine_category = CUISINE_MOTHIC
+
+/datum/crafting_recipe/food/reaction/soup/chili_sin_carne/ghost
+	name = "Ghost Chili Sin Carne (Vegetarian Chili)"
+	reaction = /datum/chemical_reaction/food/soup/chili_sin_carne/ghost

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
@@ -447,12 +447,3 @@
 /datum/crafting_recipe/food/reaction/soup/cheese_porridge
 	reaction = /datum/chemical_reaction/food/soup/cheese_porridge
 	cuisine_category = CUISINE_MOTHIC
-
-/datum/crafting_recipe/food/reaction/soup/chili_sin_carne
-	name = "Chili Sin Carne (Vegetarian Chili)"
-	reaction = /datum/chemical_reaction/food/soup/chili_sin_carne
-	cuisine_category = CUISINE_MOTHIC
-
-/datum/crafting_recipe/food/reaction/soup/chili_sin_carne/ghost
-	name = "Ghost Chili Sin Carne (Vegetarian Chili)"
-	reaction = /datum/chemical_reaction/food/soup/chili_sin_carne/ghost


### PR DESCRIPTION
## About The Pull Request

- Renames "Hot Chili" to Chili Con Carne, moves it to the Mexican cuisine category
- Renames "Cold Chili" to Chili Frio, moves it to the Mexican cuisine category
- Moves "Chili Con Carnival" to the Mexican cuisine category
- Moves "Chili Sin Carne" to the Mexican cuisine category
- Allows you to make "Ghost Chili Con Carne" and "Ghost Chili Sin Carne" by replacing the chili in the recipe with ghost chilis. The recipe is otherwise identical.

## Why It's Good For The Game

Renames: Done for consistency. We had "Hot Chili" and "Chili Sin Carne". 
Category shuttle: For consistency again. All of them are in the Mexican category now. Easier to find (and Vegan Chili is not particularly Mothic) 
Recipe: I found it a little silly that I couldn't make hotter chili with the hotter chili. Now you can make even hotter chili.

## Changelog

:cl: Melbert
spellcheck: Renames "Hot Chili" to "Chili Con Carne"
spellcheck: Renames "Cold Chili" to "Chili Frio"
qol: Chili Con Carne, Chili Sin Carne, Chili Con Carnival, and Chili Frio are now all in the "Mexican" cuisine category
qol: You can now use ghost chilis in the chili recipes, making "Ghost Chili Con Carne" or "Ghost Chili Sin Carne". 
/:cl:
