### PR TITLE
Ashen Eyes description fix

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/side_knowledge/tier_one.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_knowledge/tier_one.dm
@@ -23,7 +23,7 @@
 /datum/heretic_knowledge/medallion
 	name = "Ashen Eyes"
 	desc = "Sculpt an Eldritch Medallion.<br>\
-		The Eldritch Medallion grants you thermal vision while worn, and also functions as a focus."
+		The Eldritch Medallion grants you thermal vision while worn."
 	transmute_text = "Transmute a pair of eyes, a candle, and a glass shard."
 	gain_text = "Piercing eyes guided them through the mundane. Neither darkness nor terror could stop them."
 	required_atoms = list(


### PR DESCRIPTION

## About The Pull Request
Removes the focus reference from Ashen Eyes.
## Why It's Good For The Game

Ashen Eyes description no longer states that they are a focus (they are not anymore)
## Changelog
:cl:

fix: Ashen Eyes description no longer states that they are a focus

/:cl:
