### PR TITLE
fix a missing wire on Ice Box

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -69677,6 +69677,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/security/execution/education)
 "tFs" = (


### PR DESCRIPTION

## About The Pull Request
Added a missing wire on Ice Box for the education chamber APC.

## Why It's Good For The Game
The APC needs power.

## Changelog
:cl: Metek
fix: Fixed a missing wire in Ice Box education chamber.
/:cl:
