### PR TITLE
Fixes a 4yr old projectile goof

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -615,7 +615,7 @@
 			user.pixel_x = 8
 			user.pixel_y = -12
 
-	emitter.last_projectile_params = calculate_projectile_angle_and_pixel_offsets(user, null, list2params(modifiers))
+	emitter.last_projectile_params = calculate_projectile_angle_and_pixel_offsets(user, null, modifiers)
 
 	if(emitter.charge >= 10 && world.time > delay)
 		emitter.charge -= 10

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1339,7 +1339,7 @@
 
 	var/ox = round(screenview[1] * 0.5) - user.client.pixel_x //"origin" x
 	var/oy = round(screenview[2] * 0.5) - user.client.pixel_y //"origin" y
-	angle = ATAN2(tx - oy, ty - ox)
+	angle = ATAN2(ty - oy, tx - ox)
 	return list(angle, p_x, p_y)
 
 /obj/projectile/experience_pressure_difference()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes a bug *somewhat* introduced in Oroboros': 
- https://github.com/tgstation/tgstation/pull/63654

The bug is located in ``proc/calculate_projectile_angle_and_pixel_offsets`` and you can locate the disconnect pretty clearly
https://github.com/tgstation/tgstation/blob/3d7be3d6288b8e94bbaaaaf89d748475b649a373/code/modules/projectiles/projectile.dm#L1306-L1343

one macro call of ATAN2 does ``angle = ATAN2(dy, dx)``

and the next macro call does ``angle = ATAN2(tx - oy, ty - ox)``

Prior to the mentioned PR, the second call passed the y first as intended.
However, afterwards, the y origin is now subtracted from the x target, and vice-versa.

On a normal viewport, ``ox == oy``, so the subtraction cancels itself out and leaves you with ``ATAN2(dx, dy)``. The angle mirrored across the 45 degree diagonal.

The primary beneficiary of this code, emitters, which never have a target, also was passing a bad modifiers arg. This is unrelated to the projectile PR, and seems to just have been some code that survived a few attack() refactors, and seems to originate circa 2021.

With some hilarity, both of these bugs have managed to cancel eachother out since atleast 2022. The emitter runtimes on the first LAZYACCESS, and so doesnt set ``last_projectile_params``, making ``fire_beam()`` fall back to ``projectile.fire(dir2angle(dir))``. 

Got all that? Good

Both are now fixed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A garbage, mirrored angle will *always* occur when the calculation proc is called with modifiers and no target.

At most, this bugfix just makes manual emitters fire at cursor, as opposed to snapping to a cardinal direction.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: rkz/Tsar-Salat
fix: manually aimed emitters now fire where you clicked instead of snapping to the direction they face
fix: fixes a 4 year old projectile code bug that mirrored the angle across the diagonal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
