### PR TITLE
PKA cooldown upgrades now no longer care about what order they're provided in.

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -429,7 +429,7 @@
 /obj/item/borg/upgrade/modkit/cooldown/proc/get_recharge_time(obj/item/gun/energy/recharge/kinetic_accelerator/KA)
 	var/new_recharge_time = initial(KA.recharge_time)
 	for(var/obj/item/borg/upgrade/modkit/modkit_upgrade as anything in KA.modkits)
-		if(istype(modkit_upgrade, /obj/item/borg/upgrade/modkit/cooldown))
+		if(istype(modkit_upgrade, src))
 			new_recharge_time += modkit_upgrade.modifier
 
 	return new_recharge_time

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -1,3 +1,6 @@
+#define PKA_COOLDOWN_INCREMENT 3.2
+#define STANDARD_RECHARGE_TIME 16
+
 /obj/item/gun/energy/recharge/kinetic_accelerator
 	name = "proto-kinetic accelerator"
 	desc = "A self recharging, ranged mining tool that does increased damage in low pressure."
@@ -10,6 +13,7 @@
 	resistance_flags = FIRE_PROOF
 	weapon_weight = WEAPON_LIGHT
 	gun_flags = NOT_A_REAL_GUN
+	recharge_time = STANDARD_RECHARGE_TIME
 	///List of all mobs that projectiles fired from this gun will ignore.
 	var/list/ignored_mob_types
 	///List of all modkits currently in the kinetic accelerator.
@@ -417,7 +421,7 @@
 /obj/item/borg/upgrade/modkit/cooldown
 	name = "cooldown decrease"
 	desc = "Decreases the cooldown of a kinetic accelerator. Not rated for minebot use."
-	modifier = 3.2
+	modifier = -PKA_COOLDOWN_INCREMENT
 	minebot_upgrade = FALSE
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT * 0.75, /datum/material/gold = SHEET_MATERIAL_AMOUNT * 0.75, /datum/material/uranium = HALF_SHEET_MATERIAL_AMOUNT)
 
@@ -425,8 +429,8 @@
 /obj/item/borg/upgrade/modkit/cooldown/proc/get_recharge_time(obj/item/gun/energy/recharge/kinetic_accelerator/KA)
 	var/new_recharge_time = initial(KA.recharge_time)
 	for(var/obj/item/borg/upgrade/modkit/modkit_upgrade as anything in KA.modkits)
-		if(istype(modkit_upgrade, src))
-			new_recharge_time -= modifier
+		if(istype(modkit_upgrade, /obj/item/borg/upgrade/modkit/cooldown))
+			new_recharge_time += modkit_upgrade.modifier
 
 	return new_recharge_time
 
@@ -515,7 +519,7 @@
 	turf_aoe = TRUE
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 4, /datum/material/silver = SHEET_MATERIAL_AMOUNT, /datum/material/gold = SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT * 0.75)
 	// Negates one CD modifier
-	modifier = -/obj/item/borg/upgrade/modkit/cooldown::modifier
+	modifier = PKA_COOLDOWN_INCREMENT
 
 /obj/item/borg/upgrade/modkit/cooldown/aoe/mobs
 	name = "offensive explosion"
@@ -747,3 +751,6 @@
 
 	var/new_color = tgui_color_picker(user, "", "Choose Color", bolt_color)
 	bolt_color = new_color || bolt_color
+
+#undef PKA_COOLDOWN_INCREMENT
+#undef STANDARD_RECHARGE_TIME


### PR DESCRIPTION
## About The Pull Request

Alright, tldr, the logic used to check every modkit in the gun, then use that to adjust the gun's new `recharge_time`.
Issue, the proc that tallied that up also didn't look at what modifier EACH MODKIT was using. There are 2 cooldown modkits, one that lowers cooldown, and another that adds cooldown in exchange for AOE damage.
Result: Installing an AOE modkit after 3 cooldown modkits made the gun 3x as slow as it was supposed to be.
Additional result: Installing the AOE modkit first and cooldown modkits second made it the gun even faster, almost instant.

## Why It's Good For The Game

Good lord this has never worked properly once.
Also, while I was here, I cleaned up a bit of magic number syndrome in the file.

## Changelog
:cl:
fix: Cooldown modkits and AOE modkits now work as intended. Cooldowns make the gun shoot faster, and AOE modkits will make the gun slightly slower, regardless of the order they're installed in.
/:cl: