### PR TITLE
You can no longer open the Codex while it's open

### DIFF
--- a/code/modules/antagonists/heretic/items/forbidden_book.dm
+++ b/code/modules/antagonists/heretic/items/forbidden_book.dm
@@ -41,6 +41,9 @@
 	if(.)
 		return
 
+	if(book_open)
+		return
+
 	open_animation()
 	update_weight_class(WEIGHT_CLASS_NORMAL)
 	addtimer(CALLBACK(src, PROC_REF(close_book)), 30 SECONDS)


### PR DESCRIPTION

## About The Pull Request
You can no longer open the Codex while it's open
## Why It's Good For The Game
It looked weird and it wasn't intended
## Changelog
:cl:
fix: You can no longer open the Codex Cicatrix/Morbus while it's open.
/:cl:
