### PR TITLE
Fixes a bug where chat wouldn't scroll all the way and you'd have to constantly manually scroll

### DIFF
--- a/tgui/packages/tgui-panel/chat/renderer.tsx
+++ b/tgui/packages/tgui-panel/chat/renderer.tsx
@@ -548,6 +548,8 @@ class ChatRenderer {
 
           const reactRoot = createRoot(childNode);
 
+          // `flushSync()` because of a chat scroll issue where whether or not
+          // the line wraps was being decided before the name loaded
           flushSync(() => {
             reactRoot.render(
               <Element {...outputProps}>

--- a/tgui/packages/tgui-panel/chat/renderer.tsx
+++ b/tgui/packages/tgui-panel/chat/renderer.tsx
@@ -4,6 +4,7 @@
  * @license MIT
  */
 
+import { flushSync } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { createLogger } from 'tgui/logging';
 import { Tooltip } from 'tgui-core/components';
@@ -129,8 +130,8 @@ function isRadioChannelName(node: Text): boolean {
   const match = RADIO_CHANNEL_LABEL.exec(text);
   return Boolean(
     node.parentElement?.classList.contains('name') &&
-      match &&
-      match[0].length === text.length,
+    match &&
+    match[0].length === text.length,
   );
 }
 
@@ -547,11 +548,13 @@ class ChatRenderer {
 
           const reactRoot = createRoot(childNode);
 
-          reactRoot.render(
-            <Element {...outputProps}>
-              <span dangerouslySetInnerHTML={oldHtml} />
-            </Element>,
-          );
+          flushSync(() => {
+            reactRoot.render(
+              <Element {...outputProps}>
+                <span dangerouslySetInnerHTML={oldHtml} />
+              </Element>,
+            );
+          });
         }
 
         // Highlight text


### PR DESCRIPTION

## About The Pull Request

https://github.com/tgstation/tgstation/pull/97613 Introduced a bug where the chat wouldn't scroll down all the way, requiring you to manually scroll, specifically on chat messages that wouldn't wrap without the name, but would wrap with the name. So lets use the magic React function to fix this

## Changelog
:cl: PapaMichael
fix: Chat should scroll properly on some messages that wrap now.
/:cl:
