### PR TITLE
Bump bootstrap python to 3.14.6

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -17,7 +17,7 @@ export BUN_VERSION=1.3.5
 export SPACEMAN_DMM_VERSION=suite-1.11
 
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.11.0
+export PYTHON_VERSION=3.14.6
 
 #dreamluau repo
 export DREAMLUAU_REPO="tgstation/dreamluau"

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,6 +1,6 @@
 pygit2==1.19.0
 bidict==0.23.1
-Pillow==11.1.0
+Pillow==12.3.0
 
 # changelogs
 PyYaml==6.0.3


### PR DESCRIPTION

## About The Pull Request

Bump the python version from 3.11.0 to 3.14.6 (the latest stable), also bumps Pillow to latest because it no longer compiled as-is on 3.14.6

## Why It's Good For The Game

The behavior tree compiler requires features only available on 3.13+ but this was covered up because the only thing that runs that part is the CI workflow and it uses system python instead of bootstrap

## Changelog

N/A
