### PR TITLE
Removes spear breaking

### DIFF
--- a/code/game/objects/items/weaponry/melee/spear.dm
+++ b/code/game/objects/items/weaponry/melee/spear.dm
@@ -34,10 +34,6 @@
 	var/force_unwielded = 10
 	/// How much damage to do wielded
 	var/force_wielded = 18
-	/// Whether or not hitting with this spear causes damage to the spear itself
-	var/improvised_construction = TRUE
-	/// What is left over when a spear breaks
-	var/spear_leftovers = /obj/item/stack/rods
 	/// What pike do we construct if someone kills themselves with us?
 	var/pike_type = /obj/structure/headpike
 
@@ -111,7 +107,6 @@
 /obj/item/spear/on_craft_completion(list/components, datum/crafting_recipe/current_recipe, atom/crafter)
 	var/obj/item/stack/rods/rod = locate() in components
 	if (rod)
-		spear_leftovers = rod.type
 		set_material_slot(/datum/material_slot/handle/spear, rod.get_master_material())
 
 	var/obj/item/shard/tip = locate() in components
@@ -175,24 +170,6 @@
 	if (!tip_material)
 		return ..()
 	return custom_materials[tip_material] ? tip_material : ..()
-
-/obj/item/spear/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
-	if(improvised_construction && !QDELETED(src))
-		take_damage(force / 2, sound_effect = FALSE)
-
-/obj/item/spear/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-	. = ..()
-	if (.) //spear was caught
-		return
-	if(improvised_construction && !QDELETED(src))
-		take_damage(throwforce / 2, sound_effect = FALSE)
-
-/obj/item/spear/atom_destruction(damage_flag)
-	playsound(src, 'sound/effects/grillehit.ogg', 50)
-	new spear_leftovers(get_turf(src))
-	if(isliving(loc))
-		loc.balloon_alert(loc, "spear broken!")
-	return ..()
 
 /obj/item/spear/get_material_prefixes(list/materials)
 	var/datum/material/material = get_material_from_slot(/datum/material_slot/weapon_head/speartip)
@@ -388,7 +365,6 @@
 	attack_verb_simple = list("gore")
 	force_unwielded = 15
 	force_wielded = 25
-	improvised_construction = FALSE
 
 /obj/item/spear/grey_tide/afterattack(atom/movable/target, mob/living/user, list/modifiers, list/attack_modifiers)
 	user.add_ally("greytide([REF(user)])")
@@ -417,7 +393,6 @@
 	throw_range = 9
 	throw_speed = 5
 	sharpness = NONE // we break bones instead of cutting flesh
-	improvised_construction = FALSE
 	pike_type = /obj/structure/headpike/military
 
 /obj/item/spear/military/add_headpike_component()
@@ -453,7 +428,6 @@
 	force_unwielded = 13
 	force_wielded = 21
 	armour_penetration = 15
-	improvised_construction = FALSE
 	custom_materials =  list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 42,
 		/datum/material/alloy/plasteel = SHEET_MATERIAL_AMOUNT * 15,
@@ -511,7 +485,6 @@
 	material_slots = list(/datum/material_slot/weapon_head/speartip = /datum/material/bone, /datum/material_slot/handle/spear = /datum/material/bone)
 	force_unwielded = 12
 	force_wielded = 20
-	spear_leftovers = /obj/item/stack/sheet/bone
 	pike_type = /obj/structure/headpike/bone
 
 /obj/item/spear/bonespear/add_headpike_component()
@@ -535,7 +508,6 @@
 	throwforce = 23	//Better to throw
 	custom_materials = list(/datum/material/bamboo = SHEET_MATERIAL_AMOUNT * 25)
 	material_slots = list(/datum/material_slot/weapon_head/speartip = /datum/material/bamboo, /datum/material_slot/handle/spear = /datum/material/bamboo)
-	spear_leftovers = /obj/item/stack/sheet/mineral/bamboo
 	pike_type = /obj/structure/headpike/bamboo
 
 /obj/item/spear/bamboospear/add_headpike_component()
@@ -569,7 +541,6 @@
 	material_slots = list(/datum/material_slot/weapon_head/speartip = /datum/material/diamond, /datum/material_slot/handle/spear = /datum/material/alloy/plastitaniumglass)
 	action_slots = ITEM_SLOT_HANDS
 	actions_types = list(/datum/action/item_action/skybulge)
-	improvised_construction = FALSE
 
 ///The action button the spear gives, usable once a minute.
 /datum/action/item_action/skybulge


### PR DESCRIPTION

## About The Pull Request

Entirely removes spear breaking mechanics.

## Why It's Good For The Game

Wasn't really as good a limitation as I thought, and mostly just pissed people off. People don't actually use spears against people as much as you'd think, which is a shame. Hell, people don't even use it for the reach. They should, but I can't make people use it. One for the folk in the know I guess.

But as a consequence, this predominantly hurt their functionality when used to break objects. And people more often used them to break objects. (ignore that it has a demolish malice, people do not see the numbers). Which usually has more integrity than a single spear.

So generally speaking, giving spears 'pseudo-ammo' was mostly just a colossal pain in the ass for their most common use, and may have also just actively discouraged their use as weapons further.

## Changelog
:cl:
balance: Spears no longer break from overuse without repair.
/:cl:
