### PR TITLE
fix: correct filter handling on the Big Manipulator

### DIFF
--- a/code/game/machinery/big_manipulator/big_manipulator_interactions.dm
+++ b/code/game/machinery/big_manipulator/big_manipulator_interactions.dm
@@ -142,7 +142,7 @@
 		return
 
 	var/obj/item/held_item = obj_resolve
-	var/atom/type_to_use = destination_task.find_type_priority(destination_task.skip_anchored)
+	var/atom/type_to_use = destination_task.find_type_priority(destination_task.skip_anchored, TRUE)
 
 	if(isnull(type_to_use))
 		use_in_progress = FALSE
@@ -221,7 +221,7 @@
 		finish_manipulation()
 		return
 
-	var/atom/type_to_use = destination_task.find_type_priority(destination_task.skip_anchored)
+	var/atom/type_to_use = destination_task.find_type_priority(destination_task.skip_anchored, TRUE)
 	if(isnull(type_to_use))
 		finish_manipulation()
 		return

--- a/code/game/machinery/big_manipulator/manipulator_tasks.dm
+++ b/code/game/machinery/big_manipulator/manipulator_tasks.dm
@@ -140,7 +140,7 @@
 /datum/manipulator_task/cargo/proc/fill_priority_list(manipulator_tier)
 	return list()
 
-/datum/manipulator_task/cargo/proc/find_type_priority(skip_anchored = FALSE)
+/datum/manipulator_task/cargo/proc/find_type_priority(skip_anchored = FALSE, respect_filters = FALSE)
 	var/atom/movable/best_candidate = null
 	var/best_priority_index = INFINITY
 
@@ -151,7 +151,7 @@
 
 			var/datum/manipulator_priority/prio = interaction_priorities[i]
 
-			if(!prio.active || ispath(prio, /turf))
+			if(!prio.active || prio.atom_typepath == /turf)
 				continue
 
 			if(!istype(thing, prio.atom_typepath))
@@ -164,6 +164,9 @@
 				var/mob/living/living_mob = thing
 				if(living_mob.stat == DEAD)
 					continue
+
+			if(respect_filters && should_use_filters && isitem(thing) && !check_filters_for_atom(thing))
+				continue
 
 			best_candidate = thing
 			best_priority_index = i
@@ -374,7 +377,7 @@
 		return FALSE
 	if(!manipulator.monkey_worker?.resolve())
 		return FALSE
-	if(!find_type_priority(skip_anchored))
+	if(!find_type_priority(skip_anchored, TRUE))
 		return FALSE
 	return can_accept(target)
 
@@ -495,9 +498,7 @@
 /datum/manipulator_task/cargo/dropoff_base/use/can_accept(atom/movable/target)
 	if(!is_valid())
 		return FALSE
-	if(should_use_filters && !check_filters_for_atom(target))
-		return FALSE
-	return TRUE
+	return find_type_priority(skip_anchored, TRUE) != null
 
 /datum/manipulator_task/cargo/dropoff_base/use/serialize()
 	var/list/data = ..()
@@ -540,7 +541,7 @@
 /datum/manipulator_task/cargo/interact/can_run(obj/machinery/big_manipulator/manipulator)
 	if(!..())
 		return FALSE
-	return find_type_priority() != null
+	return find_type_priority(skip_anchored, TRUE) != null
 
 /datum/manipulator_task/cargo/interact/run_task(obj/machinery/big_manipulator/manipulator)
 	manipulator.rotate_to_point(src, src, PROC_REF(try_interact))


### PR DESCRIPTION
## About The Pull Request

Fixes the Big Manipulator incorrectly comparing objects when checking if a task was available

## Why It's Good For The Game

<img width="917" height="683" alt="dreamseeker_PXrKXMQmXb" src="https://github.com/user-attachments/assets/11e879cd-7259-4bba-a9bd-3adff1b57d5f" />

## Changelog

:cl:
fix: Big Manipulator now correctly respects filters
/:cl:

