### PR TITLE
pAI health is now on a health HUD

### DIFF
--- a/code/_onclick/hud/pai.dm
+++ b/code/_onclick/hud/pai.dm
@@ -4,6 +4,7 @@
 
 /datum/hud/pai/initialize_screen_objects()
 	. = ..()
+	add_screen_object(/atom/movable/screen/healthdoll/living, HUD_MOB_HEALTHDOLL, HUD_GROUP_INFO)
 	add_screen_object(/atom/movable/screen/language_menu, HUD_MOB_LANGUAGE_MENU, ui_style, ui_pai_language_menu)
 	add_screen_object(/atom/movable/screen/navigate, HUD_MOB_NAVIGATE_MENU, ui_style, ui_pai_navigate_menu)
 	add_screen_object(/atom/movable/screen/memories, HUD_MOB_MEMORIES, HUD_GROUP_STATIC, ui_style, ui_pai_memories_menu)

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -306,7 +306,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	if(blobstrain)
 		. += "Its strain is <font color=\"[blobstrain.color]\">[blobstrain.name]</font>."
 
-/mob/eye/blob/update_health_hud()
+/mob/eye/blob/update_health_hud(healthpercent)
 	if(!blob_core)
 		return FALSE
 	var/current_health = round((blob_core.get_integrity() / blob_core.max_integrity) * 100)

--- a/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
@@ -188,7 +188,7 @@
 	. += "Unused Stolen Essence: [essence_excess] SE"
 	. += "Perfect Souls Stolen: [perfectsouls]"
 
-/mob/living/basic/revenant/update_health_hud()
+/mob/living/basic/revenant/update_health_hud(healthpercent)
 	if(isnull(hud_used))
 		return
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -689,7 +689,7 @@
 	if(locked_record)
 		locked_record.name = newname
 
-/mob/living/carbon/human/update_health_hud()
+/mob/living/carbon/human/update_health_hud(healthpercent)
 	if(!client || !hud_used)
 		return
 	// Updates the health bar, also sends signal

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -865,6 +865,8 @@ GAME_VERB_PROC(/mob/living, mob_sleep, "Sleep", null)
 			livingdoll.add_filter("mob_shape_mask", 1, alpha_mask_filter(icon = mob_mask))
 			livingdoll.add_filter("inset_drop_shadow", 2, drop_shadow_filter(size = -1))
 		livingdoll.health_overlay.maptext = MAPTEXT("<div align='center' valign='middle' style='position:relative'>[round(healthpercent, 1)]%</div>")
+		if(livingdoll.hovering)
+			livingdoll.update_appearance(UPDATE_ICON)
 
 	if(severity > 0)
 		overlay_fullscreen("brute", /atom/movable/screen/fullscreen/brute, severity)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -834,9 +834,10 @@ GAME_VERB_PROC(/mob/living, mob_sleep, "Sleep", null)
 	update_stamina()
 	SEND_SIGNAL(src, COMSIG_LIVING_HEALTH_UPDATE)
 
-/mob/living/update_health_hud()
+/mob/living/update_health_hud(healthpercent)
 	var/severity = 0
-	var/healthpercent = (health/maxHealth) * 100
+	if(!healthpercent)
+		healthpercent = (health/maxHealth) * 100
 	var/atom/movable/screen/healthdoll/living/livingdoll = hud_used?.screen_objects[HUD_MOB_HEALTHDOLL]
 	if(istype(livingdoll)) //to really put you in the boots of a simplemob
 		switch(healthpercent)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -34,7 +34,7 @@
 
 	update_cell_hud_icon()
 
-/mob/living/silicon/robot/update_health_hud()
+/mob/living/silicon/robot/update_health_hud(healthpercent)
 	if(!client || !hud_used)
 		return
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1217,7 +1217,7 @@ GAME_VERB_NATIVE(/mob, DisDblClick, ".dblclick", null, argu = null as anything, 
 	SIGNAL_HANDLER
 	return
 
-/mob/proc/update_health_hud()
+/mob/proc/update_health_hud(healthpercent)
 	return
 
 /// Changes the stamina HUD based on new information

--- a/code/modules/pai/defense.dm
+++ b/code/modules/pai/defense.dm
@@ -71,6 +71,7 @@
 		fold_in(force = TRUE)
 	if(amount > 0)
 		to_chat(src, span_userdanger("The impact degrades your holochassis!"))
+	update_health_hud()
 	return amount
 
 /// Called when we take burn or brute damage, pass it to the shell instead

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -168,13 +168,6 @@
 	. = ..()
 	. += "Its master ID string seems to be [(!master_name || emagged) ? "empty" : master_name]."
 
-/mob/living/silicon/pai/get_status_tab_items()
-	. = ..()
-	if(!stat)
-		. += "Emitter Integrity: [holochassis_health * (100 / HOLOCHASSIS_MAX_HEALTH)]."
-	else
-		. += "Systems nonfunctional."
-
 /mob/living/silicon/pai/Exited(atom/movable/gone, direction)
 	if(gone == atmos_analyzer)
 		atmos_analyzer = null
@@ -243,7 +236,9 @@
 	laws.name = "PAI Directives"
 
 /mob/living/silicon/pai/process(seconds_per_tick)
-	holochassis_health = clamp((holochassis_health + (HOLOCHASSIS_REGEN_PER_SECOND * seconds_per_tick)), -50, HOLOCHASSIS_MAX_HEALTH)
+	if(holochassis_health != HOLOCHASSIS_MAX_HEALTH)
+		holochassis_health = clamp((holochassis_health + (HOLOCHASSIS_REGEN_PER_SECOND * seconds_per_tick)), -50, HOLOCHASSIS_MAX_HEALTH)
+		update_health_hud()
 
 /mob/living/silicon/pai/Process_Spacemove(movement_dir = 0, continuous_move = FALSE)
 	. = ..()
@@ -487,3 +482,7 @@
 /mob/living/silicon/pai/proc/on_tried_access(datum/source, obj/door_attempt, list/player_access)
 	SIGNAL_HANDLER
 	return ACCESS_DISALLOWED
+
+/mob/living/silicon/pai/update_health_hud(healthpercent)
+	healthpercent = (holochassis_health / HOLOCHASSIS_MAX_HEALTH) * 100
+	return ..()


### PR DESCRIPTION
## About The Pull Request

pAIs now get one of these

<img width="98" height="102" alt="image" src="https://github.com/user-attachments/assets/0dac6cdc-f921-485a-81f5-c1a7521bebcf" />

Which replaces their Stat panel entry

Also makes the healthdoll's maptext update as you heal, so you don't have to unhover and re-hover to update it. I noticed this cause pAIs heal rather consistently and my shit wasn't updating, which annoyed me. Hope this is worth the cost.

HOWEVER
Cyborgs have their own version, which I thought might be worth adding, but they don't know exact % which I think pAIs do need more as it tells exactly when you're able to pop out into holochassis mode once destroyed.

<img width="82" height="97" alt="image" src="https://github.com/user-attachments/assets/a77b3b35-701f-45c9-bc72-00e092c39893" />

Idk if it would be better to generalize this cyborg behavior so pAIs can have it too, and use that instead.


## Why It's Good For The Game

It's a very minor point in https://hackmd.io/443_dE5lRWeEAp9bjGcKYw?view while also making pAIs work more similar to just about every single other mob in existence in this game.
Don't know if I should remove their laws too though.

## Changelog

:cl:
qol: pAIs now have a health hud instead of it being tucked away in the stat panel.
fix: Health HUDs exact HP % text now update as you heal/injure.
/:cl: