### PR TITLE
Reduces crusher trophy crafting costs, makes them smaller and holdable by webbings, reduces icewing trophy backstep

### DIFF
--- a/code/datums/components/crafting/melee_weapon.dm
+++ b/code/datums/components/crafting/melee_weapon.dm
@@ -287,8 +287,8 @@
 	name = "Watcher Wing Trophy"
 	result = /obj/item/crusher_trophy/watcher_wing
 	reqs = list(
-		/obj/item/stack/sheet/sinew = 7,
-		/obj/item/stack/ore/diamond = 10,
+		/obj/item/stack/sheet/sinew = 5,
+		/obj/item/stack/ore/diamond = 6,
 		/obj/item/stack/sheet/bone = 5,
 	)
 
@@ -297,7 +297,7 @@
 	result = /obj/item/crusher_trophy/ice_wing
 	reqs = list(
 		/obj/item/stack/sheet/sinew/icewing = 3,
-		/obj/item/stack/ore/diamond = 6,
+		/obj/item/stack/ore/diamond = 5,
 		/obj/item/stack/sheet/bone = 3,
 	)
 
@@ -306,7 +306,7 @@
 	result = /obj/item/crusher_trophy/magma_wing
 	reqs = list(
 		/obj/item/stack/sheet/sinew/magmawing = 3,
-		/obj/item/stack/ore/diamond = 6,
+		/obj/item/stack/ore/diamond = 2,
 		/obj/item/stack/sheet/bone = 3,
 	)
 
@@ -315,7 +315,7 @@
 	result = /obj/item/crusher_trophy/goliath_tentacle
 	reqs = list(
 		/obj/item/stack/sheet/animalhide/goliath_hide = 3,
-		/obj/item/stack/sheet/bone = 8,
+		/obj/item/stack/sheet/bone = 6,
 	)
 
 /datum/crafting_recipe/crusher_trophy/legion_skull
@@ -323,23 +323,23 @@
 	result = /obj/item/crusher_trophy/legion_skull
 	reqs = list(
 		/obj/item/organ/monster_core/regenerative_core/legion = 3, // Good sink for expired cores
-		/obj/item/stack/sheet/bone = 5,
+		/obj/item/stack/sheet/bone = 4,
 	)
 
 /datum/crafting_recipe/crusher_trophy/lobster_claw
 	name = "Lobster Claw Trophy"
 	result = /obj/item/crusher_trophy/lobster_claw
 	reqs = list(
-		/obj/item/organ/monster_core/rush_gland = 3,
-		/obj/item/stack/sheet/bone = 5,
-		/obj/item/food/meat/slab/rawcrab = 3,
+		/obj/item/organ/monster_core/rush_gland = 2,
+		/obj/item/stack/sheet/bone = 4,
+		/obj/item/food/meat/slab/rawcrab = 2,
 	)
 
 /datum/crafting_recipe/crusher_trophy/brimdemon_fang
 	name = "Brimdemon Fang Trophy"
 	result = /obj/item/crusher_trophy/brimdemon_fang
 	reqs = list(
-		/obj/item/organ/monster_core/brimdust_sac = 3,
+		/obj/item/organ/monster_core/brimdust_sac = 2,
 		/datum/reagent/brimdust = 45,
 	)
 
@@ -348,5 +348,5 @@
 	result = /obj/item/crusher_trophy/bileworm_spewlet
 	reqs = list(
 		/obj/item/stack/sheet/animalhide/bileworm = 3,
-		/obj/item/stack/ore/gold = 12,
+		/obj/item/stack/ore/gold = 8,
 	)

--- a/code/datums/storage/subtypes/belts.dm
+++ b/code/datums/storage/subtypes/belts.dm
@@ -156,6 +156,7 @@
 		/obj/item/wrench,
 		/obj/item/wormhole_jaunter,
 		/obj/item/skeleton_key,
+		/obj/item/crusher_trophy,
 	))
 
 ///Primitive mining belt

--- a/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher_trophies.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/kinetic_crusher_trophies.dm
@@ -7,6 +7,7 @@
 	desc = "A strange spike with no usage."
 	icon = 'icons/obj/mining_zones/artefacts.dmi'
 	icon_state = "tail_spike"
+	w_class = WEIGHT_CLASS_SMALL
 	/// If it has a bonus effect, this is how much that effect is
 	var/bonus_value = 10
 	/// ID of the trophy to be sent by the signal

--- a/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
@@ -97,7 +97,7 @@
 	name = "icewing watcher wing"
 	desc = "A carefully preserved frozen wing from an icewing watcher. Suitable as a trophy for a kinetic crusher."
 	icon_state = "ice_wing"
-	bonus_value = 2
+	bonus_value = 1
 	denied_type = /obj/item/crusher_trophy/ice_wing
 	wildhunter_drops = list(/obj/item/stack/sheet/sinew/icewing = 3)
 	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 6, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 3)

--- a/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
@@ -10,7 +10,7 @@
 	denied_type = /obj/item/crusher_trophy/watcher_wing
 	trophy_id = TROPHY_WATCHER
 	bonus_value = 5
-	wildhunter_drops = list(/obj/item/stack/sheet/sinew = 7)
+	wildhunter_drops = list(/obj/item/stack/sheet/sinew = 5)
 	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 10, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 5)
 
 /obj/item/crusher_trophy/watcher_wing/effect_desc()

--- a/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/trophies_fauna.dm
@@ -11,7 +11,7 @@
 	trophy_id = TROPHY_WATCHER
 	bonus_value = 5
 	wildhunter_drops = list(/obj/item/stack/sheet/sinew = 5)
-	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 10, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 5)
+	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 6, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 5)
 
 /obj/item/crusher_trophy/watcher_wing/effect_desc()
 	return "mark detonation to prevent certain creatures from using certain attacks for <b>[bonus_value*0.1]</b> second\s"
@@ -35,7 +35,7 @@
 	icon_state = "magma_wing"
 	denied_type = /obj/item/crusher_trophy/magma_wing
 	wildhunter_drops = list(/obj/item/stack/sheet/sinew/magmawing = 3)
-	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 6, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 3)
+	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 2, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 3)
 	/// List of mobs we've marked
 	var/list/mob/living/marked_targets = list()
 
@@ -100,7 +100,7 @@
 	bonus_value = 1
 	denied_type = /obj/item/crusher_trophy/ice_wing
 	wildhunter_drops = list(/obj/item/stack/sheet/sinew/icewing = 3)
-	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 6, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 3)
+	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 5, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 3)
 
 /obj/item/crusher_trophy/ice_wing/effect_desc()
 	return "user to backstep [bonus_value] tile\s when detonating a mark"
@@ -129,7 +129,7 @@
 	denied_type = /obj/item/crusher_trophy/legion_skull
 	bonus_value = 3
 	// No wildhunter drop to prevent refresh cheese
-	custom_materials = list(/datum/material/bone = SHEET_MATERIAL_AMOUNT * 5)
+	custom_materials = list(/datum/material/bone = SHEET_MATERIAL_AMOUNT * 4)
 
 /obj/item/crusher_trophy/legion_skull/effect_desc()
 	return "a kinetic crusher to recharge <b>[bonus_value*0.1]</b> second\s faster"
@@ -153,7 +153,7 @@
 	bonus_value = 2
 	trophy_id = TROPHY_GOLIATH_TENTACLE
 	wildhunter_drops = list(/obj/item/stack/sheet/animalhide/goliath_hide = 3)
-	custom_materials = list(/datum/material/bone = SHEET_MATERIAL_AMOUNT * 8)
+	custom_materials = list(/datum/material/bone = SHEET_MATERIAL_AMOUNT * 6)
 	/// Your missing health is multiplied by this value to find the bonus damage
 	var/missing_health_ratio = 0.1
 
@@ -179,7 +179,7 @@
 	trophy_id = TROPHY_LOBSTER_CLAW
 	bonus_value = 1
 	// No wildhunter drop to prevent refresh cheese
-	custom_materials = list(/datum/material/meat = SHEET_MATERIAL_AMOUNT * 12, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 5)
+	custom_materials = list(/datum/material/meat = SHEET_MATERIAL_AMOUNT * 8, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 4)
 
 /obj/item/crusher_trophy/lobster_claw/effect_desc()
 	return "mark detonation to briefly rebuke the target for [bonus_value] second[bonus_value > 1 ? "s" : ""]"
@@ -215,7 +215,7 @@
 	desc = "A baby bileworm. Suitable as a trophy for a kinetic crusher."
 	denied_type = /obj/item/crusher_trophy/bileworm_spewlet
 	wildhunter_drops = list(/obj/item/stack/sheet/animalhide/bileworm = 3)
-	custom_materials = list(/datum/material/gold = SHEET_MATERIAL_AMOUNT * 12)
+	custom_materials = list(/datum/material/gold = SHEET_MATERIAL_AMOUNT * 8)
 	///item ability that handles the effect
 	var/datum/action/cooldown/mob_cooldown/projectile_attack/dir_shots/spewlet/ability
 

--- a/code/modules/mob/living/basic/lavaland/bileworm/bileworm_instrument.dm
+++ b/code/modules/mob/living/basic/lavaland/bileworm/bileworm_instrument.dm
@@ -6,7 +6,7 @@
 	icon_state = "bilehorn"
 	allowed_instrument_ids = "bilehorn"
 	inhand_icon_state = null
-	custom_materials = list(/datum/material/gold = SHEET_MATERIAL_AMOUNT * 12, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 2)
+	custom_materials = list(/datum/material/gold = SHEET_MATERIAL_AMOUNT * 8, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 2)
 
 /datum/crafting_recipe/bilehorn
 	name = "Bilehorn"


### PR DESCRIPTION

## About The Pull Request

Reduces crusher trophy costs in bone and ores (plus a few other misc. items) across the board, makes trophies small and allows them to be held by explorer webbings
Icewing trophy now only pushes you 1 tile away rather than 2, which should be significantly less disorienting

## Why It's Good For The Game

From both my own experience, player feedback feedback (and with #97343 reducing spawns) crusher trophies are a bit too expensive, specifically on bone and ores. Some nerfs would make them less of a pain to acquire, especially when it comes to non-stackable items like cores or meat, and ore cost drops ensure that killing a rare icewing/magmawing guarantees a trophy like before.

Two tiles of backstep prevented client camera from smoothing, causing a very jank and disorienting teleport to occur rather than the intended smooth backstep. One tile of distance still prevents you from being melee'd, which is the intent behind the trophy.

## Changelog
:cl:
balance: Crusher trophies are now small and can be stowed in explorer webbings
balance: Crusher trophies are slightly cheaper to craft
balance: Icewing trophy backstep distance reduced from 2 to 1 to be less disorienting
/:cl:
