### PR TITLE
Non-encoded legacy tgui_text_input mode acctually clamps text

### DIFF
--- a/code/__DEFINES/song.dm
+++ b/code/__DEFINES/song.dm
@@ -1,7 +1,3 @@
-#define MUSICIAN_HEARCHECK_MINDELAY 4
-#define MUSIC_MAXLINES 1000
-#define MUSIC_MAXLINECHARS 300
-
 #define BPM_TO_TEMPO_SETTING(value) (600 / round(value, 1))
 
 //Return values of song/should_stop_playing()

--- a/code/controllers/subsystem/processing/instruments.dm
+++ b/code/controllers/subsystem/processing/instruments.dm
@@ -8,11 +8,11 @@ PROCESSING_SUBSYSTEM_DEF(instruments)
 	/// List of all song datums.
 	var/static/list/datum/song/songs = list()
 	/// Max lines in songs
-	var/static/musician_maxlines = 600
+	var/static/musician_maxlines = 1000
 	/// Max characters per line in songs
 	var/static/musician_maxlinechars = 300
 	/// Deciseconds between hearchecks. Too high and instruments seem to lag when people are moving around in terms of who can hear it. Too low and the server lags from this.
-	var/static/musician_hearcheck_mindelay = 5
+	var/static/musician_hearcheck_mindelay = 4
 	/// Maximum instrument channels total instruments are allowed to use. This is so you don't have instruments deadlocking all sound channels.
 	var/static/max_instrument_channels = MAX_INSTRUMENT_CHANNELS
 	/// Current number of channels allocated for instruments

--- a/code/modules/instruments/songs/editor.dm
+++ b/code/modules/instruments/songs/editor.dm
@@ -59,8 +59,8 @@
 	data["max_volume"] = max_volume
 	data["note_shift_min"] = note_shift_min
 	data["note_shift_max"] = note_shift_max
-	data["max_line_chars"] = MUSIC_MAXLINECHARS
-	data["max_lines"] = MUSIC_MAXLINES
+	data["max_line_chars"] = SSinstruments.musician_maxlinechars
+	data["max_lines"] = SSinstruments.musician_maxlines
 	return data
 
 /datum/song/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
@@ -105,15 +105,15 @@
 		if("import_song")
 			var/song_text = ""
 			do
-				song_text = tgui_input_text(user, "Please paste the entire song, formatted:", name, max_length = (MUSIC_MAXLINES * MUSIC_MAXLINECHARS), multiline = TRUE)
+				song_text = tgui_input_text(user, "Please paste the entire song, formatted:", name, max_length = (SSinstruments.musician_maxlines * SSinstruments.musician_maxlinechars), multiline = TRUE)
 				if(!in_range(parent, user))
 					return
 
-				if(length_char(song_text) >= MUSIC_MAXLINES * MUSIC_MAXLINECHARS)
+				if(length_char(song_text) >= SSinstruments.musician_maxlines * SSinstruments.musician_maxlinechars)
 					var/should_continue = tgui_alert(user, "Your message is too long! Would you like to continue editing it?", "Warning", list("Yes", "No"))
 					if(should_continue != "Yes")
 						break
-			while(length_char(song_text) > MUSIC_MAXLINES * MUSIC_MAXLINECHARS)
+			while(length_char(song_text) > SSinstruments.musician_maxlines * SSinstruments.musician_maxlinechars)
 			ParseSong(user, song_text)
 			return TRUE
 		if("start_new_song")
@@ -122,13 +122,13 @@
 			tempo = sanitize_tempo(5) // default 120 BPM
 			return TRUE
 		if("add_new_line")
-			var/newline = tgui_input_text(user, "Enter your line", parent.name, max_length = MUSIC_MAXLINECHARS)
+			var/newline = tgui_input_text(user, "Enter your line", parent.name, max_length = SSinstruments.musician_maxlinechars)
 			if(!newline || !in_range(parent, user))
 				return
-			if(lines.len > MUSIC_MAXLINES)
+			if(lines.len > SSinstruments.musician_maxlines)
 				return
-			if(length(newline) > MUSIC_MAXLINECHARS)
-				newline = copytext(newline, 1, MUSIC_MAXLINECHARS)
+			if(length(newline) > SSinstruments.musician_maxlinechars)
+				newline = copytext(newline, 1, SSinstruments.musician_maxlinechars)
 			lines.Add(newline)
 		if("delete_line")
 			var/line_to_delete = params["line_deleted"]
@@ -140,7 +140,7 @@
 			var/line_to_edit = params["line_editing"]
 			if(line_to_edit > lines.len || line_to_edit < 1)
 				return FALSE
-			var/new_line_text = tgui_input_text(user, "Enter your line ", parent.name, lines[line_to_edit], max_length = MUSIC_MAXLINECHARS)
+			var/new_line_text = tgui_input_text(user, "Enter your line ", parent.name, lines[line_to_edit], max_length = SSinstruments.musician_maxlinechars)
 			if(isnull(new_line_text) || !in_range(parent, user))
 				return FALSE
 			lines[line_to_edit] = new_line_text
@@ -207,13 +207,13 @@
 			lines.Cut(1, 2)
 		else
 			tempo = sanitize_tempo(5) // default 120 BPM
-		if(lines.len > MUSIC_MAXLINES)
+		if(lines.len > SSinstruments.musician_maxlines)
 			if(user)
 				to_chat(user, "Too many lines!")
-			lines.Cut(MUSIC_MAXLINES + 1)
+			lines.Cut(SSinstruments.musician_maxlines + 1)
 		var/linenum = 1
 		for(var/l in lines)
-			if(length_char(l) > MUSIC_MAXLINECHARS)
+			if(length_char(l) > SSinstruments.musician_maxlinechars)
 				if(user)
 					to_chat(user, "Line [linenum] too long!")
 				lines.Remove(l)

--- a/code/modules/instruments/songs/play_legacy.dm
+++ b/code/modules/instruments/songs/play_legacy.dm
@@ -77,7 +77,7 @@
 		return
 	// and play
 	var/turf/source = get_turf(parent)
-	if((world.time - MUSICIAN_HEARCHECK_MINDELAY) > last_hearcheck)
+	if((world.time - SSinstruments.musician_hearcheck_mindelay) > last_hearcheck)
 		do_hearcheck()
 	var/sound/music_played = sound(soundfile)
 	for(var/i in hearing_mobs)

--- a/code/modules/instruments/songs/play_synthesized.dm
+++ b/code/modules/instruments/songs/play_synthesized.dm
@@ -44,7 +44,7 @@
  */
 /datum/song/proc/playkey_synth(key, atom/player)
 	key = clamp(key + note_shift, key_min, key_max)
-	if((world.time - MUSICIAN_HEARCHECK_MINDELAY) > last_hearcheck)
+	if((world.time - SSinstruments.musician_hearcheck_mindelay) > last_hearcheck)
 		do_hearcheck()
 	var/datum/instrument_key/K = using_instrument.samples[num2text(key)] //See how fucking easy it is to make a number text? You don't need a complicated 9 line proc!
 	//Should probably add channel limiters here at some point but I don't care right now.

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -37,9 +37,9 @@
 				return stripped_input(user, message, title, default, PREVENT_CHARACTER_TRIM_LOSS(max_length))
 		else
 			if(multiline)
-				return input(user, message, title, default) as message|null
+				return trim(input(user, message, title, default) as message|null, max_length)
 			else
-				return input(user, message, title, default) as text|null
+				return trim(input(user, message, title, default) as text|null, max_length)
 	var/datum/tgui_input_text/text_input = new(user, message, title, default, max_length, multiline, encode, timeout, ui_state)
 	text_input.ui_interact(user)
 	text_input.wait()


### PR DESCRIPTION

## About The Pull Request
Fixes #97607

https://github.com/user-attachments/assets/5b1186e9-a2a5-42cd-b45b-ab5629a54def

Text still looks ass, those buttons should prob be allowed to be bigger. but idgaf and this is just trying to fix the underlying oversight in the input code.
Also makes these static vars on the song subsystem actually used cause we had them and the defines fulfilling the same job. 
## Why It's Good For The Game
Fix good.
## Changelog
:cl:
fix: Chem dispenser custom recipes (and maybe a few other spots) now properly clamp text when using `Input: Enable TGUI`
/:cl:
