### PR TITLE
TGUI unlimited windows preference

### DIFF
--- a/code/__DEFINES/tgui.dm
+++ b/code/__DEFINES/tgui.dm
@@ -11,6 +11,8 @@
 #define TGUI_WINDOW_SOFT_LIMIT 5
 /// Maximum number of open windows
 #define TGUI_WINDOW_HARD_LIMIT 9
+/// Maximum number of open windows when user has prefs set to unlimited, basically infinite. You dont need 200 windows; you'll run out of memory by then
+#define TGUI_WINDOW_UNLIMITED_LIMIT 200
 
 /// Maximum ping timeout allowed to detect zombie windows
 #define TGUI_PING_TIMEOUT (4 SECONDS)

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -96,10 +96,11 @@ SUBSYSTEM_DEF(tgui)
 		return null
 	var/list/windows = user.client.tgui_windows
 	var/window_id
+	var/window_limit = user.client.prefs?.read_preference(/datum/preference/toggle/tgui_unlimited_windows) ? TGUI_WINDOW_UNLIMITED_LIMIT : TGUI_WINDOW_HARD_LIMIT
 	var/datum/tgui_window/window
 	var/window_found = FALSE
 	// Find a usable window
-	for(var/i in 1 to TGUI_WINDOW_HARD_LIMIT)
+	for(var/i in 1 to window_limit)
 		window_id = TGUI_WINDOW_ID(i)
 		window = windows[window_id]
 		// As we are looping, create missing window datums
@@ -131,7 +132,8 @@ SUBSYSTEM_DEF(tgui)
 	log_tgui(user, context = "SStgui/force_close_all_windows")
 	if(user.client)
 		user.client.tgui_windows = list()
-		for(var/i in 1 to TGUI_WINDOW_HARD_LIMIT)
+		var/window_limit = user.client.prefs.read_preference(/datum/preference/toggle/tgui_unlimited_windows) ? TGUI_WINDOW_UNLIMITED_LIMIT : TGUI_WINDOW_HARD_LIMIT
+		for(var/i in 1 to window_limit)
 			var/window_id = TGUI_WINDOW_ID(i)
 			user << browse(null, "window=[window_id]")
 

--- a/code/modules/client/preferences/tgui.dm
+++ b/code/modules/client/preferences/tgui.dm
@@ -63,6 +63,13 @@
 		// Force it to reload either way
 		tgui.update_static_data(client.mob)
 
+// But no games.
+/datum/preference/toggle/tgui_unlimited_windows
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "tgui_unlimited_windows"
+	savefile_identifier = PREFERENCE_PLAYER
+	default_value = FALSE
+
 /// Light mode for tgui say
 /datum/preference/toggle/tgui_say_light_mode
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES

--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -147,10 +147,11 @@
  * return bool
  */
 /datum/tgui_window/proc/can_be_suspended()
+	var/unlimited_windows = client?.prefs?.read_preference(/datum/preference/toggle/tgui_unlimited_windows)
 	return !fatally_errored \
 		&& pooled \
 		&& pool_index > 0 \
-		&& pool_index <= TGUI_WINDOW_SOFT_LIMIT \
+		&& (unlimited_windows || pool_index <= TGUI_WINDOW_SOFT_LIMIT) \
 		&& status == TGUI_WINDOW_READY
 
 /**

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/tgui.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/tgui.tsx
@@ -28,6 +28,14 @@ export const tgui_lock: FeatureToggle = {
   component: CheckboxInput,
 };
 
+export const tgui_unlimited_windows: FeatureToggle = {
+  name: 'Uncap TGUI window limit',
+  category: 'UI',
+  description:
+    'Disables the window limit for TGUI windows. Having more than 5 windows open can tank performance on lower end computers.',
+  component: CheckboxInput,
+};
+
 export const ui_scale: FeatureToggle = {
   name: 'Toggle UI scaling',
   category: 'UI',


### PR DESCRIPTION

## About The Pull Request
A port of https://github.com/Monkestation/Monkestation2.0/pull/11479, don't see why I shouldn't bring it here.

>Allows unlimited windows, warns the user about performance in the description.

## Why It's Good For The Game

I have needs that must be met. (I play AI sometimes.... and i need more windows)
OR
you're an insane admin that has windows for everything.

## Changelog
:cl:
add: you can now have unlimited TGUI windows in preferences
/:cl:
