### PR TITLE
Makes ant mob plural as intended

### DIFF
--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -6,7 +6,7 @@
 	health = 20
 	maxHealth = 20
 	max_stamina = BASIC_MOB_STAMINA_MATCH_HEALTH
-	gender = PLURAL
+	gender = PLURAL // Plural means we randomize by default.
 	living_flags = MOVES_ON_ITS_OWN
 	status_flags = CANPUSH | CANSTUN
 	fire_stack_decay_rate = -5 // Reasonably fast as NPCs will not usually actively extinguish themselves
@@ -85,6 +85,9 @@
 	///We only try to show a gibbing animation if this exists.
 	var/icon_gib = null
 
+	/// If we randomize our gender when its default is set to plural
+	var/randomize_gender = TRUE
+
 	///If the mob can be spawned with a gold slime core. HOSTILE_SPAWN are spawned with plasma, FRIENDLY_SPAWN are spawned with blood.
 	var/gold_core_spawnable = NO_SPAWN
 	///Sentience type, for slime potions. SHOULD BE AN ELEMENT BUT I DONT CARE ABOUT IT FOR NOW
@@ -107,7 +110,7 @@
 /mob/living/basic/Initialize(mapload)
 	. = ..()
 
-	if(gender == PLURAL)
+	if((gender == PLURAL) && randomize_gender)
 		gender = pick(MALE,FEMALE)
 
 	if(!real_name)

--- a/code/modules/mob/living/basic/cult/shade.dm
+++ b/code/modules/mob/living/basic/cult/shade.dm
@@ -3,6 +3,7 @@
 	real_name = "Shade"
 	desc = "A bound spirit."
 	gender = PLURAL
+	randomize_gender = FALSE
 	icon = 'icons/mob/nonhuman-player/cult.dmi'
 	icon_state = "shade_cult"
 	icon_living = "shade_cult"

--- a/code/modules/mob/living/basic/farm_animals/rabbit.dm
+++ b/code/modules/mob/living/basic/farm_animals/rabbit.dm
@@ -13,7 +13,6 @@
 	icon_state = "rabbit_white"
 	icon_living = "rabbit_white"
 	icon_dead = "rabbit_white_dead"
-	gender = PLURAL
 	mob_biotypes = MOB_ORGANIC | MOB_BEAST
 	health = 15
 	maxHealth = 15

--- a/code/modules/mob/living/basic/space_fauna/ant.dm
+++ b/code/modules/mob/living/basic/space_fauna/ant.dm
@@ -7,6 +7,7 @@
 	icon_dead = "ant_dead"
 	speak_emote = list("buzzes", "chitters")
 	gender = PLURAL // We are Ven-ant
+	randomize_gender = FALSE
 	pass_flags = PASSTABLE
 	mob_size = MOB_SIZE_SMALL
 	mob_biotypes = MOB_ORGANIC|MOB_BUG


### PR DESCRIPTION

## About The Pull Request
The code surronding basic (and simple but i dont care about them) meant that any plural gender mob had it randomized (forcefemmed). Adds a bool to toggle that behavoir off so we can actually have plural basic mobs.
## Why It's Good For The Game
Oversight bad. Seems like ancient behavoir from simple animals.
## Changelog
:cl:
fix: Ants and shade mobs are plural is seemingly intended
/:cl:
