### PR TITLE
getting my fix of blood decal hard deletes

### DIFF
--- a/code/game/objects/effects/decals/cleanable/blood.dm
+++ b/code/game/objects/effects/decals/cleanable/blood.dm
@@ -304,6 +304,8 @@
 
 /obj/effect/decal/cleanable/blood/trail_holder/Initialize(mapload, list/datum/disease/diseases, list/blood_or_dna = get_default_blood_type())
 	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	icon_state = "nothing"
 	update_appearance() // Cut possible overlays
 	if(mapload)
@@ -537,6 +539,8 @@
 
 /obj/effect/decal/cleanable/blood/gibs/Initialize(mapload, list/datum/disease/diseases, list/blood_or_dna = get_default_blood_type())
 	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	leave_blood = has_blood_flag(GET_ATOM_BLOOD_DNA(src), BLOOD_COVER_TURFS)
 	if(squishy)
 		AddElement(/datum/element/squish_sound)
@@ -691,6 +695,8 @@
 
 /obj/effect/decal/cleanable/blood/footprints/Initialize(mapload, list/datum/disease/diseases, list/blood_or_dna = get_default_blood_type())
 	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	icon_state = "" // All of the footprint visuals come from overlays
 	if(mapload)
 		entered_dirs |= dir // Keep the same appearance as in the map editor
@@ -817,6 +823,8 @@
 
 /obj/effect/decal/cleanable/blood/hitsplatter/Initialize(mapload, list/datum/disease/diseases, list/blood_or_dna = get_default_blood_type(), splatter_strength)
 	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	leave_blood = has_blood_flag(GET_ATOM_BLOOD_DNA(src), BLOOD_COVER_TURFS)
 	prev_loc = loc //Just so we are sure prev_loc exists
 	if(splatter_strength)

--- a/code/game/objects/effects/decals/cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/cleanable/fuel.dm
@@ -12,13 +12,15 @@
 	var/burning = FALSE
 	/// Type of hotspot fuel pool spawns upon being ignited
 	var/hotspot_type = /obj/effect/hotspot
-
-/obj/effect/decal/cleanable/fuel_pool/Initialize(mapload, burn_stacks)
-	. = ..()
 	var/static/list/loc_connections = list(
 		COMSIG_TURF_MOVABLE_THROW_LANDED = PROC_REF(ignition_trigger),
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered)
 	)
+
+/obj/effect/decal/cleanable/fuel_pool/Initialize(mapload, burn_stacks)
+	. = ..()
+	if(. == INITIALIZE_HINT_QDEL)
+		return
 	AddElement(/datum/element/connect_loc, loc_connections)
 	for(var/obj/effect/decal/cleanable/fuel_pool/pool in get_turf(src)) //Can't use locate because we also belong to that turf
 		if(pool == src)
@@ -30,6 +32,10 @@
 		burn_amount = max(min(burn_stacks, 10), 1)
 
 	return INITIALIZE_HINT_LATELOAD
+
+/obj/effect/decal/cleanable/fuel_pool/Destroy(force)
+	RemoveElement(/datum/element/connect_loc, loc_connections)
+	return ..()
 
 // Just in case of fires, do this after mapload.
 /obj/effect/decal/cleanable/fuel_pool/LateInitialize()

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -5,6 +5,9 @@
 	abstract_type = /obj/effect/decal
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	var/static/list/decal_move_connections = list(
+		COMSIG_TURF_CHANGE = PROC_REF(on_decal_move),
+	)
 
 /obj/effect/decal/Initialize(mapload)
 	. = ..()
@@ -13,13 +16,14 @@
 			stack_trace("[name] spawned in a bad turf ([loc]) at [AREACOORD(src)] in \the [get_area(src)]. \
 				Please remove it or allow it to pass NeverShouldHaveComeHere if it's intended.")
 		return INITIALIZE_HINT_QDEL
-	var/static/list/loc_connections = list(
-		COMSIG_TURF_CHANGE = PROC_REF(on_decal_move),
-	)
 	while(isopenspaceturf(loc) && can_z_move(DOWN, z_move_flags = ZMOVE_ALLOW_ANCHORED))
 		zMove(DOWN, z_move_flags = ZMOVE_ALLOW_ANCHORED)
-	AddElement(/datum/element/connect_loc, loc_connections)
+	AddElement(/datum/element/connect_loc, decal_move_connections)
 	AddElement(/datum/element/force_move_pulled)
+
+/obj/effect/decal/Destroy(force)
+	RemoveElement(/datum/element/connect_loc, decal_move_connections)
+	return ..()
 
 /obj/effect/decal/blob_act(obj/structure/blob/B)
 	if(B && B.loc == loc)


### PR DESCRIPTION
## About The Pull Request

Fourth time the charm? I have tested this through multiple CI runs and not seen it resurface so 🙏 

Fixes https://github.com/tgstation/tgstation/issues/97267
Fixes https://github.com/tgstation/tgstation/issues/97276
Fixes https://github.com/tgstation/tgstation/issues/97293
Fixes https://github.com/tgstation/tgstation/issues/97321
Fixes https://github.com/tgstation/tgstation/issues/97298
Fixes https://github.com/tgstation/tgstation/issues/97271
Fixes https://github.com/tgstation/tgstation/issues/97270

A few things are going on here...

Decals use `/datum/element/connect_loc`'s (plural yes, that comes up later) to listen for signals on whatever turf they're sitting on. Because it's an  `ELEMENT_BESPOKE`, the args you pass to `RemoveElement` are what determines which instance of the element gets removed. For lists, that is the list's object reference, not its contents.

So basically `Destroy()` must pass the _literal same list object that `Initialize()` used_, or `RemoveElement()` silently finds nothing to detach and the turf signal registration is just left free to hang refs. And that was happening, because these static lists were proc-scoped, oh and remember how I mentioned there are actually two unique bespoke connect_loc elements at play here which both pass separate lists that are _both_ named `loc_connections`?... aaaaaaa.

the base `/obj/effect/decal` never `RemoveElement()'d its own connect_loc, either. which means only 1/2 of the total elements were being cleaned up properly.

So to make things less awful and confusing I have renamed the base decal type's `loc_connections` list to `decal_move_connections` and true to its name moved it the heck out of the proc scope because it needs to be able to be seen by `Destroy()`.

Also some of the sibling blood decal types were still missing their `INITIALIZE_HINT_QDEL` guards, as was `/obj/effect/decal/cleanable/fuel_pool` so I've added them there.

So TL;DR just a lot of stupid subtle stuff going on that is easily overlooked. I have run this through CI many times to test now and haven't had it crop up in any tests, where previously it almost always showed up in each and every one of them.

I am hopeful that this is truly the last we will see of this bug!

## Why It's Good For The Game

_primal screams_

## Changelog

Not player-facing