### PR TITLE
ADD: Adding an operational delay before firing for shrink ray pistol 

### DIFF
--- a/_maps/RandomZLevels/heretic.dmm
+++ b/_maps/RandomZLevels/heretic.dmm
@@ -8176,7 +8176,7 @@
 "Qz" = (
 /obj/structure/table,
 /obj/machinery/light/floor,
-/obj/item/gun/energy/shrink_ray/one_shot,
+/obj/item/gun/energy/recharge/shrink_ray/one_shot,
 /turf/open/floor/iron/large,
 /area/awaymission/caves/heretic_laboratory_clean)
 "QA" = (

--- a/_maps/virtual_domains/abductor_ship.dmm
+++ b/_maps/virtual_domains/abductor_ship.dmm
@@ -275,7 +275,7 @@
 	pixel_x = 6;
 	pixel_y = -5
 	},
-/obj/item/gun/energy/shrink_ray{
+/obj/item/gun/energy/recharge/shrink_ray{
 	pixel_x = -5;
 	pixel_y = 7
 	},

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -264,7 +264,7 @@
 	recharge_time = 2 SECONDS
 	recharge_sound = 'sound/items/eshield_recharge.ogg'
 	holds_charge = TRUE
-	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
+	trigger_guard = TRIGGER_GUARD_ALLOW_ALL// variable-size trigger, get it? (abductors need this to be set so the gun is usable for them)
 
 /obj/item/gun/energy/recharge/shrink_ray/suicide_act(mob/living/user)
 	. = ..()

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -261,7 +261,7 @@
 	inhand_icon_state = "shrink_ray"
 	icon_state = "shrink_ray"
 	automatic_charge_overlays = FALSE
-	fire_delay = 3 SECONDS
+	self_charge_amount = 2000
 	selfcharge = 1//shot costs 200 energy, has a max capacity of 1000 for 5 shots. self charge returns 25 energy every couple ticks, so about 1 shot charged every 12~ seconds
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL// variable-size trigger, get it? (abductors need this to be set so the gun is usable for them)
 
@@ -278,6 +278,20 @@
 	// Have to wait until the animate is done
 	sleep(30 SECONDS)
 	user.gib(DROP_ALL_REMAINS)
+
+/obj/item/gun/energy/shrink_ray
+	COOLDOWN_DECLARE(shrink_cooldown)
+
+/obj/item/gun/energy/shrink_ray/can_shoot()
+	if(!COOLDOWN_FINISHED(src, shrink_cooldown))
+		return FALSE
+	return ..()
+
+/obj/item/gun/energy/shrink_ray/shoot_live_shot(mob/living/user, pointblank = FALSE, atom/pbtarget = null, message = TRUE)
+	. = ..()
+	if(.)
+		COOLDOWN_START(src, shrink_cooldown, 2 SECONDS)
+		playsound(src, "sound/items/eshield_recharge.ogg", 30, TRUE)
 
 /obj/item/paper/guides/antag/abductor
 	name = "Dissection Guide"

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -252,7 +252,7 @@
 	inhand_icon_state = "alienpistol"
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 
-/obj/item/gun/energy/shrink_ray
+/obj/item/gun/energy/recharge/shrink_ray
 	name = "shrink ray blaster"
 	desc = "This is a piece of frightening alien tech that enhances the magnetic pull of atoms in a localized space to temporarily make an object shrink. \
 			That or it's just space magic. Either way, it shrinks stuff."
@@ -261,37 +261,24 @@
 	inhand_icon_state = "shrink_ray"
 	icon_state = "shrink_ray"
 	automatic_charge_overlays = FALSE
-	self_charge_amount = 2000
-	selfcharge = 1//shot costs 200 energy, has a max capacity of 1000 for 5 shots. self charge returns 25 energy every couple ticks, so about 1 shot charged every 12~ seconds
-	trigger_guard = TRIGGER_GUARD_ALLOW_ALL// variable-size trigger, get it? (abductors need this to be set so the gun is usable for them)
+	recharge_time = 2 SECONDS
+	recharge_sound = 'sound/items/eshield_recharge.ogg'
+	holds_charge = TRUE
+	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 
-/obj/item/gun/energy/shrink_ray/suicide_act(mob/living/user)
+/obj/item/gun/energy/recharge/shrink_ray/suicide_act(mob/living/user)
 	. = ..()
 	user.visible_message(span_suicide("[user] points [src] at [user.p_their()] head, it looks like [user.p_theyre()] going to commit suicide!"))
 	// we want an animation, so lets manually handle suicide.
 	addtimer(CALLBACK(src, PROC_REF(shrink_death), user), 0)
 	return MANUAL_SUICIDE
 
-/obj/item/gun/energy/shrink_ray/proc/shrink_death(mob/living/user)
-	var/shrink = user.transform.Scale(0.1,0.1)
-	animate(user, 30 SECONDS, transform=shrink)
+/obj/item/gun/energy/recharge/shrink_ray/proc/shrink_death(mob/living/user)
+	var/shrink = user.transform.Scale(0.1, 0.1)
+	animate(user, 30 SECONDS, transform = shrink)
 	// Have to wait until the animate is done
 	sleep(30 SECONDS)
 	user.gib(DROP_ALL_REMAINS)
-
-/obj/item/gun/energy/shrink_ray
-	COOLDOWN_DECLARE(shrink_cooldown)
-
-/obj/item/gun/energy/shrink_ray/can_shoot()
-	if(!COOLDOWN_FINISHED(src, shrink_cooldown))
-		return FALSE
-	return ..()
-
-/obj/item/gun/energy/shrink_ray/shoot_live_shot(mob/living/user, pointblank = FALSE, atom/pbtarget = null, message = TRUE)
-	. = ..()
-	if(.)
-		COOLDOWN_START(src, shrink_cooldown, 2 SECONDS)
-		playsound(src, "sound/items/eshield_recharge.ogg", 30, TRUE)
 
 /obj/item/paper/guides/antag/abductor
 	name = "Dissection Guide"

--- a/code/modules/antagonists/abductor/equipment/orderable_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/orderable_gear.dm
@@ -79,7 +79,7 @@ GLOBAL_LIST_INIT(abductor_gear, subtypesof(/datum/abductor_gear))
 				That or it's just space magic. Either way, it shrinks stuff."
 	id = "shrink_ray"
 	cost = 2
-	build_path = list(/obj/item/gun/energy/shrink_ray = 1)
+	build_path = list(/obj/item/gun/energy/recharge/shrink_ray = 1)
 	category = CATEGORY_ADVANCED_GEAR
 
 /datum/abductor_gear/omnitool

--- a/code/modules/awaymissions/mission_code/heretic/heretic_gateway_guns.dm
+++ b/code/modules/awaymissions/mission_code/heretic/heretic_gateway_guns.dm
@@ -3,6 +3,7 @@
 	desc = "This is a piece of frightening alien tech that enhances the magnetic pull of atoms in a localized space to temporarily make an object shrink. \
 		That or it's just space magic. Either way, it shrinks stuff, This one is jerry-rigged to work with a non alien cell. It still recharges though."
 	ammo_type = list(/obj/item/ammo_casing/energy/shrink/worse)
+	holds_charge = TRUE
 
 /obj/item/ammo_casing/energy/shrink/worse
 	projectile_type = /obj/projectile/magic/shrink/alien

--- a/code/modules/awaymissions/mission_code/heretic/heretic_gateway_guns.dm
+++ b/code/modules/awaymissions/mission_code/heretic/heretic_gateway_guns.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/energy/shrink_ray/one_shot
+/obj/item/gun/energy/recharge/shrink_ray/one_shot
 	name = "shrink ray blaster"
 	desc = "This is a piece of frightening alien tech that enhances the magnetic pull of atoms in a localized space to temporarily make an object shrink. \
 		That or it's just space magic. Either way, it shrinks stuff, This one is jerry-rigged to work with a non alien cell. It still recharges though."

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -677,7 +677,7 @@
 	r_pocket = /obj/item/grenade/gluon
 	l_hand = /obj/item/gun/energy/alien
 	r_hand = /obj/item/gun/energy/alien
-	belt = /obj/item/gun/energy/shrink_ray
+	belt = /obj/item/gun/energy/recharge/shrink_ray
 
 /datum/outfit/deathmatch_loadout/battler/clown/upgraded
 	name = "Deathmatch: Clown (Syndicate Gear)"

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -73,7 +73,7 @@
 /obj/item/ammo_casing/energy/shrink
 	projectile_type = /obj/projectile/magic/shrink/alien
 	select_name = "shrink ray"
-	e_cost = LASER_SHOTS(5, STANDARD_CELL_CHARGE)
+	e_cost = LASER_SHOTS(3, STANDARD_CELL_CHARGE)
 
 /obj/item/ammo_casing/energy/marksman
 	projectile_type = /obj/projectile/bullet/marksman

--- a/code/modules/research/techweb/nodes/alien_nodes.dm
+++ b/code/modules/research/techweb/nodes/alien_nodes.dm
@@ -18,7 +18,7 @@
 		/obj/item/circular_saw/alien,
 		/obj/item/crowbar/abductor,
 		/obj/item/gun/energy/alien,
-		/obj/item/gun/energy/shrink_ray,
+		/obj/item/gun/energy/recharge/shrink_ray,
 		/obj/item/hemostat/alien,
 		/obj/item/melee/baton/abductor,
 		/obj/item/multitool/abductor,
@@ -53,7 +53,7 @@
 	)
 	required_items_to_unlock = list(
 		/obj/item/crowbar/abductor,
-		/obj/item/gun/energy/shrink_ray,
+		/obj/item/gun/energy/recharge/shrink_ray,
 		/obj/item/melee/baton/abductor,
 		/obj/item/multitool/abductor,
 		/obj/item/screwdriver/abductor,
@@ -86,7 +86,7 @@
 		/obj/item/circular_saw/alien,
 		/obj/item/crowbar/abductor,
 		/obj/item/gun/energy/alien,
-		/obj/item/gun/energy/shrink_ray,
+		/obj/item/gun/energy/recharge/shrink_ray,
 		/obj/item/hemostat/alien,
 		/obj/item/melee/baton/abductor,
 		/obj/item/multitool/abductor,


### PR DESCRIPTION

## About The Pull Request

Adds a functional firing delay to the Abductor "Shrink Ray" pistol, replacing the non-functional ````firing_delay````.

## Why It's Good For The Game

It makes the Abductor weapon more skill-dependent to fire (which was apparently the intention, given the existence of a non-functional cooldown option) and prevents it from being spammed.

## Changelog

:cl:
add: Adds a functional firing delay to the Abductor "Shrink Ray" pistol
/:cl:
