### PR TITLE
Small heretic updates

### DIFF
--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -310,7 +310,7 @@
 
 	if(the_spell != created_action_ref || isnull(the_spell.owner))
 		return NONE
-	if(charges > 0)
+	if(has_charges(the_spell.owner))
 		return NONE
 	var/datum/antagonist/heretic/our_heretic = GET_HERETIC(the_spell.owner)
 	if(our_heretic?.ascended)
@@ -325,7 +325,7 @@
 
 	if(the_spell != created_action_ref)
 		return NONE
-	if(charges > 0)
+	if(has_charges(source))
 		return NONE
 	var/datum/antagonist/heretic/our_heretic = GET_HERETIC(source)
 	if(our_heretic?.ascended)
@@ -334,16 +334,26 @@
 	to_chat(source, span_mansus("You don't have enough charges to cast this spell! [transmute_text]"))
 	return SPELL_CANCEL_CAST
 
+/// Checks if we have enough charges to cast the spell
+/datum/heretic_knowledge/spell/proc/has_charges(mob/living/user)
+	return charges > 0
+
 /datum/heretic_knowledge/spell/proc/deduct_charge(mob/living/source, datum/action/cooldown/the_spell)
 	SIGNAL_HANDLER
 
 	if(the_spell != created_action_ref)
+		return
+	if(!should_deduct_charge(source))
 		return
 	var/datum/antagonist/heretic/our_heretic = GET_HERETIC(source)
 	if(our_heretic?.ascended)
 		return
 
 	remove_charges(1)
+
+/// Checks if casting the spell should deduct a charge
+/datum/heretic_knowledge/spell/proc/should_deduct_charge(mob/living/user)
+	return TRUE
 
 /// Add a number of charges, optionally bypassing the cap
 /datum/heretic_knowledge/spell/proc/add_charges(num, uncapped = FALSE)

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -225,6 +225,12 @@
 	holywater_drain_amount = 0.33
 	notice = "&bull; Cannot be used near living sentient beings.<br>&bull; Cancelled if you are hit with an anti-magic item."
 
+/datum/heretic_knowledge/spell/caretaker_refuge/has_charges(mob/living/user)
+	return user.has_status_effect(/datum/status_effect/caretaker_refuge) || ..()
+
+/datum/heretic_knowledge/spell/caretaker_refuge/should_deduct_charge(mob/living/user)
+	return !user.has_status_effect(/datum/status_effect/caretaker_refuge)
+
 /datum/heretic_knowledge/ultimate/lock_final
 	name = "Unlock the Labyrinth"
 	desc = "The ascension ritual of the Path of Knock. \

--- a/code/modules/antagonists/heretic/knowledge/side_knowledge/tier_four.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_knowledge/tier_four.dm
@@ -19,6 +19,12 @@
 	/// Tracks tim ein EVA
 	var/seconds_in_eva = 0
 
+/datum/heretic_knowledge/spell/space_phase/has_charges(mob/living/user)
+	return HAS_TRAIT(user, TRAIT_MAGICALLY_PHASED) || ..()
+
+/datum/heretic_knowledge/spell/space_phase/should_deduct_charge(mob/living/user)
+	return !HAS_TRAIT(user, TRAIT_MAGICALLY_PHASED)
+
 /datum/heretic_knowledge/spell/space_phase/on_gain(mob/user, datum/antagonist/heretic/our_heretic)
 	. = ..()
 	RegisterSignal(user, COMSIG_MOB_CRUSHED_BLUESPACE_CRYSTAL, PROC_REF(on_crystal_crushed))

--- a/code/modules/antagonists/heretic/magic/caretaker.dm
+++ b/code/modules/antagonists/heretic/magic/caretaker.dm
@@ -17,8 +17,7 @@
 	spell_requirements = NONE
 
 /datum/action/cooldown/spell/caretaker/Remove(mob/living/remove_from)
-	if(remove_from.has_status_effect(/datum/status_effect/caretaker_refuge))
-		remove_from.remove_status_effect(/datum/status_effect/caretaker_refuge)
+	remove_from.remove_status_effect(/datum/status_effect/caretaker_refuge)
 	return ..()
 
 /datum/action/cooldown/spell/caretaker/is_valid_target(atom/cast_on)

--- a/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
+++ b/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
@@ -113,8 +113,8 @@
 /datum/status_effect/heretic_passive/ash/tick(seconds_between_ticks)
 	. = ..()
 	var/seconds_gained = 0
-	for(var/mob/living/nearby_guy in view(owner, 3))
-		if(!nearby_guy.on_fire || nearby_guy.stat == DEAD || nearby_guy == owner)
+	for(var/mob/living/nearby_guy in oview(owner, 3))
+		if(nearby_guy.stat == DEAD || !nearby_guy.on_fire)
 			continue
 		if(ismonkey(nearby_guy) && isnull(nearby_guy.mind))
 			continue
@@ -712,8 +712,6 @@
 	)
 	/// Tracks total seconds nearby mobs are exposed to cold temperature, used to determine when to recharge spells
 	VAR_PRIVATE/seconds_of_cold = 0
-	/// Threshold for what counts as cold temperature, used to determine when to recharge spells
-	VAR_PRIVATE/cold_threshold = T0C - 20
 
 /datum/status_effect/heretic_passive/void/on_apply()
 	. = ..()
@@ -734,8 +732,9 @@
 /datum/status_effect/heretic_passive/void/tick(seconds_between_ticks)
 	. = ..()
 	var/seconds_gained = 0
-	for(var/mob/living/nearby_guy in view(owner, 4))
-		if(nearby_guy.bodytemperature <= cold_threshold || nearby_guy.stat == DEAD || nearby_guy == owner)
+	for(var/mob/living/nearby_guy in oview(owner, 4))
+		// -75c required - easily achievable with void chill but can also be achieved via spacing (even on icebox)
+		if(nearby_guy.stat == DEAD || nearby_guy.bodytemperature > T0C - 75)
 			continue
 		if(ismonkey(nearby_guy) && isnull(nearby_guy.mind))
 			continue

--- a/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
+++ b/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
@@ -92,7 +92,7 @@
 		"Resistance to high and low pressure."
 	)
 	/// Tracks total seconds nearby mobs are on fire, used to determine when to recharge spells
-	var/seconds_of_fire = 0
+	VAR_PRIVATE/seconds_of_fire = 0
 
 /datum/status_effect/heretic_passive/ash/on_apply()
 	. = ..()
@@ -318,7 +318,7 @@
 	if(!isliving(target) || target == source || target.stat <= HARD_CRIT)
 		return
 
-	if(locate(/obj/effect/forcefield/cosmic_field) in target.loc)
+	if(locate(/obj/effect/forcefield/cosmic_field) in range(1, target))
 		addtimer(CALLBACK(src, PROC_REF(check_crit), target), 0.2 SECONDS, TIMER_DELETE_ME|TIMER_UNIQUE)
 
 /datum/status_effect/heretic_passive/cosmic/proc/check_crit(mob/living/target)
@@ -704,19 +704,20 @@
 /datum/status_effect/heretic_passive/void
 	name = "Aristocrat's Way"
 	id = "void_passive"
-	recharge_description = "Recharge spells by knocking foes who are exposed to sub-zero temperature into critical condition."
+	recharge_description = "Recharge spells by freezing nearby foes."
 	passive_descriptions = list(
 		"Cold and low pressure immunity.",
 		"You no longer need to breathe.",
 		"Water, ice and slippery surfaces no slip you."
 	)
-
-	var/list/gained_charges_from
+	/// Tracks total seconds nearby mobs are exposed to cold temperature, used to determine when to recharge spells
+	VAR_PRIVATE/seconds_of_cold = 0
+	/// Threshold for what counts as cold temperature, used to determine when to recharge spells
+	VAR_PRIVATE/cold_threshold = T0C - 20
 
 /datum/status_effect/heretic_passive/void/on_apply()
 	. = ..()
 	owner.add_traits(list(TRAIT_RESISTCOLD, TRAIT_RESISTLOWPRESSURE), REF(src))
-	RegisterSignal(owner, COMSIG_USER_PRE_ITEM_ATTACK, PROC_REF(hit_someone))
 
 /datum/status_effect/heretic_passive/void/heretic_level_upgrade()
 	. = ..()
@@ -729,27 +730,26 @@
 /datum/status_effect/heretic_passive/void/on_remove()
 	. = ..()
 	owner.remove_traits(list(TRAIT_RESISTCOLD, TRAIT_RESISTLOWPRESSURE, TRAIT_NOBREATH, TRAIT_NO_SLIP_WATER, TRAIT_NO_SLIP_ICE, TRAIT_NO_SLIP_SLIDE), REF(src))
-	UnregisterSignal(owner, COMSIG_USER_PRE_ITEM_ATTACK)
 
-/datum/status_effect/heretic_passive/void/proc/hit_someone(mob/living/source, mob/living/target, obj/item/used_weapon)
-	SIGNAL_HANDLER
+/datum/status_effect/heretic_passive/void/tick(seconds_between_ticks)
+	. = ..()
+	var/seconds_gained = 0
+	for(var/mob/living/nearby_guy in view(owner, 4))
+		if(nearby_guy.bodytemperature <= cold_threshold || nearby_guy.stat == DEAD || nearby_guy == owner)
+			continue
+		if(ismonkey(nearby_guy) && isnull(nearby_guy.mind))
+			continue
 
-	if(!isliving(target) || target == source || target.stat <= HARD_CRIT || LAZYFIND(gained_charges_from, REF(target)))
+		seconds_gained += seconds_between_ticks
+		if(seconds_gained >= 6)
+			break
+
+	seconds_of_cold += seconds_gained
+	if(seconds_of_cold < 30)
 		return
 
-	var/turf/target_turf = get_turf(target)
-	if(target_turf?.GetTemperature() <= T0C)
-		addtimer(CALLBACK(src, PROC_REF(check_crit), target), 0.2 SECONDS, TIMER_DELETE_ME|TIMER_UNIQUE)
-
-/datum/status_effect/heretic_passive/void/proc/check_crit(mob/living/target)
-	if(QDELETED(target) || target.stat == STABLE)
-		return
-	LAZYADD(gained_charges_from, REF(target))
-	addtimer(CALLBACK(src, PROC_REF(remove_gained_from), REF(target)), 5 MINUTES, TIMER_DELETE_ME|TIMER_UNIQUE)
+	seconds_of_cold = 0
 	recharge_spells()
-
-/datum/status_effect/heretic_passive/void/proc/remove_gained_from(target_ref)
-	LAZYREMOVE(gained_charges_from, target_ref)
 
 #undef HERETIC_LEVEL_START
 #undef HERETIC_LEVEL_UPGRADE


### PR DESCRIPTION
## About The Pull Request

- Fixes space phase deducting a charge on entrance and edit, now only deducts a charge on exit
- Cosmic recharge is expanded slightly to "crit targets within a tile of a cosmic field" (was "crit targets on a cosmic field")
- Void recharge changed to "Recharge spells by standing near freezing foes", i.e., standing near crewmembers who have a bodytemperature of below -75c (easily achievable with void chill, but also via spacing rooms) (was "crit targets who are freezing)

## Why It's Good For The Game

Responding to some feedback about the heretic changes
- Bugfix
- Critting someone on top of a field isn't the easiest since they block people, but critting someone who was blocked by a field makes sense and feels as fitting
- Changes void to be less reliant on attacking random people

## Changelog

:cl: Melbert
fix: Fixes space phase deducting a charge on entrance and edit. Now only deducts a charge on exit
balance: Cosmic spell recharge condition changed to "crit targets within a tile of a cosmic field" instead of "on a cosmic field"
balance: Void spell recharge condition changed to "Stand near freezing enemies" instead of "Crit freezing enemies" 
/:cl:
