### PR TITLE
X-ray vision lets you look through the floor vertically

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2373,8 +2373,8 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	var/turf/check_turf = get_step_multiz(src, direction == DOWN ? NONE : direction)
 	if(!get_step_multiz(src, direction)) //We are at the edge z-level.
 		to_chat(src, span_warning("There's nothing interesting there."))
-		return
-	else if(!istransparentturf(check_turf)) //There is no turf we can look through above us
+		return null
+	if(!istransparentturf(check_turf) && !HAS_TRAIT(src, TRAIT_XRAY_VISION)) //There is no turf we can look through above us
 		var/turf/front_hole = get_step(check_turf, dir)
 		if(istransparentturf(front_hole))
 			check_turf = front_hole
@@ -2385,7 +2385,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 					break
 		if(!istransparentturf(check_turf))
 			to_chat(src, span_warning("You can't see through the floor [direction == DOWN ? "below" : "above"] you."))
-			return
+			return null
 	return direction == DOWN ? get_step_multiz(check_turf, DOWN) : check_turf
 
 /**


### PR DESCRIPTION
## About The Pull Request

If you've got x-ray vision, you can "look up" or "look down" through solid floors / ceilings on multi-z maps

## Why It's Good For The Game

I don't see why not

(Trying to extend this to similar sight modifiers (thermals or meson) would require a lot more work which is why I started here)

## Changelog

:cl: Melbert
add: X-ray vision lets you look vertically through the floor or ceiling on multi-z maps
/:cl:
