### PR TITLE
De-hardcodes more job/antag related HUDs

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -72,6 +72,8 @@
 
 // Security HUD icon_state defines
 
+#define DEFAULT_HUDS_DMI 'icons/mob/huds/hud.dmi'
+
 #define SECHUD_NO_ID "hudno_id"
 #define SECHUD_UNKNOWN "hudunknown"
 #define SECHUD_CENTCOM "hudcentcom"

--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -42,7 +42,7 @@
 /obj/item/proc/get_sechud_job_icon()
 	var/obj/item/card/id/id_card = GetID()
 
-	return id_card?.get_trim_sechud_icon() || SECHUD_NO_ID
+	return id_card?.get_trim_sechud_icon() || DEFAULT_HUDS_DMI
 
 
 /// Returns the SecHUD job icon state for whatever this object's ID card is, if it has one.

--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -14,6 +14,8 @@
 	var/assignment
 	/// The name of the job for interns. If unset it will default to "[assignment] (Intern)".
 	var/intern_alt_name = null
+	/// The dmi icon file associated with this trim, as it will show on the security HUD.
+	var/sechud_icon = DEFAULT_HUDS_DMI
 	/// The icon_state associated with this trim, as it will show on the security HUD.
 	var/sechud_icon_state = SECHUD_UNKNOWN
 	/// How threatened does a security bot feel when scanning this ID? A negative value may cause them to forgive things which would otherwise cause aggro.
@@ -35,6 +37,13 @@
 
 /datum/id_trim/proc/find_job()
 	return null
+
+/// Returns the SecHUD job icon state for whatever this object's ID card is, if it has one.
+/obj/item/proc/get_sechud_job_icon()
+	var/obj/item/card/id/id_card = GetID()
+
+	return id_card?.get_trim_sechud_icon() || SECHUD_NO_ID
+
 
 /// Returns the SecHUD job icon state for whatever this object's ID card is, if it has one.
 /obj/item/proc/get_sechud_job_icon_state()

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -268,6 +268,7 @@ Security HUDs! Basic mode shows only the job.
 	var/sechud_icon = wear_id?.get_sechud_job_icon()
 	var/sechud_icon_state = wear_id?.get_sechud_job_icon_state()
 	if(!sechud_icon_state || HAS_TRAIT(src, TRAIT_UNKNOWN_APPEARANCE))
+		sechud_icon = DEFAULT_HUDS_DMI
 		sechud_icon_state = "hudno_id"
 	set_hud_image_state(ID_HUD, sechud_icon, sechud_icon_state)
 	sec_hud_set_security_status()

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -557,10 +557,7 @@ Diagnostic HUDs!
 		return
 	if (!istype(holder)) // Can contain lists for HUD_LIST_LIST hinted HUDs, if someone fucks up and passes this here we wanna know about it
 		CRASH("[src] ([type]) had a HUD_LIST_LIST hud_type [hud_type] passed into set_hud_image_state!")
-	if(hud_icon)
-		holder.icon = hud_icon
-	else
-		holder.icon = DEFAULT_HUDS_DMI
+	holder.icon = hud_icon
 	holder.icon_state = hud_state
 	adjust_hud_position(holder)
 	if (x_offset || y_offset)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -549,7 +549,7 @@ Diagnostic HUDs!
 	holder.pixel_w = get_hud_x_offset()
 	holder.pixel_z = get_hud_y_offset()
 
-/atom/proc/set_hud_image_state(hud_type, hud_icon, hud_state, x_offset = 0, y_offset = 0)
+/atom/proc/set_hud_image_state(hud_type, hud_icon = DEFAULT_HUDS_DMI, hud_state, x_offset = 0, y_offset = 0)
 	if (!hud_list) // Still initializing
 		return
 	var/image/holder = hud_list[hud_type]

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -172,54 +172,54 @@ Medical HUD! Basic mode needs suit sensors on.
 
 //called when a living mob changes health
 /mob/living/proc/med_hud_set_health()
-	set_hud_image_state(HEALTH_HUD, "hud[RoundHealth(src)]")
+	set_hud_image_state(HEALTH_HUD, hud_state = "hud[RoundHealth(src)]")
 
 // Called when a carbon changes stat, virus or XENO_HOST
 // Returns TRUE if the mob is considered "perfectly healthy", FALSE otherwise
 /mob/living/proc/med_hud_set_status()
 	if(IS_DEAD_OR_FAKING(src))
-		set_hud_image_state(STATUS_HUD, "huddead")
+		set_hud_image_state(STATUS_HUD, hud_state = "huddead")
 		return FALSE
 
-	set_hud_image_state(STATUS_HUD, "hudhealthy")
+	set_hud_image_state(STATUS_HUD, hud_state = "hudhealthy")
 	return TRUE
 
 /mob/living/carbon/med_hud_set_status()
 	if(HAS_TRAIT(src, TRAIT_XENO_HOST))
-		set_hud_image_state(STATUS_HUD, "hudxeno")
+		set_hud_image_state(STATUS_HUD, hud_state = "hudxeno")
 		return FALSE
 
 	if(IS_DEAD_OR_FAKING(src))
 		if(can_defib_client())
-			set_hud_image_state(STATUS_HUD, "huddefib")
+			set_hud_image_state(STATUS_HUD, hud_state = "huddefib")
 		else if(HAS_TRAIT(src, TRAIT_GHOSTROLE_ON_REVIVE))
-			set_hud_image_state(STATUS_HUD, "hudghost")
+			set_hud_image_state(STATUS_HUD, hud_state = "hudghost")
 		else
-			set_hud_image_state(STATUS_HUD, "huddead")
+			set_hud_image_state(STATUS_HUD, hud_state = "huddead")
 		return FALSE
 
 	var/virus_threat = check_virus()
 	if (!virus_threat)
-		set_hud_image_state(STATUS_HUD, "hudhealthy")
+		set_hud_image_state(STATUS_HUD, hud_state = "hudhealthy")
 		return TRUE
 
 	switch(virus_threat)
 		if(DISEASE_SEVERITY_UNCURABLE)
-			set_hud_image_state(STATUS_HUD, "hudill6")
+			set_hud_image_state(STATUS_HUD, hud_state = "hudill6")
 		if(DISEASE_SEVERITY_BIOHAZARD)
-			set_hud_image_state(STATUS_HUD, "hudill5")
+			set_hud_image_state(STATUS_HUD, hud_state = "hudill5")
 		if(DISEASE_SEVERITY_DANGEROUS)
-			set_hud_image_state(STATUS_HUD, "hudill4")
+			set_hud_image_state(STATUS_HUD, hud_state = "hudill4")
 		if(DISEASE_SEVERITY_HARMFUL)
-			set_hud_image_state(STATUS_HUD, "hudill3")
+			set_hud_image_state(STATUS_HUD, hud_state = "hudill3")
 		if(DISEASE_SEVERITY_MEDIUM)
-			set_hud_image_state(STATUS_HUD, "hudill2")
+			set_hud_image_state(STATUS_HUD, hud_state = "hudill2")
 		if(DISEASE_SEVERITY_MINOR)
-			set_hud_image_state(STATUS_HUD, "hudill1")
+			set_hud_image_state(STATUS_HUD, hud_state = "hudill1")
 		if(DISEASE_SEVERITY_NONTHREAT)
-			set_hud_image_state(STATUS_HUD, "hudill0")
+			set_hud_image_state(STATUS_HUD, hud_state = "hudill0")
 		if(DISEASE_SEVERITY_POSITIVE)
-			set_hud_image_state(STATUS_HUD, "hudbuff")
+			set_hud_image_state(STATUS_HUD, hud_state = "hudbuff")
 	return FALSE
 
 /mob/living/carbon/human/med_hud_set_status()
@@ -228,7 +228,7 @@ Medical HUD! Basic mode needs suit sensors on.
 		return
 	var/obj/item/clothing/under/uniform = w_uniform
 	if(istype(uniform) && uniform.has_sensor == BROKEN_SENSORS)
-		set_hud_image_state(STATUS_HUD, "hudnosensor")
+		set_hud_image_state(STATUS_HUD, hud_state = "hudnosensor")
 		return FALSE
 
 
@@ -247,14 +247,14 @@ FAN HUDs! For identifying other fans on-sight.
 	set_hud_image_active(FAN_HUD)
 	for(var/accessory in undershirt.attached_accessories)
 		if(istype(accessory, /obj/item/clothing/accessory/mime_fan_pin))
-			set_hud_image_state(FAN_HUD, "mime_fan_pin")
+			set_hud_image_state(FAN_HUD, hud_state = "mime_fan_pin")
 			return
 
 		if(istype(accessory, /obj/item/clothing/accessory/clown_enjoyer_pin))
-			set_hud_image_state(FAN_HUD, "clown_enjoyer_pin")
+			set_hud_image_state(FAN_HUD, hud_state = "clown_enjoyer_pin")
 			return
 
-	set_hud_image_state(FAN_HUD, "hudfan_no")
+	set_hud_image_state(FAN_HUD, hud_state = "hudfan_no")
 
 /***********************************************
 Security HUDs! Basic mode shows only the job.
@@ -265,10 +265,11 @@ Security HUDs! Basic mode shows only the job.
 /mob/living/carbon/human/proc/update_ID_card()
 	SIGNAL_HANDLER
 
+	var/sechud_icon = wear_id?.get_sechud_job_icon()
 	var/sechud_icon_state = wear_id?.get_sechud_job_icon_state()
 	if(!sechud_icon_state || HAS_TRAIT(src, TRAIT_UNKNOWN_APPEARANCE))
 		sechud_icon_state = "hudno_id"
-	set_hud_image_state(ID_HUD, sechud_icon_state)
+	set_hud_image_state(ID_HUD, sechud_icon, sechud_icon_state)
 	sec_hud_set_security_status()
 	update_visible_name()
 
@@ -281,16 +282,16 @@ Security HUDs! Basic mode shows only the job.
 		if(current_implant.implant_flags & IMPLANT_TYPE_SECURITY)
 			switch(security_slot)
 				if(1)
-					set_hud_image_state(IMPSEC_FIRST_HUD, current_implant.hud_icon_state)
+					set_hud_image_state(IMPSEC_FIRST_HUD, hud_state = current_implant.hud_icon_state)
 					set_hud_image_active(IMPSEC_FIRST_HUD)
 					security_slot++
 
 				if(2) //Theoretically if we somehow get multiple sec implants, whatever the most recently implanted implant is will take over the 2nd position
-					set_hud_image_state(IMPSEC_SECOND_HUD, current_implant.hud_icon_state, x_offset = (ICON_SIZE_X / 4 - 1)) //Adds an offset that mirrors the hud blip to the other side of the mob
+					set_hud_image_state(IMPSEC_SECOND_HUD, hud_state = current_implant.hud_icon_state, x_offset = (ICON_SIZE_X / 4 - 1)) //Adds an offset that mirrors the hud blip to the other side of the mob
 					set_hud_image_active(IMPSEC_SECOND_HUD)
 
 	if(HAS_TRAIT(src, TRAIT_MINDSHIELD))
-		set_hud_image_state(IMPLOYAL_HUD, "hud_imp_loyal")
+		set_hud_image_state(IMPLOYAL_HUD, hud_state = "hud_imp_loyal")
 		set_hud_image_active(IMPLOYAL_HUD)
 
 /mob/living/carbon/human/proc/sec_hud_set_security_status()
@@ -299,7 +300,7 @@ Security HUDs! Basic mode shows only the job.
 		return
 
 	if (HAS_TRAIT(src, TRAIT_ALWAYS_WANTED))
-		set_hud_image_state(WANTED_HUD, "hudwanted")
+		set_hud_image_state(WANTED_HUD, hud_state = "hudwanted")
 		set_hud_image_active(WANTED_HUD)
 		return
 
@@ -316,15 +317,15 @@ Security HUDs! Basic mode shows only the job.
 
 	switch(target.wanted_status)
 		if(WANTED_ARREST)
-			set_hud_image_state(WANTED_HUD, "hudwanted")
+			set_hud_image_state(WANTED_HUD, hud_state = "hudwanted")
 		if(WANTED_PRISONER)
-			set_hud_image_state(WANTED_HUD, "hudincarcerated")
+			set_hud_image_state(WANTED_HUD, hud_state = "hudincarcerated")
 		if(WANTED_SUSPECT)
-			set_hud_image_state(WANTED_HUD, "hudsuspected")
+			set_hud_image_state(WANTED_HUD, hud_state = "hudsuspected")
 		if(WANTED_PAROLE)
-			set_hud_image_state(WANTED_HUD, "hudparolled")
+			set_hud_image_state(WANTED_HUD, hud_state = "hudparolled")
 		if(WANTED_DISCHARGED)
-			set_hud_image_state(WANTED_HUD, "huddischarged")
+			set_hud_image_state(WANTED_HUD, hud_state = "huddischarged")
 
 	set_hud_image_active(WANTED_HUD)
 
@@ -370,26 +371,26 @@ Diagnostic HUDs!
 //Sillycone hooks
 /mob/living/silicon/proc/diag_hud_set_health()
 	if(stat == DEAD)
-		set_hud_image_state(DIAG_HUD, "huddiagdead")
+		set_hud_image_state(DIAG_HUD, hud_state = "huddiagdead")
 	else
-		set_hud_image_state(DIAG_HUD, "huddiag[RoundDiagBar(health/maxHealth)]")
+		set_hud_image_state(DIAG_HUD, hud_state = "huddiag[RoundDiagBar(health/maxHealth)]")
 
 /mob/living/silicon/proc/diag_hud_set_status()
 	if(IS_UNCONSCIOUS(src))
-		set_hud_image_state(DIAG_STAT_HUD, "hudoffline")
+		set_hud_image_state(DIAG_STAT_HUD, hud_state = "hudoffline")
 		return
 	if(stat == DEAD)
-		set_hud_image_state(DIAG_STAT_HUD, "huddead2")
+		set_hud_image_state(DIAG_STAT_HUD, hud_state = "huddead2")
 		return
-	set_hud_image_state(DIAG_STAT_HUD, "hudstat")
+	set_hud_image_state(DIAG_STAT_HUD, hud_state = "hudstat")
 
 //Borgie battery tracking!
 /mob/living/silicon/robot/proc/diag_hud_set_borgcell()
 	if(QDELETED(cell) || (cell.maxcharge == 0))
-		set_hud_image_state(DIAG_BATT_HUD, "hudnobatt")
+		set_hud_image_state(DIAG_BATT_HUD, hud_state = "hudnobatt")
 	else
 		var/chargelvl = (cell.charge/cell.maxcharge)
-		set_hud_image_state(DIAG_BATT_HUD, "hudbatt[RoundDiagBar(chargelvl)]")
+		set_hud_image_state(DIAG_BATT_HUD, hud_state = "hudbatt[RoundDiagBar(chargelvl)]")
 
 //borg-AI shell tracking
 /mob/living/silicon/robot/proc/diag_hud_set_aishell() //Shows if AI is controlling a cyborg via a BORIS module
@@ -397,9 +398,9 @@ Diagnostic HUDs!
 		set_hud_image_inactive(DIAG_TRACK_HUD)
 		return
 	if(deployed) //AI shell in use by an AI
-		set_hud_image_state(DIAG_TRACK_HUD, "hudtrackingai")
+		set_hud_image_state(DIAG_TRACK_HUD, hud_state = "hudtrackingai")
 	else //Empty AI shell
-		set_hud_image_state(DIAG_TRACK_HUD, "hudtracking")
+		set_hud_image_state(DIAG_TRACK_HUD, hud_state = "hudtracking")
 	set_hud_image_active(DIAG_TRACK_HUD)
 
 //AI side tracking of AI shell control
@@ -408,28 +409,28 @@ Diagnostic HUDs!
 		set_hud_image_inactive(DIAG_TRACK_HUD)
 		return
 	//AI is currently controlling a shell
-	set_hud_image_state(DIAG_TRACK_HUD, "hudtrackingai")
+	set_hud_image_state(DIAG_TRACK_HUD, hud_state = "hudtrackingai")
 	set_hud_image_active(DIAG_TRACK_HUD)
 
 /*~~~~~~~~~~~~~~~~~~~~
 	BIG STOMPY MECHS
 ~~~~~~~~~~~~~~~~~~~~~*/
 /obj/vehicle/sealed/mecha/proc/diag_hud_set_mechhealth()
-	set_hud_image_state(DIAG_MECH_HUD, "huddiag[RoundDiagBar(atom_integrity/max_integrity)]")
+	set_hud_image_state(DIAG_MECH_HUD, hud_state = "huddiag[RoundDiagBar(atom_integrity/max_integrity)]")
 
 /obj/vehicle/sealed/mecha/proc/diag_hud_set_mechcell()
 	if(QDELETED(cell) || (cell.maxcharge == 0))
-		set_hud_image_state(DIAG_BATT_HUD, "hudnobatt")
+		set_hud_image_state(DIAG_BATT_HUD, hud_state = "hudnobatt")
 	else
 		var/chargelvl = cell.charge/cell.maxcharge
-		set_hud_image_state(DIAG_BATT_HUD, "hudbatt[RoundDiagBar(chargelvl)]")
+		set_hud_image_state(DIAG_BATT_HUD, hud_state = "hudbatt[RoundDiagBar(chargelvl)]")
 
 /obj/vehicle/sealed/mecha/proc/diag_hud_set_mechstat()
 	if(!internal_damage)
 		set_hud_image_inactive(DIAG_STAT_HUD)
 		return
 
-	set_hud_image_state(DIAG_STAT_HUD, "hudwarn")
+	set_hud_image_state(DIAG_STAT_HUD, hud_state = "hudwarn")
 	set_hud_image_active(DIAG_STAT_HUD)
 
 ///Shows tracking beacons on the mech
@@ -441,7 +442,7 @@ Diagnostic HUDs!
 			break //Immediately terminate upon finding an AI beacon to ensure it is always shown over the normal one, as mechs can have several trackers.
 		else
 			new_icon_state = "hudtracking"
-	set_hud_image_state(DIAG_TRACK_HUD, new_icon_state)
+	set_hud_image_state(DIAG_TRACK_HUD, hud_state = new_icon_state)
 
 ///Shows inbuilt camera on the mech; if the camera's view range was affected by an EMP, shows a red blip while it's affected
 /obj/vehicle/sealed/mecha/proc/diag_hud_set_camera()
@@ -451,9 +452,9 @@ Diagnostic HUDs!
 
 	set_hud_image_active(DIAG_CAMERA_HUD)
 	if(chassis_camera?.is_emp_scrambled)
-		set_hud_image_state(DIAG_CAMERA_HUD, "hudcamera_empd")
+		set_hud_image_state(DIAG_CAMERA_HUD, hud_state = "hudcamera_empd")
 	else
-		set_hud_image_state(DIAG_CAMERA_HUD, "hudcamera")
+		set_hud_image_state(DIAG_CAMERA_HUD, hud_state = "hudcamera")
 
 /*~~~~~~~~~~~~
 	Airlocks!
@@ -480,7 +481,7 @@ Diagnostic HUDs!
 
 /mob/living/proc/blood_hud_set_status()
 	if (CAN_HAVE_BLOOD(src))
-		set_hud_image_state(BLOOD_HUD, round_blood_for_hud(src))
+		set_hud_image_state(BLOOD_HUD, hud_state = round_blood_for_hud(src))
 
 #define CACHED_WIDTH_INDEX "width"
 #define CACHED_HEIGHT_INDEX "height"
@@ -547,7 +548,7 @@ Diagnostic HUDs!
 	holder.pixel_w = get_hud_x_offset()
 	holder.pixel_z = get_hud_y_offset()
 
-/atom/proc/set_hud_image_state(hud_type, hud_state, x_offset = 0, y_offset = 0)
+/atom/proc/set_hud_image_state(hud_type, hud_icon, hud_state, x_offset = 0, y_offset = 0)
 	if (!hud_list) // Still initializing
 		return
 	var/image/holder = hud_list[hud_type]
@@ -555,6 +556,10 @@ Diagnostic HUDs!
 		return
 	if (!istype(holder)) // Can contain lists for HUD_LIST_LIST hinted HUDs, if someone fucks up and passes this here we wanna know about it
 		CRASH("[src] ([type]) had a HUD_LIST_LIST hud_type [hud_type] passed into set_hud_image_state!")
+	if(hud_icon)
+		holder.icon = hud_icon
+	else
+		holder.icon = DEFAULT_HUDS_DMI
 	holder.icon_state = hud_state
 	adjust_hud_position(holder)
 	if (x_offset || y_offset)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1019,6 +1019,10 @@
 	return trim?.assignment || assignment
 
 /// Returns the trim sechud icon state.
+/obj/item/card/id/proc/get_trim_sechud_icon()
+	return trim?.sechud_icon || DEFAULT_HUDS_DMI
+
+/// Returns the trim sechud icon state.
 /obj/item/card/id/proc/get_trim_sechud_icon_state()
 	return trim?.sechud_icon_state || SECHUD_UNKNOWN
 

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -50,11 +50,11 @@
 	if(!owner)
 		return
 	if(active_mind_control)
-		owner.set_hud_image_state(GLAND_HUD, "hudgland_active")
+		owner.set_hud_image_state(GLAND_HUD, hud_state = "hudgland_active")
 	else if(mind_control_uses)
-		owner.set_hud_image_state(GLAND_HUD, "hudgland_ready")
+		owner.set_hud_image_state(GLAND_HUD, hud_state = "hudgland_ready")
 	else
-		owner.set_hud_image_state(GLAND_HUD, "hudgland_spent")
+		owner.set_hud_image_state(GLAND_HUD, hud_state = "hudgland_spent")
 
 /obj/item/organ/heart/gland/proc/mind_control(command, mob/living/user)
 	if(!ownerCheck() || !mind_control_uses || active_mind_control)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -568,7 +568,8 @@
 	new_profile.profile_snapshot = entry
 
 	// Grab the target's sechut icon.
-	new_profile.id_icon = target.wear_id?.get_sechud_job_icon_state()
+	new_profile.id_icon = target.wear_id?.get_sechud_job_icon()
+	new_profile.id_icon_state = target.wear_id?.get_sechud_job_icon_state()
 
 	var/list/slots = list("head", "wear_mask", "wear_neck", "back", "wear_suit", "w_uniform", "shoes", "belt", "gloves", "glasses", "ears", "wear_id", "s_store")
 	for(var/slot in slots)
@@ -862,6 +863,7 @@
 		if(istype(new_flesh_item, /obj/item/changeling/id) && chosen_profile.id_icon)
 			var/obj/item/changeling/id/flesh_id = new_flesh_item
 			flesh_id.hud_icon = chosen_profile.id_icon
+			flesh_id.hud_icon_state = chosen_profile.id_icon_state
 
 		if(equip)
 			user.equip_to_slot_or_del(new_flesh_item, slot2slot[slot], indirect_action = TRUE)
@@ -919,6 +921,8 @@
 	var/datum/icon_snapshot/profile_snapshot
 	/// ID HUD icon associated with the profile
 	var/id_icon
+	/// ID HUD icon state associated with the profile
+	var/id_icon_state
 	/// The age of the profile source.
 	var/age
 	/// The body type of the profile source.

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -144,12 +144,14 @@
 	var/icon/cached_flat_icon
 	/// HUD job icon of the ID
 	var/hud_icon
+	///HUD job icon state of the ID
+	var/hud_icon_state
 
 /obj/item/changeling/id/equipped(mob/user, slot, initial)
 	. = ..()
 	if(!hud_icon)
 		return
-	user.set_hud_image_state(ID_HUD, hud_icon)
+	user.set_hud_image_state(ID_HUD, hud_icon, hud_icon_state)
 
 /**
  * Returns cached flat icon of the ID, creates one if there is not one already cached

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -668,7 +668,7 @@
 	var/icon = job_trim::sechud_icon
 	var/icon_state = job_trim::sechud_icon_state
 	if(!icon || !icon_state || icon_state == SECHUD_UNKNOWN)
-		CRASH("[src.type] has no job icon state.")
+		CRASH("[src.type] has no job icon or icon state.")
 
 	return icon(icon, icon_state)
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -665,11 +665,12 @@
 	if(!job_outfit || !job_outfit::id_trim)
 		CRASH("[src.type] has no job outfit but isn't overwriting get_lobby_icon().")
 	var/datum/id_trim/job_trim = job_outfit::id_trim
+	var/icon = job_trim::sechud_icon
 	var/icon_state = job_trim::sechud_icon_state
-	if(!icon_state || icon_state == SECHUD_UNKNOWN)
+	if(!icon || !icon_state || icon_state == SECHUD_UNKNOWN)
 		CRASH("[src.type] has no job icon state.")
 
-	return icon('icons/mob/huds/hud.dmi', icon_state)
+	return icon(icon, icon_state)
 
 /datum/job/proc/display_order_with_department()
 	var/datum/job_department/main_department = departments_list?[1]

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -98,4 +98,4 @@
 	new_character.AIize()
 
 /datum/job/ai/get_lobby_icon()
-	return icon('icons/mob/huds/hud.dmi', "hudai")
+	return icon(DEFAULT_HUDS_DMI, "hudai")

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -41,4 +41,4 @@
 	new_character.Robotize(TRUE)
 
 /datum/job/cyborg/get_lobby_icon()
-	return icon('icons/mob/huds/hud.dmi', "hudcyborg")
+	return icon(DEFAULT_HUDS_DMI, "hudcyborg")

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -166,7 +166,8 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 
 		serialized["antag"] = antag.name
 		serialized["antag_group"] = antag.antagpanel_category
-		serialized["antag_icon"] = antag.antag_hud_name
+		serialized["icon"] = antag.hud_icon
+		serialized["icon_state"] = antag.antag_hud_name
 
 		return serialized
 

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -215,12 +215,14 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 	serialized["health"] = FLOOR((player.health / player.maxHealth * 100), 1)
 	if(issilicon(player))
 		serialized["job"] = player.job
-		serialized["icon"] = "borg"
+		serialized["icon"] = DEFAULT_HUDS_DMI
+		serialized["icon_state"] = "borg"
 		return serialized
 
 	var/obj/item/card/id/id_card = player.get_idcard(hand_first = FALSE)
 	serialized["job"] = id_card?.get_trim_assignment()
-	serialized["icon"] = id_card?.get_trim_sechud_icon_state()
+	serialized["icon"] = id_card?.get_trim_sechud_icon()
+	serialized["icon_state"] = id_card?.get_trim_sechud_icon_state()
 
 	var/datum/job/job = player.mind?.assigned_role
 	if (isnull(job))
@@ -233,7 +235,8 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 
 	var/datum/id_trim/trim = outfit.id_trim
 	if (!isnull(trim))
-		serialized["mind_icon"] = trim::sechud_icon_state
+		serialized["mind_icon"] = trim::sechud_icon
+		serialized["mind_icon_state"] = trim::sechud_icon_state
 	return serialized
 
 /// Gets a list: Misc data and whether it's critical. Handles all snowflakey type cases

--- a/code/modules/mob/living/basic/bots/bot_hud.dm
+++ b/code/modules/mob/living/basic/bots/bot_hud.dm
@@ -1,35 +1,35 @@
 /mob/living/basic/bot/proc/diag_hud_set_bothealth()
-	set_hud_image_state(DIAG_HUD, "huddiag[RoundDiagBar(health/maxHealth)]")
+	set_hud_image_state(DIAG_HUD, hud_state = "huddiag[RoundDiagBar(health/maxHealth)]")
 
 /mob/living/basic/bot/proc/diag_hud_set_botstat() //On (With wireless on or off), Off, EMP'ed
 	if(bot_mode_flags & BOT_MODE_ON)
-		set_hud_image_state(DIAG_STAT_HUD, "hudstat")
+		set_hud_image_state(DIAG_STAT_HUD, hud_state = "hudstat")
 		return
 
 	if(IS_UNCONSCIOUS_OR_CRIT(src))
-		set_hud_image_state(DIAG_STAT_HUD, "hudoffline")
+		set_hud_image_state(DIAG_STAT_HUD, hud_state = "hudoffline")
 		return
 
-	set_hud_image_state(DIAG_STAT_HUD, "huddead2")
+	set_hud_image_state(DIAG_STAT_HUD, hud_state = "huddead2")
 
 /mob/living/basic/bot/proc/diag_hud_set_botmode() //Shows a bot's current operation
 	if(client) //If the bot is player controlled, it will not be following mode logic!
-		set_hud_image_state(DIAG_BOT_HUD, "hudsentient")
+		set_hud_image_state(DIAG_BOT_HUD, hud_state = "hudsentient")
 		return
 
 	switch(mode)
 		if(BOT_SUMMON, BOT_RESPONDING) //Responding to PDA or AI summons
-			set_hud_image_state(DIAG_BOT_HUD, "hudcalled")
+			set_hud_image_state(DIAG_BOT_HUD, hud_state = "hudcalled")
 		if(BOT_CLEANING, BOT_HEALING) //Cleanbot cleaning, Floorbot fixing, or Medibot Healing
-			set_hud_image_state(DIAG_BOT_HUD, "hudworking")
+			set_hud_image_state(DIAG_BOT_HUD, hud_state = "hudworking")
 		if(BOT_PATROL, BOT_START_PATROL) //Patrol mode
-			set_hud_image_state(DIAG_BOT_HUD, "hudpatrol")
+			set_hud_image_state(DIAG_BOT_HUD, hud_state = "hudpatrol")
 		if(BOT_PREP_ARREST, BOT_ARREST, BOT_HUNT) //STOP RIGHT THERE, CRIMINAL SCUM!
-			set_hud_image_state(DIAG_BOT_HUD, "hudalert")
+			set_hud_image_state(DIAG_BOT_HUD, hud_state = "hudalert")
 		if(BOT_MOVING, BOT_DELIVER, BOT_GO_HOME, BOT_NAV) //Moving to target for normal bots, moving to deliver or go home for MULES.
-			set_hud_image_state(DIAG_BOT_HUD, "hudmove")
+			set_hud_image_state(DIAG_BOT_HUD, hud_state = "hudmove")
 		else
-			set_hud_image_state(DIAG_BOT_HUD, "")
+			set_hud_image_state(DIAG_BOT_HUD, hud_state = "")
 
 ///proc that handles drawing and transforming the bot's path onto diagnostic huds
 /mob/living/basic/bot/proc/generate_bot_path(datum/move_loop/has_target/jps/source, list/path)

--- a/code/modules/mob/living/basic/bots/mulebot/mulebot_hud.dm
+++ b/code/modules/mob/living/basic/bots/mulebot/mulebot_hud.dm
@@ -1,11 +1,11 @@
 /mob/living/basic/bot/mulebot/proc/set_cell_hud()
 	if(!has_power())
-		set_hud_image_state(DIAG_BATT_HUD, "hudnobatt")
+		set_hud_image_state(DIAG_BATT_HUD, hud_state = "hudnobatt")
 		return
 
 	var/atom/movable/screen/mob_charge/charge_hud = hud_used?.screen_objects[HUD_MULEBOT_CHARGE]
 	charge_hud?.calculate_charge()
-	set_hud_image_state(DIAG_BATT_HUD, "hudbatt[RoundDiagBar(cell.charge/cell.maxcharge)]")
+	set_hud_image_state(DIAG_BATT_HUD, hud_state = "hudbatt[RoundDiagBar(cell.charge/cell.maxcharge)]")
 
 /atom/movable/screen/mob_charge
 	icon = 'icons/obj/machines/cell_charger.dmi'

--- a/code/modules/mob/living/basic/drone/_drone.dm
+++ b/code/modules/mob/living/basic/drone/_drone.dm
@@ -171,18 +171,18 @@
 	return length(lines) ? jointext(lines, "\n") : base_laws
 
 /mob/living/basic/drone/med_hud_set_health()
-	set_hud_image_state(DIAG_HUD, "huddiag[RoundDiagBar(health/maxHealth)]")
+	set_hud_image_state(DIAG_HUD, hud_state = "huddiag[RoundDiagBar(health/maxHealth)]")
 
 /mob/living/basic/drone/med_hud_set_status()
 	if(stat == DEAD)
-		set_hud_image_state(DIAG_STAT_HUD, "huddead2")
+		set_hud_image_state(DIAG_STAT_HUD, hud_state = "huddead2")
 		return
 
 	if(incapacitated)
-		set_hud_image_state(DIAG_STAT_HUD, "hudoffline")
+		set_hud_image_state(DIAG_STAT_HUD, hud_state = "hudoffline")
 		return
 
-	set_hud_image_state(DIAG_STAT_HUD, "hudstat")
+	set_hud_image_state(DIAG_STAT_HUD, hud_state = "hudstat")
 
 /mob/living/basic/drone/Destroy()
 	GLOB.drones_list -= src

--- a/code/modules/mob/living/basic/space_fauna/morph.dm
+++ b/code/modules/mob/living/basic/space_fauna/morph.dm
@@ -77,14 +77,14 @@
 		return ..()
 
 	//we hide medical hud while in regular state or an item
-	set_hud_image_state(HEALTH_HUD, null)
+	set_hud_image_state(HEALTH_HUD, hud_state = null)
 
 /mob/living/basic/morph/med_hud_set_status()
 	if(isliving(form_typepath))
 		return ..()
 
 	//we hide medical hud while in regular state or an item
-	set_hud_image_state(STATUS_HUD, null)
+	set_hud_image_state(STATUS_HUD, hud_state = null)
 
 /mob/living/basic/morph/death(gibbed)
 	if(HAS_TRAIT(src, TRAIT_DISGUISED))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -191,7 +191,7 @@
 			hud_list[hud] = list()
 
 		else
-			var/image/I = image('icons/mob/huds/hud.dmi', src, "")
+			var/image/I = image(DEFAULT_HUDS_DMI, src, "")
 			I.appearance_flags = RESET_COLOR|PIXEL_SCALE|KEEP_APART
 			hud_list[hud] = I
 		set_hud_image_active(hud, update_huds = FALSE) //by default everything is active. but dont add it to huds to keep control.

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -273,7 +273,7 @@
 			offset_old = pixel_x
 			pixel_x = -APC_PIXEL_OFFSET
 
-	var/image/hud_image = image(icon = 'icons/mob/huds/hud.dmi', icon_state = "apc_hacked")
+	var/image/hud_image = image(icon = DEFAULT_HUDS_DMI, icon_state = "apc_hacked")
 	hud_image.pixel_w = pixel_x
 	hud_image.pixel_z = pixel_y
 	hud_list = list(

--- a/code/modules/wiremod/dcs_components/component_boris_circuit_container.dm
+++ b/code/modules/wiremod/dcs_components/component_boris_circuit_container.dm
@@ -16,7 +16,7 @@
 	. = ..()
 	RegisterSignal(parent, COMSIG_ATOM_ATTACK_AI, PROC_REF(on_ai_click))
 	var/atom/parent_atom = parent
-	var/image/indicator_image = image('icons/mob/huds/hud.dmi', parent_atom, "hudtracking", pixel_x = 8)
+	var/image/indicator_image = image(DEFAULT_HUDS_DMI, parent_atom, "hudtracking", pixel_x = 8)
 	SET_PLANE_EXPLICIT(indicator_image, ABOVE_LIGHTING_PLANE, parent_atom)
 	indicator_weakref = WEAKREF(parent_atom.add_alt_appearance(
 		/datum/atom_hud/alternate_appearance/basic/ais,

--- a/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
@@ -8,17 +8,20 @@ type Props = {
   realNameDisplay: boolean;
 };
 
-type IconSettings = {
+type JobIconSettings = {
+  transform: string;
+};
+
+type AntagIconSettings = {
   dmi: string;
   transform: string;
 };
 
-const normalIcon: IconSettings = {
-  dmi: 'icons/mob/huds/hud.dmi',
+const normalIcon: JobIconSettings = {
   transform: 'scale(2.3) translateX(9px) translateY(1px)',
 };
 
-const antagIcon: IconSettings = {
+const antagIcon: AntagIconSettings = {
   dmi: 'icons/mob/huds/antag_hud.dmi',
   transform: 'scale(1.8) translateX(-16px) translateY(7px)',
 };
@@ -27,27 +30,36 @@ export function JobIcon(props: Props) {
   const { item, realNameDisplay } = props;
 
   // We don't need to cast here but typescript isn't smart enough to know that
-  const { icon = '', job = '', mind_icon = '', mind_job = '' } = item;
-  let usedIcon = realNameDisplay ? mind_icon || icon : icon;
-  let usedJob = realNameDisplay ? mind_job || job : job;
+  const {
+    icon = '',
+    icon_state = '',
+    job = '',
+    mind_icon = '',
+    mind_icon_state = '',
+  } = item;
+  const usedIcon = realNameDisplay ? mind_icon || icon : icon;
+  let usedIconState = realNameDisplay
+    ? mind_icon_state || icon_state
+    : icon_state;
+  let usedJob = realNameDisplay ? mind_icon || job : job;
 
-  let iconSettings: IconSettings;
+  let iconSettings: AntagIconSettings | JobIconSettings;
   if ('antag' in item && !realNameDisplay) {
     iconSettings = antagIcon;
     usedJob = item.antag;
-    usedIcon = item.antag_icon;
+    usedIconState = item.antag_icon;
   } else {
     iconSettings = normalIcon;
   }
 
   return (
     <div className="JobIcon">
-      {icon === 'borg' ? (
+      {icon_state === 'borg' ? (
         <Icon color="lightblue" name={JOB2ICON[usedJob]} ml={0.3} mt={0.4} />
       ) : (
         <DmIcon
-          icon={iconSettings.dmi}
-          icon_state={usedIcon}
+          icon={usedIcon}
+          icon_state={usedIconState}
           style={{
             transform: iconSettings.transform,
           }}

--- a/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
@@ -8,22 +8,16 @@ type Props = {
   realNameDisplay: boolean;
 };
 
-type JobIconSettings = {
+type IconSettings = {
   transform: string;
 };
 
-type AntagIconSettings = {
-  dmi: string;
-  transform: string;
-};
-
-const normalIcon: JobIconSettings = {
+const normalIcon: IconSettings = {
   transform: 'scale(2.3) translateX(9px) translateY(1px)',
 };
 
-const antagIcon: AntagIconSettings = {
-  dmi: 'icons/mob/huds/antag_hud.dmi',
-  transform: 'scale(1.8) translateX(-16px) translateY(7px)',
+const antagIcon: IconSettings = {
+  transform: 'scale(2) translateX(-15px) translateY(8px)',
 };
 
 export function JobIcon(props: Props) {
@@ -38,16 +32,15 @@ export function JobIcon(props: Props) {
     mind_icon_state = '',
   } = item;
   const usedIcon = realNameDisplay ? mind_icon || icon : icon;
-  let usedIconState = realNameDisplay
+  const usedIconState = realNameDisplay
     ? mind_icon_state || icon_state
     : icon_state;
   let usedJob = realNameDisplay ? mind_icon || job : job;
 
-  let iconSettings: AntagIconSettings | JobIconSettings;
+  let iconSettings: IconSettings;
   if ('antag' in item && !realNameDisplay) {
     iconSettings = antagIcon;
     usedJob = item.antag;
-    usedIconState = item.antag_icon;
   } else {
     iconSettings = normalIcon;
   }

--- a/tgui/packages/tgui/interfaces/Orbit/OrbitItem.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/OrbitItem.tsx
@@ -17,13 +17,13 @@ type Props = {
 /** Each button on the observable section */
 export function OrbitItem(props: Props) {
   const { item, realNameDisplay, viewMode, color } = props;
-  const { full_name, icon, job, name, orbiters, ref } = item;
+  const { full_name, icon_state, job, name, orbiters, ref } = item;
 
   const { data } = useBackend<OrbitData>();
   const { orbiting } = data;
 
   const selected = ref === orbiting?.ref;
-  const validIcon = !!job && !!icon && icon !== 'hudunknown';
+  const validIcon = !!icon_state && icon_state !== 'hudunknown';
 
   const hasTooltip = item.health || item.extra;
 

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -32,7 +32,9 @@ export type Observable = {
   extra: string;
   health: number;
   icon: string;
+  icon_state: string;
   mind_icon: string;
+  mind_icon_state: string;
   job: string;
   mind_job: string;
   name: string;

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -5,7 +5,8 @@ import type { VIEWMODE } from './constants';
 export type Antagonist = Observable & {
   antag: string;
   antag_group: string;
-  antag_icon: string;
+  icon: string;
+  icon_state: string;
 };
 
 export type AntagGroup = [string, Antagonist[]];


### PR DESCRIPTION
## About The Pull Request

So you know how we got ``trim_icon`` (jobs) and ``hud_icon`` (antags) so they can have modular HUDs? Turns out this doesn't mean we've got modular icons, for ``sechud_icon_state`` is hardcoded to 1 file, and the Orbit Menu does not support having different files.

This hopes to fix these issues, and along the way I fixed antag icons not working on the Orbit menu

<img width="710" height="623" alt="image" src="https://github.com/user-attachments/assets/e843ec94-1580-426a-bb41-6c8ba78bd0dc" />


## Why It's Good For The Game

Fixes antag HUDs not appearing in the orbit menu, makes HUDs more modular as we have already tried doing in the past.

## Changelog

:cl:
fix: Orbit menu should now show antag HUDs as it was seemingly supposed to from the start, instead of some antags simply showing a rev icon.
refactor: De-hardcoded HUDs for jobs & antags, report any icons missing.
/:cl: