### PR TITLE
Fix Fancy Weather prefrences not being respected

### DIFF
--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -137,6 +137,9 @@
 /atom/movable/screen/plane_master/rendering_plate/particle_weather/proc/z_changed(datum/source, new_z)
 	SIGNAL_HANDLER
 
+	if(!(src in SSweather.particle_planemasters))
+		return
+
 	if(!SSmapping.initialized)
 		return
 

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -120,7 +120,7 @@
 	if(!istype(mymob) || !mymob.canon_client?.prefs?.read_preference(/datum/preference/toggle/particle_weather))
 		return
 
-	SSweather.particle_planemasters += src
+	SSweather.particle_planemasters[src] = TRUE
 
 	// Lobby HUDs, we don't care about weather during init anyways
 	if(!SSmapping.initialized)
@@ -137,7 +137,7 @@
 /atom/movable/screen/plane_master/rendering_plate/particle_weather/proc/z_changed(datum/source, new_z)
 	SIGNAL_HANDLER
 
-	if(!(src in SSweather.particle_planemasters))
+	if(!SSweather.particle_planemasters[src])
 		return
 
 	if(!SSmapping.initialized)


### PR DESCRIPTION

## About The Pull Request
This pull request should fix #97518 

And fixes an issue in which the Fancy Weather preferences don't get respected when you change Z-levels or teleport around as a ghost.

This PR in short just added one extra check 
```dm
	if(!(src in SSweather.particle_planemasters))
		return
```
Within the `z_changed` proc, If the client/player is not in the Fancy weather list (people who have it enabled), then do an early return.

This should handle cases such as.. when the round starts, when you join a round, teleporting as a ghost, anything that might trigger a Z-level change.
## Why It's Good For The Game
Bug Fix.

### Screenshots/Videos
<details>
<summary=Click me>

**Before**

https://github.com/user-attachments/assets/43ad6dd4-1a1e-4565-9d4d-73647e763df1


**After**

https://github.com/user-attachments/assets/45d3e306-1715-4a22-8fae-a5f1238afe97

</details>

## Changelog
:cl: Richard Blonski
fix: Fixed Fancy Weather preference, not being applied upon Z-Level change.
/:cl:
