### PR TITLE
fix orbit menu crashing if a borg's `mind.assigned_role.tgui_icon` is null

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -228,7 +228,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 		return serialized
 
 	serialized["mind_job"] = job.title
-	serialized["mind_job_icon"] = job.tgui_icon
+	serialized["mind_job_icon"] = job.tgui_icon || FA_ICON_QUESTION
 	var/datum/outfit/outfit = job.get_outfit()
 	if (isnull(outfit))
 		return serialized


### PR DESCRIPTION
## About The Pull Request

if a borg's `mind.assigned_role.tgui_icon` is null, `mind_job_icon` gets passed to ui data as null, and the tgui `<Icon>` freaks out because it was passed null instead of an icon name, and shits itself trying to actually check the icon name.

so this just makes it so that if there's no `tgui_icon`, it defaults to a question mark. simple as that.

## Changelog
:cl:
fix: Fixed the existence of borgs sometimes causing the orbit menu to crash.
/:cl:
