### PR TITLE
Fixes Dynamic ignoring `min_antag_cap` and `max_antag_cap` for midrounds

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -728,18 +728,19 @@ SUBSYSTEM_DEF(dynamic)
 			data += "\]\n"
 		else
 			data += "blacklisted_roles = \[\]\n"
-		if(islist(ruleset.min_antag_cap))
-			for(var/ruleset_min_antag_cap in ruleset.min_antag_cap)
-				data += "min_antag_cap.[ruleset_min_antag_cap] = [ruleset.min_antag_cap[ruleset_min_antag_cap]]\n"
-		else
-			data += "min_antag_cap = [ruleset.min_antag_cap || 0]\n"
-		if(islist(ruleset.max_antag_cap))
-			for(var/ruleset_max_antag_cap in ruleset.max_antag_cap)
-				data += "max_antag_cap.[ruleset_max_antag_cap] = [ruleset.max_antag_cap[ruleset_max_antag_cap]]\n"
-		else if(!isnull(ruleset.max_antag_cap))
-			data += "max_antag_cap = [ruleset.max_antag_cap]\n"
-		else
-			data += "# max_antag_cap = min_antag_cap\n"
+		if(!istype(ruleset, /datum/dynamic_ruleset/latejoin))
+			if(islist(ruleset.min_antag_cap))
+				for(var/ruleset_min_antag_cap in ruleset.min_antag_cap)
+					data += "min_antag_cap.[ruleset_min_antag_cap] = [ruleset.min_antag_cap[ruleset_min_antag_cap]]\n"
+			else
+				data += "min_antag_cap = [ruleset.min_antag_cap || 0]\n"
+			if(islist(ruleset.max_antag_cap))
+				for(var/ruleset_max_antag_cap in ruleset.max_antag_cap)
+					data += "max_antag_cap.[ruleset_max_antag_cap] = [ruleset.max_antag_cap[ruleset_max_antag_cap]]\n"
+			else if(!isnull(ruleset.max_antag_cap))
+				data += "max_antag_cap = [ruleset.max_antag_cap]\n"
+			else
+				data += "# max_antag_cap = min_antag_cap\n"
 		data += "repeatable_weight_decrease = [ruleset.repeatable_weight_decrease]\n"
 		data += "repeatable = [ruleset.repeatable]\n"
 		data += "minimum_required_age = [ruleset.minimum_required_age]\n"

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -728,19 +728,18 @@ SUBSYSTEM_DEF(dynamic)
 			data += "\]\n"
 		else
 			data += "blacklisted_roles = \[\]\n"
-		if(!istype(ruleset, /datum/dynamic_ruleset/latejoin) && !istype(ruleset, /datum/dynamic_ruleset/midround/from_living))
-			if(islist(ruleset.min_antag_cap))
-				for(var/ruleset_min_antag_cap in ruleset.min_antag_cap)
-					data += "min_antag_cap.[ruleset_min_antag_cap] = [ruleset.min_antag_cap[ruleset_min_antag_cap]]\n"
-			else
-				data += "min_antag_cap = [ruleset.min_antag_cap || 0]\n"
-			if(islist(ruleset.max_antag_cap))
-				for(var/ruleset_max_antag_cap in ruleset.max_antag_cap)
-					data += "max_antag_cap.[ruleset_max_antag_cap] = [ruleset.max_antag_cap[ruleset_max_antag_cap]]\n"
-			else if(!isnull(ruleset.max_antag_cap))
-				data += "max_antag_cap = [ruleset.max_antag_cap]\n"
-			else
-				data += "# max_antag_cap = min_antag_cap\n"
+		if(islist(ruleset.min_antag_cap))
+			for(var/ruleset_min_antag_cap in ruleset.min_antag_cap)
+				data += "min_antag_cap.[ruleset_min_antag_cap] = [ruleset.min_antag_cap[ruleset_min_antag_cap]]\n"
+		else
+			data += "min_antag_cap = [ruleset.min_antag_cap || 0]\n"
+		if(islist(ruleset.max_antag_cap))
+			for(var/ruleset_max_antag_cap in ruleset.max_antag_cap)
+				data += "max_antag_cap.[ruleset_max_antag_cap] = [ruleset.max_antag_cap[ruleset_max_antag_cap]]\n"
+		else if(!isnull(ruleset.max_antag_cap))
+			data += "max_antag_cap = [ruleset.max_antag_cap]\n"
+		else
+			data += "# max_antag_cap = min_antag_cap\n"
 		data += "repeatable_weight_decrease = [ruleset.repeatable_weight_decrease]\n"
 		data += "repeatable = [ruleset.repeatable]\n"
 		data += "minimum_required_age = [ruleset.minimum_required_age]\n"

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_latejoin.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_latejoin.dm
@@ -3,6 +3,16 @@
 	max_antag_cap = 1
 	repeatable = TRUE
 
+/datum/dynamic_ruleset/latejoin/set_config_value(nvar, nval)
+	if(nvar == NAMEOF(src, min_antag_cap) || nvar == NAMEOF(src, max_antag_cap))
+		return FALSE
+	return ..()
+
+/datum/dynamic_ruleset/latejoin/vv_edit_var(var_name, var_value)
+	if(var_name == NAMEOF(src, min_antag_cap) || var_name == NAMEOF(src, max_antag_cap))
+		return FALSE
+	return ..()
+
 /datum/dynamic_ruleset/latejoin/is_valid_candidate(mob/candidate, client/candidate_client)
 	if(isnull(candidate.mind))
 		return FALSE

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_latejoin.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_latejoin.dm
@@ -3,16 +3,6 @@
 	max_antag_cap = 1
 	repeatable = TRUE
 
-/datum/dynamic_ruleset/latejoin/set_config_value(nvar, nval)
-	if(nvar == NAMEOF(src, min_antag_cap) || nvar == NAMEOF(src, max_antag_cap))
-		return FALSE
-	return ..()
-
-/datum/dynamic_ruleset/latejoin/vv_edit_var(var_name, var_value)
-	if(var_name == NAMEOF(src, min_antag_cap) || var_name == NAMEOF(src, max_antag_cap))
-		return FALSE
-	return ..()
-
 /datum/dynamic_ruleset/latejoin/is_valid_candidate(mob/candidate, client/candidate_client)
 	if(isnull(candidate.mind))
 		return FALSE

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -1113,16 +1113,6 @@
 	max_antag_cap = 1
 	repeatable = TRUE
 
-/datum/dynamic_ruleset/midround/from_living/set_config_value(nvar, nval)
-	if(nvar == NAMEOF(src, min_antag_cap) || nvar == NAMEOF(src, max_antag_cap))
-		return FALSE
-	return ..()
-
-/datum/dynamic_ruleset/midround/from_living/vv_edit_var(var_name, var_value)
-	if(var_name == NAMEOF(src, min_antag_cap) || var_name == NAMEOF(src, max_antag_cap))
-		return FALSE
-	return ..()
-
 /datum/dynamic_ruleset/midround/from_living/collect_candidates()
 	return GLOB.alive_player_list
 

--- a/config/dynamic.toml
+++ b/config/dynamic.toml
@@ -364,7 +364,7 @@ repeatable_weight_decrease = 2
 repeatable = 1
 minimum_required_age = 0
 
-["Midround Mass Changelings"]
+["Mass Changelings"]
 weight.1 = 0
 weight.2 = 3
 weight.3 = 4
@@ -437,7 +437,7 @@ repeatable_weight_decrease = 2
 repeatable = 1
 minimum_required_age = 0
 
-["Midround Mass Traitors"]
+["Mass Traitors"]
 weight.1 = 0
 weight.2 = 3
 weight.3 = 8


### PR DESCRIPTION

## About The Pull Request

The code was explicitly throwing away `min_antag_cap` and `max_antag_cap` for midrounds , but some rulesets (Mass Traitors and Mass Changelings) use them. ~~I'm not sure why they were thrown away at all and someone smarter than me should probably chime in on why this is the case before this is merged.~~

Also the config tags for Mass Traitors and Mass Changelings were typoed, that's already been fixed on the real config.

## Changelog
:cl: PapaMichael
fix: The server should obey the config's `min_antag_cap` and `max_antag_cap` for midround rulesets now.
/:cl:
