### PR TITLE
Sets Nightwatcher's Lantern research cost to 2

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -133,6 +133,7 @@
 	transmute_text = "Transmute a lamp, lantern, or seclight, a pair of eyes, a flash, and four lit candles."
 	gain_text = "The Nightwatcher did not venture out in the dark. That was foolish, even the Watch knew that. \
 		Their lantern burned with a light that could burn the sun."
+	cost = 2
 	result_atoms = list(/obj/item/flashlight/lantern/heretic)
 	required_atoms = list(
 		list(/obj/item/flashlight/lamp, /obj/item/flashlight/lantern, /obj/item/flashlight/seclite) = 1,


### PR DESCRIPTION

## About The Pull Request
Nightwatcher's Lantern, in Ash Path, is free to research, which is an oversight
Mask of Madness costed 2, so it only makes sense for Nightwatcher's Lantern, which takes its place, to cost 2
## Changelog
:cl:
fix: Nightwatcher's Lantern now costs what it should cost (2 knowledge points)
/:cl:
