### PR TITLE
Fix stoat fang typo

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/stoat_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/stoat_organs.dm
@@ -132,8 +132,8 @@
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/stoat)
 	AddElement(/datum/element/update_icon_blocker)
 
-/obj/item/organ/fangs/stout
-	desc = "Stout DNA infused into what was once some normal teeth."
+/obj/item/organ/fangs/stoat
+	desc = "Stoat DNA infused into what was once some normal teeth."
 	bite_low = 7
 	bite_high = 7
 	bite_effectiveness = 20


### PR DESCRIPTION

## About The Pull Request
Silly little typo, fangs/stout get defined and then fangs/stoat get the initialize override so both exist but neither work properly
## Why It's Good For The Game
My chompers are not feeling particularly stout today
## Changelog
:cl:
fix: Stoat fangs properly exist
/:cl:
