### PR TITLE
It's good to be the king: Captain gets a discount in all departments

### DIFF
--- a/code/modules/vending/vendor/_vending.dm
+++ b/code/modules/vending/vendor/_vending.dm
@@ -187,6 +187,15 @@
 
 	//the path of the fish_source datum to use for the fishing_spot component
 	var/fish_source_path = /datum/fish_source/vending
+	var/static/alist/boss_trims = alist(
+		/datum/id_trim/job/chief_engineer = TRUE,
+		/datum/id_trim/job/chief_medical_officer = TRUE,
+		/datum/id_trim/job/head_of_security = TRUE,
+		/datum/id_trim/job/head_of_personnel = TRUE,
+		/datum/id_trim/job/research_director = TRUE,
+		/datum/id_trim/job/quartermaster = TRUE
+		)
+	var/static/datum/id_trim/job/big_boss_trim = /datum/id_trim/job/captain
 
 /datum/armor/machinery_vending
 	melee = 20

--- a/code/modules/vending/vendor/_vending.dm
+++ b/code/modules/vending/vendor/_vending.dm
@@ -187,6 +187,10 @@
 
 	//the path of the fish_source datum to use for the fishing_spot component
 	var/fish_source_path = /datum/fish_source/vending
+	/**
+	 * used to check for discounting and for displaying discounted prices in the UI; not a static proc-local var because the code for displaying and applying
+	 * discounts isn't unified across DM and tgui
+	 */
 	var/static/datum/id_trim/job/big_boss_trim = /datum/id_trim/job/captain
 
 /datum/armor/machinery_vending

--- a/code/modules/vending/vendor/_vending.dm
+++ b/code/modules/vending/vendor/_vending.dm
@@ -187,14 +187,6 @@
 
 	//the path of the fish_source datum to use for the fishing_spot component
 	var/fish_source_path = /datum/fish_source/vending
-	var/static/alist/boss_trims = alist(
-		/datum/id_trim/job/chief_engineer = TRUE,
-		/datum/id_trim/job/chief_medical_officer = TRUE,
-		/datum/id_trim/job/head_of_security = TRUE,
-		/datum/id_trim/job/head_of_personnel = TRUE,
-		/datum/id_trim/job/research_director = TRUE,
-		/datum/id_trim/job/quartermaster = TRUE
-		)
 	var/static/datum/id_trim/job/big_boss_trim = /datum/id_trim/job/captain
 
 /datum/armor/machinery_vending

--- a/code/modules/vending/vendor/inventory.dm
+++ b/code/modules/vending/vendor/inventory.dm
@@ -293,12 +293,8 @@
 
 /obj/machinery/vending/proc/discount_check(obj/item/card/id/paying_id_card, premium)
 	PROTECTED_PROC(TRUE)
-	var/big_boss_that_makes_all_the_rules = istype(paying_id_card.trim, big_boss_trim)
-	var/is_the_boss = big_boss_that_makes_all_the_rules || boss_trims[paying_id_card.trim?.type]
+	if(premium)
+		return FALSE
 	var/datum/bank_account/account = paying_id_card.registered_account
-	//captain gets a dicount in every department
-	if(big_boss_that_makes_all_the_rules || account.account_job?.paycheck_department == payment_department)
-	//heads of staff get a discount even on premium goods; it's good to be the king
-		if(!premium || is_the_boss)
-			return TRUE
-	return FALSE
+	//captain gets a discount in every department
+	return istype(paying_id_card.trim, big_boss_trim) || account.account_job?.paycheck_department == payment_department

--- a/code/modules/vending/vendor/inventory.dm
+++ b/code/modules/vending/vendor/inventory.dm
@@ -185,7 +185,7 @@
 			flick(icon_deny, src)
 			return
 
-		if(!proceed_payment(card_used, living_user, item_record, price_to_use, params["discountless"]))
+		if(!proceed_payment(card_used, living_user, item_record, price_to_use, params["premium"]))
 			return
 
 	if(last_shopper != REF(user) || purchase_message_cooldown < world.time)
@@ -265,9 +265,9 @@
  * mob_paying - the mob that is trying to purchase the item.
  * product_to_vend - the product record of the item we're trying to vend.
  * price_to_use - price of the item we're trying to vend.
- * discountless - whether or not to apply discounts
+ * premium - whether or not to apply premium pricing
  */
-/obj/machinery/vending/proc/proceed_payment(obj/item/card/id/paying_id_card, mob/living/mob_paying, datum/data/vending_product/product_to_vend, price_to_use, discountless)
+/obj/machinery/vending/proc/proceed_payment(obj/item/card/id/paying_id_card, mob/living/mob_paying, datum/data/vending_product/product_to_vend, price_to_use, premium)
 	PROTECTED_PROC(TRUE)
 
 	//returned items are free
@@ -278,7 +278,7 @@
 	var/datum/bank_account/account = paying_id_card.registered_account
 
 	//deduct money from person
-	if(!discountless && account.account_job?.paycheck_department == payment_department)
+	if(discount_check(paying_id_card, premium))
 		price_to_use = max(round(price_to_use * DEPARTMENT_DISCOUNT), 1) //No longer free, but signifigantly cheaper.
 	if(attempt_charge(src, mob_paying, price_to_use) & COMPONENT_OBJ_CANCEL_CHARGE)
 		speak("You do not possess the funds to purchase [product_to_vend.name].")
@@ -290,3 +290,15 @@
 	log_econ("[price_to_use] [MONEY_NAME] were inserted into [src] by [account.account_holder] to buy [product_to_vend].")
 	credits_contained += round(price_to_use * VENDING_CREDITS_COLLECTION_AMOUNT)
 	return TRUE
+
+/obj/machinery/vending/proc/discount_check(obj/item/card/id/paying_id_card, premium)
+	PROTECTED_PROC(TRUE)
+	var/big_boss_that_makes_all_the_rules = istype(paying_id_card.trim, big_boss_trim)
+	var/is_the_boss = big_boss_that_makes_all_the_rules || boss_trims[paying_id_card.trim?.type]
+	var/datum/bank_account/account = paying_id_card.registered_account
+	//captain gets a dicount in every department
+	if(big_boss_that_makes_all_the_rules || account.account_job?.paycheck_department == payment_department)
+	//heads of staff get a discount even on premium goods; it's good to be the king
+		if(!premium || is_the_boss)
+			return TRUE
+	return FALSE

--- a/code/modules/vending/vendor/ui_data.dm
+++ b/code/modules/vending/vendor/ui_data.dm
@@ -114,6 +114,8 @@
 		user_data = list()
 		user_data["name"] = card_used.registered_account.account_holder
 		user_data["cash"] = fetch_balance_to_use(card_used) + held_cash
+		user_data["is_captain_card"] = istype(card_used.trim, big_boss_trim)
+		user_data["is_boss"] = (istype(card_used.trim, big_boss_trim) || boss_trims[card_used.trim?.type]) ? TRUE : FALSE
 		if(card_used.registered_account.account_job)
 			user_data["job"] = card_used.registered_account.account_job.title
 			user_data["department"] = card_used.registered_account.account_job.paycheck_department

--- a/code/modules/vending/vendor/ui_data.dm
+++ b/code/modules/vending/vendor/ui_data.dm
@@ -115,7 +115,6 @@
 		user_data["name"] = card_used.registered_account.account_holder
 		user_data["cash"] = fetch_balance_to_use(card_used) + held_cash
 		user_data["is_captain_card"] = istype(card_used.trim, big_boss_trim)
-		user_data["is_boss"] = (istype(card_used.trim, big_boss_trim) || boss_trims[card_used.trim?.type]) ? TRUE : FALSE
 		if(card_used.registered_account.account_job)
 			user_data["job"] = card_used.registered_account.account_job.title
 			user_data["department"] = card_used.registered_account.account_job.paycheck_department

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -37,6 +37,8 @@ type UserData = {
   cash: number;
   job: string;
   department: string;
+  is_captain_card: boolean;
+  is_boss: boolean;
 };
 
 type Category = {
@@ -258,7 +260,9 @@ const Product = (props: ProductProps) => {
 
   const colorable = !!product.colorable;
   const free = all_products_free || productStock.free || product.price === 0;
-  const discount = !product.premium && department === user?.department;
+  const discount =
+    user?.is_captain_card ||
+    (department === user?.department && (!product.premium || user?.is_boss));
   const remaining = productStock.amount;
   const redPrice = Math.round(product.price * jobDiscount);
   const disabled =
@@ -282,7 +286,7 @@ const Product = (props: ProductProps) => {
     onClick: () => {
       act('vend', {
         ref: product.ref,
-        discountless: !!product.premium,
+        premium: !!product.premium,
       });
     },
   };

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -38,7 +38,6 @@ type UserData = {
   job: string;
   department: string;
   is_captain_card: boolean;
-  is_boss: boolean;
 };
 
 type Category = {
@@ -261,8 +260,8 @@ const Product = (props: ProductProps) => {
   const colorable = !!product.colorable;
   const free = all_products_free || productStock.free || product.price === 0;
   const discount =
-    user?.is_captain_card ||
-    (department === user?.department && (!product.premium || user?.is_boss));
+    !product.premium &&
+    (user?.is_captain_card || department === user?.department);
   const remaining = productStock.amount;
   const redPrice = Math.round(product.price * jobDiscount);
   const disabled =


### PR DESCRIPTION

## About The Pull Request
The Captain is treated as a member of every department for the sake of discounts.

The additional logic for this is associated to the trim on the current ID, rather than on their bank account's job information. I preferred this, so that acting captains would benefit from the unilateral discounting, and also because it seemed annoying to do it the other way.

## Why It's Good For The Game
It lets the Captain get discounts everywhere like a boss.

## Changelog
:cl: Metek
balance: The Captain is now treated as a member of every department, for the purpose of department-related vendor discounts.
code: The logic for determining a discount has been cleaned up a bit.
/:cl:
