### PR TITLE
Puts showers and destructive scanners on more sensible layers

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_INIT(shower_mode_descriptions, list(
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "shower"
 	density = FALSE
-	layer = ABOVE_WINDOW_LAYER
+	layer = ABOVE_MOB_LAYER
 	use_power = NO_POWER_USE
 	subsystem_type = /datum/controller/subsystem/processing/plumbing
 	///Does the user want the shower on or off?

--- a/code/modules/experisci/destructive_scanner.dm
+++ b/code/modules/experisci/destructive_scanner.dm
@@ -9,7 +9,6 @@
 	icon = 'icons/obj/machines/destructive_scanner.dmi'
 	icon_state = "tube_open"
 	circuit = /obj/item/circuitboard/machine/destructive_scanner
-	layer = MOB_LAYER
 	var/scanning = FALSE
 
 // Late load to ensure the component initialization occurs after the machines are initialized


### PR DESCRIPTION

## About The Pull Request
Title

## Why It's Good For The Game
Before:
<img width="624" height="415" alt="image" src="https://github.com/user-attachments/assets/b2a2ea22-3180-4859-9092-dd977a39f59e" />

After:
<img width="618" height="411" alt="image" src="https://github.com/user-attachments/assets/e90663b9-6dd8-4c05-8d9c-f8013324783c" />


## Changelog
:cl: PapaMichael
fix: Showers and destructive scanners now render on their proper layers
/:cl:
