### PR TITLE
Presawn off subtypes for Guns

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -227,8 +227,6 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 //Sawn off nerfs
 ///accuracy penalty of sawn off guns
 #define SAWN_OFF_ACC_PENALTY 25
-///added recoil of sawn off guns
-#define SAWN_OFF_RECOIL 1
 
 //ammo box sprite defines
 ///ammo box will always use provided icon state

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -390,7 +390,7 @@
 #define COMSIG_GUN_CHAMBER_PROCESSED "gun_chamber_processed"
 ///called in /obj/item/gun/ballistic/process_chamber (casing)
 #define COMSIG_CASING_EJECTED "casing_ejected"
-///called in /obj/item/gun/ballistic/sawoff(mob/user, obj/item/saw, handle_modifications) : (mob/user)
+///called in /obj/item/gun/ballistic/try_sawoff(mob/user, obj/item/saw, handle_modifications) : (mob/user)
 #define COMSIG_GUN_BEING_SAWNOFF "gun_being_sawnoff"
 	#define COMPONENT_CANCEL_SAWING_OFF (1<<0)
 #define COMSIG_GUN_SAWN_OFF "gun_sawn_off"

--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -157,7 +157,7 @@
 			// This is not arm wound, so we don't care
 			return
 
-	if(gun.recoil > 0 && severity >= WOUND_SEVERITY_SEVERE && prob(25 * (severity - 1)))
+	if(gun.calculate_recoil(victim, gun.recoil) > 1 && severity >= WOUND_SEVERITY_SEVERE && prob(25 * (severity - 1)))
 		if(!HAS_TRAIT(victim, TRAIT_ANALGESIA))
 			to_chat(victim, span_danger("The fracture in your [limb.plaintext_zone] explodes with pain as [gun] kicks back!"))
 		victim.apply_damage(rand(1, 3) * (severity - 1) * gun.weapon_weight, BRUTE, limb, wound_bonus = CANT_WOUND, wound_clothing = FALSE)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -105,10 +105,12 @@
 	var/must_hold_to_load = FALSE
 	///Whether the gun can be sawn off by sawing tools
 	var/can_be_sawn_off = FALSE
+	///Added recoil of sawn off guns
+	var/sawoff_bonus_recoil = 1
 	///Starts presawn-off
 	var/spawn_sawn_off = FALSE
 	///pixel offset for the suppressor overlay on the x axis.
-	var/suppressor_x_offset 
+	var/suppressor_x_offset
 	///pixel offset for the suppressor overlay on the y axis.
 	var/suppressor_y_offset
 	/// Check if you are able to see if a weapon has a bullet loaded in or not.
@@ -631,7 +633,7 @@
 
 /obj/item/gun/ballistic/calculate_recoil(mob/living/user, recoil_amount)
 	if(sawn_off)
-		recoil_amount += SAWN_OFF_RECOIL
+		recoil_amount += sawoff_bonus_recoil
 	. = ..()
 
 /obj/item/gun/ballistic/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -105,8 +105,12 @@
 	var/must_hold_to_load = FALSE
 	///Whether the gun can be sawn off by sawing tools
 	var/can_be_sawn_off = FALSE
-	var/suppressor_x_offset ///pixel offset for the suppressor overlay on the x axis.
-	var/suppressor_y_offset ///pixel offset for the suppressor overlay on the y axis.
+	///Starts presawn-off
+	var/spawn_sawn_off = FALSE
+	///pixel offset for the suppressor overlay on the x axis.
+	var/suppressor_x_offset 
+	///pixel offset for the suppressor overlay on the y axis.
+	var/suppressor_y_offset
 	/// Check if you are able to see if a weapon has a bullet loaded in or not.
 	var/hidden_chambered = FALSE
 
@@ -162,6 +166,9 @@
 		chamber_round()
 	else
 		chamber_round(replace_new_round = TRUE)
+	if(spawn_sawn_off)
+		do_sawoff()
+
 	update_appearance()
 	RegisterSignal(src, COMSIG_ITEM_RECHARGED, PROC_REF(instant_reload))
 
@@ -584,7 +591,7 @@
 		install_suppressor(tool)
 		return ITEM_INTERACT_SUCCESS
 
-	if (can_be_sawn_off && sawoff(user, tool))
+	if (can_be_sawn_off && try_sawoff(user, tool))
 		return ITEM_INTERACT_SUCCESS
 
 /obj/item/gun/ballistic/proc/load_gun(obj/item/ammo, mob/living/user)
@@ -617,10 +624,15 @@
 		to_chat(user, span_userdanger("[src] misfires!"))
 		return
 
-	if (sawn_off)
+	if(sawn_off)
 		bonus_spread += SAWN_OFF_ACC_PENALTY
 
 	return ..()
+
+/obj/item/gun/ballistic/calculate_recoil(mob/living/user, recoil_amount)
+	if(sawn_off)
+		recoil_amount += SAWN_OFF_RECOIL
+	. = ..()
 
 /obj/item/gun/ballistic/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
 	if(isnull(chambered))
@@ -799,7 +811,7 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 	)))
 
 ///Handles all the logic of sawing off guns,
-/obj/item/gun/ballistic/proc/sawoff(mob/user, obj/item/saw, handle_modifications = TRUE)
+/obj/item/gun/ballistic/proc/try_sawoff(mob/user, obj/item/saw)
 	if(!saw.get_sharpness() || (!is_type_in_typecache(saw, GLOB.gun_saw_types) && saw.tool_behaviour != TOOL_SAW)) //needs to be sharp. Otherwise turned off eswords can cut this.
 		return
 	if(sawn_off)
@@ -820,10 +832,14 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 	if(sawn_off)
 		return
 	user.visible_message(span_notice("[user] shortens [src]!"), span_notice("You shorten [src]."))
+	. = do_sawoff()
+	update_appearance()
+
+/obj/item/gun/ballistic/proc/do_sawoff()
+	SHOULD_CALL_PARENT(TRUE)
 	sawn_off = TRUE
 	SEND_SIGNAL(src, COMSIG_GUN_SAWN_OFF)
-	if(!handle_modifications)
-		return TRUE
+
 	name = "sawn-off [src.name]"
 	desc = sawn_desc
 	update_weight_class(WEIGHT_CLASS_NORMAL)
@@ -836,8 +852,6 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 	worn_icon_state = "gun"
 	slot_flags &= ~ITEM_SLOT_BACK //you can't sling it on your back
 	slot_flags |= ITEM_SLOT_BELT //but you can wear it on your belt (poorly concealed under a trenchcoat, ideally)
-	recoil = SAWN_OFF_RECOIL
-	update_appearance()
 	return TRUE
 
 /obj/item/gun/ballistic/wrench_act(mob/living/user, obj/item/I)

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -75,6 +75,10 @@
 
 	SET_BASE_PIXEL(-8, 0)
 
+/obj/item/gun/ballistic/rifle/boltaction/presawn
+	WHEN_MAP(icon_state = "sakhno_sawn")
+	spawn_sawn_off = TRUE
+
 /obj/item/gun/ballistic/rifle/boltaction/add_deep_lore()
 	AddElement(/datum/element/examine_lore, \
 		lore = "The Sakhno Precision Rifle's origins are closely tied to the Sakhno Concern, one of the Third Soviet Union's \
@@ -95,12 +99,10 @@
 /obj/item/gun/ballistic/rifle/boltaction/add_bayonet_point()
 	AddComponent(/datum/component/bayonet_attachable, offset_x = 41, offset_y = 14, bayonet_overlay = "bayonet_thin")
 
-/obj/item/gun/ballistic/rifle/boltaction/sawoff(mob/user)
+/obj/item/gun/ballistic/rifle/boltaction/do_sawoff()
 	. = ..()
-	if(.)
-		spread = 36
-		SET_BASE_PIXEL(0, 0)
-		update_appearance()
+	spread = 36
+	SET_BASE_PIXEL(0, 0)
 
 /obj/item/gun/ballistic/rifle/boltaction/attack_self(mob/user)
 	if(jammed)
@@ -194,10 +196,9 @@
 	. = ..()
 	AddComponent(/datum/component/scope, range_modifier = 1.5)
 
-/obj/item/gun/ballistic/rifle/boltaction/prime/sawoff(mob/user)
+/obj/item/gun/ballistic/rifle/boltaction/prime/do_sawoff()
 	. = ..()
-	if(.)
-		name = "\improper Obrez Moderna" // wear it loud and proud
+	name = "\improper Obrez Moderna" // wear it loud and proud
 
 /obj/item/gun/ballistic/rifle/boltaction/donkrifle
 	name = "\improper Donk Co. Jezail"
@@ -230,11 +231,10 @@
 			no risk of receiving a refurbished, poorly-kept surplus arm that jams more than it shoots." \
 	)
 
-/obj/item/gun/ballistic/rifle/boltaction/donkrifle/sawoff(mob/user) //the heavy price one pays for fitting this in a backpack
+/obj/item/gun/ballistic/rifle/boltaction/donkrifle/do_sawoff() //the heavy price one pays for fitting this in a backpack
 	. = ..()
-	if(.)
-		projectile_damage_multiplier = 0.75
-		spread = 50
+	projectile_damage_multiplier = 0.75
+	spread = 50
 
 /obj/item/gun/ballistic/rifle/rebarxbow
 	name = "heated rebar crossbow"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -355,13 +355,16 @@
 	can_be_sawn_off = TRUE
 	pb_knockback = 3 // it's a super shotgun!
 
+/obj/item/gun/ballistic/shotgun/doublebarrel/presawn
+	WHEN_MAP(icon_state = "dshotgun_sawn")
+	spawn_sawn_off = TRUE
+
 /obj/item/gun/ballistic/shotgun/doublebarrel/setup_reskins()
 	AddComponent(/datum/component/reskinable_item, /datum/atom_skin/bar_shotgun)
 
-/obj/item/gun/ballistic/shotgun/doublebarrel/sawoff(mob/user)
+/obj/item/gun/ballistic/shotgun/doublebarrel/do_sawoff()
 	. = ..()
-	if(.)
-		weapon_weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_MEDIUM
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/slugs
 	name = "hunting shotgun"


### PR DESCRIPTION

## About The Pull Request
cleanup sawnoff and recoil behavoir, the current code meant if you want to varedit or map a sawn off weapon you have to manually set every varible.
This moves the actual behavoir that SETS sawnoff stuff into a proc called by the try behavoir. That way we can call it as part of initialize 

<img width="343" height="216" alt="image" src="https://github.com/user-attachments/assets/84a5fe16-45d2-4c11-bb4f-3bae8d65cbf1" />

## Why It's Good For The Game
Sawnoffs are kinda weird snow-flaky behavior atm and this makes them a bit better.

## Changelog
:cl:
fix: sawnoff recoil is ADDED to existing recoil rather then setting it
code: Adds support for pre-sawnoff guns and cleans up sawnoff behavoir
/:cl:
