### PR TITLE
Deathsquad thermal vision moved to their organs

### DIFF
--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -444,7 +444,6 @@
 	)
 	belt = /obj/item/gun/ballistic/revolver/mateba
 	ears = /obj/item/radio/headset/headset_cent/alt
-	glasses = /obj/item/clothing/glasses/hud/toggle/thermal
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	shoes = /obj/item/clothing/shoes/combat/swat

--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -51,7 +51,7 @@
 	var/obj/effect/abstract/eyelid_effect/eyelid_left
 	var/obj/effect/abstract/eyelid_effect/eyelid_right
 
-	/// Glasses cannot be worn over these eyes. Currently unused
+	/// Glasses cannot be worn over these eyes.
 	var/no_glasses = FALSE
 	/// Native FOV that will be applied if a config is enabled
 	var/native_fov = FOV_90_DEGREES

--- a/code/modules/surgery/organs/internal/eyes/eyes_augments.dm
+++ b/code/modules/surgery/organs/internal/eyes/eyes_augments.dm
@@ -962,7 +962,7 @@
 		return
 
 	if(get_iff_signature(target) == IFF_FRIENDLY)
-		examine_overrides[EXAMINE_OVERRIDE_PRIORITY_IFF] = span_notice("Centcom personnel. Do not attack.")
+		examine_overrides[EXAMINE_OVERRIDE_PRIORITY_IFF] = span_notice("CentCom personnel. Do not attack.")
 	else
 		examine_overrides[EXAMINE_OVERRIDE_PRIORITY_IFF] = span_boldwarning("KILL KILL KILL KILL KILL KILL!!!")
 

--- a/code/modules/surgery/organs/internal/eyes/eyes_augments.dm
+++ b/code/modules/surgery/organs/internal/eyes/eyes_augments.dm
@@ -509,7 +509,7 @@
 #define IFF_FACTION_EVERYONE "Non-Allies"
 
 /obj/item/organ/eyes/robotic/tacvisor
-	name = "tactical EFF visor"
+	name = "tactical IFF visor"
 	desc = "A failed attempt at integrating IFF systems directly into soldiers' prefrontal cortex, this complex sensor array has proved to be impractical as the additional load impared the user's ability to recognize people's appearances or voices. The screen is there just for intimidation."
 	icon_state = "eyes_tacvisor"
 	eye_icon_state = "eyes_tacvisor"
@@ -949,10 +949,22 @@
 	), COLORSPACE_HSL)
 
 /obj/item/organ/eyes/robotic/tacvisor/deathsquad
+	name = "Deathsquad IFF Visor"
 	friendly_faction = IFF_FACTION_CENTCOM
 	hostile_faction = IFF_FACTION_EVERYONE
 	actions_types = null
 	user_controls = FALSE
+	organ_traits = list(TRAIT_THERMAL_VISION)
+
+/obj/item/organ/eyes/robotic/tacvisor/deathsquad/on_examine(mob/source, atom/target, list/examine_strings, list/examine_overrides)
+
+	if (target == owner || !iscarbon(target) && !(isliving(target) && (obj_flags & EMAGGED)))
+		return
+
+	if(get_iff_signature(target) == IFF_FRIENDLY)
+		examine_overrides[EXAMINE_OVERRIDE_PRIORITY_IFF] = span_warning("Centcom personnel. Do not attack.")
+	else
+		examine_overrides[EXAMINE_OVERRIDE_PRIORITY_IFF] = span_boldwarning("KILL KILL KILL KILL KILL KILL!!!")
 
 /obj/item/organ/eyes/robotic/tacvisor/deathsquad/ui_status(mob/user, datum/ui_state/state)
 	return UI_CLOSE

--- a/code/modules/surgery/organs/internal/eyes/eyes_augments.dm
+++ b/code/modules/surgery/organs/internal/eyes/eyes_augments.dm
@@ -962,7 +962,7 @@
 		return
 
 	if(get_iff_signature(target) == IFF_FRIENDLY)
-		examine_overrides[EXAMINE_OVERRIDE_PRIORITY_IFF] = span_warning("Centcom personnel. Do not attack.")
+		examine_overrides[EXAMINE_OVERRIDE_PRIORITY_IFF] = span_notice("Centcom personnel. Do not attack.")
 	else
 		examine_overrides[EXAMINE_OVERRIDE_PRIORITY_IFF] = span_boldwarning("KILL KILL KILL KILL KILL KILL!!!")
 


### PR DESCRIPTION
## About The Pull Request

IFF visors block your eyes, and deathsquads wear thermal goggles. This fixes that issue by adding thermal vision to the deathsquad IFF eyes. Also renames EFF visors to IFF visors and removes a code comment saying that eyes blocking glasses was unused, because it isn't anymore. Also removes security scanning from deathsquad eyes since they don't really care about that stuff at all. Instead, they get a helpful little line of text telling them what to do when they see someone that isn't centcom personnel.

## Why It's Good For The Game

bugfix

## Changelog

:cl:
fix: moves deathsquad thermal vision to their IFF visors
spellcheck: tactical EFF visors are now called IFF visors.
qol: deathsquaddies can no longer check security records with their eyes
/:cl:
