### PR TITLE
Fix AI Holopads leaking unknown languages via runechat

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -859,7 +859,7 @@ GAME_VERB_PROC_DESC(/mob/living/silicon/ai, set_automatic_say_channel, "Set Auto
 	var/rendered = "<i><span class='game say'>[start][span_name("[hrefpart][namepart] ([jobpart])</a> ")]<span class='message'>[treated_message]</span></span></i>"
 
 	if (client?.prefs.read_preference(/datum/preference/toggle/enable_runechat) && (client.prefs.read_preference(/datum/preference/toggle/enable_runechat_non_mobs) || ismob(speaker)))
-		create_chat_message(speaker, message_language, raw_message, spans)
+		create_chat_message(speaker, message_language, raw_translation, spans)
 	show_message(rendered, 2)
 
 /mob/living/silicon/ai/fully_replace_character_name(oldname, newname, log_new_name = FALSE)


### PR DESCRIPTION

## About The Pull Request
Closes https://github.com/tgstation/tgstation/issues/97294

## Why It's Good For The Game

Fix a bug

## Changelog
:cl: PapaMichael
fix: AI Holopads no longer leak unknown languages in runechat
/:cl:
