### PR TITLE
Fixes cable-based robotic limb repairs when not wearing an uniform

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -651,7 +651,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 /obj/item/stack/cable_coil/proc/try_heal_loop(atom/interacting_with, mob/living/user, repeating = FALSE)
 	var/mob/living/carbon/human/attacked_humanoid = interacting_with
 	var/obj/item/clothing/under/uniform = attacked_humanoid.w_uniform
-	if(!istype(uniform) || uniform.repair_sensors(user))
+	if(istype(uniform) && uniform.repair_sensors(user))
 		return ITEM_INTERACT_SUCCESS
 
 	var/obj/item/bodypart/affecting = attacked_humanoid.get_bodypart(check_zone(user.zone_selected))

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -650,8 +650,8 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 
 /obj/item/stack/cable_coil/proc/try_heal_loop(atom/interacting_with, mob/living/user, repeating = FALSE)
 	var/mob/living/carbon/human/attacked_humanoid = interacting_with
-	var/obj/item/clothing/under/uniform = attacked_humanoid.w_uniform
-	if(istype(uniform) && uniform.repair_sensors(user))
+
+	if(astype(attacked_humanoid.w_uniform, /obj/item/clothing/under)?.repair_sensors(user))
 		return ITEM_INTERACT_SUCCESS
 
 	var/obj/item/bodypart/affecting = attacked_humanoid.get_bodypart(check_zone(user.zone_selected))


### PR DESCRIPTION

## About The Pull Request
Title.
Currently, an istype in the proc that handles cable usage for repairing limbs & sensors using cables returns out early when not wearing a jumpsuit (or something not of that type), despite most of the proc not being affected by said condition. This corrects said check to only block the part of the proc it is supposed to block.
## Why It's Good For The Game
Bugs getting fixed tends to be good for the game.
## Changelog
:cl:
fix: Cable-based robotic limb repairs are no longer impossible while not wearing an uniform.
/:cl:
