### PR TITLE
Windows hint that they can be reinforced via crowbar

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -97,7 +97,7 @@
 			. += span_notice("The window is <i>unscrewed</i> but <b>pried</b> into the frame.")
 		if(WINDOW_OUT_OF_FRAME)
 			if (anchored)
-				. += span_notice("The window is <b>screwed</b> to the floor.")
+				. += span_notice("The window is <b>screwed</b> to the floor. It can be <b>pried</b> into a more secure position.")
 			else
 				. += span_notice("The window is <i>unscrewed</i> from the floor, and could be deconstructed by <b>wrenching</b>.")
 
@@ -942,6 +942,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/titanium/spawner, 0
 
 /obj/structure/window/reinforced/survival_pod/unanchored
 	anchored = FALSE
+	state = WINDOW_OUT_OF_FRAME
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/survival_pod/spawner, 0)
 


### PR DESCRIPTION
## About The Pull Request

Nothing says you can use a crowbar to move a reinforced window from secured to needs to be heated with a welder in order to be deconstructed. Also I fixed a bug I found while testing.

## Why It's Good For The Game

It confused the heck out of me as a new player

## Changelog

:cl:
qol: reinforced windows hint that they can be secured on examine
fix: plastitanium windows are in the correct state once constructed
/:cl: