### PR TITLE
Fixes Filterrific bluescreening when creating a color filter

### DIFF
--- a/tgui/packages/tgui/interfaces/Filterrific.jsx
+++ b/tgui/packages/tgui/interfaces/Filterrific.jsx
@@ -324,7 +324,7 @@ const FilterMatrixEntry = (props) => {
               {matrix_row.map((matrix_elem, elem_index) => (
                 <Stack.Item key={elem_index}>
                   <NumberInput
-                    value={matrix[row_index * row_width + elem_index]}
+                    value={matrix[row_index * row_width + elem_index] || 0}
                     minValue={-4}
                     maxValue={4}
                     step={0.01}


### PR DESCRIPTION

## About The Pull Request

Editing a newly created color filter would bluescreen Filterrific as it would not have any matrix values set, which would cause an error as undefined cannot be stringified by our number inputs

## Changelog
:cl:
fix: Fixed Filterrific bluescreening when creating a color filter
/:cl:
