### PR TITLE
Makes Hanzo Steel sheath respect nullrod traits. Little element refactor

### DIFF
--- a/code/datums/elements/nullrod_core.dm
+++ b/code/datums/elements/nullrod_core.dm
@@ -1,6 +1,8 @@
 ///Proxy element that attaches components, elements and traits that are common to more or less all nullrods.
 /datum/element/nullrod_core
 
+	var/list/attached_components = list()
+
 /**
  * Called when the element is added to a datum. If the 'chaplain_spawnable' arg is TRUE and unit testing is enabled,
  * we check that the target is actually in the nullrod_variants global list
@@ -10,23 +12,39 @@
 	if(!istype(target))
 		return ELEMENT_INCOMPATIBLE
 
-	target.AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
-	target.AddComponent(/datum/component/effect_remover, \
+	var/datum/component/anti_magic/am = target.AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
+	var/datum/component/effect_remover/remover = target.AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You disrupt the magic of %THEEFFECT with %THEWEAPON.", \
 		success_forcesay = rune_remove_line, \
 		tip_text = "Clear rune", \
 		on_clear_callback = CALLBACK(src, PROC_REF(on_cult_rune_removed), target), \
 		effects_we_clear = list(/obj/effect/rune, /obj/effect/heretic_rune, /obj/effect/cosmic_rune), \
 	)
-	target.AddComponent(/datum/component/cult_kill_tracker)
-	target.AddComponent(/datum/component/bane, affected_biotypes = MOB_SPIRIT, added_damage = 25)
+	var/datum/component/cult_kill_tracker/tracker = target.AddComponent(/datum/component/cult_kill_tracker)
+	var/datum/component/bane/bane_comp = target.AddComponent(/datum/component/bane, affected_biotypes = MOB_SPIRIT, added_damage = 25)
 	ADD_TRAIT(target, TRAIT_NULLROD_ITEM, ELEMENT_TRAIT(type))
+
+	attached_components[target] = list(am, remover, tracker, bane_comp)
+
+	if(ismob(target.loc))
+		am.register_antimagic_signals(target.loc)
 
 	if(!PERFORM_ALL_TESTS(focus_only/nullrod_variants) || !chaplain_spawnable)
 		return
 
 	if(!GLOB.nullrod_variants[target.type])
 		stack_trace("[target.type] is absent from the nullrod_variants global list. Please include it.")
+
+
+/datum/element/nullrod_core/Detach(obj/item/target)
+	var/list/refs = attached_components[target]
+	if(refs)
+		for(var/datum/component/comp as anything in refs)
+			qdel(comp)
+		attached_components -= target
+
+	REMOVE_TRAIT(target, TRAIT_NULLROD_ITEM, ELEMENT_TRAIT(type))
+	return ..()
 
 /// Callback for effect remover, invoked when a cult rune is cleared
 /datum/element/nullrod_core/proc/on_cult_rune_removed(obj/item/nullrod, obj/effect/target, mob/living/user)

--- a/code/datums/elements/nullrod_core.dm
+++ b/code/datums/elements/nullrod_core.dm
@@ -25,9 +25,7 @@
 	ADD_TRAIT(target, TRAIT_NULLROD_ITEM, ELEMENT_TRAIT(type))
 
 	attached_components[target] = list(am, remover, tracker, bane_comp)
-
-	if(ismob(target.loc))
-		am.register_antimagic_signals(target.loc)
+	am.register_antimagic_signals(target.loc)
 
 	if(!PERFORM_ALL_TESTS(focus_only/nullrod_variants) || !chaplain_spawnable)
 		return

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -976,11 +976,10 @@
 
 /obj/item/storage/belt/sheath/hanzo_katana/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, COMSIG_ATOM_STORED_ITEM, PROC_REF(on_insert))
-	RegisterSignal(src, COMSIG_ATOM_REMOVED_ITEM, PROC_REF(on_remove))
+	RegisterSignal(src, COMSIG_ATOM_REMOVED_ITEM, PROC_REF(on_katana_remove))
 
-/obj/item/storage/belt/sheath/hanzo_katana/proc/on_katana_insert(atom/source, atom/movable/arrived)
-	SIGNAL_HANDLER
+/obj/item/storage/belt/sheath/hanzo_katana/post_resheath(atom/source, atom/movable/arrived)
+	. = ..()
 	AddElement(/datum/element/nullrod_core)
 
 /obj/item/storage/belt/sheath/hanzo_katana/proc/on_katana_remove(atom/source, atom/movable/gone, direction)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -974,6 +974,19 @@
 	storage_type = /datum/storage/hanzo_sheath
 	stored_blade = /obj/item/nullrod/claymore/katana
 
+/obj/item/storage/belt/sheath/hanzo_katana/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_ATOM_STORED_ITEM, PROC_REF(on_insert))
+	RegisterSignal(src, COMSIG_ATOM_REMOVED_ITEM, PROC_REF(on_remove))
+
+/obj/item/storage/belt/sheath/hanzo_katana/proc/on_katana_insert(atom/source, atom/movable/arrived)
+	SIGNAL_HANDLER
+	AddElement(/datum/element/nullrod_core)
+
+/obj/item/storage/belt/sheath/hanzo_katana/proc/on_katana_remove(atom/source, atom/movable/gone, direction)
+	SIGNAL_HANDLER
+	RemoveElement(/datum/element/nullrod_core)
+
 /obj/item/storage/belt/sheath/hanzo_katana/empty
 	stored_blade = NONE
 


### PR DESCRIPTION
## About The Pull Request

closes #96953

## Changelog

:cl:
refactor: Rewritten "nullrod_core" element so it can be correctly handled by storage insert/remove signal, WHICH allows to assign this element to the sheath.
/:cl:
