### PR TITLE
Only install libcurl if the version needs it

### DIFF
--- a/.github/actions/restore_or_install_byond/action.yml
+++ b/.github/actions/restore_or_install_byond/action.yml
@@ -30,6 +30,8 @@ runs:
         echo "BYOND_MINOR=$BYOND_MINOR" >> $GITHUB_ENV
 
     - name: Install 32-bit libcurl
+      # Only required in 516.1664+
+      if: env.BYOND_MAJOR >= 516 && env.BYOND_MINOR >= 1664
       shell: bash
       run: |
         sudo dpkg --add-architecture i386


### PR DESCRIPTION

## About The Pull Request

For the time being our minimum CI version is earlier than the point 32-bit libcurl was required, so lets not install it if we don't have to

## Why It's Good For The Game

CI time savings

## Changelog

N/A
