### PR TITLE
Fixes mirrors giving you bad luck with each hit, rather only when broken

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -298,8 +298,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror/broken, 28)
 	return .
 
 /obj/structure/mirror/attacked_by(obj/item/I, mob/living/user, list/modifiers, list/attack_modifiers)
+	if(broken)
+		return ..()
 	. = ..()
-	if(broken || . <= 0) // breaking a mirror truly gets you bad luck!
+	if(!broken || . <= 0) // breaking a mirror truly gets you bad luck!
 		return
 	to_chat(user, span_warning("A chill runs down your spine as [src] shatters..."))
 	user.AddComponent(/datum/component/omen, incidents_left = 7)


### PR DESCRIPTION

## About The Pull Request

Been broken for at least a year

## Changelog
:cl:
fix: Fixed mirrors giving you bad luck with each hit, rather only when broken
/:cl:
