### PR TITLE
Painting and Trophy manager can be used more then once

### DIFF
--- a/code/modules/admin/admin_fax_panel.dm
+++ b/code/modules/admin/admin_fax_panel.dm
@@ -1,6 +1,6 @@
 ADMIN_VERB(fax_panel, R_ADMIN, "Fax Panel", "View and respond to faxes sent to CC.", ADMIN_CATEGORY_EVENTS)
-	var/datum/fax_panel_interface/ui = new /datum/fax_panel_interface(user.mob)
-	ui.ui_interact(user.mob)
+	var/datum/fax_panel_interface/tgui = new(user.mob)
+	tgui.ui_interact(user.mob)
 
 /// Admin Fax Panel. Tool for sending fax messages faster.
 /datum/fax_panel_interface

--- a/code/modules/admin/outfit_manager.dm
+++ b/code/modules/admin/outfit_manager.dm
@@ -1,5 +1,5 @@
 ADMIN_VERB(outfit_manager, R_DEBUG|R_ADMIN, "Outfit Manager", "View and edit outfits.", ADMIN_CATEGORY_DEBUG)
-	var/static/datum/outfit_manager/ui = new
+	var/datum/outfit_manager/ui = new()
 	ui.ui_interact(user.mob)
 
 /datum/outfit_manager

--- a/code/modules/admin/outfit_manager.dm
+++ b/code/modules/admin/outfit_manager.dm
@@ -1,6 +1,6 @@
 ADMIN_VERB(outfit_manager, R_DEBUG|R_ADMIN, "Outfit Manager", "View and edit outfits.", ADMIN_CATEGORY_DEBUG)
-	var/datum/outfit_manager/ui = new()
-	ui.ui_interact(user.mob)
+	var/datum/outfit_manager/tgui = new()
+	tgui.ui_interact(user.mob)
 
 /datum/outfit_manager
 

--- a/code/modules/admin/painting_manager.dm
+++ b/code/modules/admin/painting_manager.dm
@@ -1,5 +1,5 @@
 ADMIN_VERB(painting_manager, R_ADMIN, "Paintings Manager", "View and redact paintings.", ADMIN_CATEGORY_MAIN)
-	var/static/datum/paintings_manager/ui = new
+	var/datum/paintings_manager/ui = new()
 	ui.ui_interact(user.mob)
 
 /// Painting Admin Management Panel
@@ -7,9 +7,6 @@ ADMIN_VERB(painting_manager, R_ADMIN, "Paintings Manager", "View and redact pain
 
 /datum/paintings_manager/ui_state(mob/user)
 	return ADMIN_STATE(R_ADMIN)
-
-/datum/paintings_manager/ui_close(mob/user)
-	qdel(src)
 
 /datum/paintings_manager/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/admin/painting_manager.dm
+++ b/code/modules/admin/painting_manager.dm
@@ -1,6 +1,6 @@
 ADMIN_VERB(painting_manager, R_ADMIN, "Paintings Manager", "View and redact paintings.", ADMIN_CATEGORY_MAIN)
-	var/datum/paintings_manager/ui = new()
-	ui.ui_interact(user.mob)
+	var/datum/paintings_manager/tgui = new()
+	tgui.ui_interact(user.mob)
 
 /// Painting Admin Management Panel
 /datum/paintings_manager

--- a/code/modules/admin/trophy_manager.dm
+++ b/code/modules/admin/trophy_manager.dm
@@ -1,15 +1,12 @@
 ADMIN_VERB(trophy_manager, R_ADMIN, "Trophy Manager", "View all trophies.", ADMIN_CATEGORY_MAIN)
-	var/static/datum/trophy_manager/ui = new
-	ui.ui_interact(user.mob)
+	var/datum/trophy_manager/tgui = new()
+	tgui.ui_interact(user.mob)
 
 /// Trophy Admin Management Panel
 /datum/trophy_manager
 
 /datum/trophy_manager/ui_state(mob/user)
 	return ADMIN_STATE(R_ADMIN)
-
-/datum/trophy_manager/ui_close(mob/user)
-	qdel(src)
 
 /datum/trophy_manager/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/admin/verbs/commandreport.dm
+++ b/code/modules/admin/verbs/commandreport.dm
@@ -19,7 +19,7 @@ ADMIN_VERB(change_command_name, R_ADMIN, "Change Command Name", "Change the name
 /// Verb to open the create command report window and send command reports.
 ADMIN_VERB(create_command_report, R_ADMIN, "Create Command Report", "Create a command report to be sent to the station.", ADMIN_CATEGORY_EVENTS)
 	BLACKBOX_LOG_ADMIN_VERB("Create Command Report")
-	var/datum/command_report_menu/tgui = new /datum/command_report_menu(user.mob)
+	var/datum/command_report_menu/tgui = new(user.mob)
 	tgui.ui_interact(user.mob)
 
 /// Datum for holding the TGUI window for command reports.

--- a/code/modules/admin/verbs/lawpanel.dm
+++ b/code/modules/admin/verbs/lawpanel.dm
@@ -1,7 +1,7 @@
 ADMIN_VERB(law_panel, R_ADMIN, "Law Panel", "View the AI laws.", ADMIN_CATEGORY_EVENTS)
 	if(!isobserver(user) && SSticker.HasRoundStarted())
 		message_admins("[key_name_admin(user)] checked AI laws via the Law Panel.")
-	var/datum/law_panel/tgui = new
+	var/datum/law_panel/tgui = new()
 	tgui.ui_interact(user.mob)
 	BLACKBOX_LOG_ADMIN_VERB("Law Panel")
 

--- a/code/modules/admin/verbs/policy_panel.dm
+++ b/code/modules/admin/verbs/policy_panel.dm
@@ -3,7 +3,7 @@ ADMIN_VERB(policy_panel, R_ADMIN, "Policy Panel", "View all policy the server ha
 		tgui_alert(usr, "Policy hasn't loaded yet (or the server has none set).", "Policy Panel", list("OK"))
 		return
 
-	var/datum/policy_panel/tgui = new
+	var/datum/policy_panel/tgui = new()
 	tgui.ui_interact(user.mob)
 	BLACKBOX_LOG_ADMIN_VERB("Policy Panel")
 

--- a/code/modules/admin/verbs/selectequipment.dm
+++ b/code/modules/admin/verbs/selectequipment.dm
@@ -1,7 +1,7 @@
 ADMIN_VERB_ONLY_CONTEXT_MENU(select_equipment, R_FUN, "Select Equipment", /mob)
 	VERB_ARG_TYPED(target, VERB_ARG_TYPE_MOB, VERB_ARG_SOURCE_WORLD, /mob)
-	var/datum/select_equipment/ui = new(user, target)
-	ui.ui_interact(user.mob)
+	var/datum/select_equipment/tgui = new(user, target)
+	tgui.ui_interact(user.mob)
 
 /*
  * This is the datum housing the select equipment UI.

--- a/code/modules/fishing/admin.dm
+++ b/code/modules/fishing/admin.dm
@@ -1,5 +1,5 @@
 ADMIN_VERB(fishing_calculator, R_DEBUG, "Fishing Calculator", "A calculator... for fishes?", ADMIN_CATEGORY_DEBUG)
-	var/datum/fishing_calculator/ui = new
+	var/datum/fishing_calculator/ui = new()
 	ui.ui_interact(user.mob)
 
 /datum/fishing_calculator

--- a/code/modules/fishing/admin.dm
+++ b/code/modules/fishing/admin.dm
@@ -1,6 +1,6 @@
 ADMIN_VERB(fishing_calculator, R_DEBUG, "Fishing Calculator", "A calculator... for fishes?", ADMIN_CATEGORY_DEBUG)
-	var/datum/fishing_calculator/ui = new()
-	ui.ui_interact(user.mob)
+	var/datum/fishing_calculator/tgui = new()
+	tgui.ui_interact(user.mob)
 
 /datum/fishing_calculator
 	var/list/current_table


### PR DESCRIPTION

## About The Pull Request
Old behavoir meant they got qdeled when you close it and never remade.

Also makes them non-static.  As per melbert's suggestion.
<img width="511" height="562" alt="image" src="https://github.com/user-attachments/assets/1630334a-f215-4ad2-af68-750170747b4a" />

Also did a 1 minute pass to standerdize the syntax across random admin panel creation.
## Why It's Good For The Game
Dont qdel a static varible. lol. lmao.
## Changelog
:cl:
admin: Painting and Trophy manager no longer permanently deletes itself after the first close
/:cl:
