### PR TITLE
Gun kits can be only printed at the Rnd, not Brig, except Horizon riffle, its still Sec

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -331,7 +331,7 @@
 	category = list(
 		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_KITS
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 	autolathe_exportable = FALSE
 
 /datum/design/nuclear_gun
@@ -344,7 +344,7 @@
 	category = list(
 		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_KITS
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 	autolathe_exportable = FALSE
 
 /datum/design/tele_shield
@@ -408,7 +408,7 @@
 	category = list(
 		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_KITS
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 	autolathe_exportable = FALSE
 
 /datum/design/flora_gun
@@ -481,7 +481,7 @@
 	category = list(
 		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_KITS
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 	autolathe_exportable = FALSE
 
 /datum/design/ioncarbine
@@ -494,7 +494,7 @@
 	category = list(
 		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_KITS
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 	autolathe_exportable = FALSE
 
 /datum/design/wormhole_projector
@@ -618,7 +618,7 @@
 	category = list(
 		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_KITS
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 	autolathe_exportable = FALSE
 
 /datum/design/cleric_mace
@@ -661,4 +661,4 @@
 	category = list(
 		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_KITS
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alternative to https://github.com/tgstation/tgstation/pull/97311

Rnd now can print gun kits(tesla, ion, another stuff). Except the Horizon riffle, its still can be printed only at sec dep.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

So security not so offent get these guns, cause scientis and secs are here for different goals, they came home after stuff, opened ss13 and they have different moods. Some wanna just run after lings\tots, fire stuff, play that funny cat & mouse game, they dont know\dont wanna craft stuff, except really easy recipes. Some wanna just be at RND, and some researching\debugging\building\printing stuff for many stuff.

So one of them like print\assemble stuff, one of them like to fire guns\running around with guns.

Moving the job of printing and assembling the updgraded guns from sec to science will allow Secs to get the laser gun from armory, go to Rnd, give them gun, wait some and get the upgraded gun. Sec dont need to not just know the recipe, he even dont need to know, thats something is crafting. He just need to do, what he loves so much, come to department and order something to someone. Secs loves to speak and order, Scientist loves to know many aspects of the game and cost of crafting of the gun(mindcomputing\mental) is much more lower.

So Secs taking the guns and to go to Rnd, asking for upgrade. Scientist crafting printing and assemble.

But not for Horizon riffle, its still Security Gun Kit, so even if you are really good tot, you still need to somehow got into brig to get the kit.

ALSO: There is a issue, Secs ordering these thermal pistols or whatver, from Cargo, and just demolish everything. Allowing them to buy even Hellfire Tesla guns from cargo will make it even more like, more demolishing from security. Cargo guns can be surely ordered from most researched stations\objects, but their price can be at least really big, really, so local production of guns would not much more cheap

UPDATE 2: Also the most important stuff, removing the ability of ordinary Assistant with a Dream, from the chance of like, making its own Rnd, or at least, getting the gun kit, so he can craft his Hellfire laser gun somewhere underground at the maints, from his own mined mats or stuff, so he can produce, so he doesnt have only way to obtain it via going into cargo and buy it, he can produce it from its own mining and research

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: gun kits now can be printed not at sec, but at rnd, except Horizon riffle, its still only at sec
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
