### PR TITLE
Fixes two bugs in the lua signal helpers

### DIFF
--- a/lua/SS13_base.lua
+++ b/lua/SS13_base.lua
@@ -199,7 +199,7 @@ function SS13.unregister_signal(datum, signal, func)
 		end
 	else
 		handler_data.functions[func] = nil
-		if not (#handler_data.functions or (signal == "parent_qdeleting")) then
+		if not (next(handler_data.functions) or (signal == "parent_qdeleting")) then
 			handler_data.callback:UnregisterSignal(datum, signal)
 			__SS13_signal_handlers[datum][signal] = nil
 		end

--- a/lua/handler_group.lua
+++ b/lua/handler_group.lua
@@ -30,7 +30,7 @@ end
 
 -- Clears all the signals that have been registered on this HandlerGroup when a specific signal is sent on a datum.
 function HandlerGroup:clear_on(datum, signal, func)
-	SS13.register_signal(datum, signal, function(...)
+	self:register_signal(datum, signal, function(...)
 		if func then
 			func(...)
 		end


### PR DESCRIPTION
## About The Pull Request

This PR fixes 2 things:

- `SS13.unregister_signal` never releases the `/datum/callback`.
- `HandlerGroup.register_once` fires every time.

`handler_data.functions` is a table keyed by the handler functions, so it has no array part and `#handler_data.functions` is always `0` which is truthy in Lua, making the teardown condition unconditionally `false`. The `/datum/callback` therefore stays registered on the datum even after its last lua handler is gone, and every send still round trips into an empty `signal_handler`.
Swapped in `next(...)`, the correct emptiness test for a keyed table.

`clear_on` registers its wrapper with `SS13.register_signal` instead of `self:register_signal`, so the wrapper never lands in `self.registered` and `clear()` cannot remove it. `register_once` builds on `clear_on` with an empty group, so its "once" never happens, the callback runs on every send.

## Why It's Good For The Game

`register_once` does not do what its name says, with no way to tell from the calling side.
Scripts that unregister signals also leak a dead `/datum/callback` per datum/signal pair.

## Changelog

:cl:
fix: SS13.unregister_signal now actually detaches a signal's callback once its last handler has been removed.
fix: HandlerGroup.register_once now fires only once, instead of on every send of the signal.
/:cl:
