### PR TITLE
Fixes hearing radio TTS while unconscious

### DIFF
--- a/code/controllers/subsystem/tts.dm
+++ b/code/controllers/subsystem/tts.dm
@@ -670,7 +670,7 @@ SUBSYSTEM_DEF(tts)
 	if(!SStts.tts_enabled)
 		return FALSE
 
-	if(HAS_TRAIT(hearer, TRAIT_DEAF))
+	if(HAS_TRAIT(hearer, TRAIT_DEAF) || IS_UNCONSCIOUS(hearer))
 		return FALSE
 
 	var/tts_pref = hearer.client?.prefs.read_preference(/datum/preference/choiced/sound_tts) || TTS_SOUND_OFF


### PR DESCRIPTION

## About The Pull Request

You no longer hear radio TTS when unconscious
(Well, presumably. It's not like I can test this locally)

## Why It's Good For The Game

Probably closes https://github.com/tgstation/tgstation/issues/97430? I've only noticed this occurring with radio TTS myself.

## Changelog
:cl: PapaMichael
fix: You no longer hear radio TTS while unconscious
/:cl:
