### PR TITLE
[NO GBP] Fixes robotic ethereal surgery

### DIFF
--- a/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
+++ b/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
@@ -59,7 +59,7 @@
 		return multitool_act(user, tool)
 
 	var/obj/item/bodypart/targeted_part = owner.get_bodypart(user.zone_selected)
-	if(!(targeted_part && targeted_part.bodytype == BODYTYPE_ROBOTIC))
+	if(isnull(targeted_part) || targeted_part.bodytype != BODYTYPE_ROBOTIC)
 		return multitool_act(user, tool)
 
 	if(HAS_TRAIT(targeted_part, TRAIT_READY_TO_OPERATE))

--- a/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
+++ b/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
@@ -54,6 +54,17 @@
 /obj/item/organ/stomach/ethereal/proc/on_multitool_act(atom/source, mob/user, obj/item/tool)
 	SIGNAL_HANDLER
 
+	// Checks to ensure we're not doing surgery on a robotic part.
+	if(!owner)
+		return multitool_act(user, tool)
+
+	var/obj/item/bodypart/targeted_part = owner.get_bodypart(user.zone_selected)
+	if(!(targeted_part && targeted_part.bodytype == BODYTYPE_ROBOTIC))
+		return multitool_act(user, tool)
+
+	if(HAS_TRAIT(targeted_part, TRAIT_READY_TO_OPERATE))
+		return
+
 	return multitool_act(user, tool)
 
 /obj/item/organ/stomach/ethereal/multitool_act(mob/living/user, obj/item/tool)


### PR DESCRIPTION

## About The Pull Request
With the ethereal multitooling interaction added in #96904, surgery on augmented/robotic ethereal limbs became nearly impossible. If you get to a step where a multitool is required, you cannot avoid checking the ethereal's charge and end up needing a hemostat. This PR fixes that by adding a couple of checks.
## Why It's Good For The Game
This PR fixes an oversight.
## Changelog
:cl:
fix: Surgery on robotic ethereal limbs is no longer broken by multitool charge checking.
/:cl:
