### PR TITLE
Removes Xenomorph stat panel entry

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -377,6 +377,9 @@
 #define CRYSTALIZE_STAGE_ENCROACHING 300 //In switches
 #define CRYSTALIZE_STAGE_SMALL 600 //Because they're not static
 
+///Max growth for a xeno larva to evolve into a regular xeno. This is used as % based.
+#define XENOMORPH_MAX_GROWTH 100
+
 //Slime evolution threshold. Controls how fast slimes can split/grow
 #define SLIME_EVOLUTION_THRESHOLD 10
 

--- a/code/modules/mob/living/basic/basic_defense.dm
+++ b/code/modules/mob/living/basic/basic_defense.dm
@@ -99,7 +99,7 @@
 	if(. && stat != DEAD) //successful larva bite
 		var/damage_done = apply_damage(rand(attacking_larva.melee_damage_lower, attacking_larva.melee_damage_upper), BRUTE)
 		if(damage_done > 0)
-			attacking_larva.amount_grown = min(attacking_larva.amount_grown + damage_done, attacking_larva.max_grown)
+			attacking_larva.amount_grown = min(attacking_larva.amount_grown + damage_done, XENOMORPH_MAX_GROWTH)
 
 /mob/living/basic/attack_drone(mob/living/basic/drone/attacking_drone)
 	if(attacking_drone.combat_mode) //No kicking dogs even as a rogue drone. Use a weapon.

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -35,7 +35,6 @@
 	)
 
 	var/amount_grown = 0
-	var/max_grown = 100
 	var/time_of_birth
 
 
@@ -46,14 +45,7 @@
 		/datum/action/cooldown/alien/larva_evolve,
 	)
 	grant_actions_by_list(innate_actions)
-
 	return ..()
-
-//This needs to be fixed
-// This comment is 12 years old I hope it's fixed by now
-/mob/living/carbon/alien/larva/get_status_tab_items()
-	. = ..()
-	. += "Progress: [amount_grown]/[max_grown]"
 
 /mob/living/carbon/alien/larva/Login()
 	. = ..()
@@ -63,7 +55,7 @@
 
 /mob/living/carbon/alien/larva/adjustPlasma(amount)
 	if(stat != DEAD && amount > 0)
-		amount_grown = min(amount_grown + 1, max_grown)
+		amount_grown = min(amount_grown + 1, XENOMORPH_MAX_GROWTH)
 	..(amount)
 
 //can't equip anything

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -3,10 +3,10 @@
 /mob/living/carbon/alien/larva/Life(seconds_per_tick = SSMOBS_DT)
 	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	if(!..() || HAS_TRAIT(src, TRAIT_STASIS) || (amount_grown >= max_grown))
+	if(!..() || HAS_TRAIT(src, TRAIT_STASIS) || (amount_grown >= XENOMORPH_MAX_GROWTH))
 		return // We're dead, in stasis, or already grown.
 	// GROW!
-	amount_grown = min(amount_grown + (0.5 * seconds_per_tick), max_grown)
+	amount_grown = min(amount_grown + (0.5 * seconds_per_tick), XENOMORPH_MAX_GROWTH)
 	update_icons()
 
 /mob/living/carbon/alien/larva/on_knockedout_trait_loss(datum/source)

--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -34,7 +34,7 @@
 
 /datum/action/cooldown/alien/larva_evolve/create_button(mob/viewer)
 	var/atom/movable/screen/movable/action_button/button = ..()
-	button.maptext_x = 2
+	button.maptext_x = 1
 	return button
 
 /datum/action/cooldown/alien/larva_evolve/update_button_status(atom/movable/screen/movable/action_button/button, force = FALSE)

--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -29,7 +29,18 @@
 	name = "Evolve"
 	desc = "Evolve into a higher alien caste."
 	button_icon_state = "alien_evolve_larva"
+	transparent_when_unavailable = FALSE
 	plasma_cost = 0
+
+/datum/action/cooldown/alien/larva_evolve/create_button(mob/viewer)
+	var/atom/movable/screen/movable/action_button/button = ..()
+	button.maptext_x = 2
+	return button
+
+/datum/action/cooldown/alien/larva_evolve/update_button_status(atom/movable/screen/movable/action_button/button, force = FALSE)
+	. = ..()
+	var/mob/living/carbon/alien/larva/larva_owner = owner
+	button.maptext = MAPTEXT_TINY_UNICODE("[(larva_owner.amount_grown / XENOMORPH_MAX_GROWTH) * 100]%")
 
 /datum/action/cooldown/alien/larva_evolve/IsAvailable(feedback = FALSE)
 	. = ..()
@@ -41,7 +52,7 @@
 	var/mob/living/carbon/alien/larva/larva = owner
 	if(larva.handcuffed || larva.legcuffed) // Cuffing larvas ? Eh ?
 		return FALSE
-	if(larva.amount_grown < larva.max_grown)
+	if(larva.amount_grown < XENOMORPH_MAX_GROWTH)
 		return FALSE
 	if(larva.movement_type & VENTCRAWLING)
 		return FALSE

--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -40,7 +40,7 @@
 /datum/action/cooldown/alien/larva_evolve/update_button_status(atom/movable/screen/movable/action_button/button, force = FALSE)
 	. = ..()
 	var/mob/living/carbon/alien/larva/larva_owner = owner
-	button.maptext = MAPTEXT_TINY_UNICODE("[(larva_owner.amount_grown / XENOMORPH_MAX_GROWTH) * 100]%")
+	button.maptext = MAPTEXT_TINY_UNICODE("<span style='text-align: center'>[(larva_owner.amount_grown / XENOMORPH_MAX_GROWTH) * 100]%</span>")
 
 /datum/action/cooldown/alien/larva_evolve/IsAvailable(feedback = FALSE)
 	. = ..()

--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -40,7 +40,7 @@
 /datum/action/cooldown/alien/larva_evolve/update_button_status(atom/movable/screen/movable/action_button/button, force = FALSE)
 	. = ..()
 	var/mob/living/carbon/alien/larva/larva_owner = owner
-	button.maptext = MAPTEXT_TINY_UNICODE("<span style='text-align: center'>[(larva_owner.amount_grown / XENOMORPH_MAX_GROWTH) * 100]%</span>")
+	button.maptext = MAPTEXT_TINY_UNICODE("<span style='text-align: center'>[round((larva_owner.amount_grown / XENOMORPH_MAX_GROWTH) * 100, 0.1)]%</span>")
 
 /datum/action/cooldown/alien/larva_evolve/IsAvailable(feedback = FALSE)
 	. = ..()

--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -40,7 +40,9 @@
 /datum/action/cooldown/alien/larva_evolve/update_button_status(atom/movable/screen/movable/action_button/button, force = FALSE)
 	. = ..()
 	var/mob/living/carbon/alien/larva/larva_owner = owner
-	button.maptext = MAPTEXT_TINY_UNICODE("<span style='text-align: center'>[round((larva_owner.amount_grown / XENOMORPH_MAX_GROWTH) * 100, 0.1)]%</span>")
+	var/percentage_shown = "[round((larva_owner.amount_grown / XENOMORPH_MAX_GROWTH) * 100, 0.1)]"
+	button.maptext_x = (length(percentage_shown) >= 3) ? 0 : 1
+	button.maptext = MAPTEXT_TINY_UNICODE("<span style='text-align: center'>[percentage_shown]%</span>")
 
 /datum/action/cooldown/alien/larva_evolve/IsAvailable(feedback = FALSE)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -250,7 +250,7 @@
 	if(check_block(worm, damage, "\the [worm]", attack_type = UNARMED_ATTACK))
 		return FALSE
 	if(stat != DEAD)
-		worm.amount_grown = min(worm.amount_grown + damage, worm.max_grown)
+		worm.amount_grown = min(worm.amount_grown + damage, XENOMORPH_MAX_GROWTH)
 		var/obj/item/bodypart/affecting = get_bodypart(get_random_valid_zone(worm.zone_selected))
 		var/armor_block = run_armor_check(affecting, MELEE)
 		apply_damage(damage, BRUTE, affecting, armor_block)

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -87,7 +87,7 @@
 	if(. && stat != DEAD) //successful larva bite
 		var/damage_done = apply_damage(rand(L.melee_damage_lower, L.melee_damage_upper), BRUTE)
 		if(damage_done > 0)
-			L.amount_grown = min(L.amount_grown + damage_done, L.max_grown)
+			L.amount_grown = min(L.amount_grown + damage_done, XENOMORPH_MAX_GROWTH)
 
 /mob/living/simple_animal/attack_drone(mob/living/basic/drone/user)
 	if(user.combat_mode) //No kicking dogs even as a rogue drone. Use a weapon.


### PR DESCRIPTION
## About The Pull Request

Alien larvas have a stat panel entry for their growth, used solely in their Evolve button

Now it's a % to be fully evolved, overlayed on the action button itself.

<img width="390" height="102" alt="image" src="https://github.com/user-attachments/assets/96cb1823-9196-4269-9a22-8c68dd2baf95" />


## Why It's Good For The Game

Better visibility for alien larvas. Did you know you're **not** ready when you turn red? That's at 80%. This meant stat panel was the ONLY way to know for sure when the one button was available.

This is also a minor entry in https://hackmd.io/443_dE5lRWeEAp9bjGcKYw?view

## Changelog

:cl:
qol: Alien larva's 'Evolve' button now says when it's ready, rather than being in the stat panel.
/:cl:
