### PR TITLE
feat: updates the NTOS main menu UI, removes header programs, cleanup for two apps

### DIFF
--- a/code/__DEFINES/modular_computer.dm
+++ b/code/__DEFINES/modular_computer.dm
@@ -24,10 +24,8 @@
 #define PROGRAM_ON_SYNDINET_STORE (1<<2)
 ///The program is unique and will delete itself upon being transferred to ensure only one copy exists.
 #define PROGRAM_UNIQUE_COPY (1<<3)
-///The program is a header and will show up at the top of the ModPC's UI.
-#define PROGRAM_HEADER (1<<4)
 ///The circuit ports of this program can be triggered even if the program is not open
-#define PROGRAM_CIRCUITS_RUN_WHEN_CLOSED (1<<5)
+#define PROGRAM_CIRCUITS_RUN_WHEN_CLOSED (1<<4)
 
 //Program categories
 #define PROGRAM_CATEGORY_DEVICE "Device Tools"

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -693,14 +693,10 @@
 		if(NTNET_ETHERNET_SIGNAL)
 			data["PC_ntneticon"] = "sig_lan.gif"
 
-	var/list/program_headers = list()
 	if(length(idle_threads))
 		for(var/datum/computer_file/program/idle_programs as anything in idle_threads)
 			if(!idle_programs.ui_header)
 				continue
-			program_headers.Add(list(list("icon" = idle_programs.ui_header)))
-
-	data["PC_programheaders"] = program_headers
 
 	data["PC_stationtime"] = round_timestamp()
 	data["PC_stationdate"] = "[time2text(world.realtime, "DDD, Month DD", NO_TIMEZONE)], [CURRENT_STATION_YEAR]"

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -119,7 +119,6 @@
 		data["programs"] += list(list(
 			"name" = program.filename,
 			"desc" = program.filedesc,
-			"header_program" = !!(program.program_flags & PROGRAM_HEADER),
 			"running" = !!(program in idle_threads),
 			"icon" = program.program_icon,
 			"alert" = program.alert_pending,

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -82,6 +82,11 @@
 
 /obj/item/modular_computer/ui_data(mob/user)
 	var/list/data = get_header_data()
+
+	data["alert_style"] = get_security_level_relevancy()
+	data["alert_color"] = SSsecurity_level?.current_security_level?.announcement_color
+	data["alert_name"] = SSsecurity_level?.current_security_level?.name_shortform
+
 	if(active_program)
 		data += active_program.ui_data(user)
 		return data
@@ -119,10 +124,6 @@
 			"icon" = program.program_icon,
 			"alert" = program.alert_pending,
 		))
-
-	data["alert_style"] = get_security_level_relevancy()
-	data["alert_color"] = SSsecurity_level?.current_security_level?.announcement_color
-	data["alert_name"] = SSsecurity_level?.current_security_level?.name_shortform
 
 	return data
 

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -8,7 +8,7 @@
 	/// (PROGRAM_ALL | PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_PDA)
 	var/can_run_on_flags = PROGRAM_ALL
 	/// Program-specific bitflags that tells the ModPC what the app is able to do special.
-	/// (PROGRAM_REQUIRES_NTNET|PROGRAM_ON_NTNET_STORE|PROGRAM_ON_SYNDINET_STORE|PROGRAM_UNIQUE_COPY|PROGRAM_HEADER)
+	/// (PROGRAM_REQUIRES_NTNET|PROGRAM_ON_NTNET_STORE|PROGRAM_ON_SYNDINET_STORE|PROGRAM_UNIQUE_COPY)
 	var/program_flags = PROGRAM_ON_NTNET_STORE
 	///How much power running this program costs.
 	var/power_cell_use = PROGRAM_BASIC_CELL_USE
@@ -242,7 +242,7 @@
 ///Sends the running program to the background/idle threads. Header programs can't be minimized and will kill instead.
 /datum/computer_file/program/proc/background_program(mob/user)
 	SHOULD_CALL_PARENT(TRUE)
-	if(program_flags & PROGRAM_HEADER || length(computer.idle_threads) > computer.max_idle_programs)
+	if(length(computer.idle_threads) > computer.max_idle_programs)
 		return kill_program()
 
 	computer.idle_threads.Add(src)

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -9,6 +9,8 @@
 	tgui_id = "NtosRevelation"
 	program_icon = "magnet"
 	var/armed = 0
+	/// Whether the device is currently displaying the blue screen of death.
+	var/bluescreen = FALSE
 
 /datum/computer_file/program/revelation/on_start(mob/living/user)
 	. = ..(user)
@@ -23,18 +25,32 @@
 			addtimer(CALLBACK(modularInterface.silicon_owner, TYPE_PROC_REF(/mob/living/silicon/robot/, death)), 2 SECONDS, TIMER_UNIQUE)
 			return
 
+		if(bluescreen) //Already triggered, don't double-schedule the wipe.
+			return
+
 		computer.visible_message(span_notice("\The [computer]'s screen brightly flashes and loud electrical buzzing is heard."))
-		computer.enabled = FALSE
+		bluescreen = TRUE
 		computer.update_appearance()
+		INVOKE_ASYNC(computer, TYPE_PROC_REF(/obj/item/modular_computer, update_tablet_open_uis))
+		addtimer(CALLBACK(src, PROC_REF(wipe_device)), 2 SECONDS, TIMER_UNIQUE)
 
-		QDEL_LIST(computer.stored_files)
-
-		computer.take_damage(25, BRUTE, 0, 0)
-
-		if(computer.internal_cell && prob(25))
-			QDEL_NULL(computer.internal_cell)
-			computer.visible_message(span_notice("\The [computer]'s battery explodes in rain of sparks."))
-			do_sparks(3, FALSE, src)
+/// Purges the device: kills all running programs, wipes every stored file and damages the hardware
+/datum/computer_file/program/revelation/proc/wipe_device()
+	var/obj/item/modular_computer/computer_ref = computer
+	if(!computer_ref || QDELETED(computer_ref))
+		return
+	computer_ref.enabled = FALSE
+	computer_ref.close_all_programs()
+	for(var/datum/computer_file/file as anything in computer_ref.stored_files)
+		qdel(file, force = TRUE)
+	computer_ref.stored_files.Cut()
+	computer_ref.used_capacity = 0
+	computer_ref.update_appearance()
+	computer_ref.take_damage(25, BRUTE, 0, 0)
+	if(computer_ref.internal_cell && prob(25))
+		QDEL_NULL(computer_ref.internal_cell)
+		computer_ref.visible_message(span_notice("\The [computer_ref]'s battery explodes in rain of sparks."))
+		do_sparks(3, FALSE, computer_ref)
 
 /datum/computer_file/program/revelation/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
@@ -62,5 +78,6 @@
 	var/list/data = list()
 
 	data["armed"] = armed
+	data["bluescreen"] = bluescreen
 
 	return data

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -14,7 +14,7 @@
 	size = 0
 	undeletable = TRUE // It comes by default in tablets, can't be downloaded, takes no space and should obviously not be able to be deleted.
 	power_cell_use = NONE
-	program_flags = PROGRAM_HEADER | PROGRAM_CIRCUITS_RUN_WHEN_CLOSED
+	program_flags = PROGRAM_CIRCUITS_RUN_WHEN_CLOSED
 	can_run_on_flags = PROGRAM_PDA
 	ui_header = "ntnrc_idle.gif"
 	tgui_id = "NtosMessenger"
@@ -79,7 +79,7 @@
 	viewing_messages_of = null
 
 /datum/computer_file/program/messenger/Destroy(force)
-	if(!QDELETED(computer))
+	if(!QDELETED(computer) && !force)
 		stack_trace("Attempted to qdel messenger of [computer] without qdeling computer, this will cause problems later")
 	remove_messenger(src)
 	return ..()

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -5,7 +5,6 @@
 	extended_desc = "A built-in app for cyborg self-management and diagnostics."
 	ui_header = "robotact.gif" //DEBUG -- new icon before PR
 	program_open_overlay = "command"
-	program_flags = PROGRAM_HEADER
 	undeletable = TRUE
 	can_run_on_flags = PROGRAM_PDA
 	size = 5

--- a/code/modules/modular_computers/file_system/programs/theme_selector.dm
+++ b/code/modules/modular_computers/file_system/programs/theme_selector.dm
@@ -5,7 +5,7 @@
 	program_open_overlay = "generic"
 	undeletable = TRUE
 	size = 0
-	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_HEADER
+	program_flags = PROGRAM_ON_NTNET_STORE
 	tgui_id = "NtosThemeConfigure"
 	program_icon = "paint-roller"
 

--- a/tgui/packages/tgui/interfaces/NtosMain.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMain.tsx
@@ -33,10 +33,7 @@ export const NtosMain = (props) => {
       z
     >
       <NtosWindow.Content scrollable>
-        {Boolean(
-          removable_media.length ||
-            programs.some((program) => program.header_program),
-        ) && (
+        {programs.some((program) => program.header_program) && (
           <Section>
             <Stack>
               {filtered_programs.map((app) => (
@@ -53,68 +50,75 @@ export const NtosMain = (props) => {
                 </Stack.Item>
               ))}
             </Stack>
-            <Stack>
-              {removable_media.map((device) => (
-                <Stack.Item key={device} mt={1}>
+          </Section>
+        )}
+        <Section>
+          <Stack>
+            {removable_media.length ? (
+              removable_media.map((device) => (
+                <Stack.Item key={device}>
                   <Button
-                    fluid
                     icon="eject"
                     content={device}
                     onClick={() => act('PC_Eject_Disk', { name: device })}
-                    disabled={!device}
                   />
                 </Stack.Item>
-              ))}
-            </Stack>
-          </Section>
-        )}
-        <Section
-          title="Details"
-          buttons={
-            <>
-              {!!has_light && (
-                <>
-                  <Button onClick={() => act('PC_light_color')}>
-                    <ColorBox
-                      style={{
-                        position: 'relative',
-                        marginTop: '3px',
-                        marginBottom: '-3px',
-                        marginRight: '-2px',
-                        marginLeft: '-2px',
-                      }}
-                      color={comp_light_color}
-                    />
-                  </Button>
-                  <Button
-                    icon="lightbulb"
-                    color={light_on && 'good'}
-                    selected={light_on}
-                    onClick={() => act('PC_toggle_light')}
-                  />
-                </>
-              )}
+              ))
+            ) : (
+              <Stack.Item>
+                <Button icon="eject" content="Eject Disk" disabled />
+              </Stack.Item>
+            )}
+            <Stack.Item>
+              <Button
+                disabled={!has_light}
+                onClick={() => act('PC_light_color')}
+              >
+                <ColorBox
+                  style={{
+                    position: 'relative',
+                    marginTop: '3px',
+                    marginBottom: '-3px',
+                    marginRight: '-2px',
+                    marginLeft: '-2px',
+                  }}
+                  color={comp_light_color}
+                />
+              </Button>
+            </Stack.Item>
+            <Stack.Item>
+              <Button
+                icon="lightbulb"
+                color={has_light && light_on && 'good'}
+                selected={has_light && light_on}
+                disabled={!has_light}
+                onClick={() => act('PC_toggle_light')}
+              />
+            </Stack.Item>
+            <Stack.Item>
               <Button
                 icon="eject"
                 content="Eject ID"
                 disabled={!proposed_login.IDInserted}
                 onClick={() => act('PC_Eject_Disk', { name: 'ID' })}
               />
-              {!!show_imprint && (
-                <Button
-                  icon="dna"
-                  content="Link ID"
-                  disabled={
-                    !proposed_login.IDName ||
-                    (proposed_login.IDName === login.IDName &&
-                      proposed_login.IDJob === login.IDJob)
-                  }
-                  onClick={() => act('PC_Imprint_ID', { name: 'ID' })}
-                />
-              )}
-            </>
-          }
-        >
+            </Stack.Item>
+            <Stack.Item>
+              <Button
+                icon="dna"
+                content="Sync"
+                disabled={
+                  !show_imprint ||
+                  !proposed_login.IDName ||
+                  (proposed_login.IDName === login.IDName &&
+                    proposed_login.IDJob === login.IDJob)
+                }
+                onClick={() => act('PC_Imprint_ID', { name: 'ID' })}
+              />
+            </Stack.Item>
+          </Stack>
+        </Section>
+        <Section>
           <Table>
             <Table.Row>
               ID Name:{' '}

--- a/tgui/packages/tgui/interfaces/NtosMain.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMain.tsx
@@ -4,18 +4,9 @@ import { useBackend } from '../backend';
 import { NtosWindow } from '../layouts';
 import type { NTOSData } from '../layouts/NtosWindow';
 
-export enum alert_relevancies {
-  ALERT_RELEVANCY_SAFE,
-  ALERT_RELEVANCY_WARN,
-  ALERT_RELEVANCY_PERTINENT,
-}
-
 export const NtosMain = (props) => {
   const { act, data } = useBackend<NTOSData>();
   const {
-    alert_style,
-    alert_color,
-    alert_name,
     PC_device_theme,
     show_imprint,
     programs = [],
@@ -61,28 +52,6 @@ export const NtosMain = (props) => {
                   />
                 </Stack.Item>
               ))}
-              <Stack.Item right={0}>
-                <Button
-                  className={
-                    alert_style === alert_relevancies.ALERT_RELEVANCY_PERTINENT
-                      ? 'alertIndicator alertBlink'
-                      : 'alertIndicator'
-                  }
-                  textColor={
-                    alert_style === alert_relevancies.ALERT_RELEVANCY_SAFE
-                      ? alert_color
-                      : '#000000'
-                  }
-                  backgroundColor={
-                    alert_style === alert_relevancies.ALERT_RELEVANCY_SAFE
-                      ? '#0000000'
-                      : alert_color
-                  }
-                  tooltip="The current alert level. Indicator becomes more intense when there is a threat, moreso if your department is responsible for handling it."
-                >
-                  {alert_name}
-                </Button>
-              </Stack.Item>
             </Stack>
             <Stack>
               {removable_media.map((device) => (
@@ -106,11 +75,20 @@ export const NtosMain = (props) => {
               {!!has_light && (
                 <>
                   <Button onClick={() => act('PC_light_color')}>
-                    <ColorBox color={comp_light_color} />
+                    <ColorBox
+                      style={{
+                        position: 'relative',
+                        marginTop: '3px',
+                        marginBottom: '-3px',
+                        marginRight: '-2px',
+                        marginLeft: '-2px',
+                      }}
+                      color={comp_light_color}
+                    />
                   </Button>
                   <Button
                     icon="lightbulb"
-                    color={light_on ? 'good' : 'bad'}
+                    color={light_on && 'good'}
                     selected={light_on}
                     onClick={() => act('PC_toggle_light')}
                   />
@@ -125,7 +103,7 @@ export const NtosMain = (props) => {
               {!!show_imprint && (
                 <Button
                   icon="dna"
-                  content="Imprint ID"
+                  content="Link ID"
                   disabled={
                     !proposed_login.IDName ||
                     (proposed_login.IDName === login.IDName &&

--- a/tgui/packages/tgui/interfaces/NtosMain.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMain.tsx
@@ -18,9 +18,6 @@ export const NtosMain = (props) => {
     proposed_login,
     pai,
   } = data;
-  const filtered_programs = programs.filter(
-    (program) => program.header_program,
-  );
 
   return (
     <NtosWindow
@@ -33,25 +30,6 @@ export const NtosMain = (props) => {
       z
     >
       <NtosWindow.Content scrollable>
-        {programs.some((program) => program.header_program) && (
-          <Section>
-            <Stack>
-              {filtered_programs.map((app) => (
-                <Stack.Item key={app.name}>
-                  <Button
-                    content={app.desc}
-                    icon={app.icon}
-                    onClick={() =>
-                      act('PC_runprogram', {
-                        name: app.name,
-                      })
-                    }
-                  />
-                </Stack.Item>
-              ))}
-            </Stack>
-          </Section>
-        )}
         <Section>
           <Stack>
             {removable_media.length ? (
@@ -184,14 +162,11 @@ const ProgramsTable = (props) => {
   const { act, data } = useBackend<NTOSData>();
   const { programs = [] } = data;
   // add the program filename to this list to have it excluded from the main menu program list table
-  const filtered_programs = programs.filter(
-    (program) => !program.header_program,
-  );
 
   return (
     <Section title="Programs">
       <Table>
-        {filtered_programs.map((program) => (
+        {programs.map((program) => (
           <Table.Row key={program.name}>
             <Table.Cell>
               <Button

--- a/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
@@ -1,6 +1,7 @@
 import { sortBy } from 'es-toolkit';
 import { useState } from 'react';
 import {
+  BlockQuote,
   Box,
   Button,
   Dimmer,
@@ -94,11 +95,13 @@ const AccessDeniedScreen = (props: any) => {
     <Stack fill vertical>
       <Stack.Item>
         <Section>
-          <Stack vertical textAlign="center">
-            <Box bold>
-              <Icon name="address-card" />
-              SpaceMessenger V6.5.3
-            </Box>
+          <Stack>
+            <Stack.Item>
+              <Box bold>
+                <Icon name="address-card" />
+                SpaceMessenger V7.0.1
+              </Box>
+            </Stack.Item>
           </Stack>
         </Section>
       </Stack.Item>
@@ -198,24 +201,31 @@ const ContactsScreen = (props: any) => {
     <Stack fill vertical>
       <Stack.Item>
         <Section>
-          <Stack vertical textAlign="center">
-            <Box bold>
-              <Icon name="address-card" mr={1} />
-              SpaceMessenger V6.5.4
-            </Box>
-            <Box italic opacity={0.3} mt={1}>
-              Bringing you spy-proof communications since 2467.
-            </Box>
-            <Divider hidden />
+          <Stack vertical>
+            <Stack.Item>
+              <Stack>
+                <Stack.Item>
+                  {' '}
+                  <Icon name="address-card" mr={1} />
+                  SpaceMessenger V7.2
+                </Stack.Item>
+                <Stack.Item>
+                  <BlockQuote>
+                    Bringing you spy-proof communications since 2467.
+                  </BlockQuote>
+                </Stack.Item>
+              </Stack>
+            </Stack.Item>
+            <Divider />
             <Box>
-              <Button
+              <Button.Checkbox
                 icon="bell"
                 disabled={!alert_able}
-                content={
-                  alert_able && !alert_silenced ? 'Ringer: On' : 'Ringer: Off'
-                }
+                checked={alert_able && !alert_silenced}
                 onClick={() => act('PDA_toggleAlerts')}
-              />
+              >
+                Ringer
+              </Button.Checkbox>
               <Button
                 icon="address-card"
                 content={
@@ -275,14 +285,6 @@ const ContactsScreen = (props: any) => {
       )}
       <Stack.Item grow={2}>
         <Stack vertical fill>
-          <Section>
-            <Stack>
-              <Box m={0.5}>
-                <Icon name="address-card" mr={1} />
-                Detected Messengers
-              </Box>
-            </Stack>
-          </Section>
           <Section fill scrollable>
             <Stack vertical pb={1} fill>
               {messengerButtons.length === 0 && (

--- a/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMessenger/index.tsx
@@ -219,22 +219,20 @@ const ContactsScreen = (props: any) => {
             <Divider />
             <Box>
               <Button.Checkbox
-                icon="bell"
                 disabled={!alert_able}
                 checked={alert_able && !alert_silenced}
                 onClick={() => act('PDA_toggleAlerts')}
+                color="default"
               >
                 Ringer
               </Button.Checkbox>
-              <Button
-                icon="address-card"
-                content={
-                  sending_and_receiving
-                    ? 'Send / Receive: On'
-                    : 'Send / Receive: Off'
-                }
+              <Button.Checkbox
+                checked={sending_and_receiving}
                 onClick={() => act('PDA_toggleSendingAndReceiving')}
-              />
+                color="default"
+              >
+                Online
+              </Button.Checkbox>
               <Button
                 icon="bell"
                 content="Set Ringtone"
@@ -246,12 +244,13 @@ const ContactsScreen = (props: any) => {
                 onClick={() => act('PDA_changeSortStyle')}
               />
               {!!virus_attach && (
-                <Button
-                  icon="bug"
+                <Button.Checkbox
                   color="bad"
-                  content={`Attach Virus: ${sending_virus ? 'Yes' : 'No'}`}
                   onClick={() => act('PDA_toggleVirus')}
-                />
+                  checked={sending_virus}
+                >
+                  Attach Virus
+                </Button.Checkbox>
               )}
             </Box>
           </Stack>

--- a/tgui/packages/tgui/interfaces/NtosRevelation.tsx
+++ b/tgui/packages/tgui/interfaces/NtosRevelation.tsx
@@ -1,4 +1,11 @@
-import { Button, LabeledList, Section } from 'tgui-core/components';
+import {
+  BlockQuote,
+  Box,
+  Button,
+  Input,
+  Section,
+  Stack,
+} from 'tgui-core/components';
 import type { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
@@ -6,49 +13,109 @@ import { NtosWindow } from '../layouts';
 
 type Data = {
   armed: BooleanLike;
+  bluescreen: BooleanLike;
 };
 
 export const NtosRevelation = (props) => {
   const { act, data } = useBackend<Data>();
-  const { armed } = data;
+  const { armed, bluescreen } = data;
 
   return (
     <NtosWindow width={400} height={250}>
       <NtosWindow.Content>
-        <Section>
-          <Button.Input
-            fluid
-            buttonText="Obfuscate Name..."
-            onCommit={(value) =>
-              act('PRG_obfuscate', {
-                new_name: value,
-              })
-            }
-            mb={1}
-          />
-          <LabeledList>
-            <LabeledList.Item
-              label="Payload Status"
-              buttons={
-                <Button
-                  content={armed ? 'ARMED' : 'DISARMED'}
-                  color={armed ? 'bad' : 'average'}
-                  onClick={() => act('PRG_arm')}
-                />
-              }
-            />
-          </LabeledList>
-          <Button
-            fluid
-            bold
-            content="ACTIVATE"
-            textAlign="center"
-            color="bad"
-            disabled={!armed}
-            onClick={() => act('PRG_activate')}
-          />
-        </Section>
+        {!!bluescreen && <BlueScreen />}
+        {!bluescreen && (
+          <Section fill>
+            <Stack fill direction="column">
+              <Stack.Item>
+                <Stack>
+                  <Stack.Item style={{ lineHeight: '1.5em' }}>
+                    Display Name:
+                  </Stack.Item>
+                  <Stack.Item grow>
+                    <Input
+                      fluid
+                      onChange={(value) =>
+                        act('PRG_obfuscate', {
+                          new_name: value,
+                        })
+                      }
+                      mb={1}
+                    />
+                  </Stack.Item>
+                </Stack>
+              </Stack.Item>
+              <Stack.Item>
+                <BlockQuote>
+                  Upon arming the program, opening it again will wipe the
+                  device. Make sure all sensitive data isn't backed up.
+                </BlockQuote>
+              </Stack.Item>
+              <Stack.Item mt="auto">
+                <Stack direction="column">
+                  <Stack.Item>
+                    <Button
+                      fluid
+                      style={{
+                        textAlign: 'center',
+                        fontSize: '20px',
+                      }}
+                      color={armed ? 'bad' : 'average'}
+                      onClick={() => act('PRG_arm')}
+                    >
+                      {armed ? 'DISARM' : 'ARM'}
+                    </Button>
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Button.Confirm
+                      fluid
+                      bold
+                      confirmContent="ARE YOU SURE?"
+                      textAlign="center"
+                      color="bad"
+                      disabled={!armed}
+                      onClick={() => act('PRG_activate')}
+                      style={{ marginBottom: '0px' }}
+                    >
+                      ACTIVATE NOW
+                    </Button.Confirm>
+                  </Stack.Item>
+                </Stack>
+              </Stack.Item>
+            </Stack>
+          </Section>
+        )}
       </NtosWindow.Content>
     </NtosWindow>
+  );
+};
+
+const BlueScreen = () => {
+  return (
+    <Box
+      width="100%"
+      height="100%"
+      backgroundColor="#0000aa"
+      color="#ffffff"
+      fontFamily="'Courier New', monospace"
+      py={2}
+      px={3}
+    >
+      <Box bold fontSize="16px">
+        System Failure
+      </Box>
+      <Box mt={2}>
+        A fatal exception 0xE has occurred at 0028:C0011E36 in VXD_SYSPURGE(01)
+        + 00002B9C. The current application will be terminated.
+      </Box>
+      <Box mt={2}>
+        * Press any key to terminate the current application.
+        <br />
+        You will lose any unsaved information in all applications.
+      </Box>
+      <Box mt={4} italic>
+        Press any key to continue...
+      </Box>
+    </Box>
   );
 };

--- a/tgui/packages/tgui/interfaces/NtosRevelation.tsx
+++ b/tgui/packages/tgui/interfaces/NtosRevelation.tsx
@@ -105,17 +105,10 @@ const BlueScreen = () => {
         System Failure
       </Box>
       <Box mt={2}>
-        A fatal exception 0xE has occurred at 0028:C0011E36 in VXD_SYSPURGE(01)
+        A fatal exception 0xE has occurred at 0028:C0011E36 in VXD_SYSCALLRM(01)
         + 00002B9C. The current application will be terminated.
       </Box>
-      <Box mt={2}>
-        * Press any key to terminate the current application.
-        <br />
-        You will lose any unsaved information in all applications.
-      </Box>
-      <Box mt={4} italic>
-        Press any key to continue...
-      </Box>
+      <Box mt={2}>* Press any key to terminate the current application.</Box>
     </Box>
   );
 };

--- a/tgui/packages/tgui/layouts/NtosWindow.tsx
+++ b/tgui/packages/tgui/layouts/NtosWindow.tsx
@@ -36,6 +36,12 @@ export type NTOSData = {
   show_imprint: BooleanLike;
 };
 
+enum alert_relevancies {
+  ALERT_RELEVANCY_SAFE,
+  ALERT_RELEVANCY_WARN,
+  ALERT_RELEVANCY_PERTINENT,
+}
+
 type Program = {
   alert: BooleanLike;
   desc: string;
@@ -64,6 +70,9 @@ export const NtosWindow = (props) => {
     PC_programheaders = [],
     PC_showexitprogram,
     PC_lowpower_mode,
+    alert_style,
+    alert_color,
+    alert_name,
   } = data;
 
   return (
@@ -89,6 +98,22 @@ export const NtosWindow = (props) => {
             </Box>
           </div>
           <div className="NtosHeader__right">
+            <Box
+              inline
+              mr={1}
+              className={
+                alert_style === alert_relevancies.ALERT_RELEVANCY_PERTINENT
+                  ? 'alertIndicator alertBlink'
+                  : 'alertIndicator'
+              }
+              textColor={
+                alert_style === alert_relevancies.ALERT_RELEVANCY_SAFE
+                  ? '#0000000'
+                  : alert_color
+              }
+            >
+              {alert_name}
+            </Box>
             {PC_programheaders.map((header) => (
               <Box key={header.icon} inline mr={1}>
                 <img


### PR DESCRIPTION
## About The Pull Request

Cleans up the NTOS main menu UI, moving the alert level to the status bar, making the buttons consistent.

<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/5e686b91-e467-4188-9f3c-dd18ce7d31e6" />

Makes the Revelation program display a funny BSOD on triggering instead of opening the program itself before bricking the device. Fixes the runtime it caused when clearing the installed apps and files.

<img width="787" height="679" alt="dreamseeker_Uj45vWH9Xq" src="https://github.com/user-attachments/assets/d822797d-d27d-44d9-883f-ab5b89ebdcf7" />

Cleans up the Direct Messenger UI.

<img width="600" height="850" alt="image" src="https://github.com/user-attachments/assets/954c88d8-edb2-4171-bafe-077c622347bb" />

Removes header programs: all programs are now in the Programs list.

## Why It's Good For The Game

Cleaner UI. Misc buttons (functional/temporary/apps) were all around the place. Now the app buttons are in the app list and the functional buttons are in a separate section. The messenger app now uses checkboxes for toggleable features.

## Changelog
:cl:
qol: Direct Messenger, Robotact and Themeify are now along with the other apps in the application list.
qol: The NTOS main menu/status bar are now cleaner.
fix: The Revelation app no longer causes runtimes and actually wipes the device now.
/:cl:
