### PR TITLE
Fixes firefighting foam immediately burning away in heat and not doing its effects

### DIFF
--- a/code/datums/elements/atmos_sensitive.dm
+++ b/code/datums/elements/atmos_sensitive.dm
@@ -20,7 +20,7 @@
 
 /datum/element/atmos_sensitive/Detach(atom/source)
 	if(source.loc)
-		UnregisterSignal(source.loc, COMSIG_TURF_EXPOSE)
+		source.UnregisterSignal(source.loc, COMSIG_TURF_EXPOSE) // Attach registers this on the atom, not the element
 	UnregisterSignal(source, COMSIG_MOVABLE_MOVED)
 	if(source.flags_1 & ATMOS_IS_PROCESSING_1)
 		source.atmos_end()


### PR DESCRIPTION

## About The Pull Request

Title


## Changelog
:cl: PapaMichael
fix: Firefighting foam no longer immediately burns away in heat without getting a chance to do its firefighting foam effects
/:cl:
