### PR TITLE
The IDC-27 displays symptom levels

### DIFF
--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -420,6 +420,7 @@
 			symptom_data["spread_by"] = "N/A"
 			symptom_data["cured_by"] = symptom_type::symptom_cure::name
 			symptom_data["id"] = symptom_type
+			symptom_data["level"] = symptom_type::level
 			disease_info += list(symptom_data)
 
 		var/list/advanced_virus_info = list(

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -408,6 +408,7 @@
 			disease_data["spread_by"] = disease_type::spread_text || get_disease_spread_text(disease_type::spread_flags)
 			disease_data["cured_by"] = disease_type::cure_text
 			disease_data["id"] = disease_type
+			disease_data["level"] = "N/A"
 			disease_info += list(disease_data)
 
 		for(var/datum/symptom/symptom_type as anything in valid_subtypesof(/datum/symptom))
@@ -420,7 +421,7 @@
 			symptom_data["spread_by"] = "N/A"
 			symptom_data["cured_by"] = symptom_type::symptom_cure::name
 			symptom_data["id"] = symptom_type
-			symptom_data["level"] = symptom_type::level
+			symptom_data["level"] = "[symptom_type::level]"
 			disease_info += list(symptom_data)
 
 		var/list/advanced_virus_info = list(

--- a/tgui/packages/tgui/interfaces/IDCBook.tsx
+++ b/tgui/packages/tgui/interfaces/IDCBook.tsx
@@ -152,14 +152,12 @@ function renderDSMEntry(entry: BookEntry<Disease>) {
               </Box>{' '}
               {entry.desc}
             </Stack.Item>
-            {!!entry.level && (
-              <Stack.Item>
-                <Box inline color="label">
-                  Level:
-                </Box>{' '}
-                {entry.level}
-              </Stack.Item>
-            )}
+            <Stack.Item>
+              <Box inline color="label">
+                Level:
+              </Box>{' '}
+              {entry.level}
+            </Stack.Item>
             {entry.illness !== 'Unidentified' && (
               <Stack.Item>
                 <Box inline color="label">
@@ -249,6 +247,7 @@ export const IDCBook = () => {
       spread_by: disease.spread_by,
       cured_by: disease.cured_by,
       illness: disease.illness,
+      level: disease.level,
     }))
     .sort((a, b) =>
       a.form > b.form ? 1 : a.form < b.form ? -1 : a.name > b.name ? 1 : -1,

--- a/tgui/packages/tgui/interfaces/IDCBook.tsx
+++ b/tgui/packages/tgui/interfaces/IDCBook.tsx
@@ -11,6 +11,7 @@ type Disease = {
   spread_by: string; // used by diseases - how the disease is spread, like "Airborne" or "Contact"
   cured_by: string | null; // used by symptoms and diseases - how the disease or symptom is cured, like a medicine name or "Unknown"
   illness: string; // used by symptoms - the common illness associated with the symptom, like "Flu" for "Fever"
+  level: string; // used by symptoms - determines how to obtain the symptom
   id: string;
 };
 
@@ -99,13 +100,15 @@ function estimateHeight(entry: BookEntry<Disease>) {
     const desc_height = Math.ceil(entry.desc.length / 50) * 14;
     const illness_height = entry.illness !== 'Unidentified' ? 10 : 0;
     const cured_by_height = 10;
+    const level_height = 10;
 
     return (
       title_height +
       desc_height +
       illness_height +
       cured_by_height +
-      extra_spacing
+      extra_spacing +
+      level_height
     );
   }
 
@@ -149,6 +152,14 @@ function renderDSMEntry(entry: BookEntry<Disease>) {
               </Box>{' '}
               {entry.desc}
             </Stack.Item>
+            {!!entry.level && (
+              <Stack.Item>
+                <Box inline color="label">
+                  Level:
+                </Box>{' '}
+                {entry.level}
+              </Stack.Item>
+            )}
             {entry.illness !== 'Unidentified' && (
               <Stack.Item>
                 <Box inline color="label">


### PR DESCRIPTION
## About The Pull Request

<img width="473" height="175" alt="image" src="https://github.com/user-attachments/assets/4d8aadb3-75c0-4c7d-818c-14b1e1c1728b" />

## Why It's Good For The Game

"Gee, this symptom looks cool, I wonder how I get it?"
As part of the book's original purpose, this helps to make looking things up on the wiki or github less necessary. 
Are symptom levels "canon"? Maybe. Is knowing levels something helpful you'd actually want to read about in this book? Yes.

## Changelog

:cl:
qol: IDC-27 contains symptom levels
/:cl:
