### PR TITLE
Adds organ wounds

### DIFF
--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -45,6 +45,8 @@
 #define ORGAN_UNUSABLE (1<<16)
 /// Used for organs that aren't really real organs, but holders for stuff and whatnot
 #define ORGAN_FAKE (1<<17)
+/// Used for organs that have been wounded
+#define ORGAN_WOUNDED (1<<18)
 
 /// Organ flags that correspond to bodytypes
 #define ORGAN_TYPE_FLAGS (ORGAN_ORGANIC | ORGAN_ROBOTIC | ORGAN_MINERAL | ORGAN_GHOST)

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -301,21 +301,19 @@
 			//assess heart
 			if(body_part == BODY_ZONE_CHEST)//if we're listening to the chest
 				if(isnull(heart) || !heart.is_beating() || carbon_patient.stat == DEAD)
-					render_list += "<span class='danger ml-1'>You don't hear a heartbeat!</span>\n"//they're dead or their heart isn't beating
+					render_list += span_danger_ml("You don't hear a heartbeat\n")//they're dead or their heart isn't beating
 					heart_noises = FALSE
 				else if(having_heart_attack)
 					if(heart.organ_flags & ORGAN_WOUNDED)
-						render_list += "<span class='danger ml-1'>You hear a muffled yet rapid and irregular heartbeat.</span>\n"
+						render_list += span_danger_ml("You hear a weak yet rapid and irregular heartbeat.\n")
 					else
-						render_list += "<span class='danger ml-1'>You hear a rapid, irregular heartbeat.</span>\n"
-				else if (heart.organ_flags & ORGAN_WOUNDED)
-					render_list += "<span class='danger ml-1'>You hear a muffled heartbeat.</span>\n"
-				else if(heart.damage > 10 || carbon_patient.get_blood_volume(apply_modifiers = TRUE) <= BLOOD_VOLUME_OKAY)
-					render_list += "<span class='danger ml-1'>You hear a weak heartbeat.</span>\n"//their heart is damaged, or they have critical blood
+						render_list += span_danger_ml("You hear a rapid, irregular heartbeat.\n")
+				else if(heart.damage > 10 || carbon_patient.get_blood_volume(apply_modifiers = TRUE) <= BLOOD_VOLUME_OKAY || heart.organ_flags & ORGAN_WOUNDED)
+					render_list += span_danger_ml("You hear a weak heartbeat.\n")//their heart is damaged, or they have critical blood
 				else
-					render_list += "<span class='notice ml-1'>You hear a healthy heartbeat.</span>\n"//they're okay :D
+					render_list += span_danger_ml("You hear a healthy heartbeat.\n")//they're okay :D
 				if(heart_noises)
-					render_list += "<span class='notice ml-1'>[heart.hear_beat_noise(user)]</span>\n"
+					render_list += span_notice_ml("[heart.hear_beat_noise(user)]\n")
 
 		if(BODY_ZONE_PRECISE_GROIN)//If we're targeting the groin
 			render_list += span_info("You carefully press down on [carbon_patient]'s abdomen:\n")

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -323,22 +323,24 @@
 			var/appendix_okay = TRUE
 			var/liver_okay = TRUE
 			if(!liver)//sanity check, ensure the patient actually has a liver
-				render_list += "<span class='danger ml-1'>You can't feel anything where [target.p_their()] liver would be.</span>\n"
+				render_list += span_danger_ml("You can't feel anything where [target.p_their()] liver would be.\n")
 				liver_okay = FALSE
 			else
+				if(liver.organ_flags & ORGAN_WOUNDED)
+					render_list += span_danger_ml("You feel fluid surrounding [target.p_their()] liver.\n")
 				if(liver.damage > 10)
-					render_list += "<span class='danger ml-1'>[target.p_Their()] liver feels firm.</span>\n"//their liver is damaged
+					render_list += span_danger_ml("[target.p_Their()] liver feels firm.\n")//their liver is damaged
 					liver_okay = FALSE
 			if(!appendix)//sanity check, ensure the patient actually has an appendix
-				render_list += "<span class='danger ml-1'>You can't feel anything where [target.p_their()] appendix would be.</span>\n"
+				render_list += span_danger_ml("You can't feel anything where [target.p_their()] appendix would be.\n")
 				appendix_okay = FALSE
 			else
-				if(appendix.damage > 10 && !IS_UNCONSCIOUS_OR_CRIT(carbon_patient))
-					render_list += "<span class='danger ml-1'>[target] screams when you lift your hand from [target.p_their()] appendix!</span>\n"//scream if their appendix is damaged and they're awake
+				if((appendix.damage > 10 || appendix.inflamation_stage || appendix.organ_flags & ORGAN_WOUNDED) && !IS_UNCONSCIOUS_OR_CRIT(carbon_patient) && !HAS_TRAIT(carbon_patient, TRAIT_ANALGESIA))
+					render_list += span_danger_ml("[target] screams when you lift your hand from [target.p_their()] appendix!\n")//scream if their appendix is damaged and they're awake
 					target.emote("scream")
 					appendix_okay = FALSE
 			if(liver_okay && appendix_okay)//if they have all their organs and have no detectable damage
-				render_list += "<span class='notice ml-1'>You don't find anything abnormal.</span>\n"//they're okay :D
+				render_list += span_danger_ml("You don't find anything abnormal.\n")//they're okay :D
 
 		if(BODY_ZONE_PRECISE_EYES)
 			balloon_alert(user, "can't do that!")
@@ -360,7 +362,7 @@
 
 			//assess pulse (heart & blood level)
 			if(isnull(heart) || !heart.is_beating() || cached_blood_volume <= BLOOD_VOLUME_OKAY || carbon_patient.stat == DEAD)
-				render_list += "<span class='danger ml-1'>You can't find a pulse!</span>\n"//they're dead, their heart isn't beating, or they have critical blood
+				render_list += span_danger_ml("You can't find a pulse!</span>\n")//they're dead, their heart isn't beating, or they have critical blood
 			else
 				if(having_heart_attack)
 					heart_strength = span_danger("irregular")
@@ -374,7 +376,7 @@
 				else
 					pulse_pressure = span_notice("strong")//they're okay :D
 
-				render_list += "<span class='notice ml-1'>[target.p_Their()] pulse is [pulse_pressure] and [heart_strength].</span>\n"
+				render_list += span_notice_ml("[target.p_Their()] pulse is [pulse_pressure] and [heart_strength].\n")
 
 	//display our packaged information in an examine block for easy reading
 	to_chat(user, boxed_message(jointext(render_list, "")), type = MESSAGE_TYPE_INFO)

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -285,24 +285,31 @@
 				|| (HAS_TRAIT(carbon_patient, TRAIT_NOBREATH))\
 				|| carbon_patient.failed_last_breath \
 				|| carbon_patient.losebreath)//If pt is dead or otherwise not breathing
-				render_list += "<span class='danger ml-1'>[target.p_Theyre()] not breathing!</span>\n"
+				render_list += span_danger_ml("[target.p_Theyre()] not breathing!\n")
 				lung_noises = FALSE
 
+			else if(lungs.organ_flags & ORGAN_WOUNDED)
+				render_list += span_danger_ml("You hear shallow breathing and fluid in [target.p_their()] lungs!\n")
 			else if(lungs.damage > 10)//if breathing, check for lung damage
-				render_list += "<span class='danger ml-1'>You hear fluid in [target.p_their()] lungs!</span>\n"
+				render_list += span_danger_ml("You hear fluid in [target.p_their()] lungs!\n")
 			else if(oxy_loss > 10)//if they have suffocation damage
-				render_list += "<span class='danger ml-1'>[target.p_Theyre()] breathing heavily!</span>\n"
+				render_list += span_danger_ml("[target.p_Theyre()] breathing heavily!\n")
 			else
-				render_list += "<span class='notice ml-1'>[target.p_Theyre()] breathing normally.</span>\n"//they're okay :D
+				render_list += span_notice("[target.p_Theyre()] breathing normally.\n")//they're okay :D
 			if(lung_noises)
-				render_list += "<span class='notice ml-1'>[lungs.hear_breath_noise(user)]</span>\n"
+				render_list += span_notice_ml("[lungs.hear_breath_noise(user)]\n")
 			//assess heart
 			if(body_part == BODY_ZONE_CHEST)//if we're listening to the chest
 				if(isnull(heart) || !heart.is_beating() || carbon_patient.stat == DEAD)
 					render_list += "<span class='danger ml-1'>You don't hear a heartbeat!</span>\n"//they're dead or their heart isn't beating
 					heart_noises = FALSE
 				else if(having_heart_attack)
-					render_list += "<span class='danger ml-1'>You hear a rapid, irregular heartbeat.</span>\n"
+					if(heart.organ_flags & ORGAN_WOUNDED)
+						render_list += "<span class='danger ml-1'>You hear a muffled yet rapid and irregular heartbeat.</span>\n"
+					else
+						render_list += "<span class='danger ml-1'>You hear a rapid, irregular heartbeat.</span>\n"
+				else if (heart.organ_flags & ORGAN_WOUNDED)
+					render_list += "<span class='danger ml-1'>You hear a muffled heartbeat.</span>\n"
 				else if(heart.damage > 10 || carbon_patient.get_blood_volume(apply_modifiers = TRUE) <= BLOOD_VOLUME_OKAY)
 					render_list += "<span class='danger ml-1'>You hear a weak heartbeat.</span>\n"//their heart is damaged, or they have critical blood
 				else

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -69,6 +69,8 @@
 	var/list/organ_effects
 	/// String displayed when the organ has decayed.
 	var/failing_desc = "has decayed for too long, and has turned a sickly color. It probably won't work without repairs."
+	/// String displayed when the organ has a wound but has not decayed.
+	var/wounded_desc = "has a large tear."
 	/// Assoc list of alternate zones where this can organ be slotted to organ slot for that zone
 	var/list/valid_zones = null
 	/// The cell line we can spawn on us
@@ -214,6 +216,10 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 
 	if(organ_flags & ORGAN_FAILING)
 		. += span_warning("[src] [failing_desc]")
+		return
+
+	if(organ_flags & ORGAN_WOUNDED)
+		. += span_warning("[src] [wounded_desc] It needs to be <b>stitched up</b> before it'll work properly.")
 		return
 
 	if(damage > high_threshold)

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -56,6 +56,8 @@
 
 	/// Time this organ has failed for
 	var/failure_time = 0
+	/// Time this organ has been wounded for
+	var/wounded_time = 0
 	/// Do we affect the appearance of our mob. Used to save time in preference code
 	var/visual = TRUE
 	/**
@@ -75,6 +77,8 @@
 	var/cells_minimum = 0
 	/// The maximum cells we can spawn
 	var/cells_maximum = 0
+	/// Can this organ be wounded?
+	var/woundable
 
 // Players can look at prefs before atoms SS init, and without this
 // they would not be able to see external organs, such as moth wings.
@@ -176,6 +180,9 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	if(organ_flags & ORGAN_FAILING)
 		handle_failing_organs(seconds_per_tick)
 		return
+
+	if(organ_flags & ORGAN_WOUNDED)
+		on_wounded_life(seconds_per_tick)
 
 	if(failure_time > 0)
 		failure_time--
@@ -348,6 +355,9 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		for(var/obj/item/organ/organ as anything in organs)
 			if(organ.organ_flags & ORGAN_EMP)
 				organ.organ_flags &= ~ORGAN_EMP
+			if(organ.organ_flags & ORGAN_WOUNDED)
+				organ.organ_flags &= ~ORGAN_WOUNDED
+				organ.wounded_time = 0
 			if(remove_hazardous && (organ.organ_flags & ORGAN_HAZARDOUS))
 				qdel(organ)
 				continue
@@ -544,3 +554,32 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 			all_organ_slots |= initial(an_organ.slot)
 
 	return all_organ_slots
+
+// This isn't a real attack because we don't actually want to destroy the organ, but
+/obj/item/organ/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+	if(!woundable || attacking_item.force = 0 || (attacking_item.item_flags & NOBLUDGEON))
+		return ..()
+	if(isliving(user))
+		var/mob/living/living_user = user
+		if(!living_user.combat_mode)
+			return..()
+	if(!(organ_flags & ORGAN_ROBOTIC)) // Remove this if robotic organ wounds ever become a thing
+		return ..()
+	user.changeNext_move(CLICK_CD_MELEE)
+	user.do_attack_animation(src)
+	visible_message(span_danger("[user] hits [src] with [attacking_item]!"))
+	to_chat(user, span_danger("You hit [src] with [attacking_item]!"))
+	var/sound_to_play = 'sound/effects/meatslap.ogg'
+	if(organ_flags & ORGAN_ROBOTIC || organ_flags & ORGAN_MINERAL)
+		sound_to_play = 'sound/effects/wounds/crack1.ogg'
+	playsound(loc, sound_to_play, 50)
+	set_organ_damage(maxHealth)
+	wounded(attacking_item, user, modifiers, attack_modifiers)
+
+/obj/item/organ/proc/wounded(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+	organ_flags |= ORGAN_WOUNDED
+
+/obj/item/organ/proc/on_wounded_life(seconds_per_tick)
+	wounded_time += seconds_per_tick
+	return
+

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -557,7 +557,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 
 // This isn't a real attack because we don't actually want to destroy the organ, but
 /obj/item/organ/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
-	if(!woundable || attacking_item.force = 0 || (attacking_item.item_flags & NOBLUDGEON))
+	if(!woundable || attacking_item.force == 0 || (attacking_item.item_flags & NOBLUDGEON))
 		return ..()
 	if(isliving(user))
 		var/mob/living/living_user = user

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -179,12 +179,12 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 /obj/item/organ/proc/on_life(seconds_per_tick) //repair organ damage if the organ is not failing
 	SHOULD_CALL_PARENT(TRUE)
 
+	if(organ_flags & ORGAN_WOUNDED)
+		on_wounded_life(seconds_per_tick)
+
 	if(organ_flags & ORGAN_FAILING)
 		handle_failing_organs(seconds_per_tick)
 		return
-
-	if(organ_flags & ORGAN_WOUNDED)
-		on_wounded_life(seconds_per_tick)
 
 	if(failure_time > 0)
 		failure_time--

--- a/code/modules/surgery/organs/internal/appendix/_appendix.dm
+++ b/code/modules/surgery/organs/internal/appendix/_appendix.dm
@@ -128,7 +128,7 @@
 		return
 	. = ..()
 	// forced to ensure people don't use it to heal tox as slime person
-	var/wounded_scaling = clamp(wounded_time / 180, 0, 0.5)
+	var/wounded_scaling = clamp(wounded_time / 120, 0, 0.5)
 	if(HAS_TRAIT(owner, TRAIT_VIRUS_RESISTANCE))
 		wounded_scaling /= 3
 	owner.adjust_tox_loss(wounded_scaling, forced = TRUE)

--- a/code/modules/surgery/organs/internal/appendix/_appendix.dm
+++ b/code/modules/surgery/organs/internal/appendix/_appendix.dm
@@ -16,6 +16,7 @@
 	now_failing = span_warning("An explosion of pain erupts in your lower right abdomen!")
 	now_fixed = span_info("The pain in your abdomen has subsided.")
 	visual = FALSE
+	woundable = TRUE
 
 	var/inflamation_stage = 0
 
@@ -36,7 +37,7 @@
 		return
 
 	if(organ_flags & ORGAN_FAILING)
-		// forced to ensure people don't use it to gain tox as slime person
+		// forced to ensure people don't use it to heal tox as slime person
 		owner.adjust_tox_loss(2 * seconds_per_tick, forced = TRUE)
 	else if(inflamation_stage)
 		inflamation(seconds_per_tick)
@@ -118,7 +119,22 @@
 	REMOVE_TRAIT(owner, TRAIT_DISEASELIKE_SEVERITY_MEDIUM, type)
 	owner.med_hud_set_status()
 
+/obj/item/organ/appendix/wounded()
+	. = ..()
+	inflamation_stage = min(inflamation_stage, 1)
+
+/obj/item/organ/appendix/on_wounded_life(seconds_per_tick)
+	if(organ_flags & ORGAN_FAILING) // Don't deal tox damage from a partial failure if the organ has already failed totally
+		return
+	. = ..()
+	// forced to ensure people don't use it to heal tox as slime person
+	owner.adjust_tox_loss(clamp(wounded_time / 180, 0, 0.5), forced = TRUE)
+	if(SPT_PROB(1, seconds_per_tick))
+		to_chat(owner, span_warning("You feel a spreading pain around your [HAS_TRAIT(owner, TRAIT_SELF_AWARE) ? "appendix" : "lower abdomen"]."))
+
 /obj/item/organ/appendix/get_status_text(scanpower, add_tooltips, colored)
+	if(organ_flags & ORGAN_WOUNDED)
+		return conditional_tooltip(span_warning("Ruptured"), "Remove or repair surgically.", add_tooltips)
 	if(!(organ_flags & ORGAN_FAILING) && inflamation_stage)
 		return conditional_tooltip("<font color='#ff9933'>Inflamed</font>", "Remove surgically.", add_tooltips)
 	return ..()

--- a/code/modules/surgery/organs/internal/appendix/_appendix.dm
+++ b/code/modules/surgery/organs/internal/appendix/_appendix.dm
@@ -121,21 +121,28 @@
 
 /obj/item/organ/appendix/wounded()
 	. = ..()
+	// We don't need to deal organ damage since inflamation stages do that for us.
 	inflamation_stage = min(inflamation_stage, 1)
 
 /obj/item/organ/appendix/on_wounded_life(seconds_per_tick)
 	if(organ_flags & ORGAN_FAILING) // Don't deal tox damage from a partial failure if the organ has already failed totally
 		return
 	. = ..()
-	// forced to ensure people don't use it to heal tox as slime person
+	// Forced to ensure people don't use it to heal tox as slime person
 	var/wounded_scaling = clamp(wounded_time / 120, 0, 0.5)
 	if(HAS_TRAIT(owner, TRAIT_VIRUS_RESISTANCE))
 		wounded_scaling /= 3
 	owner.adjust_tox_loss(wounded_scaling, forced = TRUE)
 	if(SPT_PROB(1, seconds_per_tick))
-		to_chat(owner, span_warning("You feel a spreading pain around your [HAS_TRAIT(owner, TRAIT_SELF_AWARE) ? "appendix" : "lower abdomen"]."))
+		var/self_aware = HAS_TRAIT(owner, TRAIT_SELF_AWARE)
+		var/alert_message = ""
+		if(HAS_TRAIT(owner, TRAIT_ANALGESIA))
+			alert_message = "You feel sick."
+		else
+			alert_message = "You feel a spreading pain around your [self_aware ? "appendix" : "lower abdomen"]."
+		to_chat(owner, span_warning(alert_message))
 
-/obj/item/organ/appendix/get_status_text(scanpower, add_tooltips, colored)
+/obj/item/organ/appendix/get_status_appendix(scanpower, add_tooltips, colored)
 	if(organ_flags & ORGAN_WOUNDED)
 		return conditional_tooltip(span_warning("Ruptured"), "Remove or repair surgically.", add_tooltips)
 	if(!(organ_flags & ORGAN_FAILING) && inflamation_stage)

--- a/code/modules/surgery/organs/internal/appendix/_appendix.dm
+++ b/code/modules/surgery/organs/internal/appendix/_appendix.dm
@@ -128,7 +128,10 @@
 		return
 	. = ..()
 	// forced to ensure people don't use it to heal tox as slime person
-	owner.adjust_tox_loss(clamp(wounded_time / 180, 0, 0.5), forced = TRUE)
+	var/wounded_scaling = clamp(wounded_time / 180, 0, 0.5)
+	if(HAS_TRAIT(owner, TRAIT_VIRUS_RESISTANCE))
+		wounded_scaling /= 3
+	owner.adjust_tox_loss(wounded_scaling, forced = TRUE)
 	if(SPT_PROB(1, seconds_per_tick))
 		to_chat(owner, span_warning("You feel a spreading pain around your [HAS_TRAIT(owner, TRAIT_SELF_AWARE) ? "appendix" : "lower abdomen"]."))
 

--- a/code/modules/surgery/organs/internal/appendix/_appendix.dm
+++ b/code/modules/surgery/organs/internal/appendix/_appendix.dm
@@ -125,14 +125,16 @@
 	inflamation_stage = min(inflamation_stage, 1)
 
 /obj/item/organ/appendix/on_wounded_life(seconds_per_tick)
+	. = ..()
 	if(organ_flags & ORGAN_FAILING) // Don't deal tox damage from a partial failure if the organ has already failed totally
 		return
-	. = ..()
 	// Forced to ensure people don't use it to heal tox as slime person
-	var/wounded_scaling = clamp(wounded_time / 120, 0, 0.5)
+	var/wounded_scaling = min(wounded_time / 120, 0.5)
 	if(HAS_TRAIT(owner, TRAIT_VIRUS_RESISTANCE))
 		wounded_scaling /= 3
 	owner.adjust_tox_loss(wounded_scaling, forced = TRUE)
+	if(SPT_PROB(wounded_scaling * 3, seconds_per_tick))
+		owner.adjust_disgust(15)
 	if(SPT_PROB(1, seconds_per_tick))
 		var/self_aware = HAS_TRAIT(owner, TRAIT_SELF_AWARE)
 		var/alert_message = ""
@@ -144,7 +146,7 @@
 
 /obj/item/organ/appendix/get_status_appendix(scanpower, add_tooltips, colored)
 	if(organ_flags & ORGAN_WOUNDED)
-		return conditional_tooltip(span_warning("Ruptured"), "Remove or repair surgically.", add_tooltips)
+		return conditional_tooltip(span_warning("Ruptured"), "Remove surgically, [/datum/reagent/medicine/spaceacillin::name] may temporarily reduce effects.", add_tooltips)
 	if(!(organ_flags & ORGAN_FAILING) && inflamation_stage)
 		return conditional_tooltip("<font color='#ff9933'>Inflamed</font>", "Remove surgically.", add_tooltips)
 	return ..()

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -114,6 +114,11 @@
 		return conditional_tooltip("<font color='#cc3333'>Cardiac Arrest</font>", "Repair tissue damage and apply defibrillation immediately.", add_tooltips)
 	return ..()
 
+/obj/item/organ/heart/get_status_appendix(scanpower, add_tooltips)
+	if(organ_flags & ORGAN_WOUNDED)
+		return conditional_tooltip(span_warning("Cardiac Tamponade"), "Apply a chest drain and coagulants or fix surgically.", add_tooltips)
+	. = ..()
+
 /obj/item/organ/heart/show_on_condensed_scans()
 	// Always show if the guy needs a heart (so its status can be monitored)
 	return ..() || owner.needs_heart()
@@ -167,6 +172,11 @@
 /// by default, returns the hearts beat_noise var as a notice span. May do other things when overridden, such as eldritch insanity or electrocution. Whatever you want, really.
 /obj/item/organ/heart/proc/hear_beat_noise(mob/living/hearer)
 	return span_notice("[owner.p_Their()] heart produces [beat_noise].")
+
+/obj/item/organ/heart/proc/on_wounded_life()
+	. = ..()
+	var/wounded_scaling = min(wounded_time / 320, 1) // The slowest and most lethal
+	apply_organ_damage(wounded_scaling) // No maximum damage, unlike other organ wounds
 
 /obj/item/organ/heart/cursed
 	name = "cursed heart"

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -173,7 +173,7 @@
 /obj/item/organ/heart/proc/hear_beat_noise(mob/living/hearer)
 	return span_notice("[owner.p_Their()] heart produces [beat_noise].")
 
-/obj/item/organ/heart/proc/on_wounded_life()
+/obj/item/organ/heart/on_wounded_life()
 	. = ..()
 	var/wounded_scaling = min(wounded_time / 320, 1) // The slowest and most lethal
 	apply_organ_damage(wounded_scaling) // No maximum damage, unlike other organ wounds

--- a/code/modules/surgery/organs/internal/liver/_liver.dm
+++ b/code/modules/surgery/organs/internal/liver/_liver.dm
@@ -22,6 +22,7 @@
 	cells_maximum = 2
 
 	visual = FALSE
+	woundable = TRUE
 
 	/// Affects how much damage the liver takes from alcohol
 	var/alcohol_tolerance = ALCOHOL_RATE
@@ -221,6 +222,18 @@
 	if(damage < high_threshold)
 		return span_warning("Your [self_aware ? "liver" : "lower abdomen"] feels sore.")
 	return span_boldwarning("Your [self_aware ? "liver" : "lower abdomen"] feels like it's on fire!")
+
+/obj/item/organ/liver/get_status_text(scanpower, add_tooltips, colored)
+	if(organ_flags & ORGAN_WOUNDED)
+		return conditional_tooltip(span_warning("Hepatic Avulsion"), "Fix surgically.", add_tooltips)
+	return ..()
+
+/obj/item/organ/liver/wounded(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+	. = ..()
+
+/obj/item/organ/liver/on_wounded_life(seconds_per_tick)
+	. = ..()
+
 
 // alien livers can ignore up to 15u of toxins, but they take x3 liver damage
 /obj/item/organ/liver/alien

--- a/code/modules/surgery/organs/internal/liver/_liver.dm
+++ b/code/modules/surgery/organs/internal/liver/_liver.dm
@@ -224,9 +224,9 @@
 		return span_warning("Your [self_aware ? "liver" : "lower abdomen"] feels sore.")
 	return span_boldwarning("Your [self_aware ? "liver" : "lower abdomen"] feels like it's on fire!")
 
-/obj/item/organ/liver/get_status_text(scanpower, add_tooltips, colored)
+/obj/item/organ/liver/get_status_appendix(scanpower, add_tooltips, colored)
 	if(organ_flags & ORGAN_WOUNDED)
-		return conditional_tooltip(span_warning("Hepatic Avulsion"), "Use coagulants or fix surgically.", add_tooltips)
+		return conditional_tooltip(span_warning("Lacerated"), "Use coagulants or fix surgically.", add_tooltips)
 	return ..()
 
 /obj/item/organ/liver/wounded(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
@@ -237,8 +237,9 @@
 /obj/item/organ/liver/on_wounded_life(seconds_per_tick)
 	. = ..()
 	var/wounded_scaling = clamp(wounded_time / 160, 0, 1)
-	if(wounded_scaling >= 0.5)
-		owner.adjust_tox_loss(wounded_scaling * 0.35)
+	apply_organ_damage(wounded_scaling, maxHealth * 0.8)
+	owner.adjust_blood_volume(-0.5 * wounded_scaling, BLOOD_VOLUME_OKAY)
+	owner.adjust_tox_loss(wounded_scaling * 0.5)
 	if(SPT_PROB(1 + wounded_scaling * 1.5, seconds_per_tick))
 		to_chat(owner, span_warning(pick("You feel faint.", "You feel tired.")))
 

--- a/code/modules/surgery/organs/internal/liver/_liver.dm
+++ b/code/modules/surgery/organs/internal/liver/_liver.dm
@@ -23,6 +23,7 @@
 
 	visual = FALSE
 	woundable = TRUE
+	wounded_desc = "has been torn nearly in half."
 
 	/// Affects how much damage the liver takes from alcohol
 	var/alcohol_tolerance = ALCOHOL_RATE
@@ -225,15 +226,21 @@
 
 /obj/item/organ/liver/get_status_text(scanpower, add_tooltips, colored)
 	if(organ_flags & ORGAN_WOUNDED)
-		return conditional_tooltip(span_warning("Hepatic Avulsion"), "Fix surgically.", add_tooltips)
+		return conditional_tooltip(span_warning("Hepatic Avulsion"), "Use coagulants or fix surgically.", add_tooltips)
 	return ..()
 
 /obj/item/organ/liver/wounded(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	. = ..()
+	playsound(owner, 'sound/effects/wounds/pierce1.ogg')
+	apply_organ_damage(40)
 
 /obj/item/organ/liver/on_wounded_life(seconds_per_tick)
 	. = ..()
-
+	var/wounded_scaling = clamp(wounded_time / 160, 0, 1)
+	if(wounded_scaling >= 0.5)
+		owner.adjust_tox_loss(wounded_scaling * 0.35)
+	if(SPT_PROB(1 + wounded_scaling * 1.5, seconds_per_tick))
+		to_chat(owner, span_warning(pick("You feel faint.", "You feel tired.")))
 
 // alien livers can ignore up to 15u of toxins, but they take x3 liver damage
 /obj/item/organ/liver/alien

--- a/code/modules/surgery/organs/internal/liver/_liver.dm
+++ b/code/modules/surgery/organs/internal/liver/_liver.dm
@@ -226,7 +226,7 @@
 
 /obj/item/organ/liver/get_status_appendix(scanpower, add_tooltips, colored)
 	if(organ_flags & ORGAN_WOUNDED)
-		return conditional_tooltip(span_warning("Lacerated"), "Use coagulants or fix surgically.", add_tooltips)
+		return conditional_tooltip(span_warning("Lacerated"), "Apply coagulants or fix surgically.", add_tooltips)
 	return ..()
 
 /obj/item/organ/liver/wounded(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
@@ -236,9 +236,9 @@
 
 /obj/item/organ/liver/on_wounded_life(seconds_per_tick)
 	. = ..()
-	var/wounded_scaling = clamp(wounded_time / 160, 0, 1)
+	var/wounded_scaling = min(wounded_time / 160, 1)
 	apply_organ_damage(wounded_scaling, maxHealth * 0.8)
-	owner.adjust_blood_volume(-0.5 * wounded_scaling, BLOOD_VOLUME_OKAY)
+	owner.adjust_blood_volume(-1 * wounded_scaling, BLOOD_VOLUME_OKAY)
 	owner.adjust_tox_loss(wounded_scaling * 0.5)
 	if(SPT_PROB(1 + wounded_scaling * 1.5, seconds_per_tick))
 		to_chat(owner, span_warning(pick("You feel faint.", "You feel tired.")))

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -21,6 +21,8 @@
 	cells_maximum = 2
 
 	visual = FALSE
+	woundable = TRUE
+	wounded_desc = "has a hole in one of it lobes that air can escape through."
 
 	var/failed = FALSE
 	var/operated = FALSE //whether we can still have our damages fixed through surgery
@@ -861,37 +863,64 @@
 	return span_boldwarning("It feels extremely tight[HAS_TRAIT(owner, TRAIT_NOBREATH) ?  "" : ", and every breath is a struggle"].")
 
 /obj/item/organ/lungs/get_status_appendix(scanpower, add_tooltips)
+	var/lung_dilation_data = ""
+	var/wound_data = ""
 	var/initial_pressure_mult = initial(received_pressure_mult)
-	if (received_pressure_mult == initial_pressure_mult)
-		return
+	if (received_pressure_mult != initial_pressure_mult)
+		var/tooltip
+		var/dilation_text
+		var/beginning_text = "Lung Dilation: "
+		if (received_pressure_mult > initial_pressure_mult) // higher than usual
+			beginning_text = span_blue("<b>[beginning_text]</b>")
+			dilation_text = span_blue("[(received_pressure_mult * 100) - 100]%")
+			tooltip = "Subject's lungs are dilated and breathing more air than usual. \
+				Increases the effectiveness of healium and other gases."
 
-	var/tooltip
-	var/dilation_text
-	var/beginning_text = "Lung Dilation: "
-	if (received_pressure_mult > initial_pressure_mult) // higher than usual
-		beginning_text = span_blue("<b>[beginning_text]</b>")
-		dilation_text = span_blue("[(received_pressure_mult * 100) - 100]%")
-		tooltip = "Subject's lungs are dilated and breathing more air than usual. \
-			Increases the effectiveness of healium and other gases."
-
-	else
-		beginning_text = span_alert("<b>[beginning_text]</b>")
-		if (received_pressure_mult <= 0) // lethal
-			dilation_text = span_alert("<b>[received_pressure_mult * 100]%</b>")
-			tooltip = "Subject's lungs are completely shut. Subject is unable to breathe and requires emergency surgery. \
-				If asthmatic, perform asthmatic bypass surgery and adminster albuterol inhalant. \
-				Otherwise, replace lungs."
 		else
-			dilation_text = span_alert("[received_pressure_mult * 100]%")
-			tooltip = "Subject's lungs are partially shut. \
-				If unable to breathe, administer a high-pressure internals tank or replace lungs. \
-				If asthmatic, inhaled albuterol or bypass surgery will likely help."
+			beginning_text = span_alert("<b>[beginning_text]</b>")
+			if (received_pressure_mult <= 0) // lethal
+				dilation_text = span_alert("<b>[received_pressure_mult * 100]%</b>")
+				tooltip = "Subject's lungs are completely shut. Subject is unable to breathe and requires emergency surgery. \
+					If asthmatic, perform asthmatic bypass surgery and adminster albuterol inhalant. \
+					Otherwise, replace lungs."
+			else
+				dilation_text = span_alert("[received_pressure_mult * 100]%")
+				tooltip = "Subject's lungs are partially shut. \
+					If unable to breathe, administer a high-pressure internals tank or replace lungs. \
+					If asthmatic, inhaled albuterol or bypass surgery will likely help."
 
-	return beginning_text + conditional_tooltip(dilation_text, tooltip, add_tooltips)
+		lung_dilation_data = beginning_text + conditional_tooltip(dilation_text, tooltip, add_tooltips)
+
+	if(organ_flags & ORGAN_WOUNDED)
+		wound_data = conditional_tooltip(span_warning("Hemopneumothroax"), "Apply a chest drain and coagulants or fix surgically.", add_tooltips)
+
+	return lung_dilation_data + wound_data
 
 /// by default, returns the lungs' breath_noise var as a notice. called when stethoscope is used on chest, uses the return as a message for stethoscope user.
 /obj/item/organ/lungs/proc/hear_breath_noise(mob/living/hearer)
 	return span_notice("[owner.p_Their()] lungs emit [breath_noise].")
+
+/obj/item/organ/stomach/wounded(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+	. = ..()
+	playsound(owner, 'sound/effects/wounds/pierce1.ogg')
+
+/obj/item/organ/lungs/on_wounded_life(seconds_per_tick)
+	. = ..()
+	var/wounded_scaling = clamp(wounded_time / 120, 1) // These build up fast but the effects aren't very strong.
+	apply_organ_damage(wounded_scaling, maxHealth * 0.7)
+	if(owner.get_oxy_loss() < wounded_scaling * 25)
+		owner.adjust_oxy_loss(wounded_scaling)
+	if(prob(wounded_scaling * 35) || !HAS_TRAIT(owner, TRAIT_NOBREATH))
+		owner.losebreath++
+		if(prob(25) && !IS_UNCONSCIOUS(owner))
+			var/alert_message = ""
+			if(HAS_TRAIT(owner, TRAIT_SELF_AWARE))
+				alert_message = "Your lungs aren't expanding properly!"
+			else if (HAS_TRAIT(owner, TRAIT_ANALGESIA))
+				alert_message = "Breathing feels difficult!"
+			else
+				alert_message = "It hurts to breathe!"
+			to_chat(owner, alert_message)
 
 #define SMOKER_ORGAN_HEALTH (STANDARD_ORGAN_THRESHOLD * 0.75)
 #define SMOKER_LUNG_HEALING (STANDARD_ORGAN_HEALING * 0.75)

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -865,6 +865,7 @@
 /obj/item/organ/lungs/get_status_appendix(scanpower, add_tooltips)
 	var/lung_dilation_data = ""
 	var/wound_data = ""
+	var/connector = ""
 	var/initial_pressure_mult = initial(received_pressure_mult)
 	if (received_pressure_mult != initial_pressure_mult)
 		var/tooltip
@@ -890,11 +891,13 @@
 					If asthmatic, inhaled albuterol or bypass surgery will likely help."
 
 		lung_dilation_data = beginning_text + conditional_tooltip(dilation_text, tooltip, add_tooltips)
+		if (organ_flags & ORGAN_WOUNDED)
+			connector = " + " // Awkward but it works
 
 	if(organ_flags & ORGAN_WOUNDED)
 		wound_data = conditional_tooltip(span_warning("Hemopneumothroax"), "Apply a chest drain and coagulants or fix surgically.", add_tooltips)
 
-	return lung_dilation_data + wound_data
+	return lung_dilation_data + connector + wound_data
 
 /// by default, returns the lungs' breath_noise var as a notice. called when stethoscope is used on chest, uses the return as a message for stethoscope user.
 /obj/item/organ/lungs/proc/hear_breath_noise(mob/living/hearer)
@@ -906,7 +909,9 @@
 
 /obj/item/organ/lungs/on_wounded_life(seconds_per_tick)
 	. = ..()
-	var/wounded_scaling = clamp(wounded_time / 120, 1) // These build up fast but the effects aren't very strong.
+	if(organ_flags & ORGAN_FAILING) // You can't exactly suffocate twice
+		return
+	var/wounded_scaling = min(wounded_time / 120, 1) // These build up fast but the effects aren't very strong
 	apply_organ_damage(wounded_scaling, maxHealth * 0.7)
 	if(owner.get_oxy_loss() < wounded_scaling * 25)
 		owner.adjust_oxy_loss(wounded_scaling)

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -434,9 +434,9 @@
 	// If we're forced to vomit, try to spew out at least one item
 	empty_contents(chance = 60, damaging = TRUE, min_amount = (force ? 1 : 0))
 
-/obj/item/organ/stomach/get_status_text(scanpower, add_tooltips, colored)
+/obj/item/organ/stomach/get_status_appendix(scanpower, add_tooltips, colored)
 	if(organ_flags & ORGAN_WOUNDED)
-		return conditional_tooltip(span_warning("Gastric Perforation"), "Fix surgically.", add_tooltips)
+		return conditional_tooltip(span_warning("Perforated"), "Fix surgically.", add_tooltips)
 	if(cut_open_damage)
 		return conditional_tooltip("<font color='#ff9933'>Incised</font>", "Remove and cauterize.", add_tooltips)
 	return ..()
@@ -451,13 +451,17 @@
 	var/wounded_scaling = clamp(wounded_time / 180, 0, 1)
 	if(HAS_TRAIT(owner, TRAIT_VIRUS_RESISTANCE))
 		wounded_scaling /= 3
-	apply_organ_damage(wounded_scaling)
+	apply_organ_damage(wounded_scaling, maxHealth * 0.8)
 	owner.adjust_tox_loss(wounded_scaling, forced = TRUE)
-	if(SPT_PROB(wounded_scaling * 5, seconds_per_tick))
+	if(SPT_PROB(wounded_scaling * 4, seconds_per_tick))
 		owner.adjust_disgust(15)
 	if(SPT_PROB((1 + wounded_scaling * 1.5), seconds_per_tick))
 		var/self_aware = HAS_TRAIT(owner, TRAIT_SELF_AWARE)
-		var/alert_message = "You feel a spreading pain around your [self_aware ? "stomach" : "lower abdomen"]."
+		var/alert_message = ""
+		if(HAS_TRAIT(owner, TRAIT_ANALGESIA))
+			alert_message = "You feel sick."
+		else
+			alert_message = "You feel a spreading pain around your [self_aware ? "stomach" : "lower abdomen"]."
 		to_chat(owner, span_warning(alert_message))
 
 /obj/item/organ/stomach/tool_act(mob/living/user, obj/item/tool, list/modifiers)

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -278,7 +278,7 @@
 	var/obj/item/bodypart/chest/chest = owner.get_bodypart(zone)
 	var/datum/wound/slash/flesh/slash = chest.get_wound_type(/datum/wound/slash/flesh)
 	// A chance to spill out all the contents
-	if (cut_open_damage && slash?.severity >= WOUND_SEVERITY_CRITICAL)
+	if ((cut_open_damage || (organ_flags & ORGAN_WOUNDED)) && slash?.severity >= WOUND_SEVERITY_CRITICAL)
 		if (SPT_PROB(chest.get_damage(), seconds_per_tick * 3))
 			var/emptied = empty_contents()
 			if (emptied > 0)
@@ -302,15 +302,19 @@
 
 		var/obj/item/as_item = thing
 		// If your stomach is cut open, it will hurt like hell
-		if (cut_open_damage)
+		if (cut_open_damage || (organ_flags & ORGAN_WOUNDED))
 			if (chest && !chest.cavity_item && as_item.w_class <= WEIGHT_CLASS_NORMAL)
 				// Oopsie!
 				chest.cavity_item = as_item
 				LAZYREMOVE(stomach_contents, as_item)
 				continue
 
-			owner.apply_damage(as_item.w_class * (as_item.sharpness ? 2 : 1), BRUTE, BODY_ZONE_CHEST, wound_bonus = CANT_WOUND,
-				sharpness = as_item.sharpness, attacking_item = as_item, wound_clothing = FALSE)
+			var/item_sharpness = as_item.sharpness
+			owner.apply_damage(as_item.w_class * (item_sharpness ? 2 : 1), BRUTE, BODY_ZONE_CHEST, wound_bonus = CANT_WOUND,
+				sharpness = item_sharpness, attacking_item = as_item, wound_clothing = FALSE)
+			if(item_sharpness || prob(50))
+				wounded(as_item)
+				to_chat(owner, span_boldwarning(HAS_TRAIT(owner, TRAIT_SELF_AWARE) ? "You feel your stomach tearing further open." : "You feel a burning pain in your lower abdomen!"))
 
 		if (!as_item.sharpness)
 			continue
@@ -427,6 +431,26 @@
 	SIGNAL_HANDLER
 	// If we're forced to vomit, try to spew out at least one item
 	empty_contents(chance = 60, damaging = TRUE, min_amount = (force ? 1 : 0))
+
+/obj/item/organ/stomach/get_status_text(scanpower, add_tooltips, colored)
+	if(organ_flags & ORGAN_WOUNDED)
+		return conditional_tooltip(span_warning("Ruptured"), "Fix surgically.", add_tooltips)
+	if(cut_open_damage)
+		return conditional_tooltip("<font color='#ff9933'>Incised</font>", "Remove and cauterize.", add_tooltips)
+	return ..()
+
+/obj/item/organ/stomach/on_wounded_life(seconds_per_tick)
+	. = ..()
+	// Starts lower but scales higher than appendixes
+	var/wounded_scaling = clamp(wounded_time / 240, 0, 1)
+	owner.adjust_tox_loss(wounded_scaling, forced = TRUE)
+	owner.adjust_blood_volume(-0.05, BLOOD_VOLUME_OKAY)
+	if(SPT_PROB(wounded_scaling * 5, seconds_per_tick))
+		owner.adjust_disgust(15)
+	if(SPT_PROB((1 + wounded_scaling * 1.5), seconds_per_tick))
+		var/self_aware = HAS_TRAIT(owner, TRAIT_SELF_AWARE)
+		var/alert_message = "You feel a spreading pain around your [self_aware ? "appendix" : "lower abdomen"]."
+		to_chat(owner, span_warning(alert_message))
 
 /obj/item/organ/stomach/tool_act(mob/living/user, obj/item/tool, list/modifiers)
 	if (tool.tool_behaviour == TOOL_SCALPEL)

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -30,6 +30,7 @@
 
 	visual = FALSE
 	woundable = TRUE
+	wounded_desc = "has ruptured, leaking digestive juices onto its surface."
 
 	///The rate that disgust decays
 	var/disgust_metabolism = 1
@@ -440,15 +441,18 @@
 		return conditional_tooltip("<font color='#ff9933'>Incised</font>", "Remove and cauterize.", add_tooltips)
 	return ..()
 
+/obj/item/organ/stomach/wounded(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+	. = ..()
+	playsound(owner, 'sound/effects/wounds/pierce1.ogg')
+
 /obj/item/organ/stomach/on_wounded_life(seconds_per_tick)
 	. = ..()
 	// Starts lower but scales higher than appendixes
-	var/wounded_scaling = clamp(wounded_time / 240, 0, 1)
+	var/wounded_scaling = clamp(wounded_time / 180, 0, 1)
 	if(HAS_TRAIT(owner, TRAIT_VIRUS_RESISTANCE))
 		wounded_scaling /= 3
 	apply_organ_damage(wounded_scaling)
 	owner.adjust_tox_loss(wounded_scaling, forced = TRUE)
-	owner.adjust_blood_volume(-0.05, BLOOD_VOLUME_OKAY)
 	if(SPT_PROB(wounded_scaling * 5, seconds_per_tick))
 		owner.adjust_disgust(15)
 	if(SPT_PROB((1 + wounded_scaling * 1.5), seconds_per_tick))

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -29,6 +29,7 @@
 	cells_maximum = 2
 
 	visual = FALSE
+	woundable = TRUE
 
 	///The rate that disgust decays
 	var/disgust_metabolism = 1
@@ -434,7 +435,7 @@
 
 /obj/item/organ/stomach/get_status_text(scanpower, add_tooltips, colored)
 	if(organ_flags & ORGAN_WOUNDED)
-		return conditional_tooltip(span_warning("Ruptured"), "Fix surgically.", add_tooltips)
+		return conditional_tooltip(span_warning("Gastric Perforation"), "Fix surgically.", add_tooltips)
 	if(cut_open_damage)
 		return conditional_tooltip("<font color='#ff9933'>Incised</font>", "Remove and cauterize.", add_tooltips)
 	return ..()
@@ -443,13 +444,16 @@
 	. = ..()
 	// Starts lower but scales higher than appendixes
 	var/wounded_scaling = clamp(wounded_time / 240, 0, 1)
+	if(HAS_TRAIT(owner, TRAIT_VIRUS_RESISTANCE))
+		wounded_scaling /= 3
+	apply_organ_damage(wounded_scaling)
 	owner.adjust_tox_loss(wounded_scaling, forced = TRUE)
 	owner.adjust_blood_volume(-0.05, BLOOD_VOLUME_OKAY)
 	if(SPT_PROB(wounded_scaling * 5, seconds_per_tick))
 		owner.adjust_disgust(15)
 	if(SPT_PROB((1 + wounded_scaling * 1.5), seconds_per_tick))
 		var/self_aware = HAS_TRAIT(owner, TRAIT_SELF_AWARE)
-		var/alert_message = "You feel a spreading pain around your [self_aware ? "appendix" : "lower abdomen"]."
+		var/alert_message = "You feel a spreading pain around your [self_aware ? "stomach" : "lower abdomen"]."
 		to_chat(owner, span_warning(alert_message))
 
 /obj/item/organ/stomach/tool_act(mob/living/user, obj/item/tool, list/modifiers)

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -436,7 +436,7 @@
 
 /obj/item/organ/stomach/get_status_appendix(scanpower, add_tooltips, colored)
 	if(organ_flags & ORGAN_WOUNDED)
-		return conditional_tooltip(span_warning("Perforated"), "Fix surgically.", add_tooltips)
+		return conditional_tooltip(span_warning("Perforated"), "Fix surgically, [/datum/reagent/medicine/spaceacillin::name] may temporarily reduce effects.", add_tooltips)
 	if(cut_open_damage)
 		return conditional_tooltip("<font color='#ff9933'>Incised</font>", "Remove and cauterize.", add_tooltips)
 	return ..()
@@ -448,7 +448,7 @@
 /obj/item/organ/stomach/on_wounded_life(seconds_per_tick)
 	. = ..()
 	// Starts lower but scales higher than appendixes
-	var/wounded_scaling = clamp(wounded_time / 180, 0, 1)
+	var/wounded_scaling = min(wounded_time / 180, 1)
 	if(HAS_TRAIT(owner, TRAIT_VIRUS_RESISTANCE))
 		wounded_scaling /= 3
 	apply_organ_damage(wounded_scaling, maxHealth * 0.8)


### PR DESCRIPTION
## About The Pull Request

[Okay here's your hackmd](https://hackmd.io/@Fghj240/rJiz7hXuMx)

Adds organ wounds. They're kind of like heart attacks and inflamed appendixes, but for all the organs and a bit worse. Organ wounds are supposed to be rare and moderately difficult to treat. They aren't supposed to be immediately deadly, but their effects will ramp up over time.

Outside the body, you can wound an organ by attacking it like a brain and fix it with sutures. Inside the body, you can wound it by getting caught in an explosion or getting hit in the chest while you have a critical blunt or pierce wound and fix it surgically by exposing the organs and then using sutures. The "toxic" wounds (burst stomach and appendix) can be alleviated with spaceacillin while the "bloody" wounds (torn lung, heart) can be alleviated using a chest drain found in nanomeds. Damaged livers can't be alleviated but their symptoms very easily can be.

Surgery (or fullheals, or using an autosurgeon to replace the organ with a new one) as the only cure for an affliction isn't generally a good idea imo, but the reason these wounds require them is because they should only be inflicted by effects that already would require medical intervention to cure. 

Edit: They'll be curable solo with medical gear.

## Why It's Good For The Game

Medical depth/adds variety to treating corpses, also adds something to organs that isn't just a number.

## Changelog

:cl:
add: Adds organ wounds
code: stethoscope uses span_danger_ml procs
add: Health analyzers show you if someone's stomach is sliced open
/:cl:
