### PR TITLE
Add step to restore or install byond workflow that determines fastest APT mirror

### DIFF
--- a/.github/actions/restore_or_install_byond/action.yml
+++ b/.github/actions/restore_or_install_byond/action.yml
@@ -31,6 +31,9 @@ runs:
 
     - name: Find fastest APT mirror
       uses: vegardit/fast-apt-mirror.sh@v1
+      with:
+        sample-size: 8192
+        sample-time: 5
     - name: Install 32-bit libcurl
       shell: bash
       run: |

--- a/.github/actions/restore_or_install_byond/action.yml
+++ b/.github/actions/restore_or_install_byond/action.yml
@@ -29,6 +29,8 @@ runs:
         echo "BYOND_MAJOR=$BYOND_MAJOR" >> $GITHUB_ENV
         echo "BYOND_MINOR=$BYOND_MINOR" >> $GITHUB_ENV
 
+    - name: Find fastest APT mirror
+      uses: vegardit/fast-apt-mirror.sh@v1
     - name: Install 32-bit libcurl
       shell: bash
       run: |


### PR DESCRIPTION

## About The Pull Request

Since adding the install 32 bit libcurl step to CI, I've noticed that fairly often the job will take noticeably longer to complete, over a minute and sometimes even timing out after 5. This is because the default apt mirror in the runner image randomly slows down a TON. I found an action created specifically because of this problem, that tests the connection to a set of mirrors and picks the fastest one, and I thought it'd be worth trying (it would add a few seconds to CI, but in my eyes a guaranteed addition of a few seconds is better than a random chance of a few extra minutes when the mirror slows down)

## Why It's Good For The Game

hopefully less CI slowdown/timeouts

## Changelog

N/A
