### PR TITLE
Fix for weapon recharger completion message spam with PDAs

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -155,6 +155,11 @@
 			if(charging_cell.charge >= charging_cell.maxcharge) //Inserted thing is at max charge/ammo, notify those around us
 				playsound(src, 'sound/machines/ping.ogg', 30, TRUE)
 				say("[charging] has finished recharging!")
+				// Modular computers (mainly PDAs) can remain on and drain their cell while charging.
+				// Unless we stop, the computer will constantly spam the finished recharging message.
+				if(istype(charging, /obj/item/modular_computer))
+					update_appearance()
+					return PROCESS_KILL
 			else
 				using_power = TRUE
 		update_appearance()

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -854,7 +854,12 @@
 		pre_fail()
 		return
 
-	if(!vampire_charge_amount || !length(ingredients) || vampire_charge_amount < 25 || (cell_powered && (isnull(cell) || !cell.charge)))
+	if(cell_powered && (isnull(cell) || !cell.charge))
+		playsound(src, 'sound/machines/buzz/buzz-sigh.ogg', 50, FALSE)
+		balloon_alert(cooker, "no power draw!")
+		return
+
+	if(!vampire_charge_amount || !length(ingredients) || vampire_charge_amount < 25)
 		vampire_cell = null
 		charge_loop_finish(cooker)
 		return


### PR DESCRIPTION

## About The Pull Request
This PR makes weapon chargers stop charging PDAs once they reach full capacity (regardless of further power draw). Additionally, microwaves will indicate that they don't have a charged internal cell if charging is attempted without one.
## Why It's Good For The Game
Currently, when rechargers finish charging a PDA, the PDA (if on) will draw power from its cell. The recharger will then charge it again and repeat its "finished charging" message/SFX. This will continue so long as the recharger has power to charge with.

As to the microwaves, they currently give no feedback when charging is attempted without a microwave cell. This can lead some to the false assumption that they _still_ can't truly charge PDAs.
## Changelog
:cl:
qol: Microwaves now emphasize that they lack power if PDA charging is attempted with an empty microwave cell.
fix: Rechargers no longer spam the "finished charging" message when done charging PDAs.
/:cl:
