### PR TITLE
Kudzu DLC - New Mutations and Changes (Venus Flytraps Inheritable Effects)

### DIFF
--- a/code/__DEFINES/_flags.dm
+++ b/code/__DEFINES/_flags.dm
@@ -325,10 +325,26 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define DO_AFTER_CHECK_NEXT_MOVE (1<<5)
 
 // Spacevine-related flags
-/// Is the spacevine / flower bud heat resistant
+/// Is the spacevine heat resistant
 #define SPACEVINE_HEAT_RESISTANT (1 << 0)
-/// Is the spacevine / flower bud cold resistant
+/// Is the spacevine cold resistant
 #define SPACEVINE_COLD_RESISTANT (1 << 1)
+/// Is the spacevine toxin resistant
+#define SPACEVINE_TOXIN_RESISTANT (1 << 2)
+/// Is the spacevine aggressive spreading
+#define SPACEVINE_AGGRESSIVE_SPREADING (1 << 3)
+/// Is the spacevine hardened
+#define SPACEVINE_HARDENED (1 << 4)
+/// Is the spacevine timid
+#define SPACEVINE_TIMID (1 << 5)
+/// Is the spacevine light emitting
+#define SPACEVINE_LIGHT (1 << 6)
+/// Is the spacevine explosive
+#define SPACEVINE_EXPLOSIVE (1 << 7)
+/// Is the spacevine transparent
+#define SPACEVINE_TRANSPARENT (1 << 8)
+/// Is the spacevine thorny
+#define SPACEVINE_THORNY (1 << 9)
 
 // Flags for flora structures
 #define FLORA_HERBAL (1 << 0)

--- a/code/__DEFINES/_flags.dm
+++ b/code/__DEFINES/_flags.dm
@@ -324,28 +324,6 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 /// Cancel the action if the user does another action (mainly via clicking)
 #define DO_AFTER_CHECK_NEXT_MOVE (1<<5)
 
-// Spacevine-related flags
-/// Is the spacevine heat resistant
-#define SPACEVINE_HEAT_RESISTANT (1 << 0)
-/// Is the spacevine cold resistant
-#define SPACEVINE_COLD_RESISTANT (1 << 1)
-/// Is the spacevine toxin resistant
-#define SPACEVINE_TOXIN_RESISTANT (1 << 2)
-/// Is the spacevine aggressive spreading
-#define SPACEVINE_AGGRESSIVE_SPREADING (1 << 3)
-/// Is the spacevine hardened
-#define SPACEVINE_HARDENED (1 << 4)
-/// Is the spacevine timid
-#define SPACEVINE_TIMID (1 << 5)
-/// Is the spacevine light emitting
-#define SPACEVINE_LIGHT (1 << 6)
-/// Is the spacevine explosive
-#define SPACEVINE_EXPLOSIVE (1 << 7)
-/// Is the spacevine transparent
-#define SPACEVINE_TRANSPARENT (1 << 8)
-/// Is the spacevine thorny
-#define SPACEVINE_THORNY (1 << 9)
-
 // Flags for flora structures
 #define FLORA_HERBAL (1 << 0)
 #define FLORA_WOODEN (1 << 1)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -487,7 +487,7 @@
 	var/obj/item/reagent_containers/cup/beaker/beaker_one = new(src)
 	var/obj/item/reagent_containers/cup/beaker/beaker_two = new(src)
 
-	beaker_one.reagents.add_reagent(/datum/reagent/toxin/plantbgone, 25)
+	beaker_one.reagents.add_reagent(/datum/reagent/toxin/plantbgone/weedkiller, 25)
 	beaker_one.reagents.add_reagent(/datum/reagent/potassium, 25)
 	beaker_two.reagents.add_reagent(/datum/reagent/phosphorus, 25)
 	beaker_two.reagents.add_reagent(/datum/reagent/consumable/sugar, 25)

--- a/code/modules/events/space_vines/vine_controller.dm
+++ b/code/modules/events/space_vines/vine_controller.dm
@@ -82,7 +82,7 @@ GLOBAL_LIST_INIT(vine_mutations_list, init_vine_mutation_list())
 				mutation.add_mutation_to_vinepiece(vine)
 				break
 	if(parent)
-		vine.mutations += parent.mutations
+		vine.mutations |= parent.mutations
 
 		var/parentcolor = parent.atom_colours[FIXED_COLOUR_PRIORITY]
 		vine.add_atom_colour(parentcolor, FIXED_COLOUR_PRIORITY)

--- a/code/modules/events/space_vines/vine_controller.dm
+++ b/code/modules/events/space_vines/vine_controller.dm
@@ -82,8 +82,9 @@ GLOBAL_LIST_INIT(vine_mutations_list, init_vine_mutation_list())
 				mutation.add_mutation_to_vinepiece(vine)
 				break
 	if(parent)
-		vine.mutations |= parent.mutations
-		vine.trait_flags |= parent.trait_flags
+		vine.mutations += parent.mutations
+		//vine.trait_flags += parent.trait_flags
+
 		var/parentcolor = parent.atom_colours[FIXED_COLOUR_PRIORITY]
 		vine.add_atom_colour(parentcolor, FIXED_COLOUR_PRIORITY)
 		if(prob(mutativeness))

--- a/code/modules/events/space_vines/vine_controller.dm
+++ b/code/modules/events/space_vines/vine_controller.dm
@@ -83,7 +83,6 @@ GLOBAL_LIST_INIT(vine_mutations_list, init_vine_mutation_list())
 				break
 	if(parent)
 		vine.mutations += parent.mutations
-		//vine.trait_flags += parent.trait_flags
 
 		var/parentcolor = parent.atom_colours[FIXED_COLOUR_PRIORITY]
 		vine.add_atom_colour(parentcolor, FIXED_COLOUR_PRIORITY)

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -477,8 +477,8 @@
 /datum/spacevine_mutation/slippery/on_grow(obj/structure/spacevine/vine)
 	vine.AddComponent(/datum/component/slippery, 5 SECONDS, NO_SLIP_WHEN_WALKING|SLIDE)
 
-/datum/spacevine_mutation/slippery/on_hit(obj/structure/spacevine/vine, mob/hitter, obj/item/attacking_item, expected_damage)
-	if(prob(15))
-		attacking_item.AddComponent(/datum/component/slippery_item, fall_catch_chance=25, duration=5 SECONDS)
+/datum/spacevine_mutation/slippery/on_hit(obj/structure/spacevine/vine, obj/item/item,  mob/living/hitter, list/attack_modifiers)
+	if(prob(20) && !(HAS_TRAIT(hitter, TRAIT_PLANT_SAFE)))
+		item?.AddComponent(/datum/component/slippery_item, fall_catch_chance=25, duration=5 SECONDS)
 
-	return expected_damage
+	return ..()

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -481,6 +481,18 @@
 	if(prob(20))
 		item?.AddComponent(/datum/component/slippery_item, fall_chance=25, fall_catch_chance=25, duration=5 SECONDS)
 
+/datum/spacevine_mutation/slippery/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
+	RegisterSignal(venus_trap, COMSIG_ATOM_ATTACKBY, PROC_REF(on_venus_hit), override=TRUE)
+
+/datum/spacevine_mutation/slippery/proc/on_venus_hit(mob/living/basic/venus_human_trap/venus_trap, obj/item/attacking_item, mob/living/attacker, params)
+	SIGNAL_HANDLER
+
+	if(isvineimmune(attacker) || HAS_TRAIT(attacker, TRAIT_PLANT_SAFE))
+		return
+
+	if(prob(20))
+		attacking_item?.AddComponent(/datum/component/slippery_item, fall_chance=25, fall_catch_chance=25, duration=5 SECONDS)
+
 /datum/spacevine_mutation/conductive
 	name = "Conductive"
 	description = "Causes the vines to be electrified when on top of cables"

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -19,7 +19,7 @@
 /datum/spacevine_mutation/proc/on_buckle(obj/structure/spacevine/vine, mob/living/buckled)
 	SHOULD_CALL_PARENT(TRUE)
 	buckled.layer = SPACEVINE_MOB_LAYER
-	RegisterSignal(buckled, COMSIG_MOB_UNBUCKLED, PROC_REF(on_unbuckle))
+	RegisterSignal(buckled, COMSIG_MOB_UNBUCKLED, PROC_REF(on_unbuckle), override=TRUE)
 
 /datum/spacevine_mutation/proc/on_unbuckle(datum/source)
 	SHOULD_CALL_PARENT(TRUE)
@@ -145,7 +145,7 @@
 	explosion(vine, light_impact_range = EXPLOSION_MUTATION_IMPACT_RADIUS, adminlog = FALSE)
 
 /datum/spacevine_mutation/explosive/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
-	RegisterSignal(venus_trap, COMSIG_LIVING_DEATH, PROC_REF(on_venus_trap_death))
+	RegisterSignal(venus_trap, COMSIG_LIVING_DEATH, PROC_REF(on_venus_trap_death), override=TRUE)
 
 /datum/spacevine_mutation/explosive/proc/on_venus_trap_death(mob/living/spawned_mob, mob/mob_possessor, apply_prefs)
 	SIGNAL_HANDLER
@@ -519,6 +519,7 @@
 	attempt_shock(vine, hitter, item)
 
 /datum/spacevine_mutation/conductive/on_buckle(obj/structure/spacevine/vine, mob/living/buckled)
+	. = ..()
 	attempt_shock(vine, buckled)
 
 /datum/spacevine_mutation/radioactive

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -508,3 +508,34 @@
 
 /datum/spacevine_mutation/conductive/on_buckle(obj/structure/spacevine/vine, mob/living/buckled)
 	attempt_shock(vine, buckled)
+
+/datum/spacevine_mutation/radioactive
+	name = "Radioactive"
+	description = "Causes the vines to be radioactive"
+	hue = "#09b82f"
+	quality = NEGATIVE
+	severity = SEVERITY_MAJOR
+
+/datum/spacevine_mutation/radioactive/on_birth(obj/structure/spacevine/vine)
+	vine.AddElement(/datum/element/radioactive, chance = DEFAULT_RADIATION_CHANCE / 3)
+
+/datum/spacevine_mutation/radioactive/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
+	RegisterSignal(venus_trap, COMSIG_ATOM_ATTACKBY, PROC_REF(on_venus_hit), override=TRUE)
+
+/datum/spacevine_mutation/radioactive/proc/on_venus_hit(mob/living/basic/venus_human_trap/venus_trap, obj/item/attacking_item, mob/living/attacker, params)
+	SIGNAL_HANDLER
+
+	if(isvineimmune(attacker) || HAS_TRAIT(attacker, TRAIT_PLANT_SAFE))
+		return
+	if(!SSradiation.can_irradiate_basic(attacker))
+		return
+	if(ishuman(attacker) && SSradiation.wearing_rad_protected_clothing(attacker))
+		return
+
+	radiation_pulse(
+		venus_trap,
+		max_range = 1,
+		threshold = RAD_VERY_LIGHT_INSULATION,
+		chance = (DEFAULT_RADIATION_CHANCE / 3),
+		minimum_exposure_time = 3 SECONDS,
+	)

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -9,9 +9,11 @@
 	var/hue
 	/// The quality of our mutation (how good or bad is it?)
 	var/quality
+	/// The trait to add to our vine
+	var/trait
 
 /datum/spacevine_mutation/proc/add_mutation_to_vinepiece(obj/structure/spacevine/holder)
-	holder.mutations |= src
+	holder.mutations |= trait
 	holder.add_atom_colour(hue, FIXED_COLOUR_PRIORITY)
 
 /datum/spacevine_mutation/proc/on_buckle(obj/structure/spacevine/holder, mob/living/buckled)
@@ -70,6 +72,7 @@
 	hue = "#B2EA70"
 	quality = POSITIVE
 	severity = SEVERITY_TRIVIAL
+	trait = SPACEVINE_LIGHT
 
 /datum/spacevine_mutation/light/on_grow(obj/structure/spacevine/holder)
 	if(holder.growth_stage)
@@ -81,6 +84,7 @@
 	hue = "#9B3675"
 	severity = SEVERITY_AVERAGE
 	quality = NEGATIVE
+	trait = SPACEVINE_TOXIN_RESISTANT
 	var/required_coverage = HEAD|CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 
 /datum/spacevine_mutation/toxicity/on_cross(obj/structure/spacevine/holder, mob/living/crosser)
@@ -118,6 +122,7 @@
 	hue = "#D83A56"
 	quality = NEGATIVE
 	severity = SEVERITY_MAJOR
+	trait = SPACEVINE_EXPLOSIVE
 
 /datum/spacevine_mutation/explosive/on_explosion(explosion_severity, target, obj/structure/spacevine/holder)
 	if(explosion_severity >= EXPLODE_DEVASTATE)
@@ -136,10 +141,7 @@
 	hue = "#FF616D"
 	quality = MINOR_NEGATIVE
 	severity = SEVERITY_ABOVE_AVERAGE
-
-/datum/spacevine_mutation/fire_proof/add_mutation_to_vinepiece(obj/structure/spacevine/holder)
-	. = ..()
-	holder.trait_flags |= SPACEVINE_HEAT_RESISTANT
+	trait = SPACEVINE_HEAT_RESISTANT
 
 /datum/spacevine_mutation/fire_proof/on_hit(obj/structure/spacevine/holder, mob/hitter, obj/item/attacking_item, expected_damage)
 	if(attacking_item && attacking_item.damtype == BURN)
@@ -152,10 +154,7 @@
 	hue = "#0BD5D9"
 	quality = MINOR_NEGATIVE
 	severity = SEVERITY_AVERAGE
-
-/datum/spacevine_mutation/cold_proof/add_mutation_to_vinepiece(obj/structure/spacevine/holder)
-	. = ..()
-	holder.trait_flags |= SPACEVINE_COLD_RESISTANT
+	trait = SPACEVINE_COLD_RESISTANT
 
 /datum/spacevine_mutation/temp_stabilisation
 	name = "Temperature stabilisation"
@@ -199,6 +198,7 @@
 	hue = "#316b2f"
 	severity = SEVERITY_MAJOR
 	quality = NEGATIVE
+	trait = SPACEVINE_AGGRESSIVE_SPREADING
 
 /// Checks mobs on spread-target's turf to see if they should be hit by a damaging proc or not.
 /datum/spacevine_mutation/aggressive_spread/on_spread(obj/structure/spacevine/holder, turf/turf, mob/living)
@@ -226,7 +226,6 @@
 	var/mob/living/carbon/victim = living_mob
 	var/obj/item/bodypart/limb = victim.get_bodypart(victim.get_random_valid_zone(even_weights = TRUE))
 	var/armor = victim.run_armor_check(def_zone = limb, attack_flag = MELEE)
-
 
 	if(!HAS_TRAIT(victim, TRAIT_PIERCEIMMUNE))
 		var/datum/spacevine_mutation/thorns/thorn = locate() in vine.mutations
@@ -264,6 +263,7 @@
 	hue = ""
 	quality = POSITIVE
 	severity = SEVERITY_TRIVIAL
+	trait = SPACEVINE_TRANSPARENT
 
 /datum/spacevine_mutation/transparency/on_birth(obj/structure/spacevine/holder)
 	holder.light_state = PASS_LIGHT
@@ -329,6 +329,7 @@
 	hue = "#9ECCA4"
 	severity = SEVERITY_AVERAGE
 	quality = NEGATIVE
+	trait = SPACEVINE_THORNY
 
 /datum/spacevine_mutation/thorns/on_cross(obj/structure/spacevine/holder, mob/living/crosser)
 	if(isvineimmune(crosser) || HAS_TRAIT(crosser, TRAIT_PIERCEIMMUNE))
@@ -361,6 +362,7 @@
 	hue = "#997700"
 	quality = NEGATIVE
 	severity = SEVERITY_ABOVE_AVERAGE
+	trait = SPACEVINE_HARDENED
 
 /datum/spacevine_mutation/hardened/on_grow(obj/structure/spacevine/holder)
 	if(holder.growth_stage)

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -13,7 +13,7 @@
 	var/venus_flavor_text = ""
 
 /datum/spacevine_mutation/proc/add_mutation_to_vinepiece(obj/structure/spacevine/vine)
-	vine.mutations += src
+	vine.mutations |= src
 	vine.add_atom_colour(hue, FIXED_COLOUR_PRIORITY)
 
 /datum/spacevine_mutation/proc/on_buckle(obj/structure/spacevine/vine, mob/living/buckled)

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -219,7 +219,7 @@
 	hue = "#F4A442"
 	quality = MINOR_NEGATIVE
 	severity = SEVERITY_MINOR
-	venus_flavor_text = "Vine Eating - Reduced regeneration while on vines"
+	venus_flavor_text = "Vine Eating - Increased regeneration while on vines"
 
 /// Destroys any vine on spread-target's tile. The checks for if this should be done are in the spread() proc.
 /datum/spacevine_mutation/vine_eating/on_spread(obj/structure/spacevine/vine, turf/target)

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -82,7 +82,7 @@
 		vine.set_light(LIGHT_MUTATION_BRIGHTNESS, 0.3)
 
 /datum/spacevine_mutation/light/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
-	venus_trap.light_range = LIGHT_MUTATION_BRIGHTNESS
+	venus_trap.glow = venus_trap.mob_light(LIGHT_MUTATION_BRIGHTNESS, 0.3)
 
 /datum/spacevine_mutation/toxicity
 	name = "Toxic"

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -405,4 +405,20 @@
 
 /datum/spacevine_mutation/flowering/on_cross(obj/structure/spacevine/holder, mob/living/crosser)
 	if(prob(25))
-		holder.entangle(crosser)
+		vine.entangle(crosser)
+
+/datum/spacevine_mutation/slippery
+	name = "Slippery"
+	description = "Causes the vines to be slippery"
+	hue = "#FFF269"
+	quality = NEGATIVE
+	severity = SEVERITY_MINOR
+
+/datum/spacevine_mutation/slippery/on_grow(obj/structure/spacevine/vine)
+	vine.AddComponent(/datum/component/slippery, 5 SECONDS, NO_SLIP_WHEN_WALKING|SLIDE)
+
+/datum/spacevine_mutation/slippery/on_hit(obj/structure/spacevine/vine, mob/hitter, obj/item/attacking_item, expected_damage)
+	if(prob(15))
+		attacking_item.AddComponent(/datum/component/slippery_item, fall_catch_chance=25, duration=5 SECONDS)
+
+	return expected_damage

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -469,7 +469,7 @@
 	description = "Causes the vines to be slippery"
 	hue = "#a5980c"
 	quality = NEGATIVE
-	severity = SEVERITY_MINOR
+	severity = SEVERITY_AVERAGE
 
 /datum/spacevine_mutation/slippery/on_grow(obj/structure/spacevine/vine)
 	vine.AddComponent(/datum/component/slippery, 5 SECONDS, NO_SLIP_WHEN_WALKING|SLIDE)

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -227,7 +227,7 @@
 		qdel(prey)
 
 /datum/spacevine_mutation/vine_eating/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
-	venus_trap.weed_heal = initial(venus_trap.weed_heal) * 0.5
+	venus_trap.weed_heal = initial(venus_trap.weed_heal) * 2
 
 /datum/spacevine_mutation/aggressive_spread  //very OP, but im out of other ideas currently
 	name = "Aggressive spreading"
@@ -295,7 +295,7 @@
 	log_combat(vine, living_mob, "aggressively smashed")
 
 /datum/spacevine_mutation/aggressive_spread/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
-	venus_trap.kudzu_off_distance_range = initial(venus_trap.kudzu_off_distance_range) * 3
+	venus_trap.kudzu_off_distance_range = 2
 
 /datum/spacevine_mutation/transparency
 	name = "transparent"
@@ -416,15 +416,15 @@
 /datum/spacevine_mutation/hardened/on_grow(obj/structure/spacevine/vine)
 	if(vine.growth_stage)
 		vine.set_density(TRUE)
-	vine.modify_max_integrity(100)
+	vine.modify_max_integrity(initial(vine.max_integrity) * 2)
 
 /datum/spacevine_mutation/hardened/on_hit(obj/structure/spacevine/vine, obj/item/item,  mob/living/hitter, list/modifiers, list/attack_modifiers)
 	if(item?.get_sharpness())
-		MODIFY_ATTACK_FORCE_MULTIPLIER(attack_modifiers, 0.125)
+		MODIFY_ATTACK_FORCE_MULTIPLIER(attack_modifiers, 0.5)
 
 /datum/spacevine_mutation/hardened/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
-	venus_trap.health = initial(venus_trap.health) * 1.5
-	venus_trap.maxHealth = initial(venus_trap.maxHealth) * 1.5
+	venus_trap.health = initial(venus_trap.health) * 2
+	venus_trap.maxHealth = initial(venus_trap.maxHealth) * 2
 
 /datum/spacevine_mutation/timid
 	name = "Timid"

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -420,10 +420,10 @@
 		vine.set_density(TRUE)
 	vine.modify_max_integrity(100)
 
-/datum/spacevine_mutation/hardened/on_hit(obj/structure/spacevine/vine, mob/living/hitter, obj/item/item, expected_damage)
+/datum/spacevine_mutation/hardened/on_hit(obj/structure/spacevine/vine, obj/item/item,  mob/living/hitter, list/attack_modifiers)
 	if(item?.get_sharpness())
-		return expected_damage * 0.5
-	return expected_damage
+		MODIFY_ATTACK_FORCE_MULTIPLIER(attack_modifiers, 0.5)
+	return ..()
 
 /datum/spacevine_mutation/hardened/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
 	venus_trap.health = initial(venus_trap.health) * 1.5

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -45,7 +45,7 @@
 /datum/spacevine_mutation/proc/on_death(obj/structure/spacevine/vine)
 	return
 
-/datum/spacevine_mutation/proc/on_hit(obj/structure/spacevine/vine, mob/hitter, obj/item/item, expected_damage)
+/datum/spacevine_mutation/proc/on_hit(obj/structure/spacevine/vine, obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	. = expected_damage
 
 /datum/spacevine_mutation/proc/on_cross(obj/structure/spacevine/vine, mob/crosser)
@@ -75,7 +75,7 @@
 	hue = "#B2EA70"
 	quality = POSITIVE
 	severity = SEVERITY_TRIVIAL
-	venus_flavor_text = "<b>Light</b> - Your body emits a glowing light"
+	venus_flavor_text = "Light - Your body emits a glowing light"
 
 /datum/spacevine_mutation/light/on_grow(obj/structure/spacevine/vine)
 	if(vine.growth_stage)
@@ -90,7 +90,7 @@
 	hue = "#9B3675"
 	severity = SEVERITY_AVERAGE
 	quality = NEGATIVE
-	venus_flavor_text = "<b>Toxin Resistance</b> - Immune to chemical weedkillers and toxins"
+	venus_flavor_text = "Toxin Resistance - Immune to chemical weedkillers and toxins"
 	var/required_coverage = HEAD|CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 
 /datum/spacevine_mutation/toxicity/on_cross(obj/structure/spacevine/vine, mob/living/crosser)
@@ -131,7 +131,7 @@
 	hue = "#D83A56"
 	quality = NEGATIVE
 	severity = SEVERITY_MAJOR
-	venus_flavor_text = "<b>Explosive</b> - You will violently explode upon death"
+	venus_flavor_text = "Explosive - You will violently explode upon death"
 
 /datum/spacevine_mutation/explosive/on_explosion(explosion_severity, target, obj/structure/spacevine/vine)
 	if(explosion_severity >= EXPLODE_DEVASTATE)
@@ -145,9 +145,9 @@
 	explosion(vine, light_impact_range = EXPLOSION_MUTATION_IMPACT_RADIUS, adminlog = FALSE)
 
 /datum/spacevine_mutation/explosive/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
-	RegisterSignal(venus_trap, COMSIG_LIVING_DEATH, PROC_REF(on_death))
+	RegisterSignal(venus_trap, COMSIG_LIVING_DEATH, PROC_REF(on_venus_trap_death))
 
-/datum/spacevine_mutation/explosive/proc/on_death(mob/living/spawned_mob, mob/mob_possessor, apply_prefs)
+/datum/spacevine_mutation/explosive/proc/on_venus_trap_death(mob/living/spawned_mob, mob/mob_possessor, apply_prefs)
 	SIGNAL_HANDLER
 
 	explosion(spawned_mob, light_impact_range = EXPLOSION_MUTATION_IMPACT_RADIUS, adminlog = FALSE)
@@ -158,7 +158,7 @@
 	hue = "#FF616D"
 	quality = MINOR_NEGATIVE
 	severity = SEVERITY_ABOVE_AVERAGE
-	venus_flavor_text = "<b>Heat Resistance</b> - Immune to extreme heat and fire"
+	venus_flavor_text = "Heat Resistance - Immune to extreme heat and fire"
 
 /datum/spacevine_mutation/fire_proof/on_hit(obj/structure/spacevine/vine, mob/hitter, obj/item/attacking_item, expected_damage)
 	if(attacking_item && attacking_item.damtype == BURN)
@@ -179,7 +179,7 @@
 	hue = "#0BD5D9"
 	quality = MINOR_NEGATIVE
 	severity = SEVERITY_AVERAGE
-	venus_flavor_text = "<b>Cold Resistance</b> - Immune to freezing temperatures"
+	venus_flavor_text = "Cold Resistance - Immune to freezing temperatures"
 
 /datum/spacevine_mutation/cold_proof/on_grow(obj/structure/spacevine/vine)
 	vine.resistance_flags |= FREEZE_PROOF
@@ -219,7 +219,7 @@
 	hue = "#F4A442"
 	quality = MINOR_NEGATIVE
 	severity = SEVERITY_MINOR
-	venus_flavor_text = "<b>Vine Eating</b> - Reduced regeneration while on vines"
+	venus_flavor_text = "Vine Eating - Reduced regeneration while on vines"
 
 /// Destroys any vine on spread-target's tile. The checks for if this should be done are in the spread() proc.
 /datum/spacevine_mutation/vine_eating/on_spread(obj/structure/spacevine/vine, turf/target)
@@ -235,7 +235,7 @@
 	hue = "#316b2f"
 	severity = SEVERITY_MAJOR
 	quality = NEGATIVE
-	venus_flavor_text = "<b>Aggressive Spreading</b> - Can travel farther away from vines before taking damage"
+	venus_flavor_text = "Aggressive Spreading - Can travel farther away from vines before taking damage"
 
 /// Checks mobs on spread-target's turf to see if they should be hit by a damaging proc or not.
 /datum/spacevine_mutation/aggressive_spread/on_spread(obj/structure/spacevine/vine, turf/turf, mob/living)
@@ -303,7 +303,7 @@
 	hue = ""
 	quality = POSITIVE
 	severity = SEVERITY_TRIVIAL
-	venus_flavor_text = "<b>Transparency</b> - Your body is transparent"
+	venus_flavor_text = "Transparency - Your body is transparent"
 
 /datum/spacevine_mutation/transparency/on_birth(obj/structure/spacevine/vine)
 	vine.light_state = PASS_LIGHT
@@ -372,7 +372,7 @@
 	hue = "#9ECCA4"
 	severity = SEVERITY_AVERAGE
 	quality = NEGATIVE
-	venus_flavor_text = "<b>Thorny</b> - Your physical attacks deal reduced damage but cause wounds"
+	venus_flavor_text = "Thorny - Your physical attacks deal reduced damage but cause wounds"
 
 /datum/spacevine_mutation/thorns/on_cross(obj/structure/spacevine/vine, mob/living/crosser)
 	if(isvineimmune(crosser) || HAS_TRAIT(crosser, TRAIT_PIERCEIMMUNE))
@@ -413,7 +413,7 @@
 	hue = "#997700"
 	quality = NEGATIVE
 	severity = SEVERITY_ABOVE_AVERAGE
-	venus_flavor_text = "<b>Hardened</b> - Increased health"
+	venus_flavor_text = "Hardened - Increased health"
 
 /datum/spacevine_mutation/hardened/on_grow(obj/structure/spacevine/vine)
 	if(vine.growth_stage)
@@ -435,7 +435,7 @@
 	hue = "#a4a9ac"
 	quality = POSITIVE
 	severity = SEVERITY_MINOR
-	venus_flavor_text = "<b>Timid</b> - You no longer have the ability to shoot tangling vines at targets"
+	venus_flavor_text = "Timid - You no longer have the ability to shoot tangling vines at targets"
 
 //This specific mutation only covers floors instead of structures, items, mobs and cant tangle mobs
 /datum/spacevine_mutation/timid/on_birth(obj/structure/spacevine/vine)
@@ -470,7 +470,7 @@
 /datum/spacevine_mutation/slippery
 	name = "Slippery"
 	description = "Causes the vines to be slippery"
-	hue = "#FFF269"
+	hue = "#a5980c"
 	quality = NEGATIVE
 	severity = SEVERITY_MINOR
 

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -481,4 +481,30 @@
 	if(prob(20) && !(HAS_TRAIT(hitter, TRAIT_PLANT_SAFE)))
 		item?.AddComponent(/datum/component/slippery_item, fall_catch_chance=25, duration=5 SECONDS)
 
-	return ..()
+/datum/spacevine_mutation/conductive
+	name = "Conductive"
+	description = "Causes the vines to be electrified when on top of cables"
+	hue = "#ad5c00"
+	quality = NEGATIVE
+	severity = SEVERITY_MINOR
+
+/datum/spacevine_mutation/conductive/proc/attempt_shock(obj/structure/spacevine/vine, mob/living/victim, obj/item/attacking_item)
+	if(isvineimmune(victim) || HAS_TRAIT(victim, TRAIT_PLANT_SAFE))
+		return
+	if(attacking_item && !(attacking_item.obj_flags & CONDUCTS_ELECTRICITY))
+		return
+
+	var/turf/vine_loc = get_turf(vine)
+	if(vine_loc.overfloor_placed)
+		return
+	var/obj/structure/cable/cable = vine_loc.get_cable_node()
+	if(isnull(cable))
+		return
+
+	vine.shock(victim, 100, cable)
+
+/datum/spacevine_mutation/conductive/on_hit(obj/structure/spacevine/vine, obj/item/item,  mob/living/hitter, list/modifiers, list/attack_modifiers)
+	attempt_shock(vine, hitter, item)
+
+/datum/spacevine_mutation/conductive/on_buckle(obj/structure/spacevine/vine, mob/living/buckled)
+	attempt_shock(vine, buckled)

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -9,14 +9,14 @@
 	var/hue
 	/// The quality of our mutation (how good or bad is it?)
 	var/quality
-	/// The trait to add to our vine
-	var/trait
+	/// The flavor text to add to the venus flytrap ghost role spawners
+	var/venus_flavor_text = ""
 
-/datum/spacevine_mutation/proc/add_mutation_to_vinepiece(obj/structure/spacevine/holder)
-	holder.mutations |= trait
-	holder.add_atom_colour(hue, FIXED_COLOUR_PRIORITY)
+/datum/spacevine_mutation/proc/add_mutation_to_vinepiece(obj/structure/spacevine/vine)
+	vine.mutations += src
+	vine.add_atom_colour(hue, FIXED_COLOUR_PRIORITY)
 
-/datum/spacevine_mutation/proc/on_buckle(obj/structure/spacevine/holder, mob/living/buckled)
+/datum/spacevine_mutation/proc/on_buckle(obj/structure/spacevine/vine, mob/living/buckled)
 	SHOULD_CALL_PARENT(TRUE)
 	buckled.layer = SPACEVINE_MOB_LAYER
 	RegisterSignal(buckled, COMSIG_MOB_UNBUCKLED, PROC_REF(on_unbuckle))
@@ -30,37 +30,40 @@
 	buckled.layer = initial(buckled.layer)
 	UnregisterSignal(buckled, COMSIG_MOB_UNBUCKLED)
 
-/datum/spacevine_mutation/proc/process_mutation(obj/structure/spacevine/holder)
+/datum/spacevine_mutation/proc/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
 	return
 
-/datum/spacevine_mutation/proc/on_birth(obj/structure/spacevine/holder)
+/datum/spacevine_mutation/proc/process_mutation(obj/structure/spacevine/vine)
 	return
 
-/datum/spacevine_mutation/proc/on_grow(obj/structure/spacevine/holder)
+/datum/spacevine_mutation/proc/on_birth(obj/structure/spacevine/vine)
 	return
 
-/datum/spacevine_mutation/proc/on_death(obj/structure/spacevine/holder)
+/datum/spacevine_mutation/proc/on_grow(obj/structure/spacevine/vine)
 	return
 
-/datum/spacevine_mutation/proc/on_hit(obj/structure/spacevine/holder, mob/hitter, obj/item/item, expected_damage)
+/datum/spacevine_mutation/proc/on_death(obj/structure/spacevine/vine)
+	return
+
+/datum/spacevine_mutation/proc/on_hit(obj/structure/spacevine/vine, mob/hitter, obj/item/item, expected_damage)
 	. = expected_damage
 
-/datum/spacevine_mutation/proc/on_cross(obj/structure/spacevine/holder, mob/crosser)
+/datum/spacevine_mutation/proc/on_cross(obj/structure/spacevine/vine, mob/crosser)
 	return
 
-/datum/spacevine_mutation/proc/on_chem(obj/structure/spacevine/holder, datum/reagent/chem)
+/datum/spacevine_mutation/proc/on_chem(obj/structure/spacevine/vine, datum/reagent/chem)
 	return
 
-/datum/spacevine_mutation/proc/on_eat(obj/structure/spacevine/holder, mob/living/eater)
+/datum/spacevine_mutation/proc/on_eat(obj/structure/spacevine/vine, mob/living/eater)
 	return
 
-/datum/spacevine_mutation/proc/on_spread(obj/structure/spacevine/holder, turf/target)
+/datum/spacevine_mutation/proc/on_spread(obj/structure/spacevine/vine, turf/target)
 	return
 
-/datum/spacevine_mutation/proc/on_explosion(severity, target, obj/structure/spacevine/holder)
+/datum/spacevine_mutation/proc/on_explosion(severity, target, obj/structure/spacevine/vine)
 	return FALSE
 
-/datum/spacevine_mutation/proc/additional_atmos_processes(obj/structure/spacevine/holder, datum/gas_mixture/air)
+/datum/spacevine_mutation/proc/additional_atmos_processes(obj/structure/spacevine/vine, datum/gas_mixture/air)
 	return
 
 /datum/spacevine_mutation/aggressive_spread/proc/aggrospread_act(obj/structure/spacevine/vine, mob/living/M)
@@ -72,11 +75,14 @@
 	hue = "#B2EA70"
 	quality = POSITIVE
 	severity = SEVERITY_TRIVIAL
-	trait = SPACEVINE_LIGHT
+	venus_flavor_text = "<b>Light</b> - Your body emits a glowing light"
 
-/datum/spacevine_mutation/light/on_grow(obj/structure/spacevine/holder)
-	if(holder.growth_stage)
-		holder.set_light(LIGHT_MUTATION_BRIGHTNESS, 0.3)
+/datum/spacevine_mutation/light/on_grow(obj/structure/spacevine/vine)
+	if(vine.growth_stage)
+		vine.set_light(LIGHT_MUTATION_BRIGHTNESS, 0.3)
+
+/datum/spacevine_mutation/light/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
+	venus_trap.light_range = LIGHT_MUTATION_BRIGHTNESS
 
 /datum/spacevine_mutation/toxicity
 	name = "Toxic"
@@ -84,16 +90,16 @@
 	hue = "#9B3675"
 	severity = SEVERITY_AVERAGE
 	quality = NEGATIVE
-	trait = SPACEVINE_TOXIN_RESISTANT
+	venus_flavor_text = "<b>Toxin Resistance</b> - Immune to chemical weedkillers and toxins"
 	var/required_coverage = HEAD|CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 
-/datum/spacevine_mutation/toxicity/on_cross(obj/structure/spacevine/holder, mob/living/crosser)
+/datum/spacevine_mutation/toxicity/on_cross(obj/structure/spacevine/vine, mob/living/crosser)
 	if(isvineimmune(crosser) || issilicon(crosser))
 		return
 	if(!prob(TOXICITY_MUTATION_PROB))
 		return
 
-	var/datum/spacevine_mutation/thorns/thorns = locate() in holder.mutations
+	var/datum/spacevine_mutation/thorns/thorns = locate() in vine.mutations
 
 	if(thorns)
 		to_chat(crosser, span_alert("You are pricked by thorns and feel a strange sensation."))
@@ -112,9 +118,12 @@
 	to_chat(crosser, span_alert("You accidentally touch the vine and feel a strange sensation."))
 	crosser.apply_damage(20, TOX)
 
-/datum/spacevine_mutation/toxicity/on_eat(obj/structure/spacevine/holder, mob/living/eater)
+/datum/spacevine_mutation/toxicity/on_eat(obj/structure/spacevine/vine, mob/living/eater)
 	if(!isvineimmune(eater))
 		eater.apply_damage(20, TOX)
+
+/datum/spacevine_mutation/toxicity/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
+	ADD_TRAIT(venus_trap, TRAIT_TOXIMMUNE, INNATE_TRAIT)
 
 /datum/spacevine_mutation/explosive  // JC IT'S A BOMB
 	name = "Explosive"
@@ -122,18 +131,26 @@
 	hue = "#D83A56"
 	quality = NEGATIVE
 	severity = SEVERITY_MAJOR
-	trait = SPACEVINE_EXPLOSIVE
+	venus_flavor_text = "<b>Explosive</b> - You will violently explode upon death"
 
-/datum/spacevine_mutation/explosive/on_explosion(explosion_severity, target, obj/structure/spacevine/holder)
+/datum/spacevine_mutation/explosive/on_explosion(explosion_severity, target, obj/structure/spacevine/vine)
 	if(explosion_severity >= EXPLODE_DEVASTATE)
-		QDEL_IN(holder, 0.5 SECONDS)
+		QDEL_IN(vine, 0.5 SECONDS)
 		return TRUE
 
-	qdel(holder)
+	qdel(vine)
 	return FALSE
 
-/datum/spacevine_mutation/explosive/on_death(obj/structure/spacevine/holder, mob/hitter, obj/item/item)
-	explosion(holder, light_impact_range = EXPLOSION_MUTATION_IMPACT_RADIUS, adminlog = FALSE)
+/datum/spacevine_mutation/explosive/on_death(obj/structure/spacevine/vine, mob/hitter, obj/item/item)
+	explosion(vine, light_impact_range = EXPLOSION_MUTATION_IMPACT_RADIUS, adminlog = FALSE)
+
+/datum/spacevine_mutation/explosive/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
+	RegisterSignal(venus_trap, COMSIG_LIVING_DEATH, PROC_REF(on_death))
+
+/datum/spacevine_mutation/explosive/proc/on_death(mob/living/spawned_mob, mob/mob_possessor, apply_prefs)
+	SIGNAL_HANDLER
+
+	explosion(spawned_mob, light_impact_range = EXPLOSION_MUTATION_IMPACT_RADIUS, adminlog = FALSE)
 
 /datum/spacevine_mutation/fire_proof
 	name = "Fire proof"
@@ -141,12 +158,20 @@
 	hue = "#FF616D"
 	quality = MINOR_NEGATIVE
 	severity = SEVERITY_ABOVE_AVERAGE
-	trait = SPACEVINE_HEAT_RESISTANT
+	venus_flavor_text = "<b>Heat Resistance</b> - Immune to extreme heat and fire"
 
-/datum/spacevine_mutation/fire_proof/on_hit(obj/structure/spacevine/holder, mob/hitter, obj/item/attacking_item, expected_damage)
+/datum/spacevine_mutation/fire_proof/on_hit(obj/structure/spacevine/vine, mob/hitter, obj/item/attacking_item, expected_damage)
 	if(attacking_item && attacking_item.damtype == BURN)
 		return 0
 	return expected_damage
+
+/datum/spacevine_mutation/fire_proof/on_grow(obj/structure/spacevine/vine)
+	vine.resistance_flags |= FIRE_PROOF
+
+/datum/spacevine_mutation/fire_proof/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
+	venus_trap.unsuitable_heat_damage = 0
+	venus_trap.resistance_flags |= FIRE_PROOF
+	ADD_TRAIT(venus_trap, TRAIT_RESISTHEAT, INNATE_TRAIT)
 
 /datum/spacevine_mutation/cold_proof
 	name = "Cold proof"
@@ -154,7 +179,15 @@
 	hue = "#0BD5D9"
 	quality = MINOR_NEGATIVE
 	severity = SEVERITY_AVERAGE
-	trait = SPACEVINE_COLD_RESISTANT
+	venus_flavor_text = "<b>Cold Resistance</b> - Immune to freezing temperatures"
+
+/datum/spacevine_mutation/cold_proof/on_grow(obj/structure/spacevine/vine)
+	vine.resistance_flags |= FREEZE_PROOF
+
+/datum/spacevine_mutation/cold_proof/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
+	venus_trap.unsuitable_cold_damage = 0
+	venus_trap.resistance_flags |= FREEZE_PROOF
+	ADD_TRAIT(venus_trap, TRAIT_RESISTCOLD, INNATE_TRAIT)
 
 /datum/spacevine_mutation/temp_stabilisation
 	name = "Temperature stabilisation"
@@ -163,11 +196,11 @@
 	quality = POSITIVE
 	severity = SEVERITY_MINOR
 
-/datum/spacevine_mutation/temp_stabilisation/add_mutation_to_vinepiece(obj/structure/spacevine/holder)
+/datum/spacevine_mutation/temp_stabilisation/add_mutation_to_vinepiece(obj/structure/spacevine/vine)
 	. = ..()
-	holder.always_atmos_process = TRUE
+	vine.always_atmos_process = TRUE
 
-/datum/spacevine_mutation/temp_stabilisation/additional_atmos_processes(obj/structure/spacevine/holder, datum/gas_mixture/air)
+/datum/spacevine_mutation/temp_stabilisation/additional_atmos_processes(obj/structure/spacevine/vine, datum/gas_mixture/air)
 	var/heat_capacity = air.heat_capacity()
 	if(!heat_capacity) // No heating up space or vacuums
 		return
@@ -178,7 +211,7 @@
 	if(air.temperature > T20C)
 		delta_temperature *= -1
 	air.temperature += delta_temperature
-	holder.air_update_turf(FALSE, FALSE)
+	vine.air_update_turf(FALSE, FALSE)
 
 /datum/spacevine_mutation/vine_eating
 	name = "Vine eating"
@@ -186,11 +219,15 @@
 	hue = "#F4A442"
 	quality = MINOR_NEGATIVE
 	severity = SEVERITY_MINOR
+	venus_flavor_text = "<b>Vine Eating</b> - Reduced regeneration while on vines"
 
 /// Destroys any vine on spread-target's tile. The checks for if this should be done are in the spread() proc.
-/datum/spacevine_mutation/vine_eating/on_spread(obj/structure/spacevine/holder, turf/target)
+/datum/spacevine_mutation/vine_eating/on_spread(obj/structure/spacevine/vine, turf/target)
 	for(var/obj/structure/spacevine/prey in target)
 		qdel(prey)
+
+/datum/spacevine_mutation/vine_eating/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
+	venus_trap.weed_heal = initial(venus_trap.weed_heal) * 0.5
 
 /datum/spacevine_mutation/aggressive_spread  //very OP, but im out of other ideas currently
 	name = "Aggressive spreading"
@@ -198,17 +235,17 @@
 	hue = "#316b2f"
 	severity = SEVERITY_MAJOR
 	quality = NEGATIVE
-	trait = SPACEVINE_AGGRESSIVE_SPREADING
+	venus_flavor_text = "<b>Aggressive Spreading</b> - Can travel farther away from vines before taking damage"
 
 /// Checks mobs on spread-target's turf to see if they should be hit by a damaging proc or not.
-/datum/spacevine_mutation/aggressive_spread/on_spread(obj/structure/spacevine/holder, turf/turf, mob/living)
+/datum/spacevine_mutation/aggressive_spread/on_spread(obj/structure/spacevine/vine, turf/turf, mob/living)
 	for(var/mob/living/victim in turf)
-		aggrospread_act(holder, victim)
+		aggrospread_act(vine, victim)
 
 /// What happens if an aggr spreading vine buckles a mob.
-/datum/spacevine_mutation/aggressive_spread/on_buckle(obj/structure/spacevine/holder, mob/living/buckled)
+/datum/spacevine_mutation/aggressive_spread/on_buckle(obj/structure/spacevine/vine, mob/living/buckled)
 	. = ..()
-	aggrospread_act(holder, buckled)
+	aggrospread_act(vine, buckled)
 
 /// Hurts mobs. To be used when a vine with aggressive spread mutation spreads into the mob's tile or buckles them.
 /datum/spacevine_mutation/aggressive_spread/aggrospread_act(obj/structure/spacevine/vine, mob/living/living_mob)
@@ -257,30 +294,36 @@
 	span_userdanger("You are smashed by a large vine!"))
 	log_combat(vine, living_mob, "aggressively smashed")
 
+/datum/spacevine_mutation/aggressive_spread/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
+	venus_trap.kudzu_off_distance_range = initial(venus_trap.kudzu_off_distance_range) * 3
+
 /datum/spacevine_mutation/transparency
 	name = "transparent"
 	description = "Allows light to pass through."
 	hue = ""
 	quality = POSITIVE
 	severity = SEVERITY_TRIVIAL
-	trait = SPACEVINE_TRANSPARENT
+	venus_flavor_text = "<b>Transparency</b> - Your body is transparent"
 
-/datum/spacevine_mutation/transparency/on_birth(obj/structure/spacevine/holder)
-	holder.light_state = PASS_LIGHT
-	holder.alpha = 125
-	holder.unblock_sunlight()
+/datum/spacevine_mutation/transparency/on_birth(obj/structure/spacevine/vine)
+	vine.light_state = PASS_LIGHT
+	vine.alpha = 125
+	vine.unblock_sunlight()
+
+/datum/spacevine_mutation/transparency/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
+	venus_trap.alpha = initial(venus_trap.alpha) * 0.5
 
 /datum/spacevine_mutation/gas_eater
 	abstract_type = /datum/spacevine_mutation/gas_eater
 	/// Type of gas consumed by this mutation
 	var/datum/gas/gas_type = null
 
-/datum/spacevine_mutation/gas_eater/process_mutation(obj/structure/spacevine/holder)
+/datum/spacevine_mutation/gas_eater/process_mutation(obj/structure/spacevine/vine)
 	if(isnull(gas_type))
 		stack_trace("gas_type not set for gas_eater mutation [type]")
 		return
 
-	var/turf/open/floor/turf = holder.loc
+	var/turf/open/floor/turf = vine.loc
 	if(!istype(turf))
 		return
 
@@ -288,7 +331,7 @@
 	if(!gas_mix.moles[gas_type])
 		return
 
-	gas_mix.set_gas(gas_type, max(gas_mix.moles[gas_type] - GAS_MUTATION_REMOVAL_MULTIPLIER * holder.growth_stage, 0))
+	gas_mix.set_gas(gas_type, max(gas_mix.moles[gas_type] - GAS_MUTATION_REMOVAL_MULTIPLIER * vine.growth_stage, 0))
 	gas_mix.garbage_collect()
 
 /datum/spacevine_mutation/gas_eater/oxy_eater
@@ -329,9 +372,9 @@
 	hue = "#9ECCA4"
 	severity = SEVERITY_AVERAGE
 	quality = NEGATIVE
-	trait = SPACEVINE_THORNY
+	venus_flavor_text = "<b>Thorny</b> - Your physical attacks deal reduced damage but cause wounds"
 
-/datum/spacevine_mutation/thorns/on_cross(obj/structure/spacevine/holder, mob/living/crosser)
+/datum/spacevine_mutation/thorns/on_cross(obj/structure/spacevine/vine, mob/living/crosser)
 	if(isvineimmune(crosser) || HAS_TRAIT(crosser, TRAIT_PIERCEIMMUNE))
 		return
 	if(prob(THORN_MUTATION_CUT_PROB))
@@ -339,7 +382,7 @@
 		if(victim.apply_damage(15, BRUTE, blocked = victim.run_armor_check(attack_flag = MELEE, silent = TRUE), spread_damage = TRUE))
 			to_chat(victim, span_danger("You cut yourself on the thorny vines."))
 
-/datum/spacevine_mutation/thorns/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/item, expected_damage)
+/datum/spacevine_mutation/thorns/on_hit(obj/structure/spacevine/vine, mob/living/hitter, obj/item/item, expected_damage)
 	if(isvineimmune(hitter) || HAS_TRAIT(hitter, TRAIT_PIERCEIMMUNE) || HAS_TRAIT(hitter, TRAIT_PLANT_SAFE))
 		return expected_damage
 
@@ -356,23 +399,35 @@
 
 	return expected_damage
 
+/datum/spacevine_mutation/thorns/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
+	venus_trap.melee_damage_lower = initial(venus_trap.melee_damage_lower) * 0.5
+	venus_trap.melee_damage_upper = initial(venus_trap.melee_damage_upper) * 0.5
+	venus_trap.obj_damage = initial(venus_trap.obj_damage) * 0.5
+	venus_trap.wound_bonus = 5
+	venus_trap.exposed_wound_bonus = 15
+	venus_trap.sharpness = SHARP_POINTY
+
 /datum/spacevine_mutation/hardened
 	name = "Hardened"
 	description = "Provides resistance to cutting attacks, makes vines hardier, and prevents light from passing through."
 	hue = "#997700"
 	quality = NEGATIVE
 	severity = SEVERITY_ABOVE_AVERAGE
-	trait = SPACEVINE_HARDENED
+	venus_flavor_text = "<b>Hardened</b> - Increased health"
 
-/datum/spacevine_mutation/hardened/on_grow(obj/structure/spacevine/holder)
-	if(holder.growth_stage)
-		holder.set_density(TRUE)
-	holder.modify_max_integrity(100)
+/datum/spacevine_mutation/hardened/on_grow(obj/structure/spacevine/vine)
+	if(vine.growth_stage)
+		vine.set_density(TRUE)
+	vine.modify_max_integrity(100)
 
-/datum/spacevine_mutation/hardened/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/item, expected_damage)
+/datum/spacevine_mutation/hardened/on_hit(obj/structure/spacevine/vine, mob/living/hitter, obj/item/item, expected_damage)
 	if(item?.get_sharpness())
 		return expected_damage * 0.5
 	return expected_damage
+
+/datum/spacevine_mutation/hardened/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
+	venus_trap.health = initial(venus_trap.health) * 1.5
+	venus_trap.maxHealth = initial(venus_trap.maxHealth) * 1.5
 
 /datum/spacevine_mutation/timid
 	name = "Timid"
@@ -380,14 +435,19 @@
 	hue = "#a4a9ac"
 	quality = POSITIVE
 	severity = SEVERITY_MINOR
+	venus_flavor_text = "<b>Timid</b> - You no longer have the ability to shoot tangling vines at targets"
 
 //This specific mutation only covers floors instead of structures, items, mobs and cant tangle mobs
-/datum/spacevine_mutation/timid/on_birth(obj/structure/spacevine/holder)
-	SET_PLANE_IMPLICIT(holder, FLOOR_PLANE)
-	holder.layer = ABOVE_OPEN_TURF_LAYER
-	holder.light_state = PASS_LIGHT
-	holder.can_tangle = FALSE
+/datum/spacevine_mutation/timid/on_birth(obj/structure/spacevine/vine)
+	SET_PLANE_IMPLICIT(vine, FLOOR_PLANE)
+	vine.layer = ABOVE_OPEN_TURF_LAYER
+	vine.light_state = PASS_LIGHT
+	vine.can_tangle = FALSE
 	return ..()
+
+/datum/spacevine_mutation/timid/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
+	var/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle/tangle_action
+	tangle_action.Remove(venus_trap)
 
 /datum/spacevine_mutation/flowering
 	name = "Flowering"
@@ -396,14 +456,14 @@
 	quality = NEGATIVE
 	severity = SEVERITY_MAJOR
 
-/datum/spacevine_mutation/flowering/on_grow(obj/structure/spacevine/holder)
-	if(locate(/obj/structure/alien/resin/flower_bud) in range(5, holder))
+/datum/spacevine_mutation/flowering/on_grow(obj/structure/spacevine/vine)
+	if(locate(/obj/structure/alien/resin/flower_bud) in range(5, vine))
 		return
-	if(holder.growth_stage == 2 && prob(FLOWERING_MUTATION_SPAWN_PROB))
-		var/obj/structure/alien/resin/flower_bud/spawned_flower_bud = new(holder.loc)
-		spawned_flower_bud.trait_flags = holder.trait_flags
+	if(vine.growth_stage == 2 && prob(FLOWERING_MUTATION_SPAWN_PROB))
+		var/obj/structure/alien/resin/flower_bud/spawned_flower_bud = new(vine.loc)
+		spawned_flower_bud.mutations = vine.mutations
 
-/datum/spacevine_mutation/flowering/on_cross(obj/structure/spacevine/holder, mob/living/crosser)
+/datum/spacevine_mutation/flowering/on_cross(obj/structure/spacevine/vine, mob/living/crosser)
 	if(prob(25))
 		vine.entangle(crosser)
 

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -46,7 +46,7 @@
 	return
 
 /datum/spacevine_mutation/proc/on_hit(obj/structure/spacevine/vine, obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
-	. = expected_damage
+	return
 
 /datum/spacevine_mutation/proc/on_cross(obj/structure/spacevine/vine, mob/crosser)
 	return
@@ -160,10 +160,10 @@
 	severity = SEVERITY_ABOVE_AVERAGE
 	venus_flavor_text = "Heat Resistance - Immune to extreme heat and fire"
 
-/datum/spacevine_mutation/fire_proof/on_hit(obj/structure/spacevine/vine, mob/hitter, obj/item/attacking_item, expected_damage)
-	if(attacking_item && attacking_item.damtype == BURN)
-		return 0
-	return expected_damage
+/datum/spacevine_mutation/fire_proof/on_hit(obj/structure/spacevine/vine, obj/item/item,  mob/living/hitter, list/modifiers, list/attack_modifiers)
+	if(item?.damtype == BURN)
+		MODIFY_ATTACK_FORCE_MULTIPLIER(attack_modifiers, 0)
+	return ..()
 
 /datum/spacevine_mutation/fire_proof/on_grow(obj/structure/spacevine/vine)
 	vine.resistance_flags |= FIRE_PROOF
@@ -382,22 +382,20 @@
 		if(victim.apply_damage(15, BRUTE, blocked = victim.run_armor_check(attack_flag = MELEE, silent = TRUE), spread_damage = TRUE))
 			to_chat(victim, span_danger("You cut yourself on the thorny vines."))
 
-/datum/spacevine_mutation/thorns/on_hit(obj/structure/spacevine/vine, mob/living/hitter, obj/item/item, expected_damage)
+/datum/spacevine_mutation/thorns/on_hit(obj/structure/spacevine/vine, obj/item/item,  mob/living/hitter, list/modifiers, list/attack_modifiers)
 	if(isvineimmune(hitter) || HAS_TRAIT(hitter, TRAIT_PIERCEIMMUNE) || HAS_TRAIT(hitter, TRAIT_PLANT_SAFE))
-		return expected_damage
+		return
 
 	if(iscarbon(hitter))
 		var/mob/living/carbon/carbon_victim = hitter
 		for(var/obj/item/clothing/worn_item in carbon_victim.get_equipped_items())
 			if((worn_item.body_parts_covered & HANDS) && (worn_item.clothing_flags & THICKMATERIAL))
-				return expected_damage
+				return
 
 	if(prob(THORN_MUTATION_CUT_PROB))
 		var/mob/living/victim = hitter
 		if(victim.apply_damage(15, BRUTE, blocked = victim.run_armor_check(attack_flag = MELEE, silent = TRUE), spread_damage = TRUE))
 			to_chat(victim, span_danger("You cut yourself on the thorny vines."))
-
-	return expected_damage
 
 /datum/spacevine_mutation/thorns/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
 	venus_trap.melee_damage_lower = initial(venus_trap.melee_damage_lower) * 0.5
@@ -420,10 +418,9 @@
 		vine.set_density(TRUE)
 	vine.modify_max_integrity(100)
 
-/datum/spacevine_mutation/hardened/on_hit(obj/structure/spacevine/vine, obj/item/item,  mob/living/hitter, list/attack_modifiers)
+/datum/spacevine_mutation/hardened/on_hit(obj/structure/spacevine/vine, obj/item/item,  mob/living/hitter, list/modifiers, list/attack_modifiers)
 	if(item?.get_sharpness())
-		MODIFY_ATTACK_FORCE_MULTIPLIER(attack_modifiers, 0.5)
-	return ..()
+		MODIFY_ATTACK_FORCE_MULTIPLIER(attack_modifiers, 0.125)
 
 /datum/spacevine_mutation/hardened/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
 	venus_trap.health = initial(venus_trap.health) * 1.5
@@ -477,9 +474,12 @@
 /datum/spacevine_mutation/slippery/on_grow(obj/structure/spacevine/vine)
 	vine.AddComponent(/datum/component/slippery, 5 SECONDS, NO_SLIP_WHEN_WALKING|SLIDE)
 
-/datum/spacevine_mutation/slippery/on_hit(obj/structure/spacevine/vine, obj/item/item,  mob/living/hitter, list/attack_modifiers)
-	if(prob(20) && !(HAS_TRAIT(hitter, TRAIT_PLANT_SAFE)))
-		item?.AddComponent(/datum/component/slippery_item, fall_catch_chance=25, duration=5 SECONDS)
+/datum/spacevine_mutation/slippery/on_hit(obj/structure/spacevine/vine, obj/item/item,  mob/living/hitter, list/modifiers, list/attack_modifiers)
+	if(isvineimmune(hitter) || HAS_TRAIT(hitter, TRAIT_PLANT_SAFE))
+		return
+
+	if(prob(20))
+		item?.AddComponent(/datum/component/slippery_item, fall_chance=25, fall_catch_chance=25, duration=5 SECONDS)
 
 /datum/spacevine_mutation/conductive
 	name = "Conductive"

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -440,10 +440,10 @@
 	vine.layer = ABOVE_OPEN_TURF_LAYER
 	vine.light_state = PASS_LIGHT
 	vine.can_tangle = FALSE
-	return ..()
 
 /datum/spacevine_mutation/timid/equip_venus_trap(mob/living/basic/venus_human_trap/venus_trap)
 	var/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle/tangle_action
+	tangle_action = locate(/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle) in venus_trap.actions
 	tangle_action.Remove(venus_trap)
 
 /datum/spacevine_mutation/flowering

--- a/code/modules/events/space_vines/vine_structure.dm
+++ b/code/modules/events/space_vines/vine_structure.dm
@@ -65,18 +65,19 @@
 	return ..()
 
 /obj/structure/spacevine/proc/on_chem_effect(datum/reagent/chem)
-	var/override = FALSE
+	var/chem_flags
 	for(var/datum/spacevine_mutation/mutation in mutations)
-		override += mutation.on_chem(src, chem)
-	if(!override && prob(75) && istype(chem, /datum/reagent/toxin/plantbgone))
-		qdel(src)
+		chem_flags |= mutation.on_chem(src, chem)
 
 /obj/structure/spacevine/proc/eat(mob/eater)
-	var/override = FALSE
+	var/eat_flags
 	for(var/datum/spacevine_mutation/mutation in mutations)
-		override += mutation.on_eat(src, eater)
-	if(!override)
-		qdel(src)
+		eat_flags |= mutation.on_eat(src, eater)
+
+	if(eat_flags & BLOCK_EAT_ATTEMPT)
+		return
+
+	qdel(src)
 
 /obj/structure/spacevine/attacked_by(obj/item/item, mob/living/user, list/modifiers, list/attack_modifiers)
 	LAZYSET(attack_modifiers, SILENCE_DEFAULT_MESSAGES, TRUE)

--- a/code/modules/events/space_vines/vine_structure.dm
+++ b/code/modules/events/space_vines/vine_structure.dm
@@ -81,7 +81,6 @@
 
 /obj/structure/spacevine/attacked_by(obj/item/item, mob/living/user, list/modifiers, list/attack_modifiers)
 	LAZYSET(attack_modifiers, SILENCE_DEFAULT_MESSAGES, TRUE)
-	LAZYSET(attack_modifiers, FORCE_MULTIPLIER, 1)
 	if(item.damtype == BURN)
 		MODIFY_ATTACK_FORCE_MULTIPLIER(attack_modifiers, 4)
 	if(item.get_sharpness())
@@ -108,6 +107,8 @@
 /obj/structure/spacevine/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	for(var/datum/spacevine_mutation/mutation in mutations)
 		mutation.on_hit(src, attacking_item, user, modifiers, attack_modifiers)
+
+	return ..()
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/structure/spacevine/attack_hand(mob/user, list/modifiers)

--- a/code/modules/events/space_vines/vine_structure.dm
+++ b/code/modules/events/space_vines/vine_structure.dm
@@ -105,10 +105,12 @@
 	for(var/datum/spacevine_mutation/mutation in mutations)
 		mutation.on_cross(src, movable)
 
+/obj/structure/spacevine/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+	for(var/datum/spacevine_mutation/mutation in mutations)
+		mutation.on_hit(src, attacking_item, user, modifiers, attack_modifiers)
+
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/structure/spacevine/attack_hand(mob/user, list/modifiers)
-	for(var/datum/spacevine_mutation/mutation in mutations)
-		mutation.on_hit(src, user)
 	user_unbuckle_mob(user, user)
 	return ..()
 

--- a/code/modules/events/space_vines/vine_structure.dm
+++ b/code/modules/events/space_vines/vine_structure.dm
@@ -202,11 +202,11 @@
 /obj/structure/spacevine/atmos_expose(datum/gas_mixture/air, exposed_temperature)
 	for(var/datum/spacevine_mutation/mutation in mutations)
 		mutation.additional_atmos_processes(src, air)
-	if(!can_spread && (exposed_temperature >= VINE_FREEZING_POINT || (trait_flags & SPACEVINE_COLD_RESISTANT)))
+	if(!can_spread && (exposed_temperature >= VINE_FREEZING_POINT || (resistance_flags & FREEZE_PROOF)))
 		can_spread = TRUE // not returning here just in case its now a plasmafire and the kudzu should be deleted
-	if(exposed_temperature > FIRE_MINIMUM_TEMPERATURE_TO_SPREAD && !(trait_flags & SPACEVINE_HEAT_RESISTANT))
+	if(exposed_temperature > FIRE_MINIMUM_TEMPERATURE_TO_SPREAD && !(resistance_flags & FIRE_PROOF))
 		qdel(src)
-	else if (exposed_temperature < VINE_FREEZING_POINT && !(trait_flags & SPACEVINE_COLD_RESISTANT))
+	else if (exposed_temperature < VINE_FREEZING_POINT && !(resistance_flags & FREEZE_PROOF))
 		can_spread = FALSE
 
 /obj/structure/spacevine/CanAllowThrough(atom/movable/mover, border_dir)

--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -53,7 +53,7 @@
 	countdown.start()
 
 /obj/structure/alien/resin/flower_bud/run_atom_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
-	var/datum/spacevine_mutation/fire_proof/fire_proof = locate() in vine.mutations
+	var/datum/spacevine_mutation/fire_proof/fire_proof = locate() in mutations
 	if(fire_proof && damage_type == BURN)
 		damage_amount = 0
 

--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -184,6 +184,10 @@
 	)
 	grant_actions_by_list(innate_actions)
 
+/mob/living/basic/venus_human_trap/Destroy(force)
+	QDEL_NULL(glow)
+	return ..()
+
 /mob/living/basic/venus_human_trap/RangedAttack(atom/victim)
 	if(!combat_mode)
 		return

--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -58,7 +58,7 @@
 	countdown.start()
 
 /obj/structure/alien/resin/flower_bud/run_atom_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
-	if((var/datum/spacevine_mutation/fire_proof/fireproof in mutations) && damage_type == BURN)
+	if(is_type_in_list(/datum/spacevine_mutation/fire_proof, mutations) && damage_type == BURN)
 		damage_amount = 0
 	. = ..()
 

--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -29,8 +29,11 @@
 	/// The countdown ghosts see to when the plant will hatch
 	var/obj/effect/countdown/flower_bud/countdown
 
-	var/trait_flags = 0
+	//var/trait_flags = 0
 
+	/// List of mutations for a specific flower vine
+	var/list/mutations = list()
+	/// List of anchored vines that are attatched to the flower for the bloom/beam effect
 	var/list/vines = list()
 
 	/// The spawner that actually handles spawning the ghost role in
@@ -55,7 +58,7 @@
 	countdown.start()
 
 /obj/structure/alien/resin/flower_bud/run_atom_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
-	if((trait_flags & SPACEVINE_HEAT_RESISTANT) && damage_type == BURN)
+	if((var/datum/spacevine_mutation/fire_proof/fireproof in mutations) && damage_type == BURN)
 		damage_amount = 0
 	. = ..()
 

--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -137,8 +137,8 @@
 	health_doll_icon = "venus_human_trap"
 	mob_biotypes = MOB_ORGANIC | MOB_PLANT
 	layer = SPACEVINE_MOB_LAYER
-	health = 100
-	maxHealth = 100
+	health = 50
+	maxHealth = 50
 	obj_damage = 60
 	melee_damage_lower = 10
 	melee_damage_upper = 20

--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -23,19 +23,14 @@
 	/// The amount of time it takes to create a venus human trap.
 	var/growth_time = 120 SECONDS
 	var/growth_icon = 0
-
 	/// Used by countdown to check time, this is when the timer will complete and the venus trap will spawn.
 	var/finish_time
 	/// The countdown ghosts see to when the plant will hatch
 	var/obj/effect/countdown/flower_bud/countdown
-
-	//var/trait_flags = 0
-
 	/// List of mutations for a specific flower vine
 	var/list/mutations = list()
 	/// List of anchored vines that are attatched to the flower for the bloom/beam effect
 	var/list/vines = list()
-
 	/// The spawner that actually handles spawning the ghost role in
 	var/obj/effect/mob_spawn/ghost_role/venus_human_trap/spawner
 

--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -53,8 +53,10 @@
 	countdown.start()
 
 /obj/structure/alien/resin/flower_bud/run_atom_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
-	if(is_type_in_list(/datum/spacevine_mutation/fire_proof, mutations) && damage_type == BURN)
+	var/datum/spacevine_mutation/fire_proof/fire_proof = locate() in vine.mutations
+	if(fire_proof && damage_type == BURN)
 		damage_amount = 0
+
 	. = ..()
 
 /obj/structure/alien/resin/flower_bud/attacked_by(obj/item/item, mob/living/user, list/modifiers, list/attack_modifiers)

--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -156,7 +156,7 @@
 	lighting_cutoff_red = 10
 	lighting_cutoff_green = 35
 	lighting_cutoff_blue = 20
-	faction = list(FACTION_HOSTILE,FACTION_VINES,FACTION_PLANTS)
+	faction = list(FACTION_HOSTILE, FACTION_VINES, FACTION_PLANTS)
 	initial_language_holder = /datum/language_holder/venus
 	unique_name = TRUE
 	speed = 1.2
@@ -168,13 +168,15 @@
 	var/weed_heal = 10
 	///if the balloon alert was shown atleast once, reset after healing in weeds
 	var/alert_shown = FALSE
+	///the distance it can move away from kudzu before taking damage
+	var/kudzu_off_distance_range = 2
+	var/static/list/innate_actions = list(
+		/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle = BB_TARGETED_ACTION,
+	)
 
 /mob/living/basic/venus_human_trap/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/lifesteal, 5)
-	var/static/list/innate_actions = list(
-		/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle = BB_TARGETED_ACTION,
-	)
 	grant_actions_by_list(innate_actions)
 
 /mob/living/basic/venus_human_trap/RangedAttack(atom/victim)
@@ -190,7 +192,7 @@
 	if(!.)
 		return FALSE
 
-	var/vines_in_range = locate(/obj/structure/spacevine) in range(2, src)
+	var/vines_in_range = locate(/obj/structure/spacevine) in range(kudzu_off_distance_range, src)
 	if(!vines_in_range && !alert_shown)
 		alert_shown = TRUE
 		balloon_alert(src, "do not leave vines!")

--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -179,6 +179,9 @@
 /mob/living/basic/venus_human_trap/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/lifesteal, 5)
+	var/static/list/innate_actions = list(
+		/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle = BB_TARGETED_ACTION,
+	)
 	grant_actions_by_list(innate_actions)
 
 /mob/living/basic/venus_human_trap/RangedAttack(atom/victim)

--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -168,14 +168,13 @@
 	///how much damage we take out of weeds
 	var/no_weed_damage = 12.5
 	///how much do we heal in weeds
-	var/weed_heal = 10
+	var/weed_heal = 5
 	///if the balloon alert was shown atleast once, reset after healing in weeds
 	var/alert_shown = FALSE
 	///the distance it can move away from kudzu before taking damage
-	var/kudzu_off_distance_range = 2
-	var/static/list/innate_actions = list(
-		/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle = BB_TARGETED_ACTION,
-	)
+	var/kudzu_off_distance_range = 0
+	/// Internal dummy used to glow (very cool)
+	var/obj/effect/dummy/lighting_obj/moblight/glow
 
 /mob/living/basic/venus_human_trap/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
+++ b/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
@@ -9,7 +9,7 @@
 	prompt_name = "venus human trap"
 	you_are_text = "You are a venus human trap."
 	flavour_text = "You are a venus human trap!  Protect the kudzu at all costs, and feast on those who oppose you!"
-	faction = list(FACTION_HOSTILE,FACTION_VINES,FACTION_PLANTS)
+	faction = list(FACTION_HOSTILE, FACTION_VINES, FACTION_PLANTS)
 	spawner_job_path = /datum/job/venus_human_trap
 	invisibility = INVISIBILITY_ABSTRACT //The flower bud structure is our visible component, we just handle logic.
 	/// Physical structure housing the spawner
@@ -28,10 +28,65 @@
 	if(spawned_human_trap && flower_bud)
 		if(flower_bud.trait_flags & SPACEVINE_HEAT_RESISTANT)
 			spawned_human_trap.unsuitable_heat_damage = 0
+			spawned_human_trap.resistance_flags |= FIRE_PROOF
+			ADD_TRAIT(spawned_human_trap, TRAIT_RESISTHEAT, INNATE_TRAIT)
 		if(flower_bud.trait_flags & SPACEVINE_COLD_RESISTANT)
 			spawned_human_trap.unsuitable_cold_damage = 0
+			spawned_human_trap.resistance_flags |= FREEZE_PROOF
+			ADD_TRAIT(spawned_human_trap, TRAIT_RESISTCOLD, INNATE_TRAIT)
+		if(flower_bud.trait_flags & SPACEVINE_TOXIN_RESISTANT)
+			ADD_TRAIT(spawned_human_trap, TRAIT_TOXIMMUNE, INNATE_TRAIT)
+		if(flower_bud.trait_flags & SPACEVINE_AGGRESSIVE_SPREADING)
+			spawned_human_trap.kudzu_off_distance_range = initial(spawned_human_trap.kudzu_off_distance_range) * 3
+		if(flower_bud.trait_flags & SPACEVINE_HARDENED)
+			spawned_human_trap.health = initial(spawned_human_trap.health) * 1.5
+			spawned_human_trap.maxHealth = initial(spawned_human_trap.maxHealth) * 1.5
+		if(flower_bud.trait_flags & SPACEVINE_THORNY)
+			spawned_human_trap.melee_damage_lower = initial(spawned_human_trap.melee_damage_lower) * 0.5
+			spawned_human_trap.melee_damage_upper = initial(spawned_human_trap.melee_damage_upper) * 0.5
+			spawned_human_trap.obj_damage = initial(spawned_human_trap.obj_damage) * 0.5
+			spawned_human_trap.wound_bonus = 5
+			spawned_human_trap.exposed_wound_bonus = 15
+			spawned_human_trap.sharpness = SHARP_POINTY
+		if(flower_bud.trait_flags & SPACEVINE_LIGHT)
+			spawned_human_trap.light_range = LIGHT_MUTATION_BRIGHTNESS
+		if(flower_bud.trait_flags & SPACEVINE_TRANSPARENT)
+			spawned_human_trap.alpha = 125
+		if(flower_bud.trait_flags & SPACEVINE_EXPLOSIVE)
+			RegisterSignal(spawned_human_trap, COMSIG_LIVING_DEATH, PROC_REF(on_death))
+		if(flower_bud.trait_flags & SPACEVINE_TIMID)
+			var/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle/tangle_action
+			tangle_action.Remove(spawned_human_trap)
+
+/obj/effect/mob_spawn/ghost_role/venus_human_trap/proc/on_death(mob/living/spawned_mob, mob/mob_possessor, apply_prefs)
+	SIGNAL_HANDLER
+
+	explosion(spawned_mob, light_impact_range = EXPLOSION_MUTATION_IMPACT_RADIUS, adminlog = FALSE)
 
 /obj/effect/mob_spawn/ghost_role/venus_human_trap/special(mob/living/spawned_mob, mob/mob_possessor, apply_prefs)
+	flavour_text += "\nYou have the following vine mutations:\n"
+
+	if(flower_bud.trait_flags & SPACEVINE_HEAT_RESISTANT)
+		flavour_text += "\n<b>Heat Resistance</b> - Immune to extreme heat and fire"
+	if(flower_bud.trait_flags & SPACEVINE_COLD_RESISTANT)
+		flavour_text += "\n<b>Cold Resistance</b> - Immune to freezing temperatures"
+	if(flower_bud.trait_flags & SPACEVINE_TOXIN_RESISTANT)
+		flavour_text += "\n<b>Toxin Resistance</b> - Immune to chemical weedkillers and toxins"
+	if(flower_bud.trait_flags & SPACEVINE_AGGRESSIVE_SPREADING)
+		flavour_text += "\n<b>Aggressive Spreading</b> - Can travel farther away from vines before taking damage"
+	if(flower_bud.trait_flags & SPACEVINE_HARDENED)
+		flavour_text += "\n<b>Hardened</b> - Increased health"
+	if(flower_bud.trait_flags & SPACEVINE_THORNY)
+		flavour_text += "\n<b>Thorny</b> - Your physical attacks deal reduced damage but cause wounds"
+	if(flower_bud.trait_flags & SPACEVINE_LIGHT)
+		flavour_text += "\n<b>Light</b> - Your body emits a glowing light"
+	if(flower_bud.trait_flags & SPACEVINE_TRANSPARENT)
+		flavour_text += "\n<b>Transparency</b> - Your body is transparent"
+	if(flower_bud.trait_flags & SPACEVINE_EXPLOSIVE)
+		flavour_text += "\n<b>Explosive</b> - You will violently explode upon death"
+	if(flower_bud.trait_flags & SPACEVINE_TIMID)
+		flavour_text += "\n<b>Timid</b> - You no longer have the ability to shoot tangling vines at targets"
+
 	. = ..()
 	spawned_mob.mind.add_antag_datum(/datum/antagonist/venus_human_trap)
 

--- a/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
+++ b/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
@@ -24,69 +24,20 @@
 		flower_bud = null
 	return ..()
 
-/obj/effect/mob_spawn/ghost_role/venus_human_trap/equip(mob/living/basic/venus_human_trap/spawned_human_trap)
-	if(spawned_human_trap && flower_bud)
-		if(flower_bud.trait_flags & SPACEVINE_HEAT_RESISTANT)
-			spawned_human_trap.unsuitable_heat_damage = 0
-			spawned_human_trap.resistance_flags |= FIRE_PROOF
-			ADD_TRAIT(spawned_human_trap, TRAIT_RESISTHEAT, INNATE_TRAIT)
-		if(flower_bud.trait_flags & SPACEVINE_COLD_RESISTANT)
-			spawned_human_trap.unsuitable_cold_damage = 0
-			spawned_human_trap.resistance_flags |= FREEZE_PROOF
-			ADD_TRAIT(spawned_human_trap, TRAIT_RESISTCOLD, INNATE_TRAIT)
-		if(flower_bud.trait_flags & SPACEVINE_TOXIN_RESISTANT)
-			ADD_TRAIT(spawned_human_trap, TRAIT_TOXIMMUNE, INNATE_TRAIT)
-		if(flower_bud.trait_flags & SPACEVINE_AGGRESSIVE_SPREADING)
-			spawned_human_trap.kudzu_off_distance_range = initial(spawned_human_trap.kudzu_off_distance_range) * 3
-		if(flower_bud.trait_flags & SPACEVINE_HARDENED)
-			spawned_human_trap.health = initial(spawned_human_trap.health) * 1.5
-			spawned_human_trap.maxHealth = initial(spawned_human_trap.maxHealth) * 1.5
-		if(flower_bud.trait_flags & SPACEVINE_THORNY)
-			spawned_human_trap.melee_damage_lower = initial(spawned_human_trap.melee_damage_lower) * 0.5
-			spawned_human_trap.melee_damage_upper = initial(spawned_human_trap.melee_damage_upper) * 0.5
-			spawned_human_trap.obj_damage = initial(spawned_human_trap.obj_damage) * 0.5
-			spawned_human_trap.wound_bonus = 5
-			spawned_human_trap.exposed_wound_bonus = 15
-			spawned_human_trap.sharpness = SHARP_POINTY
-		if(flower_bud.trait_flags & SPACEVINE_LIGHT)
-			spawned_human_trap.light_range = LIGHT_MUTATION_BRIGHTNESS
-		if(flower_bud.trait_flags & SPACEVINE_TRANSPARENT)
-			spawned_human_trap.alpha = 125
-		if(flower_bud.trait_flags & SPACEVINE_EXPLOSIVE)
-			RegisterSignal(spawned_human_trap, COMSIG_LIVING_DEATH, PROC_REF(on_death))
-		if(flower_bud.trait_flags & SPACEVINE_TIMID)
-			var/datum/action/cooldown/mob_cooldown/projectile_attack/vine_tangle/tangle_action
-			tangle_action.Remove(spawned_human_trap)
+/obj/effect/mob_spawn/ghost_role/venus_human_trap/equip(mob/living/basic/venus_human_trap/venus_trap)
+	if(!venus_trap || !flower_bud)
+		return
 
-/obj/effect/mob_spawn/ghost_role/venus_human_trap/proc/on_death(mob/living/spawned_mob, mob/mob_possessor, apply_prefs)
-	SIGNAL_HANDLER
-
-	explosion(spawned_mob, light_impact_range = EXPLOSION_MUTATION_IMPACT_RADIUS, adminlog = FALSE)
+	for(var/datum/spacevine_mutation/mutation in flower_bud.mutations)
+		mutation.equip_venus_trap(venus_trap)
 
 /obj/effect/mob_spawn/ghost_role/venus_human_trap/special(mob/living/spawned_mob, mob/mob_possessor, apply_prefs)
-	flavour_text += "\nYou have the following vine mutations:\n"
-
-	if(flower_bud.trait_flags & SPACEVINE_HEAT_RESISTANT)
-		flavour_text += "\n<b>Heat Resistance</b> - Immune to extreme heat and fire"
-	if(flower_bud.trait_flags & SPACEVINE_COLD_RESISTANT)
-		flavour_text += "\n<b>Cold Resistance</b> - Immune to freezing temperatures"
-	if(flower_bud.trait_flags & SPACEVINE_TOXIN_RESISTANT)
-		flavour_text += "\n<b>Toxin Resistance</b> - Immune to chemical weedkillers and toxins"
-	if(flower_bud.trait_flags & SPACEVINE_AGGRESSIVE_SPREADING)
-		flavour_text += "\n<b>Aggressive Spreading</b> - Can travel farther away from vines before taking damage"
-	if(flower_bud.trait_flags & SPACEVINE_HARDENED)
-		flavour_text += "\n<b>Hardened</b> - Increased health"
-	if(flower_bud.trait_flags & SPACEVINE_THORNY)
-		flavour_text += "\n<b>Thorny</b> - Your physical attacks deal reduced damage but cause wounds"
-	if(flower_bud.trait_flags & SPACEVINE_LIGHT)
-		flavour_text += "\n<b>Light</b> - Your body emits a glowing light"
-	if(flower_bud.trait_flags & SPACEVINE_TRANSPARENT)
-		flavour_text += "\n<b>Transparency</b> - Your body is transparent"
-	if(flower_bud.trait_flags & SPACEVINE_EXPLOSIVE)
-		flavour_text += "\n<b>Explosive</b> - You will violently explode upon death"
-	if(flower_bud.trait_flags & SPACEVINE_TIMID)
-		flavour_text += "\n<b>Timid</b> - You no longer have the ability to shoot tangling vines at targets"
-
+	if(flower_bud && length(flower_bud.mutations))
+		var/list/flavour_mutation_list = list()
+		flavour_mutation_list += "\nYou have the following vine mutations:"
+		for(var/datum/spacevine_mutation/mutation in flower_bud.mutations)
+			flavour_mutation_list += mutation.venus_flavor_text
+		flavour_text += flavour_mutation_list.join("\n")
 	. = ..()
 	spawned_mob.mind.add_antag_datum(/datum/antagonist/venus_human_trap)
 

--- a/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
+++ b/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
@@ -36,8 +36,8 @@
 		var/list/flavour_mutation_list = list()
 		flavour_mutation_list += "\nYou have the following vine mutations:"
 		for(var/datum/spacevine_mutation/mutation in flower_bud.mutations)
-			flavour_mutation_list += mutation.venus_flavor_text
-		flavour_text += flavour_mutation_list.join("\n")
+			flavour_mutation_list += span_notice(mutation.venus_flavor_text) // double check if spans work here
+		flavour_text += flavour_mutation_list.Join("\n")
 	. = ..()
 	spawned_mob.mind.add_antag_datum(/datum/antagonist/venus_human_trap)
 

--- a/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
+++ b/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
@@ -34,9 +34,9 @@
 /obj/effect/mob_spawn/ghost_role/venus_human_trap/special(mob/living/spawned_mob, mob/mob_possessor, apply_prefs)
 	if(flower_bud && length(flower_bud.mutations))
 		var/list/flavour_mutation_list = list()
-		flavour_mutation_list += "\nYou have the following vine mutations:"
+		flavour_mutation_list += " You have the following vine mutations:"
 		for(var/datum/spacevine_mutation/mutation in flower_bud.mutations)
-			flavour_mutation_list += span_notice(mutation.venus_flavor_text) // double check if spans work here
+			flavour_mutation_list += span_notice(mutation.venus_flavor_text)
 		flavour_text += flavour_mutation_list.Join("\n")
 	. = ..()
 	spawned_mob.mind.add_antag_datum(/datum/antagonist/venus_human_trap)

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -308,7 +308,8 @@
 			output_message += "\n<span class='infoplain'><b>[flavour_text]</b></span>"
 		if(important_text != "")
 			output_message += "\n[span_userdanger("[important_text]")]"
-		to_chat(spawned_mob, output_message)
+
+		to_chat(spawned_mob, boxed_message(output_message), type = MESSAGE_TYPE_INFO)
 
 /// Checks if the spawner has zero uses left, if so, delete yourself... NOW!
 /obj/effect/mob_spawn/ghost_role/proc/check_uses()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -501,8 +501,8 @@
 	. = ..()
 	var/damage = min(round(0.4 * reac_volume, 0.1), 10)
 	if(exposed_mob.mob_biotypes & MOB_PLANT)
-		// spray bottle emits 5u so it's dealing ~15 dmg per spray
-		if(exposed_mob.adjust_tox_loss(damage * 20, required_biotype = affected_biotype))
+		damage = damage * 10 * weed_damage_multiplier
+		if(exposed_mob.adjust_tox_loss(damage, required_biotype = affected_biotype))
 			return
 
 	if(!(methods & VAPOR) || !ishuman(exposed_mob))

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -486,7 +486,7 @@
 			if(mutation.type == /datum/spacevine_mutation/toxicity)
 				return
 
-		var/flower_damage = rand(30, 50) * weed_damage_multiplier
+		var/flower_damage = rand(15, 25) * weed_damage_multiplier
 		flower.take_damage(flower_damage, BRUTE, 0)
 	if(istype(exposed_obj, /obj/structure/glowshroom)) //even a small amount is enough to kill it
 		qdel(exposed_obj)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -486,7 +486,7 @@
 			return
 
 		var/flower_damage = rand(30, 50) * weed_damage_multiplier
-		flower.take_damage(rand(30, 50), BRUTE, 0)
+		flower.take_damage(flower_damage, BRUTE, 0)
 	if(istype(exposed_obj, /obj/structure/glowshroom)) //even a small amount is enough to kill it
 		qdel(exposed_obj)
 	if(istype(exposed_obj, /obj/structure/spacevine))

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -482,8 +482,9 @@
 		qdel(exposed_obj)
 	if(istype(exposed_obj, /obj/structure/alien/resin/flower_bud))
 		var/obj/structure/alien/resin/flower_bud/flower = exposed_obj
-		if(is_type_in_list(/datum/spacevine_mutation/toxicity, flower.mutations))
-			return
+		for(var/datum/spacevine_mutation/mutation in flower.mutations)
+			if(mutation.type == /datum/spacevine_mutation/toxicity)
+				return
 
 		var/flower_damage = rand(30, 50) * weed_damage_multiplier
 		flower.take_damage(flower_damage, BRUTE, 0)
@@ -491,8 +492,9 @@
 		qdel(exposed_obj)
 	if(istype(exposed_obj, /obj/structure/spacevine))
 		var/obj/structure/spacevine/vine = exposed_obj
-		if(is_type_in_list(/datum/spacevine_mutation/toxicity, vine.mutations))
-			return
+		for(var/datum/spacevine_mutation/mutation in vine.mutations)
+			if(mutation.type == /datum/spacevine_mutation/toxicity)
+				return
 
 		if(prob(spacevine_kill_prob))
 			qdel(vine)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -467,6 +467,8 @@
 	ph = 2.7
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	randomized_spawns = REAGENT_SPAWN_ALL_RANDOM_SPAWNS
+	var/spacevine_kill_prob = 75
+	var/weed_damage_multiplier = 1
 
 // Plant-B-Gone is just as bad
 /datum/reagent/toxin/plantbgone/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)
@@ -476,17 +478,24 @@
 
 /datum/reagent/toxin/plantbgone/expose_obj(obj/exposed_obj, reac_volume, methods=TOUCH, show_message=TRUE)
 	. = ..()
-	if(istype(exposed_obj, /obj/structure/alien/weeds))
-		var/obj/structure/alien/weeds/alien_weeds = exposed_obj
-		alien_weeds.take_damage(rand(15, 35), BRUTE, 0) // Kills alien weeds pretty fast
+	if(istype(exposed_obj, /obj/structure/alien/weeds)) // alien weeds have low hp so just kill
+		qdel(exposed_obj)
 	if(istype(exposed_obj, /obj/structure/alien/resin/flower_bud))
 		var/obj/structure/alien/resin/flower_bud/flower = exposed_obj
+		if(flower.trait_flags & SPACEVINE_TOXIN_RESISTANT)
+			return
+
+		var/flower_damage = rand(30, 50) * weed_damage_multiplier
 		flower.take_damage(rand(30, 50), BRUTE, 0)
-	else if(istype(exposed_obj, /obj/structure/glowshroom)) //even a small amount is enough to kill it
+	if(istype(exposed_obj, /obj/structure/glowshroom)) //even a small amount is enough to kill it
 		qdel(exposed_obj)
-	else if(istype(exposed_obj, /obj/structure/spacevine))
-		var/obj/structure/spacevine/SV = exposed_obj
-		SV.on_chem_effect(src)
+	if(istype(exposed_obj, /obj/structure/spacevine))
+		var/obj/structure/spacevine/vine = exposed_obj
+		if(vine.trait_flags & SPACEVINE_TOXIN_RESISTANT)
+			return
+
+		if(prob(spacevine_kill_prob))
+			qdel(vine)
 
 /datum/reagent/toxin/plantbgone/expose_mob(mob/living/exposed_mob, methods = TOUCH, reac_volume)
 	. = ..()
@@ -510,6 +519,8 @@
 	ph = 3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	randomized_spawns = REAGENT_SPAWN_ALL_RANDOM_SPAWNS
+	spacevine_kill_prob = 100
+	weed_damage_multiplier = 3
 
 //Weed Spray
 /datum/reagent/toxin/plantbgone/weedkiller/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -482,9 +482,9 @@
 		qdel(exposed_obj)
 	if(istype(exposed_obj, /obj/structure/alien/resin/flower_bud))
 		var/obj/structure/alien/resin/flower_bud/flower = exposed_obj
-		for(var/datum/spacevine_mutation/mutation in flower.mutations)
-			if(mutation.type == /datum/spacevine_mutation/toxicity)
-				return
+		var/datum/spacevine_mutation/toxicity/toxicity = locate() in flower.mutations
+		if(toxicity)
+			return
 
 		var/flower_damage = rand(15, 25) * weed_damage_multiplier
 		flower.take_damage(flower_damage, BRUTE, 0)
@@ -492,9 +492,9 @@
 		qdel(exposed_obj)
 	if(istype(exposed_obj, /obj/structure/spacevine))
 		var/obj/structure/spacevine/vine = exposed_obj
-		for(var/datum/spacevine_mutation/mutation in vine.mutations)
-			if(mutation.type == /datum/spacevine_mutation/toxicity)
-				return
+		var/datum/spacevine_mutation/toxicity/toxicity = locate() in vine.mutations
+		if(toxicity)
+			return
 
 		if(prob(spacevine_kill_prob))
 			qdel(vine)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -467,7 +467,7 @@
 	ph = 2.7
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	randomized_spawns = REAGENT_SPAWN_ALL_RANDOM_SPAWNS
-	var/spacevine_kill_prob = 75
+	var/spacevine_kill_prob = 50
 	var/weed_damage_multiplier = 1
 
 // Plant-B-Gone is just as bad
@@ -519,8 +519,8 @@
 	ph = 3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	randomized_spawns = REAGENT_SPAWN_ALL_RANDOM_SPAWNS
-	spacevine_kill_prob = 100
-	weed_damage_multiplier = 3
+	spacevine_kill_prob = 75
+	weed_damage_multiplier = 2
 
 //Weed Spray
 /datum/reagent/toxin/plantbgone/weedkiller/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -482,7 +482,7 @@
 		qdel(exposed_obj)
 	if(istype(exposed_obj, /obj/structure/alien/resin/flower_bud))
 		var/obj/structure/alien/resin/flower_bud/flower = exposed_obj
-		if(flower.trait_flags & SPACEVINE_TOXIN_RESISTANT)
+		if(is_type_in_list(/datum/spacevine_mutation/toxicity, flower.mutations))
 			return
 
 		var/flower_damage = rand(30, 50) * weed_damage_multiplier
@@ -491,7 +491,7 @@
 		qdel(exposed_obj)
 	if(istype(exposed_obj, /obj/structure/spacevine))
 		var/obj/structure/spacevine/vine = exposed_obj
-		if(vine.trait_flags & SPACEVINE_TOXIN_RESISTANT)
+		if(is_type_in_list(/datum/spacevine_mutation/toxicity, vine.mutations))
 			return
 
 		if(prob(spacevine_kill_prob))


### PR DESCRIPTION

## About The Pull Request
Several big changes with Kudzu and Venus Fly Traps.

New Mutations:
- Slippery - Causes the vines to be slippery (also melee attacking items have a chance to become slippery, causing you to drop them)
- Conductive - Causes the vines to conduct electricity if they are over powered wires (similar to electrified grilles)
- Radioactive - Causes the vines to be radioactive and spread radiation to nearby objects and mobs

Mutations now directly affect the Venus Fly Traps:
- Light - Emit a glow like ethreals
- Transparent- The body is now 50% alpha (partially see-through)
- Toxic - Full immunity to toxin damage, weedkillers, pesticides, etc.
- Explosive - Will explode upon death
- Vine Eating - Doubles the weed heal rate
- Aggressive Spreading - +2 range off weeds before taking damage
- Thorns - Halves melee/object damage but gains a pointy, sharp attack that causes wounds and bleeding
- Hardened - Double health
- Timid - Removes vine tangle ability
- Slippery - Chance to cause melee attacking item to be slippery
- Radioactive - Radiation pulse when attacked

Base changes to Venus Fly Traps:
- Halved health
- Halved regeneration weed heal rate
- Off weeds start taking immediate damage (0 range)

Weedkiller/Plant-B-Gone:
- Change the weedkiller grenade to be the actual weedkiller chemical
- Halved the damage that plantbgone chem does to plants and it now has a 50% chance to remove kudzu (vs the 75% of weedkiller)
- Weedkiller/Plant-B-Gone now instakills alien weeds (which technically did already since it was so low health)

Misc:
- Add examine text blocks to flavour ghost mob spawners
- Add mutation list to flavour text for Venus Fly Traps (so you know what advantages/disadvantages you have)
- Remove redundant heat/cold flags
- Fix `on_hit` code not working which affected thorn mutation from cutting people when attacked and the hardened mutation from providing a 50% damage resistance from sharp weapons 

## Why It's Good For The Game
Currently, Venus Flytraps exist in an unhealthy balance state. Because their passive regeneration and health pool are so high, standard weapons (like lasers) cannot out-damage them. This forces crew to rely almost entirely on weedkiller gas grenades as an absolute silver bullet. This made adding cool new mutations like Toxin Immunity impossible without making Flytraps completely invincible.

This PR resolves this by making Flytraps use a mutation framework. Base stats (HP, regen, weed distance) are reduced by ~50%, making raw Kudzu outbreaks manageable with standard weapons. However, dedicated Botanists who selectively breed and prune traits can still craft an unholy, endgame biological threat.

Also, I thought it was silly for the weedkiller grenade to be using the plant-b-gone chemical inside it when there is a weedkiller chem. Upon closer code inspection, the weedkiller/plant-b-gone had no noticeable difference when it comes to fighting Kudzu with the chemical. So I cut the damage/chance in half for plant-b-gone and kept the same stats for weedkiller. (so your normal weedkiller grenade effects is unchanged)

## Changelog
:cl:
add: Add 3 new kudzu mutations - slippery, radioactive, and conductive
add: Venus Flytraps will inherit mutations from kudzu that can be beneficial or negative that can affect stats, abilities, etc.
balance: Halved Venus Flytrap health and regen. Venus Flytraps can no longer move off weeds without taking damage unless they have the aggressive spread mutation.
add: Weedkiller/Plant-B-Gone instakills alien weeds
add: Weedkiller grenades now use weedkiller chemical and not Plant-B-Gone
balance: Halved the damage from Plant-B-Gone vs kudzu and plants
fix: Fixed hardening kudzu mutation not providing a 50% resistance to sharpened weapons.
fix: Fixed thorn kudzu mutation not retaliating against players who attack it.
qol: Add examine blocks to flavour text for Venus Trap Ghost Spawners that includes their inherited mutations
/:cl:
