### PR TITLE
Makes cult pylons wither plant life

### DIFF
--- a/code/game/objects/items/kirby_plants/kirbyplants.dm
+++ b/code/game/objects/items/kirby_plants/kirbyplants.dm
@@ -99,8 +99,8 @@
 		return FALSE
 
 	playsound(src, SFX_CRUNCHY_BUSH_WHACK, 50, vary = FALSE, ignore_walls = FALSE)
-	visible_message(span_cult("In a single flash of scarlet [src] is ripped apart!"),
-		blind_message = span_warning("In one instant you hear a singular crunching of many branches."))
+	visible_message(span_cult("In a flash of scarlet [src] is ripped apart!"),
+		blind_message = span_warning("You hear a singular crunching of many branches."))
 	dead = TRUE
 	update_appearance()
 	return TRUE

--- a/code/game/objects/items/kirby_plants/kirbyplants.dm
+++ b/code/game/objects/items/kirby_plants/kirbyplants.dm
@@ -90,6 +90,13 @@
 
 	return plant_states
 
+/obj/item/kirbyplants/proc/wither()
+	if(dead)
+		return
+
+	dead = TRUE
+	update_appearance()
+
 /obj/item/kirbyplants/random
 	icon = 'icons/obj/fluff/flora/_flora.dmi'
 	icon_state = "random_plant"

--- a/code/game/objects/items/kirby_plants/kirbyplants.dm
+++ b/code/game/objects/items/kirby_plants/kirbyplants.dm
@@ -92,7 +92,7 @@
 
 /**
  * Called if a kirbyplant is withered by cult magic.
- * Should return FALSE if a kirbyplant isn't hit.
+ * Should return FALSE if the kirbyplant isn't hit.
  */
 /obj/item/kirbyplants/proc/cult_wither()
 	if(dead)

--- a/code/game/objects/items/kirby_plants/kirbyplants.dm
+++ b/code/game/objects/items/kirby_plants/kirbyplants.dm
@@ -90,12 +90,20 @@
 
 	return plant_states
 
-/obj/item/kirbyplants/proc/wither()
+/**
+ * Called if a kirbyplant is withered by cult magic.
+ * Should return FALSE if a kirbyplant isn't hit.
+ */
+/obj/item/kirbyplants/proc/cult_wither()
 	if(dead)
-		return
+		return FALSE
 
+	playsound(src, SFX_CRUNCHY_BUSH_WHACK, 50, vary = FALSE, ignore_walls = FALSE)
+	visible_message(span_cult("In a single flash of scarlet [src] is ripped apart!"),
+		blind_message = span_warning("In one instant you hear a singular crunching of many branches."))
 	dead = TRUE
 	update_appearance()
+	return TRUE
 
 /obj/item/kirbyplants/random
 	icon = 'icons/obj/fluff/flora/_flora.dmi'

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -279,6 +279,28 @@
 	var/matrix/M = matrix(transform)
 	transform = M.Turn(-previous_rotation)
 
+/**
+ * Called if the flora is withered by cult magic.
+ * Should return FALSE if the flora isn't hit.
+ */
+/obj/structure/flora/proc/cult_wither(damage)
+	var/static/list/unwitherables = typecacheof(list(
+			/obj/structure/flora/rock,
+			/obj/structure/flora/tree/dead,
+	))
+	if(is_type_in_typecache(src, unwitherables))
+		return FALSE
+
+	// If this flora isn't indestructible and the damage would destroy it...
+	if(!(resistance_flags & INDESTRUCTIBLE) && ((get_integrity() - damage) <= 0 ))
+		harvested = TRUE // ...don't leave anything behind upon destruction.
+
+	visible_message(span_cult("[src] shrivels as an air of crimson envelops it."),
+		blind_message = span_warning("You hear a violent and decaying rustle."))
+	play_attack_sound(ignore_walls = FALSE)
+	take_damage(damage, BRUTE, sound_effect = FALSE, armour_penetration = 100)
+	return TRUE
+
 /obj/structure/flora/atom_deconstruct(disassembled = TRUE)
 	if(harvested)
 		return ..()

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -119,16 +119,16 @@
 			damage_amount *= 4
 	return ..()
 
-/obj/structure/flora/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/flora/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0, ignore_walls = TRUE)
 	var/use_default_sound = TRUE //Because I don't wanna do unnecessary bitflag checks in a single if statement, while also allowing for multiple sounds to be played
 	if(flora_flags & FLORA_HERBAL)
-		playsound(src, SFX_CRUNCHY_BUSH_WHACK, 50, vary = FALSE)
+		playsound(src, SFX_CRUNCHY_BUSH_WHACK, 50, vary = FALSE, ignore_walls = ignore_walls)
 		use_default_sound = FALSE
 	if(flora_flags & FLORA_WOODEN)
-		playsound(src, SFX_TREE_CHOP, 50, vary = FALSE)
+		playsound(src, SFX_TREE_CHOP, 50, vary = FALSE, ignore_walls = ignore_walls)
 		use_default_sound = FALSE
 	if(flora_flags & FLORA_STONE)
-		playsound(src, SFX_ROCK_TAP, 50, vary = FALSE)
+		playsound(src, SFX_ROCK_TAP, 50, vary = FALSE, ignore_walls = ignore_walls)
 		use_default_sound = FALSE
 	if(use_default_sound)
 		return ..()

--- a/code/modules/antagonists/cult/cult_structure_pylon.dm
+++ b/code/modules/antagonists/cult/cult_structure_pylon.dm
@@ -104,8 +104,7 @@
 
 	// Potted kirbyplants
 	for(var/obj/item/kirbyplants/potted_plant in target_turf)
-		potted_plant.cult_wither()
-		hit_something = TRUE
+		hit_something = potted_plant.cult_wither()
 
 	// Effects on hit
 	if(hit_something)

--- a/code/modules/antagonists/cult/cult_structure_pylon.dm
+++ b/code/modules/antagonists/cult/cult_structure_pylon.dm
@@ -80,78 +80,34 @@
 
 	COOLDOWN_START(src, corruption_cooldown, corruption_cooldown_duration)
 
-/// Negatively affects plants on `target_turf`, because Nar'Sie is not the Geometer of Sap.
+/// Destroys or otherwise harms plants on `target_turf`, because Nar'Sie is not the Geometer of Sap.
 /obj/structure/destructible/cult/pylon/proc/wither_plants(turf/target_turf)
 	// If this is TRUE then we do a flash of light and a sound at the end.
 	var/hit_something = FALSE
+
+	// Flora structures
 	for(var/obj/structure/flora/plant in target_turf)
-		var/static/list/unwitherables = typecacheof(list(
-			/obj/structure/flora/rock,
-			/obj/structure/flora/tree/dead,
-		))
-		if(is_type_in_typecache(plant, unwitherables))
-			continue
+		hit_something = plant.cult_wither(plant.max_integrity / PYLON_PLANT_LETHALITY)
 
-		var/damage = plant.max_integrity / PYLON_PLANT_LETHALITY
-		// The plant will leave no produce behind ONLY if the pylon deals the final blow.
-		if(plant.get_integrity() - damage <= 0)
-			plant.harvested = TRUE
-
-		plant.play_attack_sound(ignore_walls = FALSE)
-		plant.visible_message(span_cult("[plant] shrivels as an air of crimson envelops it."),
-			blind_message = span_warning("You hear a violent and decaying rustle."))
-		plant.take_damage(damage, BRUTE, sound_effect = FALSE, armour_penetration = 100)
-		hit_something = TRUE
-
+	// Hydroponics plants
 	for(var/obj/machinery/hydroponics/plant_tray in target_turf)
-		if(plant_tray.plant_status == HYDROTRAY_NO_PLANT || plant_tray.plant_status == HYDROTRAY_PLANT_DEAD)
-			continue
-		var/obj/item/seeds/tray_seed = plant_tray.myseed
+		hit_something = plant_tray.cult_wither(-(plant_tray.plant_health / PYLON_PLANT_LETHALITY) - 15)
 
-		if(plant_tray.reagents.has_reagent(/datum/reagent/blood, 1))
-			if(plant_tray.pestlevel)
-				// Blood promotes pests and pylons kill them for health. It's a very evil arrangement.
-				plant_tray.visible_message(span_cult("A faint scarlet courses through [tray_seed.plantname]."),
-					blind_message = span_warning("A chorus of chittering quickly rises and falls silent."),
-					vision_distance = COMBAT_MESSAGE_RANGE)
-				plant_tray.adjust_pestlevel(-plant_tray.pestlevel)
-				plant_tray.adjust_plant_health(2 * plant_tray.pestlevel)
-				hit_something = TRUE // It hits the worms
-			continue
+	// Plant mobs
+	for(var/mob/living/plant_mob in target_turf)
+		hit_something = plant_mob.cult_wither(plant_mob.max_stamina / PYLON_PLANT_LETHALITY)
 
-		if(istype(tray_seed, /obj/item/seeds/watermelon/holy))
-			plant_tray.flash_lighting_fx(2, 2, COLOR_VIVID_YELLOW, 0.5 SECONDS)
-			plant_tray.visible_message(span_warning("The [tray_seed.plantname] glow against an air of encroaching crimson."))
-			continue
-
-		plant_tray.adjust_plant_health(-(plant_tray.plant_health / PYLON_PLANT_LETHALITY) - 25)
-		hit_something = TRUE
-
-	for(var/mob/living/carbon/human/species/pod/podperson in target_turf)
-		if(IS_CULTIST(podperson))
-			continue
-
-		if(podperson.can_block_magic(MAGIC_RESISTANCE_HOLY, 0))
-			continue
-
-		podperson.playsound_local(podperson, pick(GLOB.creepy_ambience), 25)
-		podperson.visible_message(span_warning("[podperson] hunches over."),
-			span_cult_large("\"You will wilt now, sapling.\""),
-			span_warning("You hear a lowering rustle."))
-		podperson.adjust_stamina_loss(50)
-		hit_something = TRUE
-
+	// Kudzu
 	for(var/obj/structure/spacevine/kudzu in range(1, target_turf))
 		kudzu.Destroy()
 		hit_something = TRUE
 
+	// Potted kirbyplants
 	for(var/obj/item/kirbyplants/potted_plant in target_turf)
-		if(potted_plant.dead)
-			continue
-
-		potted_plant.wither()
+		potted_plant.cult_wither()
 		hit_something = TRUE
 
+	// Effects on hit
 	if(hit_something)
 		target_turf.flash_lighting_fx(1.5, 2, COLOR_SOFT_RED, 0.5 SECONDS)
 		playsound(target_turf, SFX_SEAR, 20, ignore_walls = FALSE)

--- a/code/modules/antagonists/cult/cult_structure_pylon.dm
+++ b/code/modules/antagonists/cult/cult_structure_pylon.dm
@@ -1,4 +1,8 @@
-// Cult pylon. Heals nearby cultists and converts turfs to cult turfs.
+/// VERY ROUGHLY the number of "hits" it should take for a pylon to
+/// down a plant on a given turf (excepting kirbyplants and kudzu).
+#define PYLON_PLANT_LETHALITY 2
+
+// Cult pylon. Heals nearby cultists, converts turfs to cult turfs, and withers plants.
 /obj/structure/destructible/cult/pylon
 	name = "pylon"
 	desc = "A floating crystal that slowly heals those faithful to Nar'Sie."
@@ -58,6 +62,7 @@
 
 	if(length(validturfs))
 		var/turf/converted_turf = pick(validturfs)
+		wither_plants(converted_turf)
 		if(isplatingturf(converted_turf))
 			converted_turf.place_on_top(/turf/open/floor/engine/cult, flags = CHANGETURF_INHERIT_AIR)
 		else
@@ -65,6 +70,7 @@
 
 	else if (length(cultturfs))
 		var/turf/open/floor/engine/cult/cult_turf = pick(cultturfs)
+		wither_plants(cult_turf)
 		new /obj/effect/temp_visual/cult/turf/floor(cult_turf)
 
 	else
@@ -74,6 +80,82 @@
 
 	COOLDOWN_START(src, corruption_cooldown, corruption_cooldown_duration)
 
+/// Negatively affects plants on `target_turf`, because Nar'Sie is not the Geometer of Sap.
+/obj/structure/destructible/cult/pylon/proc/wither_plants(turf/target_turf)
+	// If this is TRUE then we do a flash of light and a sound at the end.
+	var/hit_something = FALSE
+	for(var/obj/structure/flora/plant in target_turf)
+		var/static/list/unwitherables = typecacheof(list(
+			/obj/structure/flora/rock,
+			/obj/structure/flora/tree/dead,
+		))
+		if(is_type_in_typecache(plant, unwitherables))
+			continue
+
+		var/damage = plant.max_integrity / PYLON_PLANT_LETHALITY
+		// The plant will leave no produce behind ONLY if the pylon deals the final blow.
+		if(plant.get_integrity() - damage <= 0)
+			plant.harvested = TRUE
+
+		plant.play_attack_sound(ignore_walls = FALSE)
+		plant.visible_message(span_cult("[plant] shrivels as an air of crimson envelops it."),
+			blind_message = span_warning("You hear a violent and decaying rustle."))
+		plant.take_damage(damage, BRUTE, sound_effect = FALSE, armour_penetration = 100)
+		hit_something = TRUE
+
+	for(var/obj/machinery/hydroponics/plant_tray in target_turf)
+		if(plant_tray.plant_status == HYDROTRAY_NO_PLANT || plant_tray.plant_status == HYDROTRAY_PLANT_DEAD)
+			continue
+		var/obj/item/seeds/tray_seed = plant_tray.myseed
+
+		if(plant_tray.reagents.has_reagent(/datum/reagent/blood, 1))
+			if(plant_tray.pestlevel)
+				// Blood promotes pests and pylons kill them for health. It's a very evil arrangement.
+				plant_tray.visible_message(span_cult("A faint scarlet courses through [tray_seed.plantname]."),
+					blind_message = span_warning("A chorus of chittering quickly rises and falls silent."),
+					vision_distance = COMBAT_MESSAGE_RANGE)
+				plant_tray.adjust_pestlevel(-plant_tray.pestlevel)
+				plant_tray.adjust_plant_health(2 * plant_tray.pestlevel)
+				hit_something = TRUE // It hits the worms
+			continue
+
+		if(istype(tray_seed, /obj/item/seeds/watermelon/holy))
+			plant_tray.flash_lighting_fx(2, 2, COLOR_VIVID_YELLOW, 0.5 SECONDS)
+			plant_tray.visible_message(span_warning("The [tray_seed.plantname] glow against an air of encroaching crimson."))
+			continue
+
+		plant_tray.adjust_plant_health(-(plant_tray.plant_health / PYLON_PLANT_LETHALITY) - 25)
+		hit_something = TRUE
+
+	for(var/mob/living/carbon/human/species/pod/podperson in target_turf)
+		if(IS_CULTIST(podperson))
+			continue
+
+		if(podperson.can_block_magic(MAGIC_RESISTANCE_HOLY, 0))
+			continue
+
+		podperson.playsound_local(podperson, pick(GLOB.creepy_ambience), 25)
+		podperson.visible_message(span_warning("[podperson] hunches over."),
+			span_cult_large("\"You will wilt now, sapling.\""),
+			span_warning("You hear a lowering rustle."))
+		podperson.adjust_stamina_loss(50)
+		hit_something = TRUE
+
+	for(var/obj/structure/spacevine/kudzu in range(1, target_turf))
+		kudzu.Destroy()
+		hit_something = TRUE
+
+	for(var/obj/item/kirbyplants/potted_plant in target_turf)
+		if(potted_plant.dead)
+			continue
+
+		potted_plant.wither()
+		hit_something = TRUE
+
+	if(hit_something)
+		target_turf.flash_lighting_fx(1.5, 2, COLOR_SOFT_RED, 0.5 SECONDS)
+		playsound(target_turf, SFX_SEAR, 20, ignore_walls = FALSE)
+
 /obj/structure/destructible/cult/pylon/conceal()
 	. = ..()
 	STOP_PROCESSING(SSfastprocess, src)
@@ -81,3 +163,5 @@
 /obj/structure/destructible/cult/pylon/reveal()
 	. = ..()
 	START_PROCESSING(SSfastprocess, src)
+
+#undef PYLON_PLANT_LETHALITY

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -824,6 +824,39 @@
 	update_appearance()
 
 /**
+ * Called if the tray is withered by cult magic.
+ * Should return FALSE if the plant isn't hit.
+ */
+/obj/machinery/hydroponics/proc/cult_wither(damage)
+	if(plant_status == HYDROTRAY_NO_PLANT)
+		return FALSE
+
+	if(plant_status == HYDROTRAY_PLANT_DEAD)
+		set_seed(null) // Clears out the tray (or soil)
+		return TRUE
+
+	if(reagents.has_reagent(/datum/reagent/blood, 1))
+		// Blood promotes pests and cult magic kills them for health. It's a very evil arrangement.
+		visible_message(span_cult("A faint scarlet courses through the [myseed.plantname]."),
+			blind_message = span_warning("A chorus of chittering quickly rises and falls silent."),
+			vision_distance = COMBAT_MESSAGE_RANGE)
+		if(pestlevel)
+			adjust_pestlevel(-pestlevel)
+			adjust_plant_health(2 * pestlevel)
+		return TRUE
+
+	if(istype(myseed, /obj/item/seeds/watermelon/holy))
+		flash_lighting_fx(2, 2, COLOR_VIVID_YELLOW, 0.5 SECONDS)
+		visible_message(span_warning("The [myseed.plantname] glow against an air of encroaching crimson."),
+			blind_message = span_warning("You notice an almost imperceptible chanting."))
+		return FALSE
+
+	visible_message(span_cult("The [myseed.plantname] shrivels as an air of crimson envelops it."),
+		blind_message = span_warning("You hear a violent and decaying rustle."))
+	adjust_plant_health(damage)
+	return TRUE
+
+/**
  * Plant Death Proc.
  * Cleans up various stats for the plant upon death, including pests, harvestability, and plant health.
  */

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -3026,7 +3026,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 		return TRUE
 
 /**
- * Called if the mob is withered by cult magic.
+ * Called if a plant-like mob is withered by cult magic.
  * Should return FALSE if the plant isn't hit.
  */
 /mob/living/proc/cult_wither(stamina_loss)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -3029,7 +3029,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
  * Called if a plant-like mob is withered by cult magic.
  * Should return FALSE if the plant isn't hit.
  */
-/mob/living/proc/cult_wither(stamina_loss)
+/mob/living/proc/cult_wither(stamina_damage)
 	// Evil plant mobs which in some way embody the notion of blood.
 	var/static/list/evil_blood_plants = typecacheof(list(
 		/mob/living/basic/venus_human_trap,
@@ -3044,13 +3044,16 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	if(can_block_magic(MAGIC_RESISTANCE_HOLY, 0))
 		return FALSE
 
-	if(!get_stamina_loss()) // If at full stamina
-		adjust_stamina_loss(stamina_loss)
+	// Don't do any stamina damage if it would stun.
+	// This could be thrown off by modifiers, but that's the point of modifiers (I think).
+	if(get_stamina_loss() + stamina_damage < max_stamina)
+		adjust_stamina_loss(stamina_damage)
 		playsound_local(src, pick(GLOB.creepy_ambience), 25)
 		visible_message(span_warning("[src] hunches over."),
 			span_cult_large("\"You will wilt now, sapling.\""),
 			span_warning("You hear a lowering rustle."))
 		return TRUE
+	return FALSE
 
 ///Performs the aftereffects of blocking a projectile.
 /mob/living/proc/block_projectile_effects()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -3025,6 +3025,33 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	if(suit.clothing_flags & hat.clothing_flags & THICKMATERIAL)
 		return TRUE
 
+/**
+ * Called if the mob is withered by cult magic.
+ * Should return FALSE if the plant isn't hit.
+ */
+/mob/living/proc/cult_wither(stamina_loss)
+	// Evil plant mobs which in some way embody the notion of blood.
+	var/static/list/evil_blood_plants = typecacheof(list(
+		/mob/living/basic/venus_human_trap,
+		/mob/living/basic/killer_tomato,
+	))
+	if(!(mob_biotypes & MOB_PLANT) || is_type_in_typecache(src, evil_blood_plants))
+		return FALSE
+
+	if(IS_CULTIST(src))
+		return FALSE
+
+	if(can_block_magic(MAGIC_RESISTANCE_HOLY, 0))
+		return FALSE
+
+	if(!get_stamina_loss()) // If at full stamina
+		adjust_stamina_loss(stamina_loss)
+		playsound_local(src, pick(GLOB.creepy_ambience), 25)
+		visible_message(span_warning("[src] hunches over."),
+			span_cult_large("\"You will wilt now, sapling.\""),
+			span_warning("You hear a lowering rustle."))
+		return TRUE
+
 ///Performs the aftereffects of blocking a projectile.
 /mob/living/proc/block_projectile_effects()
 	var/static/list/icon/blocking_overlay


### PR DESCRIPTION

## About The Pull Request
This PR makes cult pylons wither plants on hit. _For the sake of absolute clarity_ in the proceeding bullet points, pylons "hit" plants whenever their turf is converted or (if already converted) selected for the pylon's conversion visual effect. Exact withering effects are as follows:

- Generic, non-hydroponics flora structures like trees, bushes, and grass are completely destroyed after being hit twice.
- Plants in hydroponics trays are similarly affected unless fertilized with blood. Since blood promotes pests, those are killed in exchange for recovering plant health. Holymelons are not affected.
- Most non-cultist mobs with the `MOB_PLANT` biotype take fifty stamina damage unless bearing anti-magic. This is just enough to slow for a bit, and the stamina damage does not occur if it would stun (stamina damage modifiers not considered). 
- Space vines within a one tile range of the hit turf are destroyed. Explosive space vines may be triggered.
- Potted kirbyplants instantaneously die and assume their dead icon state.

Any plant hits are accompanied by a brief flash of red light and a searing sound effect (which does not go through walls).
## Why It's Good For The Game
I had the idea for this PR during a round with a cult base in a maintenance hydroponics area on Meta Station. In general, I think there's a weird thematic contrast when the evil structure of spreading evil is surrounded by (living) plants. It makes cult bases look messy in a naturally unnatural way. They should of course be covered in blood, but perhaps not foliage.

The notion of giving cultists a counter against space vines arises indirectly. As is, I think it simply looks neat. If the vines aren't completely eliminated then they're left eternally encroaching at the edges of the pylon's converted area. In general, the intention behind these changes is aesthetic, and if anything is unbalanced then it ought to be changed.
## Changelog
:cl:
add: Cult pylons now destroy most forms of plant life. Holymelons and hydroponics plants fertilized with blood are not affected.
balance: As a result, cult pylons are now a decent counter to space vines.
/:cl:
