### PR TITLE
Walls now remember what griders were used to make them.

### DIFF
--- a/code/datums/elements/uses_girder_wall_recipes.dm
+++ b/code/datums/elements/uses_girder_wall_recipes.dm
@@ -96,6 +96,13 @@
 	else
 		CRASH("Attempted a girder wall recipe with an invalid wall type ([recipe.wall_type])")
 
+	if(istype(wall, /turf/closed/wall))
+		var/turf/closed/wall/griderholder = wall
+		griderholder.girder_type = structure.type
+	if(istype(wall, /obj/structure/falsewall))
+		var/obj/structure/falsewall/griderholder = wall
+		griderholder.girder_type = structure.type
+
 	user.visible_message(
 		message = span_notice("\The [user] finish[user.p_es()] building \a [wall] on \the [structure]."),
 		self_message = span_notice("You finish building \a [wall] on \the [structure]."),


### PR DESCRIPTION
## About The Pull Request

Playing a round, made a cog grider, put some iron on it, changed my mind, welded it off, and... Iron grider. Bronze being highly limited resource, kinda sucked to have it literally vanish out of reality like that. So, here's a fix to that.

Right now:
https://github.com/user-attachments/assets/e2162c95-d278-4a00-bdb8-6de342c63b4a

Fixed:
https://github.com/user-attachments/assets/b451f8e4-f105-4459-9417-62318762b414

## Why It's Good For The Game

Unique material dissapearing into thin air is just a feels bad, plus, it just kinda makes sense for a wall to return to a grider it was made from, yeah?

## Changelog

:cl:
fix: Walls now remember what kind of grider was used to build them to return to upon deconstruction.
/:cl:
