### PR TITLE
Optimize /mob/living/carbon/human/check_breath() by ~41%

### DIFF
--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -28,15 +28,15 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment/organ_tissue = 5, /datum/reagent/medicine/salbutamol = 5)
 
 	/// Our previous breath's partial pressures, in the form gas id -> partial pressure
-	var/list/last_partial_pressures = list()
+	var/alist/last_partial_pressures = alist()
 	/// List of gas to treat as other gas, in the form list(inital_gas, treat_as, multiplier)
 	var/list/treat_as = list()
-	/// Assoc list of procs to run while a gas is present, in the form gas id -> proc_path
-	var/list/breath_present = list()
-	/// Assoc list of procs to run when a gas is immediately removed from the breath, in the form gas id -> proc_path
-	var/list/breath_lost = list()
-	/// Assoc list of procs to always run, in the form gas_id -> proc_path
-	var/list/breathe_always = list()
+	/// Alist of procs to run while a gas is present, in the form gas id -> proc_path
+	var/alist/breath_present = alist()
+	/// Alist of procs to run when a gas is immediately removed from the breath, in the form gas id -> proc_path
+	var/alist/breath_lost = alist()
+	/// Alist of procs to always run, in the form gas_id -> proc_path
+	var/alist/breathe_always = alist()
 
 	/// Gas mixture to breath out when we're done processing a breath
 	/// Will get emptied out when it's all done
@@ -168,12 +168,12 @@
 	// This is very "manual" I realize, but it's useful to ensure cleanup for gases we're removing happens
 	// Avoids stuck alerts and such
 	var/static/datum/gas_mixture/immutable/dummy = new(BREATH_VOLUME)
-	for(var/gas_id in last_partial_pressures)
+	for(var/gas_id, partial_pressure in last_partial_pressures)
 		var/on_loss = breath_lost[gas_id]
 		if(!on_loss)
 			continue
 
-		call(src, on_loss)(organ_owner, dummy, last_partial_pressures[gas_id])
+		call(src, on_loss)(organ_owner, dummy, partial_pressure)
 	dummy.garbage_collect()
 
 /**
@@ -633,13 +633,13 @@
 	var/old_euphoria = (n2o_euphoria == EUPHORIA_ACTIVE || healium_euphoria == EUPHORIA_ACTIVE)
 
 	// Cache for sonic speed
-	var/list/last_partial_pressures = src.last_partial_pressures
-	var/list/breathe_always = src.breathe_always
-	var/list/breath_present = src.breath_present
-	var/list/breath_lost = src.breath_lost
+	var/alist/last_partial_pressures = src.last_partial_pressures
+	var/alist/breathe_always = src.breathe_always
+	var/alist/breath_present = src.breath_present
+	var/alist/breath_lost = src.breath_lost
 
 	// Build out our partial pressures, for use as we go
-	var/list/partial_pressures = list()
+	var/alist/partial_pressures = alist()
 	for(var/gas_id, amount in breath_moles)
 		partial_pressures[gas_id] = breath.get_breath_partial_pressure(amount * received_pressure_mult)
 
@@ -655,11 +655,10 @@
 
 	// First, we breathe the stuff that always wants to be processed
 	// This is typically things like o2, stuff the mob needs to live
-	for(var/breath_id in breathe_always)
+	// Ensures the gas will always be instanciated, so people can interact with it safely
+	for(var/breath_id, inhale in breathe_always)
 		var/partial_pressure = partial_pressures[breath_id] || 0
 		var/old_partial_pressure = last_partial_pressures[breath_id] || 0
-		// Ensures the gas will always be instanciated, so people can interact with it safely
-		var/inhale = breathe_always[breath_id]
 		call(src, inhale)(breather, breath, partial_pressure, old_partial_pressure)
 
 	// Now we'll handle the callbacks that want to be run conditionally off our current breath
@@ -675,7 +674,7 @@
 				call(src, on_lose)(breather, breath, partial_pressures[gas_id], last_partial_pressures[gas_id])
 
 	// Finally, we'll run the callbacks that aren't in breath_gases, but WERE in our last breath
-	for(var/gas_id in last_partial_pressures)
+	for(var/gas_id, partial_pressure in last_partial_pressures)
 		// If we still have it, go away
 		if(breath_moles[gas_id])
 			continue
@@ -683,7 +682,7 @@
 		if(!on_loss)
 			continue
 
-		call(src, on_loss)(breather, breath, last_partial_pressures[gas_id])
+		call(src, on_loss)(breather, breath, partial_pressure)
 
 	src.last_partial_pressures = partial_pressures
 


### PR DESCRIPTION

## About The Pull Request
<img width="2050" height="1149" alt="image" src="https://github.com/user-attachments/assets/bf1cd63d-bec3-454c-aa01-afad30c9fa2a" />

[Traces can be downloaded here, compressed into a .7z](https://drive.google.com/file/d/1aZqDoA9FWSwFC0x-Fn51JnIRx1VzkNQV/view?usp=sharing)


## Why It's Good For The Game
CPU number go down.

## Changelog
:cl: Metek
refactor: Thanks to cutting edge technological advances, check_breath() calculations have been optimized by approximately 41% ( using alist() instead of list() )
/:cl:
