### PR TITLE
Fixes async blinking forcing an eye shut forever

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -523,7 +523,9 @@
 		. += wait_time
 		if (anim_times && !sync_blinking)
 			// Make sure that we're somewhat in sync with the other eye
-			animate(time = anim_times[i + 1] - wait_time)
+			var/offset_time = anim_times[i + 1] - wait_time
+			if(offset_time) // For some reason having time == 0 in this case breaks animate
+				animate(time = offset_time)
 		animate(alpha = 255, time = 0)
 		animate(time = BLINK_DURATION)
 		if (i != cycles)


### PR DESCRIPTION

## About The Pull Request

Closes #97540
Fixes #93654

It seems like doing 2 `animate(time = 0)` in a row breaks looping animations completely for reasons that I don't quite understand.

<details>
<summary>Demonstration of fix working</summary>

https://github.com/user-attachments/assets/a141307d-43fe-4701-98ca-92d89ef43d39

</details>

## Alien Specimen

<img width="2048" height="1843" alt="image" src="https://github.com/user-attachments/assets/02bd990d-6a96-434e-8b7f-4010b1dc24f4" />


## Changelogs

:cl:
fix: Lizards and brain-damaged animals no longer suffer from unintended spontaneous aneurysms
/:cl: