### PR TITLE
Adds a nullcheck for job icons when filling manifest

### DIFF
--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -42,7 +42,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 			misc_list[++misc_list.len] = list(
 				"name" = name,
 				"rank" = rank,
-				"trim" = job.tgui_icon,
+				"trim" = job?.tgui_icon,
 				)
 			continue
 		for(var/department_type in job.departments_list)


### PR DESCRIPTION
## About The Pull Request

About what it says on the tin. Closes #97641.

## Why It's Good For The Game

Adding an entry to the crew manifest without breaking the manifest is probably a good idea.

## Changelog

:cl:
fix: Crew manifests should no longer break when adding new entries.
/:cl:
