### PR TITLE
Setting a crate's access no longer repeatedy appends the new authority to the description

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -767,10 +767,10 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 			if("Personal") //only the player who swiped their id has access.
 				id_card = WEAKREF(card)
 				name = "[card.registered_name]'s locker"
-				desc += " It has been ID locked to [card.registered_name]."
+				desc = initial(desc) + " It has been ID locked to [card.registered_name]."
 			if("Job") //anyone who has the same access permissions as this id has access. Does NOT apply to the whole department.
 				name = "[card.assignment]'s locker"
-				desc += " It has been access locked to [card.assignment]s."
+				desc = initial(desc) + " It has been access locked to [card.assignment]s."
 				set_access(card.GetAccess())
 			if("None") //free for all
 				name = initial(name)


### PR DESCRIPTION

## About The Pull Request

As written.

## Why It's Good For The Game

fixes #97380

## Changelog
:cl:

fix: Resetting a crate's access no longer repeatedly appends the new authority to the description

/:cl:
