### PR TITLE
fixes the lobby countdown not starting properly

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -459,6 +459,7 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 	var/msg = "Initializations complete within [time] second[time == 1 ? "" : "s"]!"
 	to_chat(world, span_boldannounce("[msg]"), MESSAGE_TYPE_DEBUG)
 	log_world(msg)
+	SSticker.start_at = world.time + (CONFIG_GET(number/lobby_countdown) * (1 SECONDS))
 
 
 	if(world.system_type == MS_WINDOWS && CONFIG_GET(flag/toast_notification_on_init) && !length(GLOB.clients))

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -111,8 +111,6 @@ SUBSYSTEM_DEF(ticker)
 	else
 		set_lobby_music("[global.config.directory]/title_music/sounds/[pick(music)]")
 
-	start_at = world.time + (CONFIG_GET(number/lobby_countdown) * (1 SECONDS))
-
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/ticker/fire()


### PR DESCRIPTION
## About The Pull Request

The lobby countdown is initialized along with the SSticker. Unfortunately, SSticker is initialized like 30 seconds before the initializations are finished, making it so that when the round start timer actually starts, the cooldown is about (not precisely) 30 seconds shorter than in the configs. This PR changes it by moving the assignment of the `start_at` value to the very end of Master subsystem initialization.

Now, I know that players can get ready before the timer starts, but I am personally irked out by the round start timer not starting at the same value that's set in the configs. The time between SSticker initialization and end of all initializations isn't constant anyway, so imo it's better to have it more reliable.

## Why It's Good For The Game

Makes it so that the value for ready up time set in configs is actually the value we have to wait after the game is initialized.

## Changelog

I'm not sure which category to put it in but I think code works

:cl: Swan
code: Made it so the round start timer starts precisely at the value specified in configs
/:cl: