### PR TITLE
Fixes blood decal hard dels, part 3

### DIFF
--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -58,12 +58,9 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 				original_baseturf_count = length(original_baseturfs)
 		else
 			var/atom/creation = new type_path(spawn_at)
-			if(QDELETED(creation))
-				// Same as below
-				creation = null
-				continue
-			//Go all in
-			qdel(creation, force = TRUE)
+			if(!QDELETED(creation))
+				//Go all in
+				qdel(creation, force = TRUE)
 			//This will hold a ref to the last thing we process unless we set it to null
 			//Yes byond is fucking sinful
 			creation = null
@@ -72,7 +69,7 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 		var/list/to_del = spawn_at.contents - cached_contents
 		if(length(to_del))
 			for(var/atom/to_kill in to_del)
-				qdel(to_kill)
+				qdel(to_kill, force = TRUE)
 
 	GLOB.running_create_and_destroy = FALSE
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/96354
Fixes https://github.com/tgstation/tgstation/issues/97120
Fixes https://github.com/tgstation/tgstation/issues/97089
Fixes https://github.com/tgstation/tgstation/issues/97115
Fixes https://github.com/tgstation/tgstation/issues/97118

When QDELETED(creation) is true, like if something hint qdels itself in initialize, the continue skips the shared cleanup block further down that force qdels any leftover spawned stuff. so like anything that got created as a side effect never gets deleted and lingers there.

(in this case it'd be the blood decal merging with another)

This will likely fix a lot of other similar hard deletes...

## Why It's Good For The Game

Hopefully less ci failures

## Changelog

Not player-facing, this is a unit-test only bug.