### PR TITLE
Makes "MOD" items improper

### DIFF
--- a/code/game/objects/effects/spawners/random/exotic.dm
+++ b/code/game/objects/effects/spawners/random/exotic.dm
@@ -118,7 +118,7 @@
 	)
 
 /obj/item/mod/module/energy_shield/prototype
-	name = "MOD prototype energy shield"
+	name = "\improper MOD prototype energy shield"
 	desc = "An early prototype of energy shield adapted for use inside of a MOD, the energy shield before this saw \
 	extensive use in now defunct construction, combat, and mining exosuits with exosuits being something between a \
 	modsuit and a mech with most still functioning exosuits either being in a museaum or a military parade"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -420,7 +420,7 @@
 	base_icon_state = "robo"
 
 /obj/structure/closet/crate/mod
-	name = "MOD crate"
+	name = "\improper MOD crate"
 	icon_state = "robo"
 	base_icon_state = "robo"
 

--- a/code/modules/awaymissions/mission_code/heretic/fake_items.dm
+++ b/code/modules/awaymissions/mission_code/heretic/fake_items.dm
@@ -19,7 +19,7 @@
 	anchored = 1
 
 /obj/item/fake_items/time_stopper
-	name = "MOD timestopper module"
+	name = "\improper MOD timestopper module"
 	desc = "A module that can halt time in a small radius around the user... for as long as they \
 			want! Great for monologues or lunch breaks. Keep in mind moving will end the stop, and the \
 			module has a hefty cooldown period to avoid reality errors."

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -31,7 +31,7 @@
 	cost = CARGO_CRATE_VALUE
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/mod/construction/plating/security)
-	crate_name = "MOD plating crate"
+	crate_name = "\improper MOD plating crate"
 
 /datum/supply_pack/security/disabler
 	name = "Disabler Crate"

--- a/code/modules/mod/adding_new_mod.md
+++ b/code/modules/mod/adding_new_mod.md
@@ -192,7 +192,7 @@ As it's a medical module, we'll put it [here](modules/modules_medical.dm). Let's
 
 ```dm
 /obj/item/mod/module/neuron_healer
-	name = "MOD neuron healer module"
+	name = "\improper MOD neuron healer module"
 	desc = "A module made experimentally by DeForest Medical Corporation. On demand it releases waves \
 		that heal neuron damage of everyone nearby, getting their brains to a better state."
 	icon_state = "neuron_healer"
@@ -209,7 +209,7 @@ As we have an usable module, we want to set a cooldown time. All modules are als
 
 ```dm
 /obj/item/mod/module/neuron_healer
-	name = "MOD neuron healer module"
+	name = "\improper MOD neuron healer module"
 	desc = "A module made experimentally by DeForest Medical Corporation. On demand it releases waves \
 		that heal neuron damage of everyone nearby, getting their brains to a better state."
 	icon_state = "neuron_healer"
@@ -245,7 +245,7 @@ We now have a basic module, we can add it to the techwebs to make it printable i
 
 ```dm
 /obj/item/mod/module/neuron_healer/advanced
-	name = "MOD advanced neuron healer module"
+	name = "\improper MOD advanced neuron healer module"
 	complexity = 0
 	brain_damage_healed = 50
 ```

--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -1,5 +1,5 @@
 /obj/item/clothing/head/mod
-	name = "MOD helmet"
+	name = "\improper MOD helmet"
 	desc = "A helmet for a MODsuit."
 	icon = 'icons/obj/clothing/modsuit/mod_clothing.dmi'
 	icon_state = "standard-helmet"
@@ -17,7 +17,7 @@
 	AddComponent(/datum/component/hat_stabilizer, loose_hat = TRUE)
 
 /obj/item/clothing/suit/mod
-	name = "MOD chestplate"
+	name = "\improper MOD chestplate"
 	desc = "A chestplate for a MODsuit."
 	icon = 'icons/obj/clothing/modsuit/mod_clothing.dmi'
 	icon_state = "standard-chestplate"
@@ -40,7 +40,7 @@
 	ADD_TRAIT(src, TRAIT_NO_SPEED_POTION, INNATE_TRAIT)
 
 /obj/item/clothing/gloves/mod
-	name = "MOD gauntlets"
+	name = "\improper MOD gauntlets"
 	desc = "A pair of gauntlets for a MODsuit."
 	icon = 'icons/obj/clothing/modsuit/mod_clothing.dmi'
 	icon_state = "standard-gauntlets"
@@ -59,7 +59,7 @@
 	ADD_TRAIT(src, TRAIT_NO_SPEED_POTION, INNATE_TRAIT)
 
 /obj/item/clothing/shoes/mod
-	name = "MOD boots"
+	name = "\improper MOD boots"
 	desc = "A pair of boots for a MODsuit."
 	icon = 'icons/obj/clothing/modsuit/mod_clothing.dmi'
 	icon_state = "standard-boots"
@@ -78,7 +78,7 @@
 	ADD_TRAIT(src, TRAIT_NO_SPEED_POTION, INNATE_TRAIT)
 
 /obj/item/clothing/glasses/mod
-	name = "MOD glasses"
+	name = "\improper MOD glasses"
 	desc = "A pair of glasses for a MODsuit."
 	icon = 'icons/obj/clothing/modsuit/mod_clothing.dmi'
 	icon_state = "standard-glasses"
@@ -94,7 +94,7 @@
 	ADD_TRAIT(src, TRAIT_NO_SPEED_POTION, INNATE_TRAIT)
 
 /obj/item/clothing/neck/mod
-	name = "MOD tie"
+	name = "\improper MOD tie"
 	desc = "An tie for a MODsuit."
 	icon = 'icons/obj/clothing/modsuit/mod_clothing.dmi'
 	icon_state = "standard-tie"

--- a/code/modules/mod/mod_construction.dm
+++ b/code/modules/mod/mod_construction.dm
@@ -4,7 +4,7 @@
 	inhand_icon_state = "rack_parts"
 
 /obj/item/mod/construction/helmet
-	name = "MOD helmet"
+	name = "\improper MOD helmet"
 	icon_state = "helmet"
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2.5)
 
@@ -13,7 +13,7 @@
 	. += span_notice("You could insert it into a <b>MOD shell</b>...")
 
 /obj/item/mod/construction/chestplate
-	name = "MOD chestplate"
+	name = "\improper MOD chestplate"
 	icon_state = "chestplate"
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2.5)
 
@@ -22,7 +22,7 @@
 	. += span_notice("You could insert it into a <b>MOD shell</b>...")
 
 /obj/item/mod/construction/gauntlets
-	name = "MOD gauntlets"
+	name = "\improper MOD gauntlets"
 	icon_state = "gauntlets"
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2.5)
 
@@ -31,7 +31,7 @@
 	. += span_notice("You could insert these into a <b>MOD shell</b>...")
 
 /obj/item/mod/construction/boots
-	name = "MOD boots"
+	name = "\improper MOD boots"
 	icon_state = "boots"
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2.5)
 
@@ -88,7 +88,7 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/mod/construction/plating
-	name = "MOD external plating"
+	name = "\improper MOD external plating"
 	desc = "External plating used to finish a MOD control unit."
 	icon_state = "standard-plating"
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 3, /datum/material/glass = SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/plasma = SMALL_MATERIAL_AMOUNT * 5)
@@ -97,7 +97,7 @@
 /obj/item/mod/construction/plating/Initialize(mapload)
 	. = ..()
 	var/datum/mod_theme/used_theme = GLOB.mod_themes[theme]
-	name = "MOD [used_theme.name] external plating"
+	name = "\improper MOD [used_theme.name] external plating"
 	desc = "[desc] [used_theme.desc]"
 	icon_state = "[used_theme.default_skin]-plating"
 
@@ -139,7 +139,7 @@
 #define SCREWED_ASSEMBLY_STEP "screwed_assembly"
 
 /obj/item/mod/construction/shell
-	name = "MOD shell"
+	name = "\improper MOD shell"
 	icon_state = "mod-construction_start"
 	desc = "A MOD shell."
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5, /datum/material/plasma = SHEET_MATERIAL_AMOUNT * 2.5)

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -6,7 +6,7 @@
 	worn_icon = 'icons/mob/clothing/modsuit/mod_clothing.dmi'
 
 /obj/item/mod/control
-	name = "MOD control unit"
+	name = "\improper MOD control unit"
 	desc = "The control unit of a Modular Outerwear Device, a powered suit that protects against various environments."
 	icon_state = "standard-control"
 	inhand_icon_state = "mod_control"

--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -1,5 +1,5 @@
 /obj/item/mod/core
-	name = "MOD core"
+	name = "\improper MOD core"
 	desc = "A non-functional MOD core. Inform the admins if you see this."
 	icon = 'icons/obj/clothing/modsuit/mod_construction.dmi'
 	icon_state = "mod-core"
@@ -66,7 +66,7 @@
 		([round((100 * charge_amount) / max_charge_amount, 1)]%)"
 
 /obj/item/mod/core/infinite
-	name = "MOD infinite core"
+	name = "\improper MOD infinite core"
 	icon_state = "mod-core-infinite"
 	desc = "A fusion core using the rare Fixium to sustain enough energy for the lifetime of the MOD's user. \
 		This might be because of the slowly killing poison inside, but those are just rumors."
@@ -99,7 +99,7 @@
 	return "Infinite"
 
 /obj/item/mod/core/standard
-	name = "MOD standard core"
+	name = "\improper MOD standard core"
 	icon_state = "mod-core-standard"
 	desc = "Growing in the most lush, fertile areas of the planet Sprout, there is a crystal known as the Heartbloom. \
 		These rare, organic piezoelectric crystals are of incredible cultural significance to the artist castes of the \
@@ -295,7 +295,7 @@
 		mod.update_charge_alert()
 
 /obj/item/mod/core/ethereal
-	name = "MOD ethereal core"
+	name = "\improper MOD ethereal core"
 	icon_state = "mod-core-ethereal"
 	desc = "A reverse engineered core of a Modular Outerwear Device. Using natural liquid electricity from Ethereals, \
 		preventing the need to use external sources to convert electric charge. As the suits are naturally charged by \
@@ -360,7 +360,7 @@
 #define PLASMA_CORE_SHEET_CHARGE (2 * STANDARD_CELL_CHARGE)
 
 /obj/item/mod/core/plasma
-	name = "MOD plasma core"
+	name = "\improper MOD plasma core"
 	icon_state = "mod-core-plasma"
 	desc = "Nanotrasen's attempt at capitalizing on their plasma research. These plasma cores are refueled \
 		through plasma fuel, allowing for easy continued use by their mining squads."
@@ -445,7 +445,7 @@
 #undef PLASMA_CORE_SHEET_CHARGE
 
 /obj/item/mod/core/plasma/lavaland
-	name = "MOD plasma flower core"
+	name = "\improper MOD plasma flower core"
 	icon_state = "mod-core-plasma-flower"
 	desc = "A strange flower from the desolate wastes of lavaland. It pulses with a strange purple glow.  \
 		The wires coming out of it could be hooked into a MODsuit."
@@ -499,7 +499,7 @@
 	QDEL_IN(flower_boots, 1 SECONDS)
 
 /obj/item/mod/core/soul
-	name = "MOD soul shard core"
+	name = "\improper MOD soul shard core"
 	desc = "A soul shard haphazardly jammed into a hand-crafted MOD core frame."
 	icon = 'icons/map_icons/items/_item.dmi'
 	icon_state = "/obj/item/mod/core/soul"

--- a/code/modules/mod/mod_paint.dm
+++ b/code/modules/mod/mod_paint.dm
@@ -140,7 +140,7 @@
 #undef MODPAINT_MIN_OVERALL_COLORS
 
 /obj/item/mod/skin_applier
-	name = "MOD skin applier"
+	name = "\improper MOD skin applier"
 	desc = "This one-use skin applier will add a skin to MODsuits of a specific type. Must be used on an inactive control unit."
 	icon = 'icons/obj/clothing/modsuit/mod_construction.dmi'
 	icon_state = "skinapplier"
@@ -148,7 +148,7 @@
 
 /obj/item/mod/skin_applier/Initialize(mapload)
 	. = ..()
-	name = "MOD [skin] skin applier"
+	name = "\improper MOD [skin] skin applier"
 
 /obj/item/mod/skin_applier/interact_with_atom(atom/attacked_atom, mob/living/user, params)
 	if(!istype(attacked_atom, /obj/item/mod/control))

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -1,6 +1,6 @@
 ///MOD Module - A special device installed in a MODsuit allowing the suit to do new stuff.
 /obj/item/mod/module
-	name = "MOD module"
+	name = "\improper MOD module"
 	icon = 'icons/obj/clothing/modsuit/mod_modules.dmi'
 	icon_state = "module"
 	abstract_type = /obj/item/mod/module
@@ -465,7 +465,7 @@
 
 ///Anomaly Locked - Mostly just a wrapper for modules that don't need to descend from any other module but need the anomaly_locked_module component
 /obj/item/mod/module/anomaly_locked
-	name = "MOD anomaly locked module"
+	name = "\improper MOD anomaly locked module"
 	desc = "A form of a module, locked behind an anomalous core to function."
 	/// Accepted types of anomaly cores.
 	var/list/accepted_anomalies = list(/obj/item/assembly/signaler/anomaly)

--- a/code/modules/mod/modules/module_holding.dm
+++ b/code/modules/mod/modules/module_holding.dm
@@ -2,7 +2,7 @@
 #define HOLDING_MODULE_CHECK_CONFIRMED 2
 
 /obj/item/mod/module/storage/holding
-	name = "MOD storage module of holding"
+	name = "\improper MOD storage module of holding"
 	desc = "A prototype storage module utilizing the power of anomalous bluespace phenomena \
 		to store copious amounts of matter. Unfortunately, it suffers from the same drawbacks as its standalone counterpart, \
 		including <b>tearing catastrophic rifts in reality</b> when nested inside bluespace pockets produced through similar means."

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -1,6 +1,6 @@
 ///Kinesis - Gives you the ability to move and launch objects.
 /obj/item/mod/module/anomaly_locked/kinesis
-	name = "MOD kinesis module"
+	name = "\improper MOD kinesis module"
 	desc = "A modular plug-in to the forearm, this module was presumed lost for many years, \
 		despite the suits it used to be mounted on still seeing some circulation. \
 		This piece of technology allows the user to generate precise anti-gravity fields, \
@@ -255,7 +255,7 @@
 	core_removable = FALSE
 
 /obj/item/mod/module/anomaly_locked/kinesis/prototype
-	name = "MOD prototype kinesis module"
+	name = "\improper MOD prototype kinesis module"
 	prebuilt = TRUE
 	complexity = 0
 	use_energy_cost = DEFAULT_CHARGE_DRAIN * 5
@@ -263,7 +263,7 @@
 	core_removable = FALSE
 
 /obj/item/mod/module/anomaly_locked/kinesis/plus
-	name = "MOD kinesis+ module"
+	name = "\improper MOD kinesis+ module"
 	desc = "A modular plug-in to the forearm, this module was recently redeveloped in secret. \
 		The bane of all ne'er-do-wells, the kinesis+ module is a powerful tool that allows the user \
 		to manipulate the world around them. Like its older counterpart, it's capable of manipulating \
@@ -274,7 +274,7 @@
 
 /// Admin suit version of kinesis. Can grab anything at any range, may enable phasing through walls.
 /obj/item/mod/module/anomaly_locked/kinesis/admin
-	name = "MOD kinesis++ module"
+	name = "\improper MOD kinesis++ module"
 	desc = "A modular plug-in to the forearm, this module was recently reredeveloped in super secret. \
 		This one can force some of the grasped objects to phase through walls. Oh no."
 	complexity = 0

--- a/code/modules/mod/modules/module_pathfinder.dm
+++ b/code/modules/mod/modules/module_pathfinder.dm
@@ -2,7 +2,7 @@
 
 ///Pathfinder - Can fly the suit from a long distance to an implant installed in someone.
 /obj/item/mod/module/pathfinder
-	name = "MOD pathfinder module"
+	name = "\improper MOD pathfinder module"
 	desc = "This module, brought to you by Nakamura Engineering, has two components. \
 		The first component is a series of thrusters and a computerized location subroutine installed into the \
 		very control unit of the suit, allowing it flight at highway speeds using the suit's access locks \
@@ -193,7 +193,7 @@
 
 
 /obj/item/implant/mod
-	name = "MOD pathfinder implant"
+	name = "\improper MOD pathfinder implant"
 	desc = "Lets you recall a MODsuit to you at any time."
 	actions_types = list(/datum/action/item_action/mod_recall)
 	allow_multiple = TRUE // Surgrey is annoying if you loose your MOD

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -2,7 +2,7 @@
 
 ///Energy Shield - Gives you a rechargeable energy shield that nullifies attacks.
 /obj/item/mod/module/energy_shield
-	name = "MOD energy shield module"
+	name = "\improper MOD energy shield module"
 	desc = "A personal, protective forcefield typically seen in military applications. \
 		This advanced deflector shield is essentially a scaled down version of those seen on starships, \
 		and the power cost can be an easy indicator of this. However, it is capable of blocking nearly any incoming attack, \
@@ -72,7 +72,7 @@
 	return NONE
 
 /obj/item/mod/module/energy_shield/wizard
-	name = "MOD battlemage shield module"
+	name = "\improper MOD battlemage shield module"
 	desc = "The caster wielding this spell gains a visible barrier around them, channeling arcane power through \
 		specialized runes engraved onto the surface of the suit to generate a wall of force. \
 		This shield can perfectly nullify attacks ranging from high-caliber rifles to magic missiles, \
@@ -90,7 +90,7 @@
 
 ///Magic Nullifier - Protects you from magic.
 /obj/item/mod/module/anti_magic
-	name = "MOD magic nullifier module"
+	name = "\improper MOD magic nullifier module"
 	desc = "A series of obsidian rods installed into critical points around the suit, \
 		vibrated at a certain low frequency to enable them to resonate. \
 		This creates a low-range, yet strong, magic nullification field around the user, \
@@ -108,7 +108,7 @@
 	mod.wearer.remove_traits(list(TRAIT_ANTIMAGIC, TRAIT_HOLY), REF(src))
 
 /obj/item/mod/module/anti_magic/wizard
-	name = "MOD magic neutralizer module"
+	name = "\improper MOD magic neutralizer module"
 	desc = "The caster wielding this spell gains an invisible barrier around them, channeling arcane power through \
 		specialized runes engraved onto the surface of the suit to generate anti-magic field. \
 		The field will neutralize all magic that comes into contact with the user. \
@@ -124,7 +124,7 @@
 
 ///Insignia - Gives you a skin specific stripe.
 /obj/item/mod/module/insignia
-	name = "MOD insignia module"
+	name = "\improper MOD insignia module"
 	desc = "Despite the existence of IFF systems, radio communique, and modern methods of deductive reasoning involving \
 		the wearer's own eyes, colorful paint jobs remain a popular way for different factions in the galaxy to display who \
 		they are. This system utilizes a series of tiny moving paint sprayers to both apply and remove different \
@@ -167,7 +167,7 @@
 
 ///Anti Slip - Prevents you from slipping on water.
 /obj/item/mod/module/noslip
-	name = "MOD anti slip module"
+	name = "\improper MOD anti slip module"
 	desc = "These are a modified variant of standard magnetic boots, utilizing piezoelectric crystals on the soles. \
 		The two plates on the bottom of the boots automatically extend and magnetize as the user steps; \
 		a pull that's too weak to offer them the ability to affix to a hull, but just strong enough to \
@@ -203,7 +203,7 @@
 
 ///Flamethrower - Launches fire across the area.
 /obj/item/mod/module/flamethrower
-	name = "MOD flamethrower module"
+	name = "\improper MOD flamethrower module"
 	desc = "A custom-manufactured flamethrower, used to burn through your path. Burn well."
 	icon_state = "flamethrower"
 	module_type = MODULE_ACTIVE
@@ -228,7 +228,7 @@
 
 ///Power kick - Lets the user launch themselves at someone to kick them.
 /obj/item/mod/module/power_kick
-	name = "MOD power kick module"
+	name = "\improper MOD power kick module"
 	desc = "This module uses high-power myomer to generate an incredible amount of energy, transferred into the power of a kick."
 	icon_state = "power_kick"
 	module_type = MODULE_ACTIVE
@@ -289,7 +289,7 @@
 
 ///Chameleon - lets the suit disguise as any item that would fit on that slot.
 /obj/item/mod/module/chameleon
-	name = "MOD chameleon module"
+	name = "\improper MOD chameleon module"
 	desc = "A module using chameleon technology to disguise the suit as another object."
 	icon_state = "chameleon"
 	module_type = MODULE_USABLE
@@ -365,7 +365,7 @@
 
 ///Plate Compression - Compresses the suit to normal size
 /obj/item/mod/module/plate_compression
-	name = "MOD plate compression module"
+	name = "\improper MOD plate compression module"
 	desc = "A module that keeps the suit in a very tightly fit state, lowering the overall size. \
 		Due to the pressure on all the parts, typical storage modules do not fit."
 	icon_state = "plate_compression"
@@ -393,7 +393,7 @@
 	mod.forceMove(mod.drop_location())
 
 /obj/item/mod/module/demoralizer
-	name = "MOD psi-echo demoralizer module"
+	name = "\improper MOD psi-echo demoralizer module"
 	desc = "One incredibly morbid member of the RND team at Roseus Galactic posed a question to her colleagues. \
 	'I desire the power to scar my enemies mentally as I murder them. Who will stop me implementing this in our next project?' \
 	And thus the Psi-Echo Demoralizer Device was reluctantly invented. The future of psychological warfare, today!"
@@ -412,7 +412,7 @@
 	QDEL_NULL(demoralizer)
 
 /obj/item/mod/module/infiltrator
-	name = "MOD infiltration core programs module"
+	name = "\improper MOD infiltration core programs module"
 	desc = "The primary stealth systems operating within the suit. Utilizing electromagnetic signals, \
 		the wearer simply cannot be observed closely, or heard clearly by those around them.\
 		It also contains some dampening systems to help protect a user from blows to the head."
@@ -462,7 +462,7 @@
 
 ///Medbeam - Medbeam but built into a modsuit
 /obj/item/mod/module/medbeam
-	name = "MOD medical beamgun module"
+	name = "\improper MOD medical beamgun module"
 	desc = "A wrist mounted variant of the medbeam gun, allowing the user to heal their allies without the risk of dropping it."
 	icon_state = "chronogun"
 	module_type = MODULE_ACTIVE
@@ -475,10 +475,10 @@
 	required_slots = list(ITEM_SLOT_BACK)
 
 /obj/item/gun/medbeam/mod
-	name = "MOD medbeam"
+	name = "\improper MOD medbeam"
 
 /obj/item/mod/module/stealth/wraith
-	name = "MOD Wraith Cloaking Module"
+	name = "\improper MOD Wraith Cloaking Module"
 	desc = "A more destructive adaptation of the stealth module. Incompatible with armor modules"
 	icon_state = "cloak_traitor"
 	stealth_alpha = 30

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -2,7 +2,7 @@
 
 ///Welding Protection - Makes the helmet protect from flashes and welding.
 /obj/item/mod/module/welding
-	name = "MOD welding protection module"
+	name = "\improper MOD welding protection module"
 	desc = "A module installed into the visor of the suit, this projects a \
 		polarized, holographic overlay in front of the user's eyes. It's rated high enough for \
 		immunity against extremities such as spot and arc welding, solar eclipses, and handheld flashlights."
@@ -27,7 +27,7 @@
 		head_cover.flash_protect = initial(head_cover.flash_protect)
 
 /obj/item/mod/module/welding/syndicate
-	name = "MODsuit flash-protected optical suite"
+	name = "\improper MODsuit flash-protected optical suite"
 	complexity = 0
 	removable = FALSE
 	incompatible_modules = list(/obj/item/mod/module/welding, /obj/item/mod/module/welding/syndicate, /obj/item/mod/module/stealth/wraith)
@@ -59,7 +59,7 @@
 
 ///T-Ray Scan - Scans the terrain for undertile objects.
 /obj/item/mod/module/t_ray
-	name = "MOD t-ray scan module"
+	name = "\improper MOD t-ray scan module"
 	desc = "A module installed into the visor of the suit, allowing the user to use a pulse of terahertz radiation \
 		to essentially echolocate things beneath the floor, mostly cables and pipes. \
 		A staple of atmospherics work, and counter-smuggling work."
@@ -78,7 +78,7 @@
 
 ///Magnetic Stability - Gives the user a slowdown but makes them negate gravity and be immune to slips.
 /obj/item/mod/module/magboot
-	name = "MOD magnetic stability module"
+	name = "\improper MOD magnetic stability module"
 	desc = "These are powerful electromagnets fitted into the suit's boots, allowing users both \
 		excellent traction no matter the condition indoors, and to essentially hitch a ride on the exterior of a hull. \
 		However, these basic models do not feature computerized systems to automatically toggle them on and off, \
@@ -117,14 +117,14 @@
 		module_slowdowns += slowdown_active
 
 /obj/item/mod/module/magboot/advanced
-	name = "MOD advanced magnetic stability module"
+	name = "\improper MOD advanced magnetic stability module"
 	removable = FALSE
 	complexity = 0
 	slowdown_active = 0
 
 ///Emergency Tether - Shoots a grappling hook projectile in 0g that throws the user towards it.
 /obj/item/mod/module/tether
-	name = "MOD emergency tether module"
+	name = "\improper MOD emergency tether module"
 	desc = "A custom-built grappling-hook powered by a winch capable of hauling the user. \
 		While some older models of cargo-oriented grapples have capacities of a few tons, \
 		these are only capable of working in zero-gravity environments, a blessing to some Engineers."
@@ -370,7 +370,7 @@
 
 ///Radiation Protection - Protects the user from radiation, gives them a geiger counter and rad info in the panel.
 /obj/item/mod/module/rad_protection
-	name = "MOD radiation protection module"
+	name = "\improper MOD radiation protection module"
 	desc = "A module utilizing polymers and reflective shielding to protect the user against ionizing radiation; \
 		a common danger in space. This comes with software to notify the wearer that they're even in a radioactive area, \
 		giving a voice to an otherwise silent killer."
@@ -413,7 +413,7 @@
 
 ///Constructor - Lets you build quicker and create RCD holograms.
 /obj/item/mod/module/constructor
-	name = "MOD constructor module"
+	name = "\improper MOD constructor module"
 	desc = "This module entirely occupies the wearer's forearm, notably causing conflict with \
 		advanced arm servos meant to carry crewmembers. However, it functions as an \
 		extremely advanced construction hologram scanner, as well as containing the \
@@ -440,7 +440,7 @@
 
 ///Safety-First Head Protection - Protects your brain matter from sudden impacts.
 /obj/item/mod/module/headprotector
-	name = "MOD safety-first head protection module"
+	name = "\improper MOD safety-first head protection module"
 	desc = "A series of dampening plates are installed along the back and upper areas of \
 		the helmet. These plates absorb abrupt kinetic shocks delivered to the skull. \
 		The bulk of this module prevents it from being installed in any suit that is capable \
@@ -460,7 +460,7 @@
 
 ///Mister - Sprays water over an area.
 /obj/item/mod/module/mister
-	name = "MOD water mister module"
+	name = "\improper MOD water mister module"
 	desc = "A module containing a mister, able to spray it over areas."
 	icon_state = "mister"
 	module_type = MODULE_ACTIVE
@@ -479,7 +479,7 @@
 
 ///Resin Mister - Sprays resin over an area.
 /obj/item/mod/module/mister/atmos
-	name = "MOD resin mister module"
+	name = "\improper MOD resin mister module"
 	desc = "An atmospheric resin mister, able to fix up areas quickly."
 	device = /obj/item/extinguisher/mini/nozzle/mod
 	volume = 250
@@ -490,5 +490,5 @@
 	reagents.add_reagent(/datum/reagent/water, volume)
 
 /obj/item/extinguisher/mini/nozzle/mod
-	name = "MOD atmospheric mister"
+	name = "\improper MOD atmospheric mister"
 	desc = "An atmospheric resin mister with three modes, mounted as a module."

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -2,7 +2,7 @@
 
 ///Storage - Adds a storage component to the suit.
 /obj/item/mod/module/storage
-	name = "MOD compact storage module"
+	name = "\improper MOD compact storage module"
 	desc = "What amounts to a series of integrated storage compartments and specialized pockets installed across \
 		the surface of the suit, useful for storing various bits, and or bobs. This version has been trimmed down to save space."
 	icon_state = "storage"
@@ -49,7 +49,7 @@
 	mod.wearer.temporarilyRemoveItemFromInventory(mod.wearer.s_store)
 
 /obj/item/mod/module/storage/large_capacity
-	name = "MOD storage module"
+	name = "\improper MOD storage module"
 	desc = "Reverse engineered by Nakamura Engineering from Donk Company designs, this system of hidden compartments \
 		is entirely within the suit, distributing items and weight evenly to ensure a comfortable experience for the user; \
 		whether smuggling, or simply hauling."
@@ -59,7 +59,7 @@
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2.5, /datum/material/uranium = SHEET_MATERIAL_AMOUNT)
 
 /obj/item/mod/module/storage/syndicate
-	name = "MOD syndicate storage module"
+	name = "\improper MOD syndicate storage module"
 	desc = "A storage system using nanotechnology developed by Cybersun Industries, these compartments use \
 		esoteric technology to compress the physical matter of items put inside of them, \
 		essentially shrinking items for much easier and more portable storage."
@@ -68,7 +68,7 @@
 	storage_type = /datum/storage/mod_storage/syndicate
 
 /obj/item/mod/module/storage/belt
-	name = "MOD case storage module"
+	name = "\improper MOD case storage module"
 	desc = "Some concessions had to be made when creating a compressed modular suit core. \
 		As a result, Roseus Galactic equipped their suit with a slimline storage case.  \
 		If you find this equipped to a standard modular suit, then someone has almost certainly shortchanged you on a proper storage module."
@@ -78,7 +78,7 @@
 	storage_type = /datum/storage/mod_storage/belt
 
 /obj/item/mod/module/storage/bluespace
-	name = "MOD bluespace storage module"
+	name = "\improper MOD bluespace storage module"
 	desc = "A storage system developed by Nanotrasen, these compartments employ \
 		miniaturized bluespace pockets for the ultimate in storage technology; regardless of the weight of objects put inside."
 	complexity = 3
@@ -87,7 +87,7 @@
 
 ///Ion Jetpack - Lets the user fly freely through space using battery charge.
 /obj/item/mod/module/jetpack
-	name = "MOD ion jetpack module"
+	name = "\improper MOD ion jetpack module"
 	desc = "A series of electric thrusters installed across the suit, this is a module highly anticipated by trainee Engineers. \
 		Rather than using gasses for combustion thrust, these jets are capable of accelerating ions using \
 		charge from the suit's charge. Some say this isn't Nakamura Engineering's first foray into jet-enabled suits."
@@ -170,7 +170,7 @@
 	REMOVE_TRAIT(mod.wearer, TRAIT_NOGRAV_ALWAYS_DRIFT, REF(src))
 
 /obj/item/mod/module/jetpack/advanced
-	name = "MOD advanced ion jetpack module"
+	name = "\improper MOD advanced ion jetpack module"
 	desc = "An improvement on the previous model of electric thrusters. This one achieves higher precision \
 		and spartial stability through mounting of more jets and application of red paint."
 	icon_state = "jetpack_advanced"
@@ -183,7 +183,7 @@
 
 ///Jump Jet - Briefly removes the effect of gravity and pushes you up one z-level if possible.
 /obj/item/mod/module/jump_jet
-	name = "MOD ionic jump jet module"
+	name = "\improper MOD ionic jump jet module"
 	desc = "A specialised ionic thruster which provides a short but powerful boost capable of pushing against gravity, \
 		after which time it needs to recharge."
 	icon_state = "jump_jet"
@@ -219,7 +219,7 @@
 
 ///Status Readout - Puts a lot of information including health, nutrition, fingerprints, temperature to the suit TGUI.
 /obj/item/mod/module/status_readout
-	name = "MOD status readout module"
+	name = "\improper MOD status readout module"
 	desc = "A once-common module, this technology unfortunately went out of fashion in the safer regions of space; \
 		and found new life in the research networks of the Periphery. This particular unit hooks into the suit's spine, \
 		capable of capturing and displaying all possible biometric data of the wearer; sleep, nutrition, fitness, fingerprints, \
@@ -315,7 +315,7 @@
 
 ///Eating Apparatus - Lets the user eat/drink with the suit on.
 /obj/item/mod/module/mouthhole
-	name = "MOD eating apparatus module"
+	name = "\improper MOD eating apparatus module"
 	desc = "A favorite by Miners, this modification to the helmet utilizes a nanotechnology barrier infront of the mouth \
 		to allow eating and drinking while retaining protection and atmosphere. However, it won't free you from masks, \
 		lets pepper spray pass through and it will do nothing to improve the taste of a goliath steak."
@@ -372,7 +372,7 @@
 
 ///EMP Shield - Protects the suit from EMPs.
 /obj/item/mod/module/emp_shield
-	name = "MOD EMP shield module"
+	name = "\improper MOD EMP shield module"
 	desc = "A field inhibitor installed into the suit, protecting it against feedback such as \
 		electromagnetic pulses that would otherwise damage the electronic systems of the suit or it's modules. \
 		However, it will take from the suit's power to do so."
@@ -400,7 +400,7 @@
 		mod_part.emp_protection -= protection_factor/all_parts.len
 
 /obj/item/mod/module/emp_shield/advanced
-	name = "MOD advanced EMP shield module"
+	name = "\improper MOD advanced EMP shield module"
 	desc = "An advanced field inhibitor installed into the suit, protecting it against feedback such as \
 		electromagnetic pulses that would otherwise damage the electronic systems of the suit or electronic devices on the wearer, \
 		including augmentations. However, it will take from the suit's power to do so."
@@ -414,7 +414,7 @@
 
 ///Flashlight - Gives the suit a customizable flashlight.
 /obj/item/mod/module/flashlight
-	name = "MOD flashlight module"
+	name = "\improper MOD flashlight module"
 	desc = "A simple pair of configurable flashlights installed on the left and right sides of the helmet, \
 		useful for providing light in a variety of ranges and colors. \
 		Some survivalists prefer the color green for their illumination, for reasons unknown."
@@ -486,7 +486,7 @@
 
 ///Like the flashlight module, except the light color is stuck to black and cannot be changed.
 /obj/item/mod/module/flashlight/darkness
-	name = "MOD flashdark module"
+	name = "\improper MOD flashdark module"
 	desc = "A quirky pair of configurable flashdarks installed on the sides of the helmet, \
 		useful for providing darkness at a configurable range."
 	light_color = COLOR_BLACK
@@ -501,7 +501,7 @@
 
 ///Dispenser - Dispenses an item after a time passes.
 /obj/item/mod/module/dispenser
-	name = "MOD burger dispenser module"
+	name = "\improper MOD burger dispenser module"
 	desc = "A rare piece of technology reverse-engineered from a prototype found in a Donk Company vessel. \
 		This can draw incredible amounts of power from the suit's charge to create edible organic matter in the \
 		palm of the wearer's glove; however, research seemed to have entirely stopped at burgers. \
@@ -531,7 +531,7 @@
 
 ///Longfall - Nullifies fall damage, removing charge instead.
 /obj/item/mod/module/longfall
-	name = "MOD longfall module"
+	name = "\improper MOD longfall module"
 	desc = "Useful for protecting both the suit and the wearer, \
 		utilizing commonplace systems to convert the possible damage from a fall into kinetic charge, \
 		as well as internal gyroscopes to ensure the user's safe falling. \
@@ -570,7 +570,7 @@
 
 ///Thermal Regulator - Regulates the wearer's core temperature.
 /obj/item/mod/module/thermal_regulator
-	name = "MOD thermal regulator module"
+	name = "\improper MOD thermal regulator module"
 	desc = "Advanced climate control, using an inner body glove interwoven with thousands of tiny, \
 		flexible cooling lines. This circulates coolant at various user-controlled temperatures, \
 		ensuring they're comfortable; even if they're some that like it hot."
@@ -602,7 +602,7 @@
 
 ///DNA Lock - Prevents people without the set DNA from activating the suit.
 /obj/item/mod/module/dna_lock
-	name = "MOD DNA lock module"
+	name = "\improper MOD DNA lock module"
 	desc = "A module which engages with the various locks and seals tied to the suit's systems, \
 		enabling it to only be worn by someone corresponding with the user's exact DNA profile; \
 		however, this incredibly sensitive module is shorted out by EMPs. Luckily, cloning has been outlawed."
@@ -678,7 +678,7 @@
 
 ///Plasma Stabilizer - Prevents plasmamen from igniting in the suit
 /obj/item/mod/module/plasma_stabilizer
-	name = "MOD plasma stabilizer module"
+	name = "\improper MOD plasma stabilizer module"
 	desc = "This system essentially forms an atmosphere of its own, within the suit, \
 		efficiently and quickly preventing oxygen from causing the user's head to burst into flame. \
 		This allows plasmamen to safely remove their helmet, allowing for easier \
@@ -711,7 +711,7 @@
 //Finally, https://pipe.miroware.io/5b52ba1d94357d5d623f74aa/mspfa/Nuke%20Ops/Panels/0648.gif can be real:
 ///Hat Stabilizer - Allows displaying a hat over the MOD-helmet, à la plasmamen helmets.
 /obj/item/mod/module/hat_stabilizer
-	name = "MOD hat stabilizer module"
+	name = "\improper MOD hat stabilizer module"
 	desc = "A simple set of deployable stands, directly atop one's head; \
 		these will deploy under a hat to keep it from falling off, allowing them to be worn atop the sealed helmet. \
 		You still need to take the hat off your head while the helmet deploys, though. \
@@ -742,7 +742,7 @@
 	helmet.AddComponent(/datum/component/hat_stabilizer, loose_hat = TRUE)
 
 /obj/item/mod/module/hat_stabilizer/syndicate
-	name = "MOD elite hat stabilizer module"
+	name = "\improper MOD elite hat stabilizer module"
 	desc = "A simple set of deployable stands, directly atop one's head; \
 		these will deploy under a hat to keep it from falling off, allowing them to be worn atop the sealed helmet. \
 		You still need to take the hat off your head while the helmet deploys, though. This is a must-have for \
@@ -752,7 +752,7 @@
 
 ///Sign Language Translator - allows people to sign over comms using the modsuit's gloves.
 /obj/item/mod/module/signlang_radio
-	name = "MOD glove translator module"
+	name = "\improper MOD glove translator module"
 	desc = "A module that adds motion sensors into the suit's gloves, \
 		which works in tandem with a short-range subspace transmitter, \
 		letting the audibly impaired use sign language over comms."
@@ -771,7 +771,7 @@
 
 ///A module that recharges the suit by an itsy tiny bit whenever the user takes a step. Originally called "magneto module" but the videogame reference sounds cooler.
 /obj/item/mod/module/joint_torsion
-	name = "MOD joint torsion ratchet module"
+	name = "\improper MOD joint torsion ratchet module"
 	desc = "A compact, weak AC generator that charges the suit's internal cell through the power of deambulation. It doesn't work in zero G. More than one can be installed."
 	icon_state = "joint_torsion"
 	complexity = 1
@@ -808,7 +808,7 @@
 
 /// Module that shoves garbage inside its material container when the user crosses it, and eject the recycled material with MMB.
 /obj/item/mod/module/recycler
-	name = "MOD recycler module"
+	name = "\improper MOD recycler module"
 	desc = "An innovative garbage collection module that recycles gathered trash into usable material. \
 		Doesn't work on debris and some items. May recycle live ammunition. \
 		Activate on a nearby turf or storage to unload stored material."
@@ -926,7 +926,7 @@
 
 ///A black market variant of the above that dispenses riot foam dart boxes
 /obj/item/mod/module/recycler/donk
-	name = "MOD riot foam dart recycler module"
+	name = "\improper MOD riot foam dart recycler module"
 	desc = "A mod module collects and repackages fired foam darts (and garbage) into half-sized boxes of riot foam darts. \
 		Activate on a nearby turf or storage to unload stored ammo boxes."
 	icon_state = "donk_recycler"
@@ -950,7 +950,7 @@
 	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 50, TRUE)
 
 /obj/item/mod/module/fishing_glove
-	name = "MOD fishing glove module"
+	name = "\improper MOD fishing glove module"
 	desc = "A MOD module that takes in an external fishing rod to enable the user to fish without having to hold one, while also making it slightly easier."
 	icon_state = "fishing_glove"
 	complexity = 1
@@ -1024,7 +1024,7 @@
 		qdel(gloves.GetComponent(/datum/component/profound_fisher))
 
 /obj/item/mod/module/shock_absorber
-	name = "MOD shock absorption module"
+	name = "\improper MOD shock absorption module"
 	desc = "A module that makes the user resistant to the knockdown and CNS disruption inflicted by Stun Batons."
 	icon_state = "no_baton"
 	complexity = 1

--- a/code/modules/mod/modules/modules_maint.dm
+++ b/code/modules/mod/modules/modules_maint.dm
@@ -2,7 +2,7 @@
 
 ///Springlock Mechanism - allows your modsuit to activate faster, but reagents are very dangerous.
 /obj/item/mod/module/springlock
-	name = "MOD springlock module"
+	name = "\improper MOD springlock module"
 	desc = "A module that spans the entire size of the MOD unit, sitting under the outer shell. \
 		This mechanical exoskeleton pushes out of the way when the user enters and it helps in booting \
 		up, but was taken out of modern suits because of the springlock's tendency to \"snap\" back \
@@ -105,7 +105,7 @@
 
 ///Rave Visor - Gives you a rainbow visor and plays jukebox music to you.
 /obj/item/mod/module/visor/rave
-	name = "MOD rave visor module"
+	name = "\improper MOD rave visor module"
 	desc = "A Super Cool Awesome Visor (SCAV), intended for modular suits."
 	icon_state = "rave_visor"
 	complexity = 1
@@ -188,7 +188,7 @@
 
 ///Tanner - Tans you with spraytan.
 /obj/item/mod/module/tanner
-	name = "MOD tanning module"
+	name = "\improper MOD tanning module"
 	desc = "A tanning module for modular suits. Skin cancer functionality has not been ever proven, \
 		although who knows with the rumors..."
 	icon_state = "tanning"
@@ -210,7 +210,7 @@
 
 ///Balloon Blower - Blows a balloon.
 /obj/item/mod/module/balloon
-	name = "MOD balloon blower module"
+	name = "\improper MOD balloon blower module"
 	desc = "A strange module invented years ago by some ingenious mimes. It blows balloons."
 	icon_state = "bloon"
 	module_type = MODULE_USABLE
@@ -234,7 +234,7 @@
 
 ///Paper Dispenser - Dispenses (sometimes burning) paper sheets.
 /obj/item/mod/module/paper_dispenser
-	name = "MOD paper dispenser module"
+	name = "\improper MOD paper dispenser module"
 	desc = "A simple module designed by the bureaucrats of Torch Bay. \
 		It dispenses 'warm, clean, and crisp sheets of paper' onto a nearby table. Usually."
 	icon_state = "paper_maker"
@@ -276,7 +276,7 @@
 
 ///Stamper - Extends a stamp that can switch between accept/deny modes.
 /obj/item/mod/module/stamp
-	name = "MOD stamper module"
+	name = "\improper MOD stamper module"
 	desc = "A module installed into the wrist of the suit, this functions as a high-power stamp, \
 		able to switch between accept, deny, and void modes."
 	icon_state = "stamp"
@@ -289,7 +289,7 @@
 	required_slots = list(ITEM_SLOT_GLOVES|ITEM_SLOT_NECK)
 
 /obj/item/stamp/mod
-	name = "MOD electronic stamp"
+	name = "\improper MOD electronic stamp"
 	desc = "A high-power stamp, able to switch between accept, deny, and void modes when used."
 	icon_state = "stamp-ok"
 
@@ -315,7 +315,7 @@
 
 ///Atrocinator - Flips your gravity.
 /obj/item/mod/module/atrocinator
-	name = "MOD atrocinator module"
+	name = "\improper MOD atrocinator module"
 	desc = "A mysterious orb that has mysterious effects when inserted in a MODsuit."
 	icon_state = "atrocinator"
 	module_type = MODULE_TOGGLE
@@ -423,7 +423,7 @@
 
 
 /obj/item/mod/module/recycler/donk/safe
-	name = "MOD foam dart recycler module"
+	name = "\improper MOD foam dart recycler module"
 	desc = "A mod module that collects and repackages fired foam darts into half-sized ammo boxes. \
 		Activate on a nearby turf or storage to unload stored ammo boxes."
 	icon_state = "donk_safe_recycler"

--- a/code/modules/mod/modules/modules_medical.dm
+++ b/code/modules/mod/modules/modules_medical.dm
@@ -6,7 +6,7 @@
 
 ///Health Analyzer - Gives the user a ranged health analyzer and their health status in the panel.
 /obj/item/mod/module/health_analyzer
-	name = "MOD health analyzer module"
+	name = "\improper MOD health analyzer module"
 	desc = "A module installed into the glove of the suit. This is a high-tech biological scanning suite, \
 		allowing the user indepth information on the vitals and injuries of others even at a distance, \
 		all with the flick of the wrist. Data is displayed in a convenient package, but it's up to you to do something with it."
@@ -66,7 +66,7 @@
 
 ///Quick Carry - Lets the user carry bodies quicker.
 /obj/item/mod/module/quick_carry
-	name = "MOD quick carry module"
+	name = "\improper MOD quick carry module"
 	desc = "A suite of advanced servos, redirecting power from the suit's arms to help carry the wounded; \
 		or simply for fun. However, Nanotrasen has locked the module's ability to assist in hand-to-hand combat."
 	icon_state = "carry"
@@ -88,14 +88,14 @@
 	REMOVE_TRAIT(mod.wearer, quick_carry_trait, REF(src))
 
 /obj/item/mod/module/quick_carry/advanced
-	name = "MOD advanced quick carry module"
+	name = "\improper MOD advanced quick carry module"
 	removable = FALSE
 	complexity = 0
 	quick_carry_trait = TRAIT_QUICKER_CARRY
 
 ///Injector - Gives the suit an extendable large-capacity piercing syringe.
 /obj/item/mod/module/injector
-	name = "MOD injector module"
+	name = "\improper MOD injector module"
 	desc = "A module installed into the wrist of the suit, this functions as a high-capacity syringe, \
 		with a tip fine enough to locate the emergency injection ports on any suit of armor, \
 		penetrating it with ease. Even yours."
@@ -110,7 +110,7 @@
 	custom_materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = HALF_SHEET_MATERIAL_AMOUNT)
 
 /obj/item/reagent_containers/syringe/mod
-	name = "MOD injector syringe"
+	name = "\improper MOD injector syringe"
 	desc = "A high-capacity syringe, with a tip fine enough to locate \
 		the emergency injection ports on any suit of armor, penetrating it with ease. Even yours."
 	icon_state = "mod_0"
@@ -129,7 +129,7 @@
 
 ///Organizer - Lets you shoot organs, immediately replacing them if the target has the organ manipulation surgery.
 /obj/item/mod/module/organizer
-	name = "MOD organizer module"
+	name = "\improper MOD organizer module"
 	desc = "A device recovered from a crashed Interdyne Pharmaceuticals vessel, \
 		this module has been unearthed for better or for worse. \
 		It's an arm-mounted device utilizing technology similar to modern rapid part exchange devices, \
@@ -219,7 +219,7 @@
 
 ///Patrient Transport - Generates hardlight bags you can put people in.
 /obj/item/mod/module/criminalcapture/patienttransport
-	name = "MOD patient transport module"
+	name = "\improper MOD patient transport module"
 	desc = "A module built into the forearm of the suit. Countless waves of mostly-lost mining teams being sent to \
 		Indecipheries and other hazardous locations have taught the DeForest Medical Company many lessons. \
 		Physical bodybags are difficult to store, hard to deploy, and even worse to keep intact in tough scenarios. \
@@ -234,7 +234,7 @@
 
 ///Defibrillator - Gives the suit an extendable pair of shock paddles.
 /obj/item/mod/module/defibrillator
-	name = "MOD defibrillator module"
+	name = "\improper MOD defibrillator module"
 	desc = "A module built into the gauntlets of the suit; commonly known as the 'Healing Hands' by medical professionals. \
 		The user places their palms above the patient. Onboard computers in the suit calculate the necessary voltage, \
 		and a modded targeting computer determines the best position for the user to push. \
@@ -264,14 +264,14 @@
 	return COMPONENT_DEFIB_STOP
 
 /obj/item/shockpaddles/mod
-	name = "MOD defibrillator gauntlets"
+	name = "\improper MOD defibrillator gauntlets"
 	req_defib = FALSE
 	icon_state = "defibgauntlets0"
 	inhand_icon_state = "defibgauntlets0"
 	base_icon_state = "defibgauntlets"
 
 /obj/item/mod/module/defibrillator/combat
-	name = "MOD combat defibrillator module"
+	name = "\improper MOD combat defibrillator module"
 	desc = "A module built into the gauntlets of the suit; commonly known as the 'Healing Hands' by medical professionals. \
 		The user places their palms above the patient. Onboard computers in the suit calculate the necessary voltage, \
 		and a modded targeting computer determines the best position for the user to push. \
@@ -289,7 +289,7 @@
 	defib_cooldown = 2.5 SECONDS
 
 /obj/item/shockpaddles/syndicate/mod
-	name = "MOD combat defibrillator gauntlets"
+	name = "\improper MOD combat defibrillator gauntlets"
 	req_defib = FALSE
 	icon_state = "syndiegauntlets0"
 	inhand_icon_state = "syndiegauntlets0"
@@ -297,7 +297,7 @@
 
 ///Thread Ripper - Temporarily rips apart clothing to make it not cover the body.
 /obj/item/mod/module/thread_ripper
-	name = "MOD thread ripper module"
+	name = "\improper MOD thread ripper module"
 	desc = "A custom-built module integrated with the suit's wrist. The thread ripper is built from \
 		recent technology dating back to the start of 2562, after an attempt by a well-known Nanotrasen researcher to \
 		expand on the rapid-tailoring technology found in Autodrobes. Rather than being capable of creating \
@@ -378,7 +378,7 @@
 
 ///Surgical Processor - Lets you do advanced surgeries portably.
 /obj/item/mod/module/surgical_processor
-	name = "MOD surgical processor module"
+	name = "\improper MOD surgical processor module"
 	desc = "A module using an onboard surgical computer which can be connected to other computers to download and \
 		perform advanced surgeries on the go."
 	icon_state = "surgical_processor"
@@ -391,7 +391,7 @@
 	custom_materials = list(/datum/material/silver = SHEET_MATERIAL_AMOUNT * 0.75, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/titanium = SMALL_MATERIAL_AMOUNT * 2.5)
 
 /obj/item/surgical_processor/mod
-	name = "MOD surgical processor"
+	name = "\improper MOD surgical processor"
 	custom_materials = null
 
 /obj/item/mod/module/surgical_processor/preloaded

--- a/code/modules/mod/modules/modules_ninja.dm
+++ b/code/modules/mod/modules/modules_ninja.dm
@@ -2,7 +2,7 @@
 
 ///Cloaking - Lowers the user's visibility, can be interrupted by being touched or attacked.
 /obj/item/mod/module/stealth
-	name = "MOD prototype cloaking module"
+	name = "\improper MOD prototype cloaking module"
 	desc = "A complete retrofitting of the suit, this is a form of visual concealment tech employing esoteric technology \
 		to bend light around the user, as well as mimetic materials to make the surface of the suit match the \
 		surroundings based off sensor data. For some reason, this tech is rarely seen."
@@ -59,7 +59,7 @@
 
 //Advanced Cloaking - Doesn't turf off on bump, less power drain, more stealthy.
 /obj/item/mod/module/stealth/ninja
-	name = "MOD advanced cloaking module"
+	name = "\improper MOD advanced cloaking module"
 	desc = "The latest in stealth technology, this module is a definite upgrade over previous versions. \
 		The field has been tuned to be even more responsive and fast-acting, with enough stability to \
 		continue operation of the field even if the user bumps into others. \
@@ -83,7 +83,7 @@
 
 ///Camera Vision - Prevents flashes, blocks tracking.
 /obj/item/mod/module/welding/camera_vision
-	name = "MOD camera vision module"
+	name = "\improper MOD camera vision module"
 	desc = "A module installed into the suit's helmet. This specialized piece of technology is built for subterfuge, \
 		replacing the standard visor with a nanotech display; capable of displaying specialized imagery at \
 		just the right frequency to jam all known forms of camera tracking and facial recognition, \
@@ -117,7 +117,7 @@
 
 //Ninja Star Dispenser - Dispenses ninja stars.
 /obj/item/mod/module/dispenser/ninja
-	name = "MOD ninja star dispenser module"
+	name = "\improper MOD ninja star dispenser module"
 	desc = "This piece of Spider Clan technology can exploit known energy-matter equivalence principles, \
 		using the nanites already hosted in the wearer's suit to transmute into monomolecular shuriken. \
 		While these lack the intense bleeding edge of conventional throwing stars, \
@@ -176,7 +176,7 @@
 
 ///Hacker - This module hooks onto your right-clicks with empty hands and causes ninja actions.
 /obj/item/mod/module/hacker
-	name = "MOD hacker module"
+	name = "\improper MOD hacker module"
 	desc = "Built for one purpose, electronic warfare, this module is built into the hands. \
 		Using near-field communication alongside precise electro-stimulation of the wires in machines, \
 		this decker's dream is normally used to pass through doors like a phantom. \
@@ -679,7 +679,7 @@
 #undef NINJA_MAX_DRAIN
 ///Weapon Recall - Teleports your katana to you, prevents gun use.
 /obj/item/mod/module/weapon_recall
-	name = "MOD weapon recall module"
+	name = "\improper MOD weapon recall module"
 	desc = "The cornerstone of a clanmember's life as a blademaster, and a module symbolizing their eternal bond with their weapon. \
 		This hooks to the micro bluespace drive inside an energy katana's handle, capable of recalling it to the user's \
 		skilled hands wherever they are. However, those that make such a bond with their weapon are cursed to \
@@ -770,7 +770,7 @@
 
 //Reinforced DNA Lock - Gibs if wrong DNA, emp-proof.
 /obj/item/mod/module/dna_lock/reinforced
-	name = "MOD reinforced DNA lock module"
+	name = "\improper MOD reinforced DNA lock module"
 	desc = "A module which engages with the various locks and seals tied to the suit's systems, \
 		enabling it to only be worn by someone corresponding with the user's exact DNA profile. \
 		Due to utilizing a skintight dampening shield, this one is entirely sealed against electromagnetic interference; \
@@ -795,7 +795,7 @@
 
 //EMP Pulse - In addition to normal shielding, can also launch an EMP itself.
 /obj/item/mod/module/emp_shield/pulse
-	name = "MOD EMP pulse module"
+	name = "\improper MOD EMP pulse module"
 	desc = "This module is normally set to activate on dramatic gestures, inverting and expanding the suit's \
 		EMP dampening shield to cause an electromagnetic pulse of its own. While this won't interfere with the wearer, \
 		it will piss off everyone around them."
@@ -811,7 +811,7 @@
 
 /// Ninja Status Readout - Like the normal status display (see the base type), but with a clock.
 /obj/item/mod/module/status_readout/ninja
-	name = "MOD Spider Clan status readout module"
+	name = "\improper MOD Spider Clan status readout module"
 	desc = "A once-common module, this technology unfortunately went out of fashion in the safer regions of space; \
 		and, according to the extra markings on this particular unit's casing, right into the arachnid grip of the Spider Clan. \
 		Like other similar units, this one hooks into the suit's spine, and is capable of capturing and displaying \
@@ -825,7 +825,7 @@
 
 ///Energy Net - Ensnares enemies in a net that prevents movement.
 /obj/item/mod/module/energy_net
-	name = "MOD energy net module"
+	name = "\improper MOD energy net module"
 	desc = "A custom-built net-thrower. While conventional implementations of this capturing device \
 		utilize monomolecular fibers or cutting razorwire, this uses hardlight technology to deploy a \
 		trapping field capable of immobilizing even the strongest opponents."
@@ -947,7 +947,7 @@
 
 ///Adrenaline Boost - Stops all stuns the ninja is affected with, increases his speed.
 /obj/item/mod/module/adrenaline_boost
-	name = "MOD adrenaline boost module"
+	name = "\improper MOD adrenaline boost module"
 	desc = "The secrets of the Spider Clan are many. The exact specifications of their suits, \
 		the techniques they use to make every singular cut make their enemies weep with admiration, \
 		but one of their greatest mysteries is the chemical compound their assassin-saboteurs use in times of need. \

--- a/code/modules/mod/modules/modules_science.dm
+++ b/code/modules/mod/modules/modules_science.dm
@@ -2,7 +2,7 @@
 
 ///Reagent Scanner - Lets the user scan reagents.
 /obj/item/mod/module/reagent_scanner
-	name = "MOD reagent scanner module"
+	name = "\improper MOD reagent scanner module"
 	desc = "A module based off research-oriented Nanotrasen HUDs, this is capable of scanning the contents of \
 		containers and projecting the information in an easy-to-read format on the wearer's display. \
 		It cannot detect flavors, so that's up to you."
@@ -21,7 +21,7 @@
 	REMOVE_TRAIT(mod.wearer, TRAIT_REAGENT_SCANNER, REF(src))
 
 /obj/item/mod/module/reagent_scanner/advanced
-	name = "MOD advanced reagent scanner module"
+	name = "\improper MOD advanced reagent scanner module"
 	desc = "An advanced module with all the features of research-oriented Nanotrasen HUDs, this is capable of scanning \
 		the contents of containers and projecting the information in an easy-to-read format on the wearer's display. \
 		It also contains a research scanner and an explosion sensor that gives details on nearby explosions. \
@@ -52,7 +52,7 @@
 
 ///Anti-Gravity - Makes the user weightless.
 /obj/item/mod/module/anomaly_locked/antigrav
-	name = "MOD anti-gravity module"
+	name = "\improper MOD anti-gravity module"
 	desc = "A module that uses a gravitational core to make the user completely weightless."
 	icon_state = "antigrav"
 	module_type = MODULE_TOGGLE
@@ -85,7 +85,7 @@
 
 ///Teleporter - Lets the user teleport to a nearby location.
 /obj/item/mod/module/anomaly_locked/teleporter
-	name = "MOD teleporter module"
+	name = "\improper MOD teleporter module"
 	desc = "A module that uses a bluespace core to let the user transport their particles elsewhere."
 	icon_state = "teleporter"
 	module_type = MODULE_ACTIVE

--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -2,7 +2,7 @@
 
 ///Magnetic Harness - Automatically puts guns in your suit storage when you drop them.
 /obj/item/mod/module/magnetic_harness
-	name = "MOD magnetic harness module"
+	name = "\improper MOD magnetic harness module"
 	desc = "Based off old TerraGov harness kits, this magnetic harness automatically attaches dropped guns back to the wearer."
 	icon_state = "mag_harness"
 	complexity = 2
@@ -72,7 +72,7 @@
 
 ///Pepper Shoulders - When hit, reacts with a spray of pepper spray around the user.
 /obj/item/mod/module/pepper_shoulders
-	name = "MOD pepper shoulders module"
+	name = "\improper MOD pepper shoulders module"
 	desc = "A module that attaches two pepper sprayers on shoulders of a MODsuit, reacting to touch with a spray around the user."
 	icon_state = "pepper_shoulder"
 	module_type = MODULE_USABLE
@@ -106,7 +106,7 @@
 
 ///Holster - Instantly holsters any not huge gun.
 /obj/item/mod/module/holster
-	name = "MOD holster module"
+	name = "\improper MOD holster module"
 	desc = "Based off typical storage compartments, this system allows the suit to holster a \
 		standard firearm across its surface and allow for extremely quick retrieval. \
 		While some users prefer the chest, others the forearm for quick deployment, \
@@ -156,7 +156,7 @@
 
 ///Megaphone - Lets you speak loud.
 /obj/item/mod/module/megaphone
-	name = "MOD megaphone module"
+	name = "\improper MOD megaphone module"
 	desc = "A microchip megaphone linked to a MODsuit, for very important purposes, like: loudness."
 	icon_state = "megaphone"
 	module_type = MODULE_TOGGLE
@@ -187,7 +187,7 @@
 
 ///Criminal Capture - Generates hardlight bags you can put people in and sinch.
 /obj/item/mod/module/criminalcapture
-	name = "MOD criminal capture module"
+	name = "\improper MOD criminal capture module"
 	desc = "The private security that had orders to take in people dead were quite \
 		happy with their space-proofed suit, but for those who wanted to bring back \
 		whomever their targets were still breathing needed a way to \"share\" the \
@@ -273,7 +273,7 @@
 
 ///Mirage grenade dispenser - Dispenses grenades that copy the user's appearance.
 /obj/item/mod/module/dispenser/mirage
-	name = "MOD mirage grenade dispenser module"
+	name = "\improper MOD mirage grenade dispenser module"
 	desc = "This module can create mirage grenades at the user's liking. These grenades create holographic copies of the user."
 	icon_state = "mirage_grenade"
 	cooldown_time = 20 SECONDS
@@ -308,7 +308,7 @@
 
 ///Projectile Dampener - Weakens projectiles in range.
 /obj/item/mod/module/projectile_dampener
-	name = "MOD projectile dampener module"
+	name = "\improper MOD projectile dampener module"
 	desc = "Using technology from peaceborgs, this module weakens all projectiles in nearby range."
 	icon_state = "projectile_dampener"
 	module_type = MODULE_TOGGLE
@@ -347,7 +347,7 @@
 
 ///Active Sonar - Displays a hud circle on the turf of any living creatures in the given radius
 /obj/item/mod/module/active_sonar
-	name = "MOD active sonar"
+	name = "\improper MOD active sonar"
 	desc = "Ancient tech from the 20th century, this module uses sonic waves to detect living creatures within the user's radius. \
 		Its basic function slowly scans around the user for any bio-signatures, however it can be overclocked to scan everywhere at once.\
 		Its loud ping is much harder to hide in an indoor station than in the outdoor operations it was designed for."
@@ -464,7 +464,7 @@
  * Both modes prevent the user from dual wielding guns.
  */
 /obj/item/mod/module/shooting_assistant
-	name = "MOD shooting assistant module"
+	name = "\improper MOD shooting assistant module"
 	desc = "A botched prototype meant to boost the TGMC crayon eaters' ability with firearms. \
 		It has only two modes available in its configurations: \
 		'Quick Fire Stormtrooper' and 'Slow Ricochet Sharpshooter', \
@@ -569,7 +569,7 @@
 #undef SHARPSHOOTER_MODE
 
 /obj/item/mod/module/shove_blocker
-	name = "MOD bulwark module"
+	name = "\improper MOD bulwark module"
 	desc = "Layers upon layers of shock dampening plates, just to stop you from getting shoved into a wall by an angry mob."
 	icon_state = "bulwark"
 	complexity = 3
@@ -589,7 +589,7 @@
 	complexity = 0
 
 /obj/item/mod/module/quick_cuff
-	name = "MOD restraint assist module"
+	name = "\improper MOD restraint assist module"
 	desc = "Enhanced gauntlet grip pads that help with placing individuals in restraints more quickly. Doesn't look like they'll come off."
 	removable = FALSE
 	complexity = 0

--- a/code/modules/mod/modules/modules_service.dm
+++ b/code/modules/mod/modules/modules_service.dm
@@ -2,7 +2,7 @@
 
 ///Bike Horn - Plays a bike horn sound.
 /obj/item/mod/module/bikehorn
-	name = "MOD bike horn module"
+	name = "\improper MOD bike horn module"
 	desc = "A shoulder-mounted piece of heavy sonic artillery, this module uses the finest femto-manipulator technology to \
 		precisely deliver an almost lethal squeeze to... a bike horn, producing a significantly memorable sound."
 	icon_state = "bikehorn"
@@ -19,7 +19,7 @@
 
 ///Advanced Balloon Blower - Blows a long balloon.
 /obj/item/mod/module/balloon/advanced
-	name = "MOD advanced balloon blower module"
+	name = "\improper MOD advanced balloon blower module"
 	desc = "A relatively new piece of technology developed by finest clown engineers to make long balloons and balloon animals \
 		at party-appropriate rate."
 	cooldown_time = 20 SECONDS
@@ -28,7 +28,7 @@
 
 ///Microwave Beam - Microwaves items instantly.
 /obj/item/mod/module/microwave_beam
-	name = "MOD microwave beam module"
+	name = "\improper MOD microwave beam module"
 	desc = "An oddly domestic device, this module is installed into the user's palm, \
 		hooking up with culinary scanners located in the helmet to blast food with precise microwave radiation, \
 		allowing them to cook food from a distance, with the greatest of ease. Not recommended for use against grapes."
@@ -62,7 +62,7 @@
 
 //Waddle - Makes you waddle and squeak.
 /obj/item/mod/module/waddle
-	name = "MOD waddle module"
+	name = "\improper MOD waddle module"
 	desc = "Some of the most primitive technology in use by Honk Co. This module works off an automatic intention system, \
 		utilizing its sensitivity to the pilot's often-limited brainwaves to directly read their next step, \
 		affecting the boots they're installed in. Employing a twin-linked gravitonic drive to create \
@@ -93,7 +93,7 @@
 
 // recharging cleaner spray module
 /obj/item/mod/module/mister/cleaner
-	name = "MOD janitorial mister module"
+	name = "\improper MOD janitorial mister module"
 	desc = "A space cleaner mister, able to clean up messes quickly. Synthesizes its own supply over time (if active)."
 	device = /obj/item/reagent_containers/spray/mister/janitor
 	volume = 100
@@ -111,7 +111,7 @@
 		reagents.add_reagent(/datum/reagent/space_cleaner, refill_add)
 
 /obj/item/mod/module/selfcleaner
-	name = "MOD perfumer module"
+	name = "\improper MOD perfumer module"
 	desc = "A small spray to clean oneself up. Has a pleasant scent."
 	icon_state = "cleaner"
 	module_type = MODULE_USABLE

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -2,7 +2,7 @@
 
 ///Internal GPS - Extends a GPS you can use.
 /obj/item/mod/module/gps
-	name = "MOD internal GPS module"
+	name = "\improper MOD internal GPS module"
 	desc = "This module uses common Nanotrasen technology to calculate the user's position anywhere in space, \
 		down to the exact coordinates. This information is fed to a central database viewable from the device itself, \
 		though using it to help people is up to you."
@@ -24,7 +24,7 @@
 
 ///Hydraulic Clamp - Lets you pick up and drop crates.
 /obj/item/mod/module/clamp
-	name = "MOD hydraulic clamp module"
+	name = "\improper MOD hydraulic clamp module"
 	desc = "A series of actuators installed into both arms of the suit, boasting a lifting capacity of almost a ton. \
 		However, this design has been locked by Nanotrasen to be primarily utilized for lifting various crates. \
 		A lot of people would say that loading cargo is a dull job, but you could not disagree more."
@@ -117,7 +117,7 @@
 	return TRUE
 
 /obj/item/mod/module/clamp/loader
-	name = "MOD loader hydraulic clamp module"
+	name = "\improper MOD loader hydraulic clamp module"
 	icon_state = "clamp_loader"
 	complexity = 0
 	removable = FALSE
@@ -130,7 +130,7 @@
 
 ///Drill - Lets you dig through rock and basalt.
 /obj/item/mod/module/drill
-	name = "MOD drill module"
+	name = "\improper MOD drill module"
 	desc = "An arm-mounted drill, typically extending over the user's hand. While useful for drilling through rock, \
 		your drill is surely the one that both pierces and creates the heavens. Integrates with mining MODs' sphere \
 		transformation module, changing it from a mere traversal tool to high-powered excavation unit."
@@ -246,7 +246,7 @@
 
 /// Ore Bag - Lets you pick up ores and drop them from the suit.
 /obj/item/mod/module/orebag
-	name = "MOD ore bag module"
+	name = "\improper MOD ore bag module"
 	desc = "An integrated ore storage system installed into the suit, \
 		this utilizes precise electromagnets and storage compartments to automatically collect and deposit ore. \
 		It's recommended by Nakamura Engineering to actually deposit that ore at local refineries."
@@ -319,7 +319,7 @@
 		playsound(mod.wearer, SFX_RUSTLE, 50, TRUE)
 
 /obj/item/mod/module/hydraulic
-	name = "MOD loader hydraulic arms module"
+	name = "\improper MOD loader hydraulic arms module"
 	desc = "A pair of powerful hydraulic arms installed in a MODsuit."
 	icon_state = "launch_loader"
 	module_type = MODULE_ACTIVE
@@ -372,7 +372,7 @@
 	user.transform = user.transform.Turn(angle)
 
 /obj/item/mod/module/disposal_connector
-	name = "MOD disposal selector module"
+	name = "\improper MOD disposal selector module"
 	desc = "A module that connects to the disposal pipeline, causing the user to go into their config selected disposal. \
 		Only seems to work when the suit is on."
 	icon_state = "disposal"
@@ -410,7 +410,7 @@
 	disposal_holder.destinationTag = disposal_tag
 
 /obj/item/mod/module/magnet
-	name = "MOD loader hydraulic magnet module"
+	name = "\improper MOD loader hydraulic magnet module"
 	desc = "A powerful hydraulic electromagnet able to launch crates and lockers towards the user, and keep 'em attached."
 	icon_state = "magnet_loader"
 	module_type = MODULE_ACTIVE
@@ -464,7 +464,7 @@
 	UnregisterSignal(locker, COMSIG_ATOM_NO_LONGER_PULLED)
 
 /obj/item/mod/module/ash_accretion
-	name = "MOD ash accretion module"
+	name = "\improper MOD ash accretion module"
 	desc = "A module that collects ash from the terrain, covering the suit in a protective layer, this layer is \
 		lost when moving across standard terrain."
 	icon_state = "ash_accretion"
@@ -585,7 +585,7 @@
 		balloon_alert(mod.wearer, "ran out of ash!")
 
 /obj/item/mod/module/sphere_transform
-	name = "MOD sphere transform module"
+	name = "\improper MOD sphere transform module"
 	desc = "A module able to move the suit's parts around, turning it and the user into a sphere. If the modsuit is insulated with bileworm skin, the user will be protected from lava while active. \
 		The sphere can move quickly, even through lava, and launch mining micromissiles to decimate terrain and fauna alike."
 	icon_state = "sphere"

--- a/code/modules/mod/modules/modules_timeline.dm
+++ b/code/modules/mod/modules/modules_timeline.dm
@@ -5,7 +5,7 @@
 
 ///Eradication lock - Prevents people who aren't the owner of the suit from existing on the timeline via eradicating the suit with the intruder inside
 /obj/item/mod/module/eradication_lock
-	name = "MOD eradication lock module"
+	name = "\improper MOD eradication lock module"
 	desc = "A module which remembers the original owner of the suit, even alternate universe \
 			versions. When a non-owner enters, the eradication lock will begin eradicating the suit \
 			from the timeline... with the intruder inside. Not the way you want to go, so it turns \
@@ -57,7 +57,7 @@
 
 ///Rewinder - Activating saves a point in time, after 10 seconds you will jump back to that state.
 /obj/item/mod/module/rewinder
-	name = "MOD rewinder module"
+	name = "\improper MOD rewinder module"
 	desc = "A module that can pull the user back through time given an anchor point to \
 			pull to. Very useful tool to get the job done, but keep in mind the suit locks for \
 			safety reasons while preparing a rewind."
@@ -99,7 +99,7 @@
 
 ///Timestopper - Need I really explain? It's the wizard's time stop, but the user channels it by not moving instead of a duration.
 /obj/item/mod/module/timestopper
-	name = "MOD timestopper module"
+	name = "\improper MOD timestopper module"
 	desc = "A module that can halt time in a small radius around the user... for as long as they \
 			want! Great for monologues or lunch breaks. Keep in mind moving will end the stop, and the \
 			module has a hefty cooldown period to avoid reality errors."
@@ -149,7 +149,7 @@
 
 ///Timeline Jumper - Infinite phasing. needs some special effects
 /obj/item/mod/module/timeline_jumper
-	name = "MOD timeline jumper module"
+	name = "\improper MOD timeline jumper module"
 	desc = "A module used to traverse timelines, phasing the user in and out of the stream of events."
 	icon_state = "timeline_jumper"
 	module_type = MODULE_USABLE
@@ -201,7 +201,7 @@
 
 ///TEM - Lets you eradicate people.
 /obj/item/mod/module/tem
-	name = "MOD timestream eradication module"
+	name = "\improper MOD timestream eradication module"
 	desc = "The correction device of a fourth dimensional group outside time itself used to \
 			change the destination of a timeline. this device is capable of wiping a being from the \
 			timestream. They never are, they never were, they never will be."

--- a/code/modules/mod/modules/modules_visor.dm
+++ b/code/modules/mod/modules/modules_visor.dm
@@ -2,7 +2,7 @@
 
 ///Base Visor - Adds a specific HUD and traits to you.
 /obj/item/mod/module/visor
-	name = "MOD visor module"
+	name = "\improper MOD visor module"
 	desc = "A heads-up display installed into the visor of the suit. They say these also let you see behind you."
 	module_type = MODULE_TOGGLE
 	complexity = 1
@@ -24,7 +24,7 @@
 
 //Medical Visor - Gives you a medical HUD.
 /obj/item/mod/module/visor/medhud
-	name = "MOD medical visor module"
+	name = "\improper MOD medical visor module"
 	desc = "A heads-up display installed into the visor of the suit. This cross-references suit sensor data with a modern \
 		biological scanning suite, allowing the user to visualize the current health of organic lifeforms, as well as \
 		access data such as patient files in a convenient readout. They say these also let you see behind you."
@@ -34,7 +34,7 @@
 
 //Diagnostic Visor - Gives you a diagnostic HUD.
 /obj/item/mod/module/visor/diaghud
-	name = "MOD diagnostic visor module"
+	name = "\improper MOD diagnostic visor module"
 	desc = "A heads-up display installed into the visor of the suit. This uses a series of advanced sensors to access data \
 		from advanced machinery, exosuits, and other devices, allowing the user to visualize current power levels \
 		and integrity of such. They say these also let you see behind you."
@@ -44,7 +44,7 @@
 
 //Security Visor - Gives you a security HUD.
 /obj/item/mod/module/visor/sechud
-	name = "MOD security visor module"
+	name = "\improper MOD security visor module"
 	desc = "A heads-up display installed into the visor of the suit. This module is a heavily-retrofitted targeting system, \
 		plugged into various criminal databases to be able to view arrest records, command simple security-oriented robots, \
 		and generally know who to shoot. They say these also let you see behind you."
@@ -54,7 +54,7 @@
 
 //Meson Visor - Gives you meson vision.
 /obj/item/mod/module/visor/meson
-	name = "MOD meson visor module"
+	name = "\improper MOD meson visor module"
 	desc = "A heads-up display installed into the visor of the suit. This module is based off well-loved meson scanner \
 		technology, used by construction workers and miners across the galaxy to see basic structural and terrain layouts \
 		through walls, regardless of lighting conditions. They say these also let you see behind you."
@@ -64,7 +64,7 @@
 
 //Thermal Visor - Gives you thermal vision.
 /obj/item/mod/module/visor/thermal
-	name = "MOD thermal visor module"
+	name = "\improper MOD thermal visor module"
 	desc = "A heads-up display installed into the visor of the suit. This uses a small IR scanner to detect and identify \
 		the thermal radiation output of objects near the user. While it can detect the heat output of even something as \
 		small as a rodent, it still produces irritating red overlay. They say these also let you see behind you."
@@ -73,7 +73,7 @@
 
 //Night Visor - Gives you night vision.
 /obj/item/mod/module/visor/night
-	name = "MOD night visor module"
+	name = "\improper MOD night visor module"
 	desc = "A heads-up display installed into the visor of the suit. Typical for both civilian and military applications, \
 		this allows the user to perceive their surroundings while in complete darkness, enhancing the view by tenfold; \
 		yet brightening everything into a spooky green glow. They say these also let you see behind you."
@@ -82,7 +82,7 @@
 	visor_traits = list(TRAIT_TRUE_NIGHT_VISION)
 
 /obj/item/mod/module/night // Not Visor type so that it remains compatible with other visors
-	name = "MOD night vision module"
+	name = "\improper MOD night vision module"
 	desc = "A heads-up display installed into the visor of the suit. Typical for both civilian and military applications, \
 		this allows the user to perceive their surroundings while in complete darkness, enhancing the view by tenfold; \
 		yet brightening everything into a spooky green glow. They say these also let you see behind you. \

--- a/code/modules/wiremod/shell/module.dm
+++ b/code/modules/wiremod/shell/module.dm
@@ -1,5 +1,5 @@
 /obj/item/mod/module/circuit
-	name = "MOD circuit adapter module"
+	name = "\improper MOD circuit adapter module"
 	desc = "A module shell that allows a circuit to be inserted into, and interface with, a MODsuit."
 	module_type = MODULE_USABLE
 	complexity = 1


### PR DESCRIPTION
## About The Pull Request

Makes most items that start with "MOD" improper nouns. Improper nouns show up differently in inspect text ("This is MOD core." versus "This is a MOD core.").

MOD items were marked as proper nouns because the first letter of their name is capitalized, so appending the name with \improper switches it back to an improper noun.

Also changes the commented-out example module addition to use \improper.



This PR should have the grammar and formatting tag but I don't know how to add that tag without putting it in the changelog.

<img width="519" height="84" alt="image" src="https://github.com/user-attachments/assets/ebc03611-cc93-4e8b-85d9-6f9661adf0b9" />

## Why It's Good For The Game

MODs aren't proper nouns, and neither are any of their related items. Fixing this will make the game look better.
