### PR TITLE
Fixes stacking holodisks & balloon alert when unstacking disks

### DIFF
--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -234,7 +234,7 @@
 
 /obj/item/disk/holodisk/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(!istype(tool, /obj/item/disk/holodisk))
-		return NONE
+		return ..()
 
 	var/obj/item/disk/holodisk/holodisk_original = tool
 

--- a/code/game/objects/items/floppy_disk.dm
+++ b/code/game/objects/items/floppy_disk.dm
@@ -264,10 +264,10 @@
 
 	var/obj/item/disk/top = stacked_disks[length(stacked_disks)]
 	user.put_in_hands(top)
-	balloon_alert(user, "removed top disk")
 
 	if(length(stacked_disks) > 1)
 		update_appearance(UPDATE_OVERLAYS)
+		balloon_alert(user, "removed top disk")
 		return TRUE
 
 	var/obj/item/disk/last_disk = stacked_disks[1]
@@ -281,6 +281,7 @@
 		last_disk.pixel_x = pixel_x
 		last_disk.pixel_y = pixel_y
 
+	last_disk.balloon_alert(user, "removed top disk")
 	qdel(src)
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request

Calls parent in holodisk `item_interaction()`, & doesn't balloon alert right before `qdel(src)`ing.

## Why It's Good For The Game

Convenience and runtime

## Changelog
:cl:
fix: you can stack disks on holodisks
/:cl:
