### PR TITLE
Triples the price of 2-4 random exports every 5 minutes

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -104,3 +104,9 @@
 //Mood event from minor slot events like winning/losing a few bits.
 #define SLOTS_MOOD_CATEGORY "slots"
 
+/// Minimum amount of exports that can get boosted per economy fire
+#define EXPORT_BOOST_MIN_AMOUNT 2
+/// Maximum amount of exports that can get boosted per economy fire
+#define EXPORT_BOOST_MAX_AMOUNT 4
+/// Amount by which random exports are boosted each SSeconomy tick
+#define EXPORT_BOOST_MULT 3

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -132,9 +132,12 @@ SUBSYSTEM_DEF(economy)
 /// Pick X amount of random exports to boost in price for the tick
 /datum/controller/subsystem/economy/proc/update_boosted_exports()
 	boosted_exports.Cut()
+	// Don't randomize export values during unit tests or we'll get flakies
+#ifndef UNIT_TESTS
 	var/list/valid_exports = valid_typesof(/datum/export)
 	for (var/i in 1 to rand(EXPORT_BOOST_MIN_AMOUNT, EXPORT_BOOST_MAX_AMOUNT))
 		boosted_exports += pick_n_take(valid_exports)
+#endif
 
 /**
  * Departmental income payments are kept static and linear for every department, and paid out once every 5 minutes, as determined by MAX_GRANT_DPT.

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -62,6 +62,8 @@ SUBSYSTEM_DEF(economy)
 	var/temporary_total = 0
 	/// Determines how many ticks it takes to restock mail
 	var/ticks_per_mail = 2
+	/// Currently boosted exports
+	var/list/boosted_exports = list()
 
 /datum/controller/subsystem/economy/Initialize()
 	//removes cargo from the split
@@ -109,6 +111,7 @@ SUBSYSTEM_DEF(economy)
 		station_target = max(round(temporary_total / max(bank_accounts_by_id.len * 2, 1)) + station_target_buffer, 1)
 
 	if(processing_part == ECON_PRICE_UPDATE_STEP)
+		update_boosted_exports()
 		if(!HAS_TRAIT(SSeconomy, TRAIT_MARKET_CRASHING) && !price_update())
 			return
 
@@ -125,6 +128,13 @@ SUBSYSTEM_DEF(economy)
 	for(var/datum/bank_account/department/D in departmental_accounts)
 		if(D.department_id == dep_id)
 			return D
+
+/// Pick X amount of random exports to boost in price for the tick
+/datum/controller/subsystem/economy/proc/update_boosted_exports()
+	boosted_exports.Cut()
+	var/list/valid_exports = valid_typesof(/datum/export)
+	for (var/i in 1 to rand(EXPORT_BOOST_MIN_AMOUNT, EXPORT_BOOST_MAX_AMOUNT))
+		boosted_exports += pick_n_take(valid_exports)
 
 /**
  * Departmental income payments are kept static and linear for every department, and paid out once every 5 minutes, as determined by MAX_GRANT_DPT.

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -174,6 +174,8 @@ Then the player gets the profit from selling his own wasted time.
 	var/total = get_base_cost(exported_item) * get_amount(exported_item)
 	if(apply_elastic && initial(k_elasticity) > 0)
 		total *= k_elasticity
+	if(type in SSeconomy.boosted_exports)
+		total *= EXPORT_BOOST_MULT
 	return ROUND_UP(total)
 
 /// Checks if the item is fit for export datum.


### PR DESCRIPTION

## About The Pull Request

Every SSeconomy fire (5 minutes) 2-4 random exports get their prices boosted to 3 times the normal amount, then return to normal the next fire as 2-4 new exports are picked.

## Why It's Good For The Game

Idea came from Arcane on discord, adds something for cargo players to do to spice their gameplay loop, experimenting with possible high value exports selling them off bit by bit rather than all at once to possibly hit a jackpot and get a bunch of cash by dumping them all while the price is high.

## Changelog
:cl:
add: Every 5 minutes 2-4 random cargo exports get tripled in price, lets go gambling!
/:cl:
