### PR TITLE
buffs plasma cutter

### DIFF
--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -1,7 +1,7 @@
 /obj/projectile/plasma
 	name = "plasma blast"
 	icon_state = "plasmacutter"
-	damage_type = BURN
+	damage_type = BRUTE
 	armor_flag = ENERGY
 	damage = 5
 	range = 3
@@ -28,8 +28,10 @@
 
 /obj/projectile/plasma/adv
 	damage = 7
-	range = 4
-	mine_range = 6
+	range = 10
+	mine_range = 0
+	dismemberment = 25
+	wound_bonus = 8
 
 /obj/projectile/plasma/adv/mech
 	damage = 10


### PR DESCRIPTION
plasma beams now brute damaging BECAUSE if they dont cut how they cut?
advanced plasma cutter now has range of 10, not 4, but mining range is now 0, which if you mining changes NOTHING, plasma cutter (advanced) rips limb in 4 shots instead of 5, advanced plasma cutter now has 8 wound bonus, which means 15 wound power on hit

## DEAD SPACE

:cl: 
balance: plasma cutters beams now deal brute
balance: advanced plasma cutter now has 10 range but its range dont change when mining
balance: advanced plasma cutter cuts limb off in 4 shots instead of 5
balance: advanced plasma cutter has wound bonus of 8, which means that wound power is 15
/:cl: