### PR TITLE
Fix biogenerator UI icons being broken

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -512,6 +512,7 @@
 			cat["items"] += list(list(
 				"path" = design.type,
 				"name" = design.name,
+				"icon" = design.asset_id,
 				"is_reagent" = !isnull(design.make_reagent),
 				"cost" = design.materials[SSmaterials.get_material(/datum/material/biomass)] / efficiency,
 			))

--- a/tgui/packages/tgui/interfaces/Biogenerator.tsx
+++ b/tgui/packages/tgui/interfaces/Biogenerator.tsx
@@ -42,6 +42,7 @@ type Design = {
   path: string;
   is_reagent: BooleanLike;
   name: string;
+  icon: string;
 };
 
 export function Biogenerator(props) {
@@ -193,7 +194,7 @@ type Props = {
 
 function Item(props: Props) {
   const { item, space } = props;
-  const { cost, path, is_reagent, name } = item;
+  const { cost, path, is_reagent, name, icon } = item;
 
   const { act, data } = useBackend<Data>();
   const { biomass, beaker, efficiency, max_output, processing } = data;
@@ -217,7 +218,7 @@ function Item(props: Props) {
     <Table.Row>
       <Table.Cell>
         <span
-          className={classes(['design32x32', path])}
+          className={classes(['design32x32', icon])}
           style={{
             verticalAlign: 'middle',
           }}


### PR DESCRIPTION

## About The Pull Request

Can't use `path` for the icon it needs to be `asset_id`

## Why It's Good For The Game

<img width="726" height="568" alt="image" src="https://github.com/user-attachments/assets/44d457c8-5918-42c3-a876-3ebc8e81bc2b" />

## Changelog
:cl:
fix: fixed icons in the biogenerator UI being broken
/:cl:
