### PR TITLE
Brings back tech transfers for autolathes

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -512,7 +512,7 @@
 	for(var/datum/design/blueprint as anything in disky.blueprints)
 		if(!blueprint)
 			continue
-		if(blueprint.build_type & AUTOLATHE)
+		if(blueprint.build_type & (AUTOLATHE|PROTOLATHE))
 			imported_designs[blueprint.id] = TRUE
 		else
 			LAZYADD(not_imported, blueprint.name)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -426,6 +426,21 @@ Nothing else in the console has ID requirements.
 			if(!COOLDOWN_FINISHED(src, cooldowncopy)) // prevents MC hang
 				say("Servers busy!")
 				return
+			if(params["type"] == RND_DESIGN_DISK)
+				if(QDELETED(d_disk))
+					say("No design disk inserted!")
+					return
+				COOLDOWN_START(src, cooldowncopy, 5 SECONDS)
+				for(var/design_id in stored_research.researched_designs)
+					var/datum/design/design = SSresearch.techweb_design_by_id(design_id)
+					if(!(design.build_type & (AUTOLATHE|PROTOLATHE)))
+						continue
+					if(design in d_disk.blueprints)
+						continue
+					d_disk.blueprints += design
+				say("Downloading to design disk.")
+				return TRUE
+
 			if(QDELETED(t_disk))
 				say("No tech disk inserted!")
 				return

--- a/tgui/packages/tgui/interfaces/Techweb/disks/DiskMenu.tsx
+++ b/tgui/packages/tgui/interfaces/Techweb/disks/DiskMenu.tsx
@@ -35,8 +35,11 @@ export function TechwebDiskMenu(props: Props) {
             </Tabs>
           </Flex.Item>
           <Flex.Item align="center">
-            {diskType === 'tech' && (
-              <Button icon="save" onClick={() => act('loadTech')}>
+            {(diskType === 'tech' || diskType === 'design') && (
+              <Button
+                icon="save"
+                onClick={() => act('loadTech', { type: diskType })}
+              >
                 Web &rarr; Disk
               </Button>
             )}
@@ -61,7 +64,13 @@ export function TechwebDiskMenu(props: Props) {
           </Flex.Item>
         </Flex>
       </Flex.Item>
-      <Flex.Item grow className="Techweb__OverviewNodes">
+      <Flex.Item
+        grow
+        className="Techweb__OverviewNodes"
+        style={{
+          overflowY: 'auto',
+        }}
+      >
         <DiskContent />
       </Flex.Item>
     </Flex>


### PR DESCRIPTION
## About The Pull Request

so like #74147 this pr removed them for some reason and i dont really understand why, they were pretty soulful to me. although i can think of some balance reasons. atm i just let every tech from rd console to be transferrable on a disk without any balance concerns, if you have any - leave a review plss.

## Why It's Good For The Game

i think its cool.
jokes aside, i would really like for cargo to print more stuff than comes in their standard autolathe kit.

## Changelog

:cl:
balance: Design disks can now record RD console tech nodes and be used to print more stuff in autolathes again.
/:cl:
