### PR TITLE
You can't starve positive viruses and satiety doesn't affect your immune system.

### DIFF
--- a/code/__DEFINES/diseases.dm
+++ b/code/__DEFINES/diseases.dm
@@ -92,12 +92,6 @@ DEFINE_BITFIELD(spread_flags, list(
 /// Negative Malnutrition Recovery Penalty
 //// Flat penalty to recovery chance if malnourished or starving
 #define DISEASE_MALNUTRITION_RECOVERY_PENALTY 3
-/// Satiety Recovery Multiplier - added chance to recover based on positive satiety
-//// Multiplier of satiety/max_satiety if satiety is positive or zero. Increase to make satiety more valuable, decrease for less.
-#define DISEASE_SATIETY_RECOVERY_MULTIPLIER 3
-/// Disease Satiety Threshold - how much junk food we have to eat to start curing positive viruses.
-//// About -150 is good. May need to change if satiety/junkiness var is changed up much.
-#define DISEASE_SATIETY_THRESHOLD -150
 /// Good Sleeping Recovery Bonus - additive benefits for various types of good sleep (blanket, bed, darkness, pillows.)
 //// Raise to make each factor add this much chance to recover.
 #define DISEASE_GOOD_SLEEPING_RECOVERY_BONUS 0.6

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -248,7 +248,7 @@
 			if(SPT_PROB(recovery_prob * failure_chance, seconds_per_tick))
 				if(stage == 1 && prob(cure_chance * DISEASE_FINAL_CURE_CHANCE_MULTIPLIER)) //if we reduce FROM stage == 1, cure the virus - after defeating its cure_chance in a final battle
 					if(severity == DISEASE_SEVERITY_POSITIVE && slowdown < 1)
-						return
+						return TRUE
 					if(malnourished)
 						if(stage_peaked == FALSE) //if you didn't ride out the virus from its peak, if you're malnourished when it cures, you don't get resistance
 							cure(add_resistance = FALSE)

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -130,6 +130,7 @@
 	var/cure_mod
 	var/bad_immune = HAS_TRAIT(affected_mob, TRAIT_IMMUNODEFICIENCY) ? 2 : 1
 	var/is_sleeping = !!affected_mob.IsSleeping()
+	var/malnourished = !HAS_TRAIT(affected_mob, TRAIT_NOHUNGER) && (affected_mob.nutrition < NUTRITION_LEVEL_STARVING)
 
 	if(required_organ)
 		if(!has_required_infectious_organ(affected_mob, required_organ))
@@ -166,7 +167,7 @@
 	if(!(disease_flags & CHRONIC) && disease_flags & CURABLE && bypasses_immunity != TRUE)
 		switch(severity)
 			if(DISEASE_SEVERITY_POSITIVE)
-				if(slowdown < 1 || (!(HAS_TRAIT(affected_mob, TRAIT_NOHUNGER)) && (affected_mob.satiety < DISEASE_SATIETY_THRESHOLD || affected_mob.nutrition < NUTRITION_LEVEL_STARVING)))
+				if(slowdown < 1)
 					cycles_to_beat = max(DISEASE_RECOVERY_SCALING, DISEASE_CYCLES_POSITIVE)
 				else
 					recovery_prob = 0
@@ -192,12 +193,9 @@
 		if(slowdown < 1) //using spaceacillin can help get them over the finish line to kill a virus with decreasing effect over time
 			recovery_prob += clamp((((1 - slowdown)*(DISEASE_SLOWDOWN_RECOVERY_BONUS * 2)) * ((DISEASE_SLOWDOWN_RECOVERY_BONUS_DURATION - chemical_offsets) / DISEASE_SLOWDOWN_RECOVERY_BONUS_DURATION)), 0, DISEASE_SLOWDOWN_RECOVERY_BONUS)
 			chemical_offsets = min(chemical_offsets + 1, DISEASE_SLOWDOWN_RECOVERY_BONUS_DURATION)
-		if(!HAS_TRAIT(affected_mob, TRAIT_NOHUNGER))
-			if(affected_mob.satiety < DISEASE_SATIETY_THRESHOLD || affected_mob.nutrition < NUTRITION_LEVEL_STARVING) //being malnourished makes it a lot harder to defeat your illness
-				recovery_prob -= DISEASE_MALNUTRITION_RECOVERY_PENALTY
-			else
-				if(affected_mob.satiety > 0)
-					recovery_prob += round((DISEASE_SATIETY_RECOVERY_MULTIPLIER * (affected_mob.satiety/MAX_SATIETY)), 0.1)
+		if(malnourished) //being malnourished makes it a lot harder to defeat your illness
+			recovery_prob -= DISEASE_MALNUTRITION_RECOVERY_PENALTY
+
 
 		if(affected_mob.mob_mood) // this and most other modifiers below a shameless rip from sleeping healing buffs, but feeling good helps make it go away quicker
 			switch(affected_mob.mob_mood.sanity_level)
@@ -216,7 +214,7 @@
 
 		recovery_prob += get_immunity_recovery()
 
-		if((HAS_TRAIT(affected_mob, TRAIT_NOHUNGER) || !(affected_mob.satiety < 0 || affected_mob.nutrition < NUTRITION_LEVEL_STARVING)) && is_sleeping) //resting starved won't help, but resting helps
+		if(!malnourished && is_sleeping) //resting starved won't help, but resting helps
 			var/turf/rest_turf = get_turf(affected_mob)
 			var/is_sleeping_in_darkness = rest_turf.get_lumcount() <= LIGHTING_TILE_IS_DARK
 
@@ -249,7 +247,7 @@
 			var/failure_chance = (1 - get_recovery_failure_chance() / 100)
 			if(SPT_PROB(recovery_prob * failure_chance, seconds_per_tick))
 				if(stage == 1 && prob(cure_chance * DISEASE_FINAL_CURE_CHANCE_MULTIPLIER)) //if we reduce FROM stage == 1, cure the virus - after defeating its cure_chance in a final battle
-					if(!HAS_TRAIT(affected_mob, TRAIT_NOHUNGER) && (affected_mob.satiety < DISEASE_SATIETY_THRESHOLD || affected_mob.nutrition < NUTRITION_LEVEL_STARVING))
+					if(malnourished)
 						if(stage_peaked == FALSE) //if you didn't ride out the virus from its peak, if you're malnourished when it cures, you don't get resistance
 							cure(add_resistance = FALSE)
 							return FALSE
@@ -306,7 +304,7 @@
 		return FALSE
 	if(!has_required_infectious_organ(affected_mob, ORGAN_SLOT_LUNGS)) //also if you lack lungs
 		return FALSE
-	if(HAS_TRAIT(affected_mob, TRAIT_VIRUS_RESISTANCE) || (affected_mob.satiety > 0 && prob(affected_mob.satiety / 2))) //being full or on spaceacillin makes you less likely to spread a virus
+	if(HAS_TRAIT(affected_mob, TRAIT_VIRUS_RESISTANCE)) //being full or on spaceacillin makes you less likely to spread a virus
 		return FALSE
 	var/turf/mob_loc = affected_mob.loc
 	if(!istype(mob_loc))

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -130,7 +130,7 @@
 	var/cure_mod
 	var/bad_immune = HAS_TRAIT(affected_mob, TRAIT_IMMUNODEFICIENCY) ? 2 : 1
 	var/is_sleeping = !!affected_mob.IsSleeping()
-	var/malnourished = !HAS_TRAIT(affected_mob, TRAIT_NOHUNGER) && (affected_mob.nutrition < NUTRITION_LEVEL_STARVING)
+	var/malnourished = !HAS_TRAIT(affected_mob, TRAIT_NOHUNGER) && (affected_mob.nutrition <= NUTRITION_LEVEL_STARVING)
 
 	if(required_organ)
 		if(!has_required_infectious_organ(affected_mob, required_organ))

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -167,7 +167,7 @@
 	if(!(disease_flags & CHRONIC) && disease_flags & CURABLE && bypasses_immunity != TRUE)
 		switch(severity)
 			if(DISEASE_SEVERITY_POSITIVE)
-				if(slowdown < 1)
+				if(slowdown < 1 || malnourished)
 					cycles_to_beat = max(DISEASE_RECOVERY_SCALING, DISEASE_CYCLES_POSITIVE)
 				else
 					recovery_prob = 0
@@ -247,6 +247,8 @@
 			var/failure_chance = (1 - get_recovery_failure_chance() / 100)
 			if(SPT_PROB(recovery_prob * failure_chance, seconds_per_tick))
 				if(stage == 1 && prob(cure_chance * DISEASE_FINAL_CURE_CHANCE_MULTIPLIER)) //if we reduce FROM stage == 1, cure the virus - after defeating its cure_chance in a final battle
+					if(severity == DISEASE_SEVERITY_POSITIVE && slowdown < 1)
+						return
 					if(malnourished)
 						if(stage_peaked == FALSE) //if you didn't ride out the virus from its peak, if you're malnourished when it cures, you don't get resistance
 							cure(add_resistance = FALSE)


### PR DESCRIPTION
## About The Pull Request

Good viruses go down to stage 1 when you starve but don't go away unless you take spaceacillin. Also, satiety was removed from disease recovery calculations altogether.

Required reading: [The Ecology of Game Systems and Virology](https://hackmd.io/@Higgin/HJljdBuNp)

## Why It's Good For The Game

The logic behind behind good viruses going away if you didn't maintain them was that doing so would move the interaction of virologist to host from "commensalic" _(one player benefiting another player without getting anything in return)_ to "mutualistic" _(two players benefit each other)_. 
<img width="927" height="192" alt="Screenshot 2026-07-28 182755" src="https://github.com/user-attachments/assets/60e4629a-8be5-4c19-8904-61b977bb8a59" />
In my opinion, that change not only failed to accomplish its goal, but also severely nerfed positive virology as an _unintended side effect_. When a host maintains their positive virus by eating food and avoiding junk food, the virologist doesn't benefit at all. Eating isn't a multiplayer interaction to begin with, and while I do think virology should require some effort on the part of the host to counter the fact that it's so easy to get a positive virus half the time you don't even need to do anything, fully curing and subsequently _granting full immunity to_ a positive virus is not the reasonable outcome of eating some junk food or just not paying attention to your hunger for a while. Having the virus temporarily stop healing is a much softer outcome that doesn't put a constant (albeit lenient) time pressure on the host to fill their stomach.

Secondly, satiety is a very obscure mechanic that simply has no place in deciding if players live or die (unless you're rolling random heart attacks, because nobody cares about dying to a random heart attack). Expecting players to be well fed with high satiety at any specific time (because you can't reasonably predict when a virus outbreak will happen) is only possible with a competent chef, which means all you've done is added a second point of failure to the "waiting-on-the-other-side-of-a-table-for-someone-else-to-finish-their-minigame-before-I-die" problem. Also I don't think most players understand how junk food works or how it affects viruses, so it just widens the knowledge check of self curing. This isn't really a problem in actual rounds because most rounds have food in the kitchen and caramel doesn't count as junk food, but it's still worth removing.

## Changelog
:cl:
balance: viruses with a positive severity can't be lost by starving
balance: satiety has no effect on natural disease recovery
/:cl:
