### PR TITLE
Right-clicking a sink with a liquid container empties it down the drain

### DIFF
--- a/code/game/objects/structures/water_structures/sink.dm
+++ b/code/game/objects/structures/water_structures/sink.dm
@@ -1,3 +1,8 @@
+/// How long emptying a container into a sink takes, per unit of reagent held.
+#define SINK_EMPTY_TIME_PER_UNIT (0.02 SECONDS)
+/// Emptying a container into a sink never takes longer than this, no matter how full it is.
+#define SINK_EMPTY_TIME_MAX (3 SECONDS)
+
 /obj/structure/sink
 	name = "sink"
 	icon = 'icons/obj/watercloset.dmi'
@@ -64,6 +69,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 		context[SCREENTIP_CONTEXT_LMB] = "Wash hands"
 		return CONTEXTUAL_SCREENTIP_SET
 
+	if(can_empty_into_drain(held_item))
+		context[SCREENTIP_CONTEXT_RMB] = "Empty into drain"
+		. = CONTEXTUAL_SCREENTIP_SET
+
 	if(is_reagent_container(held_item) && held_item.is_refillable() && !held_item.reagents.holder_full())
 		context[SCREENTIP_CONTEXT_LMB] = "Fill container"
 		return CONTEXTUAL_SCREENTIP_SET
@@ -89,6 +98,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 	if(has_water_reclaimer)
 		. += span_notice("A water recycler is installed. It looks like you could pry it out.")
 	. += span_notice("[reagents.total_volume]/[reagents.maximum_volume] liquids remaining.")
+	. += span_notice("You could [EXAMINE_HINT("right-click")] it with a container to empty it down the drain.")
 
 /obj/structure/sink/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
@@ -219,6 +229,65 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 							span_notice("You wash [tool] using [src]."))
 		return ITEM_INTERACT_SUCCESS
 
+/**
+ * Returns TRUE if [tool] is holding liquid that can be tipped out into us.
+ *
+ * Anything you can normally pour or draw liquid out of qualifies. Mops are allowed on top
+ * of that, since they hold reagents without any container flags but wringing one out into
+ * a sink is exactly what you'd expect to be able to do.
+ */
+/obj/structure/sink/proc/can_empty_into_drain(obj/item/tool)
+	if(isnull(tool?.reagents))
+		return FALSE
+	if(tool.is_drawable()) // Covers both DRAWABLE and DRAINABLE holders.
+		return TRUE
+	return istype(tool, /obj/item/mop)
+
+/// Right-clicking with anything that holds liquid tips it out down the drain,
+/// mirroring the left-click interaction that fills containers up.
+/obj/structure/sink/item_interaction_secondary(mob/living/user, obj/item/tool, list/modifiers)
+	if(!can_empty_into_drain(tool))
+		return ..()
+
+	if(busy)
+		to_chat(user, span_warning("Someone's already washing here!"))
+		return ITEM_INTERACT_BLOCKING
+
+	if(!tool.reagents.total_volume)
+		balloon_alert(user, "already empty!")
+		return ITEM_INTERACT_BLOCKING
+
+	var/empty_time = min(tool.reagents.total_volume * SINK_EMPTY_TIME_PER_UNIT, SINK_EMPTY_TIME_MAX)
+
+	user.visible_message(
+		span_notice("[user] starts emptying [tool] into [src]."),
+		span_notice("You start emptying [tool] into [src]..."),
+	)
+	playsound(src, 'sound/effects/slosh.ogg', 25, TRUE)
+
+	busy = TRUE
+	if(!do_after(user, empty_time, target = src))
+		busy = FALSE
+		return ITEM_INTERACT_BLOCKING
+	busy = FALSE
+
+	// The container could have been emptied, swapped or dropped while we were pouring.
+	if(QDELETED(tool) || !user.is_holding(tool))
+		return ITEM_INTERACT_BLOCKING
+	if(!tool.reagents.total_volume)
+		balloon_alert(user, "already empty!")
+		return ITEM_INTERACT_BLOCKING
+
+	user.log_message("emptied [tool] ([tool.reagents.get_reagent_log_string()]) into [src] at [AREACOORD(src)].", LOG_GAME)
+	tool.reagents.clear_reagents()
+	playsound(src, 'sound/machines/sink-faucet.ogg', 50)
+
+	user.visible_message(
+		span_notice("[user] empties [tool] into [src]."),
+		span_notice("You empty [tool] into [src], washing its contents down the drain."),
+	)
+	return ITEM_INTERACT_SUCCESS
+
 /obj/structure/sink/wrench_act(mob/living/user, obj/item/tool)
 	tool.play_tool_sound(src)
 	deconstruct(TRUE)
@@ -307,3 +376,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink/kitchen, (-16))
 /obj/item/wallframe/sinkframe/after_attach(obj/structure/sink/greyscale/attached_to)
 	attached_to.set_custom_materials(custom_materials)
 	attached_to.update_appearance(UPDATE_OVERLAYS)
+
+#undef SINK_EMPTY_TIME_PER_UNIT
+#undef SINK_EMPTY_TIME_MAX


### PR DESCRIPTION
## About The Pull Request

Sinks already fill containers on left-click, but there was no counterpart for emptying one out. Right-clicking a sink with anything that holds liquid now tips its contents down the drain.

`can_empty_into_drain()` accepts anything `is_drawable()` — beakers, bottles, cups, buckets, rags, syringes, IV bags — plus mops, which hold reagents without any container flags but are the obvious thing to wring out into a sink. Food is deliberately excluded, since edibles create their reagent holder as `INJECTABLE` only and are not drawable.

- Reuses the sink's existing `busy` guard, so it can't race with someone washing
- Takes 0.02s per unit, capped at 3s (a 50u beaker is ~1s)
- Re-checks the container still exists and is still held after the `do_after`
- Logs to `LOG_GAME` with `get_reagent_log_string()`, recording who dumped what and where
- Adds an RMB screentip and an examine hint
- Applies to every sink subtype, including the kitchen sink, the greyscale/wallframe sink and the plasma fuel station

Reagents are destroyed rather than transferred into the sink's own holder, so you can't contaminate the water supply and dose the next person who washes their hands.

Worth flagging for review: right-clicking a sink previously fell through to the same code as left-click (filling), since `item_interaction_secondary` defaults to `item_interaction`. Anyone with that muscle memory will now empty instead.

## Why It's Good For The Game

Filling a container at a sink is a left-click away, but emptying one meant dumping it on the floor or tracking down a disposal unit. This closes an obvious gap in an interaction players already know, and makes the two directions mirror each other.

The main tradeoff is that it makes ditching incriminating chemicals easier. That's mitigated by the timed `do_after` — you're stood there visibly pouring for up to three seconds, and the message is visible to onlookers — and by the log entry, which keeps it traceable after the fact.

## Proof Of Testing

<details>
<summary>
<img width="1920" height="1044" alt="image" src="https://github.com/user-attachments/assets/2360d50e-b32a-4879-8b5d-4d57e9fc1cbe" />
</summary>

## Changelog

:cl:
add: You can now right-click a sink with any liquid-holding container - beakers, buckets, syringes, even mops - to empty it down the drain.
/:cl:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
