### PR TITLE
explicitly use new icon smoothing render pass 

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -12,3 +12,7 @@ use_typepath_names = true
 
 [debugger]
 engine = "auxtools"
+
+[map_renderer.render_passes]
+icon-smoothing = false
+icon-smoothing-2025 = true


### PR DESCRIPTION

## About The Pull Request
dmm-tools was updated previously to use the "new" icon smoothing system https://github.com/SpaceManiac/SpacemanDMM/pull/454

This PR specifies the use of this new render pass and disables the old one. 
## Why It's Good For The Game
i like when tools work and don't look bad. also this should easily be adopted by downstreams.
## Changelog
:cl:
/:cl:
