### PR TITLE
Fix VV interpreting non-assoc lists as bitfield lists

### DIFF
--- a/code/_globalvars/bitfields.dm
+++ b/code/_globalvars/bitfields.dm
@@ -29,6 +29,8 @@ GLOBAL_LIST_INIT(bitfields, generate_bitfields())
 
 /// Returns null if no such field exists, a list of all matching flags by name otherwise
 /proc/get_matching_bitflags(var_name, value)
+	if(isnum(var_name))
+		return null
 	var/list/valid_bitflags = get_valid_bitflags(var_name)
 	if(!length(valid_bitflags))
 		return null


### PR DESCRIPTION

## About The Pull Request

The `isnum` guard removed in #96022 was necessary because otherwise `GLOB.bitfields` is accessed by index instead of key and instead of returning the value (a list of flags) it returns the key (name of the bitfield var), which it then fails to loop through and returns an empty list, making VV think the value is a bitfield with no flags set (NONE)

## Why It's Good For The Game

Fixes #97264 

## Changelog
:cl:
fix: fixed VV panel erroneously displaying certain lists as full of bitfields
/:cl:
