### PR TITLE
Small pipe rendering fixes

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -113,6 +113,13 @@ DEFINE_BITFIELD(pipe_flags, list(
 	"One Per Turf" = PIPING_ONE_PER_TURF,
 ))
 
+/// When given two atmos nodes, determines which's color should be used for the pipe between them
+#define SELECT_ATMOS_NODE_COLOR(our_node, other_node) ( \
+	(isnull(other_node) || (other_node.pipe_flags & PIPING_DONT_SHARE_COLOR) || other_node.pipe_color == ATMOS_COLOR_OMNI) \
+		? our_node.pipe_color \
+		: other_node.pipe_color \
+)
+
 // Ventcrawling bitflags, handled in var/vent_movement
 ///Allows for ventcrawling to occur. All atmospheric machines have this flag on by default. Cryo is the exception
 #define VENTCRAWL_ALLOWED (1<<0)

--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -99,6 +99,19 @@
 #define PIPING_BRIDGE (1<<5)
 /// intended to connect with layers 2 and 4 only
 #define PIPING_DISTRO_AND_WASTE_LAYERS (1<<6)
+/// Applied to devices to indicate to connected pipes that they should not take this device's color
+#define PIPING_DONT_SHARE_COLOR (1<<7)
+
+DEFINE_BITFIELD(pipe_flags, list(
+	"All Colors" = PIPING_ALL_COLORS,
+	"All Layers" = PIPING_ALL_LAYER,
+	"Bridge" = PIPING_BRIDGE,
+	"Cardinal Auto-Normalize" = PIPING_CARDINAL_AUTONORMALIZE,
+	"Default Layer Only" = PIPING_DEFAULT_LAYER_ONLY,
+	"Distro and Waste Layers Only" = PIPING_DISTRO_AND_WASTE_LAYERS,
+	"Don't Share Color" = PIPING_DONT_SHARE_COLOR,
+	"One Per Turf" = PIPING_ONE_PER_TURF,
+))
 
 // Ventcrawling bitflags, handled in var/vent_movement
 ///Allows for ventcrawling to occur. All atmospheric machines have this flag on by default. Cryo is the exception

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -688,7 +688,7 @@
 
 	SET_PLANE_EXPLICIT(cap_overlay, initial(plane), our_turf)
 
-	cap_overlay.color = pipe_color
+	cap_overlay.color = (pipe_color == ATMOS_COLOR_OMNI && nodes[1].pipe_color) || pipe_color
 	cap_overlay.layer = initial(layer)
 	cap_overlay.icon_state = "[bitfield]_[piping_layer]"
 

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -688,7 +688,7 @@
 
 	SET_PLANE_EXPLICIT(cap_overlay, initial(plane), our_turf)
 
-	cap_overlay.color = (pipe_color == ATMOS_COLOR_OMNI && nodes[1].pipe_color) || pipe_color
+	cap_overlay.color = (pipe_color == ATMOS_COLOR_OMNI && nodes[1]?.pipe_color) || pipe_color
 	cap_overlay.layer = initial(layer)
 	cap_overlay.icon_state = "[bitfield]_[piping_layer]"
 

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -90,7 +90,7 @@
 		var/obj/machinery/atmospherics/node = nodes[i]
 		var/node_dir = get_dir(src, node)
 		var/mutable_appearance/pipe_appearance = mutable_appearance('icons/obj/pipes_n_cables/pipe_underlays.dmi', "intact_[node_dir]_[underlay_pipe_layer]", appearance_flags = RESET_COLOR|KEEP_APART)
-		pipe_appearance.color = (node.pipe_color == ATMOS_COLOR_OMNI || (node.pipe_flags & PIPING_DONT_SHARE_COLOR) ? pipe_color : node.pipe_color
+		pipe_appearance.color = (node.pipe_color == ATMOS_COLOR_OMNI || (node.pipe_flags & PIPING_DONT_SHARE_COLOR)) ? pipe_color : node.pipe_color
 		if (underfloor_state == UNDERFLOOR_VISIBLE || uncovered_turf)
 			pipe_appearance.layer = BELOW_CATWALK_LAYER + get_pipe_layer_offset()
 			SET_PLANE_EXPLICIT(pipe_appearance, FLOOR_PLANE, src)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -90,7 +90,7 @@
 		var/obj/machinery/atmospherics/node = nodes[i]
 		var/node_dir = get_dir(src, node)
 		var/mutable_appearance/pipe_appearance = mutable_appearance('icons/obj/pipes_n_cables/pipe_underlays.dmi', "intact_[node_dir]_[underlay_pipe_layer]", appearance_flags = RESET_COLOR|KEEP_APART)
-		pipe_appearance.color = (node.pipe_color == ATMOS_COLOR_OMNI || (node.pipe_flags & PIPING_DONT_SHARE_COLOR)) ? pipe_color : node.pipe_color
+		pipe_appearance.color = SELECT_ATMOS_NODE_COLOR(src, node)
 		if (underfloor_state == UNDERFLOOR_VISIBLE || uncovered_turf)
 			pipe_appearance.layer = BELOW_CATWALK_LAYER + get_pipe_layer_offset()
 			SET_PLANE_EXPLICIT(pipe_appearance, FLOOR_PLANE, src)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -90,7 +90,7 @@
 		var/obj/machinery/atmospherics/node = nodes[i]
 		var/node_dir = get_dir(src, node)
 		var/mutable_appearance/pipe_appearance = mutable_appearance('icons/obj/pipes_n_cables/pipe_underlays.dmi', "intact_[node_dir]_[underlay_pipe_layer]", appearance_flags = RESET_COLOR|KEEP_APART)
-		pipe_appearance.color = (node.pipe_color == ATMOS_COLOR_OMNI || istype(node, /obj/machinery/atmospherics/pipe/color_adapter)) ? pipe_color : node.pipe_color
+		pipe_appearance.color = (node.pipe_color == ATMOS_COLOR_OMNI || (node.pipe_flags & PIPING_DONT_SHARE_COLOR) ? pipe_color : node.pipe_color
 		if (underfloor_state == UNDERFLOOR_VISIBLE || uncovered_turf)
 			pipe_appearance.layer = BELOW_CATWALK_LAYER + get_pipe_layer_offset()
 			SET_PLANE_EXPLICIT(pipe_appearance, FLOOR_PLANE, src)

--- a/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
@@ -95,16 +95,16 @@
 
 	. += get_pipe_image(
 		iconfile = icon,
-		iconstate = "pipe_[nodes[1] ? "intact" : "exposed"]",
+		iconstate = "pipe_[isnull(nodes[1]) ? "exposed" : "intact"]",
 		direction = dir,
-		color = nodes[1]?.color || COLOR_BLUE,
+		color = nodes[1]?.color || COLOR_BLUE, // default to blue to indicate input
 		piping_layer = 4,
 	)
 	. += get_pipe_image(
 		iconfile = icon,
-		iconstate = "pipe_[nodes[2] ? "intact" : "exposed"]",
+		iconstate = "pipe_[isnull(nodes[2]) ? "exposed" : "intact"]",
 		direction = dir,
-		color = nodes[2]?.color || COLOR_RED,
+		color = nodes[2]?.color || COLOR_RED, // default to red to indicate output
 		piping_layer = 2,
 	)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
@@ -93,22 +93,23 @@
 	if(!underfloor_state)
 		return
 
-	var/mutable_appearance/distro_pipe_appearance = get_pipe_image(icon, "pipe_exposed", dir, COLOR_BLUE, piping_layer = 4)
-	if(nodes[1])
-		distro_pipe_appearance = get_pipe_image(icon, "pipe_intact", dir, COLOR_BLUE, piping_layer = 4)
-	. += distro_pipe_appearance
+	. += get_pipe_image(
+		iconfile = icon,
+		iconstate = "pipe_[nodes[1] ? "intact" : "exposed"]",
+		direction = dir,
+		color = nodes[1]?.color || COLOR_BLUE,
+		piping_layer = 4,
+	)
+	. += get_pipe_image(
+		iconfile = icon,
+		iconstate = "pipe_[nodes[2] ? "intact" : "exposed"]",
+		direction = dir,
+		color = nodes[2]?.color || COLOR_RED,
+		piping_layer = 2,
+	)
 
-	var/mutable_appearance/waste_pipe_appearance = get_pipe_image(icon, "pipe_exposed", dir, COLOR_RED, piping_layer = 2)
-	if(nodes[2])
-		waste_pipe_appearance = get_pipe_image(icon, "pipe_intact", dir, COLOR_RED, piping_layer = 2)
-	. += waste_pipe_appearance
-
-	var/mutable_appearance/distro_cap_appearance = get_pipe_image(icon, "vent_cap", dir, piping_layer = 4)
-	. += distro_cap_appearance
-
-	var/mutable_appearance/waste_cap_appearance = get_pipe_image(icon, "vent_cap", dir, piping_layer = 2)
-	. += waste_cap_appearance
-
+	. += get_pipe_image(icon, "vent_cap", dir, piping_layer = 4)
+	. += get_pipe_image(icon, "vent_cap", dir, piping_layer = 2)
 
 /obj/machinery/atmospherics/components/unary/airlock_pump/atmos_init(list/node_connects)
 	for(var/obj/machinery/atmospherics/target in get_step(src, dir))

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -127,7 +127,7 @@
 
 /obj/machinery/atmospherics/components/unary/thermomachine/update_overlays()
 	. = ..()
-	var/image/pipe = get_pipe_image('icons/obj/machines/atmospherics/thermomachine.dmi', "pipe", dir, pipe_color, piping_layer)
+	var/image/pipe = get_pipe_image('icons/obj/machines/atmospherics/thermomachine.dmi', "pipe", dir, SELECT_ATMOS_NODE_COLOR(src, node[1]), piping_layer)
 	pipe.appearance_flags |= RESET_COLOR | KEEP_APART
 	. += pipe
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -127,7 +127,7 @@
 
 /obj/machinery/atmospherics/components/unary/thermomachine/update_overlays()
 	. = ..()
-	var/image/pipe = get_pipe_image('icons/obj/machines/atmospherics/thermomachine.dmi', "pipe", dir, SELECT_ATMOS_NODE_COLOR(src, node[1]), piping_layer)
+	var/image/pipe = get_pipe_image('icons/obj/machines/atmospherics/thermomachine.dmi', "pipe", dir, SELECT_ATMOS_NODE_COLOR(src, nodes[1]), piping_layer)
 	pipe.appearance_flags |= RESET_COLOR | KEEP_APART
 	. += pipe
 

--- a/code/modules/atmospherics/machinery/pipes/color_adapter.dm
+++ b/code/modules/atmospherics/machinery/pipes/color_adapter.dm
@@ -54,7 +54,7 @@
 		pipe.layer = layer + 0.01
 		. += pipe
 
-/obj/machinery/atmospherics/pipe/color_adapter/proc/get_node_color(obj/machinery/atmospherics/node, node_dir)
+/obj/machinery/atmospherics/pipe/color_adapter/proc/get_node_color(obj/machinery/atmospherics/node, node_dir = get_dir(src, node))
 	// If we are omni always use input color
 	if(pipe_color == ATMOS_COLOR_OMNI)
 		return node.pipe_color

--- a/code/modules/atmospherics/machinery/pipes/color_adapter.dm
+++ b/code/modules/atmospherics/machinery/pipes/color_adapter.dm
@@ -7,7 +7,7 @@
 
 	dir = SOUTH
 	initialize_directions = NORTH | SOUTH
-	pipe_flags = PIPING_CARDINAL_AUTONORMALIZE | PIPING_ALL_COLORS | PIPING_BRIDGE
+	pipe_flags = PIPING_CARDINAL_AUTONORMALIZE | PIPING_ALL_COLORS | PIPING_BRIDGE | PIPING_DONT_SHARE_COLOR
 	device_type = BINARY
 
 	construction_type = /obj/item/pipe/binary
@@ -47,15 +47,29 @@
 	for(var/i in 1 to device_type)
 		if(!nodes[i])
 			continue
-		var/applied_color = nodes[i].pipe_color
 		var/node_dir = get_dir(src, nodes[i])
-		if (istype(nodes[i], /obj/machinery/atmospherics/pipe/color_adapter) && ((node_dir & (SOUTH|EAST)) || nodes[i].pipe_color == ATMOS_COLOR_OMNI) && pipe_color != ATMOS_COLOR_OMNI)
-			applied_color = pipe_color
-		var/image/pipe = get_pipe_image('icons/obj/pipes_n_cables/manifold.dmi', "pipe-3", node_dir, applied_color)
+		var/image/pipe = get_pipe_image('icons/obj/pipes_n_cables/manifold.dmi', "pipe-3", node_dir, get_node_color(nodes[i], node_dir))
 		pipe.appearance_flags |= RESET_COLOR|KEEP_APART
 		PIPING_LAYER_DOUBLE_SHIFT(pipe, piping_layer)
 		pipe.layer = layer + 0.01
 		. += pipe
+
+/obj/machinery/atmospherics/pipe/color_adapter/proc/get_node_color(obj/machinery/atmospherics/node, node_dir)
+	// If we are omni always use input color
+	if(pipe_color == ATMOS_COLOR_OMNI)
+		return node.pipe_color
+
+	// If we are connecting to a non-sharer (like another color adapter)
+	if(node.pipe_flags & PIPING_DONT_SHARE_COLOR)
+		// Use our own color if the other node is omni
+		if(node.pipe_color == ATMOS_COLOR_OMNI)
+			return pipe_color
+		// South/east are prioritized, so it doesn't change based on update order
+		if(node_dir & (SOUTH|EAST))
+			return pipe_color
+
+	// Otherwise just use the node's color
+	return node.pipe_color
 
 /obj/machinery/atmospherics/pipe/color_adapter/layer1
 	icon_state = "adapter_map-1"

--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -61,18 +61,21 @@
 
 	. = list()
 
+	// Conecting layer manifold to layer manifold will always use omni color pipes in between
 	if(istype(machine_check, /obj/machinery/atmospherics/pipe/layer_manifold))
+		var/preferred_color = machine_check.pipe_color == pipe_color ? pipe_color : ATMOS_COLOR_OMNI
 		for(var/i in PIPING_LAYER_MIN to PIPING_LAYER_MAX)
-			. += get_attached_image(get_dir(src, machine_check), i, machine_check.pipe_color == pipe_color ? pipe_color : ATMOS_COLOR_OMNI)
+			. += get_attached_image(get_dir(src, machine_check), i, preferred_color)
 		return
+
+	// Airlock pump has some snowflake behavior since it has two nodes
 	if(istype(machine_check, /obj/machinery/atmospherics/components/unary/airlock_pump))
 		. += get_attached_image(get_dir(src, machine_check), 4, COLOR_BLUE)
 		//. += get_attached_image(get_dir(src, machine_check), 2, COLOR_RED) // Only the distro node is added currently to the pipenet, it doesn't merge the pipenet with the waste node
 		return
-	var/passed_color = machine_check.pipe_color
-	if(istype(machine_check, /obj/machinery/atmospherics/pipe/color_adapter) || machine_check.pipe_color == ATMOS_COLOR_OMNI)
-		passed_color = pipe_color
-	. += get_attached_image(get_dir(src, machine_check), machine_check.piping_layer, passed_color)
+
+	var/connection_color = SELECT_ATMOS_NODE_COLOR(src, machine_check)
+	. += get_attached_image(get_dir(src, machine_check), machine_check.piping_layer, connection_color)
 
 /obj/machinery/atmospherics/pipe/layer_manifold/proc/get_attached_image(p_dir, p_layer, p_color)
 	var/working_layer = FLOAT_LAYER - HAS_TRAIT(src, TRAIT_UNDERFLOOR) ? 1 : 0.01

--- a/code/modules/atmospherics/machinery/pipes/multiz.dm
+++ b/code/modules/atmospherics/machinery/pipes/multiz.dm
@@ -38,7 +38,7 @@
 	. = ..()
 
 	pipe.appearance_flags |= RESET_COLOR|KEEP_APART
-	pipe.color = (isnull(nodes[1]) || (nodes[1].pipe_flags & PIPING_DONT_SHARE_COLOR)) ? pipe_color : nodes[1].color
+	pipe.color = SELECT_ATMOS_NODE_COLOR(src, nodes[1])
 	pipe.icon_state = "pipe-[piping_layer]"
 	. += pipe
 

--- a/code/modules/atmospherics/machinery/pipes/multiz.dm
+++ b/code/modules/atmospherics/machinery/pipes/multiz.dm
@@ -21,8 +21,6 @@
 	var/mutable_appearance/center = null
 	///The pipe icon
 	var/mutable_appearance/pipe = null
-	///Reference to the node
-	var/obj/machinery/atmospherics/front_node = null
 
 /obj/machinery/atmospherics/pipe/multiz/Initialize(mapload, process, setdir, init_dir)
 	icon_state = ""
@@ -38,10 +36,12 @@
 
 /obj/machinery/atmospherics/pipe/multiz/update_overlays()
 	. = ..()
+
 	pipe.appearance_flags |= RESET_COLOR|KEEP_APART
-	pipe.color = front_node ? front_node.pipe_color : ATMOS_COLOR_OMNI
+	pipe.color = (isnull(nodes[1]) || (nodes[1].pipe_flags & PIPING_DONT_SHARE_COLOR)) ? pipe_color : nodes[1].color
 	pipe.icon_state = "pipe-[piping_layer]"
 	. += pipe
+
 	center.pixel_w = PIPING_LAYER_P_X * (piping_layer - PIPING_LAYER_DEFAULT)
 	. += center
 


### PR DESCRIPTION
## About The Pull Request

Fixes multi-z adapters looking like this when connecting to omni-pipes

<img width="81" height="112" alt="image" src="https://github.com/user-attachments/assets/d656de9b-169e-40a7-9182-14e8ee18b337" />

Fixes airlock pumps disregarding connected pipe color

Makes layer adapter color selection more consistent

Makes thermo machines inlet pipe take on pipe color 

Caps leading into floor objects are colored according to input pipe color

Changed hardcoded color adapter check to a flag

## Changelog

:cl: Melbert
code: Cleaned up atmos color adapter pipe code a tiny bit, report any oddities
fix: Atmos multi-z pipes rendering weirdly when connecting with omni-pipes
fix: Atmos airlock pumps disregarding color of connected pipes
fix: Atmos layer adapter color is more consistent
qol: Thermo machines input pipe takes on pipe color (visually, mechanically no changes)
qol: Pipes leading into floor objects take on pipe color (visually, mechanically no changes)
/:cl:
