### PR TITLE
Fix runtime with tarot cards and tables

### DIFF
--- a/code/modules/cards/deck/tarot.dm
+++ b/code/modules/cards/deck/tarot.dm
@@ -22,7 +22,7 @@
 	if(prob(50))
 		var/obj/item/toy/singlecard/card = .
 		if(!card)
-			return FALSE
+			return
 
 		var/matrix/M = matrix()
 		M.Turn(180)


### PR DESCRIPTION

## About The Pull Request

`FALSE` (0) will pass an isnull check, causing `table_place_act` to run with a card reference of `0`
https://github.com/tgstation/tgstation/blob/fea1d3b2c2ab823c5814ea49049ce19f89de9843/code/game/objects/structures/tables_racks.dm#L380


## Why It's Good For The Game

Fixes #97384 

## Changelog

N/A
