### PR TITLE
Removes Bloodworm's stat panel entry

### DIFF
--- a/code/__DEFINES/alerts.dm
+++ b/code/__DEFINES/alerts.dm
@@ -28,6 +28,7 @@
 #define ALERT_SHOES_KNOT "shoealert"
 #define ALERT_RADIOACTIVE_AREA "radioactive_area"
 #define ALERT_UNPOSSESS_OBJECT "unpossess_object"
+#define ALERT_BLOODWORM_INFO "bloodworm_info"
 
 //antag related
 #define ALERT_HYPNOSIS "hypnosis"

--- a/code/_onclick/hud/screen_objects/alert.dm
+++ b/code/_onclick/hud/screen_objects/alert.dm
@@ -111,6 +111,8 @@
 
 	/// Boolean. If TRUE, the Click() proc will attempt to Click() on the master first if there is a master.
 	var/click_master = TRUE
+	///Boolean on whether we'll show a tooltip when you hover over the alert.
+	var/has_tooltip = TRUE
 
 	///If set true, instead of using the default icon file for screen alerts, it will use the hud's ui style
 	var/use_user_hud_icon = USER_HUD_STYLE_IGNORE
@@ -131,7 +133,7 @@
 
 /atom/movable/screen/alert/MouseEntered(location,control,params)
 	. = ..()
-	if(!QDELETED(src))
+	if(!QDELETED(src) && has_tooltip)
 		openToolTip(usr,src,params,title = name,content = desc,theme = alerttooltipstyle)
 
 /atom/movable/screen/alert/MouseExited()

--- a/code/_onclick/hud/screen_objects/alert.dm
+++ b/code/_onclick/hud/screen_objects/alert.dm
@@ -111,8 +111,6 @@
 
 	/// Boolean. If TRUE, the Click() proc will attempt to Click() on the master first if there is a master.
 	var/click_master = TRUE
-	///Boolean on whether we'll show a tooltip when you hover over the alert.
-	var/has_tooltip = TRUE
 
 	///If set true, instead of using the default icon file for screen alerts, it will use the hud's ui style
 	var/use_user_hud_icon = USER_HUD_STYLE_IGNORE
@@ -133,7 +131,7 @@
 
 /atom/movable/screen/alert/MouseEntered(location,control,params)
 	. = ..()
-	if(!QDELETED(src) && has_tooltip)
+	if(!QDELETED(src))
 		openToolTip(usr,src,params,title = name,content = desc,theme = alerttooltipstyle)
 
 /atom/movable/screen/alert/MouseExited()

--- a/code/modules/antagonists/blood_worm/actions/bloodworm_info.dm
+++ b/code/modules/antagonists/blood_worm/actions/bloodworm_info.dm
@@ -1,6 +1,8 @@
 /atom/movable/screen/alert/bloodworm_info
 	name = "Bloodworm Info"
 	desc = "Shows you stats on all Bloodworm-related activities when hovering over."
+	icon = 'icons/mob/actions/backgrounds.dmi'
+	icon_state = "bg_demon"
 	use_user_hud_icon = USER_HUD_STYLE_INHERIT
 	overlay_state = "highbloodpressure"
 	click_master = FALSE
@@ -17,6 +19,6 @@
 	return ..()
 
 /atom/movable/screen/alert/bloodworm_info/MouseEntered(location, control, params)
-	name = "Worm Health: [round((worm_owner.health / worm_owner.maxHealth) * 100)]%"
-	desc = worm_owner.get_special_status_tab_items()
+	name = worm_owner.get_info_title()
+	desc = worm_owner.get_info_desc()
 	return ..()

--- a/code/modules/antagonists/blood_worm/actions/bloodworm_info.dm
+++ b/code/modules/antagonists/blood_worm/actions/bloodworm_info.dm
@@ -1,0 +1,26 @@
+/atom/movable/screen/alert/bloodworm_info
+	name = "Buckled"
+	desc = "You've been buckled to something. Click the alert to unbuckle unless you're handcuffed."
+	use_user_hud_icon = USER_HUD_STYLE_INHERIT
+	overlay_state = "buckled"
+	click_master = FALSE
+	clickable_glow = TRUE
+	has_tooltip = FALSE
+
+	///Ref to the worm we're giving info about
+	var/mob/living/basic/blood_worm/worm_owner
+
+/atom/movable/screen/alert/bloodworm_info/Destroy()
+	worm_owner = null
+	return ..()
+
+/atom/movable/screen/alert/bloodworm_info/Click()
+	. = ..()
+	if(!.)
+		return
+
+	if(!worm_owner.can_resist())
+		return
+	worm_owner.changeNext_move(CLICK_CD_RESIST)
+	if(worm_owner.last_special <= world.time)
+		return worm_owner.resist_buckle()

--- a/code/modules/antagonists/blood_worm/actions/bloodworm_info.dm
+++ b/code/modules/antagonists/blood_worm/actions/bloodworm_info.dm
@@ -1,26 +1,22 @@
 /atom/movable/screen/alert/bloodworm_info
-	name = "Buckled"
-	desc = "You've been buckled to something. Click the alert to unbuckle unless you're handcuffed."
+	name = "Bloodworm Info"
+	desc = "Shows you stats on all Bloodworm-related activities when hovering over."
 	use_user_hud_icon = USER_HUD_STYLE_INHERIT
-	overlay_state = "buckled"
+	overlay_state = "highbloodpressure"
 	click_master = FALSE
-	clickable_glow = TRUE
-	has_tooltip = FALSE
 
 	///Ref to the worm we're giving info about
 	var/mob/living/basic/blood_worm/worm_owner
+
+/atom/movable/screen/alert/bloodworm_info/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	underlays += mutable_appearance('icons/mob/actions/backgrounds.dmi', "bg_demon", layer = layer, offset_spokesman = src, plane = plane)
 
 /atom/movable/screen/alert/bloodworm_info/Destroy()
 	worm_owner = null
 	return ..()
 
-/atom/movable/screen/alert/bloodworm_info/Click()
-	. = ..()
-	if(!.)
-		return
-
-	if(!worm_owner.can_resist())
-		return
-	worm_owner.changeNext_move(CLICK_CD_RESIST)
-	if(worm_owner.last_special <= world.time)
-		return worm_owner.resist_buckle()
+/atom/movable/screen/alert/bloodworm_info/MouseEntered(location, control, params)
+	name = "Worm Health: [round((worm_owner.health / worm_owner.maxHealth) * 100)]%"
+	desc = worm_owner.get_special_status_tab_items()
+	return ..()

--- a/code/modules/antagonists/blood_worm/actions/cocoon.dm
+++ b/code/modules/antagonists/blood_worm/actions/cocoon.dm
@@ -24,7 +24,9 @@
 /datum/action/cooldown/mob_cooldown/blood_worm/cocoon/update_button_status(atom/movable/screen/movable/action_button/button, force = FALSE)
 	. = ..()
 	var/mob/living/basic/blood_worm/worm = owner
-	button.maptext = MAPTEXT_TINY_UNICODE("<span style='text-align: center'>[round((worm.get_consumed_blood() / total_blood_required) * 100, 0.1)]%</span>")
+	var/percentage_shown = "[round((worm.get_consumed_blood() / total_blood_required) * 100, 0.1)]"
+	button.maptext_x = (length(percentage_shown) >= 3) ? 0 : 1
+	button.maptext = MAPTEXT_TINY_UNICODE("<span style='text-align: center'>[percentage_shown]%</span>")
 
 /datum/action/cooldown/mob_cooldown/blood_worm/cocoon/Grant(mob/granted_to)
 	. = ..()

--- a/code/modules/antagonists/blood_worm/actions/cocoon.dm
+++ b/code/modules/antagonists/blood_worm/actions/cocoon.dm
@@ -18,7 +18,7 @@
 
 /datum/action/cooldown/mob_cooldown/blood_worm/cocoon/create_button(mob/viewer)
 	var/atom/movable/screen/movable/action_button/button = ..()
-	button.maptext_x = 2
+	button.maptext_x = 1
 	return button
 
 /datum/action/cooldown/mob_cooldown/blood_worm/cocoon/update_button_status(atom/movable/screen/movable/action_button/button, force = FALSE)

--- a/code/modules/antagonists/blood_worm/actions/cocoon.dm
+++ b/code/modules/antagonists/blood_worm/actions/cocoon.dm
@@ -1,6 +1,7 @@
 /datum/action/cooldown/mob_cooldown/blood_worm/cocoon
 	cooldown_time = 30 SECONDS
 	shared_cooldown = NONE
+	transparent_when_unavailable = FALSE
 
 	click_to_activate = FALSE
 
@@ -14,6 +15,16 @@
 	var/timer_id = null
 
 	var/cocoon_time = 30 SECONDS
+
+/datum/action/cooldown/mob_cooldown/blood_worm/cocoon/create_button(mob/viewer)
+	var/atom/movable/screen/movable/action_button/button = ..()
+	button.maptext_x = 2
+	return button
+
+/datum/action/cooldown/mob_cooldown/blood_worm/cocoon/update_button_status(atom/movable/screen/movable/action_button/button, force = FALSE)
+	. = ..()
+	var/mob/living/basic/blood_worm/worm = owner
+	button.maptext = MAPTEXT_TINY_UNICODE("<span style='text-align: center'>[round((worm.get_consumed_blood() / total_blood_required) * 100, 0.1)]%</span>")
 
 /datum/action/cooldown/mob_cooldown/blood_worm/cocoon/Grant(mob/granted_to)
 	. = ..()

--- a/code/modules/antagonists/blood_worm/blood_worm_host_handling.dm
+++ b/code/modules/antagonists/blood_worm/blood_worm_host_handling.dm
@@ -21,7 +21,6 @@
 	RegisterSignal(host, COMSIG_LIVING_LIFE, PROC_REF(on_host_life))
 	RegisterSignal(host, COMSIG_LIVING_ADJUST_OXY_DAMAGE, PROC_REF(on_host_adjust_oxy_damage))
 	RegisterSignal(host, COMSIG_LIVING_PRE_UPDATE_BLOOD_STATUS, PROC_REF(on_host_pre_update_blood_status))
-	RegisterSignal(host, COMSIG_MOB_GET_STATUS_TAB_ITEMS, PROC_REF(on_host_get_status_tab_items))
 	client?.set_stat_panel()
 	RegisterSignal(host, COMSIG_MOB_EXAMINING, PROC_REF(on_host_examining))
 

--- a/code/modules/antagonists/blood_worm/blood_worm_host_handling.dm
+++ b/code/modules/antagonists/blood_worm/blood_worm_host_handling.dm
@@ -25,6 +25,9 @@
 	client?.set_stat_panel()
 	RegisterSignal(host, COMSIG_MOB_EXAMINING, PROC_REF(on_host_examining))
 
+	var/atom/movable/screen/alert/bloodworm_info/info_alert = host.throw_alert(ALERT_BLOODWORM_INFO, /atom/movable/screen/alert/bloodworm_info)
+	info_alert.worm_owner = src
+
 	START_PROCESSING(SSfastprocess, src)
 
 	add_traits(list(TRAIT_INCAPACITATED, TRAIT_IMMOBILIZED, TRAIT_MUTE, TRAIT_EMOTEMUTE), BLOOD_WORM_HOST_TRAIT)
@@ -135,6 +138,7 @@
 	sync_health(already_ejecting = TRUE)
 
 	host.hud_used?.remove_screen_object(HUD_MOB_BLOOD_LEVEL)
+	host.clear_alert(ALERT_BLOODWORM_INFO)
 
 	host.set_blood_volume(0)
 

--- a/code/modules/antagonists/blood_worm/blood_worm_mob.dm
+++ b/code/modules/antagonists/blood_worm/blood_worm_mob.dm
@@ -168,11 +168,14 @@
 		return FALSE
 	if (host)
 		ADD_TRAIT(host, TRAIT_MIND_TEMPORARILY_GONE, BLOOD_WORM_HOST_TRAIT)
+	var/atom/movable/screen/alert/bloodworm_info/info_alert = throw_alert(ALERT_BLOODWORM_INFO, /atom/movable/screen/alert/bloodworm_info)
+	info_alert.worm_owner = src
 
 /mob/living/basic/blood_worm/Logout()
 	. = ..()
 	if (host)
 		REMOVE_TRAIT(host, TRAIT_MIND_TEMPORARILY_GONE, BLOOD_WORM_HOST_TRAIT)
+	clear_alert(ALERT_BLOODWORM_INFO)
 
 /mob/living/basic/blood_worm/process(seconds_per_tick, times_fired)
 	if (!host)

--- a/code/modules/antagonists/blood_worm/blood_worm_text_feedback.dm
+++ b/code/modules/antagonists/blood_worm/blood_worm_text_feedback.dm
@@ -63,29 +63,11 @@
 
 	result += span_notice("[target.p_They()] [target.p_have()] [rounded_volume] unit[rounded_volume == 1 ? "" : "s"] of blood[growth_string]. [target.p_Their()] blood is <b>[synth_string]</b> synthetic.")
 
-/mob/living/basic/blood_worm/get_status_tab_items()
-	return ..() + get_special_status_tab_items()
-
-/mob/living/basic/blood_worm/proc/on_host_get_status_tab_items(datum/source, list/items)
-	SIGNAL_HANDLER
-	items += "Worm Health: [round((health / maxHealth) * 100)]%"
-	items += get_special_status_tab_items()
-
 /mob/living/basic/blood_worm/proc/get_special_status_tab_items()
-	. = list()
-
-	var/normal = consumed_normal_blood
-	var/synth = consumed_synth_blood
-	var/total = normal + synth
-
-	var/total_required = cocoon_action?.total_blood_required
-
-	if (total_required > 0)
-		. += "Growth: [FLOOR(total / total_required * 100, 1)]%"
-	. += "Blood Consumed"
-	. += "- Normal: [ceil(normal)]u"
-	. += "- Synthetic: [ceil(synth)]u (MAX: [maximum_synth_blood]u)"
-	. += "- Total: [ceil(total)]u (REQ: [total_required]u)"
+	. = "Blood Consumed<br/>"
+	. += "- Normal: [ceil(consumed_normal_blood)]u<br/>"
+	. += "- Synthetic: [ceil(consumed_synth_blood)]u (MAX: [maximum_synth_blood]u)<br/>"
+	. += "- Total: [ceil(consumed_normal_blood + consumed_synth_blood)]u<br/>"
 
 /// Sends text to the blood worm, whether they are possessing a host or not.
 /mob/living/basic/blood_worm/proc/to_chat_self(text)

--- a/code/modules/antagonists/blood_worm/blood_worm_text_feedback.dm
+++ b/code/modules/antagonists/blood_worm/blood_worm_text_feedback.dm
@@ -63,7 +63,10 @@
 
 	result += span_notice("[target.p_They()] [target.p_have()] [rounded_volume] unit[rounded_volume == 1 ? "" : "s"] of blood[growth_string]. [target.p_Their()] blood is <b>[synth_string]</b> synthetic.")
 
-/mob/living/basic/blood_worm/proc/get_special_status_tab_items()
+/mob/living/basic/blood_worm/proc/get_info_title()
+	. = "Worm Health: [round((health / maxHealth) * 100)]%"
+
+/mob/living/basic/blood_worm/proc/get_info_desc()
 	. = "Blood Consumed<br/>"
 	. += "- Normal: [ceil(consumed_normal_blood)]u<br/>"
 	. += "- Synthetic: [ceil(consumed_synth_blood)]u (MAX: [maximum_synth_blood]u)<br/>"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3536,6 +3536,7 @@
 #include "code\modules\antagonists\blood_worm\blood_worm_tester.dm"
 #include "code\modules\antagonists\blood_worm\blood_worm_text_feedback.dm"
 #include "code\modules\antagonists\blood_worm\actions\_base_action.dm"
+#include "code\modules\antagonists\blood_worm\actions\bloodworm_info.dm"
 #include "code\modules\antagonists\blood_worm\actions\cocoon.dm"
 #include "code\modules\antagonists\blood_worm\actions\inject_blood.dm"
 #include "code\modules\antagonists\blood_worm\actions\invade_corpse.dm"


### PR DESCRIPTION
## About The Pull Request

Bloodworm's stat panel entry lists the HP of the worm, how much growth they have, and how much blood they have consumed

Maturity has been moved to the action button pretty 1:1 to https://github.com/tgstation/tgstation/pull/97456 - However this already had feedback if you tried to use the button anyways so this is just a compliment to that

<img width="737" height="631" alt="image" src="https://github.com/user-attachments/assets/aa2f6f9e-ba8d-4514-bfea-69c588fb91bc" />


The rest has been moved to a status alert that Bloodworms have listing information when you hover over it. I considered putting it in their antag panel but from discussion, antag panel was something we wished to avoid to not obfuscate the information.

<img width="211" height="189" alt="image" src="https://github.com/user-attachments/assets/e04da68b-21c3-4fc5-ba81-d818bed2efea" />


## Why It's Good For The Game

Primarily for https://hackmd.io/443_dE5lRWeEAp9bjGcKYw?view
We're 3 mobs away from being done with stat panel entries and although I've never played blood worm before, I think this is a fine alternative.

## Changelog

:cl:
qol: Deleted Bloodworm's stat panel entry and instead moved it to their action button & a new screen alert.
/:cl: