### PR TITLE
Include alternate tests in rerun flaky tests workflow

### DIFF
--- a/tools/pull_request_hooks/rerunFlakyTests.js
+++ b/tools/pull_request_hooks/rerunFlakyTests.js
@@ -3,7 +3,7 @@ const TITLE_BOT_HEADER = 'title: ';
 
 // Only check jobs that start with these.
 // Helps make sure we don't restart something like screenshot tests or linters, which are not known to be flaky.
-const CONSIDERED_JOBS = ['Integration Tests'];
+const CONSIDERED_JOBS = ['Integration Tests', 'Alternate Tests'];
 
 async function getFailedJobsForRun(github, context, workflowRunId, runAttempt) {
   const jobs = await github.paginate(


### PR DESCRIPTION

## About The Pull Request

Alternate tests can flaky fail the same as integration tests, so the rerun flaky tests workflow should handle it too

## Why It's Good For The Game

Better auto-rerunning of flaky workflows

## Changelog

N/A
