### PR TITLE
Fix hydrogen readability in the crystallizer

### DIFF
--- a/tgui/packages/tgui/interfaces/Crystallizer.test.tsx
+++ b/tgui/packages/tgui/interfaces/Crystallizer.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+import { act, render, screen } from '@testing-library/react';
+import { gameDataAtom, store } from '../events/store';
+
+import { Crystallizer } from './Crystallizer';
+
+store.set(gameDataAtom, {
+  on: 0,
+  requirements: '',
+  internal_temperature: 293.15,
+  progress_bar: 0,
+  gas_input: 0,
+  selected: '',
+  selected_recipes: [],
+  internal_gas_data: [
+    { id: 'hydrogen', name: 'Hydrogen', amount: 1000 },
+    { id: 'o2', name: 'Oxygen', amount: 500 },
+  ],
+});
+
+describe('Crystallizer', () => {
+  it('uses dark text for hydrogen without changing other gas labels', () => {
+    act(() => render(<Crystallizer />));
+
+    const hydrogenAmount = screen.getByText(/^1000(?:\.00)? moles$/);
+    const oxygenAmount = screen.getByText(/^500(?:\.00)? moles$/);
+
+    expect(hydrogenAmount.classList.contains('color-black')).toBe(true);
+    expect(oxygenAmount.classList.contains('color-black')).toBe(false);
+  });
+});

--- a/tgui/packages/tgui/interfaces/Crystallizer.tsx
+++ b/tgui/packages/tgui/interfaces/Crystallizer.tsx
@@ -157,7 +157,13 @@ const Gases = (props) => {
               minValue={0}
               maxValue={1000}
             >
-              {`${toFixed(amount, 2)} moles`}
+              {id === 'hydrogen' ? (
+                <Box inline color="black">
+                  {`${toFixed(amount, 2)} moles`}
+                </Box>
+              ) : (
+                `${toFixed(amount, 2)} moles`
+              )}
             </ProgressBar>
           </LabeledList.Item>
         ))}


### PR DESCRIPTION
## About The Pull Request

The crystallizer now renders the hydrogen mole count in black while keeping hydrogen's white progress-bar fill. Other gases keep their existing text styling.

Adds a component regression test covering both the hydrogen contrast and an unchanged oxygen label.

Fixes #94686

## Why It's Good For The Game

Hydrogen's white fill made its light mole-count text disappear as the bar filled. Black text restores clear contrast without changing hydrogen's established gas color or affecting other gas displays.

## Testing

- `bin/tgui-build.cmd`
- TGUI production bundle compiled successfully
- TypeScript and Biome checks passed
- 26 TGUI tests passed

## Changelog

:cl:
fix: Hydrogen amounts in the crystallizer are now readable against the white progress bar.
/:cl: