### PR TITLE
Fixes the Acrobatics skillchip not overheating you like it should

### DIFF
--- a/code/datums/status_effects/debuffs/temperature_over_time.dm
+++ b/code/datums/status_effects/debuffs/temperature_over_time.dm
@@ -51,7 +51,7 @@
 	return "[owner.p_They()] [owner.p_are()] shivering!"
 
 /datum/status_effect/temperature_over_time/tick(seconds_between_ticks)
-	if((TRAIT_RESISTHEAT && temperature_value > 1) || (TRAIT_RESISTCOLD && temperature_value < 1))
+	if((HAS_TRAIT(owner, TRAIT_RESISTHEAT) && temperature_value > 1) || (HAS_TRAIT(owner, TRAIT_RESISTCOLD) && temperature_value < 1))
 		qdel(src) // git out
 		return
 	temperaturetion(seconds_between_ticks)


### PR DESCRIPTION

## About The Pull Request

`temperature_over_time` got cleared on its first tick


## Changelog

:cl: PapaMichael
fix: Using shady skillchips to flip really fast is dangerous to your body's temperature
/:cl:
