### PR TITLE
Fixes esword duping with general beepsky

### DIFF
--- a/code/modules/mob/living/basic/bots/secbot/super_beepsky.dm
+++ b/code/modules/mob/living/basic/bots/secbot/super_beepsky.dm
@@ -84,7 +84,7 @@
 /mob/living/basic/bot/secbot/grievous/explode()
 	var/atom/drop_location = drop_location()
 	//Parent is dropping the weapon, so let's drop 3 more to make up for it.
-	for(var/i in 0 to 3)
+	for(var/i in 1 to 3)
 		drop_part(baton_type, drop_location)
 
 	return ..()


### PR DESCRIPTION

## About The Pull Request

`0 to 3` contains 4 numbers

## Why It's Good For The Game

no free eswords

## Changelog
:cl:
fix: General Beepsky no longer provides an extra free esword when destroyed
/:cl:
