### PR TITLE
[s] Bumps the mandatory client version config to 516.1687 for security purposes.

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -400,10 +400,10 @@ AUTOADMIN_RANK Game Master
 #CLIENT_WARN_BUILD 1635
 #CLIENT_WARN_POPUP
 #CLIENT_WARN_MESSAGE Byond released 515 as the stable release. This comes bundled with a host of niceties, including image generation for UIs and :: operators.
-CLIENT_ERROR_VERSION 515
+CLIENT_ERROR_VERSION 516
 CLIENT_ERROR_MESSAGE Your version of byond is not supported. Please upgrade.
 ## The minimum build needed for joining the server.
-CLIENT_ERROR_BUILD 1590
+CLIENT_ERROR_BUILD 1687
 
 ## TOPIC RATE LIMITING
 ## This allows you to limit how many topic calls (clicking on an interface window) the client can do in any given game second and/or game minute.


### PR DESCRIPTION
## About The Pull Request

Bumps the mandatory client version config to 516.1687 for security purposes.

## Why It's Good For The Game

Best way to innoculate the playerbase is to just make sure all the major servers have bumped their minimum client versions. We also need to do this anyways because of escape-menu transparency support, so might as well.

## Changelog

:cl:
server: Bumps the mandatory client version config to 516.1687 for security purposes.
/:cl: