### PR TITLE
[NO GBP] Fix spawn text appearing over HUD

### DIFF
--- a/code/modules/client/spawn_text_overlay.dm
+++ b/code/modules/client/spawn_text_overlay.dm
@@ -21,7 +21,7 @@
 	spawn_text.maptext_height = 64
 	spawn_text.maptext_width = 512
 	spawn_text.layer = FLY_LAYER
-	spawn_text.plane = HUD_PLANE
+	spawn_text.plane = FULLSCREEN_PLANE
 	spawn_text.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 	spawn_text.screen_loc = "LEFT+1,BOTTOM+2"
 

--- a/code/modules/client/spawn_text_overlay.dm
+++ b/code/modules/client/spawn_text_overlay.dm
@@ -23,7 +23,7 @@
 	spawn_text.layer = FLY_LAYER
 	spawn_text.plane = FULLSCREEN_PLANE
 	spawn_text.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-	spawn_text.screen_loc = "LEFT+1,BOTTOM+2"
+	spawn_text.screen_loc = "LEFT+1,TOP-3"
 
 	screen += spawn_text
 	animate(spawn_text, alpha = 255, time = 1 SECONDS)


### PR DESCRIPTION

## About The Pull Request
- Fixes https://github.com/tgstation/tgstation/issues/97339

Moves the spawn text plane to be below UI stuff.

## Why It's Good For The Game
<img width="1338" height="1057" alt="dreamseeker_SuHwD75Ls4" src="https://github.com/user-attachments/assets/167b84d5-c952-49e8-b130-6d041fee3499" />


## Changelog
:cl:
fix: Fix spawn text appearing over HUD. Move spawn text to the top left of the screen
/:cl:
