### PR TITLE
Improves visibility of CONTRIBUTING.md for new developers in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
 | /tg/station Discord | https://tgstation13.org/phpBB/viewforum.php?f=60      |
 | Coderbus Discord    | https://discord.gg/Vh8TJp9                            |
 | Contribution Guide  | https://github.com/tgstation/tgstation/blob/master/.github/CONTRIBUTING.md |
+| Getting Started With Development | https://hackmd.io/@tgstation/HJ8OdjNBc#tgstation-Development-Guide |
+| Maintainer-Approved Design Docs | https://hackmd.io/@tgstation |
+| Common Core Lore | https://github.com/tgstation/common_core |
+
 
 This is the codebase for the /tg/station flavoured fork of SpaceStation 13.
 
@@ -41,14 +45,6 @@ _All github inquiries (such as moderation actions) may be handled via the /tg/st
 **Building tgstation in DreamMaker directly is deprecated and might produce errors**, such as `'tgui.bundle.js': cannot find file`.
 
 **[How to compile in VSCode and other build options](tools/build/README.md).**
-
-## Getting started
-
-For getting started (dev env, compilation) see the HackMD document [here](https://hackmd.io/@tgstation/HJ8OdjNBc#tgstation-Development-Guide).
-
-For overall design documentation see [HackMD](https://hackmd.io/@tgstation).
-
-For lore, [see Common Core](https://github.com/tgstation/common_core).
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 | Codedocs            | https://codedocs.tgstation13.org/                     |
 | /tg/station Discord | https://tgstation13.org/phpBB/viewforum.php?f=60      |
 | Coderbus Discord    | https://discord.gg/Vh8TJp9                            |
+| Contribution Guide  | https://github.com/tgstation/tgstation/blob/master/.github/CONTRIBUTING.md |
 
 This is the codebase for the /tg/station flavoured fork of SpaceStation 13.
 
@@ -42,8 +43,6 @@ _All github inquiries (such as moderation actions) may be handled via the /tg/st
 **[How to compile in VSCode and other build options](tools/build/README.md).**
 
 ## Getting started
-
-For contribution guidelines refer to the [Guides for Contributors](.github/CONTRIBUTING.md).
 
 For getting started (dev env, compilation) see the HackMD document [here](https://hackmd.io/@tgstation/HJ8OdjNBc#tgstation-Development-Guide).
 


### PR DESCRIPTION
## About The Pull Request

Improves visibility of CONTRIBUTING.md for new developers in the README.md

## Why It's Good For The Game

New contributors and also even old contributors have expressed to me they routinely miss the CONTRIBUTING.md because it's hard to find unless you click tiny links on the sidelines of the PR process or click the "hey there's a guide to contributing btw" button by the time you're opening your first PR, at which point you've probably already broken the style guide and contributing rules. This should help matters as most our new developers tend to not find it, and also the new developer prompt making the popup occur apparently is kinda broken these days.

## Changelog

N/A, not an in-game change, github docs.