### PR TITLE
In game chem recipe browser now has recursive wiki-like popups

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -46,7 +46,7 @@
 /datum/chemical_reaction/sodiumchloride
 	results = list(/datum/reagent/consumable/salt = 2)
 	required_reagents = list(/datum/reagent/sodium = 1, /datum/reagent/chlorine = 1) // That's what I said! Sodium Chloride!
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_FOOD | REACTION_TAG_COMPONENT
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL | REACTION_TAG_COMPONENT
 	thermic_constant = 50
 
 /datum/chemical_reaction/sodiumchloride/pre_reaction_other_checks(datum/reagents/holder)

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -1,8 +1,10 @@
+import { useEffect, useRef, useState } from 'react';
 import {
   BlockQuote,
   Box,
   Button,
   Collapsible,
+  Floating,
   Icon,
   Input,
   LabeledList,
@@ -14,7 +16,6 @@ import {
 } from 'tgui-core/components';
 import type { BooleanLike } from 'tgui-core/react';
 import { createSearch, toTitleCase } from 'tgui-core/string';
-
 import { useBackend, useSharedState } from '../backend';
 import { Window } from '../layouts';
 import { type Beaker, BeakerDisplay } from './common/BeakerDisplay';
@@ -156,6 +157,28 @@ export const ChemDispenser = (props) => {
   const mainWidth = 565;
   const reactionWidth = 245;
   const windowWidth = mainWidth + (showReactionList ? reactionWidth : 0);
+
+  const [frozenRecipes, setFrozenRecipes] = useState<string[]>([]);
+  const [hoveredRecipe, setHoveredRecipe] = useState<string | null>(null);
+
+  const recipeButtonRefs = useRef<HTMLDivElement[]>([]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        !recipeButtonRefs.current.some((ref) =>
+          ref.contains(event.target as Node),
+        )
+      ) {
+        setFrozenRecipes([]);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [recipeButtonRefs]);
 
   return (
     <Window width={windowWidth} height={620}>
@@ -421,7 +444,18 @@ export const ChemDispenser = (props) => {
                   </Stack.Item>
                   <Stack.Divider />
                   <Stack.Item grow mt={1}>
-                    <Section scrollable fill>
+                    <Section
+                      scrollable
+                      fill
+                      onScroll={() => {
+                        if (hoveredRecipe) {
+                          setHoveredRecipe(null);
+                        }
+                        if (frozenRecipes.length > 0) {
+                          setFrozenRecipes([]);
+                        }
+                      }}
+                    >
                       <Stack vertical>
                         {filteredReactions.length > 0 ? (
                           filteredReactions.map((reaction) => (
@@ -430,7 +464,11 @@ export const ChemDispenser = (props) => {
                                 reaction={reaction}
                                 pinnedReactions={pinnedReactions}
                                 setPinnedReactions={setPinnedReactions}
-                                setSearchTerm={setSearchTerm}
+                                frozenRecipes={frozenRecipes}
+                                setFrozenRecipes={setFrozenRecipes}
+                                hoveredRecipe={hoveredRecipe}
+                                setHoveredRecipe={setHoveredRecipe}
+                                recipeButtonRefs={recipeButtonRefs}
                               />
                             </Stack.Item>
                           ))
@@ -498,14 +536,92 @@ const ReagentDispenseButton = (props: ReagentDispenseButtonProps) => {
 };
 
 type ReactionDisplayProps = {
+  noDropdown?: boolean;
   reaction: ReagentReaction;
   pinnedReactions: ReactionTypepath[];
   setPinnedReactions: (reactions: ReactionTypepath[]) => void;
-  setSearchTerm: (term: string) => void;
+  frozenRecipes: string[];
+  setFrozenRecipes: (reactions: string[]) => void;
+  hoveredRecipe: string | null;
+  setHoveredRecipe: (recipe: string | null) => void;
+  recipeButtonRefs: React.RefObject<HTMLDivElement[]>;
 };
 
 const ReactionDisplay = (props: ReactionDisplayProps) => {
-  const { reaction, pinnedReactions, setPinnedReactions } = props;
+  const {
+    noDropdown,
+    reaction,
+    pinnedReactions,
+    setPinnedReactions,
+    frozenRecipes,
+    setFrozenRecipes,
+    hoveredRecipe,
+    setHoveredRecipe,
+    recipeButtonRefs,
+  } = props;
+
+  const recipeList = (
+    <BlockQuote>
+      <Stack vertical>
+        <Stack.Item>
+          <HorizontalBarWithText text="Formula" />
+        </Stack.Item>
+        {reaction.reaction.required_reagents.map((reagent) => (
+          <Stack.Item key={`${reaction.name}-${reagent.name}-req`}>
+            <ReactionComponentDisplay
+              reagentComponent={reagent}
+              pinnedReactions={pinnedReactions}
+              setPinnedReactions={setPinnedReactions}
+              frozenRecipes={frozenRecipes}
+              setFrozenRecipes={setFrozenRecipes}
+              hoveredRecipe={hoveredRecipe}
+              setHoveredRecipe={setHoveredRecipe}
+              recipeButtonRefs={recipeButtonRefs}
+            />
+          </Stack.Item>
+        ))}
+        {reaction.reaction.required_catalysts.length > 0 && (
+          <>
+            <Stack.Item>
+              <HorizontalBarWithText
+                text={`Catalyst${reaction.reaction.required_reagents.length === 1 ? '' : 's'}`}
+              />
+            </Stack.Item>
+            {reaction.reaction.required_catalysts.map((catalyst) => (
+              <Stack.Item key={`${reaction.name}-${catalyst.name}-cat`}>
+                <ReactionComponentDisplay
+                  reagentComponent={catalyst}
+                  pinnedReactions={pinnedReactions}
+                  setPinnedReactions={setPinnedReactions}
+                  frozenRecipes={frozenRecipes}
+                  setFrozenRecipes={setFrozenRecipes}
+                  hoveredRecipe={hoveredRecipe}
+                  setHoveredRecipe={setHoveredRecipe}
+                  recipeButtonRefs={recipeButtonRefs}
+                />
+              </Stack.Item>
+            ))}
+          </>
+        )}
+        <Stack.Item>
+          <HorizontalBarWithText text="Optimal temperature" />
+        </Stack.Item>
+        <Stack.Item fontSize="0.9em">
+          {getTemperatureMessage(
+            reaction.reaction.lower_temperature,
+            reaction.reaction.upper_temperature,
+          )}
+        </Stack.Item>
+        <Stack.Item>
+          <HorizontalBarWithText text="Optimal pH range" />
+        </Stack.Item>
+        <Stack.Item fontSize="0.9em">
+          {getPHMessage(reaction.reaction.lower_ph, reaction.reaction.upper_ph)}
+        </Stack.Item>
+      </Stack>
+    </BlockQuote>
+  );
+
   return (
     <Stack
       p={1}
@@ -569,65 +685,16 @@ const ReactionDisplay = (props: ReactionDisplayProps) => {
         </Stack>
       </Stack.Item>
       <Stack.Item>
-        <Collapsible
-          title="Recipe"
-          open={pinnedReactions.includes(reaction.name)}
-        >
-          <BlockQuote>
-            <Stack vertical>
-              <Stack.Item>
-                <HorizontalBarWithText text="Formula" />
-              </Stack.Item>
-              {reaction.reaction.required_reagents.map((reagent) => (
-                <Stack.Item key={`${reaction.name}-${reagent.name}-req`}>
-                  <ReactionComponentDisplay
-                    reagentComponent={reagent}
-                    setSearchTerm={props.setSearchTerm}
-                    pinnedReactions={pinnedReactions}
-                    setPinnedReactions={props.setPinnedReactions}
-                  />
-                </Stack.Item>
-              ))}
-              {reaction.reaction.required_catalysts.length > 0 && (
-                <>
-                  <Stack.Item>
-                    <HorizontalBarWithText
-                      text={`Catalyst${reaction.reaction.required_reagents.length === 1 ? '' : 's'}`}
-                    />
-                  </Stack.Item>
-                  {reaction.reaction.required_catalysts.map((catalyst) => (
-                    <Stack.Item key={`${reaction.name}-${catalyst.name}-cat`}>
-                      <ReactionComponentDisplay
-                        reagentComponent={catalyst}
-                        setSearchTerm={props.setSearchTerm}
-                        pinnedReactions={pinnedReactions}
-                        setPinnedReactions={props.setPinnedReactions}
-                      />
-                    </Stack.Item>
-                  ))}
-                </>
-              )}
-              <Stack.Item>
-                <HorizontalBarWithText text="Optimal temperature" />
-              </Stack.Item>
-              <Stack.Item fontSize="0.9em">
-                {getTemperatureMessage(
-                  reaction.reaction.lower_temperature,
-                  reaction.reaction.upper_temperature,
-                )}
-              </Stack.Item>
-              <Stack.Item>
-                <HorizontalBarWithText text="Optimal pH range" />
-              </Stack.Item>
-              <Stack.Item fontSize="0.9em">
-                {getPHMessage(
-                  reaction.reaction.lower_ph,
-                  reaction.reaction.upper_ph,
-                )}
-              </Stack.Item>
-            </Stack>
-          </BlockQuote>
-        </Collapsible>
+        {noDropdown ? (
+          recipeList
+        ) : (
+          <Collapsible
+            title="Recipe"
+            open={pinnedReactions.includes(reaction.name)}
+          >
+            {recipeList}
+          </Collapsible>
+        )}
       </Stack.Item>
     </Stack>
   );
@@ -661,9 +728,13 @@ function getPHMessage(lower: number, upper: number): string {
 
 type ReactionComponentDisplayProps = {
   reagentComponent: ReactionComponent;
-  setSearchTerm: (term: string) => void;
   pinnedReactions: ReactionTypepath[];
   setPinnedReactions: (reactions: ReactionTypepath[]) => void;
+  frozenRecipes: string[];
+  setFrozenRecipes: (reactions: string[]) => void;
+  hoveredRecipe: string | null;
+  setHoveredRecipe: (recipe: string | null) => void;
+  recipeButtonRefs: React.RefObject<HTMLDivElement[]>;
 };
 
 // linkifies a reagent name in the reaction display
@@ -673,9 +744,13 @@ type ReactionComponentDisplayProps = {
 const ReactionComponentDisplay = (props: ReactionComponentDisplayProps) => {
   const {
     reagentComponent,
-    setSearchTerm,
     pinnedReactions,
     setPinnedReactions,
+    frozenRecipes,
+    setFrozenRecipes,
+    hoveredRecipe,
+    setHoveredRecipe,
+    recipeButtonRefs,
   } = props;
   const { data } = useBackend<Data>();
   const { chemicals, reaction_list } = data;
@@ -697,49 +772,92 @@ const ReactionComponentDisplay = (props: ReactionComponentDisplayProps) => {
   const reactionReagentList = reagentListToArray(reaction_list);
 
   // check if it's a recipe
-  const isRecipe = reactionReagentList
+  const foundRecipe = reactionReagentList
     .filter((reaction) => {
       return reaction.name === reagentComponent.name;
     })
     .find((reaction) => reaction.name === reagentComponent.name);
 
-  if (isRecipe) {
+  if (!foundRecipe)
     return (
-      <Button
-        icon="book"
-        fluid
-        ellipsis
-        backgroundColor="default"
-        onContextMenu={() => {
-          // put recipe name in search box
-          setSearchTerm(reagentComponent.name);
-        }}
-        onClick={() => {
-          // pin recipe
-          setPinnedReactions([...pinnedReactions, isRecipe.name]);
-        }}
-        selected={pinnedReactions.includes(isRecipe.name)}
-        tooltip={
-          <Stack vertical>
-            <Stack.Item fontSize="0.9em">
-              Left click to pin this recipe.
-            </Stack.Item>
-            <Stack.Item fontSize="0.9em">
-              Right click to search for this recipe.
-            </Stack.Item>
-          </Stack>
-        }
-      >
+      <Button fluid ellipsis disabled icon="question">
         {formatReagentName(reagentComponent.amount, reagentComponent.name)}
       </Button>
     );
-  }
 
-  // otherwise, just display the name
   return (
-    <Button fluid ellipsis disabled icon="question">
-      {formatReagentName(reagentComponent.amount, reagentComponent.name)}
-    </Button>
+    <Floating
+      handleOpen={
+        frozenRecipes.includes(foundRecipe.name) ||
+        hoveredRecipe === foundRecipe.name
+      }
+      disabled
+      placement="left"
+      closeAfterInteract={false}
+      content={
+        <Stack
+          vertical
+          backgroundColor="black"
+          p={1}
+          style={{
+            borderRadius: '4px',
+            flexDirection: 'column',
+          }}
+        >
+          <Stack.Item fontSize="0.9em" align="center" italic>
+            Click reagent to{' '}
+            {frozenRecipes.includes(foundRecipe.name) ? 'unfreeze' : 'freeze'}{' '}
+            tooltip.
+          </Stack.Item>
+          <Stack.Item>
+            <ReactionDisplay
+              noDropdown={true}
+              reaction={foundRecipe}
+              pinnedReactions={pinnedReactions}
+              setPinnedReactions={setPinnedReactions}
+              frozenRecipes={frozenRecipes}
+              setFrozenRecipes={setFrozenRecipes}
+              hoveredRecipe={hoveredRecipe}
+              setHoveredRecipe={setHoveredRecipe}
+              recipeButtonRefs={recipeButtonRefs}
+            />
+          </Stack.Item>
+        </Stack>
+      }
+    >
+      <div
+        ref={(node) => {
+          if (node && !recipeButtonRefs.current.includes(node)) {
+            recipeButtonRefs.current.push(node);
+          }
+        }}
+      >
+        <Button
+          icon="book"
+          fluid
+          ellipsis
+          backgroundColor="default"
+          onClick={() => {
+            setFrozenRecipes(
+              frozenRecipes.includes(foundRecipe.name)
+                ? frozenRecipes.filter(
+                    (reaction) => reaction !== foundRecipe.name,
+                  )
+                : [...frozenRecipes, foundRecipe.name],
+            );
+          }}
+          onMouseEnter={() => {
+            setHoveredRecipe(foundRecipe.name);
+          }}
+          onMouseLeave={() => {
+            setHoveredRecipe(null);
+          }}
+          selected={frozenRecipes.includes(foundRecipe.name)}
+        >
+          {formatReagentName(reagentComponent.amount, reagentComponent.name)}
+        </Button>
+      </div>
+    </Floating>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef, useState } from 'react';
 import {
   BlockQuote,
   Box,
@@ -157,28 +156,6 @@ export const ChemDispenser = (props) => {
   const mainWidth = 565;
   const reactionWidth = 245;
   const windowWidth = mainWidth + (showReactionList ? reactionWidth : 0);
-
-  const [frozenRecipes, setFrozenRecipes] = useState<string[]>([]);
-  const [hoveredRecipe, setHoveredRecipe] = useState<string | null>(null);
-
-  const recipeButtonRefs = useRef<HTMLDivElement[]>([]);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        !recipeButtonRefs.current.some((ref) =>
-          ref.contains(event.target as Node),
-        )
-      ) {
-        setFrozenRecipes([]);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [recipeButtonRefs]);
 
   return (
     <Window width={windowWidth} height={620}>
@@ -444,18 +421,7 @@ export const ChemDispenser = (props) => {
                   </Stack.Item>
                   <Stack.Divider />
                   <Stack.Item grow mt={1}>
-                    <Section
-                      scrollable
-                      fill
-                      onScroll={() => {
-                        if (hoveredRecipe) {
-                          setHoveredRecipe(null);
-                        }
-                        if (frozenRecipes.length > 0) {
-                          setFrozenRecipes([]);
-                        }
-                      }}
-                    >
+                    <Section scrollable fill>
                       <Stack vertical>
                         {filteredReactions.length > 0 ? (
                           filteredReactions.map((reaction) => (
@@ -464,11 +430,6 @@ export const ChemDispenser = (props) => {
                                 reaction={reaction}
                                 pinnedReactions={pinnedReactions}
                                 setPinnedReactions={setPinnedReactions}
-                                frozenRecipes={frozenRecipes}
-                                setFrozenRecipes={setFrozenRecipes}
-                                hoveredRecipe={hoveredRecipe}
-                                setHoveredRecipe={setHoveredRecipe}
-                                recipeButtonRefs={recipeButtonRefs}
                               />
                             </Stack.Item>
                           ))
@@ -540,25 +501,10 @@ type ReactionDisplayProps = {
   reaction: ReagentReaction;
   pinnedReactions: ReactionTypepath[];
   setPinnedReactions: (reactions: ReactionTypepath[]) => void;
-  frozenRecipes: string[];
-  setFrozenRecipes: (reactions: string[]) => void;
-  hoveredRecipe: string | null;
-  setHoveredRecipe: (recipe: string | null) => void;
-  recipeButtonRefs: React.RefObject<HTMLDivElement[]>;
 };
 
 const ReactionDisplay = (props: ReactionDisplayProps) => {
-  const {
-    noDropdown,
-    reaction,
-    pinnedReactions,
-    setPinnedReactions,
-    frozenRecipes,
-    setFrozenRecipes,
-    hoveredRecipe,
-    setHoveredRecipe,
-    recipeButtonRefs,
-  } = props;
+  const { noDropdown, reaction, pinnedReactions, setPinnedReactions } = props;
 
   const recipeList = (
     <BlockQuote>
@@ -572,11 +518,6 @@ const ReactionDisplay = (props: ReactionDisplayProps) => {
               reagentComponent={reagent}
               pinnedReactions={pinnedReactions}
               setPinnedReactions={setPinnedReactions}
-              frozenRecipes={frozenRecipes}
-              setFrozenRecipes={setFrozenRecipes}
-              hoveredRecipe={hoveredRecipe}
-              setHoveredRecipe={setHoveredRecipe}
-              recipeButtonRefs={recipeButtonRefs}
             />
           </Stack.Item>
         ))}
@@ -593,11 +534,6 @@ const ReactionDisplay = (props: ReactionDisplayProps) => {
                   reagentComponent={catalyst}
                   pinnedReactions={pinnedReactions}
                   setPinnedReactions={setPinnedReactions}
-                  frozenRecipes={frozenRecipes}
-                  setFrozenRecipes={setFrozenRecipes}
-                  hoveredRecipe={hoveredRecipe}
-                  setHoveredRecipe={setHoveredRecipe}
-                  recipeButtonRefs={recipeButtonRefs}
                 />
               </Stack.Item>
             ))}
@@ -730,11 +666,6 @@ type ReactionComponentDisplayProps = {
   reagentComponent: ReactionComponent;
   pinnedReactions: ReactionTypepath[];
   setPinnedReactions: (reactions: ReactionTypepath[]) => void;
-  frozenRecipes: string[];
-  setFrozenRecipes: (reactions: string[]) => void;
-  hoveredRecipe: string | null;
-  setHoveredRecipe: (recipe: string | null) => void;
-  recipeButtonRefs: React.RefObject<HTMLDivElement[]>;
 };
 
 // linkifies a reagent name in the reaction display
@@ -742,16 +673,7 @@ type ReactionComponentDisplayProps = {
 // if it's another recipe, it will put that recipe in the search box
 // if it's nothing, it's not a button
 const ReactionComponentDisplay = (props: ReactionComponentDisplayProps) => {
-  const {
-    reagentComponent,
-    pinnedReactions,
-    setPinnedReactions,
-    frozenRecipes,
-    setFrozenRecipes,
-    hoveredRecipe,
-    setHoveredRecipe,
-    recipeButtonRefs,
-  } = props;
+  const { reagentComponent, pinnedReactions, setPinnedReactions } = props;
   const { data } = useBackend<Data>();
   const { chemicals, reaction_list } = data;
 
@@ -787,13 +709,10 @@ const ReactionComponentDisplay = (props: ReactionComponentDisplayProps) => {
 
   return (
     <Floating
-      handleOpen={
-        frozenRecipes.includes(foundRecipe.name) ||
-        hoveredRecipe === foundRecipe.name
-      }
-      disabled
       placement="left"
       closeAfterInteract={false}
+      hoverOpen={true}
+      hoverSafePolygon={true}
       content={
         <Stack
           vertical
@@ -804,59 +723,20 @@ const ReactionComponentDisplay = (props: ReactionComponentDisplayProps) => {
             flexDirection: 'column',
           }}
         >
-          <Stack.Item fontSize="0.9em" align="center" italic>
-            Click reagent to{' '}
-            {frozenRecipes.includes(foundRecipe.name) ? 'unfreeze' : 'freeze'}{' '}
-            tooltip.
-          </Stack.Item>
           <Stack.Item>
             <ReactionDisplay
               noDropdown={true}
               reaction={foundRecipe}
               pinnedReactions={pinnedReactions}
               setPinnedReactions={setPinnedReactions}
-              frozenRecipes={frozenRecipes}
-              setFrozenRecipes={setFrozenRecipes}
-              hoveredRecipe={hoveredRecipe}
-              setHoveredRecipe={setHoveredRecipe}
-              recipeButtonRefs={recipeButtonRefs}
             />
           </Stack.Item>
         </Stack>
       }
     >
-      <div
-        ref={(node) => {
-          if (node && !recipeButtonRefs.current.includes(node)) {
-            recipeButtonRefs.current.push(node);
-          }
-        }}
-      >
-        <Button
-          icon="book"
-          fluid
-          ellipsis
-          backgroundColor="default"
-          onClick={() => {
-            setFrozenRecipes(
-              frozenRecipes.includes(foundRecipe.name)
-                ? frozenRecipes.filter(
-                    (reaction) => reaction !== foundRecipe.name,
-                  )
-                : [...frozenRecipes, foundRecipe.name],
-            );
-          }}
-          onMouseEnter={() => {
-            setHoveredRecipe(foundRecipe.name);
-          }}
-          onMouseLeave={() => {
-            setHoveredRecipe(null);
-          }}
-          selected={frozenRecipes.includes(foundRecipe.name)}
-        >
-          {formatReagentName(reagentComponent.amount, reagentComponent.name)}
-        </Button>
-      </div>
+      <Button icon="book" fluid ellipsis backgroundColor="default">
+        {formatReagentName(reagentComponent.amount, reagentComponent.name)}
+      </Button>
     </Floating>
   );
 };

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   BlockQuote,
   Box,
@@ -501,10 +502,17 @@ type ReactionDisplayProps = {
   reaction: ReagentReaction;
   pinnedReactions: ReactionTypepath[];
   setPinnedReactions: (reactions: ReactionTypepath[]) => void;
+  setParentForceFloating?: (force: boolean) => void;
 };
 
 const ReactionDisplay = (props: ReactionDisplayProps) => {
-  const { noDropdown, reaction, pinnedReactions, setPinnedReactions } = props;
+  const {
+    noDropdown,
+    reaction,
+    pinnedReactions,
+    setPinnedReactions,
+    setParentForceFloating,
+  } = props;
 
   const recipeList = (
     <BlockQuote>
@@ -518,6 +526,7 @@ const ReactionDisplay = (props: ReactionDisplayProps) => {
               reagentComponent={reagent}
               pinnedReactions={pinnedReactions}
               setPinnedReactions={setPinnedReactions}
+              setParentForceFloating={setParentForceFloating}
             />
           </Stack.Item>
         ))}
@@ -534,6 +543,7 @@ const ReactionDisplay = (props: ReactionDisplayProps) => {
                   reagentComponent={catalyst}
                   pinnedReactions={pinnedReactions}
                   setPinnedReactions={setPinnedReactions}
+                  setParentForceFloating={setParentForceFloating}
                 />
               </Stack.Item>
             ))}
@@ -666,6 +676,7 @@ type ReactionComponentDisplayProps = {
   reagentComponent: ReactionComponent;
   pinnedReactions: ReactionTypepath[];
   setPinnedReactions: (reactions: ReactionTypepath[]) => void;
+  setParentForceFloating?: (force: boolean) => void;
 };
 
 // linkifies a reagent name in the reaction display
@@ -673,7 +684,12 @@ type ReactionComponentDisplayProps = {
 // if it's another recipe, it will put that recipe in the search box
 // if it's nothing, it's not a button
 const ReactionComponentDisplay = (props: ReactionComponentDisplayProps) => {
-  const { reagentComponent, pinnedReactions, setPinnedReactions } = props;
+  const {
+    reagentComponent,
+    pinnedReactions,
+    setPinnedReactions,
+    setParentForceFloating,
+  } = props;
   const { data } = useBackend<Data>();
   const { chemicals, reaction_list } = data;
 
@@ -707,12 +723,24 @@ const ReactionComponentDisplay = (props: ReactionComponentDisplayProps) => {
       </Button>
     );
 
+  const [forceFloating, setForceFloating] = useState(false);
+
   return (
     <Floating
+      handleOpen={forceFloating || undefined}
+      disabled={forceFloating || undefined}
       placement="left"
       closeAfterInteract={false}
       hoverOpen={true}
       hoverSafePolygon={true}
+      onOpenChange={(state) => {
+        if (setParentForceFloating) {
+          setParentForceFloating(state);
+        }
+        if (!state) {
+          setForceFloating(false);
+        }
+      }}
       content={
         <Stack
           vertical
@@ -729,6 +757,7 @@ const ReactionComponentDisplay = (props: ReactionComponentDisplayProps) => {
               reaction={foundRecipe}
               pinnedReactions={pinnedReactions}
               setPinnedReactions={setPinnedReactions}
+              setParentForceFloating={setForceFloating}
             />
           </Stack.Item>
         </Stack>

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -21,6 +21,12 @@ import { Window } from '../layouts';
 import { type Beaker, BeakerDisplay } from './common/BeakerDisplay';
 import { bitflagInfo } from './Reagents/types';
 
+enum DropdownState {
+  NO_DROPDOWN = 0,
+  DROPDOWN_CLOSED = 1,
+  DROPDOWN_OPEN = 2,
+}
+
 type DispensableReagent = {
   title: string;
   id: string;
@@ -428,6 +434,11 @@ export const ChemDispenser = (props) => {
                           filteredReactions.map((reaction) => (
                             <Stack.Item key={reaction.name}>
                               <ReactionDisplay
+                                dropdownState={
+                                  pinnedReactions.includes(reaction.name)
+                                    ? DropdownState.DROPDOWN_OPEN
+                                    : DropdownState.DROPDOWN_CLOSED
+                                }
                                 reaction={reaction}
                                 pinnedReactions={pinnedReactions}
                                 setPinnedReactions={setPinnedReactions}
@@ -498,16 +509,25 @@ const ReagentDispenseButton = (props: ReagentDispenseButtonProps) => {
 };
 
 type ReactionDisplayProps = {
-  noDropdown?: boolean;
+  /// Determines how the collapsible/dropdown is displayed.
+  /// NO_DROPDOWN: no dropdown is displayed, just the recipe list is shown
+  /// DROPDOWN_CLOSED: dropdown is displayed, but closed by default
+  /// DROPDOWN_OPEN: dropdown is displayed and open by default
+  /// If undefined, the default behavior is DROPDOWN_CLOSED.
+  dropdownState?: DropdownState;
+  /// The reaction to display.
   reaction: ReagentReaction;
+  /// List of reactions that are pinned to the top of the list.
   pinnedReactions: ReactionTypepath[];
+  /// Callback to update the list of pinned reactions.
   setPinnedReactions: (reactions: ReactionTypepath[]) => void;
+  /// Callback to force the parent component to keep their floating window open.
   setParentForceFloating?: (force: boolean) => void;
 };
 
 const ReactionDisplay = (props: ReactionDisplayProps) => {
   const {
-    noDropdown,
+    dropdownState,
     reaction,
     pinnedReactions,
     setPinnedReactions,
@@ -631,12 +651,12 @@ const ReactionDisplay = (props: ReactionDisplayProps) => {
         </Stack>
       </Stack.Item>
       <Stack.Item>
-        {noDropdown ? (
+        {dropdownState === DropdownState.NO_DROPDOWN ? (
           recipeList
         ) : (
           <Collapsible
             title="Recipe"
-            open={pinnedReactions.includes(reaction.name)}
+            open={dropdownState === DropdownState.DROPDOWN_OPEN}
           >
             {recipeList}
           </Collapsible>
@@ -673,9 +693,13 @@ function getPHMessage(lower: number, upper: number): string {
 }
 
 type ReactionComponentDisplayProps = {
+  /// What component of the reaction is being displayed.
   reagentComponent: ReactionComponent;
+  /// List of reactions that are pinned to the top of the list.
   pinnedReactions: ReactionTypepath[];
+  /// Callback to update the list of pinned reactions.
   setPinnedReactions: (reactions: ReactionTypepath[]) => void;
+  /// Callback to force the parent component to keep their floating window open.
   setParentForceFloating?: (force: boolean) => void;
 };
 
@@ -727,12 +751,23 @@ const ReactionComponentDisplay = (props: ReactionComponentDisplayProps) => {
 
   return (
     <Floating
+      // `|| undefined` is used to avoid passing `false`.
+      // The component treats `false` as `closed`,
+      // whereas `undefined` means "not controlled",
+      // allowing it to open and close normally.
       handleOpen={forceFloating || undefined}
-      disabled={forceFloating || undefined}
+      // No similar handling is necessary for `disabled`.
+      // If we don't disable it it will close on unhover, for some reason.
+      disabled={forceFloating}
       placement="left"
       closeAfterInteract={false}
+      // `hoverOpen` is obvious, but `hoverSafePolygon` is what is needed
+      // to allow the user to move their mouse over to the floating window.
       hoverOpen={true}
       hoverSafePolygon={true}
+      // When the window state changes, we go up the chain to inform the parent.
+      // At the same time we *always* reset forced state on close,
+      // to prevent it from being stuck in limbo if it somehow closes otherwise.
       onOpenChange={(state) => {
         if (setParentForceFloating) {
           setParentForceFloating(state);
@@ -742,25 +777,33 @@ const ReactionComponentDisplay = (props: ReactionComponentDisplayProps) => {
         }
       }}
       content={
-        <Stack
-          vertical
-          backgroundColor="black"
-          p={1}
+        <Box
+          p={0.5}
+          backgroundColor={`hsl(0, 0%, 15%)`}
           style={{
             borderRadius: '4px',
-            flexDirection: 'column',
+            backdropFilter: 'blur(12px)',
           }}
         >
-          <Stack.Item>
-            <ReactionDisplay
-              noDropdown={true}
-              reaction={foundRecipe}
-              pinnedReactions={pinnedReactions}
-              setPinnedReactions={setPinnedReactions}
-              setParentForceFloating={setForceFloating}
-            />
-          </Stack.Item>
-        </Stack>
+          <Stack
+            backgroundColor="black"
+            p={1}
+            style={{
+              borderRadius: '4px',
+              flexDirection: 'column',
+            }}
+          >
+            <Stack.Item>
+              <ReactionDisplay
+                dropdownState={DropdownState.NO_DROPDOWN}
+                reaction={foundRecipe}
+                pinnedReactions={pinnedReactions}
+                setPinnedReactions={setPinnedReactions}
+                setParentForceFloating={setForceFloating}
+              />
+            </Stack.Item>
+          </Stack>
+        </Box>
       }
     >
       <Button icon="book" fluid ellipsis backgroundColor="default">


### PR DESCRIPTION
## About The Pull Request

- Left clicking sub-recipes in the recipe browser no longer pins the recipe
- Right clicking sub-recipes in the recipe browser no longer puts text in the search bar

- Hovering the a sub-recipe shows the sub-recipe in the tooltip
- You can move your mouse over the sub-recipe tooltip to hover over sub-sub-recipes, as far as your hearts content

<img width="611" height="374" alt="image" src="https://github.com/user-attachments/assets/fb259ab7-b4a9-4f38-85cd-9186ea52c99a" />

## Why It's Good For The Game

More convenient than having to constantly change the search bar

## Changelog

:cl: Melbert
del: Chem dispenser: Left clicking sub-recipes in the recipe browser no longer pins the recipe
del: Chem dispenser: Right clicking sub-recipes in the recipe browser no longer puts the recipe in the search bar
qol: Chem dispenser: Hovering over sub-recipes shows the sub-recipe in the tooltip itself
qol: Chem dispenser: You can move your mouse over sub-recipe tooltips to view sub-sub-recipes (like how the wiki works)
qol: Chem dispenser: Sodium Chloride recipe is now shown in the recipe browser. In case you somehow forget it like me, despite the name literally being the recipe to make it
/:cl:

