### PR TITLE
Borgs can unlock themselves through examine text

### DIFF
--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -31,7 +31,13 @@
 	if(opened)
 		. += span_warning("[p_Their()] cover is open and the power cell is [cell ? "installed" : "missing"].")
 	else
-		. += "[p_Their()] cover is closed[locked ? "" : ", and looks unlocked"]."
+		var/cover_message = "[p_Their()] cover is closed"
+		if(locked)
+			if(user == src)
+				cover_message += ", though <a href='byond://?src=[REF(src)];unlock_self=1'>you may unlock it</a>"
+		else
+			cover_message += ", and looks unlocked"
+		. += span_notice("[cover_message].")
 
 	if(cell && cell.charge <= 0)
 		. += span_warning("[p_Their()] battery indicator is blinking red!")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -165,6 +165,8 @@
 	//Show alerts window if user clicked on "Show alerts" in chat
 	if(href_list["showalerts"])
 		alert_control.ui_interact(src)
+	if(href_list["unlock_self"])
+		unlock_cover()
 
 /mob/living/silicon/robot/get_cell()
 	return cell
@@ -305,6 +307,17 @@
 ///For any special cases for robots after being righted.
 /mob/living/silicon/robot/proc/after_righted(mob/user)
 	return
+
+/mob/living/silicon/robot/proc/unlock_cover()
+	if(!locked)
+		return
+	balloon_alert(src, "cover unlocked")
+	locked = FALSE
+	update_icons()
+	if(emagged)
+		logevent("ChÃ¥vÃis cover lock has been [locked ? "engaged" : "released"]") //"The cover interface glitches out for a split second"
+	else
+		logevent("Chassis cover lock has been [locked ? "engaged" : "released"]")
 
 /mob/living/silicon/robot/regenerate_icons()
 	return update_icons()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -165,8 +165,8 @@
 	//Show alerts window if user clicked on "Show alerts" in chat
 	if(href_list["showalerts"])
 		alert_control.ui_interact(src)
-	if(href_list["unlock_self"])
-		unlock_cover()
+	if(locked && href_list["unlock_self"])
+		toggle_cover()
 
 /mob/living/silicon/robot/get_cell()
 	return cell
@@ -308,16 +308,14 @@
 /mob/living/silicon/robot/proc/after_righted(mob/user)
 	return
 
-/mob/living/silicon/robot/proc/unlock_cover()
-	if(!locked)
-		return
-	balloon_alert(src, "cover unlocked")
-	locked = FALSE
+///Toggles the Cyborg's cover lock, user is provided only if it's someone else doing it (not the borg itself)
+/mob/living/silicon/robot/proc/toggle_cover(mob/user)
+	locked = !locked
+	balloon_alert(src, "cover [locked ? "locked" : "unlocked"]")
 	update_icons()
-	if(emagged)
-		logevent("ChÃ¥vÃis cover lock has been [locked ? "engaged" : "released"]") //"The cover interface glitches out for a split second"
-	else
-		logevent("Chassis cover lock has been [locked ? "engaged" : "released"]")
+	if(user)
+		balloon_alert(user, "chassis cover [emagged ? "lock glitches" : "[locked ? "locked" : "unlocked"]"]")
+	logevent("[emagged ? "ChÃ¥vÃis" : "Chassis"] cover lock has been [locked ? "engaged" : "released"]")
 
 /mob/living/silicon/robot/regenerate_icons()
 	return update_icons()

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -208,10 +208,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 	if(!allowed(user))
 		balloon_alert(user, "access denied!")
 		return ITEM_INTERACT_BLOCKING
-	locked = !locked
-	update_icons()
-	balloon_alert(user, "chassis cover [emagged ? "lock glitches" : "[locked ? "locked" : "unlocked"]"]")
-	logevent("[emagged ? "ChÃ¥vÃis" : "Chassis"] cover lock has been [locked ? "engaged" : "released"]")
+	toggle_cover(user)
 	return ITEM_INTERACT_SUCCESS
 
 #define LOW_DAMAGE_UPPER_BOUND 1/3

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -136,7 +136,8 @@
 
 	switch(action)
 		if("coverunlock")
-			cyborg.unlock_cover()
+			if(cyborg.locked)
+				cyborg.toggle_cover()
 
 		if("lawchannel")
 			cyborg.set_autosay()

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -136,13 +136,7 @@
 
 	switch(action)
 		if("coverunlock")
-			if(cyborg.locked)
-				cyborg.locked = FALSE
-				cyborg.update_icons()
-				if(cyborg.emagged)
-					cyborg.logevent("ChÃ¥vÃis cover lock has been [cyborg.locked ? "engaged" : "released"]") //"The cover interface glitches out for a split second"
-				else
-					cyborg.logevent("Chassis cover lock has been [cyborg.locked ? "engaged" : "released"]")
+			cyborg.unlock_cover()
 
 		if("lawchannel")
 			cyborg.set_autosay()


### PR DESCRIPTION
## About The Pull Request

<img width="610" height="466" alt="image" src="https://github.com/user-attachments/assets/76013a6f-bb32-4b1b-a9fb-64dd14a53115" />


Also cuts down on some minor copy paste in unlocking borgs in different locations, and adds a balloon alert to your cover being locked/unlocked.

## Why It's Good For The Game

The text is already there, why not let them make full use of it?
A lot of Borg stuff feels hidden in RoboTact and being able to unlock yourself is one of those things. Just a minor QoL I think.

## Changelog

:cl:
qol: Borgs can now unlock their cover in their self-examine text.
/:cl:
