### PR TITLE
Fixes core temperature adjusting faster than body temperature

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -58,15 +58,15 @@
 /// The multiplier that sets the speed when adjusting the difference between two body temperatures.
 #define BODYTEMP_STANDARD_CHANGE_RATE 0.06
 /// The multiplier that sets the speed for body core temperature to normalize towards default.
-#define BODYTEMP_CORE_CHANGE_RATE 0.015
+#define BODYTEMP_CORE_CHANGE_RATE (BODYTEMP_STANDARD_CHANGE_RATE * 0.25)
 /// Rate of body heat transfer from skin to core
-#define BODYTEMP_SKIN_CORE_CHANGE_RATE 0.04
+#define BODYTEMP_SKIN_CORE_CHANGE_RATE (BODYTEMP_STANDARD_CHANGE_RATE * 0.65)
 /// Rate of body heat transfer from core to skin
-#define BODYTEMP_CORE_SKIN_CHANGE_RATE 0.045
+#define BODYTEMP_CORE_SKIN_CHANGE_RATE (BODYTEMP_STANDARD_CHANGE_RATE * 0.75)
 /// Rate of body heat transfer from area to skin
-#define BODYTEMP_AREA_SKIN_CHANGE_RATE 0.05
+#define BODYTEMP_AREA_SKIN_CHANGE_RATE (BODYTEMP_STANDARD_CHANGE_RATE * 0.85)
 /// Rate of body heat transfer by space suits
-#define BODYTEMP_SUIT_CHANGE_RATE 0.08
+#define BODYTEMP_SUIT_CHANGE_RATE (BODYTEMP_STANDARD_CHANGE_RATE * 1.35)
 ///Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is lower than their body temperature. Make it lower to lose bodytemp faster.
 #define BODYTEMP_COLD_DIVISOR 15
 /// Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is higher than their body temperature. Make it lower to gain bodytemp faster.

--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -56,9 +56,17 @@
 /// Minimum amount of kelvin moved toward 310K per tick. So long as abs(310.15 - bodytemp) is more than 50.
 #define BODYTEMP_AUTORECOVERY_MINIMUM 3
 /// The multiplier that sets the speed when adjusting the difference between two body temperatures.
-#define BODYTEMP_CHANGE_RATE 0.06
+#define BODYTEMP_STANDARD_CHANGE_RATE 0.06
 /// The multiplier that sets the speed for body core temperature to normalize towards default.
-#define BODYTEMP_CORE_CHANGE_RATE (BODYTEMP_CHANGE_RATE * 0.25)
+#define BODYTEMP_CORE_CHANGE_RATE 0.015
+/// Rate of body heat transfer from skin to core
+#define BODYTEMP_SKIN_CORE_CHANGE_RATE 0.04
+/// Rate of body heat transfer from core to skin
+#define BODYTEMP_CORE_SKIN_CHANGE_RATE 0.045
+/// Rate of body heat transfer from area to skin
+#define BODYTEMP_AREA_SKIN_CHANGE_RATE 0.05
+/// Rate of body heat transfer by space suits
+#define BODYTEMP_SUIT_CHANGE_RATE 0.08
 ///Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is lower than their body temperature. Make it lower to lose bodytemp faster.
 #define BODYTEMP_COLD_DIVISOR 15
 /// Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is higher than their body temperature. Make it lower to gain bodytemp faster.

--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -55,6 +55,10 @@
 #define BODYTEMP_AUTORECOVERY_DIVISOR 28
 /// Minimum amount of kelvin moved toward 310K per tick. So long as abs(310.15 - bodytemp) is more than 50.
 #define BODYTEMP_AUTORECOVERY_MINIMUM 3
+/// The multiplier that sets the speed when adjusting the difference between two body temperatures.
+#define BODYTEMP_CHANGE_RATE 0.06
+/// The multiplier that sets the speed for body core temperature to normalize towards default.
+#define BODYTEMP_CORE_CHANGE_RATE (BODYTEMP_CHANGE_RATE * 0.25)
 ///Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is lower than their body temperature. Make it lower to lose bodytemp faster.
 #define BODYTEMP_COLD_DIVISOR 15
 /// Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is higher than their body temperature. Make it lower to gain bodytemp faster.

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -421,7 +421,7 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
  * * temp_diff (required) The difference between two temperatures
  * * change_rate (optional)(Default: 0.06) The rate of range multiplier
  */
-/proc/get_temp_change_amount(temp_diff, change_rate = BODYTEMP_CHANGE_RATE)
+/proc/get_temp_change_amount(temp_diff, change_rate = BODYTEMP_STANDARD_CHANGE_RATE)
 	if(temp_diff < 0)
 		return -(BODYTEMP_AUTORECOVERY_DIVISOR / 2) * log(1 - (temp_diff * change_rate))
 	return (BODYTEMP_AUTORECOVERY_DIVISOR / 2) * log(1 + (temp_diff * change_rate))

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -421,7 +421,7 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
  * * temp_diff (required) The difference between two temperatures
  * * change_rate (optional)(Default: 0.06) The rate of range multiplier
  */
-/proc/get_temp_change_amount(temp_diff, change_rate = 0.06)
+/proc/get_temp_change_amount(temp_diff, change_rate = BODYTEMP_CHANGE_RATE)
 	if(temp_diff < 0)
 		return -(BODYTEMP_AUTORECOVERY_DIVISOR / 2) * log(1 - (temp_diff * change_rate))
 	return (BODYTEMP_AUTORECOVERY_DIVISOR / 2) * log(1 + (temp_diff * change_rate))

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -180,7 +180,7 @@
 
 	// If we got here, it means thermals are on, the cell is in and the cell has
 	// just had enough charge subtracted from it to power the thermal regulator
-	user.adjust_bodytemperature(get_temp_change_amount((temperature_setting - user.bodytemperature), 0.08 * seconds_per_tick))
+	user.adjust_bodytemperature(get_temp_change_amount((temperature_setting - user.bodytemperature), (BODYTEMP_CHANGE_RATE * 1.4) * seconds_per_tick))
 	update_hud_icon(user)
 
 // Clean up the cell on destroy

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -180,7 +180,7 @@
 
 	// If we got here, it means thermals are on, the cell is in and the cell has
 	// just had enough charge subtracted from it to power the thermal regulator
-	user.adjust_bodytemperature(get_temp_change_amount((temperature_setting - user.bodytemperature), (BODYTEMP_CHANGE_RATE * 1.4) * seconds_per_tick))
+	user.adjust_bodytemperature(get_temp_change_amount((temperature_setting - user.bodytemperature), BODYTEMP_SUIT_CHANGE_RATE * seconds_per_tick))
 	update_hud_icon(user)
 
 // Clean up the cell on destroy

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1070,8 +1070,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	// change the core based on the skin temp
 	var/skin_core_diff = humi.bodytemperature - humi.coretemperature
-	// change rate of slightly below area to skin change rate and still having a solid curve
-	var/skin_core_change = get_temp_change_amount(skin_core_diff, (BODYTEMP_CHANGE_RATE * 0.65) * seconds_per_tick)
+	// change rate of 0.04 per second to be slightly below area to skin change rate and still have a solid curve
+	var/skin_core_change = get_temp_change_amount(skin_core_diff, BODYTEMP_SKIN_CORE_CHANGE_RATE * seconds_per_tick)
 
 	humi.adjust_coretemperature(skin_core_change)
 
@@ -1089,8 +1089,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	// Changes to the skin temperature based on the area
 	var/area_skin_diff = area_temp - humi.bodytemperature
 	if(!humi.on_fire || area_skin_diff > 0)
-		// change rate near full speed as area temp has large impact on the surface
-		var/area_skin_change = get_temp_change_amount(area_skin_diff, (BODYTEMP_CHANGE_RATE * 0.8) * seconds_per_tick)
+		// change rate of 0.05 speed as area temp has large impact on the surface
+		var/area_skin_change = get_temp_change_amount(area_skin_diff, BODYTEMP_AREA_SKIN_CHANGE_RATE * seconds_per_tick)
 
 		// We need to apply the thermal protection of the clothing when applying area to surface change
 		// If the core bodytemp goes over the normal body temp you are overheating and becom sweaty
@@ -1108,8 +1108,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(!humi.on_fire)
 		// Get the changes to the skin from the core temp
 		var/core_skin_diff = humi.coretemperature - humi.bodytemperature
-		// change rate slighty higher than core to skin to reflect temp back
-		var/core_skin_change = (1 + thermal_protection) * get_temp_change_amount(core_skin_diff, (BODYTEMP_CHANGE_RATE * 0.7) * seconds_per_tick)
+		// change rate of 0.045 to reflect temp back to the skin at the slight higher rate then core to skin
+		var/core_skin_change = (1 + thermal_protection) * get_temp_change_amount(core_skin_diff, BODYTEMP_CORE_SKIN_CHANGE_RATE * seconds_per_tick)
 
 		// We do not want to over shoot after using protection
 		if(core_skin_diff > 0)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1053,7 +1053,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
  * * humi (required) The mob we will stabilize
  */
 /datum/species/proc/body_temperature_core(mob/living/carbon/human/humi, seconds_per_tick)
-	var/natural_change = get_temp_change_amount(humi.get_body_temp_normal() - humi.coretemperature, 0.06 * seconds_per_tick)
+	var/natural_change = get_temp_change_amount(humi.get_body_temp_normal() - humi.coretemperature, BODYTEMP_CORE_CHANGE_RATE * seconds_per_tick)
 	humi.adjust_coretemperature(humi.metabolism_efficiency * natural_change)
 
 /**
@@ -1070,8 +1070,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	// change the core based on the skin temp
 	var/skin_core_diff = humi.bodytemperature - humi.coretemperature
-	// change rate of 0.04 per second to be slightly below area to skin change rate and still have a solid curve
-	var/skin_core_change = get_temp_change_amount(skin_core_diff, 0.04 * seconds_per_tick)
+	// change rate of slightly below area to skin change rate and still having a solid curve
+	var/skin_core_change = get_temp_change_amount(skin_core_diff, (BODYTEMP_CHANGE_RATE * 0.65) * seconds_per_tick)
 
 	humi.adjust_coretemperature(skin_core_change)
 
@@ -1089,8 +1089,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	// Changes to the skin temperature based on the area
 	var/area_skin_diff = area_temp - humi.bodytemperature
 	if(!humi.on_fire || area_skin_diff > 0)
-		// change rate of 0.05 as area temp has large impact on the surface
-		var/area_skin_change = get_temp_change_amount(area_skin_diff, 0.05 * seconds_per_tick)
+		// change rate near full speed as area temp has large impact on the surface
+		var/area_skin_change = get_temp_change_amount(area_skin_diff, (BODYTEMP_CHANGE_RATE * 0.8) * seconds_per_tick)
 
 		// We need to apply the thermal protection of the clothing when applying area to surface change
 		// If the core bodytemp goes over the normal body temp you are overheating and becom sweaty
@@ -1108,8 +1108,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(!humi.on_fire)
 		// Get the changes to the skin from the core temp
 		var/core_skin_diff = humi.coretemperature - humi.bodytemperature
-		// change rate of 0.045 to reflect temp back to the skin at the slight higher rate then core to skin
-		var/core_skin_change = (1 + thermal_protection) * get_temp_change_amount(core_skin_diff, 0.045 * seconds_per_tick)
+		// change rate slighty higher than core to skin to reflect temp back
+		var/core_skin_change = (1 + thermal_protection) * get_temp_change_amount(core_skin_diff, (BODYTEMP_CHANGE_RATE * 0.7) * seconds_per_tick)
 
 		// We do not want to over shoot after using protection
 		if(core_skin_diff > 0)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1070,7 +1070,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	// change the core based on the skin temp
 	var/skin_core_diff = humi.bodytemperature - humi.coretemperature
-	// change rate of 0.04 per second to be slightly below area to skin change rate and still have a solid curve
+	// change rate of slightly below area to skin change rate and still having a solid curve
 	var/skin_core_change = get_temp_change_amount(skin_core_diff, BODYTEMP_SKIN_CORE_CHANGE_RATE * seconds_per_tick)
 
 	humi.adjust_coretemperature(skin_core_change)
@@ -1089,7 +1089,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	// Changes to the skin temperature based on the area
 	var/area_skin_diff = area_temp - humi.bodytemperature
 	if(!humi.on_fire || area_skin_diff > 0)
-		// change rate of 0.05 as area temp has large impact on the surface
+		// change rate near full speed as area temp has large impact on the surface
 		var/area_skin_change = get_temp_change_amount(area_skin_diff, BODYTEMP_AREA_SKIN_CHANGE_RATE * seconds_per_tick)
 
 		// We need to apply the thermal protection of the clothing when applying area to surface change
@@ -1108,7 +1108,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(!humi.on_fire)
 		// Get the changes to the skin from the core temp
 		var/core_skin_diff = humi.coretemperature - humi.bodytemperature
-		// change rate of 0.045 to reflect temp back to the skin at the slight higher rate then core to skin
+		// change rate to reflect temp back to the skin at a slightly higher rate than skin to core
 		var/core_skin_change = (1 + thermal_protection) * get_temp_change_amount(core_skin_diff, BODYTEMP_CORE_SKIN_CHANGE_RATE * seconds_per_tick)
 
 		// We do not want to over shoot after using protection

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1089,7 +1089,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	// Changes to the skin temperature based on the area
 	var/area_skin_diff = area_temp - humi.bodytemperature
 	if(!humi.on_fire || area_skin_diff > 0)
-		// change rate of 0.05 speed as area temp has large impact on the surface
+		// change rate of 0.05 as area temp has large impact on the surface
 		var/area_skin_change = get_temp_change_amount(area_skin_diff, BODYTEMP_AREA_SKIN_CHANGE_RATE * seconds_per_tick)
 
 		// We need to apply the thermal protection of the clothing when applying area to surface change

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -598,7 +598,7 @@
 			temperature_setting = clamp(value + T0C, min_temp, max_temp)
 
 /obj/item/mod/module/thermal_regulator/on_active_process(seconds_per_tick)
-	mod.wearer.adjust_bodytemperature(get_temp_change_amount((temperature_setting - mod.wearer.bodytemperature), 0.08 * seconds_per_tick))
+	mod.wearer.adjust_bodytemperature(get_temp_change_amount((temperature_setting - mod.wearer.bodytemperature), (BODYTEMP_CHANGE_RATE * 1.4) * seconds_per_tick))
 
 ///DNA Lock - Prevents people without the set DNA from activating the suit.
 /obj/item/mod/module/dna_lock

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -598,7 +598,7 @@
 			temperature_setting = clamp(value + T0C, min_temp, max_temp)
 
 /obj/item/mod/module/thermal_regulator/on_active_process(seconds_per_tick)
-	mod.wearer.adjust_bodytemperature(get_temp_change_amount((temperature_setting - mod.wearer.bodytemperature), (BODYTEMP_CHANGE_RATE * 1.4) * seconds_per_tick))
+	mod.wearer.adjust_bodytemperature(get_temp_change_amount((temperature_setting - mod.wearer.bodytemperature), BODYTEMP_SUIT_CHANGE_RATE * seconds_per_tick))
 
 ///DNA Lock - Prevents people without the set DNA from activating the suit.
 /obj/item/mod/module/dna_lock


### PR DESCRIPTION
## About The Pull Request

- Creates a define for body temperature change rate
- Sets the rate of core temperature change to be slower than environmental body temperature change. The body should be able to autorecover towards its ideal temperature, but not powerful enough to negate the effects of the environment around you.

https://github.com/user-attachments/assets/ec867662-ca2d-427f-b8f2-41156707144b

## Why It's Good For The Game

Fixes #97333

## Changelog

:cl: LT3
fix: Players on Icebox should now take cold damage when naked outside
/:cl: