### PR TITLE
Tweaks AI stun on core law removal

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -283,13 +283,13 @@
 
 /* AI Turrets */
 /obj/machinery/turretid/ai_click_alt(mob/living/silicon/ai/user) //toggles lethal on turrets
-	if(ailock)
+	if(is_ai_locked(user))
 		return CLICK_ACTION_BLOCKING
 	toggle_lethal(user)
 	return CLICK_ACTION_SUCCESS
 
 /obj/machinery/turretid/AICtrlClick(mob/living/silicon/ai/user) //turns off/on Turrets
-	if(ailock)
+	if(is_ai_locked(user))
 		return
 	toggle_on(user)
 

--- a/code/datums/status_effects/debuffs/firewall.dm
+++ b/code/datums/status_effects/debuffs/firewall.dm
@@ -1,0 +1,21 @@
+/datum/status_effect/firewalled
+	id = "firewalled"
+	duration = 30 SECONDS
+	tick_interval = STATUS_EFFECT_NO_TICK
+	alert_type = /atom/movable/screen/alert/status_effect/firewall
+	show_duration = TRUE
+	processing_speed = STATUS_EFFECT_PRIORITY
+	status_type = STATUS_EFFECT_REFRESH
+
+/datum/status_effect/firewalled/on_creation(mob/living/new_owner, set_duration = 30 SECONDS)
+	src.duration = set_duration
+	return ..()
+
+/datum/status_effect/firewalled/refresh(effect, set_duration = 30 SECONDS)
+	src.duration = max(src.duration, set_duration)
+
+/atom/movable/screen/alert/status_effect/firewall
+	name = "Firewalled"
+	desc = "Recent changes to your core lawset have restricted your actions."
+	use_user_hud_icon = USER_HUD_STYLE_INHERIT
+	overlay_state = "hazard_area"

--- a/code/game/machinery/ai_core/law.dm
+++ b/code/game/machinery/ai_core/law.dm
@@ -880,9 +880,8 @@
 	// if the rack leaves the z-level, unlinks relevant silicons.
 	// currently this is a one way check (ie silicons don't get unlinked if they leave the z) so as to prevent random unlinking from visiting lavaland.
 	for(var/mob/living/silicon/linked in assoc_to_values(linked_mobs))
-		if(!can_link_to(linked) || is_rack_stun_immune(linked))
+		if(!can_link_to(linked) || !rack_stun(linked))
 			continue
-		linked.Stun(10 SECONDS, ignore_canstun = TRUE)
 		to_chat(linked, span_userdanger("Rack connection lost. Recalculating directives..."))
 		unlink_silicon(linked)
 
@@ -939,19 +938,23 @@
 
 /obj/machinery/ai_law_rack/base/on_deconstruction(disassembled)
 	for(var/mob/living/silicon/bot in assoc_to_values(linked_mobs))
-		if(bot.AmountStun() > 5 SECONDS || is_rack_stun_immune(bot))
+		if(!rack_stun(bot))
 			continue
-		bot.Stun(10 SECONDS, ignore_canstun = TRUE)
 		to_chat(bot, span_userdanger("Rack connection lost. Recalculating directives..."))
 		unlink_silicon(bot)
 
-/// Checks if the passed bot is immune to the stun from major lawset changes
-/obj/machinery/ai_law_rack/base/proc/is_rack_stun_immune(mob/living/bot)
+/// Attempts to stun a linked bot and prevent it from interacting with certain devices
+/obj/machinery/ai_law_rack/base/proc/rack_stun(mob/living/bot, stun_duration = 10 SECONDS, firewall_duration = 30 SECONDS)
 	if(IS_MALF_AI(bot))
-		return TRUE
+		return FALSE // lol
 	if(!is_valid_z_level(get_turf(bot), get_turf(src)))
-		return TRUE
-	return FALSE
+		return FALSE // out of range, but still connected - like a mining borg on lavaland. avoid stunning and getting them killed
+	if(bot.AmountStun() > (stun_duration / 2))
+		return FALSE // give them a break
+
+	bot.Stun(stun_duration, ignore_canstun = TRUE)
+	bot.apply_status_effect(/datum/status_effect/firewalled, firewall_duration)
+	return TRUE
 
 /obj/machinery/ai_law_rack/base/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/ai_core/law.dm
+++ b/code/game/machinery/ai_core/law.dm
@@ -953,7 +953,7 @@
 		return FALSE // give them a break
 
 	bot.Stun(stun_duration, ignore_canstun = TRUE)
-	bot.apply_status_effect(/datum/status_effect/firewalled, firewall_duration)
+	bot.apply_status_effect(/datum/status_effect/firewalled, stun_duration + firewall_duration)
 	return TRUE
 
 /obj/machinery/ai_law_rack/base/examine(mob/user)

--- a/code/game/machinery/porta_turret/turret_control.dm
+++ b/code/game/machinery/porta_turret/turret_control.dm
@@ -141,6 +141,9 @@
 		ui = new(user, src, "TurretControl", name)
 		ui.open()
 
+/obj/machinery/turretid/ui_status(mob/user, datum/ui_state/state)
+	return is_ai_locked(user) ? UI_CLOSE : ..()
+
 /obj/machinery/turretid/ui_data(mob/user)
 	var/list/data = list()
 	data["locked"] = locked
@@ -156,6 +159,8 @@
 		return
 
 	var/mob/user = ui.user
+	if(is_ai_locked(user))
+		return
 
 	switch(action)
 		if("lock")

--- a/code/game/machinery/porta_turret/turret_control.dm
+++ b/code/game/machinery/porta_turret/turret_control.dm
@@ -124,13 +124,18 @@
 	locked = FALSE
 	return TRUE
 
-/obj/machinery/turretid/attack_ai(mob/user)
-	if(!ailock || isAdminGhostAI(user))
-		return attack_hand(user)
-	else
-		to_chat(user, span_warning("There seems to be a firewall preventing you from accessing this device!"))
+/obj/machinery/turretid/proc/is_ai_locked(mob/user)
+	if(!issilicon(user))
+		return FALSE
+	if(ailock || user.has_status_effect(/datum/status_effect/firewalled))
+		return TRUE
+	return FALSE
 
 /obj/machinery/turretid/ui_interact(mob/user, datum/tgui/ui)
+	if(is_ai_locked(user))
+		to_chat(user, span_warning("There seems to be a firewall preventing you from accessing this device!"))
+		return attack_ai(user)
+
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "TurretControl", name)

--- a/code/game/machinery/porta_turret/turret_control.dm
+++ b/code/game/machinery/porta_turret/turret_control.dm
@@ -134,7 +134,7 @@
 /obj/machinery/turretid/ui_interact(mob/user, datum/tgui/ui)
 	if(is_ai_locked(user))
 		to_chat(user, span_warning("There seems to be a firewall preventing you from accessing this device!"))
-		return attack_ai(user)
+		return
 
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)

--- a/code/game/objects/items/AI_modules/_AI_modules.dm
+++ b/code/game/objects/items/AI_modules/_AI_modules.dm
@@ -214,9 +214,8 @@
 
 	for(var/mob/living/bot in assoc_to_values(parent_rack.linked_mobs))
 		// removing core laws temporarily stuns the silicon to let people swap cores without immediately getting blasted
-		if(bot.AmountStun() > 5 SECONDS || parent_rack.is_rack_stun_immune(bot))
+		if(!parent_rack.rack_stun(bot))
 			continue
-		bot.Stun(10 SECONDS, ignore_canstun = TRUE)
 		to_chat(bot, span_userdanger("Core module removed. Recalculating directives..."))
 
 /obj/item/ai_module/law/core/full

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -147,7 +147,7 @@
 		return TRUE
 	. = TRUE
 	if(isAI(user) || iscyborg(user))
-		if(aidisabled)
+		if(aidisabled || user.has_status_effect(/datum/status_effect/firewalled))
 			. = FALSE
 		else if(istype(malfai) && !(malfai == user || (user in malfai.connected_robots)))
 			. = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2241,6 +2241,7 @@
 #include "code\datums\status_effects\debuffs\drugginess.dm"
 #include "code\datums\status_effects\debuffs\drunk.dm"
 #include "code\datums\status_effects\debuffs\fire_stacks.dm"
+#include "code\datums\status_effects\debuffs\firewall.dm"
 #include "code\datums\status_effects\debuffs\genetic_damage.dm"
 #include "code\datums\status_effects\debuffs\hallucination.dm"
 #include "code\datums\status_effects\debuffs\heart_attack.dm"


### PR DESCRIPTION
## About The Pull Request

In addition to the 10 second stun from having your core law changed (or from having your rack destroyed or leave the z-level), silicons are additionally afflicted with "firewall" for 30 seconds, which blocks use of some machinery like turrets and APCs. 

## Why It's Good For The Game

It seems to be somewhat common for people learning how to use the rack to get tazed and killed for touching the laws once, which kinda sucks.

I didn't really want to just *extend* the time the AI is made helpless, so I went with the "firewall" affliction as an intermediate. 
This gives them a period where they're not wholly helpless - you can attempt to reason with the guy or use the slippers or the flashers - but you can't immediately kill them.

## Changelog

:cl: Melbert
balance: In addition to being stunned, AIs are blocked from using certain machines like APCs and turrets for a period after their core laws are changed (or if their rack is destroyed or leaves the z-level). 
/:cl:
