### PR TITLE
Juke dm target only recompiles if define arguments have changed

### DIFF
--- a/tools/build/build.ts
+++ b/tools/build/build.ts
@@ -44,6 +44,20 @@ function getCutterPath() {
 
 const cutter_path = getCutterPath();
 
+const define_params_file = 'data/last_define_params.json'
+
+// Have compilation defines changed since last build?
+function defineParametersChanged(defines: string[]): boolean {
+  const defines_string = JSON.stringify(defines);
+  if(!fs.existsSync(define_params_file)) {
+    fs.writeFileSync(define_params_file, defines_string);
+    return true;
+  }
+  const last_params = fs.readFileSync(define_params_file, { encoding: 'utf8' });
+  fs.writeFileSync(define_params_file, defines_string);
+  return last_params !== defines_string;
+}
+
 export const DefineParameter = new Juke.Parameter({
   type: 'string[]',
   alias: 'D',
@@ -203,8 +217,8 @@ export const DmTarget = new Juke.Target({
     NamedVersionFile,
   ],
   outputs: ({ get }) => {
-    if (get(DmVersionParameter) || get(DefineParameter).length > 0) {
-      // Always rebuild when a dm version or explicit CLI defines are provided to ensure juke re-runs
+    if (get(DmVersionParameter) || defineParametersChanged(get(DefineParameter))) {
+      // Always rebuild when a dm version is provided or CLI defines have changed from last run
       return [];
     }
     return [`${DME_NAME}.dmb`, `${DME_NAME}.rsc`];

--- a/tools/build/build.ts
+++ b/tools/build/build.ts
@@ -50,7 +50,9 @@ const define_params_file = 'data/last_define_params.json'
 function defineParametersChanged(defines: string[]): boolean {
   const defines_string = JSON.stringify(defines);
   if(!fs.existsSync(define_params_file)) {
-    fs.writeFileSync(define_params_file, defines_string);
+    const fd = fs.openSync(define_params_file, 'w');
+    fs.writeSync(fd, defines_string);
+    fs.closeSync(fd);
     return true;
   }
   const last_params = fs.readFileSync(define_params_file, { encoding: 'utf8' });

--- a/tools/build/build.ts
+++ b/tools/build/build.ts
@@ -47,16 +47,15 @@ const cutter_path = getCutterPath();
 const define_params_file = 'data/last_define_params.json'
 
 // Have compilation defines changed since last build?
-function defineParametersChanged(defines: string[]): boolean {
+async function defineParametersChanged(defines: string[]): Promise<boolean> {
   const defines_string = JSON.stringify(defines);
-  if(!fs.existsSync(define_params_file)) {
-    const fd = fs.openSync(define_params_file, fs.constants.O_CREAT | fs.constants.O_WRONLY);
-    fs.writeSync(fd, defines_string);
-    fs.closeSync(fd);
+  const params_file = Bun.file(define_params_file);
+  if(!await params_file.exists()) {
+    await params_file.write(defines_string);
     return true;
   }
-  const last_params = fs.readFileSync(define_params_file, { encoding: 'utf8' });
-  fs.writeFileSync(define_params_file, defines_string);
+  const last_params = await params_file.text();
+  await params_file.write(defines_string);
   return last_params !== defines_string;
 }
 
@@ -218,8 +217,8 @@ export const DmTarget = new Juke.Target({
     `${DME_NAME}.dme`,
     NamedVersionFile,
   ],
-  outputs: ({ get }) => {
-    if (get(DmVersionParameter) || defineParametersChanged(get(DefineParameter))) {
+  outputs: async ({ get }) => {
+    if (get(DmVersionParameter) || await defineParametersChanged(get(DefineParameter))) {
       // Always rebuild when a dm version is provided or CLI defines have changed from last run
       return [];
     }

--- a/tools/build/build.ts
+++ b/tools/build/build.ts
@@ -50,7 +50,7 @@ const define_params_file = 'data/last_define_params.json'
 function defineParametersChanged(defines: string[]): boolean {
   const defines_string = JSON.stringify(defines);
   if(!fs.existsSync(define_params_file)) {
-    const fd = fs.openSync(define_params_file, 'w');
+    const fd = fs.openSync(define_params_file, fs.constants.O_CREAT | fs.constants.O_WRONLY);
     fs.writeSync(fd, defines_string);
     fs.closeSync(fd);
     return true;


### PR DESCRIPTION

## About The Pull Request

#96809 added a check in the dm target to make sure a rebuild is forced if explicit define arguments are passed, but this means it sometimes rebuilds when there's no reason to i.e. you're running with the same arguments as last compile. This change makes the build script store the arguments in a json file so it can check during subsequent runs and only rebuild if the arguments changed.

## Why It's Good For The Game

One of the benefits of a build system is avoiding unnecessary rebuilds

## Changelog

N/A
