### PR TITLE
Fix helmets being flammable when armor is not

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -16,6 +16,7 @@
 	flags_cover = HEADCOVERSEYES|EARS_COVERED
 	flags_inv = HIDEHAIR
 	dog_fashion = /datum/dog_fashion/head/helmet
+	resistance_flags = NONE
 
 /datum/armor/head_helmet
 	melee = 35


### PR DESCRIPTION
## About The Pull Request

Fixes an inconsistency where helmets catch fire, but their corresponding armors do not. 

Following the ruling on #97436, armor materials (such as Kevlar) are intended to remain non-flammable. Currently, armors use the `NONE` flag (preventing flammability), while helmets incorrectly retained the default `FLAMMABLE` flag. 

Now both helmets and armor carry the `NONE` flag.

## Why It's Good For The Game

Consistency.

A player wearing a complete Kevlar vest and helmet set that catches fire would only have their headgear ignite, which did not make any sense.

Both armor and helmets should be identical.

## Changelog

:cl:
fix: Fix helmets being flammable when armor is not
/:cl: