### PR TITLE
Fixes color matrixed clothing items not showing as colored on_mob

### DIFF
--- a/code/game/atom/atom_color.dm
+++ b/code/game/atom/atom_color.dm
@@ -120,14 +120,20 @@
 
 /// Same as update_atom_color, but simplifies overlay coloring
 /atom/proc/color_atom_overlay(mutable_appearance/overlay)
-	overlay.color = color
-	if (!cached_color_filter)
+	var/list/color_filter = cached_color_filter
+	if(islist(color))
+		overlay.color = null
+		color_filter ||= color_matrix_filter(color_to_full_rgba_matrix(color), FILTER_COLOR_RGB)
+	else
+		overlay.color = color
+
+	if(!color_filter)
 		return overlay
 	// Apply the atom's color filter to the overlay using named filters so that
 	// later calls to add_filter/update_filters (e.g., height displacement filters)
 	// do not wipe out our coloration. Mirror prior behavior by propagating to
 	// child overlays unless KEEP_TOGETHER is present.
-	overlay.add_filter(ATOM_PRIORITY_COLOR_FILTER, ATOM_PRIORITY_COLOR_FILTER_PRIORITY, cached_color_filter)
+	overlay.add_filter(ATOM_PRIORITY_COLOR_FILTER, ATOM_PRIORITY_COLOR_FILTER_PRIORITY, color_filter)
 
 	if(!(overlay.appearance_flags & KEEP_TOGETHER))
 		// Recursively ensure any nested overlays/underlays also get the color filter


### PR DESCRIPTION

## About The Pull Request
Code was done by @CatoChristopherMrow and PRed here with permission from him.
<img width="410" height="90" alt="image" src="https://github.com/user-attachments/assets/4ed5c5dd-5e97-4641-b063-a995d8024302" />

As you can see in the attached screenshots, they both match now instead of on_mob being the default color.

<details>
<summary>Item Icon</summary>
<img width="148" height="100" alt="image" src="https://github.com/user-attachments/assets/b5906c60-acd4-4f51-9e74-3ae71fcb341d" />
</details>

<details>
<summary>Worn Icon</summary>
<img width="103" height="96" alt="image" src="https://github.com/user-attachments/assets/1cbbb092-4b39-4a0e-851f-71a9f76a748c" />
</details>

## Why It's Good For The Game
It allows for more unique edits in VV and I am pretty sure it was unintentional that it couldn't be done beforehand.
## Changelog
:cl: xPokee, UvvU
fix: Recoloring clothing items via 'Edit Color as Matrix' will now properly reflect when the clothing item is worn.
/:cl:
