### PR TITLE
Fixes a source of mob hard deletes

### DIFF
--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -134,14 +134,14 @@
 	viewers = list()
 	UnregisterSignal(remove_from, COMSIG_MOB_KEYDOWN)
 
-	if(isnull(owner))
+	if(isnull(remove_from))
 		return
-	SEND_SIGNAL(src, COMSIG_ACTION_REMOVED, owner)
-	SEND_SIGNAL(owner, COMSIG_MOB_REMOVED_ACTION, src)
-	UnregisterSignal(owner, COMSIG_QDELETING)
+	SEND_SIGNAL(src, COMSIG_ACTION_REMOVED, remove_from)
+	SEND_SIGNAL(remove_from, COMSIG_MOB_REMOVED_ACTION, src)
+	UnregisterSignal(remove_from, COMSIG_QDELETING)
 
 	// Clean up our check_flag signals
-	UnregisterSignal(owner, list(
+	UnregisterSignal(remove_from, list(
 		COMSIG_LIVING_SET_BODY_POSITION,
 		COMSIG_MOB_STATCHANGE,
 		COMSIG_MOVABLE_MOVED,
@@ -155,7 +155,7 @@
 		SIGNAL_REMOVETRAIT(TRAIT_MAGICALLY_PHASED),
 	))
 
-	if(target == owner)
+	if(target == remove_from)
 		RegisterSignal(target, COMSIG_QDELETING, PROC_REF(clear_ref))
 	if (owner == remove_from)
 		owner = null


### PR DESCRIPTION
## About The Pull Request

`owner` is not necessarily guaranteed to be what we need it to be here, it should be using the passed-in parameter `remove_from` instead. This can result in the mob's ref being hung by the action, which is not good.

## Why It's Good For The Game

Fixes a source of mob hard deletes.

## Changelog

Not player facing