### PR TITLE
Makes it so that EMP resistance is only tagged on EMP Resistant clothing.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -398,7 +398,7 @@
 		.["sterile"] = "Increases the speed at which reagents are administered to others by [round((1/NITRILE_GLOVES_MULTIPLIER-1)*100, 1)]%."
 	if(TRAIT_FAST_CUFFING in clothing_traits)
 		.["secure"] = "Increases the speed at which you apply restraints."
-	if(emp_protection >= EMP_PROTECTION_NONE)
+	if(emp_protection > EMP_PROTECTION_NONE)
 		.["emp resistant"] = "Reduces the effects of incoming electromagnetic pulses on the wearer."
 
 /obj/item/clothing/examine_descriptor(mob/user)


### PR DESCRIPTION
## About The Pull Request

EMP protection was checking for clothing with greater than or _equal to_ 0. Since the vast majority of clothing isn't EMP resistant, it meant that everything was tagged as a result.

## Why It's Good For The Game

Prevents all worn clothing from saying that it's EMP resistant, incorrectly.
<img width="619" height="330" alt="image" src="https://github.com/user-attachments/assets/30485bb2-ed5d-4237-84c5-998351162a63" />


## Changelog

:cl:
fix: EMP resistance is only tagged when examined on actually EMP resistant clothing.
/:cl:
