### PR TITLE
Fixes atmospherics_sanity test race condition

### DIFF
--- a/code/modules/unit_tests/atmospherics_sanity.dm
+++ b/code/modules/unit_tests/atmospherics_sanity.dm
@@ -27,6 +27,11 @@
 	crawled_areas = list()
 	remaining_areas = list()
 
+	// early-init events can destroy pipes, queuing the surviving neighbors for a pipenet rebuild. the rebuild normally happens
+	// on the next SSair.fire(), but this test can run before that fire cycle occurs, racing against it.
+	while(length(SSair.rebuild_queue) || length(SSair.expansion_queue))
+		SSair.process_rebuilds()
+
 	for(var/obj/effect/landmark/atmospheric_sanity/start_area/start_marker in GLOB.landmarks_list)
 		var/area/starting_area = get_area(start_marker)
 		if(starting_area in starting_areas)


### PR DESCRIPTION
## About The Pull Request

Pipes can be destroyed during early init events which queue neighbors for a pipenet rebuild. The unit test can run before the next SSair.fire() which can cause some confusing explosion-like results of disconnected pipenets.

The fix is to just make sure those queues are all cleared out before proceeding with the test.

## Why It's Good For The Game

Makes this unit test more robust.

## Changelog

Not player facing