### PR TITLE
Minor performance tweak for mushroom hallucinogen

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -531,6 +531,8 @@
 	. = ..()
 
 	psychonaut.add_mood_event("tripping", /datum/mood_event/high)
+	if(!psychonaut.client)
+		return // No need to mess with a mob's plane masters if they physically can't see it.
 	if(!psychonaut.hud_used)
 		return
 

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -527,12 +527,23 @@
 			if(SPT_PROB(16, seconds_per_tick))
 				psychonaut.emote(pick("twitch","giggle"))
 
+/datum/reagent/drug/mushroomhallucinogen/on_mob_add(mob/living/affected_mob, amount)
+	. = ..()
+	RegisterSignal(affected_mob, COMSIG_MOB_LOGIN, PROC_REF(trip))
+
+/datum/reagent/drug/mushroomhallucinogen/on_mob_delete(mob/living/affected_mob)
+	. = ..()
+	UnregisterSignal(affected_mob, COMSIG_MOB_LOGIN)
+
 /datum/reagent/drug/mushroomhallucinogen/on_mob_metabolize(mob/living/psychonaut)
 	. = ..()
-
 	psychonaut.add_mood_event("tripping", /datum/mood_event/high)
 	if(!psychonaut.client)
 		return // No need to mess with a mob's plane masters if they physically can't see it.
+	trip(psychonaut)
+
+/// Proc that handles the changes
+/datum/reagent/drug/mushroomhallucinogen/proc/trip(mob/living/psychonaut)
 	if(!psychonaut.hud_used)
 		return
 


### PR DESCRIPTION
## About The Pull Request

Today it was discussed that mushroom hallucinogen has an exceptionally expensive set of operations within on_mob_metabolize. However, these effects are almost entirely purely visual, regardless of target.

In a very minor shortcut to see if it prevents some access processing, I've added an early return to the visual/plane-master side of the proc that ends if the mob in question lacks a client.

There is almost, genuinely certainly a more elegant solution to this that involves deepdiving both into the animation procs, as well as the planecube-specific implications of these operations, but for a literal 5 minute coding adventure, this should at least cut down on a tiny bit of it's processing cost when we don't need to, like when caused by a vent overflow on icebox.

## Why It's Good For The Game

Minor easy performance savings on multi-z maps, where potentially relevant.

## Changelog

:cl:
fix: Mushroom hallucinogen does not apply it's drug effect if the target has no client.
/:cl: