### PR TITLE
Chat Highlight Sound Additions

### DIFF
--- a/tgui/packages/tgui-panel/chat/renderer.tsx
+++ b/tgui/packages/tgui-panel/chat/renderer.tsx
@@ -121,6 +121,40 @@ function playHighlightSound(soundFile: string, volume: number) {
   Byond.command(`.sound '${soundFile}' volume=${Math.round(volume * 100)}`);
 }
 
+const RADIO_CHANNEL_LABEL = /^\[[^\]]+\]\s*/;
+
+// Check if a text node is a radio channel name, e.g. "[Radio] ".
+function isRadioChannelName(node: Text): boolean {
+  const text = node.textContent || '';
+  const match = RADIO_CHANNEL_LABEL.exec(text);
+  return Boolean(
+    node.parentElement?.classList.contains('name') &&
+      match &&
+      match[0].length === text.length,
+  );
+}
+
+// Split the radio channel label from the name node so that it can be highlighted separately. (used to avoid highlighting radio channel names)
+function splitRadioChannelLabel(root: HTMLElement): void {
+  const nameNodes = root.querySelectorAll('.name');
+  for (let i = 0; i < nameNodes.length; i++) {
+    const firstChild = nameNodes[i].firstChild;
+    if (firstChild?.nodeType !== Node.TEXT_NODE) {
+      continue;
+    }
+    const text = firstChild.textContent || '';
+    const match = RADIO_CHANNEL_LABEL.exec(text);
+    if (match && match[0].length < text.length) {
+      (firstChild as Text).splitText(match[0].length);
+    }
+  }
+}
+
+// Check if a message is a self-action message, such as "You put on your helmet.", we don't want to highlight it as, it's you doing the action.
+function isSelfActionMessage(text: string): boolean {
+  return /^\s*You\b/.test(text);
+}
+
 class ChatRenderer {
   loaded: boolean;
   rootNode: HTMLElement | null;
@@ -522,6 +556,7 @@ class ChatRenderer {
 
         // Highlight text
         if (!message.avoidHighlighting && this.highlightParsers) {
+          splitRadioChannelLabel(node);
           let messageHighlighted = false;
           this.highlightParsers
             .filter((parser) => parser.enabled && this.matchesFilters(parser))
@@ -531,6 +566,7 @@ class ChatRenderer {
                 parser.highlightRegex,
                 parser.highlightWords,
                 (text) => createHighlightNode(text, parser.highlightColor),
+                (textNode) => !isRadioChannelName(textNode), // Exclude radio channel names from highlighting
               );
               if (highlighted && parser.highlightWholeMessage) {
                 node.className += ' ChatMessage--highlighted';
@@ -542,7 +578,10 @@ class ChatRenderer {
               // Highlight sounds - Plays a sound once per message if enabled, will not play if the text was prased. (aka when relogging or reapplying chat).
               if (highlighted && parser.playSound && !messageHighlighted) {
                 messageHighlighted = true;
-                if (!suppressHighlightSound) {
+                if (
+                  !suppressHighlightSound &&
+                  !isSelfActionMessage(node.textContent || '')
+                ) {
                   playHighlightSound(
                     parser.soundFile,
                     parser.soundVolume ?? 0.5,

--- a/tgui/packages/tgui-panel/chat/replaceInTextNode.ts
+++ b/tgui/packages/tgui-panel/chat/replaceInTextNode.ts
@@ -13,6 +13,8 @@ type ReplaceInTextNodeParams = {
   captureAdjust?: (str: string) => string;
 };
 
+type HighlightNodeFilter = (node: Text) => boolean;
+
 /**
  * Replaces text matching a regular expression with a custom node.
  */
@@ -165,6 +167,7 @@ export function highlightNode(
   /** List of words to highlight */
   words: string[],
   createNode: NodeCreator = createHighlightNode,
+  filter: HighlightNodeFilter = () => true,
 ): number {
   if (!createNode) {
     createNode = createHighlightNode;
@@ -174,10 +177,10 @@ export function highlightNode(
   for (let i = 0; i < childNodes.length; i++) {
     const node = childNodes[i];
     // Is a text node
-    if (node.nodeType === 3) {
+    if (node.nodeType === 3 && filter(node as Text)) {
       n += replaceInTextNode(regex, words, createNode)(node);
     } else {
-      n += highlightNode(node, regex, words, createNode);
+      n += highlightNode(node, regex, words, createNode, filter);
     }
   }
   return n;

--- a/tgui/packages/tgui-panel/settings/migration.ts
+++ b/tgui/packages/tgui-panel/settings/migration.ts
@@ -70,7 +70,7 @@ function migrateHighlights(next: HighlightState): HighlightState {
       setting.enabled = true;
     }
     if (setting.playSound === undefined) {
-      setting.playSound = true;
+      setting.playSound = false;
     }
     if (!setting.soundFile) {
       setting.soundFile = defaultHighlightSetting.soundFile;


### PR DESCRIPTION

## About The Pull Request

This is a follow up for PR #97523
This Pull Request does the following:
- Makes chat highlight sounds **off** by default.
- Added a check to avoid highlighting radio channel names, like ("Medical", "Engineering") as putting "Medi" or "Engie" in your highlights is common.
- Added a check to avoid highlighting self-action messages such as "You put on your helmet", most of those messages start with "You" so we just check for that.

## Why It's Good For The Game

The Chat Highlights is not intended to be on by default.
It makes the chat highlight sounds less **spammy**, as you ultimitly want the highlight sounds to happen when someone does an action or tells you something, not when you do an action.

## Testing


https://github.com/user-attachments/assets/bd1f5d4a-024d-4fbc-9ee1-35f10053e0c5



## Changelog
:cl: Richard Blonski
fix: Chat Highlight sounds are off by default now.
qol: Chat Highlights won't trigger on self-actions or radio channel names.
/:cl:
