### PR TITLE
Fixing infinite z move loop

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -417,8 +417,9 @@
 	return TRUE
 
 /// Returns a list of movables that should also be affected when src moves through zlevels, and src.
-/atom/movable/proc/get_z_move_affected(z_move_flags)
-	. = list(src)
+/atom/movable/proc/get_z_move_affected(z_move_flags, list/returning_list = list())
+	. = returning_list
+	. |= src
 	if(buckled_mobs)
 		. |= buckled_mobs
 	if(!(z_move_flags & ZMOVE_INCLUDE_PULLED))
@@ -426,15 +427,11 @@
 	for(var/mob/living/buckled as anything in buckled_mobs)
 		if(buckled.pulling)
 			. |= buckled.pulling
-	if(pulling)
-		. |= pulling
-		if (pulling.buckled_mobs)
-			. |= pulling.buckled_mobs
-
-		//makes conga lines work with ladders and flying up and down; checks if the guy you are pulling is pulling someone,
-		//then uses recursion to run the same function again
-		if (pulling.pulling)
-			. |= pulling.pulling.get_z_move_affected(z_move_flags)
+	//makes conga lines work with ladders and flying up and down; checks if the guy you are pulling is pulling someone,
+	//then uses recursion to run the same function again
+	//we pass in the list from this proc to ensure we dont reach an infinite loop due to mobs grabbed in a loop or two mobs grabing eachother.
+	if(pulling && !(pulling in .))
+		. |= pulling.get_z_move_affected(z_move_flags, .)
 
 /**
  * Checks if the destination turf is elegible for z movement from the start turf to a given direction and returns it if so.


### PR DESCRIPTION

## About The Pull Request
Cleans up some code so that infinite loops cant be created by mobs grabbed in a chain together.

https://github.com/user-attachments/assets/546363b4-dc9a-4820-aee4-1793c60e8a47

https://github.com/user-attachments/assets/0891dd44-0371-4495-a322-f589e36c5e0e

This also cleans up some weird handling where we only run the proc on the 3rd atom in the chain rather then every mob. I believe this should make congo lines not break in a really wierd way where the grab chain stays connected but only the first 2 transfer through.

pre-pr code for the bug in question. 
<img width="2333" height="517" alt="image" src="https://github.com/user-attachments/assets/6317d44d-339c-4c05-b0bd-7fa01cd88120" />
<img width="2280" height="609" alt="image" src="https://github.com/user-attachments/assets/86633640-a3be-4a9b-9270-082e1bbfe817" />
## Why It's Good For The Game
At-least on a downstream with a [similar proc](https://github.com/ApocryphaXIII/Apocrypha13/pull/128/changes), it was able to full crash the input subsystem.
I can reproduce that on local hosting but i believe its applicable to TG as well.
## Changelog
:cl:
code: Fixes infinite loop caused by zmoving while having a looped chain of grabbed mobs
/:cl:
