### PR TITLE
Corrects regal condor magazine's accepted caliber

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -124,7 +124,7 @@
 	icon_state = "r45-8"
 	base_icon_state = "r45"
 	ammo_type = /obj/item/ammo_casing/c45/reaper
-	caliber = CALIBER_10MM
+	caliber = CALIBER_45
 	max_ammo = 8
 	multiple_sprites = AMMO_BOX_PER_BULLET
 	multiple_sprite_use_base = TRUE


### PR DESCRIPTION

## About The Pull Request

Regal condor is now chambered only in .45 rather than crafted .45 reaper and autolathe's 10mm
PR that converted condor to .45
- #96056
## Why It's Good For The Game

Bugfix
## Changelog
:cl:
fix: Regal condor's magazine now properly accepts .45 instead of 10mm.
/:cl:
