### PR TITLE
Adds a missing wall to Catwalk's upper atmospherics room

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -75788,9 +75788,6 @@
 "ujb" = (
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
-"ujd" = (
-/turf/open/floor/plating,
-/area/station/engineering/atmos/upper)
 "ujr" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
@@ -205790,7 +205787,7 @@ gtC
 gtC
 gtC
 fHO
-ujd
+unl
 bYd
 bYd
 eaU


### PR DESCRIPTION

## About The Pull Request
This PR adds a singular wall to Catwalk's upper atmospheric room.
## Why It's Good For The Game
Without this wall, Catwalk's upper atmospheric room is exposed to the void of space.
## Changelog
:cl:
fix: Fixed Catwalk's upper atmospherics room being exposed to space by default.
/:cl:
