### PR TITLE
Fix R&D console showing empty elements for unprintable designs

### DIFF
--- a/tgui/packages/tgui/interfaces/Techweb/nodes/TechNode.tsx
+++ b/tgui/packages/tgui/interfaces/Techweb/nodes/TechNode.tsx
@@ -212,39 +212,44 @@ export function TechNode(props: Props) {
             asset={['', design_cache[k].class]}
             tooltip={
               <Stack vertical>
-                <Stack.Item mt={0.3} ml={0.3}>
+                <Stack.Item mt={0.3} ml={0.3} mb={0.3}>
                   {design_cache[k].name}
                 </Stack.Item>
-                <Stack.Item mt={-2} mb={-2} ml={-3}>
-                  <ul>
-                    <li>
-                      {Object.keys(build_types)
-                        .filter((key) => design_cache[k].build_types & +key)
-                        .map((key) => build_types[key])
-                        .join(', ')}
-                    </li>
-                    {!!Object.keys(department_flags).find(
-                      (key) => !(+key & design_cache[k].department_flags),
-                    ) && (
-                      <li>
-                        {Object.keys(department_flags)
-                          .filter(
-                            (key) => design_cache[k].department_flags & +key,
-                          )
-                          .map((key) => department_flags[key])
-                          .join(', ')}
-                      </li>
-                    )}
-                  </ul>
-                </Stack.Item>
-                <Stack.Divider />
-                <Stack.Item mt={-1}>
-                  <MaterialCostSequence
-                    design={design_cache[k]}
-                    amount={1}
-                    SHEET_MATERIAL_AMOUNT={SHEET_MATERIAL_AMOUNT}
-                  />
-                </Stack.Item>
+                {design_cache[k].build_types !== null && (
+                  <>
+                    <Stack.Item mt={-2} mb={-2} ml={-3}>
+                      <ul>
+                        <li>
+                          {Object.keys(build_types)
+                            .filter((key) => design_cache[k].build_types & +key)
+                            .map((key) => build_types[key])
+                            .join(', ')}
+                        </li>
+                        {!!Object.keys(department_flags).find(
+                          (key) => !(+key & design_cache[k].department_flags),
+                        ) && (
+                          <li>
+                            {Object.keys(department_flags)
+                              .filter(
+                                (key) =>
+                                  design_cache[k].department_flags & +key,
+                              )
+                              .map((key) => department_flags[key])
+                              .join(', ')}
+                          </li>
+                        )}
+                      </ul>
+                    </Stack.Item>
+                    <Stack.Divider />
+                    <Stack.Item mt={-1}>
+                      <MaterialCostSequence
+                        design={design_cache[k]}
+                        amount={1}
+                        SHEET_MATERIAL_AMOUNT={SHEET_MATERIAL_AMOUNT}
+                      />
+                    </Stack.Item>
+                  </>
+                )}
               </Stack>
             }
             tooltipPosition={i % 15 < 7 ? 'right' : 'left'}


### PR DESCRIPTION

## About The Pull Request

If `build_types` is null there's no need to include any of this other stuff

## Why It's Good For The Game

Fixes #97310 

## Changelog
:cl:
fix: fixed R&D console showing extraneous fields for unprintable designs
/:cl:
