### PR TITLE
Attempt at a small bit of paper sanity

### DIFF
--- a/code/game/objects/items/secret_documents.dm
+++ b/code/game/objects/items/secret_documents.dm
@@ -20,6 +20,9 @@
 	layer = MOB_LAYER
 	pressure_resistance = 2
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	// Could use a more specific sound since it's a lot of paper. (Ditto with `/paperwork`)
+	drop_sound = 'sound/items/handling/paper_drop.ogg'
+	pickup_sound = 'sound/items/handling/paper_pickup.ogg'
 
 ///Nanotrasen documents
 /obj/item/documents/nanotrasen

--- a/code/game/objects/items/secret_documents.dm
+++ b/code/game/objects/items/secret_documents.dm
@@ -20,7 +20,7 @@
 	layer = MOB_LAYER
 	pressure_resistance = 2
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-	// Could use a more specific sound since it's a lot of paper. (Ditto with `/paperwork`)
+	// Could use a more specific sound since it's a lot of paper (ditto with `/paperwork`).
 	drop_sound = 'sound/items/handling/paper_drop.ogg'
 	pickup_sound = 'sound/items/handling/paper_pickup.ogg'
 

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -143,6 +143,10 @@
 		update_appearance()
 		return ITEM_INTERACT_SUCCESS
 
+	// Always label the clipboard so all of the papers don't have to be taken out.
+	if(istype(tool, /obj/item/hand_labeler))
+		return tool.interact_with_atom(src, user)
+
 	if(top_paper)
 		top_paper.item_interaction(user, user.get_active_held_item())
 		update_appearance()

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -95,16 +95,10 @@
 
 /obj/item/folder/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(is_type_in_typecache(tool, folder_insertables))
-		return insertables_act(user, tool)
+		return interact_with_insertables(tool, user)
 	if(tool.tool_behaviour == TOOL_KNIFE || tool.tool_behaviour == TOOL_WIRECUTTER)
 		return sharp_thing_act(user, tool)
 	return NONE
-
-/obj/item/folder/proc/insertables_act(mob/living/user, obj/item/tool)
-	if(!user.transferItemToLoc(tool, src, silent = FALSE))
-		return ITEM_INTERACT_BLOCKING
-	update_appearance()
-	return ITEM_INTERACT_SUCCESS
 
 /obj/item/folder/nameformat(input, user)
 	playsound(src, SFX_WRITING_PEN, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, SOUND_FALLOFF_EXPONENT + 3, ignore_walls = FALSE)
@@ -133,7 +127,9 @@
 		interacting_with.do_pickup_animation(src)
 		interacting_with.forceMove(src)
 
-	playsound(src, interacting_with.pickup_sound, PICKUP_SOUND_VOLUME, interacting_with.sound_vary, ignore_walls = FALSE)
+	if(interacting_with.pickup_sound)
+		playsound(src, interacting_with.pickup_sound, PICKUP_SOUND_VOLUME, interacting_with.sound_vary, ignore_walls = FALSE)
+
 	update_appearance()
 	return ITEM_INTERACT_SUCCESS
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -416,7 +416,7 @@ GAME_VERB_SRC(/obj/item/paper, rename, usr, "Rename paper", null)
 	return new_plane
 
 /obj/item/paper/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	// Enable picking paper up by clicking on it with the clipboard or paper bin
+	// Enable picking paper up by clicking on it with a clipboard, paper bin, or folder
 	if(istype(tool, /obj/item/clipboard) || istype(tool, /obj/item/paper_bin) || istype(tool, /obj/item/folder))
 		tool.item_interaction(user, src)
 		return ITEM_INTERACT_SUCCESS

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -417,7 +417,7 @@ GAME_VERB_SRC(/obj/item/paper, rename, usr, "Rename paper", null)
 
 /obj/item/paper/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	// Enable picking paper up by clicking on it with the clipboard or paper bin
-	if(istype(tool, /obj/item/clipboard) || istype(tool, /obj/item/paper_bin))
+	if(istype(tool, /obj/item/clipboard) || istype(tool, /obj/item/paper_bin) || istype(tool, /obj/item/folder))
 		tool.item_interaction(user, src)
 		return ITEM_INTERACT_SUCCESS
 

--- a/code/modules/paperwork/paper_biscuit.dm
+++ b/code/modules/paperwork/paper_biscuit.dm
@@ -81,11 +81,6 @@
 
 	return ..()
 
-/obj/item/folder/biscuit/insertables_act(mob/living/user, obj/item/tool)
-	if(!crack_check(user))
-		return ITEM_INTERACT_BLOCKING
-	return ..()
-
 /obj/item/folder/biscuit/interact_with_insertables(atom/interacting_with, mob/living/user)
 	if(!crack_check(user))
 		return ITEM_INTERACT_BLOCKING

--- a/code/modules/paperwork/paperwork.dm
+++ b/code/modules/paperwork/paperwork.dm
@@ -21,6 +21,9 @@
 	throw_range = 1
 	throw_speed = 1
 	layer = MOB_LAYER
+	// Could use a more specific sound since it's a lot of paper (ditto with `/documents`).
+	drop_sound = 'sound/items/handling/paper_drop.ogg'
+	pickup_sound = 'sound/items/handling/paper_pickup.ogg'
 	///The stamp overlay, used to show that the paperwork is complete without making a bunch of sprites
 	var/mutable_appearance/stamp_overlay
 	///The specific stamp icon to be overlaid on the paperwork


### PR DESCRIPTION

## About The Pull Request
Currently, clicking a piece of paper with a folder will force you to read that paper. I vaguely recall this not happening at some point, so I assume it's related to the recent refactors from `attackby()` to `item_interaction()`.

Additionally, I noticed that folders have two very similar procs (`insertables_act()` and `interact_with_insertables()`). They seem to do the same thing, but `insertables_act()` doesn't include animation and sounds. Since they're used in similar contexts, I've removed `insertables_act()` and added a conditional check for the existence of a sound to `interact_with_insertables()`.

Also, I've added the generic paper pickup and drop sounds to the top-secret document and paperwork fluff objects.
## Why It's Good For The Game
It's difficult to put multiple papers into a folder if you have to click out of every one you pick up.
## Changelog
:cl:
fix: Clicking on a piece of paper with a folder no longer forces you to read that paper.
/:cl:
