### PR TITLE
Atmos mix tank output starts disabled

### DIFF
--- a/code/game/machinery/computer/atmos_computers/outlets.dm
+++ b/code/game/machinery/computer/atmos_computers/outlets.dm
@@ -18,6 +18,7 @@
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/mix_output
 	name = "mix tank output inlet"
+	on = FALSE
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrous_output
 	name = "nitrous oxide tank output inlet"


### PR DESCRIPTION
## About The Pull Request

Mix tank outlet vent pump defaults to disabled

## Why It's Good For The Game

Mix tank does two things

1. Acts as a collection for unsorted waste gases 
(So why would it immediately spit out the unsorted waste gases back into the network?)

or

2. Acts as a place to mix things
(So why would you want the mix chamber to default to spitting your mix out before it can mix?)

## Changelog

:cl: Melbert
qol: Atmos mix tank output starts disabled.
/:cl:

