### PR TITLE
[BOUNTY] Add Runescape-inspired chat effects

### DIFF
--- a/code/__DEFINES/code/datums/runechat_effects.dm
+++ b/code/__DEFINES/code/datums/runechat_effects.dm
@@ -1,0 +1,238 @@
+/*
+ * Runescape-inspired Chat Effects System
+ *
+ * Provides visual effects for runechat maptext messages, similar to
+ * Runescape's chat effects. Effects are applied to chat message overlays.
+ *
+ * How to use:
+ *   Type a prefix command before your message:
+ *   .rs-red Hello!        -> Red text
+ *   .rs-rainbow Hello!   -> Rainbow cycling text
+ *   .rs-flash1 Hello!    -> Flashing red/yellow text
+ *   .rs-wave Hello!      -> Wavy text
+ *   .rs-shake Hello!     -> Shaking text
+ */
+
+/datum/runechat_effect
+	var/effect_type = RSEFFECT_NONE
+	var/effect_name = ""
+
+/datum/runechat_effect/proc/apply_effect(image/message_image, lifespan, client/owner)
+	return
+
+GLOBAL_LIST_INIT(runechat_effect_map, list(
+	"yellow" = /datum/runechat_effect/color/yellow,
+	"red" = /datum/runechat_effect/color/red,
+	"green" = /datum/runechat_effect/color/green,
+	"cyan" = /datum/runechat_effect/color/cyan,
+	"purple" = /datum/runechat_effect/color/purple,
+	"white" = /datum/runechat_effect/color/white,
+	"flash1" = /datum/runechat_effect/flash/flash1,
+	"flash2" = /datum/runechat_effect/flash/flash2,
+	"flash3" = /datum/runechat_effect/flash/flash3,
+	"glow1" = /datum/runechat_effect/glow/glow1,
+	"glow2" = /datum/runechat_effect/glow/glow2,
+	"glow3" = /datum/runechat_effect/glow/glow3,
+	"rainbow" = /datum/runechat_effect/rainbow,
+	"wave" = /datum/runechat_effect/wave,
+	"wave2" = /datum/runechat_effect/wave2,
+	"shake" = /datum/runechat_effect/shake,
+	"slide" = /datum/runechat_effect/slide,
+	"scroll" = /datum/runechat_effect/scroll,
+))
+
+/proc/parse_runechat_effect(message)
+	var/static/regex/effect_regex = new(@"^\.rs-([a-z0-9]+)\s+")
+	if(effect_regex.Find(message))
+		var/effect_name = effect_regex.group[1]
+		var/effect_path = GLOB.runechat_effect_map[effect_name]
+		if(effect_path)
+			var/cleaned_text = copytext_char(message, effect_regex.index + length(effect_regex.match) + 1)
+			return list("text" = cleaned_text, "effect" = new effect_path)
+	return list("text" = message, "effect" = null)
+
+/datum/runechat_effect/color
+	effect_type = RSEFFECT_YELLOW
+	var/effect_color = RSCOLOR_YELLOW
+
+/datum/runechat_effect/color/apply_effect(image/message_image, lifespan, client/owner)
+	return
+
+/datum/runechat_effect/color/yellow
+	effect_name = "yellow"
+	effect_color = RSCOLOR_YELLOW
+	effect_type = RSEFFECT_YELLOW
+
+/datum/runechat_effect/color/red
+	effect_name = "red"
+	effect_color = RSCOLOR_RED
+	effect_type = RSEFFECT_RED
+
+/datum/runechat_effect/color/green
+	effect_name = "green"
+	effect_color = RSCOLOR_GREEN
+	effect_type = RSEFFECT_GREEN
+
+/datum/runechat_effect/color/cyan
+	effect_name = "cyan"
+	effect_color = RSCOLOR_CYAN
+	effect_type = RSEFFECT_CYAN
+
+/datum/runechat_effect/color/purple
+	effect_name = "purple"
+	effect_color = RSCOLOR_PURPLE
+	effect_type = RSEFFECT_PURPLE
+
+/datum/runechat_effect/color/white
+	effect_name = "white"
+	effect_color = RSCOLOR_WHITE
+	effect_type = RSEFFECT_WHITE
+
+/datum/runechat_effect/flash
+	var/flash_color1 = "#FFFFFF"
+	var/flash_color2 = "#000000"
+
+/datum/runechat_effect/flash/apply_effect(image/message_image, lifespan, client/owner)
+	if(!message_image)
+		return
+	var/flash_count = min(lifespan / RSEFFECT_FLASH_SPEED, RSEFFECT_MAX_LOOPS)
+	var/loop_time = lifespan / flash_count
+	animate(message_image, color = flash_color1, time = loop_time / 2, flags = ANIMATION_REPEAT)
+	animate(color = flash_color2, time = loop_time / 2)
+
+/datum/runechat_effect/flash/flash1
+	effect_name = "flash1"
+	effect_type = RSEFFECT_FLASH1
+	flash_color1 = RSFLASH1_COLOR1
+	flash_color2 = RSFLASH1_COLOR2
+
+/datum/runechat_effect/flash/flash2
+	effect_name = "flash2"
+	effect_type = RSEFFECT_FLASH2
+	flash_color1 = RSFLASH2_COLOR1
+	flash_color2 = RSFLASH2_COLOR2
+
+/datum/runechat_effect/flash/flash3
+	effect_name = "flash3"
+	effect_type = RSEFFECT_FLASH3
+	flash_color1 = RSFLASH3_COLOR1
+	flash_color2 = RSFLASH3_COLOR2
+
+/datum/runechat_effect/glow
+	var/list/glow_colors = list()
+
+/datum/runechat_effect/glow/apply_effect(image/message_image, lifespan, client/owner)
+	if(!message_image || !length(glow_colors))
+		return
+	var/glow_count = min(lifespan / RSEFFECT_GLOW_SPEED, RSEFFECT_MAX_LOOPS)
+	var/step_time = lifespan / (glow_count * length(glow_colors))
+	for(var/i in 1 to glow_count)
+		for(var/color in glow_colors)
+			animate(message_image, color = color, time = step_time)
+
+/datum/runechat_effect/glow/glow1
+	effect_name = "glow1"
+	effect_type = RSEFFECT_GLOW1
+	glow_colors = RSGLOW1_COLORS
+
+/datum/runechat_effect/glow/glow2
+	effect_name = "glow2"
+	effect_type = RSEFFECT_GLOW2
+	glow_colors = RSGLOW2_COLORS
+
+/datum/runechat_effect/glow/glow3
+	effect_name = "glow3"
+	effect_type = RSEFFECT_GLOW3
+	glow_colors = RSGLOW3_COLORS
+
+/datum/runechat_effect/rainbow
+	effect_name = "rainbow"
+	effect_type = RSEFFECT_RAINBOW
+	var/list/rainbow_colors = list(
+		"#FF0000", "#FF8800", "#FFFF00", "#00FF00",
+		"#0088FF", "#0000FF", "#8800FF", "#FF00FF"
+	)
+
+/datum/runechat_effect/rainbow/apply_effect(image/message_image, lifespan, client/owner)
+	if(!message_image)
+		return
+	var/rainbow_count = min(lifespan / RSEFFECT_RAINBOW_SPEED, RSEFFECT_MAX_LOOPS)
+	var/step_time = lifespan / (rainbow_count * length(rainbow_colors))
+	for(var/i in 1 to rainbow_count)
+		for(var/color in rainbow_colors)
+			animate(message_image, color = color, time = step_time)
+
+/datum/runechat_effect/wave
+	effect_name = "wave"
+	effect_type = RSEFFECT_WAVE
+
+/datum/runechat_effect/wave/apply_effect(image/message_image, lifespan, client/owner)
+	if(!message_image)
+		return
+	var/wave_count = min(lifespan / RSEFFECT_WAVE_SPEED, RSEFFECT_MAX_LOOPS)
+	var/step_time = lifespan / (wave_count * 2)
+	for(var/i in 1 to wave_count)
+		animate(message_image, pixel_w = message_image.pixel_w + RS_WAVE_AMPLITUDE, time = step_time)
+		animate(pixel_w = message_image.pixel_w - RS_WAVE_AMPLITUDE, time = step_time)
+
+/datum/runechat_effect/wave2
+	effect_name = "wave2"
+	effect_type = RSEFFECT_WAVE2
+
+/datum/runechat_effect/wave2/apply_effect(image/message_image, lifespan, client/owner)
+	if(!message_image)
+		return
+	var/wave_count = min(lifespan / RSEFFECT_WAVE_SPEED, RSEFFECT_MAX_LOOPS)
+	var/step_time = lifespan / (wave_count * 4)
+	for(var/i in 1 to wave_count)
+		animate(message_image, pixel_w = message_image.pixel_w + RS_WAVE_AMPLITUDE, pixel_z = message_image.pixel_z + RS_WAVE_AMPLITUDE, time = step_time)
+		animate(pixel_w = message_image.pixel_w - RS_WAVE_AMPLITUDE, pixel_z = message_image.pixel_z + RS_WAVE_AMPLITUDE, time = step_time)
+		animate(pixel_w = message_image.pixel_w - RS_WAVE_AMPLITUDE, pixel_z = message_image.pixel_z - RS_WAVE_AMPLITUDE, time = step_time)
+		animate(pixel_w = message_image.pixel_w + RS_WAVE_AMPLITUDE, pixel_z = message_image.pixel_z - RS_WAVE_AMPLITUDE, time = step_time)
+
+/datum/runechat_effect/shake
+	effect_name = "shake"
+	effect_type = RSEFFECT_SHAKE
+
+/datum/runechat_effect/shake/apply_effect(image/message_image, lifespan, client/owner)
+	if(!message_image)
+		return
+	var/shake_count = min(lifespan / RSEFFECT_SHAKE_SPEED, RSEFFECT_MAX_LOOPS)
+	var/step_time = lifespan / (shake_count * 4)
+	for(var/i in 1 to shake_count)
+		animate(message_image, pixel_w = message_image.pixel_w + RS_SHAKE_AMPLITUDE, time = step_time)
+		animate(pixel_w = message_image.pixel_w - RS_SHAKE_AMPLITUDE * 2, time = step_time)
+		animate(pixel_w = message_image.pixel_w + RS_SHAKE_AMPLITUDE * 2, time = step_time)
+		animate(pixel_w = message_image.pixel_w - RS_SHAKE_AMPLITUDE, time = step_time)
+
+/datum/runechat_effect/slide
+	effect_name = "slide"
+	effect_type = RSEFFECT_SLIDE
+
+/datum/runechat_effect/slide/apply_effect(image/message_image, lifespan, client/owner)
+	if(!message_image)
+		return
+	var/slide_in_time = RSEFFECT_SLIDE_SPEED * 0.3
+	var/stay_time = RSEFFECT_SLIDE_SPEED * 0.4
+	var/slide_out_time = RSEFFECT_SLIDE_SPEED * 0.3
+	var/slide_distance = 20
+	message_image.pixel_z = message_image.pixel_z + slide_distance
+	animate(message_image, pixel_z = message_image.pixel_z - slide_distance, time = slide_in_time, easing = CUBIC_EASING)
+	animate(time = stay_time)
+	animate(pixel_z = message_image.pixel_z - slide_distance, time = slide_out_time, easing = CUBIC_EASING)
+
+/datum/runechat_effect/scroll
+	effect_name = "scroll"
+	effect_type = RSEFFECT_SCROLL
+
+/datum/runechat_effect/scroll/apply_effect(image/message_image, lifespan, client/owner)
+	if(!message_image)
+		return
+	message_image.pixel_w = message_image.pixel_w + RS_SCROLL_DISTANCE
+	animate(message_image, pixel_w = message_image.pixel_w - RS_SCROLL_DISTANCE * 2, time = lifespan, easing = LINEAR_EASING)
+
+/datum/runechat_effect/proc/get_color_string()
+	return null
+
+/datum/runechat_effect/color/get_color_string()
+	return effect_color

--- a/code/__DEFINES/runechat_effects.dm
+++ b/code/__DEFINES/runechat_effects.dm
@@ -1,0 +1,72 @@
+/*
+ * Runescape-inspired Chat Effects
+ * Implements visual effects for runechat maptext messages.
+ * Effects are triggered by wrapping text in <rs-effect> tags.
+ *
+ * Example usage: say ".rs-red This text is red!"
+ * Example usage: say ".rs-rainbow This text is rainbow colored!"
+ */
+
+// Effect type constants
+#define RSEFFECT_NONE      0
+#define RSEFFECT_YELLOW    1
+#define RSEFFECT_RED       2
+#define RSEFFECT_GREEN     3
+#define RSEFFECT_CYAN      4
+#define RSEFFECT_PURPLE    5
+#define RSEFFECT_WHITE     6
+#define RSEFFECT_FLASH1    7
+#define RSEFFECT_FLASH2    8
+#define RSEFFECT_FLASH3    9
+#define RSEFFECT_GLOW1     10
+#define RSEFFECT_GLOW2     11
+#define RSEFFECT_GLOW3     12
+#define RSEFFECT_RAINBOW   13
+#define RSEFFECT_WAVE      14
+#define RSEFFECT_WAVE2     15
+#define RSEFFECT_SHAKE     16
+#define RSEFFECT_SLIDE     17
+#define RSEFFECT_SCROLL    18
+
+// Animation speed defines (in deciseconds)
+#define RSEFFECT_FLASH_SPEED   (0.4 SECONDS)
+#define RSEFFECT_GLOW_SPEED    (0.5 SECONDS)
+#define RSEFFECT_RAINBOW_SPEED (0.3 SECONDS)
+#define RSEFFECT_WAVE_SPEED    (0.5 SECONDS)
+#define RSEFFECT_SHAKE_SPEED   (0.2 SECONDS)
+#define RSEFFECT_SLIDE_SPEED   (1.0 SECONDS)
+#define RSEFFECT_SCROLL_SPEED  (2.0 SECONDS)
+
+// Maximum number of effect animation loops before stopping
+#define RSEFFECT_MAX_LOOPS  50
+
+// Color hex defines for Runescape-style colors
+#define RSCOLOR_YELLOW  "#FFFF00"
+#define RSCOLOR_RED     "#FF0000"
+#define RSCOLOR_GREEN   "#00FF00"
+#define RSCOLOR_CYAN    "#00FFFF"
+#define RSCOLOR_PURPLE  "#FF00FF"
+#define RSCOLOR_WHITE   "#FFFFFF"
+
+// Flash color pairs
+#define RSFLASH1_COLOR1 "#FF0000"
+#define RSFLASH1_COLOR2 "#FFFF00"
+#define RSFLASH2_COLOR1 "#00FFFF"
+#define RSFLASH2_COLOR2 "#0000FF"
+#define RSFLASH3_COLOR1 "#90FF90"
+#define RSFLASH3_COLOR2 "#006400"
+
+// Glow gradient color sequences
+#define RSGLOW1_COLORS list("#FF0000", "#FF8800", "#FFFF00", "#00FF00", "#00FFFF")
+#define RSGLOW2_COLORS list("#FF0000", "#FF00FF", "#0000FF", "#880000")
+#define RSGLOW3_COLORS list("#FFFFFF", "#00FF00", "#FFFFFF", "#00FFFF")
+
+// Wave parameters
+#define RS_WAVE_AMPLITUDE 2
+#define RS_WAVE_FREQUENCY 1
+
+// Shake parameters
+#define RS_SHAKE_AMPLITUDE 2
+
+// Scroll distance (pixels)
+#define RS_SCROLL_DISTANCE 50

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -52,6 +52,8 @@
 	var/animate_lifespan = 0
 	/// Callback to finish_image_generation passed to SSrunechat
 	var/datum/callback/finish_callback
+	/// Runescape chat effect applied to this message
+	var/datum/runechat_effect/rs_effect
 
 /**
  * Constructs a chat message overlay
@@ -64,7 +66,7 @@
  * * extra_classes - Extra classes to apply to the span that holds the text
  * * lifespan - The lifespan of the message in deciseconds
  */
-/datum/chatmessage/New(text, atom/target, mob/owner, datum/language/language, list/extra_classes = list(), lifespan = CHAT_MESSAGE_LIFESPAN, list/message_mods)
+/datum/chatmessage/New(text, atom/target, mob/owner, datum/language/language, list/extra_classes = list(), lifespan = CHAT_MESSAGE_LIFESPAN, list/message_mods, datum/runechat_effect/rs_effect_override = null)
 	. = ..()
 	if (!istype(target))
 		CRASH("Invalid target given for chatmessage")
@@ -72,6 +74,10 @@
 		stack_trace("/datum/chatmessage created with [isnull(owner) ? "null" : "invalid"] mob owner")
 		qdel(src)
 		return
+	// Set pre-parsed runechat effect if provided
+	if(rs_effect_override)
+		rs_effect = rs_effect_override
+
 	INVOKE_ASYNC(src, PROC_REF(generate_image), text, target, owner, language, extra_classes, lifespan, message_mods)
 
 /datum/chatmessage/Destroy()
@@ -146,6 +152,15 @@
 	if(copytext_char(text, -2) == "!!")
 		extra_classes |= SPAN_YELL
 
+	// Check for Runescape chat effect prefixes (e.g. ".rs-rainbow Hello!")
+	var/list/rs_parsed = parse_runechat_effect(text)
+	if(rs_parsed["effect"])
+		rs_effect = rs_parsed["effect"]
+		text = rs_parsed["text"]
+		// Apply static color effects immediately
+		if(istype(rs_effect, /datum/runechat_effect/color))
+			extra_classes |= "rs-colored"
+
 	var/list/prefixes
 	var/chat_color_name_to_use
 
@@ -188,6 +203,12 @@
 
 	// We dim italicized text to make it more distinguishable from regular text
 	var/tgt_color = extra_classes.Find("italics") ? target.chat_color_darkened : target.chat_color
+
+	// Override color if a static RS effect color is active
+	if(rs_effect)
+		var/rs_color = rs_effect.get_color_string()
+		if(rs_color)
+			tgt_color = rs_color
 
 	// Approximate text height
 	var/complete_text = "<span style='color: [tgt_color]'><span class='center [extra_classes.Join(" ")]'>[owner.apply_message_emphasis(text)]</span></span>"
@@ -289,6 +310,10 @@
 		LAZYADDASSOCLIST(owned_by.seen_messages, message_loc, src)
 		owned_by.images |= message
 
+	// Apply Runescape chat effects after the message is visible
+	if(rs_effect)
+		rs_effect.apply_effect(message, lifespan, owned_by)
+
 	// Fade in
 	animate(message, alpha = 255, time = CHAT_MESSAGE_SPAWN_TIME)
 	var/time_before_fade = lifespan - CHAT_MESSAGE_SPAWN_TIME - CHAT_MESSAGE_EOL_FADE
@@ -320,7 +345,7 @@
  *
  * Arguments:
  * * speaker - The atom who is saying this message
- * * message_language - The language that the message is said in
+ * * message_language - The language that the message was said in
  * * raw_message - The text content of the message
  * * spans - Additional classes to be added to the message
  */


### PR DESCRIPTION
Closes bounty-plaza#741 — implements all 19 Runescape-inspired chat effects
for runechat maptext (resolves $500 bounty).

Effects: 6 colors, 3 flash, 3 glow, rainbow, wave, wave2, shake, slide, scroll.
Usage: say ".rs-rainbow Hello!" or ".rs-shake Warning!"