### PR TITLE
Fixes two ways that damaging things with DEL_ON_DEATH would runtime

### DIFF
--- a/code/datums/elements/table_smash.dm
+++ b/code/datums/elements/table_smash.dm
@@ -153,9 +153,6 @@
 	if (pushed_mob.loc != table.loc) //Something prevented the tabling
 		return
 
-	pushed_mob.Knockdown(3 SECONDS)
-	pushed_mob.apply_damage(10, BRUTE)
-	pushed_mob.apply_damage(40, STAMINA)
 	playsound(pushed_mob, 'sound/effects/tableslam.ogg', 90, TRUE)
 	pushed_mob.visible_message(span_danger("[user] slams [pushed_mob] onto \the [table]!"), \
 		span_userdanger("[user] slams you onto \the [table]!"))
@@ -165,15 +162,13 @@
 	if(after_smash_proccall)
 		call(table, after_smash_proccall)(pushed_mob)
 
+	pushed_mob.Knockdown(3 SECONDS)
+	pushed_mob.apply_damage(40, STAMINA)
+	pushed_mob.apply_damage(10, BRUTE)
+
 /// Even more aggressively smash a single part of a mob onto the table
 /datum/element/table_smash/proc/tablelimbsmash(mob/living/user, mob/living/pushed_mob, obj/structure/table/table)
-	pushed_mob.Knockdown(3 SECONDS)
 	var/obj/item/bodypart/banged_limb = pushed_mob.get_bodypart(user.zone_selected) || pushed_mob.get_bodypart(BODY_ZONE_HEAD)
-	var/extra_wound = 0
-	if (HAS_TRAIT(user, TRAIT_HULK))
-		extra_wound = 20
-	pushed_mob.apply_damage(30, BRUTE, banged_limb, wound_bonus = extra_wound)
-	pushed_mob.apply_damage(60, STAMINA)
 	playsound(pushed_mob, 'sound/effects/bang.ogg', 90, TRUE)
 	pushed_mob.visible_message(span_danger("[user] smashes [pushed_mob]'s [banged_limb.plaintext_zone] against \the [table]!"),
 		span_userdanger("[user] smashes your [banged_limb.plaintext_zone] against \the [table]"))
@@ -183,6 +178,10 @@
 	SEND_SIGNAL(user, COMSIG_LIVING_TABLE_LIMB_SLAMMING, pushed_mob, table)
 	if(after_smash_proccall)
 		call(table, after_smash_proccall)(pushed_mob)
+
+	pushed_mob.Knockdown(3 SECONDS)
+	pushed_mob.apply_damage(60, STAMINA)
+	pushed_mob.apply_damage(30, BRUTE, banged_limb, wound_bonus = HAS_TRAIT(user, TRAIT_HULK) ? 20 : 0)
 
 /// Called when someone is shoved into our tile
 /obj/structure/proc/on_disarm_shoved_into(datum/source, mob/living/shover, mob/living/target, shove_flags, obj/item/weapon)

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -538,11 +538,11 @@ GLOBAL_LIST_EMPTY(unconscious_appearances)
 	new /obj/effect/temp_visual/bleed(get_turf(owner))
 
 /datum/status_effect/stacking/saw_bleed/threshold_cross_effect()
-	owner.adjust_brute_loss(bleed_damage)
 	new /obj/effect/temp_visual/bleed/explode(get_turf(owner))
+	playsound(owner, SFX_DESECRATION, 100, TRUE, -1)
 	for(var/splatter_dir in GLOB.alldirs)
 		owner.create_splatter(splatter_dir)
-	playsound(owner, SFX_DESECRATION, 100, TRUE, -1)
+	owner.adjust_brute_loss(bleed_damage)
 
 /datum/status_effect/stacking/saw_bleed/bloodletting
 	id = "bloodletting"

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -631,7 +631,7 @@
 	custom_materials = list(/datum/material/wood = SHEET_MATERIAL_AMOUNT)
 
 /obj/structure/table/wood/after_smash(mob/living/smashed_onto)
-	if(QDELETED(src) || prob(66))
+	if(QDELETED(src) || QDELETED(smashed_onto) || prob(66))
 		return
 	visible_message(
 		span_warning("[src] smashes into bits!"),


### PR DESCRIPTION

## About The Pull Request

Applying brute damage to what could be a basic mob could delete it, so doing that damage should be the last thing affecting that mob in any given proc, when possible. This pr reorders the `table_smash` component & the `saw_bleed` status effect to deal their damages last. These are just the two I'm currently aware of, but I'm not going to validate every call of `adjust_brute_loss()` & `apply_damage()`, so if you're aware of any other places this would happen, please speak up.

## Why It's Good For The Game

<img width="707" height="92" alt="image" src="https://github.com/user-attachments/assets/19aa3b55-1353-46bb-ae60-83406fbb35ee" />

& an inevitable runtime in `table_smash`.

## Changelog
:cl:
fix: fixed two ways damaging basic mobs that disappear when they die could cause a runtime error
/:cl:
