### PR TITLE
Fixes examine on stock blocks that have gone liquid.

### DIFF
--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -127,7 +127,7 @@
 		return . * SSstock_market.materials_prices[material_id]
 
 	var/obj/item/stock_block/exported_block = exported_obj
-	return . * (exported_block.fluid ? SSstock_market.materials_prices[exported_block.custom_materials[1].type] : exported_block.export_value)
+	return . * (exported_block.fluid ? exported_block.update_value() : exported_block.export_value)
 
 /datum/export/material/market/sell_object(obj/sold_item, datum/export_report/report, dry_run, apply_elastic)
 	. = ..()

--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -355,31 +355,40 @@
 /obj/item/stock_block/Initialize(mapload)
 	. = ..()
 	addtimer(CALLBACK(src, PROC_REF(value_warning)), 1.5 MINUTES, TIMER_DELETE_ME)
-	addtimer(CALLBACK(src, PROC_REF(update_value)), 3 MINUTES, TIMER_DELETE_ME)
+	addtimer(CALLBACK(src, PROC_REF(become_liquid)), 3 MINUTES, TIMER_DELETE_ME)
 
 /obj/item/stock_block/examine(mob/user)
 	. = ..()
 
 	var/datum/material/export_mat = custom_materials[1]
 	var/quantity = custom_materials[export_mat] / SHEET_MATERIAL_AMOUNT
-	. += span_notice("\The [src] is worth [quantity * export_value] [MONEY_SYMBOL], from selling [quantity] sheets of [export_mat.name].")
 
 	if(fluid)
 		. += span_warning("\The [src] is currently liquid! Its value is based on the market price.")
+		update_value()
 	else
 		. += span_notice("\The [src]'s value is still [span_boldnotice("locked in")]. [span_boldnotice("Sell it")] before its value becomes liquid!")
 
+	. += span_notice("\The [src] is worth [quantity * export_value] [MONEY_SYMBOL], from selling [quantity] sheets of [export_mat.name].")
+
+/// Creates a visible effect warning nearby players that a stock block is beginning to become liquid in price.
 /obj/item/stock_block/proc/value_warning()
 	visible_message(span_warning("\The [src] is starting to become liquid!"))
 	icon_state = "stock_block_fluid"
 	update_appearance(UPDATE_ICON_STATE)
 
-/obj/item/stock_block/proc/update_value()
-	export_value = SSstock_market.materials_prices[custom_materials[1]]
+/// Creates a visible effect warning nearby players that a stock block has become liquid in price, and updates the value, icon_state, and fluidity vars.
+/obj/item/stock_block/proc/become_liquid()
+	update_value()
 	icon_state = "stock_block_liquid"
 	update_appearance(UPDATE_ICON_STATE)
 	visible_message(span_warning("\The [src] becomes liquid!"))
 	fluid = TRUE
+
+/// Updates the value of the stock block, for examine, and for sale value.
+/obj/item/stock_block/proc/update_value()
+	export_value = SSstock_market.materials_prices[custom_materials[1]]
+	return export_value
 
 #undef MAX_STACK_LIMIT
 #undef GALATIC_MATERIAL_ORDER

--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -385,9 +385,9 @@
 	visible_message(span_warning("\The [src] becomes liquid!"))
 	fluid = TRUE
 
-/// Updates the value of the stock block, for examine, and for sale value.
+/// Updates the value of the stock block, for examine, and for sale value. Export value becomes equal to the stock market value of that material.
 /obj/item/stock_block/proc/update_value()
-	export_value = SSstock_market.materials_prices[custom_materials[1]]
+	export_value = SSstock_market.materials_prices[src.custom_materials[1].type]
 	return export_value
 
 #undef MAX_STACK_LIMIT


### PR DESCRIPTION
## About The Pull Request

Stock blocks, still have value after they become liquid! Always have.
On examine however, they've been showing that they have 0 export value after they become liquid, due to the order of the logic.

This moves a few procs around, reorders the examine text, and allows you to see the correct value on examine.

## Why It's Good For The Game

Lying to the player is not usually my goal, unless it's my goal, in which case, I would probably have lied in a better way.
Fixes a pretty clear bug on player facing content. Plus it cleans up a little bit of logic on selling stock blocks regardless.

## Changelog

:cl:
fix: Stock blocks now properly show their sale value after they've become liquid, and been examined.
/:cl:
