### PR TITLE
Voltaic heart no longer grants full emp immunity (but is still emp immune)

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -958,8 +958,8 @@
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/design/cybernetic_heart/anomalock
-	name = "Voltaic combat cyberheart"
-	desc = "A cutting-edge cyberheart, originally designed for Nanotrasen killsquad usage but later declassified for normal research. Voltaic technology allows the heart to keep the body upright in dire circumstances, alongside redirecting anomalous flux energy to fully shield the user from shocks and electro-magnetic pulses. Does nothing without a flux anomaly core."
+	name = "Voltaic Combat Cyberheart"
+	desc =/obj/item/organ/heart/cybernetic/anomalock::desc
 	id = "cybernetic_heart_anomalock"
 	construction_time = 5 SECONDS
 	materials = list(

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -959,7 +959,7 @@
 
 /datum/design/cybernetic_heart/anomalock
 	name = "Voltaic Combat Cyberheart"
-	desc =/obj/item/organ/heart/cybernetic/anomalock::desc
+	desc = /obj/item/organ/heart/cybernetic/anomalock::desc
 	id = "cybernetic_heart_anomalock"
 	construction_time = 5 SECONDS
 	materials = list(

--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -31,10 +31,8 @@
 	var/core_removable = TRUE
 
 /obj/item/organ/heart/cybernetic/anomalock/Destroy()
-	if(lightning_timer)
-		deltimer(lightning_timer)
-	if(lightning_overlay)
-		lightning_overlay = null
+	deltimer(lightning_timer)
+	lightning_overlay = null
 	QDEL_NULL(core)
 	return ..()
 
@@ -48,9 +46,7 @@
 		return
 	add_lightning_overlay(30 SECONDS)
 	playsound(organ_owner, 'sound/items/eshield_recharge.ogg', 40)
-	organ_owner.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS|EMP_NO_EXAMINE)
 	RegisterSignal(organ_owner, COMSIG_MOB_STATCHANGE, PROC_REF(activate_survival_comsig))
-	RegisterSignal(organ_owner, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 
 /obj/item/organ/heart/cybernetic/anomalock/on_mob_remove(mob/living/carbon/organ_owner, special, movement_flags)
 	. = ..()
@@ -58,31 +54,32 @@
 		return
 	clear_lightning_overlay(organ_owner)
 	UnregisterSignal(organ_owner, COMSIG_MOB_STATCHANGE)
-	UnregisterSignal(organ_owner, COMSIG_ATOM_EMP_ACT)
-	organ_owner.RemoveElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS|EMP_NO_EXAMINE)
 	tesla_zap(source = organ_owner, zap_range = 20, power = 2.5e5, cutoff = 1e3)
-	QDEL_IN(src, 0)
+	apply_organ_damage(INFINITY)
 
-/obj/item/organ/heart/cybernetic/anomalock/attack(mob/living/target_mob, mob/living/user, list/modifiers, list/attack_modifiers)
-	if(target_mob != user || !istype(target_mob) || !core)
-		return ..()
+/obj/item/organ/heart/cybernetic/anomalock/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(interacting_with != user || !iscarbon(user) || isnull(core))
+		return NONE
 
+	return self_implant(user)
+
+/obj/item/organ/heart/cybernetic/anomalock/proc/self_implant(mob/living/carbon/user)
 	if(DOING_INTERACTION(user, DOAFTER_IMPLANTING_HEART))
-		return
+		return ITEM_INTERACT_BLOCKING
 	user.balloon_alert(user, "this will hurt...")
 	to_chat(user, span_userdanger("Black cyberveins tear your skin apart, pulling the heart into your ribcage. This feels unwise.."))
 	if(!do_after(user, 5 SECONDS, interaction_key = DOAFTER_IMPLANTING_HEART))
-		return ..()
-	playsound(target_mob, 'sound/items/weapons/slice.ogg', 100, TRUE)
-	user.temporarilyRemoveItemFromInventory(src, TRUE)
-	Insert(user)
+		return ITEM_INTERACT_BLOCKING
+	if(!user.temporarilyRemoveItemFromInventory(src))
+		return ITEM_INTERACT_BLOCKING
+	if(!Insert(user))
+		forceMove(user.drop_location())
+		return ITEM_INTERACT_BLOCKING
+
+	playsound(user, 'sound/items/weapons/slice.ogg', 100, TRUE)
 	user.apply_damage(100, BRUTE, BODY_ZONE_CHEST)
 	user.emote("scream")
-	return TRUE
-
-/obj/item/organ/heart/cybernetic/anomalock/proc/on_emp_act(severity)
-	SIGNAL_HANDLER
-	add_lightning_overlay(10 SECONDS)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/organ/heart/cybernetic/anomalock/proc/add_lightning_overlay(time_to_last = 10 SECONDS)
 	if(lightning_overlay)
@@ -94,8 +91,7 @@
 
 /obj/item/organ/heart/cybernetic/anomalock/proc/clear_lightning_overlay(mob/organ_owner)
 	organ_owner?.cut_overlay(lightning_overlay)
-	if(lightning_timer)
-		deltimer(lightning_timer)
+	deltimer(lightning_timer)
 	lightning_overlay = null
 
 /obj/item/organ/heart/cybernetic/anomalock/attack_self(mob/user, modifiers)
@@ -103,8 +99,8 @@
 	if(.)
 		return
 
-	if(core)
-		return attack(user, user, modifiers)
+	if(!isnull(core) && (self_implant(user) & ITEM_INTERACT_ANY_BLOCKER))
+		return TRUE
 
 /obj/item/organ/heart/cybernetic/anomalock/on_life(seconds_per_tick)
 	. = ..()
@@ -152,38 +148,47 @@
 /obj/item/organ/heart/cybernetic/anomalock/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(!istype(tool, required_anomaly))
 		return NONE
-	if(core)
+	if(!isnull(core))
 		balloon_alert(user, "core already in!")
 		return ITEM_INTERACT_BLOCKING
 	if(!user.transferItemToLoc(tool, src))
 		return ITEM_INTERACT_BLOCKING
-	core = tool
 	balloon_alert(user, "core installed")
 	playsound(src, 'sound/machines/click.ogg', 30, TRUE)
-	add_organ_trait(TRAIT_SHOCKIMMUNE)
-	blood_regeneration_multiplier = 21
-	update_icon_state()
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/organ/heart/cybernetic/anomalock/screwdriver_act(mob/living/user, obj/item/tool)
-	. = ..()
-	if(!core)
+	if(isnull(core))
 		balloon_alert(user, "no core!")
-		return
+		return ITEM_INTERACT_BLOCKING
 	if(!core_removable)
 		balloon_alert(user, "can't remove core!")
-		return
+		return ITEM_INTERACT_BLOCKING
 	balloon_alert(user, "removing core...")
 	if(!do_after(user, 3 SECONDS, target = src))
 		balloon_alert(user, "interrupted!")
-		return
+		return ITEM_INTERACT_BLOCKING
 	balloon_alert(user, "core removed")
-	core.forceMove(drop_location())
-	if(Adjacent(user) && !issilicon(user))
-		user.put_in_hands(core)
-	core = null
-	remove_organ_trait(TRAIT_SHOCKIMMUNE)
-	update_icon_state()
+	user.put_in_hands(core)
+	return ITEM_INTERACT_SUCCESS
+
+/obj/item/organ/heart/cybernetic/anomalock/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(gone == core)
+		core = null
+		blood_regeneration_multiplier = initial(blood_regeneration_multiplier)
+		remove_organ_trait(TRAIT_SHOCKIMMUNE)
+		update_appearance(UPDATE_ICON_STATE)
+		RemoveElement(/datum/element/empprotection, EMP_PROTECT_SELF)
+
+/obj/item/organ/heart/cybernetic/anomalock/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	. = ..()
+	if(istype(arrived, /obj/item/assembly/signaler/anomaly) && isnull(core))
+		core = arrived
+		blood_regeneration_multiplier = 21
+		add_organ_trait(TRAIT_SHOCKIMMUNE)
+		update_appearance(UPDATE_ICON_STATE)
+		AddElement(/datum/element/empprotection, EMP_PROTECT_SELF)
 
 /obj/item/organ/heart/cybernetic/anomalock/update_icon_state()
 	. = ..()
@@ -191,10 +196,8 @@
 
 /obj/item/organ/heart/cybernetic/anomalock/prebuilt/Initialize(mapload)
 	. = ..()
-	core = new /obj/item/assembly/signaler/anomaly/flux(src)
-	add_organ_trait(TRAIT_SHOCKIMMUNE)
-	blood_regeneration_multiplier = 21
-	update_icon_state()
+	core = new /obj/item/assembly/signaler/anomaly/flux()
+	core.forceMove(src)
 
 /datum/status_effect/voltaic_overdrive
 	id = "voltaic_overdrive"
@@ -222,7 +225,7 @@
 	owner.reagents.add_reagent(/datum/reagent/medicine/coagulant, 5)
 	owner.add_filter("emp_shield", 2, outline_filter(1, "#639BFF"))
 	to_chat(owner, span_revendanger("You feel a burst of energy! It's do or die!"))
-	owner.add_traits(list(TRAIT_NOSOFTCRIT, TRAIT_NOHARDCRIT, TRAIT_ANALGESIA), REF(src))
+	owner.add_traits(list(TRAIT_NOSOFTCRIT, TRAIT_NOHARDCRIT, TRAIT_ANALGESIA), TRAIT_STATUS_EFFECT(id))
 
 /datum/status_effect/voltaic_overdrive/on_remove()
 	. = ..()
@@ -230,7 +233,7 @@
 	owner.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 	owner.remove_filter("emp_shield")
 	owner.balloon_alert(owner, "your heart weakens")
-	owner.remove_traits(list(TRAIT_NOSOFTCRIT, TRAIT_NOHARDCRIT, TRAIT_ANALGESIA), REF(src))
+	owner.remove_traits(list(TRAIT_NOSOFTCRIT, TRAIT_NOHARDCRIT, TRAIT_ANALGESIA), TRAIT_STATUS_EFFECT(id))
 
 /// Called when an organ is lost in the owner. In the event the owner just lost their voltaic (presumably, the one giving this effect), ends the buff and clears the overlay.
 /datum/status_effect/voltaic_overdrive/proc/on_organ_lost(mob/living/carbon/source, obj/item/organ/organ, special)

--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -159,7 +159,7 @@
 	if(isnull(core))
 		balloon_alert(user, "no core!")
 		return ITEM_INTERACT_BLOCKING
-	if(!core_removable)
+	if((organ_flags & ORGAN_FAILING) || !core_removable)
 		balloon_alert(user, "can't remove core!")
 		return ITEM_INTERACT_BLOCKING
 	balloon_alert(user, "removing core...")

--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -25,8 +25,6 @@
 	var/obj/item/assembly/signaler/anomaly/core
 	///Accepted types of anomaly cores.
 	var/required_anomaly = /obj/item/assembly/signaler/anomaly/flux
-	///If this one starts with a core in.
-	var/prebuilt = FALSE
 	///If the core is removable once socketed.
 	var/core_removable = TRUE
 

--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -5,7 +5,10 @@
 
 /obj/item/organ/heart/cybernetic/anomalock
 	name = "voltaic combat cyberheart"
-	desc = "A cutting-edge cyberheart, originally designed for Nanotrasen killsquad usage but later declassified for normal research. Voltaic technology allows the heart to keep the body upright in dire circumstances, alongside redirecting anomalous flux energy to fully shield the user from shocks and electro-magnetic pulses. Requires a refined Flux core as a power source."
+	desc = "A cutting-edge cyberheart, originally designed for Nanotrasen killsquad usage but later declassified for normal research. \
+		Voltaic technology allows the heart to keep the body upright in dire circumstances, \
+		alongside redirecting anomalous flux energy to fully shield the user from shocks and the heart from electro-magnetic pulses. \
+		Requires a refined Flux core as a power source."
 	icon_state = "anomalock_heart"
 	beat_noise = "an astonishing <b>BZZZ</b> of immense electrical power"
 	bleed_prevention = TRUE


### PR DESCRIPTION
## About The Pull Request

- Voltaic heart no longer grants full EMP immunity to the wearer, but itself is still EMP immune.
- Voltaic heart no longer deletes itself on removal, instead making itself unusable (and the core unremovable) 

## Why It's Good For The Game

I have two justifications for this

1. Cybernetics tend to be entirely balanced around the fact that an EMP renders them non-functional.
 
Having full EMP immunity (relatively) easily available kinda shoots that in the foot. If you want to add a powerful cybernetic to the game and have it to offset by an equally severe emp reaction, you can't really do that, because you have to account for the fact that you can just ignore EMPs. 

2. EMPs are advertised as the prime way to counter someone who is heavily augmented and you can just ignore that

If you encounter a fully augmented person, the reasonable assumption is you should use an EMP on them. But the existence of this object means you have to second guess using an EMP on someone who should clearly be vulnerable to it because they might just be immune to it. 

## Changelog

:cl: Melbert
del: Voltaic heart no longer grants EMP immunity, though is still EMP immune itself.
del: Voltaic heart no longer deletes itself if you remove it, though it is still otherwise rendered unusable. 
/:cl:
