### PR TITLE
Weakpoints no longer spawn invisible, adjusts the number of weakpoints that spawn naturally.

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -24,9 +24,9 @@ SUBSYSTEM_DEF(minor_mapping)
 #else
 	trigger_migration(CONFIG_GET(number/mice_roundstart))
 	place_satchels(satchel_amount = 2)
-	var/weakpoint_spawns = 3
+	var/weakpoint_spawns = 5
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_SPAWN_WEAKPOINTS))
-		weakpoint_spawns = rand(4,8)
+		weakpoint_spawns = rand(6,12)
 
 	weakpoint_spawns += SSmapping.current_map.bonus_weakpoints //This will add 0 by default, or additional on large maps where it's included in the config.
 	place_weakpoints(weakpoint_spawns)

--- a/code/game/objects/effects/decals/turfdecal/weakpoint.dm
+++ b/code/game/objects/effects/decals/turfdecal/weakpoint.dm
@@ -4,6 +4,8 @@
 #define CRACK_DELAY_CHANCE 33
 #define CRACK_LENGTH_DEFAULT 8
 
+GLOBAL_LIST_EMPTY(weakpoints_spawned)
+
 /obj/effect/weakpoint
 	name = "weakpoint crack"
 	desc = "A suspicious crack runs along the ground."
@@ -12,7 +14,7 @@
 	base_icon_state = "weakpoint"
 	layer = ABOVE_NORMAL_TURF_LAYER
 	move_resist = INFINITY
-	alpha = 0
+	alpha = 255
 
 	/// The required strength of explosion for a weakpoint to propogate
 	var/required_strength = EXPLODE_LIGHT
@@ -34,6 +36,8 @@
 
 /obj/effect/weakpoint/Initialize(mapload)
 	. = ..()
+	GLOB.weakpoints_spawned += src
+	alpha = 0
 	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE, INVISIBILITY_OBSERVER, use_anchor = TRUE)
 	RegisterSignal(src, COMSIG_TURF_CHANGE, PROC_REF(turf_changed))
 	register_context()
@@ -93,6 +97,10 @@
 	. = ..()
 	. += span_notice("\The [src] could be repaired with a welder.")
 	. += span_warning("A strong enough explosion will cause [src] to expand.")
+
+/obj/effect/weakpoint/Destroy(force)
+	GLOB.weakpoints_spawned -= src
+	return ..()
 
 /**
  * Generates a list of turfs from the start location meandering along a randomized set of turns.

--- a/code/game/objects/items/devices/earthcracker.dm
+++ b/code/game/objects/items/devices/earthcracker.dm
@@ -46,9 +46,9 @@
 				return FALSE
 			flick("[base_icon_state]-active", src)
 			if(is_mining_level(z))
-				activation_timer = addtimer(CALLBACK(src, PROC_REF(mining_act), user), 1.2 SECONDS)
+				activation_timer = addtimer(CALLBACK(src, PROC_REF(mining_act), user), 0.8 SECONDS)
 				return TRUE
-			activation_timer = addtimer(CALLBACK(src, PROC_REF(strike_the_earth)), 1.2 SECONDS)
+			activation_timer = addtimer(CALLBACK(src, PROC_REF(strike_the_earth)), 0.8 SECONDS)
 			return TRUE
 		if(EARTHCRACKER_SPENT)
 			balloon_alert(user, "used up!")


### PR DESCRIPTION
## About The Pull Request
Earthcrackers no longer spawn with a baseline alpha of zero, instead spawning with full alpha, but setting their alpha to 0 before then animating to full, which was the intended effect. This worked well enough for weakpoints that were spawning in front of you, but caused weakpoints spawning under floors or when affected by their turf changing to remain invisible forever. This resolves that issue.

Also, this PR adjusts the number of weakpoints that spawn on maps as a baseline from 3 to 5, while stations spawning with the weakpoint trait to result in between 6 to 12 to spawn instead.

Lastly, mostly for testing and admin tracking purposes, all weakpoints spawned are added to a global list, allowing you to quickly find any weakpoints that naturally spawned/were spawned by players without issue.

## Why It's Good For The Game

Weakpoints are intended to be rare occurances in rounds, but with them more often then not spawning and becoming completely invisible, they were pretty much pure chance to interact with one on any given round.

Beyond that, they're also consistently rare enough that naturally occurring weakpoints were not factoring into the outcomes of rounds often if at-all. This should allow them to at least show up slightly more often, though not by such a major degree that you'd be seeing them every other round.

## Changelog

:cl:
fix: Weakpoints, and weakpoints spawned by weakpoints being detonated, should no longer be spawning invisible.
balance: The number of weakpoints that spawn on regular maps has increased from 3 to 5.
balance: The number of weakpoints that spawn on the "Structural Weaknesses" station trait now spawns 6 to 12, instead of 4 to 8 weakpoints.
/:cl:
