### PR TITLE
Removes portable from portable dispenser name

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -299,8 +299,8 @@
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/design/board/chem_dispenser
-	name = "Portable Chem Dispenser Board"
-	desc = "The circuit board for a portable chem dispenser."
+	name = "Chem Dispenser Board"
+	desc = "The circuit board for a chem dispenser."
 	id = "chem_dispenser"
 	build_path = /obj/item/circuitboard/machine/chem_dispenser
 	category = list(


### PR DESCRIPTION

## About The Pull Request
Removes the portable part of the chem dispenser in the board printer
## Why It's Good For The Game
This just prints a normal chem dispenser, so I'm not sure why it even has portable in the name
## Changelog
:cl:
spellcheck: Removed "portable" from the portable chem dispenser board (it was just a normal dispensor anyways)
/:cl:
