### PR TITLE
Borg materials now updates all materials

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -582,7 +582,9 @@
 		return FALSE
 	if(is_cyborg)
 		if(source.use_charge(used * cost))
-			update_appearance(UPDATE_NAME)
+			//this will include us
+			for(var/obj/item/stack/modules as anything in source.linked_modules)
+				modules.update_appearance(UPDATE_NAME)
 			return TRUE
 		return FALSE
 	if (amount < used)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -106,6 +106,9 @@
 
 /obj/item/stack/Destroy()
 	mats_per_unit = null
+	if(source)
+		LAZYREMOVE(source.linked_modules, src)
+		source = null
 	return ..()
 
 /obj/item/stack/update_name(updates)

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -101,6 +101,7 @@
 		var/obj/item/stack/sheet_module = added_module
 		if(ispath(sheet_module.source, /datum/robot_energy_storage))
 			sheet_module.source = get_or_create_estorage(sheet_module.source)
+			LAZYADD(sheet_module.source.linked_modules, sheet_module)
 
 		if(istype(sheet_module.source))
 			sheet_module.cost = max(sheet_module.cost, 1) // Must not cost 0 to prevent div/0 errors.
@@ -1068,6 +1069,8 @@
 	var/energy
 	///Whether this resource should refill from the aether inside a charging station.
 	var/renewable = TRUE
+	///Lazylist of all modules linked to this energy storage, so using one will update all.
+	var/list/obj/item/stack/linked_modules
 
 /datum/robot_energy_storage/New(obj/item/robot_model/model)
 	energy = max_energy
@@ -1075,6 +1078,10 @@
 		model.storages |= src
 		RegisterSignal(model.robot, COMSIG_MOB_GET_STATUS_TAB_ITEMS, PROC_REF(get_status_tab_item))
 		RegisterSignal(model, COMSIG_QDELETING, PROC_REF(unregister_from_model))
+
+/datum/robot_energy_storage/Destroy(force)
+	LAZYCLEARLIST(linked_modules)
+	return ..()
 
 /datum/robot_energy_storage/proc/unregister_from_model(obj/item/robot_model/model)
 	SIGNAL_HANDLER
@@ -1097,6 +1104,8 @@
 
 /datum/robot_energy_storage/proc/add_charge(amount)
 	energy = min(energy + amount, max_energy)
+	for(var/obj/item/stack/modules as anything in linked_modules)
+		modules.update_appearance(UPDATE_NAME)
 
 /datum/robot_energy_storage/material
 	name = "generic material storage"

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -119,6 +119,9 @@
 	return added_module
 
 /obj/item/robot_model/proc/remove_module(obj/item/removed_module)
+	if(isstack(removed_module))
+		var/obj/item/stack/sheet_module = removed_module
+		LAZYREMOVE(removed_module.source.linked_modules, sheet_module)
 	basic_modules -= removed_module
 	modules -= removed_module
 	emag_modules -= removed_module

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -119,9 +119,6 @@
 	return added_module
 
 /obj/item/robot_model/proc/remove_module(obj/item/removed_module)
-	if(isstack(removed_module))
-		var/obj/item/stack/sheet_module = removed_module
-		LAZYREMOVE(sheet_module.source.linked_modules, sheet_module)
 	basic_modules -= removed_module
 	modules -= removed_module
 	emag_modules -= removed_module

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -121,7 +121,7 @@
 /obj/item/robot_model/proc/remove_module(obj/item/removed_module)
 	if(isstack(removed_module))
 		var/obj/item/stack/sheet_module = removed_module
-		LAZYREMOVE(removed_module.source.linked_modules, sheet_module)
+		LAZYREMOVE(sheet_module.source.linked_modules, sheet_module)
 	basic_modules -= removed_module
 	modules -= removed_module
 	emag_modules -= removed_module


### PR DESCRIPTION
## About The Pull Request

As an Engineering borg, you'll notice if you use iron rods that the metal sheet amount number won't update until you take it in/out of your hands. This is fixing that with a small patch.

## Why It's Good For The Game

Nothing groundbreaking or gamebreaking I just think borg HUDs should work and not lie to the user.

## Changelog

:cl:
fix: Borg sheet numbers now updates properly between items sharing the same material type.
/:cl: