### PR TITLE
Cargo can rip manifests off of locked crates

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -111,10 +111,9 @@
 		. += lid
 
 /obj/structure/closet/crate/attack_hand(mob/user, list/modifiers)
-	. = ..()
-	if(.)
-		return
-	tear_manifest(user)
+	if(tear_manifest(user))
+		return TRUE
+	return ..()
 
 /obj/structure/closet/crate/after_open(mob/living/user, force)
 	. = ..()
@@ -147,12 +146,12 @@
 
 	UnregisterSignal(src, COMSIG_CLOSET_CONTENTS_INITIALIZED)
 
-///Removes the supply manifest from the closet
+///Removes the supply manifest from the closet, returning TRUE if one was torn off
 /obj/structure/closet/crate/proc/tear_manifest(mob/user)
 	var/obj/item/paper/fluff/jobs/cargo/manifest/our_manifest = manifest?.resolve()
 	if(QDELETED(our_manifest))
 		manifest = null
-		return
+		return FALSE
 	if(user)
 		to_chat(user, span_notice("You tear the manifest off of [src]."))
 	playsound(src, 'sound/items/poster/poster_ripped.ogg', 75, TRUE)
@@ -162,6 +161,7 @@
 		user.put_in_hands(our_manifest)
 	manifest = null
 	update_appearance()
+	return TRUE
 
 /obj/structure/closet/crate/preopen
 	opened = TRUE

--- a/code/game/objects/structures/crates_lockers/crates/large.dm
+++ b/code/game/objects/structures/crates_lockers/crates/large.dm
@@ -26,9 +26,7 @@
 
 /obj/structure/closet/crate/large/attack_hand(mob/user, list/modifiers)
 	add_fingerprint(user)
-	if(manifest)
-		tear_manifest(user)
-	else
+	if(!tear_manifest(user))
 		to_chat(user, span_warning("You need a crowbar to pry this open!"))
 
 /obj/structure/closet/crate/large/item_interaction(mob/living/user, obj/item/tool, list/modifiers)


### PR DESCRIPTION

## About The Pull Request

Cargo techs (well anyone really) can now rip manifests off of locked crates.

## Why It's Good For The Game

Felt like a bug, especially since they already could do so for departmentally-locked crates

## Changelog
:cl: PapaMichael
fix: You are now able to rip manifests off of all locked cargo crates
/:cl:
