### PR TITLE
Remove Compile BT Trees vscode task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,16 +2,6 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"type": "shell",
-			"command": "tools/bootstrap/python tools/build_bt.py",
-			"windows": {
-				"command": ".\\tools\\bootstrap\\python.bat tools/build_bt.py"
-			},
-			"group": "build",
-			"presentation": { "reveal": "silent", "panel": "shared" },
-			"label": "Compile BT Trees"
-		},
-		{
 			"type": "process",
 			"command": "tools/build/build.sh",
 			"windows": {
@@ -27,7 +17,7 @@
 				"kind": "build",
 				"isDefault": true
 			},
-			"dependsOn": ["dm: reparse", "Compile BT Trees"],
+			"dependsOn": "dm: reparse",
 			"label": "Build All"
 		},
 		{


### PR DESCRIPTION

## About The Pull Request

As the title says

## Why It's Good For The Game

Juke handles running this if it's necessary, having it as a vscode task that Build All depends on is redundant

## Changelog

N/A
