### PR TITLE
Remove lie about reflective blob

### DIFF
--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -166,7 +166,7 @@
 	if(!can_buy(BLOB_UPGRADE_REFLECTOR_COST))
 		return
 
-	to_chat(src, span_warning("You secrete a reflective ooze over the shield blob, allowing it to reflect projectiles at the cost of reduced integrity."))
+	to_chat(src, span_warning("You secrete a reflective ooze over the shield blob, allowing it to reflect projectiles."))
 	shield = shield.change_to(/obj/structure/blob/shield/reflective, src)
 	shield.balloon_alert(src, "upgraded to [shield.name]!")
 

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -166,7 +166,7 @@
 	if(!can_buy(BLOB_UPGRADE_REFLECTOR_COST))
 		return
 
-	to_chat(src, span_warning("You secrete a reflective ooze over the shield blob, allowing it to reflect projectiles."))
+	to_chat(src, span_warning("You secrete a reflective ooze over the shield blob, allowing it to reflect projectiles at the cost of reduced resistance to explosions."))
 	shield = shield.change_to(/obj/structure/blob/shield/reflective, src)
 	shield.balloon_alert(src, "upgraded to [shield.name]!")
 

--- a/tgui/packages/tgui/interfaces/AntagInfoBlob.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoBlob.tsx
@@ -173,7 +173,7 @@ const Structures = (props) => {
         </LabeledList.Item>
         <LabeledList.Item label="Reflective Blobs">
           Upgrading strong blobs creates reflective blobs, capable of reflecting
-          most projectiles at the cost of the strong blob&apos;s extra health.
+          most projectiles.
         </LabeledList.Item>
         <LabeledList.Item label="Resource Blobs">
           Blobs which produce more resources for you, build as many of these as

--- a/tgui/packages/tgui/interfaces/AntagInfoBlob.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoBlob.tsx
@@ -173,7 +173,7 @@ const Structures = (props) => {
         </LabeledList.Item>
         <LabeledList.Item label="Reflective Blobs">
           Upgrading strong blobs creates reflective blobs, capable of reflecting
-          most projectiles.
+          most projectiles at the cost of reduced resistance to explosions.
         </LabeledList.Item>
         <LabeledList.Item label="Resource Blobs">
           Blobs which produce more resources for you, build as many of these as


### PR DESCRIPTION

## About The Pull Request
Corrects the text in the blob antag panel and the feedback message about reflective blob having reduced integrity. This is a change that was introduced in #52998, that pr simply neglected to change the aforementioned text.
The reflective blob only gets reduced "explosion_block" which is a variable used for the explosion-blocking element. I have no idea what this actually does & bombing the blob is already a stupid idea, but I changed the text to just mention this regardless.
## Why It's Good For The Game
This is slander that needs to be corrected
## Changelog
:cl:
spellcheck: removed the lies about reflective blob being weaker than strong blob
/:cl:
