### PR TITLE
command bar: exact matches should autofill, no more quotes, etc [no gbp]

### DIFF
--- a/code/__DEFINES/verb.dm
+++ b/code/__DEFINES/verb.dm
@@ -36,7 +36,7 @@ _GAME_VERB(owner_type, verb_path_name, verb_name, "", verb_category, TRUE, FALSE
 #define GAME_VERB_DESC(owner_type, verb_path_name, verb_name, verb_desc, verb_category) \
 _GAME_VERB(owner_type, verb_path_name, verb_name, verb_desc, verb_category, TRUE, FALSE, FALSE)
 
-#define _GAME_VERB_CONTEXT(owner_type, verb_path_name, verb_name, verb_desc, verb_category, context_type) \
+#define _GAME_VERB_CONTEXT(owner_type, verb_path_name, verb_name, verb_desc, verb_category, context_type, src_range) \
 /datum/verb_metadata##owner_type/##verb_path_name \
 { \
 	name = ##verb_name; \
@@ -45,7 +45,7 @@ _GAME_VERB(owner_type, verb_path_name, verb_name, verb_desc, verb_category, TRUE
 	verb_path = ##owner_type/verb/##verb_path_name; \
 	body_path = ##owner_type/proc/__gvb_##verb_path_name; \
 }; \
-##owner_type/verb/##verb_path_name(var##context_type/__context_target in world) \
+##owner_type/verb/##verb_path_name(var##context_type/__context_target in src_range) \
 { \
 	set name = ##verb_name; \
 	set desc = ##verb_desc; \
@@ -58,7 +58,10 @@ _GAME_VERB(owner_type, verb_path_name, verb_name, verb_desc, verb_category, TRUE
 ##owner_type/proc/__gvb_##verb_path_name(list/structured_args)
 
 #define GAME_VERB_CONTEXT(owner_type, verb_path_name, verb_name, verb_desc, verb_category, context_type) \
-_GAME_VERB_CONTEXT(owner_type, verb_path_name, verb_name, verb_desc, verb_category, context_type)
+_GAME_VERB_CONTEXT(owner_type, verb_path_name, verb_name, verb_desc, verb_category, context_type, world)
+
+#define GAME_VERB_CONTEXT_RANGE(owner_type, verb_path_name, verb_name, verb_desc, verb_category, context_type, src_range) \
+_GAME_VERB_CONTEXT(owner_type, verb_path_name, verb_name, verb_desc, verb_category, context_type, src_range)
 
 #define GAME_VERB_HIDDEN(owner_type, verb_path_name, verb_name) \
 _GAME_VERB(owner_type, verb_path_name, verb_name, "", null, FALSE, TRUE, FALSE)
@@ -124,6 +127,7 @@ _GAME_VERB_PROC(owner_type, verb_path_name, verb_name, verb_desc, verb_category,
 	category = ##verb_category; \
 	verb_path = ##owner_type/verb/##verb_path_name; \
 	body_path = ##owner_type/proc/__gvb_##verb_path_name; \
+	src_based = TRUE; \
 }; \
 ##owner_type/verb/##verb_path_name() \
 { \
@@ -178,6 +182,10 @@ _GAME_VERB_GLOBAL_PROC(verb_path_name, verb_name, verb_desc, verb_category, FALS
 
 #define VERB_ARG_TYPED(name, arg_type, source, type_path) \
 	var/static/____reg_##name = ____register_verb_arg(__TYPE__, __PROC__, #name, arg_type, type_path, source); \
+	var##type_path/##name = structured_args[#name]
+
+#define VERB_ARG_TYPED_RANGE(name, arg_type, source, type_path, view_range) \
+	var/static/____reg_##name = ____register_verb_arg(__TYPE__, __PROC__, #name, arg_type, type_path, source, view_range); \
 	var##type_path/##name = structured_args[#name]
 
 #define VERB_ARG_TYPE_TEXT (1<<0)

--- a/code/datums/verb_metadata.dm
+++ b/code/datums/verb_metadata.dm
@@ -4,6 +4,7 @@
 	var/category
 	var/verb_path
 	var/body_path
+	var/src_based = FALSE
 	var/list/arguments = list()
 
 /datum/verb_metadata/proc/assign_to(target)
@@ -18,6 +19,7 @@
 	var/type_path
 	var/source
 	var/list/options
+	var/view_range
 
 /datum/verb_arg_metadata/proc/prompt(client/user, verb_name)
 	if(source == VERB_ARG_SOURCE_LIST && length(options))
@@ -72,12 +74,13 @@
 		structured_args[arg.name] = value
 	return structured_args
 
-/datum/verb_arg_metadata/New(name, arg_type, type_path, source, list/options)
+/datum/verb_arg_metadata/New(name, arg_type, type_path, source, list/options, view_range)
 	src.name = name
 	src.arg_type = arg_type
 	src.type_path = type_path
 	src.source = source
 	src.options = options
+	src.view_range = view_range
 
 /datum/verb_arg_metadata/proc/get_targets(client/viewer)
 	switch(source)
@@ -111,27 +114,24 @@
 /datum/verb_arg_metadata/proc/get_view_targets(client/viewer)
 	if(!viewer.mob)
 		return list()
-	var/list/visible = view(viewer.view, viewer.mob)
+	var/list/visible = view_range ? oview(view_range, viewer.mob) : view(viewer.view, viewer.mob)
+	if(!(arg_type & (VERB_ARG_TYPE_MOB | VERB_ARG_TYPE_OBJ | VERB_ARG_TYPE_TURF)))
+		return visible
+	var/list/filtered = list()
 	if(arg_type & VERB_ARG_TYPE_MOB)
-		var/list/mobs = list()
 		for(var/mob/target in visible)
-			mobs += target
-		return mobs
+			filtered += target
 	if(arg_type & VERB_ARG_TYPE_OBJ)
-		var/list/objs = list()
 		for(var/obj/target in visible)
-			objs += target
-		return objs
+			filtered += target
 	if(arg_type & VERB_ARG_TYPE_TURF)
-		var/list/turfs = list()
 		for(var/turf/target in visible)
-			turfs += target
-		return turfs
-	return visible
+			filtered += target
+	return filtered
 
 GLOBAL_LIST_INIT(____pending_verb_args, list())
 
-/proc/____register_verb_arg(owner_type, proc_path, arg_name, arg_type, arg_type_path, arg_source)
+/proc/____register_verb_arg(owner_type, proc_path, arg_name, arg_type, arg_type_path, arg_source, arg_view_range)
 	var/verb_key
 	if(ispath(owner_type, /datum/admin_verb))
 		verb_key = owner_type
@@ -140,7 +140,7 @@ GLOBAL_LIST_INIT(____pending_verb_args, list())
 
 	if(!GLOB.____pending_verb_args[verb_key])
 		GLOB.____pending_verb_args[verb_key] = list()
-	GLOB.____pending_verb_args[verb_key] += list(new /datum/verb_arg_metadata(arg_name, arg_type, arg_type_path, arg_source))
+	GLOB.____pending_verb_args[verb_key] += list(new /datum/verb_arg_metadata(arg_name, arg_type, arg_type_path, arg_source, null, arg_view_range))
 	return TRUE
 
 /proc/____register_verb_arg_list(owner_type, proc_path, arg_name, list/options)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1120,13 +1120,9 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 	src.stat_panel.send_message("init_verbs", list(panel_tabs = panel_tabs, verblist = verblist))
 
 	var/list/panel_verbs = list()
-	var/list/seen_verb_paths = list()
 	for(var/procpath/verb_to_init as anything in verbstoprocess)
 		if(!verb_to_init || verb_to_init.hidden)
 			continue
-		if(seen_verb_paths["[verb_to_init]"])
-			continue
-		seen_verb_paths["[verb_to_init]"] = TRUE
 		var/datum/verb_metadata/meta = SSverbs.verbs_by_verb_path[verb_to_init]
 		if(!meta && !SSadmin_verbs.admin_verbs_by_verb_path[verb_to_init])
 			continue

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1120,10 +1120,17 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 	src.stat_panel.send_message("init_verbs", list(panel_tabs = panel_tabs, verblist = verblist))
 
 	var/list/panel_verbs = list()
+	var/list/seen_verb_paths = list()
 	for(var/procpath/verb_to_init as anything in verbstoprocess)
 		if(!verb_to_init || verb_to_init.hidden)
 			continue
-		if(!SSverbs.verbs_by_verb_path[verb_to_init] && !SSadmin_verbs.admin_verbs_by_verb_path[verb_to_init])
+		if(seen_verb_paths["[verb_to_init]"])
+			continue
+		seen_verb_paths["[verb_to_init]"] = TRUE
+		var/datum/verb_metadata/meta = SSverbs.verbs_by_verb_path[verb_to_init]
+		if(!meta && !SSadmin_verbs.admin_verbs_by_verb_path[verb_to_init])
+			continue
+		if(meta?.src_based)
 			continue
 		panel_verbs += list(SSverbs.serialize_verb(verb_to_init))
 	tgui_panel?.window?.send_message("verbs/init", list("verbs" = panel_verbs))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -528,8 +528,8 @@
 
 //mob verbs are a lot faster than object verbs
 //for more info on why this is not atom/pull, see examinate() in mob.dm
-GAME_VERB_CONTEXT(/mob/living, pulled, "Pull", "", null, /atom/movable)
-	VERB_ARG_TYPED(thing_pulled, VERB_ARG_TYPE_MOB | VERB_ARG_TYPE_OBJ, VERB_ARG_SOURCE_VIEW, /atom/movable)
+GAME_VERB_CONTEXT_RANGE(/mob/living, pulled, "Pull", "", null, /atom/movable, oview(1))
+	VERB_ARG_TYPED_RANGE(thing_pulled, VERB_ARG_TYPE_MOB | VERB_ARG_TYPE_OBJ, VERB_ARG_SOURCE_VIEW, /atom/movable, 1)
 	if(istype(thing_pulled) && Adjacent(thing_pulled))
 		start_pulling(thing_pulled)
 

--- a/tgui/packages/tgui-panel/settings/SettingsGeneral.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsGeneral.tsx
@@ -156,6 +156,20 @@ export function SettingsGeneral(props) {
             }
           />
         </LabeledList.Item>
+        <LabeledList.Item label="Command bar">
+          <Button.Checkbox
+            checked={settings.eagerCommandBarSuggestions}
+            color="transparent"
+            onClick={() =>
+              updateSettings({
+                eagerCommandBarSuggestions:
+                  !settings.eagerCommandBarSuggestions,
+              })
+            }
+          >
+            Show suggestions while typing
+          </Button.Checkbox>
+        </LabeledList.Item>
       </LabeledList>
       <Divider />
       <Stack fill>

--- a/tgui/packages/tgui-panel/settings/atoms.ts
+++ b/tgui/packages/tgui-panel/settings/atoms.ts
@@ -4,6 +4,7 @@ import type { HighlightSetting, HighlightState, SettingsState } from './types';
 
 export const defaultSettings: SettingsState = {
   adminMusicVolume: 0.5,
+  eagerCommandBarSuggestions: true,
   fontFamily: FONTS[0],
   fontSize: 13,
   initialized: false,

--- a/tgui/packages/tgui-panel/settings/types.ts
+++ b/tgui/packages/tgui-panel/settings/types.ts
@@ -8,6 +8,7 @@ const viewSchema = z.object({
 
 export const settingsSchema = z.object({
   adminMusicVolume: z.number(),
+  eagerCommandBarSuggestions: z.boolean(),
   fontFamily: z.string(),
   fontSize: z.number(),
   initialized: z.boolean(),

--- a/tgui/packages/tgui-panel/verbs/CommandBar.tsx
+++ b/tgui/packages/tgui-panel/verbs/CommandBar.tsx
@@ -7,6 +7,7 @@ import {
 import { useAtomValue } from 'jotai';
 import { type KeyboardEvent, useEffect, useRef, useState } from 'react';
 
+import { settingsAtom } from '../settings/atoms';
 import {
   adminTargetsAtom,
   adminVerbsAtom,
@@ -191,6 +192,7 @@ export function CommandBar() {
   const focusSignal = useAtomValue(focusCommandBarAtom);
   const clearSignal = useAtomValue(clearCommandBarAtom);
   const hotkeys = useAtomValue(hotkeysAtom);
+  const { eagerCommandBarSuggestions } = useAtomValue(settingsAtom);
   const [input, setInput] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [selectedVerb, setSelectedVerb] = useState<Verb | null>(null);
@@ -200,6 +202,7 @@ export function CommandBar() {
   const inputRef = useRef<HTMLInputElement>(null);
   const historyRef = useRef<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
+  const [showSuggestions, setShowSuggestions] = useState(false);
 
   const verbArgs = selectedVerb?.args || [];
   const currentArgIndex = selectedVerb ? filledArgs.length : -1;
@@ -224,6 +227,8 @@ export function CommandBar() {
     allSuggestions,
   } = useSuggestions(input, selectedVerb, currentArg, currentToken);
   const hasSuggestions = allSuggestions.length > 0;
+  const displaySuggestions =
+    hasSuggestions && (eagerCommandBarSuggestions || showSuggestions);
   const isCurrentArgTypepath = currentArg ? isTypepathArg(currentArg) : false;
   const isCurrentArgList = currentArg ? isListArg(currentArg) : false;
 
@@ -290,6 +295,7 @@ export function CommandBar() {
     setFilledArgs([]);
     setSelectedIndex(0);
     setLastTypepathRequest('');
+    setShowSuggestions(false);
   };
 
   const enterChatMode = (chatMode: Mode) => {
@@ -456,7 +462,7 @@ export function CommandBar() {
             setHistoryIndex(-1);
             resetState();
           }
-        } else if (hasSuggestions) {
+        } else if (displaySuggestions) {
           e.preventDefault();
           setSelectedIndex((i) => Math.min(i + 1, allSuggestions.length - 1));
         } else {
@@ -472,7 +478,7 @@ export function CommandBar() {
             setHistoryIndex(newIndex);
             restoreFromHistory(historyRef.current[newIndex]);
           }
-        } else if (hasSuggestions) {
+        } else if (displaySuggestions) {
           e.preventDefault();
           setSelectedIndex((i) => Math.max(i - 1, 0));
         } else {
@@ -494,23 +500,27 @@ export function CommandBar() {
         return;
       case ' ':
         if (inQuotedArg) return;
-        if (selectedVerb && hasSuggestions) {
+        if (selectedVerb && displaySuggestions) {
           e.preventDefault();
           selectCurrentSuggestion();
           return;
         }
         if (!selectedVerb && verbSuggestions.length > 0) {
           e.preventDefault();
-          if (selectedIndex > 0) {
-            selectVerb(verbSuggestions[selectedIndex]);
-            return;
-          }
           const query = input.toLowerCase();
           const exactMatch = verbSuggestions.find(
             (v) => toKebab(v.name).toLowerCase() === query,
           );
           if (exactMatch) {
             selectVerb(exactMatch);
+            return;
+          }
+          if (!displaySuggestions) {
+            setShowSuggestions(true);
+            return;
+          }
+          if (selectedIndex > 0) {
+            selectVerb(verbSuggestions[selectedIndex]);
             return;
           }
           const prefixMatches = verbSuggestions.filter((v) =>
@@ -537,7 +547,11 @@ export function CommandBar() {
         return;
       case 'Tab':
         e.preventDefault();
-        if (!hasSuggestions || !selectCurrentSuggestion()) {
+        if (!hasSuggestions) {
+          blurToMap();
+        } else if (!displaySuggestions) {
+          setShowSuggestions(true);
+        } else if (!selectCurrentSuggestion()) {
           blurToMap();
         }
         return;
@@ -555,7 +569,7 @@ export function CommandBar() {
           } else {
             selectVerb(verb);
           }
-        } else if (selectedVerb && hasSuggestions && !isCurrentArgTypepath) {
+        } else if (selectedVerb && displaySuggestions && !isCurrentArgTypepath) {
           selectCurrentSuggestion();
         } else if (selectedVerb) {
           invokeVerb();
@@ -584,6 +598,8 @@ export function CommandBar() {
   };
 
   const handleChange = (value: string) => {
+    setShowSuggestions(false);
+
     if (!selectedVerb) {
       value = value.replaceAll(' ', '');
     }
@@ -654,7 +670,7 @@ export function CommandBar() {
   return (
     <div className="CommandBar">
       <div className="CommandBar__input-wrap">
-        {hasSuggestions && (
+        {displaySuggestions && (
           <div className="CommandBar__suggestions">
             {!selectedVerb
               ? verbSuggestions.map((verb, i) => (

--- a/tgui/packages/tgui-panel/verbs/CommandBar.tsx
+++ b/tgui/packages/tgui-panel/verbs/CommandBar.tsx
@@ -66,15 +66,28 @@ function serializeInput(verb: Verb, filled: string[], suffix = ''): string {
   if (filled.length === 0) return kebab + suffix;
   const parts = filled.map((a, i) => {
     const arg = verb.args[i];
-    return arg && isTextArg(arg) ? `"${a}"` : a;
+    return arg && isTextArg(arg) && i < verb.args.length - 1 ? `"${a}"` : a;
   });
   return `${kebab} ${parts.join(' ')}${suffix}`;
 }
 
-function suffixForArg(arg: VerbArg | undefined): string {
+function suffixForArg(
+  arg: VerbArg | undefined,
+  isLastArg: boolean,
+): string {
   if (!arg) return '';
-  if (isTextArg(arg)) return ' "';
+  if (isTextArg(arg) && !isLastArg) return ' "';
   return ' ';
+}
+
+function skipTokens(raw: string, count: number): number {
+  let pos = 0;
+  for (let j = 0; j < count; j++) {
+    while (pos < raw.length && raw[pos] === ' ') pos++;
+    while (pos < raw.length && raw[pos] !== ' ') pos++;
+  }
+  while (pos < raw.length && raw[pos] === ' ') pos++;
+  return pos;
 }
 
 const MODES = ['Command', 'Say', 'Me', 'OOC'] as const;
@@ -256,7 +269,13 @@ export function CommandBar() {
     if (verb) {
       setSelectedVerb(verb);
       const argPart = entry.slice(toKebab(verb.name).length + 1);
-      setFilledArgs(parseArgs(argPart));
+      const parsed = parseArgs(argPart);
+      const filled: string[] = [];
+      for (let i = 0; i < verb.args.length && i < parsed.length; i++) {
+        if (isTextArg(verb.args[i]) && i === verb.args.length - 1) break;
+        filled.push(parsed[i]);
+      }
+      setFilledArgs(filled);
     } else {
       setSelectedVerb(null);
       setFilledArgs([]);
@@ -280,7 +299,13 @@ export function CommandBar() {
     setFilledArgs([]);
     setSelectedIndex(0);
     setLastTypepathRequest('');
-    setInput(serializeInput(verb, [], suffixForArg(verb.args[0])));
+    setInput(
+      serializeInput(
+        verb,
+        [],
+        suffixForArg(verb.args[0], verb.args.length === 1),
+      ),
+    );
   };
 
   const cycleMode = () => {
@@ -300,7 +325,13 @@ export function CommandBar() {
     setFilledArgs([]);
     setSelectedIndex(0);
     setLastTypepathRequest('');
-    setInput(serializeInput(verb, [], suffixForArg(verb.args[0])));
+    setInput(
+      serializeInput(
+        verb,
+        [],
+        suffixForArg(verb.args[0], verb.args.length === 1),
+      ),
+    );
     const firstArg = verb.args[0];
     if (firstArg && isEntityArg(firstArg)) {
       Byond.sendMessage('verbs/request_targets', { verb_type: verb.type });
@@ -313,7 +344,13 @@ export function CommandBar() {
     setFilledArgs(newFilled);
     setSelectedIndex(0);
     const nextArg = verbArgs[newFilled.length];
-    setInput(serializeInput(selectedVerb, newFilled, suffixForArg(nextArg)));
+    setInput(
+      serializeInput(
+        selectedVerb,
+        newFilled,
+        suffixForArg(nextArg, newFilled.length === verbArgs.length - 1),
+      ),
+    );
   };
 
   const selectTypepath = (path: string) => {
@@ -328,7 +365,20 @@ export function CommandBar() {
   const invokeVerb = () => {
     if (!selectedVerb) return;
     const argValues: Record<string, string> = {};
-    for (let i = 0; i < verbArgs.length && i < parsedArgs.length; i++) {
+    for (let i = 0; i < verbArgs.length; i++) {
+      if (isTextArg(verbArgs[i]) && i === verbArgs.length - 1) {
+        const offset = skipTokens(argPortion, i);
+        let val = argPortion.slice(offset);
+        if (val.startsWith('"') && val.endsWith('"') && val.length > 1) {
+          val = val.slice(1, -1);
+        } else if (val.startsWith('"')) {
+          val = val.slice(1);
+        }
+        val = val.trim();
+        if (val) argValues[verbArgs[i].name] = val;
+        break;
+      }
+      if (i >= parsedArgs.length) break;
       let val = parsedArgs[i];
       if (isTypepathArg(verbArgs[i])) {
         val = val.replace(/\/+$/, '');
@@ -550,7 +600,12 @@ export function CommandBar() {
     setInput(value);
     setSelectedIndex(0);
 
-    if (selectedVerb && currentArg && isTextArg(currentArg)) {
+    if (
+      selectedVerb &&
+      currentArg &&
+      isTextArg(currentArg) &&
+      currentArgIndex < verbArgs.length - 1
+    ) {
       const afterVerb = value.slice(toKebab(selectedVerb.name).length + 1);
       const parsed = parseArgs(afterVerb);
       if (parsed.length > filledArgs.length && !isInQuotedArg(afterVerb)) {
@@ -559,7 +614,14 @@ export function CommandBar() {
         const nextArg = verbArgs[newFilled.length];
         if (nextArg) {
           setInput(
-            serializeInput(selectedVerb, newFilled, suffixForArg(nextArg)),
+            serializeInput(
+              selectedVerb,
+              newFilled,
+              suffixForArg(
+                nextArg,
+                newFilled.length === verbArgs.length - 1,
+              ),
+            ),
           );
         }
       }

--- a/tgui/packages/tgui-panel/verbs/CommandBar.tsx
+++ b/tgui/packages/tgui-panel/verbs/CommandBar.tsx
@@ -456,6 +456,13 @@ export function CommandBar() {
             return;
           }
           const query = input.toLowerCase();
+          const exactMatch = verbSuggestions.find(
+            (v) => toKebab(v.name).toLowerCase() === query,
+          );
+          if (exactMatch) {
+            selectVerb(exactMatch);
+            return;
+          }
           const prefixMatches = verbSuggestions.filter((v) =>
             toKebab(v.name).toLowerCase().startsWith(query),
           );


### PR DESCRIPTION

fixes #97478
fixes #97560
fixes #97563

## About The Pull Request
a few fixes and tweaks to the command bar

## Why It's Good For The Game
some better byond parity

## Changelog
:cl:
fix: in the command bar, exact matches weren't entering the verb, they now are
fix: quotes aren't required around arguments in the command bar anymore, letting you use quotes yourself in messages
fix: removes 100 pick-up verbs from the command bar
qol: added a preference to disable showing autocomplete suggestions as you type (unless you press space)
/:cl:
