### PR TITLE
Fixes moving mob holders more than is necessary

### DIFF
--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -85,7 +85,8 @@
 		if(display_messages)
 			to_chat(captor, span_warning("[released_mob] wriggles free!"))
 		captor.dropItemToGround(src)
-	released_mob.forceMove(drop_location())
+	else
+		released_mob.forceMove(drop_location())
 	released_mob.reset_perspective()
 	released_mob.setDir(SOUTH)
 	if(display_messages)


### PR DESCRIPTION

## About The Pull Request

Don't need to drop it AND `forceMove()` it. If you throw, it ends up `forceMove()`ing twice.

## Why It's Good For The Game

<img width="425" height="98" alt="image" src="https://github.com/user-attachments/assets/e89aaf6a-9629-43fe-ac8b-19fb85e1eb78" />

## Changelog
:cl:
fix: Dropping or throwing a bug will no longer say that it uncurled several times
/:cl:
