### PR TITLE
[i ded] revenant vulnerability effects have high processing priority

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/revenant/revenant_effects.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/revenant_effects.dm
@@ -1,6 +1,7 @@
 /// Parent type for all unique revenant status effects
 /datum/status_effect/revenant
 	id = STATUS_EFFECT_ID_ABSTRACT
+	processing_speed = STATUS_EFFECT_PRIORITY
 	alert_type = null
 
 /datum/status_effect/revenant/on_creation(mob/living/new_owner, duration)


### PR DESCRIPTION
## About The Pull Request

Jesus fuck even processing on SSfastprocess revenant vulnerability is lasting far longer than it should

## Why It's Good For The Game

Revenants dying to server lag is some real byond limitation bullshit

## Changelog

:cl:
fix: revenants should far less frequently be rendered vulnerable for far longer than they should be
/:cl:
