### PR TITLE
Golem foods now provide different nutrients based on the type of ore. Golem hunger buffs.

### DIFF
--- a/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
+++ b/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
@@ -8,6 +8,12 @@
 /obj/item/pen/blue{
 	pixel_x = -5
 	},
+/obj/machinery/button/door{
+	pixel_y = 7;
+	id = "golemship";
+	name = "shutter button";
+	desc = "The shutter control switch for the main research vessel."
+	},
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "aU" = (
@@ -139,6 +145,13 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
+"ge" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/preopen{
+	id = "golemship_bedroom"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
 "gv" = (
 /obj/structure/closet,
 /obj/item/storage/bag/ore,
@@ -185,6 +198,9 @@
 /area/ruin/powered/golem_ship)
 "lF" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/preopen{
+	id = "golemship"
+	},
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
 "lH" = (
@@ -194,6 +210,9 @@
 /obj/item/chair/wood{
 	pixel_x = 4;
 	pixel_y = -8
+	},
+/obj/machinery/button/door/directional/south{
+	id = "golemship_bedroom"
 	},
 /turf/open/floor/wood,
 /area/ruin/powered/golem_ship)
@@ -630,6 +649,7 @@
 /obj/item/fishing_rod,
 /obj/item/fishing_rod,
 /obj/item/fishing_rod,
+/obj/item/storage/box/lights/tubes,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "LN" = (
@@ -818,8 +838,8 @@
 (1,1,1) = {"
 wN
 Df
-lF
-lF
+ge
+ge
 Df
 wN
 wN
@@ -838,7 +858,7 @@ Df
 Df
 WL
 Ro
-lF
+ge
 wN
 wN
 lF
@@ -856,7 +876,7 @@ Df
 bu
 ET
 tY
-lF
+ge
 wN
 wN
 Df
@@ -870,13 +890,13 @@ Df
 wN
 "}
 (4,1,1) = {"
-lF
+ge
 cp
 cN
 lH
 Df
-lF
-lF
+ge
+ge
 Df
 WM
 sS
@@ -888,7 +908,7 @@ lF
 wN
 "}
 (5,1,1) = {"
-lF
+ge
 Pe
 fk
 fk
@@ -911,8 +931,8 @@ gz
 aU
 Pa
 Df
-lF
-lF
+ge
+ge
 Df
 LN
 sS
@@ -944,7 +964,7 @@ wN
 (8,1,1) = {"
 Df
 Df
-lF
+ge
 Df
 Df
 wN

--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -280,3 +280,6 @@ DEFINE_BITFIELD(food_flags, list(
 #define MEATSLAB_PROCESSED_AMOUNT 3
 /// This should be 1/3 of the amount found in a slab (a portion will be lost when rounding but it's negligible)
 #define MEATDISH_MATERIAL_AMOUNT (MEATSLAB_MATERIAL_AMOUNT / MEATSLAB_PROCESSED_AMOUNT)
+
+/// The multiplier for nutrition when a golem eats this particular type of food.
+#define GOLEMFOOD_PREPARED_MEAL 1.3

--- a/code/datums/components/food/golem_food.dm
+++ b/code/datums/components/food/golem_food.dm
@@ -8,8 +8,10 @@
 	var/obj/item/food/golem_food/golem_snack
 	/// Any extra checks which need to be done when seeing if this is edible
 	var/datum/callback/extra_validation
+	/// What additional nutrition modifiers should be added to this food? We apply extra nutrition to ores that are processed into sheets.
+	var/food_multiplier
 
-/datum/component/golem_food/Initialize(consume_on_eat = TRUE, golem_food_key, datum/callback/extra_validation)
+/datum/component/golem_food/Initialize(consume_on_eat = TRUE, golem_food_key, datum/callback/extra_validation, food_multiplier = 1)
 	if (!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 	if (!golem_food_key || !is_path_in_list(golem_food_key, GLOB.golem_stack_food_directory))
@@ -18,7 +20,8 @@
 	src.consume_on_eat = consume_on_eat
 	snack_type = GLOB.golem_stack_food_directory[golem_food_key]
 	src.extra_validation = extra_validation
-
+	if(food_multiplier)
+		src.food_multiplier = food_multiplier
 
 /datum/component/golem_food/RegisterWithParent()
 	. = ..()
@@ -59,6 +62,7 @@
 		consume_food = consume_on_eat,
 		food_buff = snack_type,
 		owner = parent,
+		nutrition_mod = food_multiplier
 	)
 	RegisterSignal(golem_snack, COMSIG_QDELETING, PROC_REF(on_food_destroyed))
 
@@ -94,11 +98,13 @@
 	consume_food = TRUE,
 	datum/golem_food_buff/food_buff,
 	atom/owner,
+	nutrition_mod,
 )
 	src.name = name
 	src.consume_food = consume_food
 	src.food_buff = food_buff
 	src.owner = owner
+	src.bite_consumption = food_buff.nutrition * nutrition_mod
 	RegisterSignal(owner, COMSIG_QDELETING, PROC_REF(on_parent_destroyed))
 
 /// Clean ourselves up if our parent dies

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -83,7 +83,6 @@
 	prefix = "_maps/RandomRuins/AnywhereRuins/"
 	suffix = "golem_ship.dmm"
 	allow_duplicates = FALSE
-	always_place = TRUE
 
 /datum/map_template/ruin/lavaland/gaia
 	name = "Lava-Ruin Patch of Eden"

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -83,6 +83,7 @@
 	prefix = "_maps/RandomRuins/AnywhereRuins/"
 	suffix = "golem_ship.dmm"
 	allow_duplicates = FALSE
+	always_place = TRUE
 
 /datum/map_template/ruin/lavaland/gaia
 	name = "Lava-Ruin Patch of Eden"

--- a/code/game/objects/items/stacks/golem_food/golem_food_buff.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_food_buff.dm
@@ -50,34 +50,42 @@
 
 /datum/golem_food_buff/uranium
 	status_effect = /datum/status_effect/golem/uranium
+	nutrition = 5
 	added_info = "If consumed this mineral will power you in place of food, pausing your digestion for five minutes."
 
 /datum/golem_food_buff/silver
 	status_effect = /datum/status_effect/golem/silver
+	nutrition = 3
 	added_info = "If consumed this mineral will repel the supernatural, affording you resistance to mystical effects."
 
 /datum/golem_food_buff/plasma
 	status_effect = /datum/status_effect/golem/plasma
+	nutrition = 5
 	added_info = "If consumed this mineral will allow you to absorb heat and convert it into power."
 
 /datum/golem_food_buff/plasteel
 	status_effect = /datum/status_effect/golem/plasteel
+	nutrition = 6.5
 	added_info = "If consumed this mineral will harden you against the hazards of space."
 
 /datum/golem_food_buff/gold
 	status_effect = /datum/status_effect/golem/gold
+	nutrition = 4
 	added_info = "If consumed this mineral will grant you a shiny coating which reflects projectiles."
 
 /datum/golem_food_buff/diamond
 	status_effect = /datum/status_effect/golem/diamond
+	nutrition = 8
 	added_info = "If consumed this mineral will reflact light around you, making you faster and harder to see."
 
 /datum/golem_food_buff/titanium
 	status_effect = /datum/status_effect/golem/titanium
+	nutrition = 4
 	added_info = "If consumed this mineral will make you tougher and punch harder."
 
 /datum/golem_food_buff/bananium
 	status_effect = /datum/status_effect/golem/bananium
+	nutrition = 10
 	added_info = "If consumed this mineral will make you funnier."
 
 /datum/golem_food_buff/lightbulb
@@ -89,6 +97,7 @@
 
 /datum/golem_food_buff/gibtonite
 	exclusive = FALSE
+	nutrition = 5
 	added_info = "After consumption, you can launch this mineral like a rocket. It's a little hard to keep down."
 
 /datum/golem_food_buff/gibtonite/apply_effects(mob/living/carbon/human/consumer, atom/movable/consumed, multiplier = 1)
@@ -107,6 +116,7 @@
 
 /datum/golem_food_buff/bluespace
 	exclusive = FALSE
+	nutrition = 10
 	added_info = "After consumption, you can use the stored power to teleport yourself."
 
 /datum/golem_food_buff/bluespace/apply_effects(mob/living/carbon/human/consumer, atom/movable/consumed, multiplier = 1)

--- a/code/game/objects/items/stacks/golem_food/golem_food_buff.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_food_buff.dm
@@ -55,32 +55,32 @@
 
 /datum/golem_food_buff/silver
 	status_effect = /datum/status_effect/golem/silver
-	nutrition = 3
+	nutrition = 4
 	added_info = "If consumed this mineral will repel the supernatural, affording you resistance to mystical effects."
 
 /datum/golem_food_buff/plasma
 	status_effect = /datum/status_effect/golem/plasma
-	nutrition = 5
+	nutrition = 6
 	added_info = "If consumed this mineral will allow you to absorb heat and convert it into power."
 
 /datum/golem_food_buff/plasteel
 	status_effect = /datum/status_effect/golem/plasteel
-	nutrition = 6.5
+	nutrition = 7
 	added_info = "If consumed this mineral will harden you against the hazards of space."
 
 /datum/golem_food_buff/gold
 	status_effect = /datum/status_effect/golem/gold
-	nutrition = 4
+	nutrition = 5
 	added_info = "If consumed this mineral will grant you a shiny coating which reflects projectiles."
 
 /datum/golem_food_buff/diamond
 	status_effect = /datum/status_effect/golem/diamond
-	nutrition = 8
+	nutrition = 9
 	added_info = "If consumed this mineral will reflact light around you, making you faster and harder to see."
 
 /datum/golem_food_buff/titanium
 	status_effect = /datum/status_effect/golem/titanium
-	nutrition = 4
+	nutrition = 5
 	added_info = "If consumed this mineral will make you tougher and punch harder."
 
 /datum/golem_food_buff/bananium

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -99,7 +99,10 @@
 	update_appearance()
 
 	if(is_path_in_list(merge_type, GLOB.golem_stack_food_directory))
-		AddComponent(/datum/component/golem_food, golem_food_key = merge_type)
+		var/processing_bonus = 1
+		if(ispath(merge_type, /obj/item/stack/sheet))
+			processing_bonus = GOLEMFOOD_PREPARED_MEAL
+		AddComponent(/datum/component/golem_food, golem_food_key = merge_type, food_multiplier = processing_bonus)
 
 /obj/item/stack/LateInitialize()
 	merge_with_loc()

--- a/code/modules/surgery/organs/internal/stomach/stomach_golem.dm
+++ b/code/modules/surgery/organs/internal/stomach/stomach_golem.dm
@@ -5,7 +5,7 @@
 	color = COLOR_GOLEM_GRAY
 	organ_flags = ORGAN_MINERAL
 	organ_traits = list(TRAIT_ROCK_EATER)
-	hunger_modifier = 10 // golems burn fuel quickly
+	hunger_modifier = 8 // golems burn fuel quickly
 	/// How slow are you when the "hungry" icon appears?
 	var/min_hunger_slowdown = 0.5
 	/// How slow are you if you have absolutely nothing in the tank?


### PR DESCRIPTION
Look at me go, making species changes as a maintainer, not something I do everyday.

## About The Pull Request

This PR hits a few pain points of playing as a golem. Some of this may still be too short, but qualitatively, this should help to make playing golem feel far less like a death sentence.

First: The golem ship now has shutters on it's windows, and mapped in shutter buttons in both the bedroom as well as the main shuttle hull. This helps to protect the golems inside from being attacked by brimdemons and goliaths from inside the safety of their own ship. These shutters are, however, mapped open, but require no access to drop the shielding.
I've also added a box of spare lights, though since the light fixtures come unwired (for some reason?) that's probably not moving the needle on anything.

Golem food has 2 different buffs (One of them is more of a fix than a buff):

1. The golem food buffs now have different nutrient values based on the material that they're spawned from. Previously, every material was only offering 2 nutrition, every single time, as the nutrition value from the golem food buff datum was never accessed. In addition to the old values, that should now work as expected, here are all the values, including the ones that have been changed:

- Glass (0.5)
- Iron (3)
- Uranium (5) (Also has a status effect that pauses hunger anyway, unchanged)
- Silver (4)
- Plasma (6)
- Plasteel (7)
- Gold (5)
- Titanium (5)
- Bananium (10)
- Lightbulbs (0)
- Gibtonite (5)
- Bluespace (10)

Additionally, eating any golem food item that's been processed into a sheet offers an additional 1.3x multiplier on the amount of nutrition a single sheet will offer. As a reminder, if a golem hits 0 nutrition at any point, they will near-instantly die, but can be revived by simply being fed additional minerals.

2. I've decreased the golem stomach's metabolism rate from 10x higher than human to 8x. This may be a half-measure, and while still high, isn't necessarily a huge step down.

## Why It's Good For The Game

First off, we discovered that golems literally get the same amount of nutrition from every mineral, regardless of processing requirements and rarity, only granting them different powers. Ironically enough, it meant that uranium was the only effect that golems were using, because it was the only effect that let them survive for _longer than 5 minutes_ at a time.

By offering additional value based on the quality of food and the amount of effort being put into obtaining them, we can incentivize golem players to use different types of golem forms, including ones out of pure necessity. Not to mention, golems getting better food from processing ores gives them an incentive to head back to their base on occasion to more efficiently heal & eat.

The decrease to the golem stomach's metabolism is an attempt to also help curb their hunger issues, as it should ideally be a constant concern as per the original design, it shouldn't be so bad to the point that you'll starve yourself the moment you start fighting mobility heavy mining mobs like bileworms or goliaths.

Fixes #95044.
We'll want to follow up on this afterwards, as this is likely a start in the right direction, but I'm confident this won't solve **every** issue specific to golems as well.

## Changelog
:cl:
balance: Golems now have slightly less aggressive metabolism.
fix: Golem foods now offer different levels of nutrition! Finally!
balance: Golems now offer more nutrition from rarer ores.
balance: Golems now get further additional nutrition from eating processed ore sheets instead of raw ore.
map: The free golem ship now has shutters to block wildlife from attacking while inside.
/:cl:
