### PR TITLE
Silence warning in upload screenshot tests step

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -71,6 +71,7 @@ jobs:
           name: test_artifacts_${{ inputs.map }}_${{ inputs.major || env.BYOND_MAJOR }}_${{ inputs.minor || env.BYOND_MINOR }}
           path: data/screenshots_new/
           retention-days: 1
+          if-no-files-found: ignore
       - name: On test fail, write a step summary
         if: always() && steps.run_tests.outcome == 'failure'
         run: |


### PR DESCRIPTION

## About The Pull Request

With how CI is split up now all but two tests don't actually produce screenshots to upload, meaning they emit a warning that we don't care about

## Why It's Good For The Game

Silence

## Changelog

N/A