### PR TITLE
Fixes the title of the Disabler SMG goody pack.

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -127,7 +127,7 @@
 	contains = list(/obj/item/gun/energy/laser/soul)
 
 /datum/supply_pack/goody/smg_single
-	name = "Disabler SMG Single_Pack"
+	name = "Disabler SMG Single Pack"
 	desc = "Contains one disabler SMG, capable of rapidly firing weak disabler beams."
 	cost = PAYCHECK_COMMAND * 6
 	access_view = ACCESS_WEAPONS


### PR DESCRIPTION
## About The Pull Request

Random typo that snuck past the censors.

## Why It's Good For The Game

🐛 💥 🔨 

## Changelog

:cl:
spellcheck: fixed typo on the disabler SMG goody from the console.
/:cl:
