### PR TITLE
Makes BSAs indicate the space they will occupy when completed

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -104,3 +104,12 @@
 /obj/effect/abstract/reach_checker
 	pass_flags = PASSTABLE
 	invisibility = INVISIBILITY_ABSTRACT
+
+/obj/effect/clear_color
+	icon = 'icons/effects/alphacolors.dmi'
+	layer = ABOVE_NORMAL_TURF_LAYER
+	plane = ABOVE_GAME_PLANE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/obj/effect/clear_color/green
+	icon_state = "green"

--- a/code/modules/paperwork/paper_premade.dm
+++ b/code/modules/paperwork/paper_premade.dm
@@ -124,7 +124,7 @@
 	<h1>3. Construction</h1>
 	1. Build three machine frames.
 	2. Determine the desired direction you want your artillery to face.
-	3. Leave six spaces in front, four behind.  The artillery cannon finishes itself after the assemblies are aligned.
+	3. Leave five spaces in front, three behind.  The artillery cannon finishes itself after the assemblies are aligned.
 	4. Place the machine frames in a horizontal line.
 	5. Wrench the three machine frames in place.
 	6. Install wires in the three machine frames.
@@ -136,7 +136,7 @@
 	12. Use a screwdriver to fasten the board, install wires and two glass sheets, use screwdriver again to turn on.
 	13. Use a multitool and interact with the generator, then the fusor.
 	14. Use a multitool again to interact with the bore, then the fusor.
-	15. Use the console to finalize construction, make sure there's enough empty space around the BSA for the assembly to commence.
+	15. Use the console to finalize construction. If the console doesn't display any error messages, a faint green hologram will indicate the BSA's position. Reposition if needed.
 	And with that, you are done!
 	<b>Commencing firing protocols requires the access of at least two heads, the console will be locked down until this requirement is met.</b>
 	<b>Always make sure you are certain before attempting to fire the BSA.</b>

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -2,6 +2,13 @@
 ///BSA unlocked by head ID swipes
 GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 
+// Spatial defines (all in tiles)
+#define BSA_WIDTH 11
+#define BSA_HEIGHT 3
+#define BSA_Y_OFFSET -1
+#define BSA_X_OFFSET_WEST -6
+#define BSA_X_OFFSET_EAST -4
+
 // Crew has to build a bluespace cannon
 // Cargo orders part for high price
 // Requires high amount of power
@@ -107,23 +114,16 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 		return "Not enough free space!"
 
 /**
- * Proc to check if the BSA has the required 10 x 1 block space to deploy.
+ * Proc to check if the BSA has the required 11 x 1 block space to deploy.
  */
 /obj/machinery/bsa/middle/proc/has_space()
-	var/cannon_dir = get_cannon_direction()
-	var/width = 10
-	var/offset
-	switch(cannon_dir)
-		if(EAST)
-			offset = -4
-		if(WEST)
-			offset = -6
-		else
-			return FALSE
+	var/x_offset = get_directional_offset()
+	if(!x_offset)
+		return FALSE
 
 	var/turf/base = get_turf(src)
 	var/blocked = FALSE
-	for(var/turf/T as anything in CORNER_BLOCK_OFFSET(base, width, 3, offset, -1))
+	for(var/turf/T as anything in CORNER_BLOCK_OFFSET(base, BSA_WIDTH, BSA_HEIGHT, x_offset, BSA_Y_OFFSET))
 		if(T.density || isspaceturf(T))
 			blocked = TRUE
 			new /obj/effect/temp_visual/point(T)
@@ -131,6 +131,17 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 		return FALSE
 
 	return TRUE
+
+/**
+ * Returns the x offset (in tiles) associated with the BSA's direction
+ */
+/obj/machinery/bsa/middle/proc/get_directional_offset()
+	var/cannon_dir = get_cannon_direction()
+	switch(cannon_dir)
+		if(EAST)
+			return BSA_X_OFFSET_EAST
+		if(WEST)
+			return BSA_X_OFFSET_WEST
 
 /obj/machinery/bsa/middle/proc/get_cannon_direction()
 	var/obj/machinery/bsa/front/front = front_ref?.resolve()
@@ -273,6 +284,30 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	var/notice
 	var/target
 	var/area_aim = FALSE //should also show areas for targeting
+	/// If we're showing roughly where the BSA will appear.
+	var/visualizing_position = FALSE
+	// The turfs of our BSA's middle and front upon the start of position visualization.
+	// Used to prevent the BSA from being moved/rotated to another valid spot mid-visualization.
+	var/turf/visualization_center
+	var/turf/visualization_front
+	/// Typepath of the effect used for position visualization.
+	var/visualization_type = /obj/effect/clear_color/green
+	/// List of effects being used to show where the BSA will appear.
+	var/visualization_effects
+
+/obj/machinery/computer/bsa_control/Initialize(mapload, obj/item/circuitboard/C)
+	. = ..()
+	visualization_effects = list()
+
+/obj/machinery/computer/bsa_control/Destroy(force)
+	. = ..()
+	if(visualizing_position)
+		stop_visualizing()
+
+/obj/machinery/computer/bsa_control/on_set_machine_stat(old_value)
+	. = ..()
+	if(machine_stat && visualizing_position)
+		stop_visualizing()
 
 /obj/machinery/computer/bsa_control/ui_state(mob/user)
 	return GLOB.physical_state
@@ -290,6 +325,7 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	data["connected"] = cannon
 	data["notice"] = notice
 	data["unlocked"] = GLOB.bsa_unlock
+	data["visualizing"] = visualizing_position
 	if(target)
 		data["target"] = get_target_name()
 	return data
@@ -302,7 +338,14 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	switch(action)
 		if("build")
 			cannon_ref = WEAKREF(deploy())
+			stop_visualizing()
 			. = TRUE
+		if("visualize")
+			if(!visualizing_position)
+				start_visualizing()
+		if("unvisualize")
+			if(visualizing_position)
+				stop_visualizing()
 		if("fire")
 			var/obj/machinery/bsa/full/cannon = cannon_ref.resolve()
 			if(cannon.use_energy(cannon.power_used_per_shot, force = FALSE))
@@ -334,7 +377,6 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	target = options[victim]
 	log_game("[key_name(user)] has aimed the bluespace artillery strike at [target].")
 
-
 /obj/machinery/computer/bsa_control/proc/get_target_name()
 	if(istype(target, /area))
 		return get_area_name(target, TRUE)
@@ -363,11 +405,9 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	var/turf/target_turf = get_impact_turf()
 	cannon.fire(user, target_turf)
 
-/obj/machinery/computer/bsa_control/proc/deploy(force=FALSE)
-	var/obj/machinery/bsa/full/prebuilt = locate() in range(7) //In case of adminspawn
-	if(prebuilt)
-		return prebuilt
-
+/// Sets `notice` and returns null if the BSA isn't complete.
+/// Returns the BSA's centerpiece if everything's alright.
+/obj/machinery/computer/bsa_control/proc/check_completion()
 	var/obj/machinery/bsa/middle/centerpiece = locate() in range(7)
 	if(!centerpiece)
 		notice = "No BSA parts detected nearby."
@@ -375,6 +415,50 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	notice = centerpiece.check_completion()
 	if(notice)
 		return null
+	return centerpiece
+
+/// Prior to BSA deployment, indicates the space which the BSA will occupy using effects.
+/obj/machinery/computer/bsa_control/proc/start_visualizing()
+	var/obj/machinery/bsa/full/prebuilt = locate() in range(7) //In case of adminspawn
+	if(prebuilt)
+		cannon_ref = WEAKREF(prebuilt)
+		return
+
+	var/obj/machinery/bsa/middle/centerpiece = check_completion()
+	if(notice)
+		return null
+
+	visualization_center = get_turf(centerpiece)
+	visualization_front = get_turf(centerpiece.front_ref?.resolve())
+	visualizing_position = TRUE
+
+	var/x_offset = centerpiece.get_directional_offset()
+	var/turf/base = get_turf(centerpiece.loc)
+	for(var/turf/deployment_turf as anything in CORNER_BLOCK_OFFSET(base, BSA_WIDTH, BSA_HEIGHT, x_offset, BSA_Y_OFFSET))
+		var/bsa_effect = new visualization_type(deployment_turf)
+		visualization_effects += bsa_effect
+
+/// Clear all effects indicating where the BSA will deploy.
+/obj/machinery/computer/bsa_control/proc/stop_visualizing()
+	visualizing_position = FALSE
+	visualization_front = null
+	visualization_center = null
+	for(var/obj/effect/bsa_visualization/deployment_visualizer in visualization_effects)
+		qdel(deployment_visualizer)
+
+/obj/machinery/computer/bsa_control/proc/deploy(force=FALSE)
+	var/obj/machinery/bsa/middle/centerpiece = check_completion()
+	if(!centerpiece)
+		return null
+	// `check_completion()` occurs both here and at `start_visualizing()`
+	// These checks must only occur after visualization.
+	if(visualization_center != get_turf(centerpiece))
+		notice = "The BSA has been moved mid-deployment."
+		return null
+	if(visualization_front != get_turf(centerpiece.front_ref?.resolve()))
+		notice = "The BSA has been rotated mid-deployment."
+		return null
+
 	//Totally nanite construction system not an immersion breaking spawning
 	do_smoke(4, get_turf(centerpiece), get_turf(centerpiece))
 	var/obj/machinery/bsa/full/cannon = new(get_turf(centerpiece),centerpiece.get_cannon_direction())
@@ -382,6 +466,7 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	QDEL_NULL(centerpiece.back_ref)
 	qdel(centerpiece)
 	return cannon
+
 /obj/machinery/computer/bsa_control/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(obj_flags & EMAGGED)
 		return FALSE
@@ -389,3 +474,9 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	balloon_alert(user, "rigged to explode")
 	to_chat(user, span_warning("You emag [src] and hear the focusing crystal short out. You get the feeling it wouldn't be wise to stand near [src] when the BSA fires..."))
 	return TRUE
+
+#undef BSA_WIDTH
+#undef BSA_HEIGHT
+#undef BSA_Y_OFFSET
+#undef BSA_X_OFFSET_WEST
+#undef BSA_X_OFFSET_EAST

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -443,7 +443,7 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	visualizing_position = FALSE
 	visualization_front = null
 	visualization_center = null
-	for(var/obj/effect/bsa_visualization/deployment_visualizer in visualization_effects)
+	for(var/obj/effect/clear_color/green/deployment_visualizer in visualization_effects)
 		qdel(deployment_visualizer)
 
 /obj/machinery/computer/bsa_control/proc/deploy(force=FALSE)

--- a/tgui/packages/tgui/interfaces/BluespaceArtillery.tsx
+++ b/tgui/packages/tgui/interfaces/BluespaceArtillery.tsx
@@ -14,12 +14,13 @@ type Data = {
   connected: BooleanLike;
   notice: string;
   unlocked: BooleanLike;
+  visualizing: BooleanLike;
   target: string;
 };
 
 export const BluespaceArtillery = (props) => {
   const { act, data } = useBackend<Data>();
-  const { notice, connected, unlocked, target } = data;
+  const { connected, notice, unlocked, visualizing, target } = data;
 
   return (
     <Window width={400} height={220}>
@@ -72,11 +73,20 @@ export const BluespaceArtillery = (props) => {
           <Section>
             <LabeledList>
               <LabeledList.Item label="Maintenance">
-                <Button
-                  icon="wrench"
-                  content="Complete Deployment"
-                  onClick={() => act('build')}
-                />
+                {(visualizing) ? (
+                  <>
+                    <Button color="good" onClick={() => act('build')}>
+                      Confirm Position
+                    </Button>
+                    <Button color="bad" onClick={() => act('unvisualize')}>
+                      Cancel
+                    </Button>
+                  </>
+                ) : (
+                  <Button icon="wrench" onClick={() => act('visualize')}>
+                    Begin Deployment
+                  </Button>
+                )}
               </LabeledList.Item>
             </LabeledList>
           </Section>


### PR DESCRIPTION

## About The Pull Request
This PR makes nearly finished BSAs create a clear green effect on the turfs that they will occupy when complete. 
<details><summary>Expand for screenshot:</summary>

<img width="714" height="387" alt="BSA_Visualization" src="https://github.com/user-attachments/assets/7df858e0-4df0-4261-aa65-df35a5bdbf90" />

</details>

This is done with generic effects rather than images. It is visible to everyone nearby and disappears upon console destruction, depowering, or (of course) BSA completion. It does not indicate which tiles are blocking the BSA from being deployed as that's (rather obscurely) done by another portion of the code. 

I also noticed that deploying BSAs check for blocking tiles within a space ten tiles wide while they actually occupy eleven. This has been corrected, so BSAs will no longer be able to overlap with blocking tiles on their right side.

## Why It's Good For The Game
It can be very difficult to tell where exactly a BSA will appear when finished. Adding to that, BSAs cannot be conventionally deconstructed and they do not drop their parts when broken. Taken together, this makes the process of working out BSA placement very frustrating. 
## Changelog
:cl:
qol: Bluespace Artillery Cannons now indicate the space they will occupy prior to deployment.
/:cl:
