### PR TITLE
Misc fixes

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 /obj/item/radio/headset/Initialize(mapload)
 	. = ..()
 	if(ispath(keyslot2))
-		keyslot2 = new keyslot2()
+		keyslot2 = new keyslot2(src)
 	set_listening(TRUE)
 	set_broadcasting(TRUE)
 	recalculateChannels()

--- a/code/game/objects/structures/signs/signs_departments.dm
+++ b/code/game/objects/structures/signs/signs_departments.dm
@@ -105,7 +105,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/engineering, 32)
 	desc = "A sign labelling an area where your life-giving air comes from."
 	icon_state = "atmos"
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/engineering, 32)
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/atmospherics, 32)
 
 ///////SCIENCE
 

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -91,8 +91,8 @@
 		playing = FALSE
 		return FALSE
 
-	for(var/modpath in modifiers)
-		GLOB.deathmatch_game.modifiers[modpath].on_start_game(src)
+	for(var/datum/deathmatch_modifier/modifier_path as anything in modifiers)
+		GLOB.deathmatch_game.modifiers[modifier_path].on_start_game(src)
 
 	for (var/key in players)
 		var/mob/dead/observer/observer = players[key]["mob"]
@@ -119,8 +119,8 @@
 	announce(span_reallybig("GO!"))
 	if(length(modifiers))
 		var/list/modifier_names = list()
-		for(var/datum/deathmatch_modifier/modifier as anything in modifiers)
-			modifier_names += uppertext(initial(modifier.name))
+		for(var/datum/deathmatch_modifier/modifier_path as anything in modifiers)
+			modifier_names += uppertext(initial(modifier_path.name))
 		announce(span_boldnicegreen("THIS MATCH MODIFIERS: [english_list(modifier_names, and_text = " ,")]."))
 	return TRUE
 
@@ -150,8 +150,8 @@
 	new_player.PossessByPlayer(ckey)
 	players_info["mob"] = new_player
 
-	for(var/datum/deathmatch_modifier/modifier as anything in modifiers)
-		GLOB.deathmatch_game.modifiers[modifier].apply(new_player, src)
+	for(var/datum/deathmatch_modifier/modifier_path as anything in modifiers)
+		GLOB.deathmatch_game.modifiers[modifier_path].apply(new_player, src)
 
 	// register death handling.
 	register_player_signals(new_player)
@@ -193,8 +193,8 @@
 		loser.ghostize(can_reenter_corpse = FALSE)
 		qdel(loser)
 
-	for(var/datum/deathmatch_modifier/modifier in modifiers)
-		GLOB.deathmatch_game.modifiers[modifier].on_end_game(src)
+	for(var/datum/deathmatch_modifier/modifier_path as anything in modifiers)
+		GLOB.deathmatch_game.modifiers[modifier_path].on_end_game(src)
 
 	clear_reservation()
 	GLOB.deathmatch_game.remove_lobby(host)
@@ -323,8 +323,8 @@
 			continue
 		players[player_key]["loadout"] = loadouts[1]
 
-	for(var/deathmatch_mod in modifiers)
-		GLOB.deathmatch_game.modifiers[deathmatch_mod].on_map_changed(src)
+	for(var/datum/deathmatch_modifier/modifier_path in modifiers)
+		GLOB.deathmatch_game.modifiers[modifier_path].on_map_changed(src)
 
 /datum/deathmatch_lobby/proc/clear_reservation()
 	if(isnull(location) || isnull(map))
@@ -393,8 +393,8 @@
 
 	if(length(modifiers))
 		var/list/mod_names = list()
-		for(var/datum/deathmatch_modifier/modpath as anything in modifiers)
-			mod_names += modpath::name
+		for(var/datum/deathmatch_modifier/modifier_path as anything in modifiers)
+			mod_names += modifier_path::name
 		data["active_mods"] = "Selected modifiers: [english_list(mod_names)]"
 
 	if(is_player && !isnull(players[user.ckey]["loadout"]))
@@ -553,8 +553,8 @@
 	if(!mod_menu_open)
 		return modifier_list
 
-	for(var/modpath in GLOB.deathmatch_game.modifiers)
-		var/datum/deathmatch_modifier/mod = GLOB.deathmatch_game.modifiers[modpath]
+	for(var/datum/deathmatch_modifier/modifier_path in GLOB.deathmatch_game.modifiers)
+		var/datum/deathmatch_modifier/mod = GLOB.deathmatch_game.modifiers[modifier_path]
 
 		UNTYPED_LIST_ADD(modifier_list, list(
 			"name" = mod.name,

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -505,13 +505,13 @@
 			return TRUE
 
 		if("toggle_modifier")
-			var/datum/deathmatch_modifier/modpath = text2path(params["modpath"])
-			if(!ispath(modpath))
+			var/datum/deathmatch_modifier/modifier_path = text2path(params["modpath"])
+			if(!ispath(modifier_path))
 				return TRUE
 			if(usr.ckey != host && !check_rights(R_ADMIN))
 				return TRUE
-			var/datum/deathmatch_modifier/chosen_modifier = GLOB.deathmatch_game.modifiers[modpath]
-			if(modpath in modifiers)
+			var/datum/deathmatch_modifier/chosen_modifier = GLOB.deathmatch_game.modifiers[modifier_path]
+			if(modifier_path in modifiers)
 				unselect_modifier(chosen_modifier)
 				return TRUE
 			if(chosen_modifier.selectable(src))
@@ -559,8 +559,8 @@
 		UNTYPED_LIST_ADD(modifier_list, list(
 			"name" = mod.name,
 			"desc" = mod.description,
-			"modpath" = "[modpath]",
-			"selected" = (modpath in modifiers),
+			"modpath" = "[modifier_path]",
+			"selected" = (modifier_path in modifiers),
 			"selectable" = is_host && mod.selectable(src),
 		))
 

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -76,9 +76,8 @@
 
 /datum/deathmatch_lobby/proc/find_spawns_and_start_delay(datum/lazy_template/source, list/atoms)
 	SIGNAL_HANDLER
-	for(var/thing in atoms)
-		if(istype(thing, /obj/effect/landmark/deathmatch_player_spawn))
-			player_spawns += thing
+	for(var/obj/effect/landmark/deathmatch_player_spawn/spawn_point in atoms)
+		player_spawns += spawn_point
 
 	UnregisterSignal(source, COMSIG_LAZY_TEMPLATE_LOADED)
 	map.template_in_use = FALSE

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -323,7 +323,7 @@
 			continue
 		players[player_key]["loadout"] = loadouts[1]
 
-	for(var/datum/deathmatch_modifier/modifier_path in modifiers)
+	for(var/datum/deathmatch_modifier/modifier_path as anything in modifiers)
 		GLOB.deathmatch_game.modifiers[modifier_path].on_map_changed(src)
 
 /datum/deathmatch_lobby/proc/clear_reservation()
@@ -553,7 +553,7 @@
 	if(!mod_menu_open)
 		return modifier_list
 
-	for(var/datum/deathmatch_modifier/modifier_path in GLOB.deathmatch_game.modifiers)
+	for(var/datum/deathmatch_modifier/modifier_path as anything in GLOB.deathmatch_game.modifiers)
 		var/datum/deathmatch_modifier/mod = GLOB.deathmatch_game.modifiers[modifier_path]
 
 		UNTYPED_LIST_ADD(modifier_list, list(

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -526,9 +526,8 @@
 	///Pick global modifiers at random.
 	for(var/iteration in 1 to rand(3, 5))
 		var/datum/deathmatch_modifier/modifier = GLOB.deathmatch_game.modifiers[pick_n_take(modifiers_pool)]
-		modifier.on_select(lobby)
+		lobby.select_modifier(modifier)
 		modifier.on_start_game(lobby)
-		lobby.modifiers += modifier.type
 		modifiers_pool -= modifier.blacklisted_modifiers
 		if(!length(modifiers_pool))
 			return


### PR DESCRIPTION

## About The Pull Request

- `keyslot2` on headsets now starts inside of the headset just like the `keyslot`, before it was just vibing in nullspace
- Fixed `/obj/structure/sign/departments/atmospherics` not having directional variant, and the engi sign having 2
- Made reffering to modifiers in `deathmatch_lobby.dm` a bit more consistent
- Made the "random modifiers" deathmatch modifier use `select_modifier()` instead of manually adding it
- changed `for(var/thing in atoms); istype(thing, /obj/effect/landmark/deathmatch_player_spawn)` to
  `for(var/obj/effect/landmark/deathmatch_player_spawn/spawn_point in atoms)`

## Why It's Good For The Game

> `keyslot2` on headsets now starts inside of the headset just like the `keyslot`, before it was just vibing in nullspace
- This shouldn't have any gameplay effect, but its still good to have the key in the headset's contents just like the primary one
> Fixed `/obj/structure/sign/departments/atmospherics` not having directional variant, and the engi sign having 2
- Delicious copy-pasta
> Made reffering to modifiers in `deathmatch_lobby.dm` a bit more consistent
- I swear `on_end_game(src)` was not working because it was being filtered and that made the no grav modifier leak onto onto other maps, but i can't reproduce it so im gonna just say its so everything looks more consistent and move on with my day
> Made the "random modifiers" deathmatch modifier use `select_modifier()` instead of manually adding it
- Feels cleaner
> changed `for(var/thing in atoms); istype(thing, /obj/effect/landmark/deathmatch_player_spawn)` to
> `for(var/obj/effect/landmark/deathmatch_player_spawn/spawn_point in atoms)`
- hopefully thats slightly faster and a tiny bit cleaner

## Changelog

:cl:
fix: if a headset starts with a 2nd key in it, it will have that key inside of itself instead of in nullspace (this has no gameplay effect)
/:cl:
