### PR TITLE
Use correct in-hand sprites for Runtime (the cat)

### DIFF
--- a/code/modules/mob/living/basic/pets/cat/runtime.dm
+++ b/code/modules/mob/living/basic/pets/cat/runtime.dm
@@ -8,6 +8,7 @@
 	icon_state = "cat"
 	icon_living = "cat"
 	icon_dead = "cat_dead"
+	held_state = "cat"
 	gender = FEMALE
 	gold_core_spawnable = NO_SPAWN
 	unique_pet = TRUE
@@ -34,6 +35,7 @@
 		icon_state = "original"
 		icon_living = "original"
 		icon_dead = "original_dead"
+		held_state = "original"
 		update_appearance()
 
 	post_birth_callback = CALLBACK(src, PROC_REF(after_birth))


### PR DESCRIPTION

## About The Pull Request

Title

## Changelog
:cl: PapaMichael
fix: Runtime no longer looks calico when held in-hand.
/:cl:
