### PR TITLE
Fixes a runtime when powergaming PKA mods

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -432,7 +432,7 @@
 		if(istype(modkit_upgrade, src))
 			new_recharge_time += modkit_upgrade.modifier
 
-	return new_recharge_time
+	return max(new_recharge_time, 0)
 
 /obj/item/borg/upgrade/modkit/cooldown/install(obj/item/gun/energy/recharge/kinetic_accelerator/KA, mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

When powergaming PKA mods for maximum cooldown, you could get it negative. This clamps it at 0.

## Why It's Good For The Game

<img width="530" height="109" alt="image" src="https://github.com/user-attachments/assets/2bd0a898-f839-4e8a-ac39-5d7c94e82373" />

## Changelog
:cl:
fix: The greed of miners no longer clogs the runtime logs
/:cl:
