### PR TITLE
Adds (relatively limited) character height preference

### DIFF
--- a/code/datums/dna/blocks/dna_identity_block.dm
+++ b/code/datums/dna/blocks/dna_identity_block.dm
@@ -148,4 +148,4 @@
 /datum/dna_block/identity/height/apply_to_mob(mob/living/carbon/human/target, dna_hash)
 	var/max_height_index = length(dna_heights)
 	var/mob_height_index = deconstruct_block(get_block(dna_hash), max_height_index, block_length)
-	target.set_mob_height(text2num(dna_heights[mob_height_index]) || HUMAN_HEIGHT_MEDIUM, update_dna = FALSE)
+	target.set_mob_height(dna_heights[mob_height_index] || HUMAN_HEIGHT_MEDIUM, update_dna = FALSE)

--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -370,6 +370,14 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 	var/is_character_preference = savefile_identifier == PREFERENCE_CHARACTER
 	return is_on_character_page == is_character_preference
 
+/// Helper for checking if one/any of the passed job types are the highest priority job for the passed preferences object
+/// Useful for filtering out certain preferences unless certain jobs are/are not active
+/datum/preference/proc/highest_priority_job_is(datum/preferences/preferences, job_type_or_types)
+	if(islist(job_type_or_types))
+		return is_type_in_list(preferences.get_highest_priority_job(), job_type_or_types)
+
+	return istype(preferences.get_highest_priority_job(), job_type_or_types)
+
 /// A preference that is a choice of one option among a fixed set.
 /// Used for preferences such as clothing.
 /datum/preference/choiced

--- a/code/modules/client/preferences/ai_core_display.dm
+++ b/code/modules/client/preferences/ai_core_display.dm
@@ -15,10 +15,7 @@
 		return uni_icon('icons/mob/silicon/ai.dmi', resolve_ai_icon_sync(value))
 
 /datum/preference/choiced/ai_core_display/is_accessible(datum/preferences/preferences)
-	if (!..(preferences))
-		return FALSE
-
-	return istype(preferences.get_highest_priority_job(), /datum/job/ai)
+	return ..() && highest_priority_job_is(preferences, /datum/job/ai)
 
 /datum/preference/choiced/ai_core_display/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return

--- a/code/modules/client/preferences/ai_emote_display.dm
+++ b/code/modules/client/preferences/ai_emote_display.dm
@@ -20,10 +20,7 @@
 		return uni_icon('icons/obj/machines/status_display.dmi', GLOB.ai_status_display_all_options[value])
 
 /datum/preference/choiced/ai_emote_display/is_accessible(datum/preferences/preferences)
-	if (!..(preferences))
-		return FALSE
-
-	return istype(preferences.get_highest_priority_job(), /datum/job/ai)
+	return ..() && highest_priority_job_is(preferences, /datum/job/ai)
 
 /datum/preference/choiced/ai_emote_display/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return

--- a/code/modules/client/preferences/ai_hologram_display.dm
+++ b/code/modules/client/preferences/ai_hologram_display.dm
@@ -16,10 +16,7 @@
 		return uni_icon(GLOB.ai_hologram_icons[value], GLOB.ai_hologram_icon_state[value])
 
 /datum/preference/choiced/ai_hologram_display/is_accessible(datum/preferences/preferences)
-	if (!..(preferences))
-		return FALSE
-
-	return istype(preferences.get_highest_priority_job(), /datum/job/ai)
+	return ..() && highest_priority_job_is(preferences, /datum/job/ai)
 
 /datum/preference/choiced/ai_hologram_display/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return

--- a/code/modules/client/preferences/height.dm
+++ b/code/modules/client/preferences/height.dm
@@ -1,0 +1,35 @@
+#define DEFAULT_HEIGHT "Average"
+
+/datum/preference/choiced/mob_height
+	savefile_key = "character_height"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	can_randomize = FALSE
+	var/list/height_to_actual = list(
+		// "Shortest" = HUMAN_HEIGHT_SHORTEST, // Reserved for Settler
+		"Short" = HUMAN_HEIGHT_SHORT,
+		DEFAULT_HEIGHT = HUMAN_HEIGHT_MEDIUM,
+		"Tall" = HUMAN_HEIGHT_TALL,
+		// "Taller" = HUMAN_HEIGHT_TALLER, // Reserved for Spacer
+		// "Tallest" = HUMAN_HEIGHT_TALLEST, // Reserved for Spacer
+	)
+
+/datum/preference/choiced/mob_height/init_possible_values()
+	return assoc_to_keys(height_to_actual)
+
+/datum/preference/choiced/mob_height/apply_to_human(mob/living/carbon/human/target, value)
+	target.set_mob_height(height_to_actual[value] || DEFAULT_HEIGHT)
+
+/datum/preference/choiced/mob_height/is_accessible(datum/preferences/preferences)
+	if(highest_priority_job_is(preferences, list(/datum/job/cyborg, /datum/job/ai)))
+		return FALSE
+	if(/datum/quirk/settler::name in preferences.all_quirks)
+		return FALSE
+	if(/datum/quirk/spacer_born::name in preferences.all_quirks)
+		return FALSE
+	return ..()
+
+/datum/preference/choiced/mob_height/create_default_value(datum/preferences/preferences)
+	return DEFAULT_HEIGHT
+
+#undef DEFAULT_HEIGHT

--- a/code/modules/client/preferences/prisoner_crime.dm
+++ b/code/modules/client/preferences/prisoner_crime.dm
@@ -15,10 +15,7 @@
 	return "Random"
 
 /datum/preference/choiced/prisoner_crime/is_accessible(datum/preferences/preferences)
-	if (!..(preferences))
-		return FALSE
-
-	return istype(preferences.get_highest_priority_job(), /datum/job/prisoner)
+	return ..() && highest_priority_job_is(preferences, /datum/job/prisoner)
 
 /// Types of Crimes Prisoners will have on their record roundstart.
 /// (They also can choose Random, which picks from these options... randomly!)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4243,6 +4243,7 @@
 #include "code\modules\client\preferences\ghost.dm"
 #include "code\modules\client\preferences\ghost_lighting.dm"
 #include "code\modules\client\preferences\glasses.dm"
+#include "code\modules\client\preferences\height.dm"
 #include "code\modules\client\preferences\hemiplegic.dm"
 #include "code\modules\client\preferences\heterochromatic.dm"
 #include "code\modules\client\preferences\hotkeys.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/height.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/height.tsx
@@ -1,0 +1,7 @@
+import type { FeatureChoiced } from '../base';
+import { FeatureDropdownInput } from '../dropdowns';
+
+export const character_height: FeatureChoiced = {
+  name: 'Character Height',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
## About The Pull Request


<img width="468" height="176" alt="image" src="https://github.com/user-attachments/assets/f64852f5-d283-4265-ac9e-bd70509a4ed2" />

Players can select between Short, Average (Normal), and Tall - the three heights indicated in green
Other heights are included for reference:

- Settlers are still given Shortest height (second height from the left)
- Spacers are still given the choice between Taller and Tallest heights (second and first from the right)
- Dwarfism is also included for reference (first height from the left)

Settlers and Spacers don't have access to the preference (they are locked Shortest or Taller/Tallest)

## Why It's Good For The Game

It's a very small detail but I find it adds a lot to the way you see other characters - For instance people will regularly call out Spacers are "freakin' huge" and annoy Settlers over being "tiny as heck". 
Quirks are a fun way of handing out height changes but there's always been a demand for people to have access to alternate heights without the drastic gameplay changes of quirks (and also to less of an extent). 

## Changelog

:cl: Melbert
add: Adds height preference, allowing you to pick between "Short", "Average", or "Tall". This doesn't override the height of Settlers or Spacers. 
fix: Fixes height resetting to average from dna swapping shenanigans like transformation sting.
/:cl:
