### PR TITLE
Gluon grenades have been broken for so long I don't know if fixing them is even a good idea, but this fixes gluon grenades

### DIFF
--- a/code/game/objects/items/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/grenades/syndieminibomb.dm
@@ -69,7 +69,7 @@
 
 	update_mob()
 	playsound(loc, 'sound/effects/empulse.ogg', 50, TRUE)
-	radiation_pulse(src, max_range = rad_range, threshold = rad_threshold, chance = 100)
+	radiation_pulse(get_turf(src), max_range = rad_range, threshold = rad_threshold, chance = 100) // Activate on the turf, because we'll be gone before SSradiation fires
 	for (var/turf/open/floor/floor in view(freeze_range, loc))
 		floor.MakeSlippery(TURF_WET_PERMAFROST, 6 MINUTES)
 		for(var/mob/living/carbon/victim in floor)


### PR DESCRIPTION

## About The Pull Request

Did you know? Gluon frag grenades are actually not just extremely weak cold grenades, they're supposed to be radiation grenades too. But they don't work, because they set themselves up as a radiation source and then `qdel(src)` before SSradiation fires. I don't care to litigate exactly how long this has been broken, but it's been at least four years and almost certainly much longer than that.

The pr makes the turf pulse instead of the grenade.

## Why It's Good For The Game

Something must be done, but whether it should be fixing the radiation effect or removing it I could go either way on. I'm perfectly happy just removing the effect instead, but fixing it's first because what if, just this once, radiation was a fun mechanic.

## Changelog
:cl:
fix: Gluon frag grenades now output radiation, like they've been trying and failing to do for at least 4 years.
/:cl:
