### PR TITLE
Command bar now stores your last mode

### DIFF
--- a/tgui/packages/tgui-panel/verbs/CommandBar.tsx
+++ b/tgui/packages/tgui-panel/verbs/CommandBar.tsx
@@ -1,3 +1,4 @@
+import { storage } from 'common/storage';
 import {
   filterTypepaths,
   isEntityArg,
@@ -215,6 +216,14 @@ export function CommandBar() {
   const isCurrentArgList = currentArg ? isListArg(currentArg) : false;
 
   useEffect(() => {
+    const loadStoredValues = async () => {
+      const storedMode = await storage.get('tgui-commandbar-mode');
+      if (storedMode !== undefined) setMode(storedMode);
+    };
+    loadStoredValues();
+  }, []);
+
+  useEffect(() => {
     Byond.sendMessage('verbs/request_verbs');
   }, []);
 
@@ -292,6 +301,7 @@ export function CommandBar() {
     } else {
       enterChatMode(nextMode);
     }
+    storage.set('tgui-commandbar-mode', nextMode);
     inputRef.current?.focus();
   };
 


### PR DESCRIPTION
## About The Pull Request

If you're not a command bar user for everything then you tend to want to keep your command bar on one mode. At least, this was able to be done in the past with ``saved-params``. This is bringing back that old behavior by saving the last mode you've swapped to and making it persistent.

## Why It's Good For The Game

Old functionality restored to the new command bar.

## Changelog

:cl:
qol: Command bar's last used mode is now persistent between rounds.
/:cl: