### PR TITLE
Prevents the destruction of clown shoes by loadouts

### DIFF
--- a/code/modules/loadout/categories/shoes.dm
+++ b/code/modules/loadout/categories/shoes.dm
@@ -9,6 +9,10 @@
 	abstract_type = /datum/loadout_item/shoes
 
 /datum/loadout_item/shoes/insert_path_into_outfit(datum/outfit/outfit, mob/living/carbon/human/equipper, visuals_only = FALSE)
+	// This prevents clown shoes from being destroyed, for such would be SACRILEGE.
+	if(!isnull(equipper) && is_clown_job(equipper.mind?.assigned_role))
+		return ..() // Parent calling puts them into the clown's backpack (as a test of character).
+
 	outfit.shoes = item_path
 
 /datum/loadout_item/shoes/sneakers

--- a/code/modules/loadout/categories/shoes.dm
+++ b/code/modules/loadout/categories/shoes.dm
@@ -10,7 +10,7 @@
 
 /datum/loadout_item/shoes/insert_path_into_outfit(datum/outfit/outfit, mob/living/carbon/human/equipper, visuals_only = FALSE)
 	// This prevents clown shoes from being destroyed, for such would be SACRILEGE.
-	if(!isnull(equipper) && is_clown_job(equipper.mind?.assigned_role))
+	if(istype(outfit, /datum/outfit/job/clown))
 		return ..() // Parent calling puts them into the clown's backpack (as a test of character).
 
 	outfit.shoes = item_path


### PR DESCRIPTION

## About The Pull Request
Closes #90202

This PR prevents the destruction of clown shoes by character loadout shoes. To this end, any loadout shoes chosen by clowns start in their backpack instead.
## Why It's Good For The Game
Clown shoes are important for clowns.
## Changelog
:cl:
qol: Clown shoes are no longer destroyed by character loadouts.
/:cl:
