### PR TITLE
ADD: Moving projectiles between Z-levels

### DIFF
--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -88,7 +88,6 @@
 	var/direct_target
 	if(target && curloc.Adjacent(targloc, target=targloc, mover=src)) //if the target is right on our location or adjacent (including diagonally if reachable) we'll skip the travelling code in the proj's fire()
 		direct_target = target
-	// BANDASTATION EDIT START: Validate Z-level transition
 	var/atom/projectile_source = tk_firing(user, fired_from) ? fired_from : user
 	if(target && projectile_source)
 		var/turf/source_turf = get_turf(projectile_source)
@@ -96,7 +95,6 @@
 		if(source_turf && target_turf && source_turf.z != target_turf.z)
 			if(!loaded_projectile.is_valid_z_transition(source_turf, target_turf))
 				return null
-	// BANDASTATION EDIT END
 	loaded_projectile.aim_projectile(target, tk_firing(user, fired_from) ? fired_from : user, params2list(params), spread)
 	var/obj/projectile/loaded_projectile_cache = loaded_projectile
 	loaded_projectile = null

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -80,16 +80,23 @@
 	var/turf/curloc = get_turf(fired_from)
 	if (!istype(targloc) || !istype(curloc) || !loaded_projectile)
 		return null
-
 	var/firing_dir
 	if(loaded_projectile.firer)
 		firing_dir = get_dir(fired_from, target)
 	if(!loaded_projectile.suppressed && firing_effect_type && !tk_firing(user, fired_from))
 		new firing_effect_type(user || get_turf(src), firing_dir)
-
 	var/direct_target
 	if(target && curloc.Adjacent(targloc, target=targloc, mover=src)) //if the target is right on our location or adjacent (including diagonally if reachable) we'll skip the travelling code in the proj's fire()
 		direct_target = target
+	// BANDASTATION EDIT START: Validate Z-level transition
+	var/atom/projectile_source = tk_firing(user, fired_from) ? fired_from : user
+	if(target && projectile_source)
+		var/turf/source_turf = get_turf(projectile_source)
+		var/turf/target_turf = get_turf(target)
+		if(source_turf && target_turf && source_turf.z != target_turf.z)
+			if(!loaded_projectile.is_valid_z_transition(source_turf, target_turf))
+				return null
+	// BANDASTATION EDIT END
 	loaded_projectile.aim_projectile(target, tk_firing(user, fired_from) ? fired_from : user, params2list(params), spread)
 	var/obj/projectile/loaded_projectile_cache = loaded_projectile
 	loaded_projectile = null

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1,4 +1,3 @@
-
 /// Not actually hitscan but close as we get without actual hitscan.
 #define MOVES_HITSCAN -1
 /// How many pixels to move the muzzle flash up so your character doesn't look like they're shitting out lasers.
@@ -272,6 +271,13 @@
 	/// If true directly targeted turfs can be hit
 	var/can_hit_turfs = FALSE
 
+	//BANDASTATION EDIT START: transitions between Z-levels
+	var/cross_z = FALSE
+	var/cross_z_up = FALSE
+	var/cross_z_target = 0
+	var/turf/cross_z_landing_turf
+	//BANDASTATION EDIT END
+
 /obj/projectile/Initialize(mapload)
 	. = ..()
 	maximum_range = range
@@ -396,6 +402,7 @@
 		reagent_note = "REAGENTS: [pretty_string_from_reagent_list(reagents.reagent_list)]"
 
 	if(ismob(firer) && !do_not_log)
+
 		log_combat(firer, living_target, "shot", src, reagent_note)
 		return BULLET_ACT_HIT
 
@@ -997,6 +1004,13 @@
 			// Move to the next tile
 			step_towards(src, new_turf)
 			SEND_SIGNAL(src, COMSIG_PROJECTILE_MOVE_PROCESS_STEP)
+
+			// BANDASTATION EDIT START: Transitions between Z-levels
+			if(try_cross_z_level())
+				new_turf = loc
+			if(try_cross_z_level_up())
+				new_turf = loc
+			// BANDASTATION EDIT END
 			// We hit something and got deleted, stop the loop
 			if (QDELETED(src))
 				return movements_done
@@ -1255,6 +1269,25 @@
 	pixel_y = source.pixel_y - source.base_pixel_y
 	original = target
 
+	// BANDASTATION EDIT START: Z-level transitions
+	if(target_loc && target_loc.z != source_loc.z)
+		cross_z_landing_turf = target_loc
+		// Lower Z -> Upper Z
+		if(target_loc.z > source_loc.z)
+			var/turf/upper_turf = locate(source_loc.x, source_loc.y, target_loc.z)
+			if(istype(upper_turf))
+				forceMove(upper_turf)
+				source_loc = upper_turf
+				starting = upper_turf
+				cross_z_up = TRUE
+		// Upper Z -> Lower Z
+		else
+			var/turf/cross_check_turf = locate(target_loc.x, target_loc.y, source_loc.z)
+			if(istype(cross_check_turf) && is_valid_cross_z_target(cross_check_turf))
+				cross_z = TRUE
+				cross_z_target = target_loc.z
+	// BANDASTATION EDIT END
+
 	// Trim off excess pixel_x/y by converting them into turf offset
 	if (abs(pixel_x) > ICON_SIZE_X / 2)
 		for (var/i in 1 to floor(abs(pixel_x) + ICON_SIZE_X / 2) / ICON_SIZE_X)
@@ -1428,3 +1461,95 @@
 		new_embed = new new_embed()
 
 	embed_data = new_embed
+
+//BANDASTATION EDIT START: Transitions between Z-levels
+/obj/projectile/proc/is_valid_cross_z_target(turf/T)
+	if(!T)
+		return FALSE
+	if(isopenspaceturf(T))
+		return TRUE
+	for(var/direction in GLOB.cardinals)
+		var/turf/check_turf = get_step(T, direction)
+		if(isopenspaceturf(check_turf))
+			return TRUE
+	return FALSE
+
+/obj/projectile/proc/try_cross_z_level()
+	if(!cross_z || !cross_z_target)
+		return FALSE
+	if(!isturf(loc))
+		return FALSE
+	if(!isopenspaceturf(loc))
+		return FALSE
+	var/turf/target_turf = cross_z_landing_turf
+	if(!target_turf)
+		return FALSE
+	if(abs(loc.x - target_turf.x) > 1 || abs(loc.y - target_turf.y) > 1)
+		return FALSE
+	var/turf/lower_turf = locate(target_turf.x, target_turf.y, cross_z_target)
+	if(!istype(lower_turf))
+		return FALSE
+	if(lower_turf == loc)
+		return FALSE
+	forceMove(lower_turf)
+	cross_z = FALSE
+	cross_z_target = 0
+	if(isliving(original) && get_turf(original) == lower_turf)
+		to_chat(original, span_userdanger("По вам ведут огонь сверху!"))
+		impact(original)
+	else
+		impact(lower_turf)
+	cross_z_landing_turf = null
+	return TRUE
+
+/obj/projectile/proc/try_cross_z_level_up()
+	if(!cross_z_up)
+		return FALSE
+	if(!isturf(loc))
+		return FALSE
+	var/turf/target_turf = cross_z_landing_turf
+	if(!target_turf)
+		return FALSE
+	if(get_dist(loc, target_turf) > 1)
+		return FALSE
+	if(isliving(original) && get_turf(original) == target_turf)
+		impact(original)
+	else
+		impact(target_turf)
+	cross_z_up = FALSE
+	cross_z_landing_turf = null
+	return TRUE
+
+/obj/projectile/proc/is_near_z_open_space(turf/T)
+	if(!T)
+		return FALSE
+	if(isopenspaceturf(T))
+		return TRUE
+	for(var/direction in GLOB.cardinals)
+		var/turf/check_turf = get_step(T, direction)
+		if(isopenspaceturf(check_turf))
+			return TRUE
+	return FALSE
+
+/obj/projectile/proc/is_valid_z_transition(turf/source_turf, turf/target_turf)
+	if(!source_turf || !target_turf)
+		return FALSE
+	if(source_turf.z == target_turf.z)
+		return TRUE
+	if(source_turf.z < target_turf.z)
+		var/turf/source_upper = locate(source_turf.x, source_turf.y, target_turf.z)
+		if(!istype(source_upper))
+			return FALSE
+		if(!is_near_z_open_space(source_upper))
+			return FALSE
+		if(!is_near_z_open_space(target_turf))
+			return FALSE
+		return TRUE
+	if(!is_near_z_open_space(source_turf))
+		return FALSE
+	var/turf/target_upper = locate(target_turf.x, target_turf.y, source_turf.z)
+	if(!istype(target_upper))
+		return FALSE
+	if(!is_near_z_open_space(target_upper))
+		return FALSE
+	return TRUE //BANDASTATION EDIT END

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1489,7 +1489,7 @@
 	cross_z = FALSE
 	cross_z_target = 0
 	if(isliving(original) && get_turf(original) == lower_turf)
-		to_chat(original, span_userdanger("По вам ведут огонь сверху!"))
+		to_chat(original, span_userdanger("You are under fire from above!"))
 		impact(original)
 	else
 		impact(lower_turf)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -271,12 +271,10 @@
 	/// If true directly targeted turfs can be hit
 	var/can_hit_turfs = FALSE
 
-	//BANDASTATION EDIT START: transitions between Z-levels
 	var/cross_z = FALSE
 	var/cross_z_up = FALSE
 	var/cross_z_target = 0
 	var/turf/cross_z_landing_turf
-	//BANDASTATION EDIT END
 
 /obj/projectile/Initialize(mapload)
 	. = ..()
@@ -1005,12 +1003,11 @@
 			step_towards(src, new_turf)
 			SEND_SIGNAL(src, COMSIG_PROJECTILE_MOVE_PROCESS_STEP)
 
-			// BANDASTATION EDIT START: Transitions between Z-levels
 			if(try_cross_z_level())
 				new_turf = loc
 			if(try_cross_z_level_up())
 				new_turf = loc
-			// BANDASTATION EDIT END
+
 			// We hit something and got deleted, stop the loop
 			if (QDELETED(src))
 				return movements_done
@@ -1269,7 +1266,6 @@
 	pixel_y = source.pixel_y - source.base_pixel_y
 	original = target
 
-	// BANDASTATION EDIT START: Z-level transitions
 	if(target_loc && target_loc.z != source_loc.z)
 		cross_z_landing_turf = target_loc
 		// Lower Z -> Upper Z
@@ -1286,7 +1282,6 @@
 			if(istype(cross_check_turf) && is_valid_cross_z_target(cross_check_turf))
 				cross_z = TRUE
 				cross_z_target = target_loc.z
-	// BANDASTATION EDIT END
 
 	// Trim off excess pixel_x/y by converting them into turf offset
 	if (abs(pixel_x) > ICON_SIZE_X / 2)
@@ -1462,7 +1457,6 @@
 
 	embed_data = new_embed
 
-//BANDASTATION EDIT START: Transitions between Z-levels
 /obj/projectile/proc/is_valid_cross_z_target(turf/T)
 	if(!T)
 		return FALSE
@@ -1552,4 +1546,4 @@
 		return FALSE
 	if(!is_near_z_open_space(target_upper))
 		return FALSE
-	return TRUE //BANDASTATION EDIT END
+	return TRUE


### PR DESCRIPTION

## About The Pull Request

Added the ability to fire between Z-levels in open-space observation areas. Projectile behavior regarding Z-levels is now subject to several considerations:

- When firing from above to below, the projectile travels through ````open space```` only immediately before making contact with the target below.
- When firing from below to above, the projectile appears instantly on the upper Z-level upon firing at a valid, visible target while viewing the upper floor.

**A shot is fired only (!)** when the target or the shooter is located either on the tile immediately adjacent to the ````open space```` or on the open space tile itself. If the target is not present in either case, the projectile impacts the floor instead of continuing its movement along the new Z-level.

<img width="739" height="747" alt="демонстрация" src="https://github.com/user-attachments/assets/3292b025-92a2-4771-8e63-e20b08e5977c" />

<img width="322" height="133" alt="после" src="https://github.com/user-attachments/assets/74af04da-d38e-4846-bec1-41c3014dccb2" />


## Why It's Good For The Game

It seemed quite illogical that you couldn't shoot at visible targets below or above you, yet could still drop various objects from the upper floors. This should add significant tactical variety to "Nuke Squad" modes and various combat events. Just how much it will affect the balance of standard rounds, however, remains a good question.

## Changelog

:cl:
add: Added the ability to fire and have projectiles travel between Z-levels. Firing at a target across levels is only possible when positioned on a tile adjacent to or directly upon an open space.
/:cl:

