### PR TITLE
Fixes door remotes & light replacers in melee + unit tests

### DIFF
--- a/code/game/objects/items/tools/control_wand.dm
+++ b/code/game/objects/items/tools/control_wand.dm
@@ -17,6 +17,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	drop_sound = 'sound/items/door_remote/door_remote_drop1.ogg'
 	pickup_sound = 'sound/items/door_remote/door_remote_pick_up1.ogg'
+	item_flags = NOBLUDGEON
 
 	var/department = "civilian"
 	var/mode = WAND_OPEN

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -416,7 +416,7 @@
 		return ITEM_INTERACT_SUCCESS
 
 	// attempt to stick weapon into light socket
-	if(status != LIGHT_EMPTY || user.combat_mode)
+	if(status != LIGHT_EMPTY || user.combat_mode || istype(tool, /obj/item/lightreplacer))
 		return NONE
 
 	if(tool.item_flags & ABSTRACT)
@@ -427,6 +427,7 @@
 		do_sparks(3, TRUE, src)
 		if (prob(75))
 			electrocute_mob(user, get_area(src), src, (rand(7,10) * 0.1), TRUE)
+
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/light/screwdriver_act(mob/living/user, obj/item/tool)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -230,6 +230,7 @@
 #include "language_transfer.dm"
 #include "leash.dm"
 #include "lesserform.dm"
+#include "light_replacer.dm"
 #include "limbsanity.dm"
 #include "ling_decap.dm"
 #include "liver.dm"

--- a/code/modules/unit_tests/interaction_door.dm
+++ b/code/modules/unit_tests/interaction_door.dm
@@ -27,3 +27,48 @@
 
 	click_wrapper(janitor, real_door)
 	TEST_ASSERT(!real_door.density, "Airlock could not be opened by janitor keyring")
+
+/// Tests that door remotes can perform their various functions on airlocks
+/datum/unit_test/door_remote
+
+/datum/unit_test/door_remote/Run()
+	var/mob/living/carbon/human/consistent/captain = EASY_ALLOCATE()
+	var/obj/item/door_remote/remote = EASY_ALLOCATE()
+	var/obj/machinery/door/airlock/instant/entrance = allocate(/obj/machinery/door/airlock/instant, get_step(run_loc_floor_bottom_left, EAST))
+
+	entrance.req_access = list(ACCESS_COMMAND)
+	captain.put_in_active_hand(remote)
+
+	click_wrapper(captain, entrance)
+	TEST_ASSERT(entrance.density, "Door remote opened a door it should not have had access to in melee")
+
+	remote.access_list = list(ACCESS_COMMAND)
+	click_wrapper(captain, entrance)
+	TEST_ASSERT(!entrance.density, "Door remote failed to open a door it should have had access to in melee")
+
+	entrance.req_access = null
+	captain.forceMove(run_loc_floor_top_right)
+	click_wrapper(captain, entrance)
+	TEST_ASSERT(entrance.density, "Door remote failed to close a door with no access requirements at range")
+
+	remote.attack_self(captain)
+	click_wrapper(captain, entrance)
+	TEST_ASSERT(entrance.locked, "Door remote failed to bolt a door")
+
+	remote.attack_self(captain)
+	click_wrapper(captain, entrance)
+	TEST_ASSERT(entrance.emergency, "Door remote failed to set a door to emergency access")
+
+	remote.obj_flags = EMAGGED
+	remote.attack_self(captain)
+	click_wrapper(captain, entrance)
+	TEST_ASSERT(entrance.isElectrified(), "Door remote failed to shock a door while emagged")
+
+	remote.attack_self(captain)
+	click_wrapper(captain, entrance)
+	TEST_ASSERT(entrance.main_power_timer, "Door remote failed to depower a door while emagged")
+
+	entrance.unbolt()
+	remote.attack_self(captain)
+	click_wrapper(captain, entrance)
+	TEST_ASSERT(entrance.density, "Door remote successfully opened a door that was depowered")

--- a/code/modules/unit_tests/light_replacer.dm
+++ b/code/modules/unit_tests/light_replacer.dm
@@ -23,6 +23,7 @@
 	TEST_ASSERT_NOTEQUAL(replacer.uses, initial(replacer.uses), "Light replacer did not consume resources replacing a tube")
 
 	janitor.put_in_active_hand(rangedreplacer, TRUE)
+	qdel(current_close_light)
 	current_close_light = allocate(/obj/machinery/light/floor, run_loc_floor_bottom_left)
 	current_close_light.burn_out()
 

--- a/code/modules/unit_tests/light_replacer.dm
+++ b/code/modules/unit_tests/light_replacer.dm
@@ -1,0 +1,33 @@
+/// Tests whether a [normal/bluespace] light replacer is capable of replacing a [broken/absent/burnt] light within a [near/far] [normal/bulb/floor] light fixure, and that resources are properly consumed, and all that.
+/datum/unit_test/light_replacer
+
+/datum/unit_test/light_replacer/Run()
+	var/mob/living/carbon/human/consistent/janitor = EASY_ALLOCATE()
+	var/obj/item/lightreplacer/replacer = EASY_ALLOCATE()
+	var/obj/item/lightreplacer/blue/rangedreplacer = EASY_ALLOCATE()
+	var/obj/machinery/light/current_close_light = EASY_ALLOCATE()
+	var/obj/machinery/light/far_bulb = allocate(/obj/machinery/light/small, run_loc_floor_top_right)
+
+	janitor.put_in_active_hand(replacer)
+	far_bulb.break_light_tube(TRUE)
+
+	click_wrapper(janitor, current_close_light)
+	TEST_ASSERT_EQUAL(replacer.uses, initial(replacer.uses), "Light replacer consumed resources replacing an already intact tube")
+
+	click_wrapper(janitor, far_bulb)
+	TEST_ASSERT_EQUAL(far_bulb.status, LIGHT_BROKEN, "Normal light replacer fixed a light from range")
+
+	current_close_light.break_light_tube(TRUE)
+	click_wrapper(janitor, current_close_light)
+	TEST_ASSERT_EQUAL(current_close_light.status, LIGHT_OK, "Light replacer failed to replace a tube")
+	TEST_ASSERT_NOTEQUAL(replacer.uses, initial(replacer.uses), "Light replacer did not consume resources replacing a tube")
+
+	janitor.put_in_active_hand(rangedreplacer, TRUE)
+	current_close_light = allocate(/obj/machinery/light/floor, run_loc_floor_bottom_left)
+	current_close_light.burn_out()
+
+	click_wrapper(janitor, far_bulb)
+	TEST_ASSERT_EQUAL(far_bulb.status, LIGHT_OK, "Ranged light replacer failed to replace broken bulb from range")
+
+	click_wrapper(janitor, current_close_light)
+	TEST_ASSERT_EQUAL(current_close_light.status, LIGHT_OK, "Ranged light replacer failed to replace burnt floor bulb in melee")


### PR DESCRIPTION

## About The Pull Request

Gives door remotes `NOBLUDGEON`, which is both a no brainer and also fixes not being able to use them in melee. 
Additionally, adds a special exception in `/obj/machinery/light/item_interaction()` to allow light replacers to go to `interact_with_atom()` in melee. 
Finally, unit tests for the various functions of both described items.

## Why It's Good For The Game

fixes #97533
fixes door remotes in melee

## Changelog
:cl:
fix: door remotes function in melee range
fix: light replacers function in melee range
/:cl:
