### PR TITLE
You can use food items in place of organs for organ manipulation

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -16,6 +16,8 @@
 #define COMSIG_ORGAN_SURGICALLY_INSERTED "organ_surgically_inserted"
 /// Called when an organ finishes inserting into a bodypart (obj/item/bodypart/limb, movement_flags)
 #define COMSIG_ORGAN_BODYPART_INSERTED "organ_bodypart_inserted"
+/// Called when an organ finishes removing from a bodypart (obj/item/bodypart/limb, movement_flags)
+#define COMSIG_ORGAN_BODYPART_REMOVED "organ_bodypart_removed"
 /// Called when a organ's damage is adjusted apply_organ_damage (damage_amount, maximum, required_organ_flag)
 #define COMSIG_ORGAN_ADJUST_DAMAGE "organ_adjust_damage"
 

--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -43,6 +43,8 @@
 #define ORGAN_MUTANT (1<<15)
 /// The organ has been chomped or otherwise rendered unusable.
 #define ORGAN_UNUSABLE (1<<16)
+/// Used for organs that aren't really real organs, but holders for stuff and whatnot
+#define ORGAN_FAKE (1<<17)
 
 /// Organ flags that correspond to bodytypes
 #define ORGAN_TYPE_FLAGS (ORGAN_ORGANIC | ORGAN_ROBOTIC | ORGAN_MINERAL | ORGAN_GHOST)

--- a/code/datums/components/arbitrary_item_organ.dm
+++ b/code/datums/components/arbitrary_item_organ.dm
@@ -1,3 +1,5 @@
+/// Applied to an organ, makes it take on the appearance of an item
+/// If the item <-> organ relationship is broken, the organ will be destroyed
 /datum/component/arbitrary_item_organ
 	/// The item our organ is representing
 	var/obj/item/base_item
@@ -39,7 +41,7 @@
 	qdel(parent)
 
 /// Any attempt to heal the organ should damage cap it again
-/datum/component/arbitrary_item_organ/proc/break_again(obj/item/organ/organ, damage_amount)
+/datum/component/arbitrary_item_organ/proc/break_again(obj/item/organ/organ, damage_amount, ...)
 	SIGNAL_HANDLER
 	if(damage_amount < INFINITY)
 		organ.apply_organ_damage(INFINITY)

--- a/code/datums/components/arbitrary_item_organ.dm
+++ b/code/datums/components/arbitrary_item_organ.dm
@@ -15,7 +15,7 @@
 	base_item.forceMove(parent)
 
 	var/obj/item/organ/organ = parent
-	organ.organ_flags |= ORGAN_FAKE|ORGAN_PROMINENT
+	organ.organ_flags |= ORGAN_FAKE|ORGAN_PROMINENT|ORGAN_HAZARDOUS
 	organ.organ_flags &= ~ORGAN_ORGANIC
 	organ.apply_organ_damage(INFINITY)
 	organ.name = base_item.name

--- a/code/datums/components/arbitrary_item_organ.dm
+++ b/code/datums/components/arbitrary_item_organ.dm
@@ -1,0 +1,51 @@
+/datum/component/arbitrary_item_organ
+	/// The item our organ is representing
+	var/obj/item/base_item
+
+/datum/component/arbitrary_item_organ/Initialize(obj/item/base_item)
+	if(!isorgan(parent))
+		return COMPONENT_INCOMPATIBLE
+	if(!isitem(base_item))
+		return COMPONENT_INCOMPATIBLE
+
+	src.base_item = base_item
+
+	base_item.forceMove(parent)
+
+	var/obj/item/organ/organ = parent
+	organ.organ_flags |= ORGAN_FAKE|ORGAN_PROMINENT
+	organ.organ_flags &= ~ORGAN_ORGANIC
+	organ.apply_organ_damage(INFINITY)
+	organ.name = base_item.name
+
+	RegisterSignal(organ, COMSIG_ORGAN_ADJUST_DAMAGE, PROC_REF(break_again))
+	RegisterSignal(organ, COMSIG_ORGAN_BODYPART_REMOVED, PROC_REF(organ_removed))
+
+	RegisterSignals(base_item, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED), PROC_REF(base_item_lost))
+
+/datum/component/arbitrary_item_organ/Destroy()
+	UnregisterSignal(parent, list(COMSIG_ORGAN_ADJUST_DAMAGE, COMSIG_ORGAN_REMOVED))
+	UnregisterSignal(base_item, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED))
+	base_item = null
+	return ..()
+
+/// If our internal item is deleted or removed from the organ's contents, nuke the organ
+/datum/component/arbitrary_item_organ/proc/base_item_lost(obj/item/base_item)
+	SIGNAL_HANDLER
+
+	if(QDELING(parent))
+		return
+
+	qdel(parent)
+
+/// Any attempt to heal the organ should damage cap it again
+/datum/component/arbitrary_item_organ/proc/break_again(obj/item/organ/organ, damage_amount)
+	SIGNAL_HANDLER
+	if(damage_amount < INFINITY)
+		organ.apply_organ_damage(INFINITY)
+
+/// If the organ is removed it reverts to being a normal item
+/datum/component/arbitrary_item_organ/proc/organ_removed(obj/item/organ/organ, obj/item/bodypart/limb, ...)
+	SIGNAL_HANDLER
+
+	base_item.forceMove(limb.owner?.drop_location() || limb.drop_location()) // triggers qdel(organ)

--- a/code/modules/surgery/operations/operation_organ_manip.dm
+++ b/code/modules/surgery/operations/operation_organ_manip.dm
@@ -21,12 +21,23 @@
 	/// Implements used to insert organs
 	var/list/insert_implements = list(
 		/obj/item/organ = 1,
+		/obj/item/food = 2,
+		/obj/item/grown = 2,
 	)
 	/// Implements used to remove organs
 	var/list/remove_implements = list(
 		TOOL_HEMOSTAT = 1,
 		TOOL_CROWBAR = 1.8,
 		/obj/item/kitchen/fork = 2.85,
+	)
+	/// List of organ typepaths we can instantiate as fake dummy organs for insertion
+	var/list/random_item_organ_pool = list(
+		/obj/item/organ/appendix,
+		/obj/item/organ/brain,
+		/obj/item/organ/heart,
+		/obj/item/organ/liver,
+		/obj/item/organ/lungs,
+		/obj/item/organ/stomach,
 	)
 
 /datum/surgery_operation/limb/organ_manipulation/New()
@@ -81,7 +92,28 @@
 	return length(get_removable_organs(limb, operated_zone)) > 0
 
 /// Check if inserting an organ is possible
-/datum/surgery_operation/limb/organ_manipulation/proc/is_insert_available(obj/item/bodypart/limb, obj/item/organ/organ, operated_zone)
+/datum/surgery_operation/limb/organ_manipulation/proc/is_insert_available(obj/item/bodypart/limb, obj/item/tool, operated_zone)
+	// Handling the case  of arbitrary items as organs
+	if(!isorgan(tool))
+		if(!LAZYLEN(random_item_organ_pool))
+			return FALSE
+		if(tool.w_class >= WEIGHT_CLASS_NORMAL)
+			return FALSE
+		if(tool.item_flags & (ABSTRACT|DROPDEL|HAND_ITEM))
+			return FALSE
+		if(limb.body_zone != deprecise_zone(operated_zone))
+			return FALSE
+		// Iterate over the organs we can have insert as dummy organs and check if any are applicable here
+		var/list/organ_pool = LAZYCOPY(random_item_organ_pool)
+		for(var/obj/item/organ/option as anything in organ_pool)
+			if(option::zone != operated_zone || (locate(option) in limb))
+				LAZYREMOVE(organ_pool, option)
+				continue
+
+		return LAZYLEN(organ_pool) > 0
+
+	// Normal organ insertion handling
+	var/obj/item/organ/organ = tool
 	if(!organ_check(limb, organ) || (organ.organ_flags & ORGAN_UNUSABLE))
 		return FALSE
 
@@ -94,29 +126,34 @@
 
 	return TRUE
 
+/datum/surgery_operation/limb/organ_manipulation/proc/is_inserting(obj/item/tool)
+	return is_type_in_list(tool, insert_implements)
+
 /datum/surgery_operation/limb/organ_manipulation/snowflake_check_availability(obj/item/bodypart/limb, mob/living/surgeon, obj/item/tool, operated_zone)
-	return isorgan(tool) ? is_insert_available(limb, tool, operated_zone) : is_remove_available(limb, operated_zone)
+	return is_inserting(tool) ? is_insert_available(limb, tool, operated_zone) : is_remove_available(limb, operated_zone)
 
 /datum/surgery_operation/limb/organ_manipulation/get_radial_options(obj/item/bodypart/limb, obj/item/tool, operating_zone)
-	return isorgan(tool) ? get_insert_options(limb, tool, operating_zone) : get_remove_options(limb, operating_zone)
+	return is_inserting(tool) ? get_insert_options(limb, tool, operating_zone) : get_remove_options(limb, operating_zone)
 
 /datum/surgery_operation/limb/organ_manipulation/proc/get_remove_options(obj/item/bodypart/limb, operating_zone)
 	var/list/options = list()
 	for(var/obj/item/organ/organ as anything in get_removable_organs(limb, operating_zone))
-		var/datum/radial_menu_choice/option = LAZYACCESS(cached_organ_manipulation_options, "[organ.type]_remove")
+		var/obj/item/actually_removing = (organ.organ_flags & ORGAN_FAKE) ? organ.contents[1].type : organ.type
+		var/remove_key = "[actually_removing.type]_remove"
+		var/datum/radial_menu_choice/option = LAZYACCESS(cached_organ_manipulation_options, remove_key)
 		if(!option)
 			option = new()
 			option.image = image('icons/hud/surgery_radial.dmi', "base")
-			option.image.overlays += add_radial_overlays(organ.type)
-			option.name = "remove [initial(organ.name)]"
-			option.info = "Remove [initial(organ.name)] from the [limb.owner ? "patient" : "limb"]."
-			LAZYSET(cached_organ_manipulation_options, "[organ.type]_remove", option)
+			option.image.overlays += add_radial_overlays(actually_removing.type)
+			option.name = "remove [initial(actually_removing.name)]"
+			option.info = "Remove [initial(actually_removing.name)] from the [limb.owner ? "patient" : "limb"]."
+			LAZYSET(cached_organ_manipulation_options, remove_key, option)
 
 		options[option] = list("[OPERATION_ACTION]" = "remove", "[OPERATION_REMOVED_ORGAN]" = organ)
 
 	return options
 
-/datum/surgery_operation/limb/organ_manipulation/proc/get_insert_options(obj/item/bodypart/limb, obj/item/organ/organ)
+/datum/surgery_operation/limb/organ_manipulation/proc/get_insert_options(obj/item/bodypart/limb, obj/item/organ)
 	var/datum/radial_menu_choice/option = LAZYACCESS(cached_organ_manipulation_options, "[organ.type]_insert")
 	if(!option)
 		option = new()
@@ -139,24 +176,24 @@
 			var/obj/item/organ/organ = operation_args[OPERATION_REMOVED_ORGAN]
 			if(QDELETED(organ) || !(organ in limb))
 				return FALSE
+
 		if("insert")
-			var/obj/item/organ/organ = tool
-			for(var/obj/item/organ/existing_organ in limb)
-				if(existing_organ.slot == organ.slot)
-					return FALSE
+			if(!is_insert_available(limb, tool, operation_args[OPERATION_TARGET_ZONE]))
+				return FALSE
 
 	return TRUE
 
 /datum/surgery_operation/limb/organ_manipulation/on_preop(obj/item/bodypart/limb, mob/living/surgeon, obj/item/tool, list/operation_args)
 	switch(operation_args[OPERATION_ACTION])
 		if("remove")
-			var/obj/item/organ = operation_args[OPERATION_REMOVED_ORGAN]
+			var/obj/item/organ/organ = operation_args[OPERATION_REMOVED_ORGAN]
 			play_operation_sound(limb, surgeon, tool, remove_preop_sound)
 			display_results(
 				surgeon,
 				limb.owner,
-				span_notice("You begin to remove [organ.name] from [FORMAT_LIMB_OWNER(limb)]..."),
-				span_notice("[surgeon] begins to remove [organ.name] from [limb.owner || limb]."),
+				// Formats the text as "removes the banana" or "removes lungs"
+				span_notice("You begin to remove [(organ.organ_flags & ORGAN_FAKE) ? organ : organ.name] from [FORMAT_LIMB_OWNER(limb)]..."),
+				span_notice("[surgeon] begins to remove [(organ.organ_flags & ORGAN_FAKE) ? organ : organ.name] from [limb.owner || limb]."),
 				span_notice("[surgeon] begins to remove something from [limb.owner || limb]."),
 			)
 			display_pain(limb.owner, "You feel a tugging sensation in your [limb.plaintext_zone]!")
@@ -165,8 +202,9 @@
 			display_results(
 				surgeon,
 				limb.owner,
-				span_notice("You begin to insert [tool.name] into [FORMAT_LIMB_OWNER(limb)]..."),
-				span_notice("[surgeon] begins to insert [tool.name] into [limb.owner || limb]."),
+				// Formats the text as "inserts the banana" or "inserts lungs"
+				span_notice("You begin to insert [isorgan(tool) ? tool.name : tool] into [FORMAT_LIMB_OWNER(limb)]..."),
+				span_notice("[surgeon] begins to insert [isorgan(tool) ? tool.name : tool] into [limb.owner || limb]."),
 				span_notice("[surgeon] begins to insert something into [limb.owner || limb]."),
 			)
 			display_pain(limb.owner, "You can feel something being placed in your [limb.plaintext_zone]!")
@@ -178,7 +216,7 @@
 			on_success_remove_organ(limb, surgeon, operation_args[OPERATION_REMOVED_ORGAN], tool)
 		if("insert")
 			play_operation_sound(limb, surgeon, tool, insert_success_sound)
-			on_success_insert_organ(limb, surgeon, tool)
+			on_success_insert_organ(limb, surgeon, operation_args[OPERATION_TARGET_ZONE], tool)
 	if(HAS_MIND_TRAIT(surgeon, TRAIT_MORBID))
 		surgeon.add_mood_event("morbid_abominable_surgery_success", /datum/mood_event/morbid_abominable_surgery_success)
 
@@ -186,8 +224,9 @@
 	display_results(
 		surgeon,
 		limb.owner,
-		span_notice("You successfully extract [organ.name] from [FORMAT_LIMB_OWNER(limb)]."),
-		span_notice("[surgeon] successfully extracts [organ.name] from [FORMAT_LIMB_OWNER(limb)]!"),
+		// Formats the text as "extracts the banana" or "extracts lungs"
+		span_notice("You successfully extract [(organ.organ_flags & ORGAN_FAKE) ? organ : organ.name] from [FORMAT_LIMB_OWNER(limb)]."),
+		span_notice("[surgeon] successfully extracts [(organ.organ_flags & ORGAN_FAKE) ? organ : organ.name] from [FORMAT_LIMB_OWNER(limb)]!"),
 		span_notice("[surgeon] successfully extracts something from [FORMAT_LIMB_OWNER(limb)]!"),
 	)
 	display_pain(limb.owner, "Your [limb.plaintext_zone] throbs with pain, you can't feel your [organ.name] anymore!")
@@ -196,11 +235,27 @@
 		organ.Remove(limb.owner)
 	else
 		organ.bodypart_remove(limb)
-	organ.forceMove(limb.owner ? limb.owner.drop_location() : limb.drop_location())
+	organ.forceMove(limb.owner?.drop_location() || limb.drop_location())
 	organ.on_surgical_removal(surgeon, limb, tool)
 
-/datum/surgery_operation/limb/organ_manipulation/proc/on_success_insert_organ(obj/item/bodypart/limb, mob/living/surgeon, obj/item/organ/organ)
-	surgeon.temporarilyRemoveItemFromInventory(organ, TRUE)
+/datum/surgery_operation/limb/organ_manipulation/proc/on_success_insert_organ(obj/item/bodypart/limb, mob/living/surgeon, operated_zone, obj/item/tool)
+	var/obj/item/organ/organ
+	if(isorgan(tool))
+		organ = tool
+
+	else
+		for(var/obj/item/organ/option as anything in shuffle(random_item_organ_pool))
+			if(option::zone == operated_zone && !(locate(option) in limb))
+				organ = new option()
+				surgeon.temporarilyRemoveItemFromInventory(tool, TRUE)
+				organ.AddComponent(/datum/component/arbitrary_item_organ, tool)
+				break
+
+	if(isnull(organ))
+		CRASH("Somehow failed to find a valid organ to insert (inserting: [tool || "null"])")
+
+	if(organ.loc == surgeon)
+		surgeon.temporarilyRemoveItemFromInventory(organ, TRUE)
 	organ.pre_surgical_insertion(surgeon, limb, limb.body_zone)
 	if (limb.owner)
 		organ.Insert(limb.owner)
@@ -210,8 +265,9 @@
 	display_results(
 		surgeon,
 		limb.owner,
-		span_notice("You successfully insert [organ.name] into [FORMAT_LIMB_OWNER(limb)]."),
-		span_notice("[surgeon] successfully inserts [organ.name] into [FORMAT_LIMB_OWNER(limb)]."),
+		// Formats the text as "inserts the banana" or "inserts lungs"
+		span_notice("You successfully insert [isorgan(tool) ? tool.name : tool] into [FORMAT_LIMB_OWNER(limb)]."),
+		span_notice("[surgeon] successfully inserts [isorgan(tool) ? tool.name : tool] into [FORMAT_LIMB_OWNER(limb)]."),
 		span_notice("[surgeon] successfully inserts something into [FORMAT_LIMB_OWNER(limb)]."),
 	)
 	display_pain(limb.owner, "Your [limb.plaintext_zone] throbs with pain as your new [organ.name] comes to life!")
@@ -266,6 +322,7 @@
 	replaced_by = /datum/surgery_operation/limb/organ_manipulation/external/abductor
 	all_surgery_states_required = SURGERY_SKIN_OPEN|SURGERY_BONE_SAWED
 	any_surgery_states_blocked = SURGERY_VESSELS_UNCLAMPED
+	random_item_organ_pool = null
 
 /datum/surgery_operation/limb/organ_manipulation/external/organ_check(obj/item/bodypart/limb, obj/item/organ/organ)
 	return (organ.organ_flags & ORGAN_EXTERNAL)

--- a/code/modules/surgery/operations/operation_organ_manip.dm
+++ b/code/modules/surgery/operations/operation_organ_manip.dm
@@ -192,7 +192,7 @@
 				surgeon,
 				limb.owner,
 				span_notice("You begin to remove [organ] from [FORMAT_LIMB_OWNER(limb)]..."),
-				span_notice("[surgeon] begins to remove [(organ.organ_flags & ORGAN_FAKE) ? organ : organ.name] from [limb.owner || limb]."),
+				span_notice("[surgeon] begins to remove [organ] from [limb.owner || limb]."),
 				span_notice("[surgeon] begins to remove something from [limb.owner || limb]."),
 			)
 			display_pain(limb.owner, "You feel a tugging sensation in your [limb.plaintext_zone]!")

--- a/code/modules/surgery/operations/operation_organ_manip.dm
+++ b/code/modules/surgery/operations/operation_organ_manip.dm
@@ -191,8 +191,7 @@
 			display_results(
 				surgeon,
 				limb.owner,
-				// Formats the text as "removes the banana" or "removes lungs"
-				span_notice("You begin to remove [(organ.organ_flags & ORGAN_FAKE) ? organ : organ.name] from [FORMAT_LIMB_OWNER(limb)]..."),
+				span_notice("You begin to remove [organ] from [FORMAT_LIMB_OWNER(limb)]..."),
 				span_notice("[surgeon] begins to remove [(organ.organ_flags & ORGAN_FAKE) ? organ : organ.name] from [limb.owner || limb]."),
 				span_notice("[surgeon] begins to remove something from [limb.owner || limb]."),
 			)
@@ -202,8 +201,7 @@
 			display_results(
 				surgeon,
 				limb.owner,
-				// Formats the text as "inserts the banana" or "inserts lungs"
-				span_notice("You begin to insert [isorgan(tool) ? tool.name : tool] into [FORMAT_LIMB_OWNER(limb)]..."),
+				span_notice("You begin to insert [tool] into [FORMAT_LIMB_OWNER(limb)]..."),
 				span_notice("[surgeon] begins to insert [isorgan(tool) ? tool.name : tool] into [limb.owner || limb]."),
 				span_notice("[surgeon] begins to insert something into [limb.owner || limb]."),
 			)
@@ -224,9 +222,8 @@
 	display_results(
 		surgeon,
 		limb.owner,
-		// Formats the text as "extracts the banana" or "extracts lungs"
-		span_notice("You successfully extract [(organ.organ_flags & ORGAN_FAKE) ? organ : organ.name] from [FORMAT_LIMB_OWNER(limb)]."),
-		span_notice("[surgeon] successfully extracts [(organ.organ_flags & ORGAN_FAKE) ? organ : organ.name] from [FORMAT_LIMB_OWNER(limb)]!"),
+		span_notice("You successfully extract [organ] from [FORMAT_LIMB_OWNER(limb)]."),
+		span_notice("[surgeon] successfully extracts [organ] from [FORMAT_LIMB_OWNER(limb)]!"),
 		span_notice("[surgeon] successfully extracts something from [FORMAT_LIMB_OWNER(limb)]!"),
 	)
 	display_pain(limb.owner, "Your [limb.plaintext_zone] throbs with pain, you can't feel your [organ.name] anymore!")

--- a/code/modules/surgery/operations/operation_organ_manip.dm
+++ b/code/modules/surgery/operations/operation_organ_manip.dm
@@ -262,9 +262,8 @@
 	display_results(
 		surgeon,
 		limb.owner,
-		// Formats the text as "inserts the banana" or "inserts lungs"
-		span_notice("You successfully insert [isorgan(tool) ? tool.name : tool] into [FORMAT_LIMB_OWNER(limb)]."),
-		span_notice("[surgeon] successfully inserts [isorgan(tool) ? tool.name : tool] into [FORMAT_LIMB_OWNER(limb)]."),
+		span_notice("You successfully insert [tool] into [FORMAT_LIMB_OWNER(limb)]."),
+		span_notice("[surgeon] successfully inserts [tool] into [FORMAT_LIMB_OWNER(limb)]."),
 		span_notice("[surgeon] successfully inserts something into [FORMAT_LIMB_OWNER(limb)]."),
 	)
 	display_pain(limb.owner, "Your [limb.plaintext_zone] throbs with pain as your new [organ.name] comes to life!")

--- a/code/modules/surgery/organs/organ_movement.dm
+++ b/code/modules/surgery/organs/organ_movement.dm
@@ -264,6 +264,8 @@
 	limb.owner?.synchronize_bodytypes()
 	limb.owner?.synchronize_bodyshapes()
 
+	SEND_SIGNAL(src, COMSIG_ORGAN_BODYPART_REMOVED, limb)
+
 	if(!bodypart_overlay)
 		return
 
@@ -278,6 +280,8 @@
 		get_greyscale_color_from_draw_color()
 	else
 		color = bodypart_overlay.draw_color // so a pink felinid doesn't drop a gray tail
+
+
 
 ///Here we define how draw_color from the bodypart overlay sets the greyscale colors of organs that use GAGS
 /obj/item/organ/proc/get_greyscale_color_from_draw_color()

--- a/code/modules/surgery/organs/organ_movement.dm
+++ b/code/modules/surgery/organs/organ_movement.dm
@@ -281,8 +281,6 @@
 	else
 		color = bodypart_overlay.draw_color // so a pink felinid doesn't drop a gray tail
 
-
-
 ///Here we define how draw_color from the bodypart overlay sets the greyscale colors of organs that use GAGS
 /obj/item/organ/proc/get_greyscale_color_from_draw_color()
 	color = bodypart_overlay.draw_color //Defaults to the legacy behaviour of applying the color to the item.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1255,6 +1255,7 @@
 #include "code\datums\components\appearance_on_aggro.dm"
 #include "code\datums\components\aquarium.dm"
 #include "code\datums\components\aquarium_content.dm"
+#include "code\datums\components\arbitrary_item_organ.dm"
 #include "code\datums\components\area_based_godmode.dm"
 #include "code\datums\components\area_sound_manager.dm"
 #include "code\datums\components\areabound.dm"


### PR DESCRIPTION
## About The Pull Request

Instead of putting an organ in someone's chest, you can put a banana. It won't work... but you can do it

<img width="534" height="283" alt="image" src="https://github.com/user-attachments/assets/31e1f177-65c4-4a12-aa80-61fe78a1c99b" />

## Why It's Good For The Game

Malpractice suggestion from OOC. Thought it was sufficiently funny

## Changelog

:cl: Melbert
add: You can use food items in place of some organs for "organ manipulation"...It won't work, but y'know, you can do it
qol: Organ manipulation will cancel mid operation if it suddenly becomes invalid, rather than allow it to continue
/:cl:
