### PR TITLE
You can see the body part coverage of anything with armor

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -437,21 +437,23 @@
 				readout += "<b><u>COVERAGE</u></b>"
 				readout += "It will block [english_list(things_blocked)]."
 
+		var/list/parts_covered = list()
+		if(body_parts_covered & HEAD)
+			parts_covered += "head"
+		if(body_parts_covered & CHEST)
+			parts_covered += "torso"
+		if(body_parts_covered & (ARMS|HANDS))
+			parts_covered += "arms"
+		if(body_parts_covered & (LEGS|FEET))
+			parts_covered += "legs"
+		if(length(parts_covered))
+			readout += "It covers the wearer's [english_list(parts_covered)]."
+
 		if((clothing_flags & STOPSPRESSUREDAMAGE) || (visor_flags & STOPSPRESSUREDAMAGE))
-			var/list/parts_covered = list()
 			var/output_string = "It"
 			if(!(clothing_flags & STOPSPRESSUREDAMAGE))
 				output_string = "When sealed, it"
-			if(body_parts_covered & HEAD)
-				parts_covered += "head"
-			if(body_parts_covered & CHEST)
-				parts_covered += "torso"
-			if(body_parts_covered & (ARMS|HANDS))
-				parts_covered += "arms"
-			if(body_parts_covered & (LEGS|FEET))
-				parts_covered += "legs"
-			if(length(parts_covered))
-				readout += "[output_string] will protect the wearer's [english_list(parts_covered)] from [span_tooltip("The extremely low pressure is the biggest danger posed by the vacuum of space.", "low pressure")]."
+			readout += "[output_string] will protect the wearer's bodyparts that it covers from [span_tooltip("The extremely low pressure is the biggest danger posed by the vacuum of space.", "low pressure")]."
 
 		var/heat_prot
 		switch (max_heat_protection_temperature)


### PR DESCRIPTION
## About The Pull Request

Examining something's protection tag shows you what parts of you it covers.
<img width="525" height="353" alt="image" src="https://github.com/user-attachments/assets/4825d87f-1d6e-4f03-a021-ccaf7efbae64" />
Spaceproofing no longer lists the body parts that it protects from pressure damage because those are the same as the parts that it covers.
<img width="532" height="242" alt="image" src="https://github.com/user-attachments/assets/95c54014-5083-4bd2-8868-20ffa15a439f" />

## Why It's Good For The Game

It took me several months of playing this video game to learn that jumpskirts don't cover your legs despite the sprite visually doing so. Also it's just handy to know that kind of stuff in general. If something doesn't have armor it usually doesn't matter where it covers so it's not displayed on everything.

## Changelog

:cl:
qol: You can see what bodyparts a piece of clothing with armor covers by examining its tag.
/:cl: