### PR TITLE
Ore vents now reset properly on loss

### DIFF
--- a/code/game/objects/structures/lavaland/vent_mining/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/vent_mining/ore_vent.dm
@@ -336,7 +336,7 @@
 	playsound(src, 'sound/effects/rock/rock_break.ogg', 50)
 	update_appearance(UPDATE_ICON_STATE)
 	reset_drone(success = FALSE)
-	reset_cooldown(src, wave_cooldown)
+	COOLDOWN_RESET(src, wave_cooldown)
 
 /**
  * Handles winning the event, gives everyone a payout and start boulder production


### PR DESCRIPTION

## About The Pull Request

Currently if you fail a vent tapping, you get stuck in limbo with the vent saying "protect the node drone!" even after it's gone and all the mobs are dead. swaps `wave_cooldown` is `COOLDOWN_DECLARE`'d so it needs `COOLDOWN_RESET` to actually zero the var, which is how the boss vent works.

## Why It's Good For The Game

bugs bad.

## Changelog
:cl:
fix: ore vents now reset properly on losses.
/:cl:
