### PR TITLE
Ion law giberish numbers are back

### DIFF
--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -119,22 +119,24 @@ GLOBAL_VAR(round_default_lawset)
 	/// If TRUE, the zeroth law of this AI is protected and cannot be removed by players under normal circumstances.
 	var/protected_zeroth = FALSE
 
-	/// Zeroth law
+	/// Zeroth law - String
 	/// A lawset can only have 1 zeroth law, it's the top dog.
 	/// Removed by things that remove core/inherent laws, but only if protected_zeroth is false. Otherwise, cannot be removed except by admins
 	var/zeroth = null
-	/// Zeroth borg law
+	/// Zeroth borg law - String
 	/// It's just a zeroth law but specially themed for cyborgs
 	/// ("follow your master" vs "accomplish your objectives")
 	var/zeroth_borg = null
-	/// Core Laws
+	/// Core Laws - Assoc list
 	/// These laws are usually applied by an ai lawset, or a law rack
+	/// This one is assoc, key = law text, value = is this an ion law
 	var/list/inherent = list()
-	/// Supplied laws
+	/// Supplied laws - Assoc list
 	/// These laws are usually applied by adminbus or niche circumstances
 	/// In the case of AIs, they will always stick around, law rack or no
+	/// This one is assoc, key = law text, value = is this an ion law
 	var/list/supplied = list()
-	/// Hacked laws
+	/// Hacked laws - Flat list
 	/// Can be supplied by a law rack, or can be added naturally
 	/// Their priority is always pushed above inherent laws
 	var/list/hacked = list()
@@ -220,13 +222,11 @@ GLOBAL_VAR(round_default_lawset)
 /// Adds the passed law as an inherent law.
 /// Can optionally be supplied an index to insert the law at.
 /// No duplicate laws allowed.
-/datum/ai_laws/proc/add_inherent_law(law, index)
-	if(isnull(index) || index > length(inherent))
-		inherent |= law
-		return
-	if(law in inherent)
+/datum/ai_laws/proc/add_inherent_law(law, index, ioned = FALSE)
+	if(isnum(index) && index <= length(inherent))
 		inherent -= law
-	inherent.Insert(index, law)
+		inherent.Insert(index, law)
+	inherent[law] = ioned
 
 /// Removes the passed law from the inherent law list.
 /datum/ai_laws/proc/remove_inherent_law(law)
@@ -281,15 +281,18 @@ GLOBAL_VAR(round_default_lawset)
 			data += "[show_numbers ? "[ion_num()]:" : ""] [render_html ? "<font color='#c00000'>[law]</font>" : law]"
 
 	var/number = 1
-	for(var/law in inherent)
+	for(var/law, is_ioned in inherent)
 		if (length(law) > 0)
-			data += "[show_numbers ? "[number]:" : ""] [law]"
-			number++
+			data += "[show_numbers ? "[is_ioned ? ion_num() : number]:" : ""] [law]"
+			if(!is_ioned)
+				number++
 
-	for(var/law in supplied)
+	for(var/law, is_ioned in supplied)
 		if (length(law) > 0)
-			data += "[show_numbers ? "[number]:" : ""] [render_html ? "<font color='#990099'>[law]</font>" : law]"
-			number++
+			data += "[show_numbers ? "[is_ioned ? ion_num() : number]:" : ""] [render_html ? "<font color='#990099'>[law]</font>" : law]"
+			if(!is_ioned)
+				number++
+
 	return data
 
 #undef AI_LAWS_ASIMOV

--- a/code/datums/ai_laws/state_laws_ui.dm
+++ b/code/datums/ai_laws/state_laws_ui.dm
@@ -29,10 +29,10 @@
 	for(var/law in owner.laws.hacked)
 		law_data += list(law_to_ui_data(law, ion_num(), "hacked"))
 	var/number = 1
-	for(var/law in owner.laws.inherent)
-		law_data += list(law_to_ui_data(law, number++, "core"))
-	for(var/law in owner.laws.supplied)
-		law_data += list(law_to_ui_data(law, number++, "supplied"))
+	for(var/law, is_ioned in owner.laws.inherent)
+		law_data += list(law_to_ui_data(law, is_ioned ? ion_num() : number++, "core"))
+	for(var/law, is_ioned in owner.laws.supplied)
+		law_data += list(law_to_ui_data(law, is_ioned ? ion_num() : number++, "supplied"))
 	return law_data
 
 /datum/state_laws_ui/proc/law_to_ui_data(law_text, law_number, law_type)

--- a/code/datums/ai_laws/state_laws_ui.dm
+++ b/code/datums/ai_laws/state_laws_ui.dm
@@ -15,7 +15,7 @@
 /// Used to update the to_state list to the passed ai law's inherent laws
 /// Call this when changing the AI's lawset entirely
 /datum/state_laws_ui/proc/update_inherent_stated_laws(datum/ai_laws/laws)
-	to_state = laws.inherent.Copy()
+	to_state = assoc_to_values(laws.inherent)
 
 /datum/state_laws_ui/Destroy()
 	owner = null
@@ -106,25 +106,24 @@
 		owner.say("[owner.radiomod] 0. [lawcache_zeroth]", forced = forced_log_message, message_mods = list(MODE_SEQUENTIAL = TRUE, SAY_MOD_VERB = "states"))
 		sleep(1 SECONDS)
 
-	for (var/index in 1 to length(lawcache_hacked))
-		var/law = lawcache_hacked[index]
+	for (var/law in lawcache_hacked)
 		if (force_all_laws || (law in to_state_cached))
 			owner.say("[owner.radiomod] [ion_num()]. [law]", forced = forced_log_message, message_mods = list(MODE_SEQUENTIAL = TRUE, SAY_MOD_VERB = "states"))
 			sleep(1 SECONDS)
 
 	var/number = 1
-	for (var/index in 1 to length(lawcache_inherent))
-		var/law = lawcache_inherent[index]
-		if (force_all_laws || (law in to_state_cached))
-			owner.say("[owner.radiomod] [number]. [law]", forced = forced_log_message, message_mods = list(MODE_SEQUENTIAL = TRUE, SAY_MOD_VERB = "states"))
-			number++
+	for (var/law_text, is_ioned in lawcache_inherent)
+		if (force_all_laws || (law_text in to_state_cached))
+			owner.say("[owner.radiomod] [is_ioned ? ion_num() : number]. [law_text]", forced = forced_log_message, message_mods = list(MODE_SEQUENTIAL = TRUE, SAY_MOD_VERB = "states"))
+			if(!is_ioned)
+				number++
 			sleep(1 SECONDS)
 
-	for (var/index in 1 to length(lawcache_supplied))
-		var/law = lawcache_supplied[index]
-		if (force_all_laws || (law in to_state_cached))
-			owner.say("[owner.radiomod] [number]. [law]", forced = forced_log_message, message_mods = list(MODE_SEQUENTIAL = TRUE, SAY_MOD_VERB = "states"))
-			number++
+	for (var/law_text, is_ioned in lawcache_supplied)
+		if (force_all_laws || (law_text in to_state_cached))
+			owner.say("[owner.radiomod] [is_ioned ? ion_num() : number]. [law_text]", forced = forced_log_message, message_mods = list(MODE_SEQUENTIAL = TRUE, SAY_MOD_VERB = "states"))
+			if(!is_ioned)
+				number++
 			sleep(1 SECONDS)
 
 	addtimer(VARSET_CALLBACK(src, locked, FALSE), 3 SECONDS)

--- a/code/game/machinery/ai_core/law.dm
+++ b/code/game/machinery/ai_core/law.dm
@@ -537,7 +537,9 @@
 		// Don't add this one if we're replacing a random law later
 		if(!core_sub_ion && prob(base_ion_prob))
 			core.set_ioned(TRUE)
-			core.laws.Insert(1, ion_message || generate_ion_law())
+			var/final_ion_message = ion_message || generate_ion_law()
+			core.laws.Insert(1, final_ion_message)
+			core.laws[final_ion_message] = TRUE
 			ion_message = null
 			log_law_change(null, "ion added law to [src] ([log_status()], text: \"[core.laws[1]]\")")
 			ions_added++
@@ -551,12 +553,14 @@
 		// For supplied laws: Chance the entire supplied law is replaced with a new ion law.
 		// If we had no core law and thus added no ion law, this is guaranteed to replace the first supplied law
 		if(ions_added < ion_limit && (ion_message || (law == core && core_sub_ion) || prob(sub_ion_prob)))
-			var/picked_law = length(law.laws) <= 1 ? 1 : rand(2, length(law.laws))
-			var/replaced_law = law.laws[picked_law]
+			var/picked_law_index = length(law.laws) <= 1 ? 1 : rand(2, length(law.laws))
+			var/replaced_law = law.laws[picked_law_index]
+			var/final_ion_message = ion_message || generate_ion_law()
 			law.set_ioned(TRUE)
-			law.laws[picked_law] = ion_message || generate_ion_law()
+			law.laws[picked_law_index] = final_ion_message
+			law.laws[final_ion_message] = TRUE
 			ion_message = null
-			log_law_change(null, "ion replaced law in [src] ([log_status()], text: \"[replaced_law]\" -> \"[law.laws[picked_law]]\")")
+			log_law_change(null, "ion replaced law in [src] ([log_status()], text: \"[replaced_law]\" -> \"[final_ion_message]\")")
 			ions_added++
 			. = TRUE
 

--- a/code/game/objects/items/AI_modules/_AI_modules.dm
+++ b/code/game/objects/items/AI_modules/_AI_modules.dm
@@ -60,6 +60,7 @@
 /obj/item/ai_module/law
 	desc = "An AI Module for programming laws to an AI."
 	/// This is where our laws get put at for the module
+	/// Assoc list, key = law text, value = is this an ion law
 	var/list/laws = list()
 	/// The laws list last time save_laws() was called
 	VAR_PRIVATE/list/saved_laws
@@ -71,22 +72,20 @@
 
 /obj/item/ai_module/law/Initialize(mapload)
 	. = ..()
-	if(mapload && HAS_TRAIT(SSstation, STATION_TRAIT_UNIQUE_AI) && is_station_level(z))
-		var/delete_module = handle_unique_ai()
-		if(delete_module)
-			return INITIALIZE_HINT_QDEL
+	if(mapload && HAS_TRAIT(SSstation, STATION_TRAIT_UNIQUE_AI) && is_station_level(z) && handle_unique_ai() == SHOULD_QDEL_MODULE)
+		return INITIALIZE_HINT_QDEL
 
 /// Logs the installation of this module to the law change log and silicon log.
 /obj/item/ai_module/law/log_install(mob/living/user, obj/machinery/ai_law_rack/rack)
 	. = ..()
-	for(var/law in laws)
-		log_law_change(user, "added law to [rack] ([rack.log_status()], text: [law])")
+	for(var/law, is_ioned in laws)
+		log_law_change(user, "added law to [rack] ([rack.log_status()], text: [law], ioned: [is_ioned])")
 
 /// Logs the uninstallation of this module to the law change log and silicon log.
 /obj/item/ai_module/law/log_uninstall(mob/living/user, obj/machinery/ai_law_rack/rack)
 	. = ..()
-	for(var/law in laws)
-		log_law_change(user, "removed law from [rack] ([rack.log_status()], text: [law])")
+	for(var/law, is_ioned in laws)
+		log_law_change(user, "removed law from [rack] ([rack.log_status()], text: [law], ioned: [is_ioned])")
 
 /obj/item/ai_module/law/examine(mob/user)
 	. = ..()
@@ -121,15 +120,15 @@
 
 /// Adds a law to the module and updates any racks we're installed in.
 /obj/item/ai_module/law/proc/add_law(law_text)
-	laws += law_text
+	laws[law_text] = FALSE
 	update_rack_laws()
 
 /// Adds a law to the module at a specific index and updates any racks we're installed in.
 /obj/item/ai_module/law/proc/add_law_to_index(law_text, index)
-	if(length(laws) <= index)
-		laws += law_text
-	else
+	if(isnum(index) && index <= length(laws))
+		laws -= law_text
 		laws.Insert(index, law_text)
+	laws[law_text] = FALSE
 	update_rack_laws()
 
 /// Update any racks we're installed in
@@ -204,8 +203,8 @@
 	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/bluespace = HALF_SHEET_MATERIAL_AMOUNT)
 
 /obj/item/ai_module/law/core/apply_to_combined_lawset(datum/ai_laws/combined_lawset)
-	for(var/law in laws)
-		combined_lawset.add_inherent_law(law)
+	for(var/law_text, is_ioned in laws)
+		combined_lawset.add_inherent_law(law_text, ioned = is_ioned)
 
 /obj/item/ai_module/law/core/pre_user_uninstall_from_rack(mob/living/user, obj/machinery/ai_law_rack/rack)
 	var/obj/machinery/ai_law_rack/base/parent_rack = rack.get_parent_rack()

--- a/code/game/objects/items/AI_modules/ion.dm
+++ b/code/game/objects/items/AI_modules/ion.dm
@@ -14,9 +14,8 @@ CONTAINS:
 
 /obj/item/ai_module/law/core/full/damaged/proc/gen_laws()
 	laws.Cut()
-	laws += generate_ion_law()
-	while(prob(75))
-		laws += generate_ion_law()
+	while(!length(laws) && prob(75))
+		laws[generate_ion_law()] = TRUE
 
 /obj/item/ai_module/law/core/full/damaged/on_rack_install(obj/machinery/ai_law_rack/rack)
 	gen_laws()
@@ -39,11 +38,12 @@ CONTAINS:
 	laws = list("")
 
 /obj/item/ai_module/law/toy_ai/apply_to_combined_lawset(datum/ai_laws/combined_lawset)
-	combined_lawset.add_inherent_law(laws[1], 1)
+	combined_lawset.add_inherent_law(laws[1], 1, ioned = TRUE)
 
 /obj/item/ai_module/law/toy_ai/configure(mob/user)
 	. = TRUE
-	laws[1] = generate_ion_law()
+	laws.Cut()
+	laws[generate_ion_law()] = TRUE
 	to_chat(user, span_notice("You press the button on [src]."))
 	playsound(user, 'sound/machines/click.ogg', 20, TRUE)
 	src.loc.visible_message(span_warning("[icon2html(src, viewers(loc))] [laws[1]]"))

--- a/tgui/packages/tgui/interfaces/StateLawUi.tsx
+++ b/tgui/packages/tgui/interfaces/StateLawUi.tsx
@@ -18,7 +18,7 @@ const lawTypeColors = {
 
 type Law = {
   text: string;
-  number: number;
+  number: number | string;
   type: LawType;
 };
 


### PR DESCRIPTION
## About The Pull Request

Ion laws have gibberish numbers rather than showing themselves in sequence

<img width="666" height="191" alt="image" src="https://github.com/user-attachments/assets/0d9ac291-59b4-4c17-a157-14e476528f6b" />

Basically I changed law lists from `list(law, law, law)` to `list(law = is_ioned, law = is_ioned, law = is_ioned)`. 
It should just work :tm: but there's a non-zero change I break something that I miss
This *does* mean that duplicate laws are no longer possible. But I think such a thing was already quite rare?

## Why It's Good For The Game

The return of this was requested but I couldn't think of a clean way until now.

## Changelog

:cl: Melbert
qol: Ion laws have gibberish numbers again
del: AIs can no longer have two laws with the exact same text.
/:cl:
