### PR TITLE
Fixes chasms, god bless 80 less runtimes per deathmatch train game

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -51,6 +51,8 @@
 	//otherwise don't do anything because turfs and areas are initialized before movables.
 	if(!mapload)
 		addtimer(CALLBACK(src, PROC_REF(drop_stuff)), 0)
+	else if(HAS_TRAIT(parent, TRAIT_CHASM_STOPPED)) // The lattice initialized before we could set our signals
+		on_chasm_stopped(parent)
 	parent.AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[/datum/fish_source/chasm])
 
 /datum/component/chasm/UnregisterFromParent()


### PR DESCRIPTION

## About The Pull Request

- Fixes chasms runtiming a bunch if they were maploaded with lattices on top of them, and then the lattice was destroyed
(Btw, i think the reason is that lattices would init before chasms and add the chasm safety trait, so chasms were too slow to register to actually react to that trait in time)

<details>
<summary>Before (89 runtimes in trainship hijack)</summary>

Image showing the evil ass chasm having all its signals that are supposed to only exist while it is NOT covered

<img width="1600" height="859" alt="image" src="https://github.com/user-attachments/assets/fd62f3cf-45a1-47a5-98de-7543071b8010" />

Image showing all the runtimes created from going into a game, deathmatch with trainship hijack, throwing myself into a chasm

<img width="1191" height="425" alt="image" src="https://github.com/user-attachments/assets/4d279cd9-065e-4366-a8de-456630c7fd32" />

</details>

<details>
<summary>After (6 runtimes in trainship hijack)</summary>

Image showing the neutral chaotic chasm having all its signals it should have (probably, i didn't check but there's less of em)

<img width="1599" height="857" alt="image" src="https://github.com/user-attachments/assets/b36d7624-603e-4453-bdad-6774424facb9" />

Image showing all the runtimes created from going into a game, deathmatch with trainship hijack, throwing myself into a chasm

<img width="600" height="343" alt="image" src="https://github.com/user-attachments/assets/1bb7ec2a-c850-4b89-bd2a-940c9084ed01" />

</details>

## Why It's Good For The Game

I hate runtimes, they run at times so i break their legs

## Changelog

:cl:
code: fixed chasms ignoring lattices on top of them in some scenario's, creating a lot of runtimes
/:cl:
