### PR TITLE
Fixes unequipping jet boots while in-flight leaving you in a permanently flying buggy state

### DIFF
--- a/code/datums/actions/items/flight.dm
+++ b/code/datums/actions/items/flight.dm
@@ -35,9 +35,9 @@
 	)
 
 /datum/action/item_action/toggle_flight/Remove(mob/remove_from)
-	. = ..()
 	if(HAS_TRAIT_FROM(remove_from, TRAIT_MOVE_FLOATING, SHOES_TRAIT))
 		switch_flight()
+	return ..()
 
 /datum/action/item_action/toggle_flight/do_effect(trigger_flags)
 	if(!ishuman(owner))


### PR DESCRIPTION

## About The Pull Request

Title


## Changelog
:cl: PapaMichael
fix: Unequipping jet boots while flying now puts you back on the ground instead of bugging you out
/:cl:
