### PR TITLE
makes an icon validation proc work again 18 months later, and cleans up the fallout from it

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1235,7 +1235,7 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 		return TRUE
 
 	var/static/list/screams = list()
-	if(!isnull(screams[file]))
+	if(isnull(screams[file]))
 		screams[file] = TRUE
 		stack_trace("State [state] in file [file] does not exist.")
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1286,6 +1286,11 @@
 	if (dropped)
 		image_dir = SOUTH
 
+	// Stumps are FAKE limbs that hold the spot for REAL limbs. thusly no sprite of their own, so early return!
+	if(IS_STUMP(src))
+		SEND_SIGNAL(src, COMSIG_BODYPART_GET_LIMB_ICON, ., dropped)
+		return .
+
 	// Handles invisibility (not alpha or actual invisibility but invisibility)
 	if(is_invisible)
 		. += image(icon_invisible, "invisible_[body_zone]", -BODYPARTS_LAYER, dir = image_dir)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1291,6 +1291,12 @@
 		SEND_SIGNAL(src, COMSIG_BODYPART_GET_LIMB_ICON, ., dropped)
 		return .
 
+	// Arms past the first pair get body_zone suffixed (l_arm_2 and so on). No state exists for them
+	// This guard is bad :)
+	if(held_index >= 3)
+		SEND_SIGNAL(src, COMSIG_BODYPART_GET_LIMB_ICON, ., dropped)
+		return .
+
 	// Handles invisibility (not alpha or actual invisibility but invisibility)
 	if(is_invisible)
 		. += image(icon_invisible, "invisible_[body_zone]", -BODYPARTS_LAYER, dir = image_dir)


### PR DESCRIPTION

## About The Pull Request

The PR that
- https://github.com/tgstation/tgstation/pull/89357

broke the variant of that proc that is supposed to scream and make stack traces.

https://github.com/tgstation/tgstation/blob/77c5a7ca1b4529be668c1290527c3e3ff9ca9b94/code/__HELPERS/icons.dm#L1229-L1242

Yeah that little ``if(!isnull(screams[file]))``? 
The conditional has been *inverted* for 18 months. Its poor little only reason for existence, meaningless.

This fixes it, I guess.

And fixes stumps rendering (they didnt, and dont, but they still pretended they were real limbs)
## Why It's Good For The Game

I like when legacy procs work :>
## Changelog
:cl: rkz/tsar-salat
fix: fixed a screaming icon stacktrace proc designed to scream, not screaming.
fix: stumps continue to not render, as they should, as opposed to not rendering because their rendering was broken
/:cl:
