### PR TITLE
Fixes goldgrub breeding parties at ore vents

### DIFF
--- a/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
+++ b/code/modules/mob/living/basic/lavaland/goldgrub/goldgrub.dm
@@ -147,16 +147,6 @@
 		max_eggs_held = 1,\
 	)
 
-/mob/living/basic/mining/goldgrub/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
-	. = ..()
-	if(!istype(arrived, /obj/item/stack/ore))
-		return
-	if(!can_lay_eggs)
-		return
-	if(!istype(arrived, /obj/item/stack/ore/bluespace_crystal) || prob(60))
-		return
-	new /obj/item/food/egg/green/grub_egg(get_turf(src))
-
 /mob/living/basic/mining/goldgrub/update_overlays()
 	. = ..()
 	if(has_emissive)


### PR DESCRIPTION

## About The Pull Request

Goldgrubs no longer spawn eggs when eating bluespace crystals unless hand-fed them, rather than doing so even when eating ore off the ground

## Why It's Good For The Game

While the removal does somewhat impact the sandbox element of the game, current behavior also results in goldgrub digging parties at untapped ore vents, as they crack open boulders and eat (guaranteed) bluespace crystals from them, spawning more goldgrubs which do the same, spawning even more goldgrubs, etc.
Wild breeding in general is risky for CPU time, so its probably best to remove this behavior regardless of the issue describing above.

## Changelog
:cl:
del: Goldgrub no longer reproduce unless hand fed ores
/:cl:
