### PR TITLE
Bitrunner domain names are no longer hidden by upgrades

### DIFF
--- a/code/modules/bitrunning/virtual_domain/virtual_domain.dm
+++ b/code/modules/bitrunning/virtual_domain/virtual_domain.dm
@@ -93,7 +93,7 @@
 
 
 /datum/lazy_template/virtual_domain/proc/can_view_name(scanner_tier, server_points)
-	return difficulty < scanner_tier && cost <= server_points + 5
+	return cost <= server_points + 5
 
 /datum/lazy_template/virtual_domain/proc/can_view_reward(scanner_tier, server_points)
 	return difficulty < (scanner_tier + 1) && cost <= server_points + 3


### PR DESCRIPTION
## About The Pull Request

All bitrunner domains no longer have their names hidden due to lacking upgraded stock parts.

Domains that require a significant amount of stars are still hidden until unlocked.

## Why It's Good For The Game

Three reasons:

1. At first I thought the names were obscured to require Bitrunners explore a variety of domains rather than play the same domain over and over again, but the actual domains don't randomize position in the list between rounds, making hidden names nothing but a memory check. 

2. Even though the names were hidden the special icons weren't, meaning you could logic out which is which (at least, until the pool is expanded significantly, but that may not happen for. Some time.) 

3. Some bitrunner domains now serve as pseudo-tutorials, so making them easier to pick out serves nicely towards that. 

## Changelog

:cl: Melbert
qol: Bitrunner domain names are no longer hidden until you upgrade the server stock parts. Distantly unaffordable domains still have their names hidden.
/:cl:
