### PR TITLE
Most suit armor is now flammable

### DIFF
--- a/code/modules/antagonists/cult/cult_armor.dm
+++ b/code/modules/antagonists/cult/cult_armor.dm
@@ -90,7 +90,7 @@
 	flags_inv = HIDEGLOVES | HIDEJUMPSUIT
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
-	resistance_flags = NONE
+	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/suit/hooded/cultrobes/hardened/Initialize(mapload)
 	. = ..()
@@ -172,7 +172,7 @@
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	flash_protect = FLASH_PROTECTION_WELDER
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
-	resistance_flags = NONE
+	resistance_flags = FIRE_PROOF
 
 /**
  * Shielded armor

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -12,7 +12,6 @@
 	strip_delay = 6 SECONDS
 	equip_delay_other = 4 SECONDS
 	max_integrity = 250
-	resistance_flags = NONE
 	armor_type = /datum/armor/suit_armor
 
 /datum/armor/suit_armor
@@ -145,6 +144,7 @@
 	icon_state = "cuirass"
 	inhand_icon_state = "armor"
 	dog_fashion = null
+	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/suit/armor/vest/cuirass/Initialize(mapload)
 	. = ..()
@@ -205,7 +205,6 @@
 	cold_protection = CHEST|GROIN|ARMS|HANDS
 	heat_protection = CHEST|GROIN|ARMS|HANDS
 	strip_delay = 7 SECONDS
-	resistance_flags = FLAMMABLE
 	dog_fashion = null
 
 /obj/item/clothing/suit/armor/vest/warden/alt
@@ -222,7 +221,6 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS|HANDS
 	heat_protection = CHEST|GROIN|ARMS|HANDS
-	resistance_flags = FLAMMABLE
 	dog_fashion = null
 
 /obj/item/clothing/suit/armor/vest/secjacket/worn_overlays(mutable_appearance/standing, isinhands, icon_file, bodyshape = NONE)
@@ -402,7 +400,6 @@
 	name = "detective's flak vest"
 	desc = "An armored vest with a detective's badge on it."
 	icon_state = "detective-armor"
-	resistance_flags = FLAMMABLE
 	dog_fashion = null
 
 /obj/item/clothing/suit/armor/vest/det_suit/Initialize(mapload)
@@ -526,13 +523,15 @@
 	desc = "A classic suit of plate armour, highly effective at stopping melee attacks."
 	icon_state = "knight_green"
 	inhand_icon_state = null
+	resistance_flags = FIRE_PROOF
 	allowed = list(
 		/obj/item/banner,
 		/obj/item/claymore,
 		/obj/item/nullrod,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
-		)
+	)
+
 /obj/item/clothing/suit/armor/riot/knight/init_rustle_component()
 	AddComponent(/datum/component/item_equipped_movement_rustle, SFX_PLATE_ARMOR_RUSTLE, 8)
 
@@ -574,7 +573,6 @@
 	strip_delay = 6 SECONDS
 	equip_delay_other = 4 SECONDS
 	max_integrity = 200
-	resistance_flags = FLAMMABLE
 	armor_type = /datum/armor/vest_durathread
 	dog_fashion = null
 
@@ -640,6 +638,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
+	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/suit/armor/elder_atmosian/Initialize(mapload)
 	. = ..()
@@ -747,6 +746,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	clothing_flags = THICKMATERIAL
 	slowdown = 0.8
+	resistance_flags = FIRE_PROOF
 
 /datum/armor/armor_warlord
 	melee = 70

--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -130,6 +130,7 @@ Slimecrossing Armor
 	item_flags = IMMUTABLE_SLOW
 	slowdown = 4
 	emp_protection = EMP_PROTECTION_MODERATE
+	resistance_flags = FIRE_PROOF
 	var/hit_reflect_chance = 40
 
 /obj/item/clothing/suit/armor/heavy/adamantine/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request
This converts most armors to be flammable with a few notable exceptions:
- Hertic armor (already `FIRE-PROOF`)
- Dragon, Bone, Berserker Armor (lavaland loot is already `FIRE-PROOF`)
- Plate/Metal/Knight Armor
- Cult hardened armor (the reg cult armor is still flammable)
- Elder atmos armor

## Why It's Good For The Game
Environmental hazards are one of the unique parts of SS13 gameplay. Armor suits are treated as fire shields simply because they default to the `NONE` flag instead of `FLAMMABLE`. (`NONE` defaults to flame immunity) Most standard clothing in the game is flammable by default. Armor was simply overlooked due to how resistance flags were assigned. This aligns suit armor behavior with the rest of the game's clothing system.

Now most armor no longer gives immunity to burning unless it is specifically heat/fire/magic resistant gear.

## Changelog
:cl:
balance: All suit armor is now flammable with a few exceptions for: Hertic, Dragon, Bone, Berserker, Plate, Metal, Knight, Cult Hardened Armor, and Elder Atmos 
/:cl:
