### PR TITLE
Set appropriate parent type for incorrect type path route in request_typepaths operations.

### DIFF
--- a/code/modules/admin/admin_verb_panel.dm
+++ b/code/modules/admin/admin_verb_panel.dm
@@ -141,6 +141,7 @@ ADMIN_VERB(admin_verb_panel, R_NONE, "Admin Verb Panel", "Browse and invoke admi
 			var/browse_type = text2path(parent_text)
 			if(isnull(browse_type))
 				browse_type = /datum
+				parent_text = "/datum"
 			typepath_parent = parent_text || "/datum"
 			typepath_children = list()
 			for(var/child_type in typesof(browse_type))

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -116,6 +116,7 @@
 		var/browse_type = text2path(parent_text)
 		if(isnull(browse_type))
 			browse_type = /datum
+			parent_text = "/datum"
 		var/list/children = list()
 		for(var/child_type in typesof(browse_type))
 			if(child_type == browse_type)


### PR DESCRIPTION

## About The Pull Request
When an invalid type path is fed into a `request_typepaths` operations, `text2path` will resolve `null` and then the default fallback is to assume the type is `/datum`.

The `parent_text` - which contains the invalid type in this circumstance - is never changed though.

Later logic utilises the length of the `parent_text` to `continue` over a for loop iteration where the type path in question is not a "direct child". When `parent_text`'s length is mismatched to `browse_type`, this logic fails:

```
			// Only include direct children (one level deeper)
			var/child_text = "[child_type]"
			var/parent_len = length(parent_text || "/datum")
			var/remainder = copytext(child_text, parent_len + 1)
			if(findtext(remainder, "/", 2))
				continue
			children += child_text
```

and parent_len inherits the length of the invalid type string instead of the length of `"/datum"`. In extreme cases like `/datum/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/` this means that datum subtypes with a path character length below this invalid type's string length get added as children even though they may not be direct children.

By default "/datum" itself ends up with a list of 663 direct children.

"/datum/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/" ends up with a list of 45k subtypes.

<img width="589" height="521" alt="image" src="https://github.com/user-attachments/assets/5456b74f-47ba-449e-8aea-83ff5c5b5383" />

That's just taking the entire `typesof(/datum)` list and coping it to a new list. In verbtime.

This **doesn't** change the fact that searching `/datum/...` subtypes does 45k iterations over a for loop in verbtime for every keystroke the admin does until the parent type is no longer `/datum`, but it does at least fix a logic flaw that could potentially cause other issues (passing around or manipulating a list of 45k elements may not have the most predictable performance) and should probably be fixed regardless.

## Why It's Good For The Game
Logic error feex.

## Changelog
:cl:
fix: Fixed a logic error in admin menu typepath auto-resolving/filtering. Shouldn't be user-facing, but may improve UI performance in some wild and nonsensical edge cases.
/:cl:
