### PR TITLE
Malf AI UI now shows hacked APC count

### DIFF
--- a/tgui/packages/tgui/interfaces/MalfunctionModulePicker.tsx
+++ b/tgui/packages/tgui/interfaces/MalfunctionModulePicker.tsx
@@ -1,15 +1,17 @@
+import { Box, Icon, Section, Stack } from 'tgui-core/components';
+
 import { Window } from '../layouts';
 import { useBackend } from '../backend';
 import { GenericUplink, type Item } from './Uplink/GenericUplink';
 
 type MalfModuleData = {
-  name: string,
-  icon: string,
-  icon_state: string,
-  cost: number,
-  desc: string,
-  category: string,
-  minimumApcs: number,
+  name: string;
+  icon: string;
+  icon_state: string;
+  cost: number;
+  desc: string;
+  category: string;
+  minimumApcs: number;
 };
 
 type Data = {
@@ -38,17 +40,32 @@ export function MalfunctionModulePicker(props) {
     icon_state: module.icon_state,
     population_tooltip: '',
     insufficient_population: false,
-  }))
+  }));
 
   return (
-    <Window width={620} height={525} theme='malfunction'>
+    <Window width={620} height={525} theme="malfunction">
       <Window.Content>
-        <GenericUplink
-          categories={categories}
-          items={items}
-          currency={`${processingTime} PT`}
-          handleBuy={(item) => act('buy', { name: item.name })}
-        />
+        <Stack vertical fill>
+          <Stack.Item>
+            <Section>
+              <Icon name="terminal" mr={1} />
+              <Box inline bold>
+                Hacked APCs:
+              </Box>
+              <Box inline ml={1}>
+                {hackedAPCs}
+              </Box>
+            </Section>
+          </Stack.Item>
+          <Stack.Item grow>
+            <GenericUplink
+              categories={categories}
+              items={items}
+              currency={`${processingTime} PT`}
+              handleBuy={(item) => act('buy', { name: item.name })}
+            />
+          </Stack.Item>
+        </Stack>
       </Window.Content>
     </Window>
   );


### PR DESCRIPTION

## About The Pull Request

DM was already sending this to tgui but it was never rendered, so this is probably just an oversight

## Why It's Good For The Game

You need 10 APCs to delta and counting to 10 is very hard

## Changelog
:cl: PapaMichael
qol: The AI Malfunction UI now shows the number of currently hacked APCs
/:cl:
