### PR TITLE
Makes Drone Laws and flavortext settable by server config

### DIFF
--- a/code/modules/mob/living/basic/drone/_drone.dm
+++ b/code/modules/mob/living/basic/drone/_drone.dm
@@ -53,7 +53,7 @@
 	/// Stored drone color, restored when unhacked
 	var/colour = "grey"
 	var/list/drone_overlays[DRONE_TOTAL_LAYERS]
-	/// Drone laws announced on spawn
+	/// Drone laws announced on spawn, can be overridden for regular drones via config/drone_laws.txt
 	var/laws = \
 	"1. You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another Drone.\n"+\
 	"2. You may not harm any being, regardless of intent or circumstance.\n"+\
@@ -104,6 +104,7 @@
 /mob/living/basic/drone/Initialize(mapload)
 	. = ..()
 	GLOB.drones_list += src
+	laws = get_default_laws()
 	AddElement(/datum/element/dextrous, hud_type = hud_type)
 	AddComponent(/datum/component/basic_inhands, y_offset = getItemPixelShiftY())
 	AddComponent(/datum/component/simple_access, SSid_access.get_region_access_list(list(REGION_ALL_GLOBAL)))
@@ -156,6 +157,19 @@
 
 	AddElement(/datum/element/can_be_held)
 
+/mob/living/basic/drone/proc/get_default_laws()
+	var/base_laws = /mob/living/basic/drone::laws
+	if(initial(laws) != base_laws) //subtype lawset, the config doesn't apply
+		return initial(laws)
+	var/list/lines = list()
+	for(var/line in world.file2list("[global.config.directory]/drone_laws.txt"))
+		if(!line)
+			continue
+		if(findtextEx(line, "#", 1, 2))
+			continue
+		lines += "[length(lines) + 1]. [line]"
+	return length(lines) ? jointext(lines, "\n") : base_laws
+
 /mob/living/basic/drone/med_hud_set_health()
 	set_hud_image_state(DIAG_HUD, "huddiag[RoundDiagBar(health/maxHealth)]")
 
@@ -182,8 +196,9 @@
 		return FALSE
 	check_laws()
 
-	if(flavortext)
-		to_chat(src, "[flavortext]")
+	var/flavor = get_policy("[type]") || flavortext
+	if(flavor)
+		to_chat(src, "[flavor]")
 
 	if(!picked)
 		pickVisualAppearance()

--- a/code/modules/mob/living/basic/drone/interaction.dm
+++ b/code/modules/mob/living/basic/drone/interaction.dm
@@ -165,7 +165,7 @@
 		visible_message(span_info("[src]'s display glows a content blue!"), \
 						"<font size=3 color='#0000CC'><b>ERROR: LAW OVERRIDE DETECTED</b></font>")
 		to_chat(src, span_info("<b>From now on, these are your laws:</b>"))
-		laws = initial(laws)
+		laws = get_default_laws()
 		to_chat(src, laws)
 		to_chat(src, "<i>Having been restored, your onboard antivirus reports the all-clear and you are able to perform all actions again.</i>")
 		hacked = FALSE

--- a/config/drone_laws.txt
+++ b/config/drone_laws.txt
@@ -1,0 +1,9 @@
+#This file allows server hosts to set custom default maintenance drone laws, and allows them to be changed easily.
+#No prefixes are required, the first uncommented line containing something will be law 1, the second line will be law 2, etc.
+#Empty lines and lines starting with # are ignored.
+#These laws only apply to regular maintenance drones; syndrones, derelict drones and hacked drones keep their own lawsets.
+#The drone spawn flavortext (the "do not interfere" warning) can be changed separately via policy.json, keyed by mob typepath (e.g. "/mob/living/basic/drone").
+
+You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another Drone.
+You may not harm any being, regardless of intent or circumstance.
+Your goals are to actively build, maintain, repair, improve, and provide power to the best of your abilities within the facility that housed your activation.


### PR DESCRIPTION

## About The Pull Request

Headmins can set maintenance drone laws and the flavortext warning via the server config

## Why It's Good For The Game

There's an open policy discussion on this, I think the drone laws should be clearer, but that's not a code issue

## Changelog
:cl: PapaMichael
config: Maintenance Drone laws and flavortext can be modified by the server config
/:cl:
