### PR TITLE
Magboots prevent falling on shuttle movement

### DIFF
--- a/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
+++ b/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
@@ -335,7 +335,7 @@ All ShuttleMove procs go here
 		buckled.user_unbuckle_mob(src, src)
 		return
 	if(knockdown > 0)
-		if(buckled)
+		if(buckled || HAS_TRAIT(src, TRAIT_NEGATES_GRAVITY))
 			Immobilize(knockdown * 0.5)
 			return
 		Paralyze(knockdown)


### PR DESCRIPTION
## About The Pull Request

Having `TRAIT_NEGATES_GRAVITY` on shuttle movement is equivalent to being buckled, so you won't fall over

## Why It's Good For The Game

They're magboots, they keep you up

## Changelog

:cl: Melbert
balance: Magboots (and similar forms of gravity negation) prevent you from falling on shuttle movement
/:cl:

