### PR TITLE
fix window resize/white flash again part 3

### DIFF
--- a/tgui/packages/tgui/events/handlers/update.ts
+++ b/tgui/packages/tgui/events/handlers/update.ts
@@ -45,9 +45,6 @@ function resume(payload: UpdatePayload): void {
       return;
     }
 
-    Byond.winset(Byond.windowId, {
-      'is-visible': true,
-    });
     perf.mark('resume/finish');
 
     if (process.env.NODE_ENV !== 'production') {

--- a/tgui/packages/tgui/layouts/Window.tsx
+++ b/tgui/packages/tgui/layouts/Window.tsx
@@ -72,8 +72,10 @@ export function Window(props: Props) {
   const { scale } = config?.window || false;
 
   useEffect(() => {
+    let cancelled = false;
+
     if (!suspended && isReadyToRender) {
-      const updateGeometry = () => {
+      const updateGeometry = async () => {
         const options = {
           ...config.window,
           size: DEFAULT_SIZE,
@@ -85,7 +87,10 @@ export function Window(props: Props) {
         if (config.window?.key) {
           setWindowKey(config.window.key);
         }
-        recallWindowGeometry(options);
+        await recallWindowGeometry(options);
+        if (cancelled) {
+          return;
+        }
         Byond.winset(Byond.windowId, {
           'is-visible': true,
         });
@@ -102,9 +107,10 @@ export function Window(props: Props) {
       updateGeometry();
     }
     return () => {
+      cancelled = true;
       logger.log('unmounting');
     };
-  }, [isReadyToRender, width, height, scale]);
+  }, [isReadyToRender, suspended, width, height, scale]);
 
   // Determine when to show dimmer
   const showDimmer =


### PR DESCRIPTION
## About The Pull Request

Fixes a brief white/resize flash when a tgui window resumes (SOMEHOW IT RETURNED)

`resume()` no longer unhides the BYOND window while it is still at its temporary suspended geometry.
Instead, `Window` now waits for `recallWindowGeometry()` to complete before setting `is-visible`, sending the
existing `visible` message, and emitting `window-geometry-finished`.

On goon we have a thing that reuses similar windows to avoid some of this but some mounting changes upstream here made it visible again downstream so I figured I'd port fixes

## Why It's Good For The Game

Tgui windows resume at their intended position and size without briefly showing a white or resize window flash.

The windows video recorder is locked to 30fps or some shit so it's only very very partially visible here, trust me it looks worse (BEFORE FIX):

https://github.com/user-attachments/assets/c0fee06a-757b-40c8-9006-81a2b442d205

here's the song i was listening to this time:
[<img width="280" alt="image" src="https://github.com/user-attachments/assets/34a918cf-48c9-4557-8590-31e74646bd1d" />](https://open.spotify.com/track/6uOGwSBWgov7b1JFDQREJe?si=87e2446e4a5a4710)

## Changelog
:cl:
fix: Fixed more TGUI window resize/white flashing
/:cl:
