### PR TITLE
Fixes AI Crew Monitoring tracking breaking on people who set an ID card honorific

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -295,7 +295,11 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			var/mob/living/silicon/ai/AI = usr
 			if(!istype(AI))
 				return
-			AI.ai_tracking_tool.track_name(AI, params["name"])
+			// We need to do this because the ID might add an honorific and otherwise break tracking
+			var/mob/living/target = locate(params["ref"]) in GLOB.mob_living_list
+			if(isnull(target))
+				return
+			AI.ai_tracking_tool.track_mob(AI, target)
 
 #undef SENSORS_UPDATE_PERIOD
 #undef UNKNOWN_JOB_ID

--- a/tgui/packages/tgui/interfaces/CrewConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.tsx
@@ -239,6 +239,7 @@ const CrewTableEntry = (props: CrewTableEntryProps) => {
     burndam,
     brutedam,
     area,
+    ref,
   } = sensor_data;
 
   return (
@@ -295,7 +296,7 @@ const CrewTableEntry = (props: CrewTableEntryProps) => {
           <Button
             onClick={() =>
               act('select_person', {
-                name: name,
+                ref: ref,
               })
             }
           >


### PR DESCRIPTION

## About The Pull Request

Trying to track someone who set an ID card honorific (the job-specific title thing) from the crew monitoring UI just didn't work.


## Changelog
:cl: PapaMichael
fix: AI tracking from the crew monitoring console now works for people who have set an ID card honorific too
/:cl:
