### PR TITLE
Great big atmos grammar and qol pas

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_core.dm
+++ b/code/__DEFINES/atmospherics/atmos_core.dm
@@ -179,3 +179,7 @@
 #define ATMOS_PRESSURE_ERROR_TOLERANCE 0.01
 /// Helper function for retrieving gas meta info for use in performace critical places
 #define GAS_META /datum/gas_mixture::gas_meta
+
+#define GAS_EXPORTABLE (1 << 0)
+#define GAS_PURCHASABLE (1 << 1)
+#define GAS_DANGEROUS (1 << 2)

--- a/code/__DEFINES/atmospherics/atmos_core.dm
+++ b/code/__DEFINES/atmospherics/atmos_core.dm
@@ -180,6 +180,10 @@
 /// Helper function for retrieving gas meta info for use in performace critical places
 #define GAS_META /datum/gas_mixture::gas_meta
 
+// Flags for gas-cargo handling
+/// Gas can be sold in canisters
 #define GAS_EXPORTABLE (1 << 0)
+/// Gas can be purchased in canisters
 #define GAS_PURCHASABLE (1 << 1)
+/// Gas is dangerous and may need additional access
 #define GAS_DANGEROUS (1 << 2)

--- a/code/__HELPERS/atmospherics.dm
+++ b/code/__HELPERS/atmospherics.dm
@@ -49,7 +49,7 @@
 			cached_gas_name[gas_path],
 			amount,
 		))
-	for(var/datum/gas_reaction/reaction_result as anything in gasmix.reaction_results)
+	for(var/datum/gas_reaction/standard/reaction_result as anything in gasmix.reaction_results)
 		.["reactions"] += list(list(
 			initial(reaction_result.id),
 			initial(reaction_result.name),
@@ -84,10 +84,11 @@ GLOBAL_LIST_EMPTY(gas_handbook)
 		gas_info["name"] = meta_information[META_GAS_NAME][gas_path]
 		gas_info["description"] = meta_information[META_GAS_DESC][gas_path]
 		gas_info["specific_heat"] = meta_information[META_GAS_SPECIFIC_HEAT][gas_path]
+		gas_info["export_value"] = (gas_path::cargo_flags & GAS_EXPORTABLE) ? gas_path::base_value : 0
 		gas_info["reactions"] = list()
 		momentary_gas_list[gas_path] = gas_info
 
-	for (var/datum/gas_reaction/reaction_path as anything in subtypesof(/datum/gas_reaction))
+	for (var/datum/gas_reaction/standard/reaction_path as anything in valid_subtypesof(/datum/gas_reaction))
 		var/datum/gas_reaction/reaction = new reaction_path
 		var/list/reaction_info = list()
 		reaction_info["id"] = reaction.id
@@ -109,44 +110,13 @@ GLOBAL_LIST_EMPTY(gas_handbook)
 				if(factor == "Temperature" || factor == "Pressure")
 					factor_info["tooltip"] = "Reaction is influenced by the [LOWER_TEXT(factor)] of the place where the reaction is occurring."
 				else if(factor == "Energy")
-					factor_info["tooltip"] = "Energy released by the reaction, may or may not result in linear temperature change depending on a slew of other factors."
+					factor_info["tooltip"] = "Energy released by the reaction. May or may not result in linear temperature change depending on a slew of other factors."
 				else if(factor == "Radiation")
-					factor_info["tooltip"] = "This reaction emits dangerous radiation! Take precautions."
+					factor_info["tooltip"] = "This reaction emits hazardous radiation - take precautions."
 				else if (factor == "Location")
 					factor_info["tooltip"] = "This reaction has special behaviour when occurring in specific locations."
 				else if(factor == "Hot Ice")
 					factor_info["tooltip"] = "Hot ice are solidified stacks of plasma. Ignition of one will result in a raging fire."
-			reaction_info["factors"] += list(factor_info)
-		GLOB.reaction_handbook += list(reaction_info)
-		qdel(reaction)
-
-	for (var/datum/electrolyzer_reaction/reaction_path as anything in subtypesof(/datum/electrolyzer_reaction))
-		var/datum/electrolyzer_reaction/reaction = new reaction_path
-		var/list/reaction_info = list()
-		reaction_info["id"] = reaction.id
-		reaction_info["name"] = reaction.name
-		reaction_info["description"] = reaction.desc
-		reaction_info["factors"] = list()
-		for (var/factor in reaction.factor)
-			var/list/factor_info = list()
-			factor_info["desc"] = reaction.factor[factor]
-
-			if(factor in momentary_gas_list)
-				momentary_gas_list[factor]["reactions"] += list(reaction.id = reaction.name)
-				factor_info["factor_id"] = momentary_gas_list[factor]["id"] //Gas id
-				factor_info["factor_type"] = "gas"
-				factor_info["factor_name"] = momentary_gas_list[factor]["name"] //Common name
-			else
-				factor_info["factor_name"] = factor
-				factor_info["factor_type"] = "misc"
-				if(factor == "Temperature" || factor == "Pressure")
-					factor_info["tooltip"] = "Reaction is influenced by the [LOWER_TEXT(factor)] of the place where the reaction is occurring."
-				else if(factor == "Energy")
-					factor_info["tooltip"] = "Energy released by the reaction, may or may not result in linear temperature change depending on a slew of other factors."
-				else if(factor == "Radiation")
-					factor_info["tooltip"] = "This reaction emits dangerous radiation! Take precautions."
-				else if (factor == "Location")
-					factor_info["tooltip"] = "This reaction has special behaviour when occurring in specific locations."
 			reaction_info["factors"] += list(factor_info)
 		GLOB.reaction_handbook += list(reaction_info)
 		qdel(reaction)
@@ -157,7 +127,7 @@ GLOBAL_LIST_EMPTY(gas_handbook)
 /// Returns an assoc list of the gas handbook and the reaction handbook.
 /// For UIs, simply do data += return_atmos_handbooks() to use.
 /proc/return_atmos_handbooks()
-	return list("gasInfo" = GLOB.gas_handbook, "reactionInfo" = GLOB.reaction_handbook)
+	return list("gasInfo" = GLOB.gas_handbook, "reactionInfo" = GLOB.reaction_handbook, "moneySymbol" = MONEY_SYMBOL, "moneyName" = MONEY_NAME)
 
 /proc/extract_id_tags(list/objects)
 	var/list/tags = list()

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -516,7 +516,7 @@
 /// RPG Magic.
 /datum/material/mythril
 	name = "mythril"
-	desc = "How this even exists is byond me"
+	desc = "How this even exists is byond me."
 	color = "#f2d5d7"
 	mat_flags = MATERIAL_BASIC_RECIPES | MATERIAL_CLASS_METAL | MATERIAL_CLASS_RIGID
 	mat_properties = list(
@@ -557,7 +557,7 @@
 //formed when freon react with o2, emits a lot of plasma when heated
 /datum/material/hot_ice
 	name = "hot ice"
-	desc = "A weird kind of ice, feels warm to the touch"
+	desc = "A crystalline solid formed when Freon reacts with Oxygen. Extremely flammable, and will easily combust when exposed to heat."
 	color = "#88cdf1"
 	alpha = 150
 	starlight_color = COLOR_BLUE_LIGHT
@@ -587,8 +587,8 @@
 
 // It's basically adamantine, but it isn't!
 /datum/material/metalhydrogen
-	name = "Metal Hydrogen"
-	desc = "Solid metallic hydrogen. Some say it should be impossible"
+	name = "metal hydrogen"
+	desc = "Hydrogen in a metallic state, formed under extreme pressure. Some say achieving this state is impossible."
 	color = "#62708A"
 	starlight_color = COLOR_MODERATE_BLUE
 	mat_flags = MATERIAL_BASIC_RECIPES | MATERIAL_CLASS_METAL | MATERIAL_CLASS_RIGID
@@ -868,7 +868,7 @@
 
 /datum/material/zaukerite
 	name = "zaukerite"
-	desc = "A light absorbing crystal"
+	desc = "A light absorbing crystal formed out of Zauker. Vaguely toxic, like the gas itself."
 	color = COLOR_ALMOST_BLACK
 	mat_flags = MATERIAL_BASIC_RECIPES | MATERIAL_CLASS_CRYSTAL | MATERIAL_CLASS_RIGID
 	mat_properties = list(

--- a/code/game/machinery/computer/atmos_computers/_atmos_control.dm
+++ b/code/game/machinery/computer/atmos_computers/_atmos_control.dm
@@ -110,6 +110,7 @@
 	data["maxOutput"] = MAX_OUTPUT_PRESSURE
 	data["control"] = control
 	data["reconnecting"] = reconnecting
+	data["defaultGas"] = get_default_gas()
 	data += return_atmos_handbooks()
 	return data
 
@@ -228,6 +229,13 @@
 		if("reconnect")
 			reconnect(ui.user)
 			return TRUE
+
+/obj/machinery/computer/atmos_control/proc/get_default_gas()
+	for(var/gas_path, gas_id in GLOB.meta_gas_info[META_GAS_ID])
+		if(gas_id == atmos_chambers[1])
+			return gas_id
+
+	return null
 
 /obj/machinery/computer/atmos_control/nocontrol
 	control = FALSE

--- a/code/game/machinery/computer/atmos_computers/air_sensors.dm
+++ b/code/game/machinery/computer/atmos_computers/air_sensors.dm
@@ -47,7 +47,7 @@
 	chamber_id = ATMOS_GAS_MONITOR_H2
 
 /obj/machinery/air_sensor/hypernoblium_tank
-	name = "hypernoblium tank gas sensor"
+	name = "hyper-noblium tank gas sensor"
 	chamber_id = ATMOS_GAS_MONITOR_HYPERNOBLIUM
 
 /obj/machinery/air_sensor/miasma_tank
@@ -83,7 +83,7 @@
 	chamber_id = ATMOS_GAS_MONITOR_HELIUM
 
 /obj/machinery/air_sensor/antinoblium_tank
-	name = "antinoblium tank gas sensor"
+	name = "anti-noblium tank gas sensor"
 	chamber_id = ATMOS_GAS_MONITOR_ANTINOBLIUM
 
 /obj/machinery/air_sensor/incinerator_tank

--- a/code/game/machinery/computer/atmos_computers/atmos_controls.dm
+++ b/code/game/machinery/computer/atmos_computers/atmos_controls.dm
@@ -4,122 +4,122 @@
 	atmos_chambers = list(ATMOS_GAS_MONITOR_DISTRO = "Distribution Loop", ATMOS_GAS_MONITOR_WASTE = "Waste Loop")
 
 /obj/machinery/computer/atmos_control/oxygen_tank
-	name = "Oxygen Supply Control"
+	name = "\improper Oxygen supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/oxygen_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_O2 = "Oxygen Supply")
 
 /obj/machinery/computer/atmos_control/plasma_tank
-	name = "Plasma Supply Control"
+	name = "\improper Plasma supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/plasma_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_PLAS = "Plasma Supply")
 
 /obj/machinery/computer/atmos_control/air_tank
-	name = "Mixed Air Supply Control"
+	name = "\improper mixed air supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/air_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_AIR = "Mixed Air Supply")
 
 /obj/machinery/computer/atmos_control/nitrous_tank
-	name = "Nitrous Oxide Supply Control"
+	name = "\improper Nitrous Oxide supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/nitrous_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_N2O = "Nitrous Oxide Supply")
 
 /obj/machinery/computer/atmos_control/nitrogen_tank
-	name = "Nitrogen Supply Control"
+	name = "\improper Nitrogen supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/nitrogen_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_N2 = "Nitrogen Supply")
 
 /obj/machinery/computer/atmos_control/carbon_tank
-	name = "Carbon Dioxide Supply Control"
+	name = "\improper Carbon Dioxide supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/carbon_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_CO2 = "Carbon Dioxide Supply")
 
 /obj/machinery/computer/atmos_control/bz_tank
-	name = "BZ Supply Control"
+	name = "\improper BZ supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/bz_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_BZ = "BZ Supply")
 
 /obj/machinery/computer/atmos_control/freon_tank
-	name = "Freon Supply Control"
+	name = "\improper Freon supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/freon_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_FREON = "Freon Supply")
 
 /obj/machinery/computer/atmos_control/halon_tank
-	name = "Halon Supply Control"
+	name = "\improper Halon supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/halon_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_HALON = "Halon Supply")
 
 /obj/machinery/computer/atmos_control/healium_tank
-	name = "Healium Supply Control"
+	name = "\improper Healium supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/healium_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_HEALIUM = "Healium Supply")
 
 /obj/machinery/computer/atmos_control/hydrogen_tank
-	name = "Hydrogen Supply Control"
+	name = "\improper Hydrogen supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/hydrogen_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_H2 = "Hydrogen Supply")
 
 /obj/machinery/computer/atmos_control/hypernoblium_tank
-	name = "Hypernoblium Supply Control"
+	name = "\improper Hyper-Noblium supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/hypernoblium_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_HYPERNOBLIUM = "Hypernoblium Supply")
 
 /obj/machinery/computer/atmos_control/miasma_tank
-	name = "Miasma Supply Control"
+	name = "\improper Miasma supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/miasma_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_MIASMA = "Miasma Supply")
 
 /obj/machinery/computer/atmos_control/nitrium_tank
-	name = "Nitrium Supply Control"
+	name = "\improper Nitrium supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/nitrium_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_NITRIUM = "Nitrium Supply")
 
 /obj/machinery/computer/atmos_control/pluoxium_tank
-	name = "Pluoxium Supply Control"
+	name = "\improper Pluoxium supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/pluoxium_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_PLUOXIUM = "Pluoxium Supply")
 
 /obj/machinery/computer/atmos_control/proto_nitrate_tank
-	name = "Proto-Nitrate Supply Control"
+	name = "\improper Proto-Nitrate supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/proto_nitrate_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_PROTO_NITRATE = "Proto-Nitrate Supply")
 
 /obj/machinery/computer/atmos_control/tritium_tank
-	name = "Tritium Supply Control"
+	name = "\improper Tritium supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/tritium_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_TRITIUM = "Tritium Supply")
 
 /obj/machinery/computer/atmos_control/water_vapor
-	name = "Water Vapor Supply Control"
+	name = "\improper Water Vapor supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/water_vapor
 	atmos_chambers = list(ATMOS_GAS_MONITOR_H2O = "Water Vapor Supply")
 
 /obj/machinery/computer/atmos_control/zauker_tank
-	name = "Zauker Supply Control"
+	name = "\improper Zauker supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/zauker_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_ZAUKER = "Zauker Supply")
 
 /obj/machinery/computer/atmos_control/helium_tank
-	name = "Helium Supply Control"
+	name = "\improper Helium supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/helium_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_HELIUM = "Helium Supply")
 
 /obj/machinery/computer/atmos_control/antinoblium_tank
-	name = "Antinoblium Supply Control"
+	name = "\improper Anti-Noblium supply control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/antinoblium_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_ANTINOBLIUM = "Antinoblium Supply")
 
 /obj/machinery/computer/atmos_control/mix_tank
-	name = "Mix Chamber Control"
+	name = "mix chamber control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/mix_tank
 	atmos_chambers = list(ATMOS_GAS_MONITOR_MIX = "Mix Chamber")
 
 /obj/machinery/computer/atmos_control/nocontrol/incinerator
-	name = "Incinerator Chamber Monitor"
+	name = "incinerator chamber monitor"
 	circuit = /obj/item/circuitboard/computer/atmos_control/nocontrol/incinerator
 	atmos_chambers = list(ATMOS_GAS_MONITOR_INCINERATOR = "Incinerator Chamber")
 
 /obj/machinery/computer/atmos_control/ordnancemix
-	name = "Ordnance Chamber Control"
+	name = "ordnance chamber control"
 	circuit = /obj/item/circuitboard/computer/atmos_control/ordnancemix
 	atmos_chambers = list(
 		ATMOS_GAS_MONITOR_ORDNANCE_BURN = "Ordnance Burn Chamber",

--- a/code/game/machinery/embedded_controller/airlock_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_controller.dm
@@ -279,7 +279,7 @@
 	return last_pressure
 
 /obj/machinery/airlock_controller/incinerator_ordmix
-	name = "Incinerator Access Console"
+	name = "incinerator access console"
 	airpump_tag = INCINERATOR_ORDMIX_DP_VENTPUMP
 	exterior_door_tag = INCINERATOR_ORDMIX_AIRLOCK_EXTERIOR
 	id_tag = INCINERATOR_ORDMIX_AIRLOCK_CONTROLLER
@@ -288,7 +288,7 @@
 	sensor_tag = INCINERATOR_ORDMIX_AIRLOCK_SENSOR
 
 /obj/machinery/airlock_controller/incinerator_atmos
-	name = "Incinerator Access Console"
+	name = "incinerator access console"
 	airpump_tag = INCINERATOR_ATMOS_DP_VENTPUMP
 	exterior_door_tag = INCINERATOR_ATMOS_AIRLOCK_EXTERIOR
 	id_tag = INCINERATOR_ATMOS_AIRLOCK_CONTROLLER
@@ -297,7 +297,7 @@
 	sensor_tag = INCINERATOR_ATMOS_AIRLOCK_SENSOR
 
 /obj/machinery/airlock_controller/incinerator_syndicatelava
-	name = "Incinerator Access Console"
+	name = "incinerator access console"
 	airpump_tag = INCINERATOR_SYNDICATELAVA_DP_VENTPUMP
 	exterior_door_tag = INCINERATOR_SYNDICATELAVA_AIRLOCK_EXTERIOR
 	id_tag = INCINERATOR_SYNDICATELAVA_AIRLOCK_CONTROLLER

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -27,6 +27,8 @@
 	var/barometer_accuracy
 	/// Cached gasmix data from ui_interact
 	var/list/last_gasmix_data
+
+	var/datum/weakref/last_scanned
 	/// Max scan distance
 	var/ranged_scan_distance = 1
 
@@ -134,39 +136,59 @@
 	return return_atmos_handbooks()
 
 /obj/item/analyzer/ui_data(mob/user)
-	LAZYINITLIST(last_gasmix_data)
-	return list("gasmixes" = last_gasmix_data)
+	var/obj/item/last_scanned_real = last_scanned?.resolve()
+	if(!QDELETED(last_scanned_real) && can_see(user, last_scanned_real, ranged_scan_distance))
+		collect_scan_info(last_scanned_real) // updates last_gasmix_data as long as we're in range
+
+	return list(
+		"gasmixes" = last_gasmix_data,
+	)
+
+/// Checks if we can use the analyzer at all
+/obj/item/analyzer/proc/can_use(mob/user)
+	if(!user.can_read(src))
+		return FALSE
+	// Logical, but it contains "tutorial information", so we should allow it.
+	// if(user.is_blind())
+	// 	return FALSE
+	return TRUE
+
+/obj/item/analyzer/ui_status(mob/user)
+	return can_use(user) ? ..() : UI_CLOSE
 
 /obj/item/analyzer/attack_self(mob/user, modifiers)
-	if(IS_UNCONSCIOUS_OR_CRIT(user) || !user.can_read(src) || user.is_blind())
-		return
-	atmos_scan(user=user, target=get_turf(src), silent=FALSE)
-	on_analyze(source=src, target=get_turf(src))
+	scan_atom(get_turf(src), user)
+	return TRUE
 
 /obj/item/analyzer/attack_self_secondary(mob/user, modifiers)
-	if(IS_UNCONSCIOUS_OR_CRIT(user) || !user.can_read(src) || user.is_blind())
-		return
-
 	ui_interact(user)
+	return TRUE
 
 /obj/item/analyzer/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(istype(interacting_with, /obj/effect/anomaly) && can_see(user, interacting_with, ranged_scan_distance))
 		var/obj/effect/anomaly/ranged_anomaly = interacting_with
 		ranged_anomaly.analyzer_act(user, src)
 		return ITEM_INTERACT_SUCCESS
+
 	return interact_with_atom(interacting_with, user, modifiers)
 
 /obj/item/analyzer/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!HAS_TRAIT(interacting_with, TRAIT_COMBAT_MODE_SKIP_INTERACTION) && can_see(user, interacting_with, ranged_scan_distance))
-		atmos_scan(user, (interacting_with.return_analyzable_air() ? interacting_with : get_turf(interacting_with)))
+		scan_atom(interacting_with.return_analyzable_air() ? interacting_with : get_turf(interacting_with), user)
 	return NONE // Non-blocking
 
-/// Called when our analyzer is used on something
-/obj/item/analyzer/proc/on_analyze(datum/source, atom/target)
-	SIGNAL_HANDLER
+/obj/item/analyzer/proc/scan_atom(atom/target, mob/living/user)
+	if(!can_use(user))
+		return
+
+	atmos_scan(user, target, silent = FALSE)
+	collect_scan_info(target)
+
+/obj/item/analyzer/proc/collect_scan_info(atom/target)
 	var/mixture = target.return_analyzable_air()
 	if(!mixture)
-		return FALSE
+		return
+
 	var/list/airs = islist(mixture) ? mixture : list(mixture)
 	var/list/new_gasmix_data = list()
 	for(var/datum/gas_mixture/air as anything in airs)
@@ -175,6 +197,12 @@
 			mix_name += " - Node [airs.Find(air)]"
 		new_gasmix_data += list(gas_mixture_parser(air, mix_name))
 	last_gasmix_data = new_gasmix_data
+	last_scanned = WEAKREF(target)
+
+/// Called when our analyzer is used on something
+/obj/item/analyzer/proc/on_analyze(datum/source, atom/target)
+	SIGNAL_HANDLER
+	collect_scan_info(target)
 
 /**
  * Outputs a message to the user describing the target's gasmixes.

--- a/code/game/objects/items/grenades/atmos_grenades.dm
+++ b/code/game/objects/items/grenades/atmos_grenades.dm
@@ -1,6 +1,7 @@
 /obj/item/grenade/gas_crystal
-	desc = "Some kind of crystal, this shouldn't spawn"
-	name = "Gas Crystal"
+	name = "gas crystal"
+	desc = "Some kind of crystal."
+	abstract_type = /obj/item/grenade/gas_crystal
 	icon = 'icons/obj/weapons/grenade.dmi'
 	icon_state = "bluefrag"
 	inhand_icon_state = "flashbang"
@@ -24,8 +25,8 @@
 	addtimer(CALLBACK(src, PROC_REF(detonate)), isnull(delayoverride)? det_time : delayoverride)
 
 /obj/item/grenade/gas_crystal/healium_crystal
-	name = "Healium crystal"
-	desc = "A crystal made from the Healium gas, it's cold to the touch."
+	name = "\improper Healium crystal"
+	desc = "A crystal made from the Healium gas. It's cold to the touch."
 	icon_state = "healium_crystal"
 	///Range of the grenade that will cool down and affect mobs
 	var/fix_range = 7
@@ -47,8 +48,8 @@
 	qdel(src)
 
 /obj/item/grenade/gas_crystal/proto_nitrate_crystal
-	name = "Proto Nitrate crystal"
-	desc = "A crystal made from the Proto Nitrate gas, you can see the liquid gases inside."
+	name = "\improper Proto-Nitrate crystal"
+	desc = "A crystal made from the Proto-Nitrate gas. It feels lighter than you'd expect."
 	icon_state = "proto_nitrate_crystal"
 	///Range of the grenade air refilling
 	var/refill_range = 5
@@ -73,8 +74,8 @@
 	qdel(src)
 
 /obj/item/grenade/gas_crystal/nitrous_oxide_crystal
-	name = "N2O crystal"
-	desc = "A crystal made from the N2O gas, you can see the liquid gases inside."
+	name = "\improper N2O crystal"
+	desc = "A crystal made from Nitrous Oxide gas. Looking at it makes you feel sleepy."
 	icon_state = "n2o_crystal"
 	///Range of the grenade air refilling
 	var/fill_range = 1
@@ -98,7 +99,7 @@
 
 /obj/item/grenade/gas_crystal/crystal_foam
 	name = "crystal foam"
-	desc = "A crystal with a foggy inside"
+	desc = "A crystal with a foggy inside."
 	icon_state = "crystal_foam"
 	var/breach_range = 7
 

--- a/code/game/objects/items/stacks/ammonia_crystals.dm
+++ b/code/game/objects/items/stacks/ammonia_crystals.dm
@@ -1,5 +1,6 @@
 /obj/item/stack/ammonia_crystals
 	name = "ammonia crystals"
+	desc = "Crystallized ammonia. Valuable for someone, but probably not you."
 	singular_name = "ammonia crystal"
 	icon = 'icons/obj/stack_objects.dmi'
 	icon_state = "ammonia_crystal"

--- a/code/game/turfs/open/floor/reinforced_floor.dm
+++ b/code/game/turfs/open/floor/reinforced_floor.dm
@@ -105,7 +105,7 @@
 	initial_gas_mix = ATMOS_TANK_CO2
 
 /turf/open/floor/engine/plasma
-	name = "plasma floor"
+	name = "\improper Plasma floor"
 	initial_gas_mix = ATMOS_TANK_PLASMA
 
 /turf/open/floor/engine/o2
@@ -139,7 +139,7 @@
 	initial_gas_mix = ATMOS_TANK_H2
 
 /turf/open/floor/engine/hypernoblium
-	name = "\improper Hypernoblium floor"
+	name = "\improper Hyper-Noblium floor"
 	initial_gas_mix = ATMOS_TANK_HYPERNOBLIUM
 
 /turf/open/floor/engine/miasma
@@ -147,7 +147,7 @@
 	initial_gas_mix = ATMOS_TANK_MIASMA
 
 /turf/open/floor/engine/nitrium
-	name = "\improper nitrium floor"
+	name = "\improper Nitrium floor"
 	initial_gas_mix = ATMOS_TANK_NITRIUM
 
 /turf/open/floor/engine/pluoxium
@@ -176,7 +176,7 @@
 	initial_gas_mix = ATMOS_TANK_HELIUM
 
 /turf/open/floor/engine/antinoblium
-	name = "\improper Antinoblium floor"
+	name = "\improper Anti-Noblium floor"
 	initial_gas_mix = ATMOS_TANK_ANTINOBLIUM
 
 /turf/open/floor/engine/air

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -1,7 +1,7 @@
 /// Returns reactions which will contribute to a hotspot's size.
 /proc/init_hotspot_reactions()
 	var/list/fire_reactions = list()
-	for (var/datum/gas_reaction/reaction as anything in subtypesof(/datum/gas_reaction))
+	for (var/datum/gas_reaction/standard/reaction as anything in subtypesof(/datum/gas_reaction/standard))
 		if(initial(reaction.expands_hotspot))
 			fire_reactions += reaction
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -523,7 +523,7 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 	//It might be worth looking into updating these after each reaction, but that makes us care more about order of operations, so be careful
 	var/temp = temperature
 	reaction_loop:
-		for(var/datum/gas_reaction/reaction as anything in reactions)
+		for(var/datum/gas_reaction/standard/reaction as anything in reactions)
 
 			var/list/reqs = reaction.requirements
 			if((reqs["MIN_TEMP"] && temp < reqs["MIN_TEMP"]) || (reqs["MAX_TEMP"] && temp > reqs["MAX_TEMP"]))
@@ -743,7 +743,7 @@ GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
  */
 /datum/gas_mixture/proc/electrolyze(working_power = 0, electrolyzer_args = list())
 	for(var/reaction in GLOB.electrolyzer_reactions)
-		var/datum/electrolyzer_reaction/current_reaction = GLOB.electrolyzer_reactions[reaction]
+		var/datum/gas_reaction/electrolyzer/current_reaction = GLOB.electrolyzer_reactions[reaction]
 
 		if(!current_reaction.reaction_check(air_mixture = src, electrolyzer_args = electrolyzer_args))
 			continue

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -13,7 +13,7 @@
 		if (gas_info[META_GAS_MOLES_VISIBLE][gas_path])
 			gas_info[META_GAS_OVERLAY][gas_path] += generate_gas_overlays(0, SSmapping.max_plane_offset, gas_path)
 		gas_info[META_GAS_FUSION_POWER][gas_path] = initial(gas_path.fusion_power)
-		gas_info[META_GAS_DANGER][gas_path] = initial(gas_path.dangerous)
+		gas_info[META_GAS_DANGER][gas_path] = initial(gas_path.cargo_flags) & GAS_DANGEROUS
 		gas_info[META_GAS_ID][gas_path] = initial(gas_path.id)
 		gas_info[META_GAS_DESC][gas_path] = initial(gas_path.desc)
 
@@ -39,44 +39,44 @@
 			return path
 	return ""
 
-/*||||||||||||||/----------\||||||||||||||*\
-||||||||||||||||[GAS DATUMS]||||||||||||||||
-||||||||||||||||\__________/||||||||||||||||
-|||| These should never be instantiated. ||||
-|||| They exist only to make it easier   ||||
-|||| to add a new gas. They are accessed ||||
-|||| only by meta_gas_list().            ||||
-\*||||||||||||||||||||||||||||||||||||||||*/
-
-//This is a plot created using the values for gas exports. Each gas has a value that works as its kind of soft-cap, which limits you from making billions of credits per sale, based on the base_value variable on the gasses themselves. Most of these gasses as a result have a rather low value when sold, like nitrogen and oxygen at 1500 and 600 respectively at their maximum value. The
+/**
+ * # Gas datums
+ *
+ * These are never and should never be instantiated,
+ * they just exist to hold data which is passed into the gas metadata list.
+ *
+ * They are templates for how gases should generally act.
+ */
 /datum/gas
 	var/id = ""
 	var/specific_heat = 0
 	var/name = ""
+	var/desc
 	///icon_state in icons/effects/atmospherics.dmi
 	var/gas_overlay = ""
 	var/moles_visible = null
-	///currently used by canisters
-	var/dangerous = FALSE
 	///How much the gas accelerates a fusion reaction
 	var/fusion_power = 0
 	/// relative rarity compared to other gases, used when setting up the reactions list.
 	var/rarity = 0
-	///Can gas of this type can purchased through cargo?
-	var/purchaseable = FALSE
-	///How does a single mole of this gas sell for? Formula to calculate maximum value is in code\modules\cargo\exports\large_objects.dm. Doesn't matter for roundstart gasses.
+	/// Flags that relate to how the gas is handled in cargo
+	/// GAS_PURCHASABLE - Can be purchased in cargo
+	/// GAS_EXPORTABLE - Can be sold in cargo
+	/// GAS_DANGEROUS - Is considered dangerous, requires elevated access to purchase
+	var/cargo_flags = NONE
+	/// How does a single mole of this gas buy/sell for?
+	/// Formula to calculate maximum value is in [code\modules\cargo\exports\large_objects.dm].
+	/// Only necessary for exportable or purchasable gases, otherwise meaningless.
 	var/base_value = 0
-	var/desc
-	///RGB code for use when a generic color representing the gas is needed. Colors taken from contants.ts
+	/// RGB code for use when a generic color representing the gas is needed. Colors taken from contants.ts
 	var/primary_color
-
 
 /datum/gas/oxygen
 	id = GAS_O2
 	specific_heat = 20
 	name = "Oxygen"
 	rarity = 900
-	purchaseable = TRUE
+	cargo_flags = GAS_PURCHASABLE
 	base_value = 0.2
 	desc = "The gas most life forms need to be able to survive. Also an oxidizer."
 	primary_color = "#0000ff"
@@ -86,7 +86,7 @@
 	specific_heat = 20
 	name = "Nitrogen"
 	rarity = 1000
-	purchaseable = TRUE
+	cargo_flags = GAS_PURCHASABLE
 	base_value = 0.1
 	desc = "A very common gas that used to pad artificial atmospheres to habitable pressure."
 	primary_color = "#ffff00"
@@ -95,9 +95,8 @@
 	id = GAS_CO2
 	specific_heat = 30
 	name = "Carbon Dioxide"
-	dangerous = TRUE
 	rarity = 700
-	purchaseable = TRUE
+	cargo_flags = GAS_PURCHASABLE | GAS_DANGEROUS
 	base_value = 0.2
 	desc = "What the fuck is carbon dioxide?"
 	primary_color = COLOR_GRAY
@@ -108,7 +107,7 @@
 	name = "Plasma"
 	gas_overlay = "plasma"
 	moles_visible = MOLES_GAS_VISIBLE
-	dangerous = TRUE
+	cargo_flags = GAS_DANGEROUS
 	rarity = 800
 	base_value = 1.5
 	desc = "A flammable gas with many other curious properties. Its research is one of NT's primary objective."
@@ -122,7 +121,7 @@
 	moles_visible = MOLES_GAS_VISIBLE
 	fusion_power = 8
 	rarity = 500
-	purchaseable = TRUE
+	cargo_flags = GAS_PURCHASABLE
 	base_value = 0.5
 	desc = "Water, in gas form. Makes floors slippery and washes items on them."
 	primary_color = "#b0c4de"
@@ -130,11 +129,12 @@
 /datum/gas/hypernoblium
 	id = GAS_HYPER_NOBLIUM
 	specific_heat = 2000
-	name = "Hyper-noblium"
+	name = "Hyper-Noblium"
 	gas_overlay = "freon"
 	moles_visible = MOLES_GAS_VISIBLE
 	fusion_power = 10
 	rarity = 50
+	cargo_flags = GAS_EXPORTABLE
 	base_value = 2.5
 	desc = "The most noble gas of them all. High quantities of hyper-noblium actively prevents reactions from occurring."
 	primary_color = COLOR_TEAL
@@ -146,9 +146,8 @@
 	gas_overlay = "nitrous_oxide"
 	moles_visible = MOLES_GAS_VISIBLE * 2
 	fusion_power = 10
-	dangerous = TRUE
 	rarity = 600
-	purchaseable = TRUE
+	cargo_flags = GAS_PURCHASABLE | GAS_DANGEROUS
 	base_value = 1.5
 	desc = "Causes drowsiness, euphoria, and eventually unconsciousness."
 	primary_color = "#ffe4c4"
@@ -160,7 +159,7 @@
 	fusion_power = 7
 	gas_overlay = "nitrium"
 	moles_visible = MOLES_GAS_VISIBLE
-	dangerous = TRUE
+	cargo_flags = GAS_PURCHASABLE | GAS_DANGEROUS
 	rarity = 1
 	base_value = 6
 	desc = "An experimental performance enhancing gas. Nitrium can have amplified effects as more of it gets into your bloodstream."
@@ -172,7 +171,7 @@
 	name = "Tritium"
 	gas_overlay = "tritium"
 	moles_visible = MOLES_GAS_VISIBLE
-	dangerous = TRUE
+	cargo_flags = GAS_DANGEROUS | GAS_EXPORTABLE
 	fusion_power = 5
 	rarity = 300
 	base_value = 2.5
@@ -183,10 +182,9 @@
 	id = GAS_BZ
 	specific_heat = 20
 	name = "BZ"
-	dangerous = TRUE
 	fusion_power = 8
 	rarity = 400
-	purchaseable = TRUE
+	cargo_flags = GAS_PURCHASABLE | GAS_EXPORTABLE | GAS_DANGEROUS
 	base_value = 1.5
 	desc = "A powerful hallucinogenic nerve agent able to induce cognitive damage."
 	primary_color = "#9370db"
@@ -197,6 +195,7 @@
 	name = "Pluoxium"
 	fusion_power = -10
 	rarity = 200
+	cargo_flags = GAS_EXPORTABLE
 	base_value = 2.5
 	desc = "A gas that could supply even more oxygen to the bloodstream when inhaled, without being an oxidizer."
 	primary_color = "#7b68ee"
@@ -205,7 +204,7 @@
 	id = GAS_MIASMA
 	specific_heat = 20
 	name = "Miasma"
-	dangerous = TRUE
+	cargo_flags = GAS_DANGEROUS | GAS_EXPORTABLE
 	gas_overlay = "miasma"
 	moles_visible = MOLES_GAS_VISIBLE * 60
 	rarity = 250
@@ -217,7 +216,7 @@
 	id = GAS_FREON
 	specific_heat = 600
 	name = "Freon"
-	dangerous = TRUE
+	cargo_flags = GAS_DANGEROUS | GAS_EXPORTABLE
 	gas_overlay = "freon"
 	moles_visible = MOLES_GAS_VISIBLE *30
 	fusion_power = -5
@@ -230,7 +229,7 @@
 	id = GAS_HYDROGEN
 	specific_heat = 15
 	name = "Hydrogen"
-	dangerous = TRUE
+	cargo_flags = GAS_DANGEROUS | GAS_EXPORTABLE
 	fusion_power = 2
 	rarity = 600
 	base_value = 1
@@ -241,7 +240,7 @@
 	id = GAS_HEALIUM
 	specific_heat = 10
 	name = "Healium"
-	dangerous = TRUE
+	cargo_flags = GAS_DANGEROUS | GAS_EXPORTABLE
 	gas_overlay = "healium"
 	moles_visible = MOLES_GAS_VISIBLE
 	rarity = 300
@@ -252,8 +251,8 @@
 /datum/gas/proto_nitrate
 	id = GAS_PROTO_NITRATE
 	specific_heat = 30
-	name = "Proto Nitrate"
-	dangerous = TRUE
+	name = "Proto-Nitrate"
+	cargo_flags = GAS_DANGEROUS | GAS_EXPORTABLE
 	gas_overlay = "proto_nitrate"
 	moles_visible = MOLES_GAS_VISIBLE
 	rarity = 200
@@ -265,7 +264,7 @@
 	id = GAS_ZAUKER
 	specific_heat = 350
 	name = "Zauker"
-	dangerous = TRUE
+	cargo_flags = GAS_DANGEROUS | GAS_EXPORTABLE
 	gas_overlay = "zauker"
 	moles_visible = MOLES_GAS_VISIBLE
 	rarity = 1
@@ -277,12 +276,12 @@
 	id = GAS_HALON
 	specific_heat = 175
 	name = "Halon"
-	dangerous = TRUE
+	cargo_flags = GAS_DANGEROUS | GAS_EXPORTABLE
 	gas_overlay = "halon"
 	moles_visible = MOLES_GAS_VISIBLE
 	rarity = 300
 	base_value = 4
-	desc = "A potent fire suppressant. Removes oxygen from high temperature fires and cools down the area"
+	desc = "A potent fire suppressant. Removes oxygen from high temperature fires and cools down the area."
 	primary_color = COLOR_PURPLE
 
 /datum/gas/helium
@@ -291,6 +290,7 @@
 	name = "Helium"
 	fusion_power = 7
 	rarity = 50
+	cargo_flags = GAS_EXPORTABLE
 	base_value = 3.5
 	desc = "A very inert gas produced by the fusion of hydrogen and its derivatives."
 	primary_color = "#f0f8ff"
@@ -298,8 +298,8 @@
 /datum/gas/antinoblium
 	id = GAS_ANTINOBLIUM
 	specific_heat = 1
-	name = "Antinoblium"
-	dangerous = TRUE
+	name = "Anti-Noblium"
+	cargo_flags = GAS_DANGEROUS | GAS_EXPORTABLE
 	gas_overlay = "antinoblium"
 	moles_visible = MOLES_GAS_VISIBLE
 	fusion_power = 20
@@ -329,4 +329,3 @@
 /obj/effect/overlay/gas/Initialize(mapload)
 	. = ..()
 	SET_PLANE_W_SCALAR(src, initial(plane), plane_offset)
-

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -98,7 +98,7 @@
 	rarity = 700
 	cargo_flags = GAS_PURCHASABLE | GAS_DANGEROUS
 	base_value = 0.2
-	desc = "What the fuck is carbon dioxide?"
+	desc = "What the fuck is Carbon Dioxide?"
 	primary_color = COLOR_GRAY
 
 /datum/gas/plasma
@@ -110,7 +110,7 @@
 	cargo_flags = GAS_DANGEROUS
 	rarity = 800
 	base_value = 1.5
-	desc = "A flammable gas with many other curious properties. Its research is one of NT's primary objective."
+	desc = "A flammable gas with many curious properties. Its research is one of Nanotrasen's primary objectives."
 	primary_color = "#ffc0cb"
 
 /datum/gas/water_vapor
@@ -136,7 +136,7 @@
 	rarity = 50
 	cargo_flags = GAS_EXPORTABLE
 	base_value = 2.5
-	desc = "The most noble gas of them all. High quantities of hyper-noblium actively prevents reactions from occurring."
+	desc = "The most noble gas of them all. High quantities actively prevents reactions from occurring."
 	primary_color = COLOR_TEAL
 
 /datum/gas/nitrous_oxide
@@ -149,7 +149,8 @@
 	rarity = 600
 	cargo_flags = GAS_PURCHASABLE | GAS_DANGEROUS
 	base_value = 1.5
-	desc = "Causes drowsiness, euphoria, and eventually unconsciousness."
+	desc = "A gas known to causes drowsiness, euphoria, and eventually unconsciousness. \
+		Commonly used as an anesthetic for surgical procedures, and occasionally, as a recreational drug."
 	primary_color = "#ffe4c4"
 
 /datum/gas/nitrium
@@ -162,7 +163,7 @@
 	cargo_flags = GAS_PURCHASABLE | GAS_DANGEROUS
 	rarity = 1
 	base_value = 6
-	desc = "An experimental performance enhancing gas. Nitrium can have amplified effects as more of it gets into your bloodstream."
+	desc = "An experimental (and slightly toxic) performance enhancing gas that increases speed and alertness when inhaled."
 	primary_color = "#a52a2a"
 
 /datum/gas/tritium
@@ -197,7 +198,8 @@
 	rarity = 200
 	cargo_flags = GAS_EXPORTABLE
 	base_value = 2.5
-	desc = "A gas that could supply even more oxygen to the bloodstream when inhaled, without being an oxidizer."
+	desc = "An alternative to oxygen that is eight times more efficient at lung diffusion \
+		and even has minor healing properties - while itself not being an oxidizer."
 	primary_color = "#7b68ee"
 
 /datum/gas/miasma
@@ -209,7 +211,8 @@
 	moles_visible = MOLES_GAS_VISIBLE * 60
 	rarity = 250
 	base_value = 1
-	desc = "Not necessarily a gas, miasma refers to biological pollutants found in the atmosphere."
+	desc = "Miasma is not necessarily a gas, but more broadly refers to biological pollutants \
+		found in the atmosphere known to cause disease and nausea."
 	primary_color = COLOR_OLIVE
 
 /datum/gas/freon
@@ -222,7 +225,7 @@
 	fusion_power = -5
 	rarity = 10
 	base_value = 5
-	desc = "A coolant gas. Mainly used for its endothermic reaction with oxygen."
+	desc = "A coolant gas. Primarily used for its endothermic reaction with oxygen."
 	primary_color = "#afeeee"
 
 /datum/gas/hydrogen
@@ -245,7 +248,8 @@
 	moles_visible = MOLES_GAS_VISIBLE
 	rarity = 300
 	base_value = 5.5
-	desc = "Causes deep, regenerative sleep."
+	desc = "An experimental alternative to anesthetic that induces a state of unconsciousness \
+		that accelerates healing and regeneration when inhaled."
 	primary_color = "#fa8072"
 
 /datum/gas/proto_nitrate
@@ -257,7 +261,7 @@
 	moles_visible = MOLES_GAS_VISIBLE
 	rarity = 200
 	base_value = 2.5
-	desc = "A very volatile gas that reacts differently with various gases."
+	desc = "A volatile gas that has wildly different reactions with other gases."
 	primary_color = "#adff2f"
 
 /datum/gas/zauker
@@ -269,7 +273,8 @@
 	moles_visible = MOLES_GAS_VISIBLE
 	rarity = 1
 	base_value = 7
-	desc = "A highly toxic gas, its production is highly regulated on top of being difficult. It also breaks down when in contact with nitrogen."
+	desc = "A highly toxic gas and difficult to produce gas. \
+		It breaks down when in contact with Nitrogen, making it relatively safe in Earth-like atmospheres."
 	primary_color = "#006400"
 
 /datum/gas/halon
@@ -281,7 +286,7 @@
 	moles_visible = MOLES_GAS_VISIBLE
 	rarity = 300
 	base_value = 4
-	desc = "A potent fire suppressant. Removes oxygen from high temperature fires and cools down the area."
+	desc = "A potent fire suppressant. It removes Oxygen from high temperature fires and cools down the area."
 	primary_color = COLOR_PURPLE
 
 /datum/gas/helium
@@ -292,7 +297,8 @@
 	rarity = 50
 	cargo_flags = GAS_EXPORTABLE
 	base_value = 3.5
-	desc = "A very inert gas produced by the fusion of hydrogen and its derivatives."
+	desc = "An inert noble gas produced by the fusion of Hydrogen and its derivatives. \
+		Commonly known for being lighter than air and its ability to raise voice pitch when inhaled."
 	primary_color = "#f0f8ff"
 
 /datum/gas/antinoblium
@@ -305,7 +311,8 @@
 	fusion_power = 20
 	rarity = 1
 	base_value = 10
-	desc = "We still don't know what it does, but it sells for a lot."
+	desc = "A mysterious and highly reactive gas known to replicate itself. \
+		It is highly sought after due to its rarity, and will export for a high price."
 	primary_color = COLOR_MAROON
 
 /obj/effect/overlay/gas

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -99,6 +99,7 @@
 	cargo_flags = GAS_PURCHASABLE | GAS_DANGEROUS
 	base_value = 0.2
 	desc = "What the fuck is Carbon Dioxide?"
+	// desc = "A colorless, odorless gas commonly produced by respiration and combustion. Potentially dangerous when inhaled in high concentrations."
 	primary_color = COLOR_GRAY
 
 /datum/gas/plasma

--- a/code/modules/atmospherics/gasmixtures/reaction_factors.dm
+++ b/code/modules/atmospherics/gasmixtures/reaction_factors.dm
@@ -1,216 +1,276 @@
-/datum/gas_reaction/water_vapor/init_factors()
+/datum/gas_reaction/standard/water_vapor/init_factors()
 	factor = list(
-		/datum/gas/water_vapor = "Condensation will consume [MOLES_GAS_VISIBLE] moles, freezing will not consume any. Both needs a minimum of [MOLES_GAS_VISIBLE] moles to occur.",
-		"Temperature" = "Freezes a turf at [WATER_VAPOR_DEPOSITION_POINT] Kelvins or below, wets it at [WATER_VAPOR_CONDENSATION_POINT] Kelvins or below.",
-		"Location" = "Can only happen on turfs.",
+		/datum/gas/water_vapor = "Condensation will consume [MOLES_GAS_VISIBLE] moles. \
+			Freezing will not consume any. Both requires a minimum of [MOLES_GAS_VISIBLE] moles to occur.",
+		"Temperature" = "Freezes a tile at [WATER_VAPOR_DEPOSITION_POINT] kelvins or below, \
+			wets it at [WATER_VAPOR_CONDENSATION_POINT] kelvins or below.",
+		"Location" = "Can only happen on tiles.",
 	)
 
-/datum/gas_reaction/miaster/init_factors()
+/datum/gas_reaction/standard/miaster/init_factors()
 	factor = list(
-		/datum/gas/miasma = "Miasma is sterilized at a rate that scales with the difference between the temperature and [MIASTER_STERILIZATION_TEMP]K.",
-		/datum/gas/oxygen = "One mole of oxygen is released per mole of miasma consumed.",
-		"Temperature" = "Higher temperature increases the speed of miasma sterilization.",
-		"Energy" = "[MIASTER_STERILIZATION_ENERGY] joules of energy is released per mole of miasma sterilized.",
+		/datum/gas/miasma = "[/datum/gas/miasma::name] is sterilized at a rate that scales \
+			with the difference between the temperature and [MIASTER_STERILIZATION_TEMP]K.",
+		/datum/gas/oxygen = "One mole of [/datum/gas/oxygen::name] is released per mole of [/datum/gas/miasma::name] consumed.",
+		"Temperature" = "Higher temperature increases the speed of [/datum/gas/miasma::name] sterilization.",
+		"Energy" = "[MIASTER_STERILIZATION_ENERGY] joules of energy is released per mole of [/datum/gas/miasma::name] sterilized.",
 	)
 
-/datum/gas_reaction/plasmafire/init_factors()
+/datum/gas_reaction/standard/plasmafire/init_factors()
 	factor = list(
-		/datum/gas/oxygen = "Oxygen consumption is determined by the temperature, ranging from [OXYGEN_BURN_RATIO_BASE] moles per mole of plasma consumed at [PLASMA_MINIMUM_BURN_TEMPERATURE] Kelvins to [OXYGEN_BURN_RATIO_BASE-1] moles per mole of plasma consumed at [PLASMA_UPPER_TEMPERATURE] Kelvins. Higher oxygen concentration up to [PLASMA_OXYGEN_FULLBURN] times the plasma increases the speed of plasma consumption.",
-		/datum/gas/plasma = "Plasma is consumed at a rate that scales with the difference between the temperature and [PLASMA_MINIMUM_BURN_TEMPERATURE]K, with maximum scaling at [PLASMA_UPPER_TEMPERATURE]K.",
-		/datum/gas/tritium = "Tritium is formed at 1 mole per mole of plasma consumed if there are at least 97 times more oxygen than plasma.",
-		/datum/gas/water_vapor = "Water vapor is formed at 0.25 moles per mole of plasma consumed if tritium isn't being formed.",
-		/datum/gas/carbon_dioxide = "Carbon Dioxide is formed at 0.75 moles per mole of plasma consumed if tritium isn't being formed.",
-		"Temperature" = "Minimum temperature of [PLASMA_MINIMUM_BURN_TEMPERATURE] kelvin to occur. Higher temperature up to [PLASMA_UPPER_TEMPERATURE]K increases the oxygen efficiency and also the plasma consumption rate.",
-		"Energy" = "[FIRE_PLASMA_ENERGY_RELEASED] joules of energy is released per mole of plasma consumed.",
+		/datum/gas/oxygen = "[/datum/gas/oxygen::name] consumption is determined by the temperature, \
+			ranging from [OXYGEN_BURN_RATIO_BASE] moles per mole of [/datum/gas/plasma::name] consumed at [PLASMA_MINIMUM_BURN_TEMPERATURE] kelvins \
+			to [OXYGEN_BURN_RATIO_BASE-1] moles per mole of [/datum/gas/plasma::name] consumed at [PLASMA_UPPER_TEMPERATURE] kelvins. \
+			Higher [/datum/gas/oxygen::name] concentration up to [PLASMA_OXYGEN_FULLBURN] times the [/datum/gas/plasma::name] \
+			increases the speed of [/datum/gas/plasma::name] consumption.",
+		/datum/gas/plasma = "[/datum/gas/plasma::name] is consumed at a rate that scales with the difference between the temperature \
+			and [PLASMA_MINIMUM_BURN_TEMPERATURE]K, with maximum scaling at [PLASMA_UPPER_TEMPERATURE]K.",
+		/datum/gas/tritium = "[/datum/gas/tritium::name] is formed at 1 mole per mole of [/datum/gas/plasma::name] consumed \
+			if there are at least 97 times more [/datum/gas/oxygen::name] than [/datum/gas/plasma::name].",
+		/datum/gas/water_vapor = "[/datum/gas/water_vapor::name] is formed at 0.25 moles per mole of [/datum/gas/plasma::name] consumed \
+			if [/datum/gas/tritium::name] isn't being formed.",
+		/datum/gas/carbon_dioxide = "[/datum/gas/carbon_dioxide::name] is formed at 0.75 moles per mole of [/datum/gas/plasma::name] consumed \
+			if [/datum/gas/tritium::name] isn't being formed.",
+		"Temperature" = "Minimum temperature of [PLASMA_MINIMUM_BURN_TEMPERATURE] kelvin to occur. \
+			Higher temperature up to [PLASMA_UPPER_TEMPERATURE]K increases the [/datum/gas/oxygen::name] efficiency \
+			and also the [/datum/gas/plasma::name] consumption rate.",
+		"Energy" = "[FIRE_PLASMA_ENERGY_RELEASED] joules of energy is released per mole of [/datum/gas/plasma::name] consumed.",
 	)
 
-/datum/gas_reaction/h2fire/init_factors()
+/datum/gas_reaction/standard/h2fire/init_factors()
 	factor = list(
-		/datum/gas/oxygen = "Oxygen is consumed at 0.5 moles per mole of hydrogen consumed. Higher oxygen concentration up to [HYDROGEN_OXYGEN_FULLBURN] times the hydrogen increases the hydrogen consumption rate.",
-		/datum/gas/hydrogen = "Hydrogen is consumed rapidly fast as long as there's enough oxygen to allow combustion.",
-		/datum/gas/water_vapor = "Water vapor is produced at 1 mole per mole of hydrogen combusted.",
+		/datum/gas/oxygen = "[/datum/gas/oxygen::name] is consumed at 0.5 moles per mole of [/datum/gas/hydrogen::name] consumed. \
+			Higher [/datum/gas/oxygen::name] concentration up to [HYDROGEN_OXYGEN_FULLBURN] times \
+			the [/datum/gas/hydrogen::name] increases the [/datum/gas/hydrogen::name] consumption rate.",
+		/datum/gas/hydrogen = "[/datum/gas/hydrogen::name] is consumed rapidly fast as long as there's enough [/datum/gas/oxygen::name] to allow combustion.",
+		/datum/gas/water_vapor = "[/datum/gas/water_vapor::name] is produced at 1 mole per mole of [/datum/gas/hydrogen::name] combusted.",
 		"Temperature" = "Minimum temperature of [FIRE_MINIMUM_TEMPERATURE_TO_EXIST] kelvin to occur",
-		"Energy" = "[FIRE_HYDROGEN_ENERGY_RELEASED] joules of energy is released per mol of hydrogen consumed.",
+		"Energy" = "[FIRE_HYDROGEN_ENERGY_RELEASED] joules of energy is released per mol of [/datum/gas/hydrogen::name] consumed.",
 	)
 
-/datum/gas_reaction/tritfire/init_factors()
+/datum/gas_reaction/standard/tritfire/init_factors()
 	factor = list(
-		/datum/gas/oxygen = "Oxygen is consumed at 0.5 moles per mole of tritium consumed. Higher oxygen concentration up to [TRITIUM_OXYGEN_FULLBURN] times the tritium increases the tritium consumption rate.",
-		/datum/gas/tritium = "Tritium is consumed at rapidly fast as long as there's enough oxygen to allow combustion.",
-		/datum/gas/water_vapor = "Water vapor is produced at 1 mole per mole of tritium combusted.",
+		/datum/gas/oxygen = "[/datum/gas/oxygen::name] is consumed at 0.5 moles per mole of [/datum/gas/tritium::name] consumed. \
+			Higher [/datum/gas/oxygen::name] concentration up to [TRITIUM_OXYGEN_FULLBURN] times \
+			the [/datum/gas/tritium::name] increases the [/datum/gas/tritium::name] consumption rate.",
+		/datum/gas/tritium = "[/datum/gas/tritium::name] is consumed at rapidly fast as long as there's enough [/datum/gas/oxygen::name] to allow combustion.",
+		/datum/gas/water_vapor = "[/datum/gas/water_vapor::name] is produced at 1 mole per mole of [/datum/gas/tritium::name] combusted.",
 		"Temperature" = "Minimum temperature of [FIRE_MINIMUM_TEMPERATURE_TO_EXIST] kelvin to occur",
-		"Energy" = "[FIRE_TRITIUM_ENERGY_RELEASED] joules of energy is released per mol of tritium consumed.",
+		"Energy" = "[FIRE_TRITIUM_ENERGY_RELEASED] joules of energy is released per mol of [/datum/gas/tritium::name] consumed.",
 		"Radiation" = "This reaction emits radiation proportional to the amount of energy released.",
 	)
 
-/datum/gas_reaction/freonfire/init_factors()
+/datum/gas_reaction/standard/freonfire/init_factors()
 	factor = list(
-		/datum/gas/oxygen = "Oxygen consumption is determined by the temperature, ranging from [OXYGEN_BURN_RATIO_BASE] moles per mole of freon consumed at [FREON_LOWER_TEMPERATURE] Kelvins to [OXYGEN_BURN_RATIO_BASE-1] moles per mole of freon consumed at [FREON_MAXIMUM_BURN_TEMPERATURE] Kelvins. Higher oxygen concentration up to [FREON_OXYGEN_FULLBURN] times the freon increases freon consumption rate.",
-		/datum/gas/freon = "Freon is consumed at a rate that scales with the distance of the temperature from [FREON_MAXIMUM_BURN_TEMPERATURE]K. Its relationship with oxygen also determines consumption rate.",
-		/datum/gas/carbon_dioxide = "Carbon Dioxide is formed at 1 mole per mole of freon consumed.",
-		"Temperature" = "Can only occur between [FREON_LOWER_TEMPERATURE] - [FREON_MAXIMUM_BURN_TEMPERATURE] Kelvin",
-		"Energy" = "[FIRE_FREON_ENERGY_CONSUMED] joules of energy is absorbed per mole of freon consumed.",
-		"Hot Ice" = "This reaction produces hot ice when occurring between [HOT_ICE_FORMATION_MINIMUM_TEMPERATURE]-[HOT_ICE_FORMATION_MAXIMUM_TEMPERATURE] kelvins",
+		/datum/gas/oxygen = "[/datum/gas/oxygen::name] consumption is determined by the temperature, \
+			ranging from [OXYGEN_BURN_RATIO_BASE] moles per mole of [/datum/gas/freon::name] consumed at [FREON_LOWER_TEMPERATURE] kelvins \
+			to [OXYGEN_BURN_RATIO_BASE - 1] moles per mole of [/datum/gas/freon::name] consumed at [FREON_MAXIMUM_BURN_TEMPERATURE] kelvins. \
+			Higher [/datum/gas/oxygen::name] concentration up to [FREON_OXYGEN_FULLBURN] times \
+			the [/datum/gas/freon::name] increases [/datum/gas/freon::name] consumption rate.",
+		/datum/gas/freon = "[/datum/gas/freon::name] is consumed at a rate that scales with the distance of the temperature \
+			from [FREON_MAXIMUM_BURN_TEMPERATURE]K. Its relationship with [/datum/gas/oxygen::name] also determines consumption rate.",
+		/datum/gas/carbon_dioxide = "[/datum/gas/carbon_dioxide::name] is formed at 1 mole per mole of [/datum/gas/freon::name] consumed.",
+		"Temperature" = "Can only occur between [FREON_LOWER_TEMPERATURE] - [FREON_MAXIMUM_BURN_TEMPERATURE] kelvin.",
+		"Energy" = "[FIRE_FREON_ENERGY_CONSUMED] joules of energy is absorbed per mole of [/datum/gas/freon::name] consumed.",
+		"Hot Ice" = "This reaction produces \"hot ice\" when occurring between [HOT_ICE_FORMATION_MINIMUM_TEMPERATURE]-[HOT_ICE_FORMATION_MAXIMUM_TEMPERATURE] kelvins.",
 	)
 
 
-/datum/gas_reaction/nitrousformation/init_factors()
+/datum/gas_reaction/standard/nitrousformation/init_factors()
 	factor = list(
-		/datum/gas/oxygen = "10 moles of Oxygen needs to be present for the reaction to occur. Oxygen is consumed at 0.5 moles per mole of nitrous oxide formed.",
-		/datum/gas/nitrogen = " 20 moles of Nitrogen needs to be present for the reaction to occur. Nitrogen is consumed at 1 mole per mole of nitrous oxide formed.",
-		/datum/gas/bz = "5 moles of BZ needs to be present for the reaction to occur. Not consumed.",
-		/datum/gas/nitrous_oxide = "Nitrous oxide gets produced rapidly.",
-		"Temperature" = "Can only occur between [N2O_FORMATION_MIN_TEMPERATURE] - [N2O_FORMATION_MAX_TEMPERATURE] Kelvin",
-		"Energy" = "[N2O_FORMATION_ENERGY] joules of energy is released per mole of nitrous oxide formed.",
+		/datum/gas/oxygen = "10 moles of [/datum/gas/oxygen::name] needs to be present for the reaction to occur. \
+			[/datum/gas/oxygen::name] is consumed at 0.5 moles per mole of [/datum/gas/nitrous_oxide::name] formed.",
+		/datum/gas/nitrogen = " 20 moles of [/datum/gas/nitrogen::name] needs to be present for the reaction to occur. \
+			[/datum/gas/nitrogen::name] is consumed at 1 mole per mole of [/datum/gas/nitrous_oxide::name] formed.",
+		/datum/gas/bz = "5 moles of [/datum/gas/bz::name] needs to be present for the reaction to occur. Not consumed.",
+		/datum/gas/nitrous_oxide = "[/datum/gas/nitrous_oxide::name] gets produced rapidly.",
+		"Temperature" = "Can only occur between [N2O_FORMATION_MIN_TEMPERATURE] - [N2O_FORMATION_MAX_TEMPERATURE] kelvin",
+		"Energy" = "[N2O_FORMATION_ENERGY] joules of energy is released per mole of [/datum/gas/nitrous_oxide::name] formed.",
 	)
 
-/datum/gas_reaction/nitrous_decomp/init_factors()
+/datum/gas_reaction/standard/nitrous_decomp/init_factors()
 	factor = list(
-		/datum/gas/nitrous_oxide = "Nitrous Oxide is decomposed at a rate that scales negatively with the distance between the temperature and average of the minimum and maximum temperature of the reaction. Minimum of [MINIMUM_MOLE_COUNT * 2] to occur.", //okay this one isn't made into a define yet.
-		/datum/gas/oxygen = "Oxygen is formed at 0.5 moles per mole of nitrous oxide decomposed.",
-		/datum/gas/nitrogen = "Nitrogen is formed at 1 mole per mole of nitrous oxide decomposed.",
+		/datum/gas/nitrous_oxide = "[/datum/gas/nitrous_oxide::name] is decomposed at a rate that scales negatively with the distance between \
+			the temperature and average of the minimum and maximum temperature of the reaction. \
+			Minimum of [MINIMUM_MOLE_COUNT * 2] to occur.", //okay this one isn't made into a define yet.
+		/datum/gas/oxygen = "[/datum/gas/oxygen::name] is formed at 0.5 moles per mole of [/datum/gas/nitrous_oxide::name] decomposed.",
+		/datum/gas/nitrogen = "[/datum/gas/nitrogen::name] is formed at 1 mole per mole of [/datum/gas/nitrous_oxide::name] decomposed.",
 		"Temperature" = "The decomposition rate scales with the product of the distances between temperature and minimum and maximum temperature. Can only happen between [N2O_DECOMPOSITION_MIN_TEMPERATURE] - [N2O_DECOMPOSITION_MAX_TEMPERATURE] kelvin.",
-		"Energy" = "[N2O_DECOMPOSITION_ENERGY] joules of energy is released per mole of nitrous oxide decomposed.",
+		"Energy" = "[N2O_DECOMPOSITION_ENERGY] joules of energy is released per mole of [/datum/gas/nitrous_oxide::name] decomposed.",
 	)
 
-/datum/gas_reaction/bzformation/init_factors()
+/datum/gas_reaction/standard/bzformation/init_factors()
 	factor = list(
-		/datum/gas/plasma = "Each mole of BZ made consumes 0.8 moles of plasma. If there is more plasma than nitrous oxide, bz formation rate gets slowed down.",
-		/datum/gas/nitrous_oxide = "Each mole of bz made consumes 0.4 moles of Nitrous oxide. If there is less nitrous oxide than plasma the reaction rate is slowed down. At three times the amount of plasma to Nitrous oxide it will start breaking down into Nitrogen and Oxygen, the lower the ratio the more Nitrous oxide decomposes.",
-		/datum/gas/bz = "The lower the pressure and larger the volume the more bz gets made. Less nitrous oxide than plasma will slow down the reaction.",
-		/datum/gas/nitrogen = "Each mole Nitrous oxide decomposed makes 1 mol Nitrogen. Lower ratio of Nitrous oxide to Plasma means a higher ratio of decomposition to BZ production.",
-		/datum/gas/oxygen = "Each mole Nitrous oxide decomposed makes 0.5 moles Oxygen. Lower ratio of Nitrous oxide to Plasma means a higher ratio of decomposition to BZ production.",
-		"Energy" = "[BZ_FORMATION_ENERGY] joules of energy is released per mol of BZ made. Nitrous oxide decomposition releases [N2O_DECOMPOSITION_ENERGY] per mol decomposed",
+		/datum/gas/plasma = "Each mole of [/datum/gas/bz::name] made consumes 0.8 moles of [/datum/gas/plasma::name]. \
+			If there is more [/datum/gas/plasma::name] than [/datum/gas/nitrous_oxide::name], [/datum/gas/bz::name] formation rate gets slowed down.",
+		/datum/gas/nitrous_oxide = "Each mole of [/datum/gas/bz::name] made consumes 0.4 moles of [/datum/gas/nitrous_oxide::name]. \
+			If there is less [/datum/gas/nitrous_oxide::name] than [/datum/gas/plasma::name] the reaction rate is slowed down. \
+			At three times the amount of [/datum/gas/plasma::name] to [/datum/gas/nitrous_oxide::name], \
+			it will start breaking down into [/datum/gas/nitrogen::name] and [/datum/gas/oxygen::name] - \
+			the lower the ratio, the more [/datum/gas/nitrous_oxide::name] decomposes.",
+		/datum/gas/bz = "The lower the pressure and larger the volume the more [/datum/gas/bz::name] gets made. \
+			Less [/datum/gas/nitrous_oxide::name] than [/datum/gas/plasma::name] will slow down the reaction.",
+		/datum/gas/nitrogen = "Each mole [/datum/gas/nitrous_oxide::name] decomposed makes 1 mol [/datum/gas/nitrogen::name]. \
+			Lower ratio of [/datum/gas/nitrous_oxide::name] to [/datum/gas/plasma::name] means a higher ratio of decomposition to [/datum/gas/bz::name] production.",
+		/datum/gas/oxygen = "Each mole [/datum/gas/nitrous_oxide::name] decomposed makes 0.5 moles [/datum/gas/oxygen::name]. \
+			Lower ratio of [/datum/gas/nitrous_oxide::name] to [/datum/gas/plasma::name] means a higher ratio of decomposition to [/datum/gas/bz::name] production.",
+		"Energy" = "[BZ_FORMATION_ENERGY] joules of energy is released per mol of [/datum/gas/bz::name] made. \
+			[/datum/gas/nitrous_oxide::name] decomposition releases [N2O_DECOMPOSITION_ENERGY] per mol decomposed.",
 	)
 
-/datum/gas_reaction/pluox_formation/init_factors()
+/datum/gas_reaction/standard/pluox_formation/init_factors()
 	factor = list(
-		/datum/gas/carbon_dioxide = "1 mole of carbon dioxide gets consumed per mole of pluoxium formed.",
-		/datum/gas/oxygen = "Oxygen is consumed at 0.5 moles per mole of pluoxium formed.",
-		/datum/gas/tritium = "Tritium is converted into hydrogen at 0.01 moles per mole of pluoxium formed.",
-		/datum/gas/pluoxium = "Pluoxium is produced at a constant rate in any given mixture.",
-		/datum/gas/hydrogen = "Hydrogen is formed from the tritium losing their neutrons.",
-		"Energy" = "[PLUOXIUM_FORMATION_ENERGY] joules of energy is released per mole of pluoxium formed.",
-		"Temperature" = "Can only occur between [PLUOXIUM_FORMATION_MIN_TEMP] - [PLUOXIUM_FORMATION_MAX_TEMP] Kelvin",
+		/datum/gas/carbon_dioxide = "1 mole of [/datum/gas/carbon_dioxide::name] gets consumed per mole of [/datum/gas/pluoxium::name] formed.",
+		/datum/gas/oxygen = "[/datum/gas/oxygen::name] is consumed at 0.5 moles per mole of [/datum/gas/pluoxium::name] formed.",
+		/datum/gas/tritium = "[/datum/gas/tritium::name] is converted into [/datum/gas/hydrogen::name] at 0.01 moles per mole of [/datum/gas/pluoxium::name] formed.",
+		/datum/gas/pluoxium = "[/datum/gas/pluoxium::name] is produced at a constant rate in any given mixture.",
+		/datum/gas/hydrogen = "[/datum/gas/hydrogen::name] is formed from the [/datum/gas/tritium::name] losing their neutrons.",
+		"Energy" = "[PLUOXIUM_FORMATION_ENERGY] joules of energy is released per mole of [/datum/gas/pluoxium::name] formed.",
+		"Temperature" = "Can only occur between [PLUOXIUM_FORMATION_MIN_TEMP] - [PLUOXIUM_FORMATION_MAX_TEMP] kelvin",
 	)
 
-/datum/gas_reaction/nitrium_formation/init_factors()
+/datum/gas_reaction/standard/nitrium_formation/init_factors()
 	factor = list(
-		/datum/gas/bz = "5 moles of BZ needs to be present for the reaction to occur. BZ is consumed at 0.05 moles per mole of nitrium formed.",
-		/datum/gas/tritium = "20 moles of tritium needs to be present for the reaction to occur. Tritium is consumed at 1 mole per mole of nitroum formed.",
-		/datum/gas/nitrogen = "10 moles of nitrogen needs to be present for the reaction to occur. Nitrogen is consumed at 1 mole per mole of nitrium formed.",
-		/datum/gas/nitrium = "Nitrium is produced at a rate that scales with the temperature.",
+		/datum/gas/bz = "5 moles of [/datum/gas/bz::name] needs to be present for the reaction to occur. \
+			[/datum/gas/bz::name] is consumed at 0.05 moles per mole of [/datum/gas/nitrium::name] formed.",
+		/datum/gas/tritium = "20 moles of [/datum/gas/tritium::name] needs to be present for the reaction to occur. \
+			[/datum/gas/tritium::name] is consumed at 1 mole per mole of [/datum/gas/nitrium::name] formed.",
+		/datum/gas/nitrogen = "10 moles of [/datum/gas/nitrogen::name] needs to be present for the reaction to occur. \
+			[/datum/gas/nitrogen::name] is consumed at 1 mole per mole of [/datum/gas/nitrium::name] formed.",
+		/datum/gas/nitrium = "[/datum/gas/nitrium::name] is produced at a rate that scales with the temperature.",
 		"Temperature" = "Can only occur above [NITRIUM_FORMATION_MIN_TEMP] kelvins",
-		"Energy" = "[NITRIUM_FORMATION_ENERGY] joules of energy is absorbed per mole of nitrium formed.",
+		"Energy" = "[NITRIUM_FORMATION_ENERGY] joules of energy is absorbed per mole of [/datum/gas/nitrium::name] formed.",
 	)
 
-/datum/gas_reaction/nitrium_decomposition/init_factors()
+/datum/gas_reaction/standard/nitrium_decomposition/init_factors()
 	factor = list(
-		/datum/gas/oxygen = "[MINIMUM_MOLE_COUNT] moles of oxygen need to be present for the reaction to occur. Not consumed.",
-		/datum/gas/nitrium = "Nitrium is consumed at a rate that scales with the temperature.",
-		/datum/gas/hydrogen = "Hydrogen is produced at 1 mole per mole of nitrium decomposed.",
-		/datum/gas/nitrogen = "Nitrogen is produced at 1 mole per mole of nitrium decomposed.",
-		"Temperature" = "Can only occur below [NITRIUM_DECOMPOSITION_MAX_TEMP]. Higher temperature increases the nitrium decomposition rate.",
-		"Energy" = "[NITRIUM_DECOMPOSITION_ENERGY] joules of energy is released per mole of nitrium decomposed.",
+		/datum/gas/oxygen = "[MINIMUM_MOLE_COUNT] moles of [/datum/gas/oxygen::name] need to be present for the reaction to occur. Not consumed.",
+		/datum/gas/nitrium = "[/datum/gas/nitrium::name] is consumed at a rate that scales with the temperature.",
+		/datum/gas/hydrogen = "[/datum/gas/hydrogen::name] is produced at 1 mole per mole of [/datum/gas/nitrium::name] decomposed.",
+		/datum/gas/nitrogen = "[/datum/gas/nitrogen::name] is produced at 1 mole per mole of [/datum/gas/nitrium::name] decomposed.",
+		"Temperature" = "Can only occur below [NITRIUM_DECOMPOSITION_MAX_TEMP]. Higher temperature increases the [/datum/gas/nitrium::name] decomposition rate.",
+		"Energy" = "[NITRIUM_DECOMPOSITION_ENERGY] joules of energy is released per mole of [/datum/gas/nitrium::name] decomposed.",
 	)
 
-/datum/gas_reaction/freonformation/init_factors()
+/datum/gas_reaction/standard/freonformation/init_factors()
 	factor = list(
-		/datum/gas/plasma = "At least 0.06 moles of plasma needs to be present. Plasma is consumed at 0.6 moles per mole of freon formed.",
-		/datum/gas/carbon_dioxide = "At least 0.03 moles of CO2 needs to be present. CO2 is consumed at 0.3 moles per mole of freon formed.",
-		/datum/gas/bz = "At least 0.01 moles of BZ needs to be present. BZ is consumed at 0.1 moles per mole of freon formed.",
-		/datum/gas/freon = "Freon is produced at a rate that scales with the sum of a quadratic exponential and sigmoidal function, with the quadratic exponential peaking at 800 Kelvin, but the sigmoidal function takes dominance at over 5,500K being up to 3 times more efficient.",
-		"Energy" = "Between 100 and 800 joules of energy is absorbed per mole of freon produced", // I don't know why the energy release is also a sigmoidal function, but it should really just be constant to be honest.
-		"Temperature" = "Minimum temperature of [FIRE_MINIMUM_TEMPERATURE_TO_EXIST + 100] Kelvin to occur, with production peak at 800 K. However at temperatures above 5500 K higher rates are possible maxing out at three times the low temperature rate at over 8500 K.",
+		/datum/gas/plasma = "At least 0.06 moles of [/datum/gas/plasma::name] needs to be present. \
+			[/datum/gas/plasma::name] is consumed at 0.6 moles per mole of [/datum/gas/freon::name] formed.",
+		/datum/gas/carbon_dioxide = "At least 0.03 moles of [/datum/gas/carbon_dioxide::name] needs to be present. \
+			[/datum/gas/carbon_dioxide::name] is consumed at 0.3 moles per mole of [/datum/gas/freon::name] formed.",
+		/datum/gas/bz = "At least 0.01 moles of [/datum/gas/bz::name] needs to be present. \
+			[/datum/gas/bz::name] is consumed at 0.1 moles per mole of [/datum/gas/freon::name] formed.",
+		/datum/gas/freon = "[/datum/gas/freon::name] is produced at a rate that scales with temperature, \
+			peaking first at 800 kelvin, then peaking again, 3 times higher, at 5,500 kelvin.",
+		"Energy" = "Between 100 and 800 joules of energy is absorbed per mole of [/datum/gas/freon::name] produced", // I don't know why the energy release is also a sigmoidal function, but it should really just be constant to be honest.
+		"Temperature" = "Minimum temperature of [FIRE_MINIMUM_TEMPERATURE_TO_EXIST + 100] kelvin to occur, \
+			with production peak at 800 K. However at temperatures above 5500 K higher rates are possible \
+			maxing out at three times the low temperature rate at over 8500 K.",
 	)
 
-/datum/gas_reaction/nobliumformation/init_factors()
+/datum/gas_reaction/standard/nobliumformation/init_factors()
 	factor = list(
-		/datum/gas/nitrogen = "10 moles of nitrogen needs to be present for the reaction to occur. Nitrogen is consumed at 10 moles per mole of hypernoblium formed.",
-		/datum/gas/tritium = "5 moles of tritium needs to be present for the reaction to occur. Tritium is consumed at 5 moles per mole of hypernoblium formed. The relative consumption rate of tritium decreases in the exposure of BZ.",
-		/datum/gas/hypernoblium = "Hyper-Noblium production scales based on the sum of the nitrogen and tritium moles.",
-		"Energy" = "[NOBLIUM_FORMATION_ENERGY] joules of energy is released per mole of hypernoblium produced.",
-		/datum/gas/bz = "BZ is not consumed in the reaction but will lower the amount of energy released. It also reduces amount of tritium consumed by a ratio between tritium and bz, greater bz than tritium will reduce more.",
+		/datum/gas/nitrogen = "10 moles of [/datum/gas/nitrogen::name] needs to be present for the reaction to occur. \
+			[/datum/gas/nitrogen::name] is consumed at 10 moles per mole of [/datum/gas/hypernoblium::name] formed.",
+		/datum/gas/tritium = "5 moles of [/datum/gas/tritium::name] needs to be present for the reaction to occur. \
+			[/datum/gas/tritium::name] is consumed at 5 moles per mole of [/datum/gas/hypernoblium::name] formed. \
+				The relative consumption rate of [/datum/gas/tritium::name] decreases in the exposure of [/datum/gas/bz::name].",
+		/datum/gas/hypernoblium = "[/datum/gas/hypernoblium::name] production scales based on the sum \
+			of the [/datum/gas/nitrogen::name] and [/datum/gas/tritium::name] moles.",
+		"Energy" = "[NOBLIUM_FORMATION_ENERGY] joules of energy is released per mole of [/datum/gas/hypernoblium::name] produced.",
+		/datum/gas/bz = "[/datum/gas/bz::name] is not consumed in the reaction but will lower the amount of energy released. \
+			It also reduces amount of [/datum/gas/tritium::name] consumed by a ratio \
+			between [/datum/gas/tritium::name] and [/datum/gas/bz::name], greater [/datum/gas/bz::name] than [/datum/gas/tritium::name] will reduce more.",
 		"Temperature" = "Can only occur between [NOBLIUM_FORMATION_MIN_TEMP] - [NOBLIUM_FORMATION_MAX_TEMP] kelvin",
 	)
 
-/datum/gas_reaction/halon_o2removal/init_factors()
+/datum/gas_reaction/standard/halon_o2removal/init_factors()
 	factor = list(
-		/datum/gas/halon = "Halon is consumed at a rate that scales with temperature.",
-		/datum/gas/oxygen = "20 moles of oxygen is consumed per mole of halon combusted.",
-		/datum/gas/carbon_dioxide = "Carbon dioxide is produced at 5 moles per mole of halon consumed.",
-		"Energy" = "[HALON_COMBUSTION_ENERGY] joules of energy is absorbed per mole of halon consumed.",
-		"Temperature" = "Can only occur above [FIRE_MINIMUM_TEMPERATURE_TO_EXIST] kelvin. Higher temperature increases halon consumption rate.",
+		/datum/gas/halon = "[/datum/gas/halon::name] is consumed at a rate that scales with temperature.",
+		/datum/gas/oxygen = "20 moles of [/datum/gas/oxygen::name] is consumed per mole of [/datum/gas/halon::name] combusted.",
+		/datum/gas/carbon_dioxide = "[/datum/gas/carbon_dioxide::name] is produced at 5 moles per mole of [/datum/gas/halon::name] consumed.",
+		"Energy" = "[HALON_COMBUSTION_ENERGY] joules of energy is absorbed per mole of [/datum/gas/halon::name] consumed.",
+		"Temperature" = "Can only occur above [FIRE_MINIMUM_TEMPERATURE_TO_EXIST] kelvin. Higher temperature increases [/datum/gas/halon::name] consumption rate.",
 	)
 
-/datum/gas_reaction/healium_formation/init_factors()
+/datum/gas_reaction/standard/healium_formation/init_factors()
 	factor = list(
-		/datum/gas/bz = "BZ is consumed at 1/12th of a mole per mole of healium formed.",
-		/datum/gas/freon = "Freon is consumed at 11/12th of a mole per mole of healium formed.",
-		/datum/gas/healium = "Healium is formed at a rate that scales with the temperature.",
-		"Temperature" = "Can only occur between [HEALIUM_FORMATION_MIN_TEMP] - [HEALIUM_FORMATION_MAX_TEMP]. Higher temperature increases healium formation rate.",
-		"Energy" = "[HEALIUM_FORMATION_ENERGY/3] joules of energy is released per mole of healium formed.",
+		/datum/gas/bz = "[/datum/gas/bz::name] is consumed at 1/12th of a mole per mole of [/datum/gas/healium::name] formed.",
+		/datum/gas/freon = "[/datum/gas/freon::name] is consumed at 11/12th of a mole per mole of [/datum/gas/healium::name] formed.",
+		/datum/gas/healium = "[/datum/gas/healium::name] is formed at a rate that scales with the temperature.",
+		"Temperature" = "Can only occur between [HEALIUM_FORMATION_MIN_TEMP] - [HEALIUM_FORMATION_MAX_TEMP]. \
+			Higher temperature increases [/datum/gas/healium::name] formation rate.",
+		"Energy" = "[HEALIUM_FORMATION_ENERGY/3] joules of energy is released per mole of [/datum/gas/healium::name] formed.",
 	)
 
-/datum/gas_reaction/zauker_formation/init_factors()
+/datum/gas_reaction/standard/zauker_formation/init_factors()
 	factor = list(
-		/datum/gas/hypernoblium = "Hyper-Noblium is consumed at 0.02 moles per mole of zauker formed.",
-		/datum/gas/nitrium = "Nitrium is consumed at 1 mole per mole of zauker formed.",
-		/datum/gas/zauker = "Zauker is produced at a rate that scales with the temperature.",
-		"Temperature" = "Can only occur between [ZAUKER_FORMATION_MIN_TEMPERATURE] - [ZAUKER_FORMATION_MAX_TEMPERATURE] kelvin. Zauker formation rate is proportional to the temperature.",
-		"Energy" = "[2 * ZAUKER_FORMATION_ENERGY] joules of energy is absorbed per mole of zauker formed.",
+		/datum/gas/hypernoblium = "[/datum/gas/hypernoblium::name] is consumed at 0.02 moles per mole of [/datum/gas/zauker::name] formed.",
+		/datum/gas/nitrium = "[/datum/gas/nitrium::name] is consumed at 1 mole per mole of [/datum/gas/zauker::name] formed.",
+		/datum/gas/zauker = "[/datum/gas/zauker::name] is produced at a rate that scales with the temperature.",
+		"Temperature" = "Can only occur between [ZAUKER_FORMATION_MIN_TEMPERATURE] - [ZAUKER_FORMATION_MAX_TEMPERATURE] kelvin. [/datum/gas/zauker::name] formation rate is proportional to the temperature.",
+		"Energy" = "[2 * ZAUKER_FORMATION_ENERGY] joules of energy is absorbed per mole of [/datum/gas/zauker::name] formed.",
 	)
 
-/datum/gas_reaction/zauker_decomp/init_factors() //Fixed reaction rate
+/datum/gas_reaction/standard/zauker_decomp/init_factors() //Fixed reaction rate
 	factor = list(
-		/datum/gas/zauker = "Zauker is consumed at [ZAUKER_DECOMPOSITION_MAX_RATE SECONDS / SSair.wait] moles per second in any unique gas mixture.",
-		/datum/gas/nitrogen = "At least [MINIMUM_MOLE_COUNT] moles of Nitrogen needs to be present for this reaction to occur. Nitrogen is produced at 0.7 moles per mole of Zauker decomposed.",
-		/datum/gas/oxygen = "Oxygen is produced at 0.3 moles per mole of zauker decomposed.",
-		"Energy" = "[ZAUKER_DECOMPOSITION_ENERGY] joules of energy is released per mole of zauker decomposed.",
+		/datum/gas/zauker = "[/datum/gas/zauker::name] is consumed at [ZAUKER_DECOMPOSITION_MAX_RATE SECONDS / SSair.wait] moles per second in any unique gas mixture.",
+		/datum/gas/nitrogen = "At least [MINIMUM_MOLE_COUNT] moles of [/datum/gas/nitrogen::name] needs to be present for this reaction to occur. \
+			[/datum/gas/nitrogen::name] is produced at 0.7 moles per mole of [/datum/gas/zauker::name] decomposed.",
+		/datum/gas/oxygen = "[/datum/gas/oxygen::name] is produced at 0.3 moles per mole of [/datum/gas/zauker::name] decomposed.",
+		"Energy" = "[ZAUKER_DECOMPOSITION_ENERGY] joules of energy is released per mole of [/datum/gas/zauker::name] decomposed.",
 	)
 
-/datum/gas_reaction/proto_nitrate_formation/init_factors()
+/datum/gas_reaction/standard/proto_nitrate_formation/init_factors()
 	factor = list(
-		/datum/gas/pluoxium = "Pluoxium is consumed at 1/11th of a mole per mole of proto-nitrate formed.",
-		/datum/gas/hydrogen = "Hydrogen is consumed at 10/11th of a mole per mole of proto-nitrate formed.",
-		/datum/gas/proto_nitrate = "Proto-Nitrate is produced at a rate that scales with the temperature.",
-		"Energy" = "[PN_FORMATION_ENERGY / 2.2] joules of energy is released per mole of proto-nitrate formed.",
-		"Temperature" = "Can only occur between [PN_FORMATION_MIN_TEMPERATURE] - [PN_FORMATION_MAX_TEMPERATURE] kelvin. Higher temperature increases proto-nitrate formation rate.",
+		/datum/gas/pluoxium = "[/datum/gas/pluoxium::name] is consumed at 1/11th of a mole per mole of [/datum/gas/proto_nitrate::name] formed.",
+		/datum/gas/hydrogen = "[/datum/gas/hydrogen::name] is consumed at 10/11th of a mole per mole of [/datum/gas/proto_nitrate::name] formed.",
+		/datum/gas/proto_nitrate = "[/datum/gas/proto_nitrate::name] is produced at a rate that scales with the temperature.",
+		"Energy" = "[PN_FORMATION_ENERGY / 2.2] joules of energy is released per mole of [/datum/gas/proto_nitrate::name] formed.",
+		"Temperature" = "Can only occur between [PN_FORMATION_MIN_TEMPERATURE] - [PN_FORMATION_MAX_TEMPERATURE] kelvin. \
+			Higher temperature increases [/datum/gas/proto_nitrate::name] formation rate.",
 	)
 
-/datum/gas_reaction/proto_nitrate_hydrogen_response/init_factors() // Fixed reaction rate
+/datum/gas_reaction/standard/proto_nitrate_hydrogen_response/init_factors() // Fixed reaction rate
 	factor = list(
-		/datum/gas/hydrogen = "[PN_HYDROGEN_CONVERSION_THRESHOLD] moles of hydrogen needs to be present for the reaction to occur. Hydrogen is consumed at 2 moles per mole of proto-nitrate formed.",
-		/datum/gas/proto_nitrate = "[MINIMUM_MOLE_COUNT] moles of proto-nitrate needs to be present for the reaction to occur. Proto nitrate is produced a rate that scales with its mole count, up to a max of [PN_HYDROGEN_CONVERSION_MAX_RATE * 0.5 SECONDS / SSair.wait] moles per second.",
-		"Energy" = "[PN_HYDROGEN_CONVERSION_ENERGY * 2] joules of energy is absorbed per mole of proto-nitrate formed.",
+		/datum/gas/hydrogen = "[PN_HYDROGEN_CONVERSION_THRESHOLD] moles of [/datum/gas/hydrogen::name] needs to be present for the reaction to occur. \
+			[/datum/gas/hydrogen::name] is consumed at 2 moles per mole of [/datum/gas/proto_nitrate::name] formed.",
+		/datum/gas/proto_nitrate = "[MINIMUM_MOLE_COUNT] moles of [/datum/gas/proto_nitrate::name] needs to be present for the reaction to occur. \
+			[/datum/gas/proto_nitrate::name] is produced a rate that scales with its mole count, \
+			up to a max of [PN_HYDROGEN_CONVERSION_MAX_RATE * 0.5 SECONDS / SSair.wait] moles per second.",
+		"Energy" = "[PN_HYDROGEN_CONVERSION_ENERGY * 2] joules of energy is absorbed per mole of [/datum/gas/proto_nitrate::name] formed.",
 	)
 
-/datum/gas_reaction/proto_nitrate_tritium_response/init_factors()
+/datum/gas_reaction/standard/proto_nitrate_tritium_response/init_factors()
 	factor = list(
-		/datum/gas/tritium = "Tritium radiates its neutrons at a rate that scales with the temperature and proto-nitrate mole count.",
-		/datum/gas/proto_nitrate = "Proto nitrate is consumed at 0.005 moles per mole of neutrons released.",
-		/datum/gas/hydrogen = "Hydrogen remains after the neutrons escape.",
+		/datum/gas/tritium = "[/datum/gas/tritium::name] radiates its neutrons at a rate that scales with the temperature and [/datum/gas/proto_nitrate::name] mole count.",
+		/datum/gas/proto_nitrate = "[/datum/gas/proto_nitrate::name] is consumed at 0.005 moles per mole of neutrons released.",
+		/datum/gas/hydrogen = "[/datum/gas/hydrogen::name] remains after the neutrons escape.",
 		"Energy" = "[PN_TRITIUM_CONVERSION_ENERGY / 2] joules of energy is released per mole of neutron released.",
-		"Radiation" = "Neutrons get released as ionising radiation.",
+		"Radiation" = "Neutrons are released as ionising radiation.",
 	)
 
-/datum/gas_reaction/proto_nitrate_bz_response/init_factors()
+/datum/gas_reaction/standard/proto_nitrate_bz_response/init_factors()
 	factor = list(
-		/datum/gas/proto_nitrate = "[MINIMUM_MOLE_COUNT] moles of proto-nitrate needs to be present for the reaction to occur. Proto-nitrate accelerates the BZ decomposition.",
-		/datum/gas/bz = "BZ gets decomposed into plasma and nitrous oxide. The nitrous oxide then decomposes into nitrogen and oxygen, with the oxygen then decaying into helium.",
-		/datum/gas/nitrogen = "Nitrogen is produced at 0.4 moles per mole of BZ decomposed.",
-		/datum/gas/helium = "Helium is produced at 1.6 moles per mole of BZ decomposed.",
-		/datum/gas/plasma = "Plasma is produced at 0.8 moles per mole of BZ decomposed.",
-		"Energy" = "[PN_BZASE_ENERGY] joules of energy is released per mole of BZ decomposed.",
-		"Radiation" = "Radiation gets released during this decomposition process.",
+		/datum/gas/proto_nitrate = "[MINIMUM_MOLE_COUNT] moles of [/datum/gas/proto_nitrate::name] needs to be present for the reaction to occur. \
+			[/datum/gas/proto_nitrate::name] accelerates the [/datum/gas/bz::name] decomposition.",
+		/datum/gas/bz = "[/datum/gas/bz::name] gets decomposed into [/datum/gas/plasma::name] and [/datum/gas/nitrous_oxide::name]. \
+			The [/datum/gas/nitrous_oxide::name] then decomposes into [/datum/gas/nitrogen::name] and [/datum/gas/oxygen::name], \
+			with the [/datum/gas/oxygen::name] then decaying into [/datum/gas/helium::name].",
+		/datum/gas/nitrogen = "[/datum/gas/nitrogen::name] is produced at 0.4 moles per mole of [/datum/gas/bz::name] decomposed.",
+		/datum/gas/helium = "[/datum/gas/helium::name] is produced at 1.6 moles per mole of [/datum/gas/bz::name] decomposed.",
+		/datum/gas/plasma = "[/datum/gas/plasma::name] is produced at 0.8 moles per mole of [/datum/gas/bz::name] decomposed.",
+		"Energy" = "[PN_BZASE_ENERGY] joules of energy is released per mole of [/datum/gas/bz::name] decomposed.",
+		"Radiation" = "Radiation is released during this decomposition process.",
 		"Hallucinations" = "This reaction can cause various carbon based lifeforms in the vicinity to hallucinate.",
-		"Nuclear Particles" = "This reaction emits extremely high energy nuclear particles, up to [2 * PN_BZASE_NUCLEAR_PARTICLE_MAXIMUM] per second per unique gas mixture.",
+		"Nuclear Particles" = "This reaction emits extremely high energy nuclear particles, \
+			up to [2 * PN_BZASE_NUCLEAR_PARTICLE_MAXIMUM] per second per unique gas mixture.",
 		"Temperature" = "Can only occur between [PN_BZASE_MIN_TEMP] - [PN_BZASE_MAX_TEMP] kelvin.",
 	)
 
-/datum/gas_reaction/antinoblium_replication/init_factors()
+/datum/gas_reaction/standard/antinoblium_replication/init_factors()
 	factor = list(
-		/datum/gas/antinoblium = "[MOLES_GAS_VISIBLE] moles of antinoblium is needed to replicate itself. Requires other gases to be converted to antinoblium.",
-		"Temperature" = "Can only occur above [REACTION_OPPRESSION_MIN_TEMP] Kelvin."
+		/datum/gas/antinoblium = "[MOLES_GAS_VISIBLE] moles of [/datum/gas/antinoblium::name] is needed to replicate itself. \
+			Requires other gases to be converted to [/datum/gas/antinoblium::name].",
+		"Temperature" = "Can only occur above [REACTION_OPPRESSION_MIN_TEMP] kelvin."
 	)
-

--- a/code/modules/atmospherics/gasmixtures/reaction_factors.dm
+++ b/code/modules/atmospherics/gasmixtures/reaction_factors.dm
@@ -2,8 +2,8 @@
 	factor = list(
 		/datum/gas/water_vapor = "Condensation will consume [MOLES_GAS_VISIBLE] moles. \
 			Freezing will not consume any. Both requires a minimum of [MOLES_GAS_VISIBLE] moles to occur.",
-		"Temperature" = "Freezes a tile at [WATER_VAPOR_DEPOSITION_POINT] kelvins or below, \
-			wets it at [WATER_VAPOR_CONDENSATION_POINT] kelvins or below.",
+		"Temperature" = "Freezes a tile at [WATER_VAPOR_DEPOSITION_POINT]K or below, \
+			wets it at [WATER_VAPOR_CONDENSATION_POINT]K or below.",
 		"Location" = "Can only happen on tiles.",
 	)
 
@@ -19,8 +19,8 @@
 /datum/gas_reaction/standard/plasmafire/init_factors()
 	factor = list(
 		/datum/gas/oxygen = "[/datum/gas/oxygen::name] consumption is determined by the temperature, \
-			ranging from [OXYGEN_BURN_RATIO_BASE] moles per mole of [/datum/gas/plasma::name] consumed at [PLASMA_MINIMUM_BURN_TEMPERATURE] kelvins \
-			to [OXYGEN_BURN_RATIO_BASE-1] moles per mole of [/datum/gas/plasma::name] consumed at [PLASMA_UPPER_TEMPERATURE] kelvins. \
+			ranging from [OXYGEN_BURN_RATIO_BASE] moles per mole of [/datum/gas/plasma::name] consumed at [PLASMA_MINIMUM_BURN_TEMPERATURE]K \
+			to [OXYGEN_BURN_RATIO_BASE-1] moles per mole of [/datum/gas/plasma::name] consumed at [PLASMA_UPPER_TEMPERATURE]K. \
 			Higher [/datum/gas/oxygen::name] concentration up to [PLASMA_OXYGEN_FULLBURN] times the [/datum/gas/plasma::name] \
 			increases the speed of [/datum/gas/plasma::name] consumption.",
 		/datum/gas/plasma = "[/datum/gas/plasma::name] is consumed at a rate that scales with the difference between the temperature \
@@ -31,7 +31,7 @@
 			if [/datum/gas/tritium::name] isn't being formed.",
 		/datum/gas/carbon_dioxide = "[/datum/gas/carbon_dioxide::name] is formed at 0.75 moles per mole of [/datum/gas/plasma::name] consumed \
 			if [/datum/gas/tritium::name] isn't being formed.",
-		"Temperature" = "Minimum temperature of [PLASMA_MINIMUM_BURN_TEMPERATURE] kelvin to occur. \
+		"Temperature" = "Minimum temperature of [PLASMA_MINIMUM_BURN_TEMPERATURE]K to occur. \
 			Higher temperature up to [PLASMA_UPPER_TEMPERATURE]K increases the [/datum/gas/oxygen::name] efficiency \
 			and also the [/datum/gas/plasma::name] consumption rate.",
 		"Energy" = "[FIRE_PLASMA_ENERGY_RELEASED] joules of energy is released per mole of [/datum/gas/plasma::name] consumed.",
@@ -44,7 +44,7 @@
 			the [/datum/gas/hydrogen::name] increases the [/datum/gas/hydrogen::name] consumption rate.",
 		/datum/gas/hydrogen = "[/datum/gas/hydrogen::name] is consumed rapidly fast as long as there's enough [/datum/gas/oxygen::name] to allow combustion.",
 		/datum/gas/water_vapor = "[/datum/gas/water_vapor::name] is produced at 1 mole per mole of [/datum/gas/hydrogen::name] combusted.",
-		"Temperature" = "Minimum temperature of [FIRE_MINIMUM_TEMPERATURE_TO_EXIST] kelvin to occur",
+		"Temperature" = "Minimum temperature of [FIRE_MINIMUM_TEMPERATURE_TO_EXIST]K to occur",
 		"Energy" = "[FIRE_HYDROGEN_ENERGY_RELEASED] joules of energy is released per mol of [/datum/gas/hydrogen::name] consumed.",
 	)
 
@@ -55,7 +55,7 @@
 			the [/datum/gas/tritium::name] increases the [/datum/gas/tritium::name] consumption rate.",
 		/datum/gas/tritium = "[/datum/gas/tritium::name] is consumed at rapidly fast as long as there's enough [/datum/gas/oxygen::name] to allow combustion.",
 		/datum/gas/water_vapor = "[/datum/gas/water_vapor::name] is produced at 1 mole per mole of [/datum/gas/tritium::name] combusted.",
-		"Temperature" = "Minimum temperature of [FIRE_MINIMUM_TEMPERATURE_TO_EXIST] kelvin to occur",
+		"Temperature" = "Minimum temperature of [FIRE_MINIMUM_TEMPERATURE_TO_EXIST]K to occur",
 		"Energy" = "[FIRE_TRITIUM_ENERGY_RELEASED] joules of energy is released per mol of [/datum/gas/tritium::name] consumed.",
 		"Radiation" = "This reaction emits radiation proportional to the amount of energy released.",
 	)
@@ -63,16 +63,16 @@
 /datum/gas_reaction/standard/freonfire/init_factors()
 	factor = list(
 		/datum/gas/oxygen = "[/datum/gas/oxygen::name] consumption is determined by the temperature, \
-			ranging from [OXYGEN_BURN_RATIO_BASE] moles per mole of [/datum/gas/freon::name] consumed at [FREON_LOWER_TEMPERATURE] kelvins \
-			to [OXYGEN_BURN_RATIO_BASE - 1] moles per mole of [/datum/gas/freon::name] consumed at [FREON_MAXIMUM_BURN_TEMPERATURE] kelvins. \
+			ranging from [OXYGEN_BURN_RATIO_BASE] moles per mole of [/datum/gas/freon::name] consumed at [FREON_LOWER_TEMPERATURE]K \
+			to [OXYGEN_BURN_RATIO_BASE - 1] moles per mole of [/datum/gas/freon::name] consumed at [FREON_MAXIMUM_BURN_TEMPERATURE]K. \
 			Higher [/datum/gas/oxygen::name] concentration up to [FREON_OXYGEN_FULLBURN] times \
 			the [/datum/gas/freon::name] increases [/datum/gas/freon::name] consumption rate.",
 		/datum/gas/freon = "[/datum/gas/freon::name] is consumed at a rate that scales with the distance of the temperature \
 			from [FREON_MAXIMUM_BURN_TEMPERATURE]K. Its relationship with [/datum/gas/oxygen::name] also determines consumption rate.",
 		/datum/gas/carbon_dioxide = "[/datum/gas/carbon_dioxide::name] is formed at 1 mole per mole of [/datum/gas/freon::name] consumed.",
-		"Temperature" = "Can only occur between [FREON_LOWER_TEMPERATURE] - [FREON_MAXIMUM_BURN_TEMPERATURE] kelvin.",
+		"Temperature" = "Can only occur between [FREON_LOWER_TEMPERATURE] - [FREON_MAXIMUM_BURN_TEMPERATURE]K.",
 		"Energy" = "[FIRE_FREON_ENERGY_CONSUMED] joules of energy is absorbed per mole of [/datum/gas/freon::name] consumed.",
-		"Hot Ice" = "This reaction produces \"hot ice\" when occurring between [HOT_ICE_FORMATION_MINIMUM_TEMPERATURE]-[HOT_ICE_FORMATION_MAXIMUM_TEMPERATURE] kelvins.",
+		"Hot Ice" = "This reaction produces \"hot ice\" when occurring between [HOT_ICE_FORMATION_MINIMUM_TEMPERATURE]-[HOT_ICE_FORMATION_MAXIMUM_TEMPERATURE]K.",
 	)
 
 
@@ -84,7 +84,7 @@
 			[/datum/gas/nitrogen::name] is consumed at 1 mole per mole of [/datum/gas/nitrous_oxide::name] formed.",
 		/datum/gas/bz = "5 moles of [/datum/gas/bz::name] needs to be present for the reaction to occur. Not consumed.",
 		/datum/gas/nitrous_oxide = "[/datum/gas/nitrous_oxide::name] gets produced rapidly.",
-		"Temperature" = "Can only occur between [N2O_FORMATION_MIN_TEMPERATURE] - [N2O_FORMATION_MAX_TEMPERATURE] kelvin",
+		"Temperature" = "Can only occur between [N2O_FORMATION_MIN_TEMPERATURE] - [N2O_FORMATION_MAX_TEMPERATURE]K",
 		"Energy" = "[N2O_FORMATION_ENERGY] joules of energy is released per mole of [/datum/gas/nitrous_oxide::name] formed.",
 	)
 
@@ -95,7 +95,7 @@
 			Minimum of [MINIMUM_MOLE_COUNT * 2] to occur.", //okay this one isn't made into a define yet.
 		/datum/gas/oxygen = "[/datum/gas/oxygen::name] is formed at 0.5 moles per mole of [/datum/gas/nitrous_oxide::name] decomposed.",
 		/datum/gas/nitrogen = "[/datum/gas/nitrogen::name] is formed at 1 mole per mole of [/datum/gas/nitrous_oxide::name] decomposed.",
-		"Temperature" = "The decomposition rate scales with the product of the distances between temperature and minimum and maximum temperature. Can only happen between [N2O_DECOMPOSITION_MIN_TEMPERATURE] - [N2O_DECOMPOSITION_MAX_TEMPERATURE] kelvin.",
+		"Temperature" = "The decomposition rate scales with the product of the distances between temperature and minimum and maximum temperature. Can only happen between [N2O_DECOMPOSITION_MIN_TEMPERATURE] - [N2O_DECOMPOSITION_MAX_TEMPERATURE]K.",
 		"Energy" = "[N2O_DECOMPOSITION_ENERGY] joules of energy is released per mole of [/datum/gas/nitrous_oxide::name] decomposed.",
 	)
 
@@ -126,7 +126,7 @@
 		/datum/gas/pluoxium = "[/datum/gas/pluoxium::name] is produced at a constant rate in any given mixture.",
 		/datum/gas/hydrogen = "[/datum/gas/hydrogen::name] is formed from the [/datum/gas/tritium::name] losing their neutrons.",
 		"Energy" = "[PLUOXIUM_FORMATION_ENERGY] joules of energy is released per mole of [/datum/gas/pluoxium::name] formed.",
-		"Temperature" = "Can only occur between [PLUOXIUM_FORMATION_MIN_TEMP] - [PLUOXIUM_FORMATION_MAX_TEMP] kelvin",
+		"Temperature" = "Can only occur between [PLUOXIUM_FORMATION_MIN_TEMP] - [PLUOXIUM_FORMATION_MAX_TEMP]K",
 	)
 
 /datum/gas_reaction/standard/nitrium_formation/init_factors()
@@ -138,7 +138,7 @@
 		/datum/gas/nitrogen = "10 moles of [/datum/gas/nitrogen::name] needs to be present for the reaction to occur. \
 			[/datum/gas/nitrogen::name] is consumed at 1 mole per mole of [/datum/gas/nitrium::name] formed.",
 		/datum/gas/nitrium = "[/datum/gas/nitrium::name] is produced at a rate that scales with the temperature.",
-		"Temperature" = "Can only occur above [NITRIUM_FORMATION_MIN_TEMP] kelvins",
+		"Temperature" = "Can only occur above [NITRIUM_FORMATION_MIN_TEMP]K",
 		"Energy" = "[NITRIUM_FORMATION_ENERGY] joules of energy is absorbed per mole of [/datum/gas/nitrium::name] formed.",
 	)
 
@@ -160,12 +160,12 @@
 			[/datum/gas/carbon_dioxide::name] is consumed at 0.3 moles per mole of [/datum/gas/freon::name] formed.",
 		/datum/gas/bz = "At least 0.01 moles of [/datum/gas/bz::name] needs to be present. \
 			[/datum/gas/bz::name] is consumed at 0.1 moles per mole of [/datum/gas/freon::name] formed.",
-		/datum/gas/freon = "[/datum/gas/freon::name] is produced at a rate that scales with temperature, \
-			peaking first at 800 kelvin, then peaking again, 3 times higher, at 5,500 kelvin.",
+		/datum/gas/freon = "[/datum/gas/freon::name] is produced at a rate that scales with temperature. \
+			See temperature factor for more information.",
 		"Energy" = "Between 100 and 800 joules of energy is absorbed per mole of [/datum/gas/freon::name] produced", // I don't know why the energy release is also a sigmoidal function, but it should really just be constant to be honest.
-		"Temperature" = "Minimum temperature of [FIRE_MINIMUM_TEMPERATURE_TO_EXIST + 100] kelvin to occur, \
-			with production peak at 800 K. However at temperatures above 5500 K higher rates are possible \
-			maxing out at three times the low temperature rate at over 8500 K.",
+		"Temperature" = "Minimum temperature of [FIRE_MINIMUM_TEMPERATURE_TO_EXIST + 100]K to occur. \
+			Production speed peaks at 800K - However, at temperatures above 5500K, \
+			production speed can exceed the low temperature peak (reaching up to three times fast at 8500K).",
 	)
 
 /datum/gas_reaction/standard/nobliumformation/init_factors()
@@ -181,7 +181,7 @@
 		/datum/gas/bz = "[/datum/gas/bz::name] is not consumed in the reaction but will lower the amount of energy released. \
 			It also reduces amount of [/datum/gas/tritium::name] consumed by a ratio \
 			between [/datum/gas/tritium::name] and [/datum/gas/bz::name], greater [/datum/gas/bz::name] than [/datum/gas/tritium::name] will reduce more.",
-		"Temperature" = "Can only occur between [NOBLIUM_FORMATION_MIN_TEMP] - [NOBLIUM_FORMATION_MAX_TEMP] kelvin",
+		"Temperature" = "Can only occur between [NOBLIUM_FORMATION_MIN_TEMP] - [NOBLIUM_FORMATION_MAX_TEMP]K",
 	)
 
 /datum/gas_reaction/standard/halon_o2removal/init_factors()
@@ -190,7 +190,7 @@
 		/datum/gas/oxygen = "20 moles of [/datum/gas/oxygen::name] is consumed per mole of [/datum/gas/halon::name] combusted.",
 		/datum/gas/carbon_dioxide = "[/datum/gas/carbon_dioxide::name] is produced at 5 moles per mole of [/datum/gas/halon::name] consumed.",
 		"Energy" = "[HALON_COMBUSTION_ENERGY] joules of energy is absorbed per mole of [/datum/gas/halon::name] consumed.",
-		"Temperature" = "Can only occur above [FIRE_MINIMUM_TEMPERATURE_TO_EXIST] kelvin. Higher temperature increases [/datum/gas/halon::name] consumption rate.",
+		"Temperature" = "Can only occur above [FIRE_MINIMUM_TEMPERATURE_TO_EXIST]K. Higher temperature increases [/datum/gas/halon::name] consumption rate.",
 	)
 
 /datum/gas_reaction/standard/healium_formation/init_factors()
@@ -208,7 +208,7 @@
 		/datum/gas/hypernoblium = "[/datum/gas/hypernoblium::name] is consumed at 0.02 moles per mole of [/datum/gas/zauker::name] formed.",
 		/datum/gas/nitrium = "[/datum/gas/nitrium::name] is consumed at 1 mole per mole of [/datum/gas/zauker::name] formed.",
 		/datum/gas/zauker = "[/datum/gas/zauker::name] is produced at a rate that scales with the temperature.",
-		"Temperature" = "Can only occur between [ZAUKER_FORMATION_MIN_TEMPERATURE] - [ZAUKER_FORMATION_MAX_TEMPERATURE] kelvin. [/datum/gas/zauker::name] formation rate is proportional to the temperature.",
+		"Temperature" = "Can only occur between [ZAUKER_FORMATION_MIN_TEMPERATURE] - [ZAUKER_FORMATION_MAX_TEMPERATURE]K. [/datum/gas/zauker::name] formation rate is proportional to the temperature.",
 		"Energy" = "[2 * ZAUKER_FORMATION_ENERGY] joules of energy is absorbed per mole of [/datum/gas/zauker::name] formed.",
 	)
 
@@ -227,7 +227,7 @@
 		/datum/gas/hydrogen = "[/datum/gas/hydrogen::name] is consumed at 10/11th of a mole per mole of [/datum/gas/proto_nitrate::name] formed.",
 		/datum/gas/proto_nitrate = "[/datum/gas/proto_nitrate::name] is produced at a rate that scales with the temperature.",
 		"Energy" = "[PN_FORMATION_ENERGY / 2.2] joules of energy is released per mole of [/datum/gas/proto_nitrate::name] formed.",
-		"Temperature" = "Can only occur between [PN_FORMATION_MIN_TEMPERATURE] - [PN_FORMATION_MAX_TEMPERATURE] kelvin. \
+		"Temperature" = "Can only occur between [PN_FORMATION_MIN_TEMPERATURE] - [PN_FORMATION_MAX_TEMPERATURE]K. \
 			Higher temperature increases [/datum/gas/proto_nitrate::name] formation rate.",
 	)
 
@@ -265,12 +265,12 @@
 		"Hallucinations" = "This reaction can cause various carbon based lifeforms in the vicinity to hallucinate.",
 		"Nuclear Particles" = "This reaction emits extremely high energy nuclear particles, \
 			up to [2 * PN_BZASE_NUCLEAR_PARTICLE_MAXIMUM] per second per unique gas mixture.",
-		"Temperature" = "Can only occur between [PN_BZASE_MIN_TEMP] - [PN_BZASE_MAX_TEMP] kelvin.",
+		"Temperature" = "Can only occur between [PN_BZASE_MIN_TEMP] - [PN_BZASE_MAX_TEMP]K.",
 	)
 
 /datum/gas_reaction/standard/antinoblium_replication/init_factors()
 	factor = list(
 		/datum/gas/antinoblium = "[MOLES_GAS_VISIBLE] moles of [/datum/gas/antinoblium::name] is needed to replicate itself. \
 			Requires other gases to be converted to [/datum/gas/antinoblium::name].",
-		"Temperature" = "Can only occur above [REACTION_OPPRESSION_MIN_TEMP] kelvin."
+		"Temperature" = "Can only occur above [REACTION_OPPRESSION_MIN_TEMP]K."
 	)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -13,7 +13,7 @@
 			/* PRIORITY_FIRE = */ list()
 		)
 
-	for(var/datum/gas_reaction/reaction as anything in subtypesof(/datum/gas_reaction))
+	for(var/datum/gas_reaction/standard/reaction as anything in subtypesof(/datum/gas_reaction/standard))
 		if(initial(reaction.exclude))
 			continue
 		reaction = new reaction
@@ -40,6 +40,13 @@
 	return priority_reactions
 
 /datum/gas_reaction
+	abstract_type = /datum/gas_reaction
+	/// Name of the reaction
+	var/name = "reaction"
+	/// A short string describing this reaction.
+	var/desc
+	/// ID of the reaction
+	var/id = "r"
 	/**
 	 * Regarding the requirements list: the minimum or maximum requirements must be non-zero.
 	 * When in doubt, use MINIMUM_MOLE_COUNT.
@@ -47,16 +54,6 @@
 	 * More complex implementations will require modifications to gas_mixture.react()
 	 */
 	var/list/requirements
-	var/major_gas //the highest rarity gas used in the reaction.
-	var/exclude = FALSE //do it this way to allow for addition/removal of reactions midmatch in the future
-	///The priority group this reaction is a part of. You can think of these as processing in batches, put your reaction into the one that's most fitting
-	var/priority_group
-	var/name = "reaction"
-	var/id = "r"
-	/// Whether the presence of our reaction should make fires bigger or not.
-	var/expands_hotspot = FALSE
-	/// A short string describing this reaction.
-	var/desc
 	/** REACTION FACTORS
 	 *
 	 * Describe (to a human) factors influencing this reaction in an assoc list format.
@@ -69,16 +66,26 @@
 	 */
 	var/list/factor
 
-/datum/gas_reaction/New()
+/datum/gas_reaction/standard
+	abstract_type = /datum/gas_reaction/standard
+	var/major_gas //the highest rarity gas used in the reaction.
+	var/exclude = FALSE //do it this way to allow for addition/removal of reactions midmatch in the future
+	///The priority group this reaction is a part of. You can think of these as processing in batches, put your reaction into the one that's most fitting
+	var/priority_group
+	/// Whether the presence of our reaction should make fires bigger or not.
+	var/expands_hotspot = FALSE
+
+/datum/gas_reaction/standard/New()
+	. = ..()
 	init_reqs()
 	init_factors()
 
-/datum/gas_reaction/proc/init_reqs() // Override this
+/datum/gas_reaction/standard/proc/init_reqs() // Override this
 	CRASH("Reaction [type] made without specifying requirements.")
 
-/datum/gas_reaction/proc/init_factors()
+/datum/gas_reaction/standard/proc/init_factors()
 
-/datum/gas_reaction/proc/react(datum/gas_mixture/air, atom/location)
+/datum/gas_reaction/standard/proc/react(datum/gas_mixture/air, atom/location)
 	return NO_REACTION
 
 
@@ -88,19 +95,19 @@
  * Makes turfs slippery.
  * Can frost things if the gas is cold enough.
  */
-/datum/gas_reaction/water_vapor
+/datum/gas_reaction/standard/water_vapor
 	priority_group = PRIORITY_POST_FORMATION
 	name = "Water Vapor Condensation"
 	id = "vapor"
-	desc = "Water vapor condensation that can make things slippery."
+	desc = "Water Vapor condensation that may make things slippery."
 
-/datum/gas_reaction/water_vapor/init_reqs()
+/datum/gas_reaction/standard/water_vapor/init_reqs()
 	requirements = list(
 		/datum/gas/water_vapor = MOLES_GAS_VISIBLE,
 		"MAX_TEMP" = WATER_VAPOR_CONDENSATION_POINT,
 	)
 
-/datum/gas_reaction/water_vapor/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/water_vapor/react(datum/gas_mixture/air, datum/holder)
 	. = NO_REACTION
 	if(!isturf(holder))
 		return
@@ -130,19 +137,19 @@
  *
  * Clears out pathogens in the air.
  */
-/datum/gas_reaction/miaster
+/datum/gas_reaction/standard/miaster
 	priority_group = PRIORITY_POST_FORMATION
 	name = "Dry Heat Sterilization"
 	id = "sterilization"
 	desc = "Pathogens cannot survive in a hot environment. Miasma decomposes on high temperature."
 
-/datum/gas_reaction/miaster/init_reqs()
+/datum/gas_reaction/standard/miaster/init_reqs()
 	requirements = list(
 		/datum/gas/miasma = MINIMUM_MOLE_COUNT,
 		"MIN_TEMP" = MIASTER_STERILIZATION_TEMP,
 	)
 
-/datum/gas_reaction/miaster/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/miaster/react(datum/gas_mixture/air, datum/holder)
 	var/list/cached_moles = air.moles
 	var/water_vapor_moles = cached_moles[/datum/gas/water_vapor]
 	var/miasma_moles = cached_moles[/datum/gas/miasma]
@@ -171,21 +178,22 @@
  * The reaction rate is dependent on the temperature of the gasmix.
  * May produce either tritium or carbon dioxide and water vapor depending on the fuel/oxydizer ratio of the gasmix.
  */
-/datum/gas_reaction/plasmafire
+/datum/gas_reaction/standard/plasmafire
 	priority_group = PRIORITY_FIRE
 	name = "Plasma Combustion"
 	id = "plasmafire"
 	expands_hotspot = TRUE
-	desc = "Combustion of oxygen and plasma. Able to produce tritium or carbon dioxide and water vapor."
+	desc = "Combustion of Oxygen and Plasma. Produces Carbon Dioxide and Water Vapor, \
+		and potentially even Tritium if the mixture is rich enough in Plasma."
 
-/datum/gas_reaction/plasmafire/init_reqs()
+/datum/gas_reaction/standard/plasmafire/init_reqs()
 	requirements = list(
 		/datum/gas/plasma = MINIMUM_MOLE_COUNT,
 		/datum/gas/oxygen = MINIMUM_MOLE_COUNT,
 		"MIN_TEMP" = PLASMA_MINIMUM_BURN_TEMPERATURE,
 	)
 
-/datum/gas_reaction/plasmafire/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/plasmafire/react(datum/gas_mixture/air, datum/holder)
 	. = NO_REACTION
 	// This reaction should proceed faster at higher temperatures.
 	var/temperature = air.temperature
@@ -249,21 +257,21 @@
  * Highly exothermic.
  * Creates hotspots.
  */
-/datum/gas_reaction/h2fire
+/datum/gas_reaction/standard/h2fire
 	priority_group = PRIORITY_FIRE
 	name = "Hydrogen Combustion"
 	id = "h2fire"
 	expands_hotspot = TRUE
-	desc = "Combustion of hydrogen with oxygen. Can be extremely fast and energetic if a few conditions are fulfilled."
+	desc = "Combustion of Hydrogen with Oxygen. May be extremely fast and energetic, if a few conditions are fulfilled."
 
-/datum/gas_reaction/h2fire/init_reqs()
+/datum/gas_reaction/standard/h2fire/init_reqs()
 	requirements = list(
 		/datum/gas/hydrogen = MINIMUM_MOLE_COUNT,
 		/datum/gas/oxygen = MINIMUM_MOLE_COUNT,
 		"MIN_TEMP" = HYDROGEN_MINIMUM_BURN_TEMPERATURE,
 	)
 
-/datum/gas_reaction/h2fire/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/h2fire/react(datum/gas_mixture/air, datum/holder)
 	. = NO_REACTION
 	var/list/cached_moles = air.moles //this speeds things up because accessing datum vars is slow
 	var/hydrogen_moles = cached_moles[/datum/gas/hydrogen]
@@ -305,21 +313,21 @@
  * Creates hotspots.
  * Creates radiation.
  */
-/datum/gas_reaction/tritfire
+/datum/gas_reaction/standard/tritfire
 	priority_group = PRIORITY_FIRE
 	name = "Tritium Combustion"
 	id = "tritfire"
 	expands_hotspot = TRUE
-	desc = "Combustion of tritium with oxygen. Can be extremely fast and energetic if a few conditions are fulfilled."
+	desc = "Combustion of Tritium with Oxygen. May be extremely fast and energetic, if a few conditions are fulfilled."
 
-/datum/gas_reaction/tritfire/init_reqs()
+/datum/gas_reaction/standard/tritfire/init_reqs()
 	requirements = list(
 		/datum/gas/tritium = MINIMUM_MOLE_COUNT,
 		/datum/gas/oxygen = MINIMUM_MOLE_COUNT,
 		"MIN_TEMP" = TRITIUM_MINIMUM_BURN_TEMPERATURE,
 	)
 
-/datum/gas_reaction/tritfire/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/tritfire/react(datum/gas_mixture/air, datum/holder)
 	. = NO_REACTION
 	var/list/cached_moles = air.moles //this speeds things up because accessing datum vars is slow
 	var/tritium_moles = cached_moles[/datum/gas/tritium]
@@ -369,14 +377,14 @@
  * Combustion of oxygen and freon.
  * Endothermic.
  */
-/datum/gas_reaction/freonfire
+/datum/gas_reaction/standard/freonfire
 	priority_group = PRIORITY_FIRE
 	name = "Freon Combustion"
 	id = "freonfire"
 	expands_hotspot = TRUE
-	desc = "Reaction between oxygen and freon that consumes a huge amount of energy and can cool things significantly. Also able to produce hot ice."
+	desc = "Reaction between Oxygen and Freon that consumes a huge amount of energy, cooling the atmosphere significantly. May produce \"hot ice\"."
 
-/datum/gas_reaction/freonfire/init_reqs()
+/datum/gas_reaction/standard/freonfire/init_reqs()
 	requirements = list(
 		/datum/gas/oxygen = MINIMUM_MOLE_COUNT,
 		/datum/gas/freon = MINIMUM_MOLE_COUNT,
@@ -384,7 +392,7 @@
 		"MAX_TEMP" = FREON_MAXIMUM_BURN_TEMPERATURE,
 	)
 
-/datum/gas_reaction/freonfire/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/freonfire/react(datum/gas_mixture/air, datum/holder)
 	. = NO_REACTION
 	var/temperature = air.temperature
 	var/temperature_scale
@@ -443,13 +451,13 @@
  * Endothermic.
  * Requires BZ as a catalyst.
  */
-/datum/gas_reaction/nitrousformation //formation of n2o, exothermic, requires bz as catalyst
+/datum/gas_reaction/standard/nitrousformation //formation of n2o, exothermic, requires bz as catalyst
 	priority_group = PRIORITY_FORMATION
 	name = "Nitrous Oxide Formation"
 	id = "nitrousformation"
-	desc = "Production of nitrous oxide with BZ as a catalyst."
+	desc = "Production of Nitrous Oxide with BZ as a catalyst."
 
-/datum/gas_reaction/nitrousformation/init_reqs()
+/datum/gas_reaction/standard/nitrousformation/init_reqs()
 	requirements = list(
 		/datum/gas/oxygen = 10,
 		/datum/gas/nitrogen = 20,
@@ -458,7 +466,7 @@
 		"MAX_TEMP" = N2O_FORMATION_MAX_TEMPERATURE,
 	)
 
-/datum/gas_reaction/nitrousformation/react(datum/gas_mixture/air)
+/datum/gas_reaction/standard/nitrousformation/react(datum/gas_mixture/air)
 	var/list/cached_moles = air.moles
 	var/oxygen_moles = cached_moles[/datum/gas/oxygen]
 	var/nitrogen_moles = cached_moles[/datum/gas/nitrogen]
@@ -485,20 +493,20 @@
  * Decomposition of N2O.
  * Exothermic.
  */
-/datum/gas_reaction/nitrous_decomp
+/datum/gas_reaction/standard/nitrous_decomp
 	priority_group = PRIORITY_POST_FORMATION
 	name = "Nitrous Oxide Decomposition"
 	id = "nitrous_decomp"
-	desc = "Decomposition of nitrous oxide under high temperature."
+	desc = "Decomposition of Nitrous Oxide under high temperature."
 
-/datum/gas_reaction/nitrous_decomp/init_reqs()
+/datum/gas_reaction/standard/nitrous_decomp/init_reqs()
 	requirements = list(
 		/datum/gas/nitrous_oxide = MINIMUM_MOLE_COUNT * 2,
 		"MIN_TEMP" = N2O_DECOMPOSITION_MIN_TEMPERATURE,
 		"MAX_TEMP" = N2O_DECOMPOSITION_MAX_TEMPERATURE,
 	)
 
-/datum/gas_reaction/nitrous_decomp/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/nitrous_decomp/react(datum/gas_mixture/air, datum/holder)
 	var/list/cached_moles = air.moles //this speeds things up because accessing datum vars is slow
 	var/nitrous_oxide_moles = cached_moles[/datum/gas/nitrous_oxide]
 	var/temperature = air.temperature
@@ -527,20 +535,20 @@
  * Formation of BZ by combining plasma and nitrous oxide at low pressures.
  * Exothermic.
  */
-/datum/gas_reaction/bzformation
+/datum/gas_reaction/standard/bzformation
 	priority_group = PRIORITY_FORMATION
 	name = "BZ Gas Formation"
 	id = "bzformation"
-	desc = "Production of BZ using plasma and nitrous oxide."
+	desc = "Production of BZ using Plasma and Nitrous Oxide."
 
-/datum/gas_reaction/bzformation/init_reqs()
+/datum/gas_reaction/standard/bzformation/init_reqs()
 	requirements = list(
 		/datum/gas/nitrous_oxide = 10,
 		/datum/gas/plasma = 10,
 		"MAX_TEMP" = BZ_FORMATION_MAX_TEMPERATURE,
 	)
 
-/datum/gas_reaction/bzformation/react(datum/gas_mixture/air)
+/datum/gas_reaction/standard/bzformation/react(datum/gas_mixture/air)
 	var/list/cached_moles = air.moles
 	var/nitrous_oxide_moles = cached_moles[/datum/gas/nitrous_oxide]
 	var/plasma_moles = cached_moles[/datum/gas/plasma]
@@ -587,13 +595,13 @@
  * Consumes a tiny amount of tritium to convert CO2 and oxygen to pluoxium.
  * Exothermic.
  */
-/datum/gas_reaction/pluox_formation
+/datum/gas_reaction/standard/pluox_formation
 	priority_group = PRIORITY_FORMATION
 	name = "Pluoxium Formation"
 	id = "pluox_formation"
-	desc = "Alternate production for pluoxium which uses tritium."
+	desc = "Alternate Production method for Pluoxium which uses Tritium."
 
-/datum/gas_reaction/pluox_formation/init_reqs()
+/datum/gas_reaction/standard/pluox_formation/init_reqs()
 	requirements = list(
 		/datum/gas/carbon_dioxide = MINIMUM_MOLE_COUNT,
 		/datum/gas/oxygen = MINIMUM_MOLE_COUNT,
@@ -602,7 +610,7 @@
 		"MAX_TEMP" = PLUOXIUM_FORMATION_MAX_TEMP,
 	)
 
-/datum/gas_reaction/pluox_formation/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/pluox_formation/react(datum/gas_mixture/air, datum/holder)
 	var/list/cached_moles = air.moles
 	var/carbon_dioxide_moles = cached_moles[/datum/gas/carbon_dioxide]
 	var/oxygen_moles = cached_moles[/datum/gas/oxygen]
@@ -635,13 +643,13 @@
  * Endothermic.
  * Requires BZ.
  */
-/datum/gas_reaction/nitrium_formation
+/datum/gas_reaction/standard/nitrium_formation
 	priority_group = PRIORITY_FORMATION
 	name = "Nitrium Formation"
 	id = "nitrium_formation"
-	desc = "Production of nitrium from BZ, tritium, and nitrogen."
+	desc = "Production of Nitrium from BZ, Tritium, and Nitrogen."
 
-/datum/gas_reaction/nitrium_formation/init_reqs()
+/datum/gas_reaction/standard/nitrium_formation/init_reqs()
 	requirements = list(
 		/datum/gas/tritium = 20,
 		/datum/gas/nitrogen = 10,
@@ -649,7 +657,7 @@
 		"MIN_TEMP" = NITRIUM_FORMATION_MIN_TEMP,
 	)
 
-/datum/gas_reaction/nitrium_formation/react(datum/gas_mixture/air)
+/datum/gas_reaction/standard/nitrium_formation/react(datum/gas_mixture/air)
 	var/list/cached_moles = air.moles
 	var/tritium_moles = cached_moles[/datum/gas/tritium]
 	var/nitrogen_moles = cached_moles[/datum/gas/nitrogen]
@@ -682,20 +690,20 @@
  * Exothermic.
  * Requires oxygen as catalyst.
  */
-/datum/gas_reaction/nitrium_decomposition
+/datum/gas_reaction/standard/nitrium_decomposition
 	priority_group = PRIORITY_PRE_FORMATION
 	name = "Nitrium Decomposition"
 	id = "nitrium_decomp"
-	desc = "Decomposition of nitrium when exposed to oxygen under normal temperatures."
+	desc = "Decomposition of Nitrium when exposed to Oxygen under normal temperatures."
 
-/datum/gas_reaction/nitrium_decomposition/init_reqs()
+/datum/gas_reaction/standard/nitrium_decomposition/init_reqs()
 	requirements = list(
 		/datum/gas/oxygen = MINIMUM_MOLE_COUNT,
 		/datum/gas/nitrium = MINIMUM_MOLE_COUNT,
 		"MAX_TEMP" = NITRIUM_DECOMPOSITION_MAX_TEMP,
 	)
 
-/datum/gas_reaction/nitrium_decomposition/react(datum/gas_mixture/air)
+/datum/gas_reaction/standard/nitrium_decomposition/react(datum/gas_mixture/air)
 	var/list/cached_moles = air.moles
 	var/nitrium_moles = cached_moles[/datum/gas/nitrium]
 	var/temperature = air.temperature
@@ -726,13 +734,13 @@
  * The formation of freon.
  * Endothermic.
  */
-/datum/gas_reaction/freonformation
+/datum/gas_reaction/standard/freonformation
 	priority_group = PRIORITY_FORMATION
 	name = "Freon Formation"
 	id = "freonformation"
-	desc = "Production of freon using plasma, carbon dioxide, and BZ under high temperature."
+	desc = "Production of Freon using Plasma, Carbon Dioxide, and BZ under high temperature."
 
-/datum/gas_reaction/freonformation/init_reqs() //minimum requirements for freon formation
+/datum/gas_reaction/standard/freonformation/init_reqs() //minimum requirements for freon formation
 	requirements = list(
 		/datum/gas/plasma = MINIMUM_MOLE_COUNT * 6,
 		/datum/gas/carbon_dioxide = MINIMUM_MOLE_COUNT * 3,
@@ -740,7 +748,7 @@
 		"MIN_TEMP" = FREON_FORMATION_MIN_TEMPERATURE,
 	)
 
-/datum/gas_reaction/freonformation/react(datum/gas_mixture/air)
+/datum/gas_reaction/standard/freonformation/react(datum/gas_mixture/air)
 	var/list/cached_moles = air.moles
 	var/plasma_moles = cached_moles[/datum/gas/plasma]
 	var/carbon_dioxide_moles = cached_moles[/datum/gas/carbon_dioxide]
@@ -779,13 +787,13 @@
  * Due to its high mass, hyper-noblium uses large amounts of nitrogen and tritium.
  * BZ can be used as a catalyst to make it less exothermic.
  */
-/datum/gas_reaction/nobliumformation
+/datum/gas_reaction/standard/nobliumformation
 	priority_group = PRIORITY_FORMATION
 	name = "Hyper-Noblium Condensation"
 	id = "nobformation"
-	desc = "Production of hyper-noblium from nitrogen and tritium under very low temperatures. Extremely energetic."
+	desc = "Production of Hyper-Noblium from Nitrogen and Tritium under very low temperatures. Extremely energetic."
 
-/datum/gas_reaction/nobliumformation/init_reqs()
+/datum/gas_reaction/standard/nobliumformation/init_reqs()
 	requirements = list(
 		/datum/gas/nitrogen = 10,
 		/datum/gas/tritium = 5,
@@ -793,7 +801,7 @@
 		"MAX_TEMP" = NOBLIUM_FORMATION_MAX_TEMP,
 	)
 
-/datum/gas_reaction/nobliumformation/react(datum/gas_mixture/air)
+/datum/gas_reaction/standard/nobliumformation/react(datum/gas_mixture/air)
 	. = NO_REACTION
 	var/list/cached_moles = air.moles
 	var/nitrogen_moles = cached_moles[/datum/gas/nitrogen]
@@ -832,20 +840,20 @@
  * Produces carbon dioxide.
  * Endothermic.
  */
-/datum/gas_reaction/halon_o2removal
+/datum/gas_reaction/standard/halon_o2removal
 	priority_group = PRIORITY_PRE_FORMATION
 	name = "Halon Oxygen Absorption"
 	id = "halon_o2removal"
-	desc = "Halon interaction with oxygen that can be used to snuff fires out."
+	desc = "Halon interaction with Oxygen that can be used to snuff fires out."
 
-/datum/gas_reaction/halon_o2removal/init_reqs()
+/datum/gas_reaction/standard/halon_o2removal/init_reqs()
 	requirements = list(
 		/datum/gas/halon = MINIMUM_MOLE_COUNT,
 		/datum/gas/oxygen = MINIMUM_MOLE_COUNT,
 		"MIN_TEMP" = HALON_COMBUSTION_MIN_TEMPERATURE,
 	)
 
-/datum/gas_reaction/halon_o2removal/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/halon_o2removal/react(datum/gas_mixture/air, datum/holder)
 	. = NO_REACTION
 	var/list/cached_moles = air.moles
 	var/halon_moles = cached_moles[/datum/gas/halon]
@@ -885,13 +893,13 @@
  *
  * Exothermic
  */
-/datum/gas_reaction/healium_formation
+/datum/gas_reaction/standard/healium_formation
 	priority_group = PRIORITY_FORMATION
 	name = "Healium Formation"
 	id = "healium_formation"
-	desc = "Production of healium using BZ and freon."
+	desc = "Production of Healium using BZ and Freon."
 
-/datum/gas_reaction/healium_formation/init_reqs()
+/datum/gas_reaction/standard/healium_formation/init_reqs()
 	requirements = list(
 		/datum/gas/bz = MINIMUM_MOLE_COUNT,
 		/datum/gas/freon = MINIMUM_MOLE_COUNT,
@@ -899,7 +907,7 @@
 		"MAX_TEMP" = HEALIUM_FORMATION_MAX_TEMP,
 	)
 
-/datum/gas_reaction/healium_formation/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/healium_formation/react(datum/gas_mixture/air, datum/holder)
 	var/list/cached_moles = air.moles
 	var/bz_moles = cached_moles[/datum/gas/bz]
 	var/freon_moles = cached_moles[/datum/gas/freon]
@@ -926,13 +934,13 @@
  * Exothermic.
  * Requires Hypernoblium.
  */
-/datum/gas_reaction/zauker_formation
+/datum/gas_reaction/standard/zauker_formation
 	priority_group = PRIORITY_FORMATION
 	name = "Zauker Formation"
 	id = "zauker_formation"
-	desc = "Production of zauker using hyper-noblium and nitrium under very high temperatures."
+	desc = "Production of Zauker using Hyper-Noblium and Nitrium under very high temperatures."
 
-/datum/gas_reaction/zauker_formation/init_reqs()
+/datum/gas_reaction/standard/zauker_formation/init_reqs()
 	requirements = list(
 		/datum/gas/hypernoblium = MINIMUM_MOLE_COUNT,
 		/datum/gas/nitrium = MINIMUM_MOLE_COUNT,
@@ -940,7 +948,7 @@
 		"MAX_TEMP" = ZAUKER_FORMATION_MAX_TEMPERATURE,
 	)
 
-/datum/gas_reaction/zauker_formation/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/zauker_formation/react(datum/gas_mixture/air, datum/holder)
 	var/list/cached_moles = air.moles
 	var/hypernoblium_moles = cached_moles[/datum/gas/hypernoblium]
 	var/nitrium_moles = cached_moles[/datum/gas/nitrium]
@@ -969,19 +977,19 @@
  * Occurs in the presence of nitrogen to prevent zauker floods.
  * Exothermic.
  */
-/datum/gas_reaction/zauker_decomp
+/datum/gas_reaction/standard/zauker_decomp
 	priority_group = PRIORITY_POST_FORMATION
 	name = "Zauker Decomposition"
 	id = "zauker_decomp"
-	desc = "Decomposition of zauker when exposed to nitrogen."
+	desc = "Decomposition of Zauker when exposed to Nitrogen."
 
-/datum/gas_reaction/zauker_decomp/init_reqs()
+/datum/gas_reaction/standard/zauker_decomp/init_reqs()
 	requirements = list(
 		/datum/gas/nitrogen = MINIMUM_MOLE_COUNT,
 		/datum/gas/zauker = MINIMUM_MOLE_COUNT,
 	)
 
-/datum/gas_reaction/zauker_decomp/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/zauker_decomp/react(datum/gas_mixture/air, datum/holder)
 	var/list/cached_moles = air.moles //this speeds things up because accessing datum vars is slow
 	var/nitrogen_moles = cached_moles[/datum/gas/nitrogen]
 	var/zauker_moles = cached_moles[/datum/gas/zauker]
@@ -1009,13 +1017,13 @@
  *
  * Exothermic.
  */
-/datum/gas_reaction/proto_nitrate_formation
+/datum/gas_reaction/standard/proto_nitrate_formation
 	priority_group = PRIORITY_FORMATION
-	name = "Proto Nitrate Formation"
+	name = "Proto-Nitrate Formation"
 	id = "proto_nitrate_formation"
-	desc = "Production of proto-nitrate from pluoxium and hydrogen under high temperatures."
+	desc = "Production of Proto-Nitrate from Pluoxium and Hydrogen under high temperatures."
 
-/datum/gas_reaction/proto_nitrate_formation/init_reqs()
+/datum/gas_reaction/standard/proto_nitrate_formation/init_reqs()
 	requirements = list(
 		/datum/gas/pluoxium = MINIMUM_MOLE_COUNT,
 		/datum/gas/hydrogen = MINIMUM_MOLE_COUNT,
@@ -1023,7 +1031,7 @@
 		"MAX_TEMP" = PN_FORMATION_MAX_TEMPERATURE,
 	)
 
-/datum/gas_reaction/proto_nitrate_formation/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/proto_nitrate_formation/react(datum/gas_mixture/air, datum/holder)
 	var/list/cached_moles = air.moles
 	var/pluoxium_moles = cached_moles[/datum/gas/pluoxium]
 	var/hydrogen_moles = cached_moles[/datum/gas/hydrogen]
@@ -1051,19 +1059,19 @@
  * Converts hydrogen into proto-nitrate.
  * Endothermic.
  */
-/datum/gas_reaction/proto_nitrate_hydrogen_response
+/datum/gas_reaction/standard/proto_nitrate_hydrogen_response
 	priority_group = PRIORITY_PRE_FORMATION
-	name = "Proto Nitrate Hydrogen Response"
+	name = "Proto-Nitrate Hydrogen Response"
 	id = "proto_nitrate_hydrogen_response"
-	desc = "Conversion of hydrogen into proto nitrate."
+	desc = "Conversion of Hydrogen into Proto-Nitrate."
 
-/datum/gas_reaction/proto_nitrate_hydrogen_response/init_reqs()
+/datum/gas_reaction/standard/proto_nitrate_hydrogen_response/init_reqs()
 	requirements = list(
 		/datum/gas/proto_nitrate = MINIMUM_MOLE_COUNT,
 		/datum/gas/hydrogen = PN_HYDROGEN_CONVERSION_THRESHOLD,
 	)
 
-/datum/gas_reaction/proto_nitrate_hydrogen_response/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/proto_nitrate_hydrogen_response/react(datum/gas_mixture/air, datum/holder)
 	var/list/cached_moles = air.moles
 	var/proto_nitrate_moles = cached_moles[/datum/gas/proto_nitrate]
 	var/hydrogen_moles = cached_moles[/datum/gas/hydrogen]
@@ -1089,13 +1097,13 @@
  * Releases radiation.
  * Exothermic.
  */
-/datum/gas_reaction/proto_nitrate_tritium_response
+/datum/gas_reaction/standard/proto_nitrate_tritium_response
 	priority_group = PRIORITY_PRE_FORMATION
-	name = "Proto Nitrate Tritium Response"
+	name = "Proto-Nitrate Tritium Response"
 	id = "proto_nitrate_tritium_response"
-	desc = "Conversion of tritium into hydrogen that consumes a small amount of proto-nitrate."
+	desc = "Conversion of Tritium into Hydrogen that consumes a small amount of Proto-Nitrate."
 
-/datum/gas_reaction/proto_nitrate_tritium_response/init_reqs()
+/datum/gas_reaction/standard/proto_nitrate_tritium_response/init_reqs()
 	requirements = list(
 		/datum/gas/proto_nitrate = MINIMUM_MOLE_COUNT,
 		/datum/gas/tritium = MINIMUM_MOLE_COUNT,
@@ -1103,7 +1111,7 @@
 		"MAX_TEMP" = PN_TRITIUM_CONVERSION_MAX_TEMP,
 	)
 
-/datum/gas_reaction/proto_nitrate_tritium_response/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/proto_nitrate_tritium_response/react(datum/gas_mixture/air, datum/holder)
 	. = NO_REACTION
 	var/list/cached_moles = air.moles
 	var/proto_nitrate_moles = cached_moles[/datum/gas/proto_nitrate]
@@ -1142,13 +1150,13 @@
  *
  * Breaks BZ down into nitrogen, helium, and plasma in the presence of proto-nitrate.
  */
-/datum/gas_reaction/proto_nitrate_bz_response
+/datum/gas_reaction/standard/proto_nitrate_bz_response
 	priority_group = PRIORITY_PRE_FORMATION
-	name = "Proto Nitrate BZ Response"
+	name = "Proto-Nitrate BZ Response"
 	id = "proto_nitrate_bz_response"
-	desc = "Breakdown of BZ into nitrogen, helium, and plasma by proto-nitrate under low temperatures."
+	desc = "Breakdown of BZ into Nitrogen, Helium, and Plasma by Proto-Nitrate under low temperatures."
 
-/datum/gas_reaction/proto_nitrate_bz_response/init_reqs()
+/datum/gas_reaction/standard/proto_nitrate_bz_response/init_reqs()
 	requirements = list(
 		/datum/gas/proto_nitrate = MINIMUM_MOLE_COUNT,
 		/datum/gas/bz = MINIMUM_MOLE_COUNT,
@@ -1156,7 +1164,7 @@
 		"MAX_TEMP" = PN_BZASE_MAX_TEMP,
 	)
 
-/datum/gas_reaction/proto_nitrate_bz_response/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/proto_nitrate_bz_response/react(datum/gas_mixture/air, datum/holder)
 	. = NO_REACTION
 	var/list/cached_moles = air.moles
 	var/proto_nitrate_moles = cached_moles[/datum/gas/proto_nitrate]
@@ -1194,24 +1202,24 @@
 		air.temperature = max((temperature * old_heat_capacity + energy_released) / new_heat_capacity, TCMB)
 	. |= REACTING
 
-/datum/gas_reaction/antinoblium_replication
+/datum/gas_reaction/standard/antinoblium_replication
 	priority_group = PRIORITY_FORMATION
-	name = "Antinoblium Replication"
+	name = "Anti-Noblium Replication"
 	id = "antinoblium_replication"
-	desc = "Antinoblium breaks down all gases into more of itself."
+	desc = "Anti-Noblium breaks down all gases into more of itself."
 
-/datum/gas_reaction/antinoblium_replication/init_reqs()
+/datum/gas_reaction/standard/antinoblium_replication/init_reqs()
 	requirements = list(
 		/datum/gas/antinoblium = MOLES_GAS_VISIBLE,
 		"MIN_TEMP" = REACTION_OPPRESSION_MIN_TEMP,
 	)
 
 /**
- * Antinoblium Recplication
+ * Anti-Noblium Replication
  *
  * Converts all gases into antinoblium.
  */
-/datum/gas_reaction/antinoblium_replication/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/standard/antinoblium_replication/react(datum/gas_mixture/air, datum/holder)
 	. = REACTING | VOLATILE_REACTION
 	var/list/cached_moles = air.moles
 	var/heat_capacity = air.heat_capacity()

--- a/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer.dm
+++ b/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer.dm
@@ -7,8 +7,8 @@
 	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN
 	icon = 'icons/obj/pipes_n_cables/atmos.dmi'
 	icon_state = "electrolyzer-off"
-	name = "space electrolyzer"
-	desc = "Thanks to the fast and dynamic response of our electrolyzers, on-site hydrogen production is guaranteed. Warranty void if used by clowns"
+	name = "electrolyzer"
+	desc = "A portable electrolyzer, allowing for on-site production of Hydrogen. Warranty void if used by clowns."
 	max_integrity = 250
 	armor_type = /datum/armor/machinery_electrolyzer
 	circuit = /obj/item/circuitboard/machine/electrolyzer
@@ -71,9 +71,9 @@
 		. += "The charge meter reads [cell ? round(cell.percent(), 1) : 0]%."
 	else
 		. += "There is no power cell installed."
-	if(in_range(user, src) || isobserver(user))
+	if(in_range(user, src) && !isobserver(user))
 		. += span_notice("<b>Alt-click</b> to toggle [on ? "off" : "on"].")
-		. += span_notice("<b>Anchor</b> to drain power from APC instead of cell")
+		. += span_notice("<b>Anchor</b> it to drain power from the area's APC instead its internal power cell.")
 	. += span_notice("It will drain power from the [anchored ? "area's APC" : "internal power cell"].")
 
 

--- a/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer_reactions.dm
+++ b/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer_reactions.dm
@@ -5,19 +5,20 @@ GLOBAL_LIST_INIT(electrolyzer_reactions, electrolyzer_reactions_list())
  */
 /proc/electrolyzer_reactions_list()
 	var/list/built_reaction_list = list()
-	for(var/reaction_path in subtypesof(/datum/electrolyzer_reaction))
-		var/datum/electrolyzer_reaction/reaction = new reaction_path()
+	for(var/reaction_path in subtypesof(/datum/gas_reaction/electrolyzer))
+		var/datum/gas_reaction/electrolyzer/reaction = new reaction_path()
 
 		built_reaction_list[reaction.id] = reaction
 
 	return built_reaction_list
 
-/datum/electrolyzer_reaction
-	var/list/requirements
-	var/name = "reaction"
-	var/id = "r"
-	var/desc = ""
-	var/list/factor
+/datum/gas_reaction/electrolyzer
+	abstract_type = /datum/gas_reaction/electrolyzer
+
+/datum/gas_reaction/electrolyzer/New()
+	. = ..()
+	factor ||= list()
+	factor["Location"] ||= "Can only happen on tiles with an active Electrolyzer."
 
 /**
  * Electrolyzer reaction.
@@ -26,7 +27,7 @@ GLOBAL_LIST_INIT(electrolyzer_reactions, electrolyzer_reactions_list())
  * * working_power: How much energy to put into the electrolysis, in electrolyzer units. A value of 1 is what a tier 1 electrolyzer would put in.
  * * electrolyzer_args: Additional arguments for alternative methods of electrolysis.
  */
-/datum/electrolyzer_reaction/proc/react(datum/gas_mixture/air_mixture, working_power, list/electrolyzer_args = list())
+/datum/gas_reaction/electrolyzer/proc/react(datum/gas_mixture/air_mixture, working_power, list/electrolyzer_args = list())
 	return
 
 /**
@@ -35,7 +36,7 @@ GLOBAL_LIST_INIT(electrolyzer_reactions, electrolyzer_reactions_list())
  * * air_mixture: The air mixture to check the requirements for.
  * * electrolyzer_args: Additional arguments for alternative methods of electrolysis.
  */
-/datum/electrolyzer_reaction/proc/reaction_check(datum/gas_mixture/air_mixture, list/electrolyzer_args = list())
+/datum/gas_reaction/electrolyzer/proc/reaction_check(datum/gas_mixture/air_mixture, list/electrolyzer_args = list())
 	var/temp = air_mixture.temperature
 	var/list/cached_moles = air_mixture.moles
 	if((requirements["MIN_TEMP"] && temp < requirements["MIN_TEMP"]) || (requirements["MAX_TEMP"] && temp > requirements["MAX_TEMP"]))
@@ -47,21 +48,20 @@ GLOBAL_LIST_INIT(electrolyzer_reactions, electrolyzer_reactions_list())
 			return FALSE
 	return TRUE
 
-/datum/electrolyzer_reaction/h2o_conversion
+/datum/gas_reaction/electrolyzer/h2o_conversion
 	name = "H2O Conversion"
 	id = "h2o_conversion"
-	desc = "Conversion of H2o into O2 and H2"
+	desc = "Conversion of H2O into H2 and O2."
 	requirements = list(
 		/datum/gas/water_vapor = MINIMUM_MOLE_COUNT
 	)
 	factor = list(
-		/datum/gas/water_vapor = "2 moles of H2O get consumed",
-		/datum/gas/oxygen = "1 mole of O2 gets produced",
-		/datum/gas/hydrogen = "2 moles of H2 get produced",
-		"Location" = "Can only happen on turfs with an active Electrolyzer.",
+		/datum/gas/water_vapor = "2 moles of H2O is consumed.",
+		/datum/gas/oxygen = "1 mole of O2 is produced.",
+		/datum/gas/hydrogen = "2 moles of H2 is produced.",
 	)
 
-/datum/electrolyzer_reaction/h2o_conversion/react(datum/gas_mixture/air_mixture, working_power, list/electrolyzer_args = list())
+/datum/gas_reaction/electrolyzer/h2o_conversion/react(datum/gas_mixture/air_mixture, working_power, list/electrolyzer_args = list())
 
 	var/old_heat_capacity = air_mixture.heat_capacity()
 
@@ -73,25 +73,25 @@ GLOBAL_LIST_INIT(electrolyzer_reactions, electrolyzer_reactions_list())
 	if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
 		air_mixture.temperature = max(air_mixture.temperature * old_heat_capacity / new_heat_capacity, TCMB)
 
-/datum/electrolyzer_reaction/nob_conversion
-	name = "Hypernob conversion"
+/datum/gas_reaction/electrolyzer/nob_conversion
+	name = "Hyper-Noblium Conversion"
 	id = "nob_conversion"
-	desc = "Conversion of Hypernoblium into Antinoblium"
+	desc = "Conversion of Hyper-Noblium into Anti-Noblium."
 	requirements = list(
 		/datum/gas/hypernoblium = MINIMUM_MOLE_COUNT,
 	)
 	factor = list(
-		/datum/gas/hypernoblium = "1 mole of Hypernoblium gets consumed",
-		/datum/gas/antinoblium = "1 mole of Antinoblium get produced",
-		"Location" = "Can only happen on turfs that are being struck by supermatter zaps with a power level above 5 GeV.",
+		/datum/gas/hypernoblium = "1 mole of Hyper-Noblium is consumed.",
+		/datum/gas/antinoblium = "1 mole of Anti-Noblium is produced.",
+		"Location" = "Can only happen on tiles that are being struck by Supermatter zaps with a power level above 5 GeV.",
 	)
 
-/datum/electrolyzer_reaction/nob_conversion/reaction_check(datum/gas_mixture/air_mixture, list/electrolyzer_args = list())
+/datum/gas_reaction/electrolyzer/nob_conversion/reaction_check(datum/gas_mixture/air_mixture, list/electrolyzer_args = list())
 	if(!electrolyzer_args[ELECTROLYSIS_ARGUMENT_SUPERMATTER_POWER] || electrolyzer_args[ELECTROLYSIS_ARGUMENT_SUPERMATTER_POWER] <= POWER_PENALTY_THRESHOLD)
 		return FALSE
-	. = ..()
+	return ..()
 
-/datum/electrolyzer_reaction/nob_conversion/react(datum/gas_mixture/air_mixture, working_power, list/electrolyzer_args = list())
+/datum/gas_reaction/electrolyzer/nob_conversion/react(datum/gas_mixture/air_mixture, working_power, list/electrolyzer_args = list())
 	/// The supermatter zap power_level.
 	var/supermatter_power = electrolyzer_args[ELECTROLYSIS_ARGUMENT_SUPERMATTER_POWER]
 	var/list/cached_moles = air_mixture.moles
@@ -107,23 +107,22 @@ GLOBAL_LIST_INIT(electrolyzer_reactions, electrolyzer_reactions_list())
 	if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
 		air_mixture.temperature = max(air_mixture.temperature * old_heat_capacity / new_heat_capacity, TCMB)
 
-/datum/electrolyzer_reaction/halon_generation
-	name = "Halon generation"
+/datum/gas_reaction/electrolyzer/halon_generation
+	name = "Halon Generation"
 	id = "halon_generation"
 	desc = "Production of halon from the electrolysis of BZ."
 	requirements = list(
 		/datum/gas/bz = MINIMUM_MOLE_COUNT,
 	)
 	factor = list(
-		/datum/gas/bz = "Consumed during reaction.",
-		/datum/gas/oxygen = "0.2 moles of oxygen gets produced per mole of BZ consumed.",
-		/datum/gas/halon = "2 moles of Halon gets produced per mole of BZ consumed.",
+		/datum/gas/bz = "All mols of BZ are consumed.",
+		/datum/gas/oxygen = "0.2 moles of oxygen is produced per mole of BZ consumed.",
+		/datum/gas/halon = "2 moles of Halon is produced per mole of BZ consumed.",
 		"Energy" = "91.2321 kJ of thermal energy is released per mole of BZ consumed.",
 		"Temperature" = "Reaction efficiency is proportional to temperature.",
-		"Location" = "Can only happen on turfs with an active Electrolyzer.",
 	)
 
-/datum/electrolyzer_reaction/halon_generation/react(datum/gas_mixture/air_mixture, working_power, list/electrolyzer_args = list())
+/datum/gas_reaction/electrolyzer/halon_generation/react(datum/gas_mixture/air_mixture, working_power, list/electrolyzer_args = list())
 	var/old_heat_capacity = air_mixture.heat_capacity()
 	air_mixture.assert_gases(/datum/gas/bz, /datum/gas/oxygen, /datum/gas/halon)
 	var/bz_moles = air_mixture.moles[/datum/gas/bz]

--- a/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer_reactions.dm
+++ b/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer_reactions.dm
@@ -115,7 +115,7 @@ GLOBAL_LIST_INIT(electrolyzer_reactions, electrolyzer_reactions_list())
 		/datum/gas/bz = MINIMUM_MOLE_COUNT,
 	)
 	factor = list(
-		/datum/gas/bz = "All mols of BZ are consumed.",
+		/datum/gas/bz = "All moles of BZ are consumed.",
 		/datum/gas/oxygen = "0.2 moles of oxygen is produced per mole of BZ consumed.",
 		/datum/gas/halon = "2 moles of Halon is produced per mole of BZ consumed.",
 		"Energy" = "91.2321 kJ of thermal energy is released per mole of BZ consumed.",

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
@@ -2,7 +2,7 @@
  * This section contain the hfr core with all the variables and the Initialize() and Destroy() procs
  */
 /obj/machinery/atmospherics/components/unary/hypertorus/core
-	name = "HFR core"
+	name = "\improper HFR core"
 	desc = "This is the Hypertorus Fusion Reactor core, an advanced piece of technology to finely tune the reaction inside of the machine. It has I/O for cooling gases."
 	icon = 'icons/obj/machines/atmospherics/hypertorus.dmi'
 	icon_state = "core"

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
@@ -99,7 +99,7 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 
 /datum/hfr_fuel/hypernob_hydrogen_fuel
 	id = "hypernob_hydrogen_fuel"
-	name = "Hypernoblium + Hydrogen fuel"
+	name = "Hyper-Noblium + Hydrogen fuel"
 	negative_temperature_multiplier = 0.2
 	positive_temperature_multiplier = 2.2
 	energy_concentration_multiplier = 0.2
@@ -113,7 +113,7 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 
 /datum/hfr_fuel/hypernob_trit_fuel
 	id = "hypernob_trit_fuel"
-	name = "Hypernoblium + Tritium fuel"
+	name = "Hyper-Noblium + Tritium fuel"
 	negative_temperature_multiplier = 0.1
 	positive_temperature_multiplier = 2.5
 	energy_concentration_multiplier = 0.1
@@ -127,7 +127,7 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 
 /datum/hfr_fuel/hypernob_antinob_fuel
 	id = "hypernob_antinob_fuel"
-	name = "Hypernoblium + Antinoblium fuel"
+	name = "Hyper-Noblium + Anti-Noblium fuel"
 	negative_temperature_multiplier = 0.01
 	positive_temperature_multiplier = 3.5
 	energy_concentration_multiplier = 2

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -70,21 +70,21 @@
 	return
 
 /obj/machinery/atmospherics/components/unary/hypertorus/fuel_input
-	name = "HFR fuel input port"
+	name = "\improper HFR fuel input port"
 	desc = "Input port for the Hypertorus Fusion Reactor, designed to take in fuels with the optimal fuel mix being a 50/50 split."
 	icon_state = "fuel_input"
 	base_icon_state = "fuel_input"
 	circuit = /obj/item/circuitboard/machine/HFR_fuel_input
 
 /obj/machinery/atmospherics/components/unary/hypertorus/waste_output
-	name = "HFR waste output port"
+	name = "\improper HFR waste output port"
 	desc = "Waste port for the Hypertorus Fusion Reactor, designed to output the hot waste gases coming from the core of the machine."
 	icon_state = "waste_output"
 	base_icon_state = "waste_output"
 	circuit = /obj/item/circuitboard/machine/HFR_waste_output
 
 /obj/machinery/atmospherics/components/unary/hypertorus/moderator_input
-	name = "HFR moderator input port"
+	name = "\improper HFR moderator input port"
 	desc = "Moderator port for the Hypertorus Fusion Reactor, designed to move gases inside the machine to cool and control the flow of the reaction."
 	icon_state = "moderator_input"
 	base_icon_state = "moderator_input"
@@ -135,7 +135,7 @@
 		. += emissive_appearance(icon, "[base_icon_state]_active", src, alpha = src.alpha)
 
 /obj/machinery/hypertorus/interface
-	name = "HFR interface"
+	name = "\improper HFR interface"
 	desc = "Interface for the HFR to control the flow of the reaction."
 	icon_state = "interface"
 	base_icon_state = "interface"
@@ -379,7 +379,7 @@
 				. = TRUE
 
 /obj/machinery/hypertorus/corner
-	name = "HFR corner"
+	name = "\improper HFR corner"
 	desc = "Structural piece of the machine."
 	icon_state = "corner"
 	base_icon_state = "corner"
@@ -411,7 +411,7 @@
 	use more advanced guides to understando how the various gases will act as moderators."
 
 /obj/item/hfr_box
-	name = "HFR box"
+	name = "\improper HFR box"
 	desc = "If you see this, call the police."
 	icon = 'icons/obj/machines/atmospherics/hypertorus.dmi'
 	icon_state = "error"
@@ -421,39 +421,39 @@
 	var/part_path
 
 /obj/item/hfr_box/corner
-	name = "HFR box corner"
+	name = "\improper HFR box corner"
 	desc = "Place this as the corner of your 3x3 multiblock fusion reactor"
 	icon_state = "box_corner"
 	box_type = "corner"
 	part_path = /obj/machinery/hypertorus/corner
 
 /obj/item/hfr_box/body
-	name = "HFR box body"
+	name = "\improper HFR box body"
 	desc = "Place this on the sides of the core box of your 3x3 multiblock fusion reactor"
 	box_type = "body"
 	icon_state = "box_body"
 
 /obj/item/hfr_box/body/fuel_input
-	name = "HFR box fuel input"
+	name = "\improper HFR box fuel input"
 	icon_state = "box_fuel"
 	part_path = /obj/machinery/atmospherics/components/unary/hypertorus/fuel_input
 
 /obj/item/hfr_box/body/moderator_input
-	name = "HFR box moderator input"
+	name = "\improper HFR box moderator input"
 	icon_state = "box_moderator"
 	part_path = /obj/machinery/atmospherics/components/unary/hypertorus/moderator_input
 
 /obj/item/hfr_box/body/waste_output
-	name = "HFR box waste output"
+	name = "\improper HFR box waste output"
 	icon_state = "box_waste"
 	part_path = /obj/machinery/atmospherics/components/unary/hypertorus/waste_output
 
 /obj/item/hfr_box/body/interface
-	name = "HFR box interface"
+	name = "\improper HFR box interface"
 	part_path = /obj/machinery/hypertorus/interface
 
 /obj/item/hfr_box/core
-	name = "HFR box core"
+	name = "\improper HFR box core"
 	desc = "Activate this with a multitool to deploy the full machine after setting up the other boxes"
 	icon_state = "box_core"
 	box_type = "core"

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 
 /datum/gas_recipe/crystallizer/proto_nitrate_grenade
 	id = "proto_nitrate_g"
-	name = "Proto nitrate crystal"
+	name = "\improper Proto-Nitrate crystal"
 	min_temp = 200
 	max_temp = 400
 	energy_release = 1500000

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 
 /datum/gas_recipe/crystallizer/zaukerite
 	id = "zaukerite"
-	name = "Solidified Zaukerite"
+	name = "Solidified Zauker"
 	min_temp = 5
 	max_temp = 20
 	energy_release = 2900000

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 
 /datum/gas_recipe/crystallizer/hypern_crystalium
 	id = "hyper_crystalium"
-	name = "Hypernoblium Crystal"
+	name = "Hyper-Noblium Crystal"
 	min_temp = 3
 	max_temp = 250
 	energy_release = -250000
@@ -47,7 +47,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 
 /datum/gas_recipe/crystallizer/metallic_hydrogen
 	id = "metal_h"
-	name = "Metallic hydrogen"
+	name = "Metallic Hydrogen"
 	min_temp = 50000
 	max_temp = 150000
 	energy_release = -2500000
@@ -56,7 +56,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 
 /datum/gas_recipe/crystallizer/healium_grenade
 	id = "healium_g"
-	name = "Healium crystal"
+	name = "Healium Crystal"
 	min_temp = 200
 	max_temp = 400
 	energy_release = -2000000
@@ -65,7 +65,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 
 /datum/gas_recipe/crystallizer/proto_nitrate_grenade
 	id = "proto_nitrate_g"
-	name = "\improper Proto-Nitrate crystal"
+	name = "Proto-Nitrate Crystal"
 	min_temp = 200
 	max_temp = 400
 	energy_release = 1500000
@@ -74,7 +74,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 
 /datum/gas_recipe/crystallizer/hot_ice
 	id = "hot_ice"
-	name = "Hot ice"
+	name = "Hot Ice"
 	min_temp = 15
 	max_temp = 35
 	energy_release = -3000000
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 
 /datum/gas_recipe/crystallizer/ammonia_crystal
 	id = "ammonia_crystal"
-	name = "Ammonia crystal"
+	name = "Ammonia Crystal"
 	min_temp = 200
 	max_temp = 240
 	energy_release = 950000
@@ -92,7 +92,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 
 /datum/gas_recipe/crystallizer/shard
 	id = "crystal_shard"
-	name = "Supermatter crystal shard"
+	name = "Supermatter Crystal Shard"
 	min_temp = 10
 	max_temp = 20
 	energy_release = 3500000
@@ -102,7 +102,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 
 /datum/gas_recipe/crystallizer/n2o_crystal
 	id = "n2o_crystal"
-	name = "Nitrous oxide crystal"
+	name = "Nitrous Oxide Crystal"
 	min_temp = 50
 	max_temp = 350
 	energy_release = 3500000
@@ -120,7 +120,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 
 /datum/gas_recipe/crystallizer/plasma_sheet
 	id = "plasma_sheet"
-	name = "Plasma sheet"
+	name = "Solidified Plasma"
 	min_temp = 10
 	max_temp = 20
 	energy_release = 3500000
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 
 /datum/gas_recipe/crystallizer/zaukerite
 	id = "zaukerite"
-	name = "Zaukerite sheet"
+	name = "Solidified Zaukerite"
 	min_temp = 5
 	max_temp = 20
 	energy_release = 2900000
@@ -147,35 +147,35 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 
 /datum/gas_recipe/crystallizer/fuel_pellet
 	id = "fuel_basic"
-	name = "standard fuel pellet"
+	name = "Standard Fuel Pellet"
 	energy_release = -6000000
 	requirements = list(/datum/gas/oxygen = 50, /datum/gas/plasma = 100)
 	products = list(/obj/item/fuel_pellet = 1)
 
 /datum/gas_recipe/crystallizer/fuel_pellet_advanced
 	id = "fuel_advanced"
-	name = "advanced fuel pellet"
+	name = "Advanced Fuel Pellet"
 	energy_release = -6000000
 	requirements = list(/datum/gas/tritium = 100, /datum/gas/hydrogen = 100)
 	products = list(/obj/item/fuel_pellet/advanced = 1)
 
 /datum/gas_recipe/crystallizer/fuel_pellet_exotic
 	id = "fuel_exotic"
-	name = "exotic fuel pellet"
+	name = "Exotic Fuel Pellet"
 	energy_release = -6000000
 	requirements = list(/datum/gas/hypernoblium = 100, /datum/gas/nitrium = 100)
 	products = list(/obj/item/fuel_pellet/exotic = 1)
 
 /datum/gas_recipe/crystallizer/crystal_foam
 	id = "crystal_foam"
-	name = "Crystal foam grenade"
+	name = "Foam Crystal"
 	energy_release = 140000
 	requirements = list(/datum/gas/carbon_dioxide = 150, /datum/gas/nitrous_oxide = 100, /datum/gas/water_vapor = 25)
 	products = list(/obj/item/grenade/gas_crystal/crystal_foam = 1)
 
 /datum/gas_recipe/crystallizer/crystallized_nitrium
 	id = "crystallized_nitrium"
-	name = "Nitrium crystal"
+	name = "Nitrium Crystal"
 	min_temp = 10
 	max_temp = 25
 	energy_release = -45000

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer_items.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer_items.dm
@@ -1,6 +1,6 @@
 /obj/item/hypernoblium_crystal
-	name = "Hypernoblium Crystal"
-	desc = "Crystallized oxygen and hypernoblium stored in a bottle to pressure-proof your clothes or stop reactions occurring in portable atmospheric devices."
+	name = "\improper Hyper-Noblium crystal"
+	desc = "Crystallized Oxygen and Hyper-Noblium stored in a bottle. Pressure-proofs clothing or stop reactions occurring in portable atmospheric devices."
 	icon = 'icons/obj/pipes_n_cables/atmos.dmi'
 	icon_state = "hypernoblium_crystal"
 	var/uses = 1
@@ -40,8 +40,8 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/nitrium_crystal
-	desc = "A weird brown crystal, it smokes when broken"
-	name = "nitrium crystal"
+	name = "\improper Nitrium crystal"
+	desc = "A strange brown crystal that emits a foul smoke when chipped."
 	icon = 'icons/obj/pipes_n_cables/atmos.dmi'
 	icon_state = "nitrium_crystal"
 	var/cloud_size = 1

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -224,57 +224,75 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos //Used for atmos waste loops
 	on = TRUE
 	icon_state = "filter_on-0"
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2
 	name = "nitrogen filter"
 	filter_type = list(/datum/gas/nitrogen)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2
 	name = "oxygen filter"
 	filter_type = list(/datum/gas/oxygen)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2
 	name = "carbon dioxide filter"
 	filter_type = list(/datum/gas/carbon_dioxide)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o
 	name = "nitrous oxide filter"
 	filter_type = list(/datum/gas/nitrous_oxide)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma
 	name = "plasma filter"
 	filter_type = list(/datum/gas/plasma)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/bz
 	name = "bz filter"
 	filter_type = list(/datum/gas/bz)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/freon
 	name = "freon filter"
 	filter_type = list(/datum/gas/freon)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/halon
 	name = "halon filter"
 	filter_type = list(/datum/gas/halon)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/healium
 	name = "healium filter"
 	filter_type = list(/datum/gas/healium)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/h2
 	name = "hydrogen filter"
 	filter_type = list(/datum/gas/hydrogen)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/hypernoblium
-	name = "hypernoblium filter"
+	name = "hyper-noblium filter"
 	filter_type = list(/datum/gas/hypernoblium)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/miasma
 	name = "miasma filter"
 	filter_type = list(/datum/gas/miasma)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/no2
 	name = "nitrium filter"
 	filter_type = list(/datum/gas/nitrium)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/pluoxium
 	name = "pluoxium filter"
 	filter_type = list(/datum/gas/pluoxium)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/proto_nitrate
 	name = "proto-nitrate filter"
 	filter_type = list(/datum/gas/proto_nitrate)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/tritium
 	name = "tritium filter"
 	filter_type = list(/datum/gas/tritium)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/h2o
 	name = "water vapor filter"
 	filter_type = list(/datum/gas/water_vapor)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/zauker
 	name = "zauker filter"
 	filter_type = list(/datum/gas/zauker)
@@ -284,71 +302,91 @@
 	filter_type = list(/datum/gas/helium)
 
 /obj/machinery/atmospherics/components/trinary/filter/atmos/antinoblium
-	name = "antinoblium filter"
+	name = "anti-noblium filter"
 	filter_type = list(/datum/gas/antinoblium)
 
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped //This feels wrong, I know
 	icon_state = "filter_on-0_f"
 	flipped = TRUE
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2
 	name = "nitrogen filter"
 	filter_type = list(/datum/gas/nitrogen)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2
 	name = "oxygen filter"
 	filter_type = list(/datum/gas/oxygen)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2
 	name = "carbon dioxide filter"
 	filter_type = list(/datum/gas/carbon_dioxide)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o
 	name = "nitrous oxide filter"
 	filter_type = list(/datum/gas/nitrous_oxide)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma
 	name = "plasma filter"
 	filter_type = list(/datum/gas/plasma)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/bz
 	name = "bz filter"
 	filter_type = list(/datum/gas/bz)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/freon
 	name = "freon filter"
 	filter_type = list(/datum/gas/freon)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/halon
 	name = "halon filter"
 	filter_type = list(/datum/gas/halon)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/healium
 	name = "healium filter"
 	filter_type = list(/datum/gas/healium)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/h2
 	name = "hydrogen filter"
 	filter_type = list(/datum/gas/hydrogen)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/hypernoblium
-	name = "hypernoblium filter"
+	name = "hyper-noblium filter"
 	filter_type = list(/datum/gas/hypernoblium)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/miasma
 	name = "miasma filter"
 	filter_type = list(/datum/gas/miasma)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/no2
 	name = "nitrium filter"
 	filter_type = list(/datum/gas/nitrium)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/pluoxium
 	name = "pluoxium filter"
 	filter_type = list(/datum/gas/pluoxium)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/proto_nitrate
 	name = "proto-nitrate filter"
 	filter_type = list(/datum/gas/proto_nitrate)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/tritium
 	name = "tritium filter"
 	filter_type = list(/datum/gas/tritium)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/h2o
 	name = "water vapor filter"
 	filter_type = list(/datum/gas/water_vapor)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/zauker
 	name = "zauker filter"
 	filter_type = list(/datum/gas/zauker)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/helium
 	name = "helium filter"
 	filter_type = list(/datum/gas/helium)
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/antinoblium
-	name = "antinoblium filter"
+	name = "anti-noblium filter"
 	filter_type = list(/datum/gas/antinoblium)
 
 // These two filter types have critical_machine flagged to on and thus causes the area they are in to be exempt from the Grid Check event.

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -122,7 +122,7 @@
 // Basic canister per gas below here
 
 /obj/machinery/portable_atmospherics/canister/air
-	name = "Air canister"
+	name = "\improper Air canister"
 	desc = "Pre-mixed air."
 	icon_state = "/obj/machinery/portable_atmospherics/canister/air"
 	post_init_icon_state = ""
@@ -130,7 +130,7 @@
 	greyscale_colors = "#c6c0b5"
 
 /obj/machinery/portable_atmospherics/canister/antinoblium
-	name = "Antinoblium canister"
+	name = "\improper Anti-Noblium canister"
 	gas_type = /datum/gas/antinoblium
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/antinoblium"
@@ -147,7 +147,7 @@
 	greyscale_colors = "#9b5d7f#d0d2a0"
 
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide
-	name = "Carbon dioxide canister"
+	name = "\improper Carbon dioxide canister"
 	gas_type = /datum/gas/carbon_dioxide
 	icon_state = "/obj/machinery/portable_atmospherics/canister/carbon_dioxide"
 	post_init_icon_state = ""
@@ -155,7 +155,7 @@
 	greyscale_colors = "#4e4c48#eaeaea"
 
 /obj/machinery/portable_atmospherics/canister/freon
-	name = "Freon canister"
+	name = "\improper Freon canister"
 	gas_type = /datum/gas/freon
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/freon"
@@ -164,7 +164,7 @@
 	greyscale_colors = "#6696ee#fefb30"
 
 /obj/machinery/portable_atmospherics/canister/halon
-	name = "Halon canister"
+	name = "\improper Halon canister"
 	gas_type = /datum/gas/halon
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/halon"
@@ -173,7 +173,7 @@
 	greyscale_colors = "#9b5d7f#368bff"
 
 /obj/machinery/portable_atmospherics/canister/healium
-	name = "Healium canister"
+	name = "\improper Healium canister"
 	gas_type = /datum/gas/healium
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/healium"
@@ -182,7 +182,7 @@
 	greyscale_colors = "#009823#ff0e00"
 
 /obj/machinery/portable_atmospherics/canister/helium
-	name = "Helium canister"
+	name = "\improper Helium canister"
 	gas_type = /datum/gas/helium
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/helium"
@@ -191,7 +191,7 @@
 	greyscale_colors = "#9b5d7f#368bff"
 
 /obj/machinery/portable_atmospherics/canister/hydrogen
-	name = "Hydrogen canister"
+	name = "\improper Hydrogen canister"
 	gas_type = /datum/gas/hydrogen
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/hydrogen"
@@ -200,7 +200,7 @@
 	greyscale_colors = "#eaeaea#be3455"
 
 /obj/machinery/portable_atmospherics/canister/miasma
-	name = "Miasma canister"
+	name = "\improper Miasma canister"
 	gas_type = /datum/gas/miasma
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/miasma"
@@ -209,7 +209,7 @@
 	greyscale_colors = "#009823#f7d5d3"
 
 /obj/machinery/portable_atmospherics/canister/nitrogen
-	name = "Nitrogen canister"
+	name = "\improper Nitrogen canister"
 	gas_type = /datum/gas/nitrogen
 	icon_state = "/obj/machinery/portable_atmospherics/canister/nitrogen"
 	post_init_icon_state = ""
@@ -217,7 +217,7 @@
 	greyscale_colors = "#e9ff5c#f4fce8"
 
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide
-	name = "Nitrous oxide canister"
+	name = "\improper Nitrous Oxide canister"
 	gas_type = /datum/gas/nitrous_oxide
 	icon_state = "/obj/machinery/portable_atmospherics/canister/nitrous_oxide"
 	post_init_icon_state = ""
@@ -225,7 +225,7 @@
 	greyscale_colors = "#c63e3b#f7d5d3"
 
 /obj/machinery/portable_atmospherics/canister/nitrium
-	name = "Nitrium canister"
+	name = "\improper Nitrium canister"
 	gas_type = /datum/gas/nitrium
 	icon_state = "/obj/machinery/portable_atmospherics/canister/nitrium"
 	post_init_icon_state = ""
@@ -233,7 +233,7 @@
 	greyscale_colors = "#7b4732"
 
 /obj/machinery/portable_atmospherics/canister/nob
-	name = "Hyper-noblium canister"
+	name = "\improper Hyper-Noblium canister"
 	gas_type = /datum/gas/hypernoblium
 	icon_state = "/obj/machinery/portable_atmospherics/canister/nob"
 	post_init_icon_state = ""
@@ -241,7 +241,7 @@
 	greyscale_colors = "#6399fc#b2b2b2"
 
 /obj/machinery/portable_atmospherics/canister/oxygen
-	name = "Oxygen canister"
+	name = "\improper Oxygen canister"
 	gas_type = /datum/gas/oxygen
 	icon_state = "/obj/machinery/portable_atmospherics/canister/oxygen"
 	post_init_icon_state = ""
@@ -249,7 +249,7 @@
 	greyscale_colors = "#2786e5#e8fefe"
 
 /obj/machinery/portable_atmospherics/canister/pluoxium
-	name = "Pluoxium canister"
+	name = "\improper Pluoxium canister"
 	gas_type = /datum/gas/pluoxium
 	icon_state = "/obj/machinery/portable_atmospherics/canister/pluoxium"
 	post_init_icon_state = ""
@@ -257,7 +257,7 @@
 	greyscale_colors = "#2786e5"
 
 /obj/machinery/portable_atmospherics/canister/proto_nitrate
-	name = "Proto Nitrate canister"
+	name = "\improper Proto-Nitrate canister"
 	gas_type = /datum/gas/proto_nitrate
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/proto_nitrate"
@@ -266,7 +266,7 @@
 	greyscale_colors = "#008200#33cc33"
 
 /obj/machinery/portable_atmospherics/canister/plasma
-	name = "Plasma canister"
+	name = "\improper Plasma canister"
 	gas_type = /datum/gas/plasma
 	icon_state = "/obj/machinery/portable_atmospherics/canister/plasma"
 	post_init_icon_state = ""
@@ -274,7 +274,7 @@
 	greyscale_colors = "#f62800#000000"
 
 /obj/machinery/portable_atmospherics/canister/tritium
-	name = "Tritium canister"
+	name = "\improper Tritium canister"
 	gas_type = /datum/gas/tritium
 	icon_state = "/obj/machinery/portable_atmospherics/canister/tritium"
 	post_init_icon_state = ""
@@ -282,7 +282,7 @@
 	greyscale_colors = "#3fcd40#000000"
 
 /obj/machinery/portable_atmospherics/canister/water_vapor
-	name = "Water vapor canister"
+	name = "\improper Water Vapor canister"
 	gas_type = /datum/gas/water_vapor
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/water_vapor"
@@ -291,7 +291,7 @@
 	greyscale_colors = "#4c4e4d#f7d5d3"
 
 /obj/machinery/portable_atmospherics/canister/zauker
-	name = "Zauker canister"
+	name = "\improper Zauker canister"
 	gas_type = /datum/gas/zauker
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/zauker"

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -131,28 +131,13 @@
 		return 0
 	var/cached_moles = canister_mix.moles
 
-	var/static/list/gases_to_check = list(
-		/datum/gas/bz,
-		/datum/gas/nitrium,
-		/datum/gas/hypernoblium,
-		/datum/gas/miasma,
-		/datum/gas/tritium,
-		/datum/gas/pluoxium,
-		/datum/gas/freon,
-		/datum/gas/hydrogen,
-		/datum/gas/healium,
-		/datum/gas/proto_nitrate,
-		/datum/gas/zauker,
-		/datum/gas/helium,
-		/datum/gas/antinoblium,
-		/datum/gas/halon,
-	)
-
 	var/worth = cost
-	for(var/gas_id in gases_to_check)
-		canister_mix.assert_gas(gas_id)
-		if(cached_moles[gas_id] > 0)
-			worth += get_gas_value(gas_id, cached_moles[gas_id])
+	for(var/datum/gas/gas as anything in GLOB.meta_gas_info[META_GAS_ID])
+		if(!(initial(gas.cargo_flags) & GAS_EXPORTABLE))
+			continue
+		canister_mix.assert_gas(gas)
+		if(cached_moles[gas] > 0)
+			worth += get_gas_value(gas, cached_moles[gas])
 			if(worth > MAX_GAS_CREDITS)
 				worth = MAX_GAS_CREDITS
 				break

--- a/code/modules/cargo/packs/materials.dm
+++ b/code/modules/cargo/packs/materials.dm
@@ -84,19 +84,18 @@
 	// This is the amount of moles in a default canister
 	var/moleCount = (initial(fakeCanister.maximum_pressure) * initial(fakeCanister.filled)) * initial(fakeCanister.volume) / (R_IDEAL_GAS_EQUATION * T20C)
 
-	for(var/gasType in GLOB.meta_gas_info[META_GAS_ID])
-		var/datum/gas/gas = gasType
-		var/name = initial(gas.name)
-		if(!initial(gas.purchaseable))
+	for(var/datum/gas/gas as anything in GLOB.meta_gas_info[META_GAS_ID])
+		if(!(initial(gas.cargo_flags) & GAS_PURCHASABLE))
 			continue
 		var/datum/supply_pack/materials/pack = new
-		pack.name = "[name] Canister"
-		pack.desc = "Contains a canister of [name]."
-		if(initial(gas.dangerous))
+		var/canname = initial(gas.name)
+		pack.name = "[canname] Canister"
+		pack.desc = "Contains a canister of [canname]."
+		if(initial(gas.cargo_flags) & GAS_DANGEROUS)
 			pack.access = ACCESS_ATMOSPHERICS
 			pack.access_view = ACCESS_ATMOSPHERICS
-		pack.crate_name = "[name] canister crate"
-		pack.id = "[type]([name])"
+		pack.crate_name = "[canname] canister crate"
+		pack.id = "[type]([canname])"
 
 		pack.cost = cost + moleCount * initial(gas.base_value) * 1.6
 		pack.cost = CEILING(pack.cost, 10)

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -89,7 +89,7 @@
 	sanitized_misc = TRUE
 	sanitized_reactions = TRUE
 	require_all = FALSE
-	required_reactions = list(/datum/gas_reaction/h2fire, /datum/gas_reaction/tritfire)
+	required_reactions = list(/datum/gas_reaction/standard/h2fire, /datum/gas_reaction/standard/tritfire)
 
 /datum/experiment/ordnance/explosive/nobliumbomb
 	name = "Noblium Explosives"
@@ -99,7 +99,7 @@
 	experiment_proper = TRUE
 	sanitized_misc = TRUE
 	sanitized_reactions = TRUE
-	required_reactions = list(/datum/gas_reaction/nobliumformation)
+	required_reactions = list(/datum/gas_reaction/standard/nobliumformation)
 
 /datum/experiment/ordnance/explosive/pressurebomb
 	name = "Reactionless Explosives"

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -63,7 +63,6 @@
 			var/datum/gas_mixture/air = turf?.return_air()
 			data["gasmixes"] = list(gas_mixture_parser(air, "Location Reading"))
 		if(ATMOZPHERE_SCAN_CLICK)
-			LAZYINITLIST(last_gasmix_data)
 			data["gasmixes"] = last_gasmix_data
 	return data
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -247,7 +247,7 @@
 
 /obj/item/stock_parts/power_store/cell/crystal_cell
 	name = "crystal power cell"
-	desc = "A very high power cell made from crystallized plasma"
+	desc = "A high power cell made from crystallized plasma."
 	icon_state = "crystal_cell"
 	maxcharge = STANDARD_CELL_CHARGE * 50
 	chargerate = 0

--- a/code/modules/research/ordnance/doppler_array.dm
+++ b/code/modules/research/ordnance/doppler_array.dm
@@ -276,7 +276,7 @@
 		// Make sure the list is indexed first.
 		if(reaction_data.len)
 			for (var/path in reaction_data[TANK_RESULTS_REACTION])
-				var/datum/gas_reaction/reaction_path = path
+				var/datum/gas_reaction/standard/reaction_path = path
 				record_data["reaction_results"] += initial(reaction_path.name)
 			if(TANK_MERGE_OVERPRESSURE in reaction_data[TANK_RESULTS_MISC])
 				record_data["reaction_results"] += "Tank overpressurized before reaction"

--- a/tgui/packages/tgui/interfaces/AtmosControlConsole.tsx
+++ b/tgui/packages/tgui/interfaces/AtmosControlConsole.tsx
@@ -25,154 +25,177 @@ type Chamber = {
   output_info?: { active: boolean; amount: number };
 };
 
+type Data = {
+  chambers: Chamber[];
+  maxInput: number;
+  maxOutput: number;
+  reconnecting: boolean;
+  control: boolean;
+  defaultGas: string | null;
+};
+
 export const AtmosControlConsole = (props) => {
-  const { act, data } = useBackend<{
-    chambers: Chamber[];
-    maxInput: number;
-    maxOutput: number;
-    reconnecting: boolean;
-    control: boolean;
-  }>();
-  const chambers = data.chambers || [];
+  const { act, data } = useBackend<Data>();
+  const {
+    chambers = [],
+    maxInput,
+    maxOutput,
+    reconnecting,
+    control,
+    defaultGas,
+  } = data;
   const [chamberId, setChamberId] = useState(chambers[0]?.id);
   const selectedChamber =
     chambers.length === 1
       ? chambers[0]
       : chambers.find((chamber) => chamber.id === chamberId);
   const [setActiveGasId, setActiveReactionId] = atmosHandbookHooks();
+
+  if (defaultGas) {
+    setActiveGasId(defaultGas);
+  }
+
   return (
-    <Window width={550} height={350}>
+    <Window width={550} height={600}>
       <Window.Content scrollable>
-        {chambers.length > 1 && (
-          <Section title="Chamber Selection">
-            <Dropdown
-              width="100%"
-              options={chambers.map((chamber) => chamber.name)}
-              selected={selectedChamber?.name}
-              onSelected={(value) =>
-                setChamberId(
-                  chambers.find((chamber) => chamber.name === value)?.id ||
-                    chambers[0].id,
+        <Stack vertical fill>
+          <Stack.Item>
+            {chambers.length > 1 && (
+              <Section title="Chamber Selection">
+                <Dropdown
+                  width="100%"
+                  options={chambers.map((chamber) => chamber.name)}
+                  selected={selectedChamber?.name}
+                  onSelected={(value) =>
+                    setChamberId(
+                      chambers.find((chamber) => chamber.name === value)?.id ||
+                        chambers[0].id,
+                    )
+                  }
+                />
+              </Section>
+            )}
+            <Section
+              title={selectedChamber ? selectedChamber.name : 'Chamber Reading'}
+              buttons={
+                !!reconnecting && (
+                  <Button
+                    icon="undo"
+                    content="Reconnect"
+                    onClick={() => act('reconnect')}
+                  />
                 )
               }
-            />
-          </Section>
-        )}
-        <Section
-          title={selectedChamber ? selectedChamber.name : 'Chamber Reading'}
-          buttons={
-            !!data.reconnecting && (
-              <Button
-                icon="undo"
-                content="Reconnect"
-                onClick={() => act('reconnect')}
-              />
-            )
-          }
-        >
-          {selectedChamber?.gasmix ? (
-            <GasmixParser
-              gasmix={selectedChamber.gasmix}
-              gasesOnClick={setActiveGasId}
-              reactionOnClick={setActiveReactionId}
-            />
-          ) : (
-            <Box italic> {'No Sensors Detected!'}</Box>
-          )}
-        </Section>
-        {!!selectedChamber && !!data.control && (
-          <Section title="Chamber Controls">
-            <Stack>
-              <Stack.Item grow>
-                {selectedChamber.input_info ? (
-                  <LabeledList>
-                    <LabeledList.Item label="Input Injector">
-                      <Button
-                        icon={
-                          selectedChamber.input_info.active
-                            ? 'power-off'
-                            : 'times'
-                        }
-                        content={
-                          selectedChamber.input_info.active
-                            ? 'Injecting'
-                            : 'Off'
-                        }
-                        selected={selectedChamber.input_info.active}
-                        onClick={() =>
-                          act('toggle_input', {
-                            chamber: selectedChamber.id,
-                          })
-                        }
-                      />
-                    </LabeledList.Item>
-                    <LabeledList.Item label="Input Rate">
-                      <NumberInput
-                        step={1}
-                        value={Number(selectedChamber.input_info.amount)}
-                        unit="L/s"
-                        width="63px"
-                        minValue={0}
-                        maxValue={data.maxInput}
-                        onChange={(value) =>
-                          act('adjust_input', {
-                            chamber: selectedChamber.id,
-                            rate: value,
-                          })
-                        }
-                      />
-                    </LabeledList.Item>
-                  </LabeledList>
-                ) : (
-                  <Box italic> {'No Input Device Detected!'}</Box>
-                )}
-              </Stack.Item>
-              <Stack.Item grow>
-                {selectedChamber.output_info ? (
-                  <LabeledList>
-                    <LabeledList.Item label="Output Regulator">
-                      <Button
-                        icon={
-                          selectedChamber.output_info.active
-                            ? 'power-off'
-                            : 'times'
-                        }
-                        content={
-                          selectedChamber.output_info.active ? 'Open' : 'Closed'
-                        }
-                        selected={selectedChamber.output_info.active}
-                        onClick={() =>
-                          act('toggle_output', {
-                            chamber: selectedChamber.id,
-                          })
-                        }
-                      />
-                    </LabeledList.Item>
-                    <LabeledList.Item label="Output Pressure">
-                      <NumberInput
-                        value={Number(selectedChamber.output_info.amount)}
-                        unit="kPa"
-                        width="75px"
-                        minValue={0}
-                        maxValue={data.maxOutput}
-                        step={10}
-                        onChange={(value) =>
-                          act('adjust_output', {
-                            chamber: selectedChamber.id,
-                            rate: value,
-                          })
-                        }
-                      />
-                    </LabeledList.Item>
-                  </LabeledList>
-                ) : (
-                  <Box italic> {'No Output Device Detected !'} </Box>
-                )}
-              </Stack.Item>
-            </Stack>
-          </Section>
-        )}
-        <AtmosHandbookContent />
+            >
+              {selectedChamber?.gasmix ? (
+                <GasmixParser
+                  gasmix={selectedChamber.gasmix}
+                  gasesOnClick={setActiveGasId}
+                  reactionOnClick={setActiveReactionId}
+                />
+              ) : (
+                <Box italic> {'No Sensors Detected!'}</Box>
+              )}
+            </Section>
+            {!!selectedChamber && !!control && (
+              <Section title="Chamber Controls">
+                <Stack>
+                  <Stack.Item grow>
+                    {selectedChamber.input_info ? (
+                      <LabeledList>
+                        <LabeledList.Item label="Input Injector">
+                          <Button
+                            icon={
+                              selectedChamber.input_info.active
+                                ? 'power-off'
+                                : 'times'
+                            }
+                            content={
+                              selectedChamber.input_info.active
+                                ? 'Injecting'
+                                : 'Off'
+                            }
+                            selected={selectedChamber.input_info.active}
+                            onClick={() =>
+                              act('toggle_input', {
+                                chamber: selectedChamber.id,
+                              })
+                            }
+                          />
+                        </LabeledList.Item>
+                        <LabeledList.Item label="Input Rate">
+                          <NumberInput
+                            step={1}
+                            value={Number(selectedChamber.input_info.amount)}
+                            unit="L/s"
+                            width="63px"
+                            minValue={0}
+                            maxValue={maxInput}
+                            onChange={(value) =>
+                              act('adjust_input', {
+                                chamber: selectedChamber.id,
+                                rate: value,
+                              })
+                            }
+                          />
+                        </LabeledList.Item>
+                      </LabeledList>
+                    ) : (
+                      <Box italic> {'No Input Device Detected!'}</Box>
+                    )}
+                  </Stack.Item>
+                  <Stack.Item grow>
+                    {selectedChamber.output_info ? (
+                      <LabeledList>
+                        <LabeledList.Item label="Output Regulator">
+                          <Button
+                            icon={
+                              selectedChamber.output_info.active
+                                ? 'power-off'
+                                : 'times'
+                            }
+                            content={
+                              selectedChamber.output_info.active
+                                ? 'Open'
+                                : 'Closed'
+                            }
+                            selected={selectedChamber.output_info.active}
+                            onClick={() =>
+                              act('toggle_output', {
+                                chamber: selectedChamber.id,
+                              })
+                            }
+                          />
+                        </LabeledList.Item>
+                        <LabeledList.Item label="Output Pressure">
+                          <NumberInput
+                            value={Number(selectedChamber.output_info.amount)}
+                            unit="kPa"
+                            width="75px"
+                            minValue={0}
+                            maxValue={maxOutput}
+                            step={10}
+                            onChange={(value) =>
+                              act('adjust_output', {
+                                chamber: selectedChamber.id,
+                                rate: value,
+                              })
+                            }
+                          />
+                        </LabeledList.Item>
+                      </LabeledList>
+                    ) : (
+                      <Box italic> {'No Output Device Detected !'} </Box>
+                    )}
+                  </Stack.Item>
+                </Stack>
+              </Section>
+            )}
+          </Stack.Item>
+          <Stack.Item grow>
+            <AtmosHandbookContent />
+          </Stack.Item>
+        </Stack>
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/GasAnalyzer.tsx
+++ b/tgui/packages/tgui/interfaces/GasAnalyzer.tsx
@@ -1,4 +1,4 @@
-import { Section } from 'tgui-core/components';
+import { Section, Stack } from 'tgui-core/components';
 
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
@@ -10,33 +10,37 @@ import type { Gasmix } from './common/GasmixParser';
 import { GasmixParser } from './common/GasmixParser';
 
 export type GasAnalyzerData = {
-  gasmixes: Gasmix[];
+  gasmixes: Gasmix[] | null;
 };
 
-export const GasAnalyzerContent = (props) => {
-  const { act, data } = useBackend<GasAnalyzerData>();
+export const GasAnalyzerContent = () => {
+  const { data } = useBackend<GasAnalyzerData>();
   const { gasmixes } = data;
   const [setActiveGasId, setActiveReactionId] = atmosHandbookHooks();
   return (
-    <>
-      {gasmixes.map((gasmix) => (
-        <Section title={gasmix.name} key={gasmix.reference}>
-          <GasmixParser
-            gasmix={gasmix}
-            gasesOnClick={setActiveGasId}
-            reactionOnClick={setActiveReactionId}
-          />
-        </Section>
-      ))}
-      <AtmosHandbookContent vertical />
-    </>
+    <Stack vertical fill>
+      <Stack.Item>
+        {gasmixes?.map((gasmix) => (
+          <Section title={gasmix.name} key={gasmix.reference}>
+            <GasmixParser
+              gasmix={gasmix}
+              gasesOnClick={setActiveGasId}
+              reactionOnClick={setActiveReactionId}
+            />
+          </Section>
+        ))}
+      </Stack.Item>
+      <Stack.Item grow>
+        <AtmosHandbookContent />
+      </Stack.Item>
+    </Stack>
   );
 };
 
-export const GasAnalyzer = (props) => {
+export const GasAnalyzer = () => {
   return (
-    <Window width={500} height={450}>
-      <Window.Content scrollable>
+    <Window width={500} height={500}>
+      <Window.Content>
         <GasAnalyzerContent />
       </Window.Content>
     </Window>

--- a/tgui/packages/tgui/interfaces/common/AtmosHandbook.tsx
+++ b/tgui/packages/tgui/interfaces/common/AtmosHandbook.tsx
@@ -1,16 +1,16 @@
 import { atom, useAtom } from 'jotai';
 import { type ReactNode, useState } from 'react';
 import {
-  Box,
   Button,
   Flex,
   Input,
   LabeledList,
   Section,
   Stack,
+  Tabs,
   Tooltip,
 } from 'tgui-core/components';
-
+import { useFuzzySearch } from 'tgui-core/fuzzysearch';
 import { useBackend } from '../../backend';
 
 /**
@@ -44,41 +44,61 @@ type Gas = {
   name: string;
   description: string;
   specific_heat: number;
+  export_value: number;
   reactions: Record<string, string> | [];
 };
 
 type GasSearchProps = {
   title: ReactNode;
+  placeholder?: string;
+  inputText?: string;
+  onEnter: (inputValue: string) => void;
   onChange: (inputValue: string) => void;
   activeInput: boolean;
   setActiveInput: (toggle: boolean) => void;
 };
 
+enum HandbookTab {
+  Gases = 1,
+  Reactions = 2,
+}
+
 type Data = {
   gasInfo: Gas[];
   reactionInfo: Reaction[];
+  moneySymbol: string;
+  moneyName: string;
 };
 
 const activeGasAtom = atom('');
 const activeReactionAtom = atom('');
 
 function GasSearchBar(props: GasSearchProps) {
-  const { title, onChange, activeInput, setActiveInput } = props;
+  const {
+    title,
+    placeholder,
+    inputText,
+    onChange,
+    onEnter,
+    activeInput,
+    setActiveInput,
+  } = props;
 
   return (
     <Flex align="center">
       <Flex.Item grow>
-        {activeInput ? (
-          <Input
-            fluid
-            onBlur={(value) => {
-              setActiveInput(false);
-              onChange(value);
-            }}
-          />
-        ) : (
-          title
-        )}
+        <Input
+          fluid
+          placeholder={placeholder}
+          value={inputText}
+          onBlur={(value) => {
+            setActiveInput(false);
+            onEnter(value);
+          }}
+          onChange={(value) => {
+            onChange(value);
+          }}
+        />
       </Flex.Item>
       <Flex.Item>
         <Button icon="search" onClick={() => setActiveInput(!activeInput)} />
@@ -87,57 +107,205 @@ function GasSearchBar(props: GasSearchProps) {
   );
 }
 
-function GasHandbook(props) {
+function getSpecificHeatColor(specificHeat: number) {
+  if (specificHeat <= 10) {
+    return 'red';
+  } else if (specificHeat <= 20) {
+    return 'orange';
+  } else if (specificHeat <= 100) {
+    return 'yellow';
+  } else if (specificHeat <= 200) {
+    return 'green';
+  } else {
+    return 'blue';
+  }
+}
+
+function getExportValueColor(exportValue: number) {
+  if (exportValue <= 0.2) {
+    return 'red';
+  } else if (exportValue <= 0.5) {
+    return 'orange';
+  } else if (exportValue <= 2.5) {
+    return 'yellow';
+  } else if (exportValue <= 5) {
+    return 'green';
+  } else {
+    return 'blue';
+  }
+}
+
+type GasHandbookProps = {
+  setTab?: (tab: number) => void;
+};
+
+function GasHandbook(props: GasHandbookProps) {
   const { act, data } = useBackend<Data>();
-  const { gasInfo } = data;
+  const { gasInfo, moneySymbol, moneyName } = data;
+  const { setTab } = props;
   const [activeGasId, setActiveGasId] = useAtom(activeGasAtom);
   const [activeReactionId, setActiveReactionId] = useAtom(activeReactionAtom);
   const [gasActiveInput, setGasActiveInput] = useState(false);
   const relevantGas = gasInfo.find((gas) => gas.id === activeGasId);
 
+  const { query, setQuery, results } = useFuzzySearch({
+    searchArray: gasInfo,
+    matchStrategy: 'smart',
+    getSearchString: (item) => item.name,
+  });
+
   return (
     <Section
+      fill
       title={
         <GasSearchBar
-          title={relevantGas ? `Gas: ${relevantGas.name}` : 'Gas Lookup'}
-          onChange={(keyword) =>
-            setActiveGasId(
-              gasInfo.find((gas) =>
-                gas.name.toLowerCase().startsWith(keyword.toLowerCase()),
-              )?.id || '',
-            )
-          }
+          title="Gas Lookup"
+          inputText={query}
+          onChange={(keyword) => setQuery(keyword)}
+          onEnter={(keyword) => {
+            const foundGas = gasInfo.find((gas) =>
+              gas.name.toLowerCase().startsWith(keyword.toLowerCase()),
+            );
+            if (foundGas) {
+              setActiveGasId(foundGas.id);
+            }
+          }}
           activeInput={gasActiveInput}
           setActiveInput={setGasActiveInput}
         />
       }
     >
-      {relevantGas && (
-        <>
-          <Box mb="0.5em">{relevantGas.description}</Box>
-          <Box mb="0.5em">
-            {`Specific heat: ${relevantGas.specific_heat} Joule/KelvinMol`}
-          </Box>
-          <Box mb="0.5em">{'Relevant Reactions:'}</Box>
-          {Object.entries(relevantGas.reactions).map(
-            ([reaction_id, reaction_name]) => (
-              <Box key={reaction_id} mb="0.5em">
-                <Button
-                  onClick={() => setActiveReactionId(reaction_id)}
-                  content={reaction_name}
-                />
-              </Box>
-            ),
-          )}
-        </>
-      )}
+      <Stack fill>
+        <Stack.Item width="60%" mr="0.2em">
+          <Stack vertical fill>
+            {relevantGas ? (
+              <>
+                <Stack.Item fontSize="1.2em" bold>
+                  &gt; {relevantGas.name}
+                </Stack.Item>
+                <Stack.Item mb="0.5em" italic>
+                  {relevantGas.description}
+                </Stack.Item>
+                <Stack.Item mb="0.5em">
+                  <Stack>
+                    <Stack.Item
+                      style={{ borderBottom: 'dotted 2px' }}
+                      color="label"
+                      shrink
+                    >
+                      <Tooltip
+                        content={
+                          <Stack vertical>
+                            <Stack.Item>
+                              The amount of energy required to raise the
+                              temperature of one mole of gas by one Kelvin.
+                            </Stack.Item>
+                            <Stack.Item>
+                              In simpler terms: The lower the specific heat of
+                              the gas, the harder it will be to heat it up.
+                            </Stack.Item>
+                          </Stack>
+                        }
+                        position="top"
+                      >
+                        Specific Heat:
+                      </Tooltip>
+                    </Stack.Item>
+                    <Stack.Item
+                      color={getSpecificHeatColor(relevantGas.specific_heat)}
+                    >{`${relevantGas.specific_heat}`}</Stack.Item>
+                    <Stack.Item italic>J/(mol * K)</Stack.Item>
+                  </Stack>
+                </Stack.Item>
+                {relevantGas.export_value > 0 && (
+                  <Stack.Item mb="0.5em">
+                    <Stack>
+                      <Stack.Item
+                        style={{ borderBottom: 'dotted 2px' }}
+                        color="label"
+                        shrink
+                      >
+                        <Tooltip
+                          content={`The amount of ${moneyName} gained per mol of gas exported.`}
+                          position="top"
+                        >
+                          Export Value:
+                        </Tooltip>
+                      </Stack.Item>
+                      <Stack.Item
+                        color={getExportValueColor(relevantGas.export_value)}
+                      >{`${relevantGas.export_value}`}</Stack.Item>
+                      <Stack.Item italic>{`${moneySymbol}/mol`}</Stack.Item>
+                    </Stack>
+                  </Stack.Item>
+                )}
+                {Object.entries(relevantGas.reactions).length > 0 && (
+                  <Stack.Item mb="0.5em" grow>
+                    <Section scrollable fill title="Relevant Reactions">
+                      <Stack vertical>
+                        {Object.entries(relevantGas.reactions)
+                          .sort((a, b) => (a[1] > b[1] ? 1 : -1))
+                          .map(([reaction_id, reaction_name]) => (
+                            <Stack.Item key={reaction_id}>
+                              <Button
+                                fluid
+                                ellipsis
+                                onClick={() => {
+                                  setActiveReactionId(reaction_id);
+                                  setTab?.(HandbookTab.Reactions);
+                                }}
+                              >
+                                {reaction_name}
+                              </Button>
+                            </Stack.Item>
+                          ))}
+                      </Stack>
+                    </Section>
+                  </Stack.Item>
+                )}
+              </>
+            ) : (
+              <Stack.Item
+                fontSize="1.5rem"
+                mt={2}
+                align="center"
+                textAlign="center"
+                italic
+                color="label"
+              >
+                No Gas Selected
+              </Stack.Item>
+            )}
+          </Stack>
+        </Stack.Item>
+        <Stack.Item grow ml="0.2em">
+          <Section scrollable fill>
+            <Stack vertical>
+              {(query ? results : gasInfo)
+                .sort((a, b) => (a.name > b.name ? 1 : -1))
+                .map((gas) => (
+                  <Stack.Item key={gas.id}>
+                    <Button fluid onClick={() => setActiveGasId(gas.id)}>
+                      {gas.name}
+                    </Button>
+                  </Stack.Item>
+                ))}
+            </Stack>
+          </Section>
+        </Stack.Item>
+      </Stack>
     </Section>
   );
 }
 
-function ReactionHandbook(props) {
+type ReactionHandbookProps = {
+  setTab?: (tab: number) => void;
+};
+
+function ReactionHandbook(props: ReactionHandbookProps) {
   const { data } = useBackend<Data>();
   const { reactionInfo } = data;
+  const { setTab } = props;
   const [activeGasId, setActiveGasId] = useAtom(activeGasAtom);
   const [activeReactionId, setActiveReactionId] = useAtom(activeReactionAtom);
   const [reactionActiveInput, setReactionActiveInput] = useState(false);
@@ -145,84 +313,149 @@ function ReactionHandbook(props) {
     (reaction) => reaction.id === activeReactionId,
   );
 
+  const { query, setQuery, results } = useFuzzySearch({
+    searchArray: reactionInfo,
+    matchStrategy: 'smart',
+    getSearchString: (item) => item.name,
+  });
+
   return (
     <Section
+      fill
       title={
         <GasSearchBar
-          title={
-            relevantReaction
-              ? `Reaction: ${relevantReaction.name}`
-              : 'Reaction Lookup'
-          }
-          onChange={(keyword) =>
-            setActiveReactionId(
-              reactionInfo.find((reaction) =>
-                reaction.name.toLowerCase().startsWith(keyword.toLowerCase()),
-              )?.id || '',
-            )
-          }
+          title="Reaction Lookup"
+          onChange={(keyword) => setQuery(keyword)}
+          onEnter={(keyword) => {
+            const foundReaction = reactionInfo.find((reaction) =>
+              reaction.name.toLowerCase().startsWith(keyword.toLowerCase()),
+            );
+            if (foundReaction) {
+              setActiveReactionId(foundReaction.id);
+            }
+          }}
+          inputText={query}
           activeInput={reactionActiveInput}
           setActiveInput={setReactionActiveInput}
         />
       }
     >
-      {relevantReaction && (
-        <>
-          <Box mb="0.5em">{relevantReaction.description}</Box>
-          <Box mb="0.5em">{'Relevant Factors:'}</Box>
-          <LabeledList>
-            {relevantReaction.factors.map((factor) => (
-              <LabeledList.Item
-                key={`${relevantReaction.id}_${factor.factor_name}`}
-                label={
-                  factor.factor_type === 'gas' && factor.factor_id ? (
-                    <Button
-                      onClick={() => setActiveGasId(String(factor.factor_id))}
-                      content={factor.factor_name}
-                    />
-                  ) : factor.tooltip ? (
-                    <Tooltip content={factor.tooltip} position="top">
-                      <Flex>
-                        <Flex.Item
-                          style={{ borderBottom: 'dotted 2px' }}
-                          shrink
+      <Stack fill>
+        <Stack.Item width="60%" mr="0.2em">
+          <Stack vertical fill>
+            {relevantReaction ? (
+              <>
+                <Stack.Item fontSize="1.2em" bold>
+                  &gt; {relevantReaction.name}
+                </Stack.Item>
+                <Stack.Item mb="0.5em" italic>
+                  {relevantReaction.description}
+                </Stack.Item>
+                <Stack.Item mb="0.5em" grow>
+                  <Section scrollable fill>
+                    <LabeledList>
+                      {relevantReaction.factors.map((factor) => (
+                        <LabeledList.Item
+                          key={`${relevantReaction.id}_${factor.factor_name}`}
+                          label={
+                            factor.factor_type === 'gas' && factor.factor_id ? (
+                              <Button
+                                onClick={() => {
+                                  setActiveGasId(String(factor.factor_id));
+                                  setTab?.(HandbookTab.Gases);
+                                }}
+                                fluid
+                              >
+                                {factor.factor_name}
+                              </Button>
+                            ) : factor.tooltip ? (
+                              <Tooltip content={factor.tooltip} position="top">
+                                <Stack>
+                                  <Stack.Item
+                                    style={{ borderBottom: 'dotted 2px' }}
+                                    shrink
+                                  >
+                                    {`${factor.factor_name}:`}
+                                  </Stack.Item>
+                                </Stack>
+                              </Tooltip>
+                            ) : (
+                              factor.factor_name
+                            )
+                          }
                         >
-                          {`${factor.factor_name}:`}
-                        </Flex.Item>
-                      </Flex>
-                    </Tooltip>
-                  ) : (
-                    factor.factor_name
-                  )
-                }
+                          {factor.desc}
+                        </LabeledList.Item>
+                      ))}
+                    </LabeledList>
+                  </Section>
+                </Stack.Item>
+              </>
+            ) : (
+              <Stack.Item
+                fontSize="1.5rem"
+                mt={2}
+                align="center"
+                textAlign="center"
+                italic
+                color="label"
               >
-                {factor.desc}
-              </LabeledList.Item>
-            ))}
-          </LabeledList>
-        </>
-      )}
+                No reaction selected
+              </Stack.Item>
+            )}
+          </Stack>
+        </Stack.Item>
+        <Stack.Item grow ml="0.2em">
+          <Section scrollable fill>
+            <Stack vertical>
+              {(query ? results : reactionInfo)
+                .sort((a, b) => (a.name > b.name ? 1 : -1))
+                .map((reaction) => (
+                  <Stack.Item key={reaction.id}>
+                    <Button
+                      fluid
+                      ellipsis
+                      onClick={() => setActiveReactionId(reaction.id)}
+                    >
+                      {reaction.name}
+                    </Button>
+                  </Stack.Item>
+                ))}
+            </Stack>
+          </Section>
+        </Stack.Item>
+      </Stack>
     </Section>
   );
 }
 
-type HandbookContentProps = {
-  vertical?: boolean;
-};
+export function AtmosHandbookContent() {
+  const [tab, setTab] = useState(HandbookTab.Gases);
 
-export function AtmosHandbookContent(props: HandbookContentProps) {
-  return props.vertical ? (
-    <>
-      <GasHandbook />
-      <ReactionHandbook />
-    </>
-  ) : (
-    <Stack>
-      <Stack.Item grow>
-        <ReactionHandbook />
+  return (
+    <Stack vertical fill>
+      <Stack.Item>
+        <Tabs fluid>
+          <Tabs.Tab
+            selected={tab === HandbookTab.Gases}
+            onClick={() => setTab(HandbookTab.Gases)}
+          >
+            Gases
+          </Tabs.Tab>
+          <Tabs.Tab
+            selected={tab === HandbookTab.Reactions}
+            onClick={() => setTab(HandbookTab.Reactions)}
+          >
+            Reactions
+          </Tabs.Tab>
+        </Tabs>
       </Stack.Item>
       <Stack.Item grow>
-        <GasHandbook />
+        {tab === HandbookTab.Reactions ? (
+          <ReactionHandbook setTab={setTab} />
+        ) : (
+          <GasHandbook setTab={setTab} />
+        )}
       </Stack.Item>
     </Stack>
   );

--- a/tgui/packages/tgui/interfaces/common/GasmixParser.tsx
+++ b/tgui/packages/tgui/interfaces/common/GasmixParser.tsx
@@ -1,13 +1,17 @@
-import { Box, Button, LabeledList } from 'tgui-core/components';
+import { Box, Button, LabeledList, Stack } from 'tgui-core/components';
+
+type GasEntry = [string, string, number]; // ID, name, and amount.
+
+type ReactionEntry = [string, string, number]; // ID, name, and amount.
 
 export type Gasmix = {
   name?: string;
-  gases: [string, string, number][]; // ID, name, and amount.
+  gases: GasEntry[]; // ID, name, and amount.
   temperature: number;
   volume: number;
   pressure: number;
   total_moles: number;
-  reactions: [string, string, number][]; // ID, name, and amount.
+  reactions: ReactionEntry[]; // ID, name, and amount.
   reference: string;
 };
 
@@ -37,101 +41,134 @@ export const GasmixParser = (props: GasmixParserProps) => {
   const { gases, temperature, volume, pressure, total_moles, reactions } =
     gasmix;
 
-  return !total_moles ? (
-    <Box nowrap italic mb="10px">
-      No Gas Detected!
-    </Box>
-  ) : (
-    <LabeledList {...rest}>
-      {gases.map((gas) => (
-        <LabeledList.Item
-          label={
-            gasesOnClick ? (
-              <Button content={gas[1]} onClick={() => gasesOnClick(gas[0])} />
-            ) : (
-              gas[1]
-            )
-          }
-          key={gas[1]}
-        >
-          {gas[2].toFixed(2) +
-            ' mol (' +
-            ((gas[2] / total_moles) * 100).toFixed(2) +
-            ' %)'}
-        </LabeledList.Item>
-      ))}
-      <LabeledList.Item
-        label={
-          temperatureOnClick ? (
-            <Button
-              content={'Temperature'}
-              onClick={() => temperatureOnClick()}
-            />
-          ) : (
-            'Temperature'
-          )
-        }
-      >
-        {`${total_moles ? temperature.toFixed(2) : '-'} K`}
-      </LabeledList.Item>
-      <LabeledList.Item
-        label={
-          volumeOnClick ? (
-            <Button content={'Volume'} onClick={() => volumeOnClick()} />
-          ) : (
-            'Volume'
-          )
-        }
-      >
-        {`${total_moles ? volume.toFixed(2) : '-'} L`}
-      </LabeledList.Item>
-      <LabeledList.Item
-        label={
-          pressureOnClick ? (
-            <Button content={'Pressure'} onClick={() => pressureOnClick()} />
-          ) : (
-            'Pressure'
-          )
-        }
-      >
-        {`${total_moles ? pressure.toFixed(2) : '-'} kPa`}
-      </LabeledList.Item>
-      {detailedReactions ? (
-        reactions.map((reaction) => (
-          <LabeledList.Item
-            key={`${gasmix.reference}-${reaction[0]}`}
-            label={
-              reactionOnClick ? (
-                <Button
-                  content={reaction[1]}
-                  onClick={() => reactionOnClick(reaction[0])}
-                />
-              ) : (
-                reaction[1]
-              )
-            }
-          >
-            {reaction[2]}
-          </LabeledList.Item>
-        ))
-      ) : (
-        <LabeledList.Item label="Gas Reactions">
-          {reactions.length
-            ? reactions.map((reaction, index) =>
-                reactionOnClick ? (
-                  <Box key={reaction[1]} mb="0.5em">
+  if (total_moles <= 0) {
+    return (
+      <Box nowrap italic mb="10px">
+        No Gas Detected!
+      </Box>
+    );
+  }
+
+  return (
+    <Stack vertical>
+      <Stack.Item>
+        <Stack>
+          <Stack.Item width="60%">
+            {gases.map((gas) => (
+              <LabeledList.Item
+                label={
+                  gasesOnClick ? (
+                    <Button fluid onClick={() => gasesOnClick(gas[0])}>
+                      {gas[1]}
+                    </Button>
+                  ) : (
+                    gas[1]
+                  )
+                }
+                key={gas[1]}
+              >
+                {gas[2].toFixed(2) +
+                  ' mol (' +
+                  ((gas[2] / total_moles) * 100).toFixed(2) +
+                  ' %)'}
+              </LabeledList.Item>
+            ))}
+          </Stack.Item>
+          <Stack.Item grow>
+            <LabeledList>
+              <LabeledList.Item
+                label={
+                  temperatureOnClick ? (
                     <Button
-                      content={reaction[1]}
-                      onClick={() => reactionOnClick(reaction[0])}
+                      content={'Temperature'}
+                      onClick={() => temperatureOnClick()}
                     />
-                  </Box>
-                ) : (
-                  <div key={reaction[1]}>{reaction[1]}</div>
-                ),
-              )
-            : 'No reactions detected'}
-        </LabeledList.Item>
+                  ) : (
+                    'Temperature'
+                  )
+                }
+              >
+                {`${total_moles ? temperature.toFixed(2) : '-'} K`}
+              </LabeledList.Item>
+              <LabeledList.Item
+                label={
+                  volumeOnClick ? (
+                    <Button
+                      content={'Volume'}
+                      onClick={() => volumeOnClick()}
+                    />
+                  ) : (
+                    'Volume'
+                  )
+                }
+              >
+                {`${total_moles ? volume.toFixed(2) : '-'} L`}
+              </LabeledList.Item>
+              <LabeledList.Item
+                label={
+                  pressureOnClick ? (
+                    <Button
+                      content={'Pressure'}
+                      onClick={() => pressureOnClick()}
+                    />
+                  ) : (
+                    'Pressure'
+                  )
+                }
+              >
+                {`${total_moles ? pressure.toFixed(2) : '-'} kPa`}
+              </LabeledList.Item>
+            </LabeledList>
+          </Stack.Item>
+        </Stack>
+      </Stack.Item>
+      {!!reactions.length && (
+        <Stack.Item>
+          <Stack vertical>
+            <Stack.Item align="center" fontSize="1.2rem" color="label">
+              Active Reactions
+            </Stack.Item>
+            {detailedReactions ? (
+              <Stack.Item>
+                {reactions.map((reaction) => (
+                  <Stack.Item key={`${gasmix.reference}-${reaction[0]}`}>
+                    {reactionOnClick ? (
+                      <Button
+                        onClick={() => reactionOnClick(reaction[0])}
+                        mr={1}
+                      >
+                        {reaction[1]}
+                      </Button>
+                    ) : (
+                      reaction[1]
+                    )}
+                    - {reaction[2]}
+                  </Stack.Item>
+                ))}
+              </Stack.Item>
+            ) : (
+              <Stack.Item>
+                <Stack>
+                  {reactions.map((reaction) => (
+                    <Stack.Item key={`${gasmix.reference}-${reaction[0]}`}>
+                      {reactionOnClick ? (
+                        <Button
+                          onClick={() => reactionOnClick(reaction[0])}
+                          mr={1}
+                        >
+                          {reaction[1]}
+                        </Button>
+                      ) : (
+                        reaction[1]
+                      )}
+                    </Stack.Item>
+                  ))}
+                </Stack>
+              </Stack.Item>
+            )}
+          </Stack>
+        </Stack.Item>
       )}
-    </LabeledList>
+    </Stack>
   );
 };


### PR DESCRIPTION
## About The Pull Request

<img width="1063" height="608" alt="image" src="https://github.com/user-attachments/assets/84815091-a5c7-4453-9757-d034ae6dfbff" />

1. Gas Analyzers, when its UI is open, will update the gas data listed constantly (so long as you remain in range of the scanned target).

2. Gas analyzer and gas chamber UIs both received facelifts. They both now list out all gases and gas reactions, as well as now has additional info like export value. 

3. Some tooltips have been simplified or cleaned up. For example, the tooltip for specific heat explains what a high or low specific heat means, or the tooltip explaining the optimal heat for freon has been dumbed down.

4. Grammar pass across a lot of atmos stuff. `\improper`s or de-capitalizing things, consistent capitalization of gas names, name adjustments (`Hypernoblium` -> `Hyper-Noblium`, `Proto Nitrate` -> `Proto-Nitrate`, `Antinoblium` -> `Anti-Noblium`), `turf` -> `tile`, other general rewording.

5. Refactored `/datum/electrolyzer_reaction` into a subtype of the new base type `/datum/gas_reaction`

6. Refactored a bit of gas-cargo handling

7. Gas chamber computers now default to the gas they hold

8. Blind people can now use the gas analyzer UI 

## Why It's Good For The Game

1. Reduce the need for atmos techs to spam the gas analyzer on whatever they're working on. Now they can just slap it once and watch the UI tick up (or down)

2. The UIs provided a lot of information, but literally all of it was hidden from you unless you already knew. Now you can peruse the gases and reactions to your heart's content. 

3. There were many tooltips which were just complete nonsense. For example:

```
Freon is produced at a rate that scales with the sum of a quadratic exponential and sigmoidal function, with the quadratic exponential peaking at 800 Kelvin, but the sigmoidal function takes dominance at over 5,500K being up to 3 times more efficient.
```
Like. This is supposed to be teaching me? It's not helping!
I tried to simplify it a bit for the layman:
```
Freon is produced at a rate that scales with temperature, peaking first at 800 Kelvin, then peaking again, 3 times higher, at 5,500 Kelvin.
```

4. Makes reading atmos stuff a bit more pleasant and consistent in general

5. They copy pasted a lot of their code

6. Less hardcoded stuff

7. Tiny detail I thought would be cute

8. Blind people could use the scan part, just not the UI part. The UI contains tutorial info, so I figured they should have access to both instead of neither.

## Changelog

:cl: Melbert
qol: Upon scanning a target with a gas analyzer, its UI will update constantly as the target's gas mixture changes (so long as you stay in range). No more spam clicking to see the status of your gas canister.
qol: Gas analyzer and gas chamber UIs both received facelifts. Both now list out all available gases and gas reactions, and now contain some additional info like export value. 
spellcheck: "Dumbed down" some atmos tooltips, for lack of a better word. 
spellcheck: Grammar pass on a lot of atmos related content.
spellcheck: Hyper-noblium renamed to Hyper-Noblium
spellcheck: Proto Nitrate renamed to Proto-Nitrate
spellcheck: Antinoblium renamed to Anti-Noblium
refactor: Refactored how gas reactions and electrolyzer reactions are setup, report anything weird with them
refactor: Refactored buying and selling gas from cargo a tiny bit, report anything weird with them
qol: Gas chamber UIs now default to showing information pertaining to whichever gas is held within
qol: Blind players can access the gas analyzer UI
/:cl:
