### PR TITLE
buff the truestrike

### DIFF
--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -58,14 +58,14 @@
 
 /obj/projectile/bullet/c38/match/true
 	name = ".38 True Strike bullet"
-	damage = 15
-	ricochet_auto_aim_range = 3
+	damage = 20
+	ricochet_auto_aim_range = 4
 	ricochet_auto_aim_angle = 100
 	ricochet_incidence_leeway = 0
 	ricochet_shoots_firer = FALSE
 	shrapnel_type = null
 	embed_type = null
-	armour_penetration = 30
+	armour_penetration = 35
 
 // premium .38 ammo from cargo, weak against armor, lower base damage, but excellent at embedding and causing slice wounds at close range
 /obj/projectile/bullet/c38/dumdum


### PR DESCRIPTION

## About The Pull Request
20 damage for 35 AP instead of 15 damage for 30 AP. Also increase the bouncing aim range to 4
## Why It's Good For The Game

15 damage for 30 AP was extremely underwhelming for something that used bluespace crystal and need exotic ammo tech. Even if that isn't necessarily the rarest thing in the world. It seems like a pretty strange commitment to make when you can just shoot at a guy until he dies with the regular ammo  which are not that expensive, plus flare shot (basically the defacto laser .38 anyway) does 20 damage and is pretty epic
## Changelog
:cl:
balance: .38 Truestrike now does 20 damage and has better AP.
/:cl:
