### PR TITLE
Adds Character and Job Specific chat highlights

### DIFF
--- a/code/datums/mind/_mind.dm
+++ b/code/datums/mind/_mind.dm
@@ -509,6 +509,7 @@
 	assigned_role = new_role
 	if(!isnull(current))
 		SEND_SIGNAL(current, COMSIG_MOB_MIND_SET_ROLE, new_role)
+		current.client?.tgui_panel?.send_player_info()
 
 ///Sets your holy role, giving/taking away traits related to if you're gaining/losing it.
 /datum/mind/proc/set_holy_role(new_holy_role)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -125,6 +125,9 @@
 		//Check if they should have a stat panel, after they deadmined.
 		client.set_stat_panel()
 
+		//Update the chat panel's job/character info for conditional highlights.
+		client.tgui_panel?.send_player_info()
+
 	log_message("Client [key_name(src)] has taken ownership of mob [src]([src.type])", LOG_OWNERSHIP)
 	log_mob_tag("TAG: [tag] NEW OWNER: [key_name(src)]")
 	SEND_SIGNAL(src, COMSIG_MOB_CLIENT_LOGIN, client)

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -86,6 +86,7 @@
 				),
 			),
 		))
+		send_player_info()
 		return TRUE
 
 	if(type == "audio/setAdminMusicVolume")
@@ -114,6 +115,19 @@
  */
 /datum/tgui_panel/proc/send_roundrestart()
 	window.send_message("roundrestart")
+
+/**
+ * public
+ *
+ * Sends the client's current job, character and saved character names,
+ * used for conditional chat highlights.
+ */
+/datum/tgui_panel/proc/send_player_info()
+	window.send_message("player/set", list(
+		"job" = client.mob?.mind?.assigned_role?.title,
+		"character" = client.prefs?.read_preference(/datum/preference/name/real_name),
+		"characters" = client.prefs?.create_character_profiles(),
+	))
 
 /**
  * private

--- a/tgui/packages/tgui-panel/chat/renderer.tsx
+++ b/tgui/packages/tgui-panel/chat/renderer.tsx
@@ -117,6 +117,8 @@ class ChatRenderer {
   scrollTracking: boolean;
   lastScrollHeight: number;
   highlightParsers: Array<any> | null;
+  currentJob: string | null;
+  currentCharacter: string | null;
   handleScroll: (type: any) => void;
 
   constructor() {
@@ -130,6 +132,8 @@ class ChatRenderer {
     // Scroll handler
 
     this.scrollNode = null;
+    this.currentJob = null;
+    this.currentCharacter = null;
     this.scrollTracking = true;
     this.lastScrollHeight = 0;
     this.handleScroll = (evt) => {
@@ -193,6 +197,35 @@ class ChatRenderer {
     }
   }
 
+  setJob(title) {
+    this.currentJob =
+      typeof title === 'string' && title ? title.trim().toLowerCase() : null;
+  }
+
+  setCharacter(name) {
+    this.currentCharacter =
+      typeof name === 'string' && name ? name.trim().toLowerCase() : null;
+  }
+
+  matchesFilters(parser) {
+    if (
+      parser.jobs?.length &&
+      !(this.currentJob && parser.jobs.includes(this.currentJob))
+    ) {
+      return false;
+    }
+    if (
+      parser.characters?.length &&
+      !(
+        this.currentCharacter &&
+        parser.characters.includes(this.currentCharacter)
+      )
+    ) {
+      return false;
+    }
+    return true;
+  }
+
   setHighlight(highlightSettings, highlightSettingById) {
     this.highlightParsers = null;
     if (!highlightSettings) {
@@ -206,6 +239,13 @@ class ChatRenderer {
       const matchWord = setting.matchWord;
       const matchCase = setting.matchCase;
       const enabled = setting.enabled;
+      const jobs = String(setting.jobFilter || '')
+        .split(',')
+        .map((str) => str.trim().toLowerCase())
+        .filter(Boolean);
+      const characters = (
+        Array.isArray(setting.characterFilter) ? setting.characterFilter : []
+      ).map((str) => String(str).trim().toLowerCase());
       const allowedRegex = /^[a-zа-яё0-9_\-$/^[\s\]\\]+$/gi;
       const regexEscapeCharacters = /[!#$%^&*)(+=.<>{}[\]:;'"|~`_\-\\/]/g;
       const lines = String(text)
@@ -281,6 +321,8 @@ class ChatRenderer {
         highlightRegex,
         highlightColor,
         highlightWholeMessage,
+        jobs,
+        characters,
       });
     });
   }
@@ -448,7 +490,7 @@ class ChatRenderer {
         // Highlight text
         if (!message.avoidHighlighting && this.highlightParsers) {
           this.highlightParsers
-            .filter((parser) => parser.enabled)
+            .filter((parser) => parser.enabled && this.matchesFilters(parser))
             .forEach((parser) => {
               const highlighted = highlightNode(
                 node,

--- a/tgui/packages/tgui-panel/events/handlers/player.ts
+++ b/tgui/packages/tgui-panel/events/handlers/player.ts
@@ -1,0 +1,27 @@
+import { chatRenderer } from '../../chat/renderer';
+import {
+  characterProfilesAtom,
+  currentCharacterAtom,
+  currentJobAtom,
+} from '../../game/atoms';
+import { store } from '../store';
+
+type PlayerSetPayload = {
+  job?: string | null;
+  character?: string | null;
+  characters?: (string | null)[] | null;
+};
+
+export function playerSet(payload: PlayerSetPayload) {
+  const job = payload?.job || null;
+  const character = payload?.character || null;
+  // Drop empty save slots and duplicates
+  const characters = [
+    ...new Set((payload?.characters || []).filter(Boolean) as string[]),
+  ];
+  store.set(currentJobAtom, job);
+  store.set(currentCharacterAtom, character);
+  store.set(characterProfilesAtom, characters);
+  chatRenderer.setJob(job);
+  chatRenderer.setCharacter(character);
+}

--- a/tgui/packages/tgui-panel/events/listeners.ts
+++ b/tgui/packages/tgui-panel/events/listeners.ts
@@ -9,6 +9,7 @@ import {
   testTelemetryCommand,
 } from '../telemetry/handlers';
 import { handleLoadAssets } from './handlers/assets';
+import { playerSet } from './handlers/player';
 import { roundrestart } from './handlers/roundrestart';
 
 const listeners = {
@@ -17,6 +18,7 @@ const listeners = {
   'audio/playMusic': playMusic,
   'audio/stopMusic': stopMusic,
   'chat/message': chatMessage,
+  'player/set': playerSet,
   'ping/reply': pingReply,
   'ping/soft': pingSoft,
   roundrestart,

--- a/tgui/packages/tgui-panel/game/atoms.ts
+++ b/tgui/packages/tgui-panel/game/atoms.ts
@@ -4,6 +4,15 @@ import { CONNECTION_LOST_AFTER } from './constants';
 
 export const roundRestartedAtAtom = atom<number | null>(null);
 
+/** Current job title of the player, as reported by the server */
+export const currentJobAtom = atom<string | null>(null);
+
+/** Name of the character the player is currently playing */
+export const currentCharacterAtom = atom<string | null>(null);
+
+/** Names of the player's saved characters */
+export const characterProfilesAtom = atom<string[]>([]);
+
 /**
  * Ticking clock atom. Only runs while something is subscribed to it.
  * (And only after we’ve had at least one ping, see connectionLostAtAtom.)

--- a/tgui/packages/tgui-panel/settings/TextHighlight.tsx
+++ b/tgui/packages/tgui-panel/settings/TextHighlight.tsx
@@ -1,9 +1,11 @@
+import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
 import {
   Box,
   Button,
   ColorBox,
   Divider,
+  Floating,
   Icon,
   Input,
   Section,
@@ -11,6 +13,7 @@ import {
   TextArea,
 } from 'tgui-core/components';
 import { chatRenderer } from '../chat/renderer';
+import { characterProfilesAtom, currentCharacterAtom } from '../game/atoms';
 import { WARN_AFTER_HIGHLIGHT_AMT } from './constants';
 import { useHighlights } from './use-highlights';
 
@@ -92,7 +95,32 @@ function TextHighlightSetting(props) {
     highlightWholeMessage,
     matchWord,
     matchCase,
+    jobFilter,
+    characterFilter,
   } = highlightSettingById[id];
+  const currentCharacter = useAtomValue(currentCharacterAtom);
+  const characterProfiles = useAtomValue(characterProfilesAtom);
+  const jobCount = jobFilter.split(',').filter((str) => str.trim()).length;
+
+  // Known characters plus any selected names no longer in the save slots,
+  // so stale selections stay visible and can be unchecked
+  const selectableCharacters = useMemo(() => {
+    const known = new Set([...characterProfiles, ...characterFilter]);
+    if (currentCharacter) {
+      known.add(currentCharacter);
+    }
+    return [...known];
+  }, [characterProfiles, characterFilter, currentCharacter]);
+
+  function toggleCharacter(name: string): void {
+    const draft = characterFilter.includes(name)
+      ? characterFilter.filter((entry) => entry !== name)
+      : [...characterFilter, name];
+    updateHighlight({
+      id,
+      characterFilter: draft,
+    });
+  }
 
   const highlightRegex = useMemo(
     () => extractRegex(highlightText),
@@ -125,13 +153,6 @@ function TextHighlightSetting(props) {
           >
             Enabled
           </Button.Checkbox>
-          <Button
-            color="transparent"
-            icon="times"
-            onClick={() => removeHighlight(id)}
-          >
-            Delete
-          </Button>
         </Stack.Item>
         <Stack.Item>
           <Button.Checkbox
@@ -191,6 +212,78 @@ function TextHighlightSetting(props) {
               })
             }
           />
+        </Stack.Item>
+      </Stack>
+      <Stack mb={1} color="label" align="baseline">
+        <Stack.Item grow>
+          <Floating
+            placement="bottom-start"
+            contentClasses="Dropdown__menu--wrapper"
+            content={
+              <div className="Dropdown__menu">
+                {selectableCharacters.map((name) => (
+                  <div key={name}>
+                    <Button.Checkbox
+                      checked={characterFilter.includes(name)}
+                      onClick={() => toggleCharacter(name)}
+                    >
+                      {name}
+                    </Button.Checkbox>
+                  </div>
+                ))}
+                {selectableCharacters.length === 0 && (
+                  <Box p={0.5} fontSize="0.9em" color="label">
+                    No known characters yet.
+                    <br />
+                    Join the game once to fill this list.
+                  </Box>
+                )}
+              </div>
+            }
+          >
+            <Box inline>
+              <Button color="transparent" icon="user">
+                {characterFilter.length
+                  ? `Characters: ${characterFilter.length}`
+                  : 'Characters: all'}
+              </Button>
+            </Box>
+          </Floating>
+          <Floating
+            placement="bottom-start"
+            contentClasses="Dropdown__menu--wrapper"
+            contentStyles={{ width: '20em' }}
+            content={
+              <div className="Dropdown__menu">
+                <Input
+                  fluid
+                  placeholder="Job titles, e.g. (Captain, Assistant)"
+                  value={jobFilter}
+                  onBlur={(value) =>
+                    updateHighlight({
+                      id,
+                      jobFilter: value,
+                    })
+                  }
+                />
+              </div>
+            }
+          >
+            <Box inline>
+              <Button color="transparent" icon="user-tag">
+                {jobCount ? `Jobs: ${jobCount}` : 'Jobs: all'}
+              </Button>
+            </Box>
+          </Floating>
+        </Stack.Item>
+        <Stack.Item>
+          <Button
+            color="transparent"
+            icon="times"
+            onClick={() => removeHighlight(id)}
+          >
+            Delete
+          </Button>
         </Stack.Item>
       </Stack>
       <TextArea

--- a/tgui/packages/tgui-panel/settings/atoms.ts
+++ b/tgui/packages/tgui-panel/settings/atoms.ts
@@ -29,6 +29,8 @@ export const defaultHighlightSetting: HighlightSetting = {
   matchWord: false,
   matchCase: false,
   enabled: true,
+  jobFilter: '',
+  characterFilter: [],
 };
 
 export const defaultHighlights: HighlightState = {

--- a/tgui/packages/tgui-panel/settings/migration.ts
+++ b/tgui/packages/tgui-panel/settings/migration.ts
@@ -60,14 +60,20 @@ function migrateHighlights(next: HighlightState): HighlightState {
       draft.highlightText ?? defaultHighlightSetting.highlightText;
   }
 
-  // Ensure that all highlights have the "enabled" var,
-  // setting it to true if it doesn't exist.
+  // Backfill vars added after highlights were first stored.
   for (const id in draft.highlightSettingById) {
-    if (
-      draft.highlightSettingById[id] &&
-      draft.highlightSettingById[id].enabled === undefined
-    ) {
-      draft.highlightSettingById[id].enabled = true;
+    const setting = draft.highlightSettingById[id];
+    if (!setting) {
+      continue;
+    }
+    if (setting.enabled === undefined) {
+      setting.enabled = true;
+    }
+    if (setting.jobFilter === undefined) {
+      setting.jobFilter = '';
+    }
+    if (!Array.isArray(setting.characterFilter)) {
+      setting.characterFilter = [];
     }
   }
 

--- a/tgui/packages/tgui-panel/settings/types.ts
+++ b/tgui/packages/tgui-panel/settings/types.ts
@@ -30,6 +30,10 @@ export type HighlightSetting = {
   matchCase: boolean;
   matchWord: boolean;
   enabled: boolean;
+  /** Comma-separated job titles this highlight is limited to. Empty = all jobs. */
+  jobFilter: string;
+  /** Character names this highlight is limited to. Empty = all characters. */
+  characterFilter: string[];
 };
 
 export type HighlightState = {


### PR DESCRIPTION

## About The Pull Request
Adds the ability to have a text highlight only apply when a specific character and/or job is played.

Video of UI:
https://files.catbox.moe/4i6dh4.mp4
## Why It's Good For The Game
99% of the time I open this menu I'm just toggling enabled depending on the character and job I'm playing

## Changelog
:cl: PapaMichael
add: You can now make text highlights only apply for specific characters or specific jobs
/:cl:
