### PR TITLE
Add spawn text overlay for players at roundstart or latejoin

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -587,6 +587,8 @@ SUBSYSTEM_DEF(ticker)
 				var/atom/movable/screen/splash/fade_out = new(null, null, living.client, TRUE)
 				fade_out.fade(TRUE)
 				living.client.init_verbs()
+				living.client.show_spawn_text_overlay()
+
 			livings += living
 	if(livings.len)
 		addtimer(CALLBACK(src, PROC_REF(release_characters), livings), 3 SECONDS, TIMER_CLIENT_TIME)

--- a/code/modules/client/spawn_text_overlay.dm
+++ b/code/modules/client/spawn_text_overlay.dm
@@ -12,8 +12,7 @@
 		job_title = mob.job
 
 	var/station_name = station_name()
-	var/area/A = get_area(mob)
-	var/area_name = A ? A.name : "Unknown Location"
+	var/area_name = get_area_name(mob, format_text = TRUE) || "Unknown Location"
 	var/time_date = server_timestamp(format = "YYYY-MM-DD hh:mm:ss", ic_time = TRUE)
 
 	var/text = {"

--- a/code/modules/client/spawn_text_overlay.dm
+++ b/code/modules/client/spawn_text_overlay.dm
@@ -35,7 +35,7 @@
 	screen += spawn_text
 	animate(spawn_text, alpha = 255, time = 1 SECONDS)
 
-	for(var/i = 1 to length_char(text) + 1)
+	for(var/i in 1 to length_char(text) + 1)
 		if(QDELETED(spawn_text) || !src)
 			return
 		spawn_text.maptext = MAPTEXT_PIXELLARI(copytext_char(text, 1, i))

--- a/code/modules/client/spawn_text_overlay.dm
+++ b/code/modules/client/spawn_text_overlay.dm
@@ -18,7 +18,8 @@
 
 	var/text = {"
 		[mob_name] - [job_title]
-		[station_name] - [area_name]
+		[station_name]
+		[area_name]
 		[time_date]
 	"}
 	text = uppertext(text)

--- a/code/modules/client/spawn_text_overlay.dm
+++ b/code/modules/client/spawn_text_overlay.dm
@@ -5,11 +5,7 @@
 		return
 
 	var/mob_name = mob.name
-	var/job_title = "Unknown"
-	if(mob.mind && mob.mind.assigned_role)
-		job_title = mob.mind.assigned_role.title
-	else if(mob.job)
-		job_title = mob.job
+	var/job_title = mob.mind?.assigned_role.title || "Unknown"
 
 	var/station_name = station_name()
 	var/area_name = get_area_name(mob, format_text = TRUE) || "Unknown Location"

--- a/code/modules/client/spawn_text_overlay.dm
+++ b/code/modules/client/spawn_text_overlay.dm
@@ -36,7 +36,7 @@
 	animate(spawn_text, alpha = 255, time = 1 SECONDS)
 
 	for(var/i in 1 to length_char(text) + 1)
-		if(QDELETED(spawn_text) || !src)
+		if(QDELETED(spawn_text) || QDELETED(src))
 			return
 		spawn_text.maptext = MAPTEXT_PIXELLARI(copytext_char(text, 1, i))
 		sleep(1)

--- a/code/modules/client/spawn_text_overlay.dm
+++ b/code/modules/client/spawn_text_overlay.dm
@@ -1,8 +1,6 @@
 /// Displays a typewriter-style spawn text overlay that includes station/area/job name and time
 /client/proc/show_spawn_text_overlay(duration = 5 SECONDS)
 	set waitfor = FALSE
-	if(!mob)
-		return
 
 	var/mob_name = mob.name
 	var/job_title = mob.mind?.assigned_role.title || "Unknown"

--- a/code/modules/client/spawn_text_overlay.dm
+++ b/code/modules/client/spawn_text_overlay.dm
@@ -1,0 +1,52 @@
+/// Displays a typewriter-style spawn text overlay that includes station/area/job name and time
+/client/proc/show_spawn_text_overlay(duration = 5 SECONDS)
+	set waitfor = FALSE
+	if(!mob)
+		return
+
+	var/mob_name = mob.name
+	var/job_title = "Unknown"
+	if(mob.mind && mob.mind.assigned_role)
+		job_title = mob.mind.assigned_role.title
+	else if(mob.job)
+		job_title = mob.job
+
+	var/station_name = station_name()
+	var/area/A = get_area(mob)
+	var/area_name = A ? A.name : "Unknown Location"
+	var/time_date = server_timestamp(format = "YYYY-MM-DD hh:mm:ss", ic_time = TRUE)
+
+	var/text = {"
+		[mob_name] - [job_title]
+		[station_name] - [area_name]
+		[time_date]
+	"}
+	text = uppertext(text)
+
+	var/atom/movable/screen/spawn_text = new()
+	spawn_text.maptext_height = 64
+	spawn_text.maptext_width = 512
+	spawn_text.layer = FLY_LAYER
+	spawn_text.plane = HUD_PLANE
+	spawn_text.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	spawn_text.screen_loc = "LEFT+1,BOTTOM+2"
+
+	screen += spawn_text
+	animate(spawn_text, alpha = 255, time = 1 SECONDS)
+
+	for(var/i = 1 to length_char(text) + 1)
+		if(QDELETED(spawn_text) || !src)
+			return
+		spawn_text.maptext = MAPTEXT_PIXELLARI(copytext_char(text, 1, i))
+		sleep(1)
+
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(fade_spawn_text_overlay), src, spawn_text), duration)
+
+/proc/fade_spawn_text_overlay(client/player_client, atom/movable/screen/spawn_text)
+	if(QDELETED(spawn_text))
+		return
+	animate(spawn_text, alpha = 0, time = 0.5 SECONDS)
+	sleep(5)
+	if(player_client && !QDELETED(spawn_text))
+		player_client.screen -= spawn_text
+	qdel(spawn_text)

--- a/code/modules/client/spawn_text_overlay.dm
+++ b/code/modules/client/spawn_text_overlay.dm
@@ -36,9 +36,9 @@
 		spawn_text.maptext = MAPTEXT_PIXELLARI(copytext_char(text, 1, i))
 		sleep(1)
 
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(fade_spawn_text_overlay), src, spawn_text), duration)
+	addtimer(CALLBACK(src, PROC_REF(fade_spawn_text_overlay), src, spawn_text), duration)
 
-/proc/fade_spawn_text_overlay(client/player_client, atom/movable/screen/spawn_text)
+/client/proc/fade_spawn_text_overlay(client/player_client, atom/movable/screen/spawn_text)
 	if(QDELETED(spawn_text))
 		return
 	animate(spawn_text, alpha = 0, time = 0.5 SECONDS)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -648,6 +648,7 @@
 /datum/job/proc/after_latejoin_spawn(mob/living/spawning)
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_JOB_AFTER_LATEJOIN_SPAWN, src, spawning)
+	spawning.client.show_spawn_text_overlay()
 
 /// Called when a mob that has this job is admin respawned
 /datum/job/proc/on_respawn(mob/new_character)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4084,6 +4084,7 @@
 #include "code\modules\client\preferences.dm"
 #include "code\modules\client\preferences_menu.dm"
 #include "code\modules\client\preferences_savefile.dm"
+#include "code\modules\client\spawn_text_overlay.dm"
 #include "code\modules\client\preferences\_preference.dm"
 #include "code\modules\client\preferences\accessibility.dm"
 #include "code\modules\client\preferences\addict.dm"


### PR DESCRIPTION

## About The Pull Request
This ports the player spawn info maptext code from [CM](https://github.com/cmss13-devs/cmss13/blob/b035a0614fdba7526abd31258426ea35f4fe8a34/code/modules/maptext_alerts/text_blurbs.dm#L17) and [Nebula](https://github.com/NebulaSS13/Nebula/blob/064044947c69a7231c881fb7566adfd17125e100/code/controllers/subsystems/jobs.dm#L584-L619) and applies it to TG when a player spawns. (excludes observers)

The formatting is as follows:
```
[mob_name] - [job_title]
[station_name]
[area_name]
[time_date]
```

## Why It's Good For The Game
It looks cool and polished.

<img width="909" height="829" alt="dreamseeker_SbxXyIUYN0" src="https://github.com/user-attachments/assets/78b1dadf-8b09-4842-9a92-654236bb4eb1" />


## Changelog
:cl:
add: Add spawn text overlay when a player spawns. (excludes observers)
/:cl:
