### PR TITLE
Stasis bodybags don't decay in freezing temperatures

### DIFF
--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -397,11 +397,8 @@
 	return null
 
 ///Return the current air environment in this atom
-/atom/proc/return_air()
-	if(loc)
-		return loc.return_air()
-	else
-		return null
+/atom/proc/return_air() as /datum/gas_mixture
+	return loc?.return_air()
 
 ///Return the air if we can analyze it
 /atom/proc/return_analyzable_air()

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -573,8 +573,9 @@
 	if(SPT_PROB(2 * (seconds_freezing / 60), seconds_per_tick))
 		freezing.Unconscious(1 SECONDS)
 
-	// Bout two minutes of time
-	take_damage(max_integrity * 0.004 * seconds_per_tick, sound_effect = FALSE)
+	if(loc?.return_air()?.return_temperature() > T0C)
+		// Bout two minutes of time
+		take_damage(max_integrity * 0.004 * seconds_per_tick, sound_effect = FALSE)
 
 /obj/structure/closet/body_bag/environmental/stasis/after_open(mob/living/user, force = FALSE)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Statis bag decay only occurs above 0c.

## Why It's Good For The Game

Just thought it'd be quaint to be able to preserve them in morgue slabs

## Changelog
:cl: Melbert
qol: Stasis bodybags don't decay in freezing temperatures, such as those present in morgue slabs
/:cl:
