### PR TITLE
Malf AI hacked APCs take power from their terminals

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -575,6 +575,12 @@
 		total_static_energy_usage += APC_CHANNEL_IS_ON(environ) * area.energy_usage[AREA_USAGE_STATIC_ENVIRON]
 	area.clear_usage()
 
+	if(malfai && COOLDOWN_FINISHED(src, malf_ai_pt_generation) && !(machine_stat & (BROKEN|MAINT)) && !failure_timer && (total_static_energy_usage + 60 KILO JOULES) <= (terminal?.surplus() + cell.charge) && malfai.malf_picker.processing_time < MALF_MAX_PP)
+	//if we're hacked, we're off point cooldown, we're not broken or off temporarily, we can gather enough power, and our ai can take more points
+		total_static_energy_usage += 60 KILO JOULES
+		COOLDOWN_START(src, malf_ai_pt_generation, 30 SECONDS)
+		malfai.malf_picker.processing_time += 1
+
 	if(total_static_energy_usage) //Use power from static power users.
 		var/grid_used = min(terminal?.surplus(), total_static_energy_usage)
 		terminal?.add_load(grid_used)
@@ -597,10 +603,6 @@
 		hacked_flicker_counter = hacked_flicker_counter - 1
 		if(hacked_flicker_counter <= 0)
 			flicker_hacked_icon()
-
-	if(malfai && COOLDOWN_FINISHED(src, malf_ai_pt_generation) && cell.use(60 KILO JOULES) > 0 && malfai.malf_picker.processing_time < MALF_MAX_PP) // Over time generation of malf points for the ai controlling it, costs a bit of power
-		COOLDOWN_START(src, malf_ai_pt_generation, 30 SECONDS)
-		malfai.malf_picker.processing_time += 1
 
 	//dont use any power from that channel if we shut that power channel off
 	if(operating)


### PR DESCRIPTION

## About The Pull Request

Moves malfunctioning AI point generation and power consumption from apcs' `late_process()` to their `early_process`, wherein the power consumption is added to `total_static_energy_usage` to be split between the terminal and the apc's cell if it has the energy to spare.
Additionally, prevents power consumption when failing to make points due to hitting maximum points, because this was making the power consumption happen every tick if the ai reached their limit, which is the opposite of what would intuitively happen.

## Why It's Good For The Game

closes #96231
closes #95807
The person who made this feature [said that this was the way it was supposed to work](https://discord.com/channels/326822144233439242/326831214667235328/1508889242141458556)
This makes more sense as a drawback than just deactivating a room

## Changelog
:cl:

balance: Malf AI hacked APCs no longer fully drain their own cells, instead draining from the powernet

/:cl:
