### PR TITLE
Fixes description and threshold mismatch in heal.dm

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -639,8 +639,8 @@
 	transmittable = -4
 	level = 9
 	threshold_descs = list(
-		"Resistance 8" = "Doubles healing speed from stable genetics.",
-		"Stage Speed 7" = "Slightly increases healing speed for all hosts without negative genetic stability.",
+		"Resistance 9" = "Doubles healing speed from stable genetics.",
+		"Stage Speed 6" = "Slightly increases healing speed for all hosts without negative genetic stability.",
 	)
 	power = 0
 	var/stability_divisor = 25


### PR DESCRIPTION
## About The Pull Request

It looks like there is a mismatch between the description strings and the actual threshold values in the code for the heal symptom (**8** vs **9**, and **7** vs **6**), or vice versa. 

`"Resistance 8"` vs `if(our_disease.totalResistance() >= 9)`
`"Stage Speed 7"` vs `if(our_disease.totalStageSpeed() >= 6)`

This PR simply updates the description strings to accurately match the mechanical thresholds (`9` and `6`).

## Why It's Good For The Game

Prevents confusion for anyone reading the symptom details. It was probably just a minor oversight while balancing things out.

## Changelog

:cl:
spellcheck: Fixed incorrect threshold numbers in the heal symptom descriptions to match their actual stats.
/:cl: