### PR TITLE
All EVA suits can now hold any jetpack/internals tank

### DIFF
--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -91,8 +91,6 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	allowed = list(
 		/obj/item/flashlight,
-		/obj/item/tank/internals,
-		/obj/item/tank/jetpack/captain,
 		)
 	slowdown = 1
 	armor_type = /datum/armor/suit_space
@@ -126,6 +124,7 @@
 
 /obj/item/clothing/suit/space/Initialize(mapload)
 	. = ..()
+	allowed |= list(/obj/item/tank)
 	if(ispath(cell))
 		cell = new cell(src)
 

--- a/code/modules/clothing/spacesuits/bountyhunter.dm
+++ b/code/modules/clothing/spacesuits/bountyhunter.dm
@@ -3,7 +3,7 @@
 	desc = "A custom version of the MK.II SWAT suit, modified to look rugged and tough. Works as a space suit, if you can find a helmet."
 	icon_state = "hunter"
 	inhand_icon_state = "swat_suit"
-	allowed = list(/obj/item/gun, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/knife/combat)
+	allowed = list(/obj/item/gun, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/knife/combat)
 	armor_type = /datum/armor/space_hunter
 	strip_delay = 13 SECONDS
 	resistance_flags = FIRE_PROOF | ACID_PROOF

--- a/code/modules/clothing/spacesuits/freedom.dm
+++ b/code/modules/clothing/spacesuits/freedom.dm
@@ -27,7 +27,7 @@
 	desc = "An advanced, light suit, fabricated from a mixture of synthetic feathers and space-resistant material. A gun holster appears to be integrated into the suit and the wings appear to be stuck in 'freedom' mode."
 	icon_state = "freedom"
 	inhand_icon_state = null
-	allowed = list(/obj/item/gun, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
+	allowed = list(/obj/item/gun, /obj/item/melee/baton, /obj/item/restraints/handcuffs)
 	armor_type = /datum/armor/space_freedom
 	strip_delay = 13 SECONDS
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT

--- a/code/modules/clothing/spacesuits/pirate.dm
+++ b/code/modules/clothing/spacesuits/pirate.dm
@@ -28,7 +28,7 @@
 	desc = "A modified suit to allow space pirates to board shuttles and stations while avoiding the maw of the void. Comes with additional protection and is lighter to move in."
 	icon_state = "spacepirate"
 	w_class = WEIGHT_CLASS_NORMAL
-	allowed = list(/obj/item/gun, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/melee/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/reagent_containers/cup/glass/bottle/rum)
+	allowed = list(/obj/item/gun, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/melee/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/reagent_containers/cup/glass/bottle/rum)
 	slowdown = 0
 	armor_type = /datum/armor/space_pirate
 	strip_delay = 4 SECONDS

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -3,7 +3,7 @@
 /obj/item/clothing/suit/space/eva/plasmaman
 	name = "EVA plasma envirosuit"
 	desc = "A special plasma containment suit designed to be space-worthy, as well as worn over other clothing. Like its smaller counterpart, it can automatically extinguish the wearer in a crisis, and holds twice as many charges."
-	allowed = list(/obj/item/gun, /obj/item/ammo_casing, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/energy/sword, /obj/item/restraints/handcuffs, /obj/item/tank)
+	allowed = list(/obj/item/gun, /obj/item/ammo_casing, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/energy/sword, /obj/item/restraints/handcuffs)
 	armor_type = /datum/armor/eva_plasmaman
 	resistance_flags = FIRE_PROOF
 	icon_state = "plasmaman_suit"

--- a/code/modules/clothing/spacesuits/softsuit.dm
+++ b/code/modules/clothing/spacesuits/softsuit.dm
@@ -10,7 +10,7 @@
 	icon_state = "void"
 	inhand_icon_state = "void_suit"
 	desc = "An old, NASA CentCom branch designed, dark red space suit."
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/multitool)
+	allowed = list(/obj/item/flashlight, /obj/item/multitool)
 
 /obj/item/clothing/head/helmet/space/nasavoid/old
 	name = "\improper engineering void helmet"
@@ -24,7 +24,7 @@
 	inhand_icon_state = "void_suit"
 	desc = "A CentCom engineering dark red space suit. Age has degraded the suit making it difficult to move around in."
 	slowdown = 4
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/multitool)
+	allowed = list(/obj/item/flashlight, /obj/item/multitool)
 
 	//EVA suit
 /obj/item/clothing/suit/space/eva

--- a/code/modules/clothing/spacesuits/specialops.dm
+++ b/code/modules/clothing/spacesuits/specialops.dm
@@ -41,7 +41,7 @@
 	slowdown = 0
 	flags_inv = 0
 	w_class = WEIGHT_CLASS_NORMAL
-	allowed = list(/obj/item/gun, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
+	allowed = list(/obj/item/gun, /obj/item/melee/baton, /obj/item/restraints/handcuffs)
 	armor_type = /datum/armor/space_officer
 	strip_delay = 13 SECONDS
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_INIT(syndicate_space_suits_to_helmets,list(
 	inhand_icon_state = "space_suit_syndicate"
 	desc = "Has a tag on it: Totally not property of an enemy corporation, honest!"
 	w_class = WEIGHT_CLASS_NORMAL
-	allowed = list(/obj/item/gun, /obj/item/melee/baton, /obj/item/melee/energy/sword/saber, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
+	allowed = list(/obj/item/gun, /obj/item/melee/baton, /obj/item/melee/energy/sword/saber, /obj/item/restraints/handcuffs)
 	armor_type = /datum/armor/space_syndicate
 	cell = /obj/item/stock_parts/power_store/cell/hyper
 	var/helmet_type = /obj/item/clothing/head/helmet/space/syndicate


### PR DESCRIPTION

## About The Pull Request

Allows to store any jetpack/internals tank on subtypes of `/obj/item/clothing/suit/space`
## Why It's Good For The Game

QOL. Previously you'd have to use your back slot or keep jetpack in hands, which sucks and annoying to use
## Changelog
:cl:
balance: You can place your jetpack/inernals tank in any space suit's storage slot.
/:cl:
