### PR TITLE
Donk. Flechette rounds aren't stealthy embeds

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -168,6 +168,7 @@
 	pain_mult = 0.5
 	jostle_pain_mult = 1.5
 	rip_time = 0.5 SECONDS
+	stealthy_embed = FALSE
 
 /obj/projectile/bullet/pellet/flechette/donk
 	name = "\improper Donk Co. 'Donk Spike' flechette"


### PR DESCRIPTION
## About The Pull Request

#89854 and #89972 were merged in quick succession, causing the Flechettes added from the latter to accidentally be categorized as stealthy embeds

## Why It's Good For The Game

I'm fairly certain they were NOT balanced about them being stealthy, so, yeah

## Changelog

:cl: Melbert
balance: Donk. Flechette rounds aren't stealthy embeds and can be hand removed
/:cl:
