### PR TITLE
Lowers the escape menu sounds

### DIFF
--- a/tgui/packages/tgui-escape-menu/audio.ts
+++ b/tgui/packages/tgui-escape-menu/audio.ts
@@ -10,7 +10,7 @@ function playOneShot(name: string) {
   const url = getAssetUrl(name);
   if (!url) return;
   const audio = new Audio(url);
-  audio.volume = 0.8;
+  audio.volume = 0.6;
   audio.play().catch(() => {});
 }
 


### PR DESCRIPTION
## About The Pull Request

Lowers all sounds from the escape menu from 80% to 60%

## Why It's Good For The Game

Every time I open the escape menu my ears gets blasted, now it's much more closely aligned with the rest of the sounds going on in game

## Changelog

:cl:
qol: Lowered the sounds coming from the escape menu.
/:cl: