### PR TITLE
Moves SM healing diode to experimental tools

### DIFF
--- a/code/modules/research/techweb/nodes/atmos_nodes.dm
+++ b/code/modules/research/techweb/nodes/atmos_nodes.dm
@@ -108,6 +108,7 @@
 		"rcd_ammo",
 		"weldingmask",
 		"magboots",
+		"diode_disk_stamina",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS)
 	discount_experiments = list(/datum/experiment/ordnance/gaseous/bz = TECHWEB_TIER_4_POINTS)

--- a/code/modules/research/techweb/nodes/engi_nodes.dm
+++ b/code/modules/research/techweb/nodes/engi_nodes.dm
@@ -178,7 +178,7 @@
 		"inducerengi",
 		"welding_goggles",
 		"tray_goggles",
-		"geigercounter"
+		"geigercounter",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 	announce_channels = list(RADIO_CHANNEL_ENGINEERING)

--- a/code/modules/research/techweb/nodes/engi_nodes.dm
+++ b/code/modules/research/techweb/nodes/engi_nodes.dm
@@ -178,8 +178,7 @@
 		"inducerengi",
 		"welding_goggles",
 		"tray_goggles",
-		"geigercounter",
-		"diode_disk_stamina"
+		"geigercounter"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 	announce_channels = list(RADIO_CHANNEL_ENGINEERING)


### PR DESCRIPTION

## About The Pull Request
Moves the electrodistruptive diode disk from the energy manipulation tech node to the experimental tools tech node.
## Why It's Good For The Game
This thing is stupidly powerful for being round-start research, and makes it possible to make an immortal SM nearly 5 minutes in. While this doesn't fix the immortal SM issue, this does make it so engineers have to at least wait some time to make one.
## Changelog
:cl:
balance: The electrodistruptive diode disk has been moved from energy manipulation research to experimental tools research
/:cl:
