### PR TITLE
Fix black broth recipe

### DIFF
--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -1463,6 +1463,7 @@
 	drink_type = MEAT | VEGETABLES | GORE
 
 /datum/chemical_reaction/food/soup/black_broth
+	required_temp = 350
 	required_reagents = list(
 		/datum/reagent/water = 40,
 		/datum/reagent/consumable/vinegar = 8,

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -1467,7 +1467,6 @@
 		/datum/reagent/water = 40,
 		/datum/reagent/consumable/vinegar = 8,
 		/datum/reagent/blood = 8,
-		/datum/reagent/consumable/ice = 4,
 	)
 	required_ingredients = list(
 		/obj/item/food/tiziran_sausage = 1,

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -1463,7 +1463,7 @@
 	drink_type = MEAT | VEGETABLES | GORE
 
 /datum/chemical_reaction/food/soup/black_broth
-	required_temp = 350
+	required_temp = 325
 	required_reagents = list(
 		/datum/reagent/water = 40,
 		/datum/reagent/consumable/vinegar = 8,


### PR DESCRIPTION
## About The Pull Request

Removes the 4 units of ice from the tiziran black broth recipe

## Why It's Good For The Game

Now you can actually make the soup because it's not expecting ice at a temperature it will immediately melt at.

## Changelog

:cl:
fix: Black broth no longer requires ice to make.
/:cl:
