### PR TITLE
Fix/Refactor Cargo Console / NT Shopping App Code

### DIFF
--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -104,109 +104,13 @@
 		message = blockade_warning
 	data["message"] = message
 
-	var/cart_list = list()
-	for(var/datum/supply_order/order in SSshuttle.shopping_list)
-		if(cart_list[order.pack.name])
-			cart_list[order.pack.name][1]["amount"]++
-			cart_list[order.pack.name][1]["cost"] += order.get_final_cost()
-			if(order.department_destination)
-				cart_list[order.pack.name][1]["dep_order"]++
-			if(!isnull(order.paying_account))
-				cart_list[order.pack.name][1]["paid"]++
-			continue
-
-		cart_list[order.pack.name] = list(list(
-			"cost_type" = order.cost_type,
-			"object" = order.pack.name,
-			"cost" = order.get_final_cost(),
-			"id" = order.id,
-			"amount" = 1,
-			"orderer" = order.orderer,
-			"paid" = !isnull(order.paying_account), //number of orders purchased privatly
-			"dep_order" = !!order.department_destination, //number of orders purchased by a department
-			"can_be_cancelled" = order.can_be_cancelled,
-		))
-	data["cart"] = list()
-	for(var/item_id in cart_list)
-		data["cart"] += cart_list[item_id]
-
-
-	data["requests"] = list()
-	for(var/datum/supply_order/order in SSshuttle.request_list)
-		var/datum/supply_pack/pack = order.pack
-		data["requests"] += list(list(
-			"object" = pack.name,
-			"cost" = pack.get_cost(),
-			"orderer" = order.orderer,
-			"reason" = order.reason,
-			"id" = order.id,
-			"account" = order.paying_account ? order.paying_account.account_holder : "Cargo Department"
-		))
+	data["cart"] = get_supply_cart_ui_data()
+	data["requests"] = get_supply_requests_ui_data()
 
 	return data
 
 /obj/machinery/computer/cargo/ui_static_data(mob/user)
-	var/list/data = list()
-	data["max_order"] = CARGO_MAX_ORDER
-	data["supplies"] = list()
-
-	var/list/packs_by_group = get_packs_data_by_group()
-	for(var/group in packs_by_group)
-		var/list/available_packs = packs_by_group[group]
-		if(!length(available_packs)) // Somehow????
-			continue
-		data["supplies"][group] = list(
-			"name" = group,
-			"packs" = available_packs,
-		)
-
-	data["displayed_currency_full_name"] = " [MONEY_NAME]"
-	data["displayed_currency_name"] = " [MONEY_SYMBOL]"
-
-	return data
-
-/**
- * returns a list of supply pack ui data by group
- */
-/obj/machinery/computer/cargo/proc/get_packs_data_by_group()
-	var/list/packs_by_group = list()
-	for(var/pack_id in SSshuttle.supply_packs)
-		var/datum/supply_pack/pack = SSshuttle.supply_packs[pack_id]
-
-		if(pack.order_flags & ORDER_INVISIBLE)
-			continue
-
-		if((pack.order_flags & ORDER_EMAG_ONLY) && !(obj_flags & EMAGGED))
-			continue
-		if((pack.order_flags & ORDER_SPECIAL) && !(pack.order_flags & ORDER_SPECIAL_ENABLED))
-			continue
-
-		if((pack.order_flags & ORDER_CONTRABAND) && !contraband)
-			continue
-
-		if(!is_express && (pack.order_flags & ORDER_POD_ONLY))
-			continue
-
-		var/obj/item/first_item = length(pack.contains) > 0 ? pack.contains[1] : null
-		var/list/packs = packs_by_group[pack.group]
-		if(isnull(packs))
-			packs = list()
-			packs_by_group[pack.group] = packs
-
-		packs += list(list(
-			"name" = pack.name,
-			"cost" = pack.get_cost() * get_discount(),
-			"id" = pack_id,
-			"desc" = pack.desc || pack.name, // If there is a description, use it. Otherwise use the pack's name.
-			"first_item_icon" = first_item?.icon,
-			"first_item_icon_state" = first_item?.icon_state,
-			"goody" = (pack.order_flags & ORDER_GOODY),
-			"access" = pack.access,
-			"contraband" = (pack.order_flags & ORDER_CONTRABAND),
-			"contains" = pack.get_contents_ui_data(),
-		))
-
-	return packs_by_group
+	return get_supply_ui_static_data(obj_flags & EMAGGED, contraband, is_express, get_discount())
 
 /**
  * returns the discount multiplier applied to all supply packs,
@@ -267,7 +171,8 @@
 				say("Invalid bank account.")
 				return
 			var/list/access = id_card.GetAccess()
-			if((pack.access_view && !(pack.access_view in access)) && !bypass)
+			var/required_access = pack.access_view || pack.access
+			if((required_access && !(required_access in access)) && !bypass)
 				say("[id_card] lacks the requisite access for this purchase.")
 				return
 
@@ -299,7 +204,8 @@
 			if(!id_card || !living_user || !access)
 				living_user = user
 				id_card = living_user.get_idcard(TRUE)
-			if(pack.access_view && !(pack.access_view in access) && personal_department)
+			var/required_access = pack.access_view || pack.access
+			if(required_access && !(required_access in access) && personal_department)
 				// We want to block cargo requests when a player is requesting a restricted pack that they don't have access to.
 				// BUT only when it's requested with non-cargo funds, as cargo had direct oversight over their own purchases with their own budget.
 				// HOWEVER, this shouldn't prevent someone from buying something using their own personal funds.
@@ -529,3 +435,106 @@
 	vars_and_tooltips_map = list(
 		"AMOUNT" = "will be replaced wuth number of orders.",
 	)
+
+// Builds the list of purchasable/requestable supply packs, grouped by category.
+/proc/get_supply_packs_by_group(emagged, contraband, is_express, discount = 1)
+	var/list/packs_by_group = list()
+	for(var/pack_id in SSshuttle.supply_packs)
+		var/datum/supply_pack/pack = SSshuttle.supply_packs[pack_id]
+
+		if(pack.order_flags & ORDER_INVISIBLE)
+			continue
+		if((pack.order_flags & ORDER_EMAG_ONLY) && !emagged)
+			continue
+		if((pack.order_flags & ORDER_SPECIAL) && !(pack.order_flags & ORDER_SPECIAL_ENABLED))
+			continue
+		if((pack.order_flags & ORDER_CONTRABAND) && !contraband)
+			continue
+		if(!is_express && (pack.order_flags & ORDER_POD_ONLY))
+			continue
+
+		var/obj/item/first_item = length(pack.contains) > 0 ? pack.contains[1] : null
+		var/list/packs = packs_by_group[pack.group]
+		if(isnull(packs))
+			packs = list()
+			packs_by_group[pack.group] = packs
+
+		packs += list(list(
+			"name" = pack.name,
+			"cost" = pack.get_cost() * discount,
+			"id" = pack_id,
+			"desc" = pack.desc || pack.name, // If there is a description, use it. Otherwise use the pack's name.
+			"first_item_icon" = first_item?.icon,
+			"first_item_icon_state" = first_item?.icon_state,
+			"goody" = (pack.order_flags & ORDER_GOODY),
+			"access" = pack.access,
+			"contraband" = (pack.order_flags & ORDER_CONTRABAND),
+			"contains" = pack.get_contents_ui_data(),
+		))
+
+	return packs_by_group
+
+// Builds the static "supplies" ui_static_data blob.
+/proc/get_supply_ui_static_data(emagged, contraband, is_express, discount = 1)
+	var/list/data = list()
+	data["max_order"] = CARGO_MAX_ORDER
+	data["displayed_currency_full_name"] = " [MONEY_NAME]"
+	data["displayed_currency_name"] = " [MONEY_SYMBOL]"
+	data["supplies"] = list()
+
+	var/list/packs_by_group = get_supply_packs_by_group(emagged, contraband, is_express, discount)
+	for(var/group in packs_by_group)
+		var/list/available_packs = packs_by_group[group]
+		if(!length(available_packs)) // Somehow????
+			continue
+		data["supplies"][group] = list(
+			"name" = group,
+			"packs" = available_packs,
+		)
+
+	return data
+
+// Builds the "cart" ui_data blob (current shopping list).
+/proc/get_supply_cart_ui_data()
+	var/list/cart_list = list()
+	for(var/datum/supply_order/order in SSshuttle.shopping_list)
+		if(cart_list[order.pack.name])
+			cart_list[order.pack.name][1]["amount"]++
+			cart_list[order.pack.name][1]["cost"] += order.get_final_cost()
+			if(order.department_destination)
+				cart_list[order.pack.name][1]["dep_order"]++
+			if(!isnull(order.paying_account))
+				cart_list[order.pack.name][1]["paid"]++
+			continue
+
+		cart_list[order.pack.name] = list(list(
+			"cost_type" = order.cost_type,
+			"object" = order.pack.name,
+			"cost" = order.get_final_cost(),
+			"id" = order.id,
+			"amount" = 1,
+			"orderer" = order.orderer,
+			"paid" = !isnull(order.paying_account), //number of orders purchased privatly
+			"dep_order" = !!order.department_destination, //number of orders purchased by a department
+			"can_be_cancelled" = order.can_be_cancelled,
+		))
+
+	var/list/cart = list()
+	for(var/item_id in cart_list)
+		cart += cart_list[item_id]
+	return cart
+
+// Builds the "requests" ui_data blob.
+/proc/get_supply_requests_ui_data()
+	var/list/requests = list()
+	for(var/datum/supply_order/order in SSshuttle.request_list)
+		var/datum/supply_pack/pack = order.pack
+		requests += list(list(
+			"object" = pack.name,
+			"cost" = pack.get_cost(),
+			"orderer" = order.orderer,
+			"reason" = order.reason,
+			"id" = order.id,
+			"account" = order.paying_account ? order.paying_account.account_holder : "Cargo Department"
+		))
+	return requests

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -100,95 +100,14 @@
 	if(SSshuttle.supply_blocked)
 		message = blockade_warning
 	data["message"] = message
-	var/cart_list = list()
-	for(var/datum/supply_order/order in SSshuttle.shopping_list)
-		if(cart_list[order.pack.name])
-			cart_list[order.pack.name][1]["amount"]++
-			cart_list[order.pack.name][1]["cost"] += order.get_final_cost()
-			if(order.department_destination)
-				cart_list[order.pack.name][1]["dep_order"]++
-			if(!isnull(order.paying_account))
-				cart_list[order.pack.name][1]["paid"]++
-			continue
 
-		cart_list[order.pack.name] = list(list(
-			"cost_type" = order.cost_type,
-			"object" = order.pack.name,
-			"cost" = order.get_final_cost(),
-			"id" = order.id,
-			"amount" = 1,
-			"orderer" = order.orderer,
-			"paid" = !isnull(order.paying_account), //number of orders purchased privatly
-			"dep_order" = !!order.department_destination, //number of orders purchased by a department
-			"can_be_cancelled" = order.can_be_cancelled,
-		))
-	data["cart"] = list()
-	for(var/item_id in cart_list)
-		data["cart"] += cart_list[item_id]
-
-
-	data["requests"] = list()
-	for(var/datum/supply_order/order in SSshuttle.request_list)
-		var/datum/supply_pack/pack = order.pack
-		data["requests"] += list(list(
-			"object" = pack.name,
-			"cost" = pack.get_cost(),
-			"orderer" = order.orderer,
-			"reason" = order.reason,
-			"id" = order.id,
-			"account" = order.paying_account ? order.paying_account.account_holder : "Cargo Department"
-		))
+	data["cart"] = get_supply_cart_ui_data()
+	data["requests"] = get_supply_requests_ui_data()
 
 	return data
 
 /datum/computer_file/program/budgetorders/ui_static_data(mob/user)
-	var/list/data = list()
-	data["max_order"] = CARGO_MAX_ORDER
-	data["displayed_currency_full_name"] = " [MONEY_NAME]"
-	data["displayed_currency_name"] = " [MONEY_SYMBOL]"
-// This is a list of all the supply packs that are available to the user. It is filtered by the user's access level and whether or not the machine is emagged.
-	data["supplies"] = list()
-	var/list/packs_by_group = list()
-	for(var/pack_id in SSshuttle.supply_packs)
-		var/datum/supply_pack/pack = SSshuttle.supply_packs[pack_id]
-		if(pack.order_flags & ORDER_INVISIBLE)
-			continue
-		if((pack.order_flags & ORDER_EMAG_ONLY) && !(computer.obj_flags & EMAGGED))
-			continue
-		if((pack.order_flags & ORDER_SPECIAL) && !(pack.order_flags & ORDER_SPECIAL_ENABLED))
-			continue
-		if((pack.order_flags & ORDER_CONTRABAND) && !contraband)
-			continue
-		if(pack.order_flags & ORDER_POD_ONLY)
-			continue
-
-		var/obj/item/first_item = length(pack.contains) > 0 ? pack.contains[1] : null
-		var/list/packs = packs_by_group[pack.group]
-		if(isnull(packs))
-			packs = list()
-			packs_by_group[pack.group] = packs
-
-		packs += list(list(
-			"name" = pack.name,
-			"cost" = pack.get_cost(),
-			"id" = pack_id,
-			"desc" = pack.desc || pack.name, // If there is a description, use it. Otherwise use the pack's name.
-			"first_item_icon" = first_item?.icon,
-			"first_item_icon_state" = first_item?.icon_state,
-			"goody" = pack.order_flags & ORDER_GOODY,
-			"access" = pack.access,
-			"contraband" = pack.order_flags & ORDER_CONTRABAND,
-			"contains" = pack.get_contents_ui_data(),
-		))
-
-	for(var/group in packs_by_group)
-		var/list/available_packs = packs_by_group[group]
-		data["supplies"][group] = list(
-			"name" = group,
-			"packs" = available_packs,
-		)
-
-	return data
+	return get_supply_ui_static_data(computer.obj_flags & EMAGGED, contraband, FALSE)
 
 /datum/computer_file/program/budgetorders/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
@@ -299,7 +218,7 @@
 
 			// If the user is attempting to purchase a pack that requires a certain access level, check it.
 			var/list/access = id_card_customer?.GetAccess()
-			if(!is_visible_pack(user, pack.access_view, access, pack.order_flags & ORDER_CONTRABAND))
+			if(!is_visible_pack(user, pack.access_view || pack.access, access, pack.order_flags & ORDER_CONTRABAND))
 				computer.say("ERROR: User lacks the requisite access for this purchase request.")
 				return
 

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -64,18 +64,18 @@
 
 	var/datum/bank_account/buyer = SSeconomy.get_dep_account(cargo_account)
 	var/obj/item/card/id/id_card = computer.stored_id?.GetID()
+	var/is_cargo = has_cargo_authority(user)
 	if(id_card?.registered_account?.account_job?.paycheck_department)
 		buyer = SSeconomy.get_dep_account(id_card?.registered_account.account_job.paycheck_department)
 		if((ACCESS_BUDGET in id_card.access))
 			requestonly = FALSE
-			can_approve_requests = TRUE
 			// If buyer is a departmental budget, replaces "Cargo" with that budget - we're not using the cargo budget here
 			data["department"] = "[buyer.account_holder] Requisitions"
 		else
 			requestonly = TRUE
-			can_approve_requests = FALSE
 	else
 		requestonly = TRUE
+	can_approve_requests = is_cargo || (id_card && (ACCESS_BUDGET in id_card.access))
 	if(buyer)
 		data["points"] = buyer.account_balance
 	// To recap above because it's kind of a mess, here's all the options:
@@ -102,7 +102,7 @@
 	data["message"] = message
 
 	data["cart"] = get_supply_cart_ui_data()
-	data["requests"] = get_supply_requests_ui_data()
+	data["requests"] = get_visible_requests_ui_data(user)
 
 	return data
 
@@ -258,6 +258,8 @@
 			var/id = text2num(params["id"])
 			for(var/datum/supply_order/SO in SSshuttle.request_list)
 				if(SO.id == id)
+					if(!can_manage_request(user, SO))
+						return
 					var/obj/item/card/id/id_card = computer.stored_id?.GetID()
 					if(id_card && id_card?.registered_account)
 						SO.paying_account = SSeconomy.get_dep_account(id_card?.registered_account?.account_job.paycheck_department)
@@ -269,11 +271,18 @@
 			var/id = text2num(params["id"])
 			for(var/datum/supply_order/SO in SSshuttle.request_list)
 				if(SO.id == id)
+					if(!can_manage_request(user, SO))
+						return
 					SSshuttle.request_list -= SO
 					. = TRUE
 					break
 		if("denyall")
-			SSshuttle.request_list.Cut()
+			if(has_cargo_authority(user))
+				SSshuttle.request_list.Cut()
+			else
+				for(var/datum/supply_order/SO in SSshuttle.request_list.Copy())
+					if(can_manage_request(user, SO))
+						SSshuttle.request_list -= SO
 			. = TRUE
 		if("toggleprivate")
 			self_paid = !self_paid
@@ -290,3 +299,49 @@
 
 	var/datum/signal/status_signal = new(list("command" = command))
 	frequency.post_signal(src, status_signal)
+
+/// Whether this user has full cargo authority (can see/approve/deny every request).
+/datum/computer_file/program/budgetorders/proc/has_cargo_authority(mob/user)
+	if(isAdminGhostAI(user))
+		return TRUE
+	var/obj/item/card/id/id_card = computer.stored_id?.GetID()
+	if(!id_card && ishuman(user))
+		var/mob/living/carbon/human/human_user = user
+		id_card = human_user.get_idcard(TRUE)
+	return id_card && (ACCESS_CARGO in id_card.GetAccess())
+
+/// The department budget account tied to the currently inserted/held ID card, if any.
+/datum/computer_file/program/budgetorders/proc/get_own_department_account()
+	var/obj/item/card/id/id_card = computer.stored_id?.GetID()
+	if(!id_card?.registered_account?.account_job)
+		return null
+	return SSeconomy.get_dep_account(id_card.registered_account.account_job.paycheck_department)
+
+/// Requests visible to this user - department heads only see their own department's requests, cargo see all.
+/datum/computer_file/program/budgetorders/proc/get_visible_requests_ui_data(mob/user)
+	var/is_cargo = has_cargo_authority(user)
+	var/datum/bank_account/own_department = get_own_department_account()
+	var/list/requests = list()
+	for(var/datum/supply_order/order in SSshuttle.request_list)
+		if(!is_cargo && order.paying_account != own_department)
+			continue
+		var/datum/supply_pack/pack = order.pack
+		requests += list(list(
+			"object" = pack.name,
+			"cost" = pack.get_cost(),
+			"orderer" = order.orderer,
+			"reason" = order.reason,
+			"id" = order.id,
+			"account" = order.paying_account ? order.paying_account.account_holder : "Cargo Department"
+		))
+	return requests
+
+/// Rather or not the user can approve/deny requests - Department heads can approve their own department, while cargo can approve all.
+/datum/computer_file/program/budgetorders/proc/can_manage_request(mob/user, datum/supply_order/SO)
+	if(has_cargo_authority(user))
+		return TRUE
+	var/obj/item/card/id/id_card = computer.stored_id?.GetID()
+	if(!id_card || !(ACCESS_BUDGET in id_card.GetAccess()))
+		return FALSE
+	var/datum/bank_account/own_department = get_own_department_account()
+	return own_department && SO.paying_account == own_department

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -83,35 +83,7 @@
 		//ID card, not a head of staff: can request items from cargo using departmental budget.
 		//No ID card, can request items from cargo using the cargo budget.
 
-	//Otherwise static data, that is being applied in ui_data as the crates visible and buyable are not static, and are determined by inserted ID.
 	data["requestonly"] = requestonly
-	data["supplies"] = list()
-	for(var/pack in SSshuttle.supply_packs)
-		var/datum/supply_pack/P = SSshuttle.supply_packs[pack]
-		if(P.order_flags & ORDER_INVISIBLE)
-			continue
-		if(!is_visible_pack(user, P.access_view , null, (P.order_flags & ORDER_CONTRABAND)) || (P.order_flags & ORDER_EMAG_ONLY))
-			continue
-		if(!data["supplies"][P.group])
-			data["supplies"][P.group] = list(
-				"name" = P.group,
-				"packs" = list()
-			)
-		if(((P.order_flags & ORDER_EMAG_ONLY) && ((P.order_flags & ORDER_CONTRABAND) && !contraband) || ((P.order_flags & ORDER_SPECIAL) && !(P.order_flags & ORDER_SPECIAL_ENABLED)) || (P.order_flags & ORDER_POD_ONLY)))
-			continue
-
-		var/obj/item/first_item = length(P.contains) > 0 ? P.contains[1] : null
-		data["supplies"][P.group]["packs"] += list(list(
-			"name" = P.name,
-			"cost" = P.get_cost(),
-			"id" = pack,
-			"desc" = P.desc || P.name, // If there is a description, use it. Otherwise use the pack's name.
-			"first_item_icon" = first_item?.icon,
-			"first_item_icon_state" = first_item?.icon_state,
-			"goody" = P.order_flags & ORDER_GOODY,
-			"access" = P.access,
-			"contains" = P.get_contents_ui_data(),
-		))
 
 	//Data regarding the User's capability to buy things.
 	data["away"] = SSshuttle.supply.getDockedId() == docking_away
@@ -174,6 +146,48 @@
 	data["max_order"] = CARGO_MAX_ORDER
 	data["displayed_currency_full_name"] = " [MONEY_NAME]"
 	data["displayed_currency_name"] = " [MONEY_SYMBOL]"
+// This is a list of all the supply packs that are available to the user. It is filtered by the user's access level and whether or not the machine is emagged.
+	data["supplies"] = list()
+	var/list/packs_by_group = list()
+	for(var/pack_id in SSshuttle.supply_packs)
+		var/datum/supply_pack/pack = SSshuttle.supply_packs[pack_id]
+		if(pack.order_flags & ORDER_INVISIBLE)
+			continue
+		if((pack.order_flags & ORDER_EMAG_ONLY) && !(computer.obj_flags & EMAGGED))
+			continue
+		if((pack.order_flags & ORDER_SPECIAL) && !(pack.order_flags & ORDER_SPECIAL_ENABLED))
+			continue
+		if((pack.order_flags & ORDER_CONTRABAND) && !contraband)
+			continue
+		if(pack.order_flags & ORDER_POD_ONLY)
+			continue
+
+		var/obj/item/first_item = length(pack.contains) > 0 ? pack.contains[1] : null
+		var/list/packs = packs_by_group[pack.group]
+		if(isnull(packs))
+			packs = list()
+			packs_by_group[pack.group] = packs
+
+		packs += list(list(
+			"name" = pack.name,
+			"cost" = pack.get_cost(),
+			"id" = pack_id,
+			"desc" = pack.desc || pack.name, // If there is a description, use it. Otherwise use the pack's name.
+			"first_item_icon" = first_item?.icon,
+			"first_item_icon_state" = first_item?.icon_state,
+			"goody" = pack.order_flags & ORDER_GOODY,
+			"access" = pack.access,
+			"contraband" = pack.order_flags & ORDER_CONTRABAND,
+			"contains" = pack.get_contents_ui_data(),
+		))
+
+	for(var/group in packs_by_group)
+		var/list/available_packs = packs_by_group[group]
+		data["supplies"][group] = list(
+			"name" = group,
+			"packs" = available_packs,
+		)
+
 	return data
 
 /datum/computer_file/program/budgetorders/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
@@ -282,6 +296,12 @@
 
 			if(!self_paid)
 				account = personal_department
+
+			// If the user is attempting to purchase a pack that requires a certain access level, check it.
+			var/list/access = id_card_customer?.GetAccess()
+			if(!is_visible_pack(user, pack.access_view, access, pack.order_flags & ORDER_CONTRABAND))
+				computer.say("ERROR: User lacks the requisite access for this purchase request.")
+				return
 
 			var/turf/T = get_turf(computer)
 			var/datum/supply_order/SO = new(pack, name, rank, ckey, reason, account)


### PR DESCRIPTION

## About The Pull Request

This pull request fixes the NT Shopping App massively lagging the player while it tries to load resources.

This pull request also refactors the NT Shopping app and Cargo Order console code into one unified location inside `code/modules/cargo/orderconsole.dm` to avoid duplicating the code/logic between both instances.

- Moved the generation and filtering of the supply packs from `ui_data()` to `ui_static_data()` in `code/modules/modular_computers/file_system/programs/budgetordering.dm`, so the full catalogue is only sent once instead of being rebuilt on every UI refresh. (The main cause of the lag).
- Added a server-sided access check inside the `add` action to make sure the ID the user has actually grants access to whatever they're trying to purchase (this was needed because the PDA App now gets all cargo packs and doesn't hide things you can't purchase).
- Extracted the pack list, cart, and request UI data builders into shared global procs in `orderconsole.dm`. Both the cargo console (`/obj/machinery/computer/cargo`) and the PDA app (`/datum/computer_file/program/budgetorders`) now call the same procs instead of maintaining two separate copies of this logic.
- Restricted the PDA app's Requests tab so it only shows/lets you approve or deny requests billed to your own department's budget, unless you have cargo access (or you are an aghost).
Because we merged the PDA and Cargo Console logic, this is necessary (This will also allow you to also beg your head of department to approve your cargo requests).

## Why It's Good For The Game

- **Performance & Optimization**: moving the supply pack data generation into `ui_static_data` reduces the constant UI refreshes which would lag the user.
- **Server-Side checks**: added a server-sided check that prevents users from purchasing/requesting supply packs they aren't supposed to have access to
- **Access Control**: Head of Staff can now see cargo requests on their own department's budget within their PDA app and approve or deny it, cargo and Aghosts still can see all of it and approve deny as they wish.
- **Maintainability**: the console and the PDA app now share one implementation of the catalogue/cart/request data instead of two copies.



## Testing


<details>
<summary>Part 1, Ordering Things as non cargo.</summary>
For the test, we spawned as the CMO, and ordered a few things from our PDA, which skips the requests.
Then we went to the cargo console and requested something, from medical and from cargo budget.

Because the request in cargo wasn't within our budget on the PDA we didn't see it as Only cargo can see cargo requests and so on (cargo see all requests).

https://github.com/user-attachments/assets/9c4daca7-da2d-4a5f-a86c-c57ef7a172c7

</details>

<details>
<summary> Part 2, Cargo Side</summary>
For this test we spawned as the QM, which has cargo access and looked at our PDA app, we can see all requests and deny approve them, while the same is true for the console.


https://github.com/user-attachments/assets/87563c0c-7130-4e64-b41e-f2df34ce7ebf



</details>
<img width="1271" height="753" alt="You only see requests per your department budget setting" src="https://github.com/user-attachments/assets/f4564125-acb0-459f-938c-d91ef40309c4" />
You can only see requests from your own department (unless you are cargo)


## Changelog
:cl: Richard Blonski
add: The NT Shopping App now allows head of departments to approve/deny cargo requests from their budget.
fix: The NT Shopping App doesn't cause you to lag horribly.
refactor: Optimized the NT Shopping App's network data.
refactor: The cargo console and NT Shopping App now share the same backend data logic.
/:cl: