### PR TITLE
Fixes unique ai so it does not choose the default lawset when config is set to specified

### DIFF
--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -85,7 +85,7 @@ GLOBAL_VAR(round_default_lawset)
 		switch(CONFIG_GET(number/default_laws))
 			if(CONFIG_ASIMOV)
 				law_weights -= AI_LAWS_ASIMOV
-			if(CONFIG_CUSTOM)
+			if(CONFIG_SPECIFIED)
 				law_weights -= specified_law_ids
 
 	while(!lawtype && law_weights.len)


### PR DESCRIPTION

## About The Pull Request
From what I can tell, CONFIG_CUSTOM, which is what it was previously, reads laws off of a text file that have no law_id attached to them, this means that they would not be able to be chosen by unique AI anyway, while default laws (unless manually overridden in the config) will still be in the pool. CONFIG_SPECIFIED does have a law ID attached, and as such that law ID's weight should be the one getting reduced.
## Why It's Good For The Game
Unique AI will properly remove default laws if they are specified by the server config
## Changelog
:cl:
fix: Unique AI properly removes law weight for default laws on the specified lawset config option
/:cl:
