### PR TITLE
Fix: Runtime parallax excessively large view range 

### DIFF
--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -345,6 +345,8 @@
 	// This could be half the size but we need to provide space for parallax movement on mob movement, and movement on scroll from shuttles, so like this instead
 	var/countx = (CEILING((viewscales[1] / 2) * parallax_scaler, 1) + 1)
 	var/county = (CEILING((viewscales[2] / 2) * parallax_scaler, 1) + 1)
+	countx = min(countx, 4)
+	county = min(county, 4)
 	for(var/x in -countx to countx)
 		for(var/y in -county to county)
 			if(x == 0 && y == 0)


### PR DESCRIPTION
## About The Pull Request
If you set `Change View Range = 37`, a runtime error occurs because `countx` or `county` become 5, which causes the parallax grid to break and throw an error.

This PR introduces a hard cap on the view range, limiting it to a maximum of 4 to prevent this issue from occurring.

<details><summary>Demonstration of changes / Testing</summary>
<p>

https://github.com/user-attachments/assets/9b73c4ed-cbc9-43fb-a2ec-eeafd2cd5611

https://github.com/user-attachments/assets/06b7c64b-214b-4eac-b010-0d4716eae5a5
</p>
</details> 

## Why It's Good For The Game
Prevents runtime errors caused by excessively large view ranges.
The parallax grid is now safely capped at 4, ensuring stability.

fix #70174

## Changelog

:cl:
fix: Capped View Range at 4 to prevent parallax crashes.
/:cl:
