### PR TITLE
Fixes a Pride ruin bug involving latticed chasms

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -524,15 +524,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 	)
 
 	var/turf/user_turf = get_turf(user)
-	var/list/levels = SSmapping.levels_by_trait(ZTRAIT_SPACE_RUINS)
-	var/turf/dest
-	if(length(levels))
-		dest = locate(user_turf.x, user_turf.y, pick(levels))
-
-	user_turf.ChangeTurf(/turf/open/chasm, flags = CHANGETURF_INHERIT_AIR)
-	var/turf/open/chasm/new_chasm = user_turf
-	new_chasm.set_target(dest)
-	new_chasm.drop(user)
+	var/turf/open/chasm/pride/new_chasm = user_turf.ChangeTurf(/turf/open/chasm/pride, flags = CHANGETURF_INHERIT_AIR)
+	// `ChangeTurf()` can itself lead to `drop()` if there's lattice present, so
+	// we only force the user down if they're still on the same turf.
+	if(get_turf(user) == user_turf)
+		new_chasm.drop(user)
 
 #undef CHANGE_HAIR
 #undef CHANGE_BEARD

--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -140,3 +140,20 @@
 		return ITEM_INTERACT_BLOCKING
 
 	return ..()
+
+// Chasm produced by the Pride ruin. Leads to a random space Z-level at the same x/y coordinate.
+/turf/open/chasm/pride
+	desc = "It's beautiful down there, dotted with pinpricks of light."
+	baseturfs = /turf/open/chasm/pride
+	light_color = COLOR_STARLIGHT
+	light_range = 1.9
+	light_power = 0.65
+
+/turf/open/chasm/pride/apply_components(mapload)
+	var/list/levels = SSmapping.levels_by_trait(ZTRAIT_SPACE_RUINS)
+	var/turf/space_turf
+	if(length(levels))
+		space_turf = locate(src.x, src.y, pick(levels))
+
+	AddComponent(/datum/component/chasm, space_turf, mapload)
+


### PR DESCRIPTION

## About The Pull Request
Fixes #97221 

As per the linked issue, Pride's Mirror currently causes those standing on lattices to suffer a normal chasm. This (as indicated by putting a `stack_trace()` before [line 193 of 'code/datums/components/chasm.dm'](https://github.com/tgstation/tgstation/blob/870d29dd56c356bdbfb9353c2009ad5312cd02a3/code/datums/components/chasm.dm#L193)) is caused by `ChangeTurf()` leading to a call of `RemoveLattice()` before the new chasm can have its target set to space.

To fix this, I have made the space chasms their own type (so that they _always_ lead to space) and added a check for the possibility of `ChangeTurf()` dropping someone.
## Why It's Good For The Game
<details><summary>This fixes a bug. Also:</summary>

<img width="200" height="180" alt="Falling_Down_to_Space" src="https://github.com/user-attachments/assets/c5a4eaf5-f9cc-446e-a35f-15ccced81b51" />

</details>

## Changelog
:cl:
fix: The Pride ruin will no longer cause those standing on latticed chasms to fall down normal chasms.
/:cl:
