### PR TITLE
Fixes runtime from ethereal glow status effect

### DIFF
--- a/code/modules/surgery/bodyparts/bodypart_effects/bodypart_effect.dm
+++ b/code/modules/surgery/bodyparts/bodypart_effects/bodypart_effect.dm
@@ -16,9 +16,6 @@
 
 /// Merge a bodypart into the effect
 /datum/status_effect/grouped/bodypart_effect/proc/add_bodypart(obj/item/bodypart/bodypart, special, lazy)
-	if(bodypart in bodyparts)
-		return FALSE
-
 	RegisterSignal(bodypart, COMSIG_BODYPART_REMOVED, PROC_REF(on_bodypart_removed))
 	RegisterSignal(bodypart, COMSIG_QDELETING, PROC_REF(on_bodypart_destroyed))
 
@@ -26,8 +23,6 @@
 
 	if(!is_active && bodyparts.len >= minimum_bodyparts)
 		activate()
-
-	return TRUE
 
 /// Remove a bodypart from the effect. Deleting = TRUE is used during clean-up phase
 /datum/status_effect/grouped/bodypart_effect/proc/remove_bodypart(mob/living/carbon/old_owner, obj/item/bodypart/bodypart, deleting)

--- a/code/modules/surgery/bodyparts/bodypart_effects/bodypart_effect.dm
+++ b/code/modules/surgery/bodyparts/bodypart_effects/bodypart_effect.dm
@@ -16,6 +16,9 @@
 
 /// Merge a bodypart into the effect
 /datum/status_effect/grouped/bodypart_effect/proc/add_bodypart(obj/item/bodypart/bodypart, special, lazy)
+	if(bodypart in bodyparts)
+		return FALSE
+
 	RegisterSignal(bodypart, COMSIG_BODYPART_REMOVED, PROC_REF(on_bodypart_removed))
 	RegisterSignal(bodypart, COMSIG_QDELETING, PROC_REF(on_bodypart_destroyed))
 
@@ -24,9 +27,11 @@
 	if(!is_active && bodyparts.len >= minimum_bodyparts)
 		activate()
 
+	return TRUE
+
 /// Remove a bodypart from the effect. Deleting = TRUE is used during clean-up phase
 /datum/status_effect/grouped/bodypart_effect/proc/remove_bodypart(mob/living/carbon/old_owner, obj/item/bodypart/bodypart, deleting)
-	UnregisterSignal(bodypart, COMSIG_BODYPART_REMOVED)
+	UnregisterSignal(bodypart, list(COMSIG_BODYPART_REMOVED, COMSIG_QDELETING))
 
 	bodyparts.Remove(bodypart)
 

--- a/code/modules/surgery/bodyparts/bodypart_effects/ethereal_glow.dm
+++ b/code/modules/surgery/bodyparts/bodypart_effects/ethereal_glow.dm
@@ -35,7 +35,7 @@
 
 /datum/status_effect/grouped/bodypart_effect/ethereal_glow/add_bodypart(obj/item/bodypart/bodypart, special, lazy)
 	. = ..()
-	if (. && !lazy)
+	if (!lazy)
 		refresh_light_color()
 
 /datum/status_effect/grouped/bodypart_effect/ethereal_glow/on_remove()

--- a/code/modules/surgery/bodyparts/bodypart_effects/ethereal_glow.dm
+++ b/code/modules/surgery/bodyparts/bodypart_effects/ethereal_glow.dm
@@ -35,7 +35,7 @@
 
 /datum/status_effect/grouped/bodypart_effect/ethereal_glow/add_bodypart(obj/item/bodypart/bodypart, special, lazy)
 	. = ..()
-	if (!lazy)
+	if (. && !lazy)
 		refresh_light_color()
 
 /datum/status_effect/grouped/bodypart_effect/ethereal_glow/on_remove()


### PR DESCRIPTION
## About The Pull Request

```[00:50:49] Runtime in code/datums/signals.dm, line 43: parent_qdeleting overridden. Use override = TRUE to suppress this warning. Target: the ethereal left leg (/obj/item/bodypart/leg/left/ethereal) Existing Proc: on_bodypart_destroyed New Proc: on_bodypart_destroyed
proc name: stack trace (/proc/_stack_trace)
usr: blah
usr.loc: (start area (8,248,1))
src: null
call stack:
stack trace("parent_qdeleting overridden. U...", "code/datums/signals.dm", 43)
/datum/status_effect/grouped/b... (/datum/status_effect/grouped/bodypart_effect/ethereal_glow): RegisterSignal(the ethereal left leg (/obj/item/bodypart/leg/left/ethereal), "parent_qdeleting", "on_bodypart_destroyed", 0)
/datum/status_effect/grouped/b... (/datum/status_effect/grouped/bodypart_effect/ethereal_glow): add bodypart(the ethereal left leg (/obj/item/bodypart/leg/left/ethereal), 1, null)
/datum/status_effect/grouped/b... (/datum/status_effect/grouped/bodypart_effect/ethereal_glow): add bodypart(the ethereal left leg (/obj/item/bodypart/leg/left/ethereal), 1, null)
/datum/status_effect/grouped/b... (/datum/status_effect/grouped/bodypart_effect/ethereal_glow): source added(/mob/living/carbon/human/dummy (/mob/living/carbon/human/dummy), the ethereal left leg (/obj/item/bodypart/leg/left/ethereal), 1, null)
/datum/status_effect/grouped/b... (/datum/status_effect/grouped/bodypart_effect/ethereal_glow): on creation(Claribel Endsley (/mob/living/carbon/human/dummy), /mob/living/carbon/human/dummy (/mob/living/carbon/human/dummy), the ethereal left leg (/obj/item/bodypart/leg/left/ethereal), 1, null)
/datum/status_effect/grouped/b... (/datum/status_effect/grouped/bodypart_effect/ethereal_glow): New(/list (/list))
Claribel Endsley (/mob/living/carbon/human/dummy): apply status effect(/datum/status_effect/grouped/b... (/datum/status_effect/grouped/bodypart_effect/ethereal_glow), /mob/living/carbon/human/dummy (/mob/living/carbon/human/dummy), the ethereal left leg (/obj/item/bodypart/leg/left/ethereal), 1, null)
Claribel Endsley (/mob/living/carbon/human/dummy): add bodypart(the ethereal left leg (/obj/item/bodypart/leg/left/ethereal), 1, null)
the ethereal left leg (/obj/item/bodypart/leg/left/ethereal): try attach limb(Claribel Endsley (/mob/living/carbon/human/dummy), 1, null)
```

Tin, just fixes this. `COMSIG_QDELETING` should be unregistered here as well, and also adds a check to stop glow color from being recalculated needlessly

## Why It's Good For The Game

Less runtimes

## Changelog

Nothing player facing