### PR TITLE
Fixes ghosts triggering AI motion-sensitive cameras

### DIFF
--- a/code/datums/components/monitored_area.dm
+++ b/code/datums/components/monitored_area.dm
@@ -58,7 +58,7 @@
 		LAZYNULL(motion_targets)
 
 /datum/motion_group/proc/track_mob(mob/gain_mob)
-	if(!ismob(gain_mob) || !LAZYLEN(motion_cameras))
+	if(!isliving(gain_mob) || !LAZYLEN(motion_cameras))
 		return
 
 	for(var/obj/machinery/camera/camera as anything in motion_cameras)
@@ -66,7 +66,7 @@
 		return //??
 
 /datum/motion_group/proc/untrack_mob(mob/lost_mob)
-	if(!ismob(lost_mob) || !LAZYLEN(motion_cameras))
+	if(!isliving(lost_mob) || !LAZYLEN(motion_cameras))
 		return
 
 	for(var/obj/machinery/camera/camera as anything in motion_cameras)


### PR DESCRIPTION

## About The Pull Request
Title
Closes https://github.com/tgstation/tgstation/issues/94481

## Changelog
:cl: PapaMichael
fix: Ghosts no longer trigger the AI's motion-sensitive camera alerts
/:cl:
