### PR TITLE
Adds foodtypes to COMSIG_LIVING_EAT_FOOD and refactors flesh heretic's tier 2 passive a lil

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_food.dm
+++ b/code/__DEFINES/dcs/signals/signals_food.dm
@@ -2,7 +2,7 @@
 //Food
 
 // Eating stuff
-/// From datum/component/edible/proc/TakeBite: (atom/owner)
+/// From datum/component/edible/proc/TakeBite: (atom/owner, foodtypes)
 #define COMSIG_LIVING_EAT_FOOD "food_bit"
 /// From datum/component/edible/proc/TakeBite: (mob/living/eater, mob/feeder, bitecount, bitesize)
 #define COMSIG_FOOD_EATEN "food_eaten"

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -496,7 +496,7 @@ Behavior that's still missing from this component that original food items had t
 	playsound(eater.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
 	if(!owner.reagents.total_volume)
 		return
-	SEND_SIGNAL(eater, COMSIG_LIVING_EAT_FOOD, owner)
+	SEND_SIGNAL(eater, COMSIG_LIVING_EAT_FOOD, owner, foodtypes)
 	var/sig_return = SEND_SIGNAL(parent, COMSIG_FOOD_EATEN, eater, feeder, bitecount, bite_consumption)
 	if(sig_return & DESTROY_FOOD)
 		qdel(owner)

--- a/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
+++ b/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
@@ -391,7 +391,7 @@
 /// Any time you take a bite of something, if it's meat or gory (probably an organ) you will heal some damage
 /datum/status_effect/heretic_passive/flesh/proc/on_eat(mob/eater, atom/food, foodtypes)
 	SIGNAL_HANDLER
-	if(foodtypes & MEAT || GORE) //All edible organs are gory, but not all of them are meat (podpeople, fishpeople.) If someone adds edible non-meat, non-gory organs, then I guess back to the drawing board.
+	if(foodtypes & (MEAT | GORE)) //All edible organs are gory, but not all of them are meat (podpeople, fishpeople.) If someone adds edible non-meat, non-gory organs, then I guess back to the drawing board.
 		heal_glutton()
 
 /datum/status_effect/heretic_passive/flesh/proc/heal_glutton()

--- a/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
+++ b/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
@@ -388,16 +388,11 @@
 	tongue.disliked_foodtypes = NONE
 	tongue.toxic_foodtypes = NONE
 
-/// Any time you take a bite of something, if it's meat or an organ you will heal some damage
-/datum/status_effect/heretic_passive/flesh/proc/on_eat(mob/eater, atom/food)
+/// Any time you take a bite of something, if it's meat or gory (probably an organ) you will heal some damage
+/datum/status_effect/heretic_passive/flesh/proc/on_eat(mob/eater, atom/food, foodtypes)
 	SIGNAL_HANDLER
-	var/obj/item/organ/consumed_organ = food
-	if(istype(consumed_organ) && consumed_organ.foodtype_flags & MEAT)
-		heal_glutton() // Heal the owner if they eat meat
-		return
-	var/obj/item/food/consumed_food = food
-	if(istype(consumed_food) && consumed_food.foodtypes & MEAT)
-		heal_glutton() // Heal the owner if they eat meat
+	if(foodtypes & MEAT || GORE) //All edible organs are gory, but not all of them are meat (podpeople, fishpeople.) If someone adds edible non-meat, non-gory organs, then I guess back to the drawing board.
+		heal_glutton()
 
 /datum/status_effect/heretic_passive/flesh/proc/heal_glutton()
 	var/healed_amount = owner.heal_overall_damage(2, 2, updating_health = FALSE)


### PR DESCRIPTION

## About The Pull Request

Adds foodtypes to the COMSIG_LIVING_EAT_FOOD signal. Also did some refactoring of the flesh heretic tier 2 passive, and as a side effect it now heals when eating anything meat or gory, which includes everything previously but also now includes fish and podpeople organs (which are seafood and plant respectively, but still gory. To my knowledge all non-meat gory foods in the game are organs of this type.)
## Why It's Good For The Game

Mostly doing this because Melbert implied it'd be a good idea. As for the fish/podperson organ thing, I'm not sure why the allowed organs were limited to meat in the first place, but it seems reasonable to me that heretics should be able to benefit from them. If you're looking for a lore justification, uh, something something THE WOOD something something The Grail drank the Tide. 
## Changelog
:cl:
fix: Flesh heretics now benefit from eating the organs of non-meaty victims, such as fish and podpeople.
/:cl:
