### PR TITLE
Require admin for verbs/request_typepaths

### DIFF
--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -110,6 +110,8 @@
 		return TRUE
 
 	if(type == "verbs/request_typepaths")
+		if(!client?.holder)
+			return TRUE
 		var/parent_text = payload["parent"]
 		var/browse_type = text2path(parent_text)
 		if(isnull(browse_type))


### PR DESCRIPTION
No non-admin paths call this, no reason for them to