### PR TITLE
Goliaths and Tendrils can be punched using your normal punches 

### DIFF
--- a/code/__DEFINES/basic_mobs.dm
+++ b/code/__DEFINES/basic_mobs.dm
@@ -14,14 +14,12 @@
 #define REMAIN_DENSE_WHILE_DEAD (1<<2)
 /// Mob can be set on fire
 #define FLAMMABLE_MOB (1<<3)
-/// Mob never takes damage from unarmed attacks
-#define IMMUNE_TO_FISTS (1<<4)
 /// Mob is immune to getting wet
-#define IMMUNE_TO_GETTING_WET (1<<5)
+#define IMMUNE_TO_GETTING_WET (1<<4)
 /// Disables the function of attacking random body zones
-#define PRECISE_ATTACK_ZONES (1<<6)
+#define PRECISE_ATTACK_ZONES (1<<5)
 /// People would be sad to see this mob die
-#define SENDS_DEATH_MOODLETS (1<<7)
+#define SENDS_DEATH_MOODLETS (1<<6)
 
 /// Temporary trait applied when an attack forecast animation has completed
 #define TRAIT_BASIC_ATTACK_FORECAST "trait_basic_attack_forecast"

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -1499,11 +1499,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_atoms_ontop)
 	icon_state = "basic_mob_flammable"
 	flag_to_give = FLAMMABLE_MOB
 
-/obj/effect/mapping_helpers/basic_mob_flags/immune_to_fists
-	name = "Basic mob immune to fists flag helper"
-	icon_state = "basic_mob_immune_to_fists"
-	flag_to_give = IMMUNE_TO_FISTS
-
 /obj/effect/mapping_helpers/basic_mob_flags/immune_to_getting_wet
 	name = "Basic mob immune to getting wet flag helper"
 	icon_state = "basic_mob_immune_to_getting_wet"

--- a/code/modules/mob/living/basic/basic_defense.dm
+++ b/code/modules/mob/living/basic/basic_defense.dm
@@ -22,7 +22,7 @@
 		to_chat(user, span_warning("You don't want to hurt [src]!"))
 		return TRUE
 	var/obj/item/bodypart/arm/active_arm = user.get_active_hand()
-	var/damage = (basic_mob_flags & IMMUNE_TO_FISTS) ? 0 : rand(active_arm.unarmed_damage_low, active_arm.unarmed_damage_high)
+	var/damage = rand(active_arm.unarmed_damage_low, active_arm.unarmed_damage_high)
 	if(check_block(user, damage, "[user]'s punch", UNARMED_ATTACK, 0, BRUTE))
 		return
 	user.do_attack_animation(src, ATTACK_EFFECT_PUNCH)

--- a/code/modules/mob/living/basic/lavaland/goliath/goliath.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/goliath.dm
@@ -10,7 +10,6 @@
 	base_pixel_x = -12
 	gender = MALE // Female ones are the bipedal elites
 	speed = 12
-	basic_mob_flags = IMMUNE_TO_FISTS
 	maxHealth = 300
 	health = 300
 	friendly_verb_continuous = "wails at"

--- a/code/modules/mob/living/basic/lavaland/tendril/tendril.dm
+++ b/code/modules/mob/living/basic/lavaland/tendril/tendril.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_INIT(tendrils, list())
 	base_pixel_w = -8
 	status_flags = NONE
 	mob_biotypes = MOB_ORGANIC | MOB_SKELETAL | MOB_MINING | MOB_SPECIAL
-	basic_mob_flags = DEL_ON_DEATH | IMMUNE_TO_FISTS
+	basic_mob_flags = DEL_ON_DEATH
 	mob_size = MOB_SIZE_HUGE
 	maxHealth = 800
 	health = 800


### PR DESCRIPTION

## About The Pull Request

Goliaths and tendrils would take zero damage from standard, unmodified punches. This is no longer the case.

This does not affect martial arts or strongarms, which were both working against goliaths just fine.

Removes the IMMUNE_TO_FISTS flag as it is now unused entirely (and there are better ways to implement it)

## Why It's Good For The Game

It literally doesn't make sense that you can punch bubblegum to death, but you can't punch even one normal goliath to death.

Tendrils are seemingly goliath-related, so I assume that is why they have the flag as well.

## Changelog
:cl:
qol: You can punch a goliath to death. This isn't recommended. But if you are committed enough, you are welcome to do so.
/:cl:
