### PR TITLE
mark compiled behavior trees as generated files in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,3 +42,5 @@
 ## Force tab indents on dm files
 *.dm whitespace=indent-with-non-tab
 
+# Mark compiled behavior trees as generated files, to avoid clogging up github diff. We have the actual thingy to give a useful BT diff anyways.
+build/behavior_trees/**/*.compiled.json linguist-generated


### PR DESCRIPTION

## About The Pull Request

this marks compiled behavior tree JSONs as `linguist-generated` in gitattributes, so they don't clog up the diff viewer online by default.

<details>
<summary><h3>Before</h3></summary>

<img width="1916" height="1229" alt="2026-08-19 (1787182703) ~ firefox" src="https://github.com/user-attachments/assets/7a86bd6f-4869-47e0-a6b1-d2c33ed9c82e" />

</details>

### After:

<img width="936" height="235" alt="2026-08-19 (1787182658) ~ firefox" src="https://github.com/user-attachments/assets/1210623e-9354-46a4-8330-8b1c78026f66" />

## Why It's Good For The Game

we have an actual BT diff bot. diffing minified JSON is not very useful to look at.

you can look at the raw json diff online if you want to for some reason, though!

## Changelog

No DM-side or in-game changes at all - just a nice-to-have for PRs.