### PR TITLE
Optimizes /datum/gas_mixture/proc/archive() by ~42%

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -135,8 +135,7 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 
 /// Update archived versions of variables
 /datum/gas_mixture/proc/archive()
-	// This proc is insanely hot so we can override values from moles_archive with ones from moles using a binary OR instead of normal iteration
-	moles_archive = moles | moles_archive
+	moles_archive = moles.Copy()
 	temperature_archived = temperature
 
 ///Merges all air from giver into self. Deletes giver. Returns: 1 if we are mutable, 0 otherwise

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -133,16 +133,11 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 /datum/gas_mixture/proc/thermal_energy()
 	return THERMAL_ENERGY(src) //see code/__DEFINES/atmospherics.dm; use the define in performance critical areas
 
-///Update archived versions of variables. Returns: 1 in all cases
+/// Update archived versions of variables
 /datum/gas_mixture/proc/archive()
-	var/list/cached_moles = moles
-	var/list/cached_moles_archive = moles_archive
-
+	// This proc is insanely hot so we can override values from moles_archive with ones from moles using a binary OR instead of normal iteration
+	moles_archive = moles | moles_archive
 	temperature_archived = temperature
-	for(var/gas_id, value in cached_moles)
-		cached_moles_archive[gas_id] = value
-
-	return TRUE
 
 ///Merges all air from giver into self. Deletes giver. Returns: 1 if we are mutable, 0 otherwise
 /datum/gas_mixture/proc/merge(datum/gas_mixture/giver)

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -15,7 +15,7 @@
 	moles_archive.Cut()
 
 /datum/gas_mixture/immutable/archive()
-	return TRUE //nothing changes, so we do nothing and the archive is successful
+	return // nothing changes, so we do nothing
 
 /datum/gas_mixture/immutable/merge()
 	return FALSE //we're immutable.


### PR DESCRIPTION

## About The Pull Request

``archive()`` is 5th hottest proc from live profiles, taking up over 1% of total CPU time so any microop that can save time is extremely valuable. And we can save almost half of said time by using BYOND's internal binary OR to update archived moles instead of manual iteration.
Old:

<img width="1284" height="985" alt="tracy-profiler_iulrSqb
8I8" src="https://github.com/user-attachments/assets/c2a0413d-11a9-45f0-900d-44a8e8b23779" />

New:

<img width="1278" height="990" alt="tracy-profiler_H8jw78ryhX" src="https://github.com/user-attachments/assets/de79ed13-7122-4c9a-978f-7f0b5daa0677" />

## Changelog
:cl:
code: Optimized /datum/gas_mixture/proc/archive() by ~42%
/:cl:
