### PR TITLE
fix for a stupid powershell issue with build scripts

### DIFF
--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -11,6 +11,8 @@
 # regardless of ExecutionPolicy.
 $host.ui.RawUI.WindowTitle = "starting :: python $args"
 $ErrorActionPreference = "Stop"
+# stupid fucking workaround for powershell 5 vs 7 bullshit.
+$Env:PSModulePath = "$Env:ProgramFiles\WindowsPowerShell\Modules;$PSHOME\Modules"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 


### PR DESCRIPTION

## About The Pull Request

fixes this stupid build issue on windows:
```
  ❯ .\bin\build.cmd
  Using vendored Bun 1.3.5
  :: Juke Build version 0.8.1
  :: Skipping 'cutter' (condition unmet)
  => Starting 'bun'
  => Starting 'behavior-tree-compiler'
  :: Skipping 'icon-cutter' (up to date)
  bun install v1.3.5 (1e86cebd)
  Get-FileHash : The term 'Get-FileHash' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the
  path is correct and try again.
  At C:\Users\Lucy\Code\byond-oh-god-why\game-codebases\tgstation\tools\bootstrap\python_.ps1:82 char:54
  + ... !(Test-Path "$PythonDir/requirements.txt") -or ((Get-FileHash "$Tools ...
  +                                                      ~~~~~~~~~~~~
      + CategoryInfo          : ObjectNotFound: (Get-FileHash:String) [], ParentContainsErrorRecordException
      + FullyQualifiedErrorId : CommandNotFoundException

  => Target 'behavior-tree-compiler' failed in 0.428s, exit code: 1
  => Target 'dm' faile
```

build.cmd shells out to old-ass powershell 5.1 for the python bootstrap step

if you're running from pwsh 7, it leaks its module path into powershell 5.1, and 5.1 gets confused and can't its own built-in `Get-FileHash` thingy anymore, causing the bootstrap to throw a shitfit because it can't verify the python download.

so this just resets the module path back to sane defaults before calling it.

tl;dr: pwoerhell

## Why It's Good For The Game

makes development less of a nightmare

## Changelog

literally only affects local builds