### PR TITLE
fix jellypeople not being able to speak slime

### DIFF
--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -620,10 +620,6 @@
 	voice_filter = @{"[0:a] asplit [out0][out2]; [out0] asetrate=%SAMPLE_RATE%*0.99,aresample=%SAMPLE_RATE%,volume=0.3 [p0]; [p0][out2] amix=inputs=2"}
 	languages_native = list(/datum/language/voltaic)
 
-// Ethereal tongues can speak all default + voltaic
-/obj/item/organ/tongue/ethereal/get_possible_languages()
-	return ..() + /datum/language/voltaic
-
 /obj/item/organ/tongue/cat
 	name = "felinid tongue"
 	desc = "A fleshy muscle mostly used for meowing. Or biting."

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -81,7 +81,7 @@
 /obj/item/organ/tongue/proc/get_possible_languages()
 	RETURN_TYPE(/list)
 	// This is the default list of languages most humans should be capable of speaking
-	return list(
+	. = list(
 		/datum/language/common,
 		/datum/language/uncommon,
 		/datum/language/spinwarder,
@@ -98,6 +98,8 @@
 		/datum/language/terrum,
 		/datum/language/nekomimetic,
 	)
+	if(languages_native)
+		. |= languages_native
 
 /obj/item/organ/tongue/proc/handle_speech(datum/source, list/speech_args)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request

currently, `get_possible_languages` on tongues is hardcoded, and slime language isn't included, meaning jelly tongues cannot speak slime.

instead of hardcoding the solution, i've made it so `get_possible_languages` also includes `languages_native`

## Why It's Good For The Game

i should be able to speak slime as a jellyperson

## Changelog
:cl:
fix: Jellypeople can speak Slime language again.
/:cl:
