### PR TITLE
Fix vscode marking rspack compilation message as an error

### DIFF
--- a/tgui/rspack.config.ts
+++ b/tgui/rspack.config.ts
@@ -6,7 +6,7 @@ import rspack, { type StatsOptions } from '@rspack/core';
 export function createStats(verbose: boolean): StatsOptions {
   return {
     assets: verbose,
-    builtAt: verbose,
+    builtAt: false,
     cached: false,
     children: false,
     chunks: false,


### PR DESCRIPTION

## About The Pull Request

rspack outputs [date and time]: rspack compiled successfully and vscode is dumb as hell so it interprets the date and hour as a filename and the minute and second as a line/column number and goes ohh i guess there was an error during compilation better put it in the problems tab. This just disables adding the timestamp because its not important information

## Why It's Good For The Game

<img width="498" height="102" alt="image" src="https://github.com/user-attachments/assets/d73c8ee0-eebb-4394-b820-1ba2b64d1b6d" />

## Changelog

N/A
