### PR TITLE
Converts Changelog to tsx

### DIFF
--- a/tgui/packages/tgui/interfaces/Changelog.tsx
+++ b/tgui/packages/tgui/interfaces/Changelog.tsx
@@ -100,13 +100,11 @@ export class ChangelogContent extends Component<any, ChangelogState> {
           return;
         }
 
+        const timeout = 50 + attemptNumber * 50;
         this.setData(`Loading changelog data${'.'.repeat(attemptNumber + 3)}`);
-        setTimeout(
-          () => {
-            this.getData(date, attemptNumber + 1);
-          },
-          50 + attemptNumber * 50,
-        );
+        setTimeout(() => {
+          this.getData(date, attemptNumber + 1);
+        }, timeout);
         return;
       }
 

--- a/tgui/packages/tgui/interfaces/Changelog.tsx
+++ b/tgui/packages/tgui/interfaces/Changelog.tsx
@@ -45,19 +45,35 @@ const icons = {
   wip: { icon: 'hammer', color: 'orange' },
 };
 
-export class Changelog extends Component {
+type Change = Record<string, string>;
+type AuthorChanges = Record<string, Change[]>;
+type ChangelogYaml = Record<string, AuthorChanges>;
+
+type ChangelogState = {
+  loaded_text: ChangelogYaml | string;
+  selectedDate: string;
+  selectedIndex: number;
+};
+
+type ChangelogData = {
+  dates: string[];
+};
+
+export class ChangelogContent extends Component<any, ChangelogState> {
+  dateChoices: string[];
+
   constructor(props) {
     super(props);
+    this.dateChoices = [];
     this.state = {
-      data: 'Loading changelog data...',
+      loaded_text: 'Loading changelog data...',
       selectedDate: '',
       selectedIndex: 0,
     };
-    this.dateChoices = [];
   }
 
-  setData(data) {
-    this.setState({ data });
+  setData(loaded_text) {
+    this.setState({ loaded_text });
   }
 
   setSelectedDate(selectedDate) {
@@ -69,7 +85,6 @@ export class Changelog extends Component {
   }
 
   getData = (date, attemptNumber = 1) => {
-    const self = this;
     const maxAttempts = 6;
 
     if (attemptNumber > maxAttempts) {
@@ -79,26 +94,32 @@ export class Changelog extends Component {
     act('get_month', { date });
 
     fetch(resolveAsset(`${date}.yml`)).then(async (changelogData) => {
-      const result = await changelogData.text();
-      const errorRegex = /^Cannot find/;
+      if (!changelogData.ok) {
+        if (attemptNumber >= maxAttempts) {
+          this.setData(`Failed to load after ${maxAttempts} attempts`);
+          return;
+        }
 
-      if (errorRegex.test(result)) {
-        const timeout = 50 + attemptNumber * 50;
-
-        self.setData(`Loading changelog data${'.'.repeat(attemptNumber + 3)}`);
-        setTimeout(() => {
-          self.getData(date, attemptNumber + 1);
-        }, timeout);
-      } else {
-        self.setData(yaml.load(result, { schema: yaml.CORE_SCHEMA }));
+        this.setData(`Loading changelog data${'.'.repeat(attemptNumber + 3)}`);
+        setTimeout(
+          () => {
+            this.getData(date, attemptNumber + 1);
+          },
+          50 + attemptNumber * 50,
+        );
+        return;
       }
+
+      const result = await changelogData.text();
+      this.setData(
+        yaml.load(result, { schema: yaml.CORE_SCHEMA }) as ChangelogYaml,
+      );
     });
   };
 
   componentDidMount() {
-    const {
-      data: { dates = [] },
-    } = useBackend();
+    const { data } = useBackend<ChangelogData>();
+    const { dates = [] } = data;
 
     if (dates) {
       dates.forEach((date) => {
@@ -110,10 +131,10 @@ export class Changelog extends Component {
   }
 
   render() {
-    const { data, selectedDate, selectedIndex } = this.state;
-    const {
-      data: { dates },
-    } = useBackend();
+    const { data } = useBackend<ChangelogData>();
+    const { dates = [] } = data;
+    const { loaded_text, selectedIndex, selectedDate } = this
+      .state as ChangelogState;
     const { dateChoices } = this;
 
     const dateDropdown = dateChoices.length > 0 && (
@@ -297,9 +318,9 @@ export class Changelog extends Component {
     );
 
     const changes =
-      typeof data === 'object' &&
-      Object.keys(data).length > 0 &&
-      Object.entries(data)
+      typeof loaded_text === 'object' &&
+      Object.keys(loaded_text).length > 0 &&
+      Object.entries(loaded_text)
         .reverse()
         .map(([date, authors]) => (
           <Section key={date} title={dateformat(date, 'd mmmm yyyy', true)}>
@@ -347,14 +368,22 @@ export class Changelog extends Component {
         ));
 
     return (
-      <Window title="Changelog" width={675} height={650}>
-        <Window.Content scrollable>
-          {header}
-          {changes}
-          {typeof data === 'string' && <p>{data}</p>}
-          {footer}
-        </Window.Content>
-      </Window>
+      <>
+        {header}
+        {changes}
+        {typeof loaded_text === 'string' && <p>{loaded_text}</p>}
+        {footer}
+      </>
     );
   }
 }
+
+export const Changelog = () => {
+  return (
+    <Window title="Changelog" width={675} height={650}>
+      <Window.Content scrollable>
+        <ChangelogContent />
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION
## About The Pull Request

Converts Changelog from jsx to tsx
Renames "data" to "loaded_text" because that's what it actually is
Makes Changelog failure work regardless of what the failure is
Splits Changelog into ChangelogContent and Changelog

## Why It's Good For The Game

We've generally been trying to move more towards tsx and I got a little confused while reading through the file while messing with it downstream, thought I might as well convert it.

## Changelog

:cl:
code: Converted Changelog to typescript.
/:cl: