### PR TITLE
Timestop stops slightly more time

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_spell.dm
+++ b/code/__DEFINES/dcs/signals/signals_spell.dm
@@ -131,3 +131,7 @@
 	#define COMPONENT_ITEM_CHARGED (1 << 0)
 	/// Return if the item had a negative side effect occur while recharging
 	#define COMPONENT_ITEM_BURNT_OUT (1 << 1)
+
+// Time Stop
+/// Sent from /datum/action/cooldown/spell/timestop/cast(), to the atom casting the spell: (datum/action/cooldown/spell/timestop/spell, list/immune_atoms)
+#define COMSIG_ATOM_STOPPING_TIME "atom_stopping_time"

--- a/code/datums/proximity_monitor/fields/timestop.dm
+++ b/code/datums/proximity_monitor/fields/timestop.dm
@@ -31,14 +31,8 @@
 	if(silent)
 		hidden = TRUE
 		alpha = 0
-	for(var/A in immune_atoms)
-		immune[A] = TRUE
-	for(var/mob/living/to_check in GLOB.player_list)
-		if(HAS_TRAIT(to_check, TRAIT_TIME_STOP_IMMUNE))
-			immune[to_check] = TRUE
-	for(var/mob/living/basic/guardian/stand in GLOB.parasites)
-		if(stand.summoner && HAS_TRAIT(stand.summoner, TRAIT_TIME_STOP_IMMUNE)) //It would only make sense that a person's stand would also be immune.
-			immune[stand] = TRUE
+	for(var/innately_immune in immune_atoms)
+		immune[innately_immune] = TRUE
 	if(start)
 		INVOKE_ASYNC(src, PROC_REF(timestop))
 
@@ -97,15 +91,15 @@
 /datum/proximity_monitor/advanced/timestop/proc/freeze_atom(atom/movable/A)
 	if(global_frozen_atoms[A] || !istype(A))
 		return FALSE
-	if(immune[A]) //a little special logic but yes immune things don't freeze
+
+	if(HAS_TRAIT(A, TRAIT_TIME_STOP_IMMUNE) || astype(A, /mob)?.can_block_magic(antimagic_flags))
+		immune[A] = TRUE
+
+	if(immune[A])
 		if(channelled)
 			RegisterSignal(A, COMSIG_MOVABLE_MOVED, PROC_REF(atom_broke_channel), override = TRUE)
 		return FALSE
-	if(ismob(A))
-		var/mob/M = A
-		if(M.can_block_magic(antimagic_flags))
-			immune[A] = TRUE
-			return
+
 	var/frozen = TRUE
 	if(isliving(A))
 		freeze_mob(A)

--- a/code/datums/proximity_monitor/fields/timestop.dm
+++ b/code/datums/proximity_monitor/fields/timestop.dm
@@ -68,7 +68,7 @@
 	edge_is_a_field = TRUE
 	var/list/immune = list()
 	var/list/frozen_things = list()
-	var/list/frozen_mobs = list() //cached separately for processing
+	var/list/frozen_mobs = list()
 	var/list/frozen_structures = list() //Also machinery, and only frozen aestethically
 	var/list/frozen_turfs = list() //Only aesthetically
 	var/antimagic_flags = NONE
@@ -83,14 +83,12 @@
 	src.antimagic_flags = antimagic_flags
 	src.channelled = channelled
 	recalculate_field(full_recalc = TRUE)
-	START_PROCESSING(SSfastprocess, src)
 
 /datum/proximity_monitor/advanced/timestop/Destroy()
 	unfreeze_all()
 	if(channelled)
 		for(var/atom in immune)
 			UnregisterSignal(atom, COMSIG_MOVABLE_MOVED)
-	STOP_PROCESSING(SSfastprocess, src)
 	return ..()
 
 /datum/proximity_monitor/advanced/timestop/field_turf_crossed(atom/movable/movable, turf/old_location, turf/new_location)
@@ -193,11 +191,6 @@
 /datum/proximity_monitor/advanced/timestop/proc/unfreeze_structure(obj/O)
 	escape_the_negative_zone(O)
 
-/datum/proximity_monitor/advanced/timestop/process()
-	for(var/i in frozen_mobs)
-		var/mob/living/m = i
-		m.Stun(20, ignore_canstun = TRUE)
-
 /datum/proximity_monitor/advanced/timestop/setup_field_turf(turf/target)
 	. = ..()
 	for(var/i in target.contents)
@@ -212,8 +205,7 @@
 
 /datum/proximity_monitor/advanced/timestop/proc/freeze_mob(mob/living/victim)
 	frozen_mobs += victim
-	victim.Stun(20, ignore_canstun = TRUE)
-	victim.add_traits(list(TRAIT_MUTE, TRAIT_EMOTEMUTE), TIMESTOP_TRAIT)
+	victim.add_traits(list(TRAIT_MUTE, TRAIT_EMOTEMUTE, TRAIT_INCAPACITATED, TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED, TRAIT_STASIS), TIMESTOP_TRAIT)
 	GLOB.move_manager.stop_looping(victim) //stops them mid pathing even if they're stunimmune //This is really dumb
 	if(isanimal(victim))
 		var/mob/living/simple_animal/animal_victim = victim
@@ -226,8 +218,7 @@
 		basic_victim.ai_controller?.force_ai_off()
 
 /datum/proximity_monitor/advanced/timestop/proc/unfreeze_mob(mob/living/victim)
-	victim.AdjustStun(-20, ignore_canstun = TRUE)
-	victim.remove_traits(list(TRAIT_MUTE, TRAIT_EMOTEMUTE), TIMESTOP_TRAIT)
+	victim.remove_traits(list(TRAIT_MUTE, TRAIT_EMOTEMUTE, TRAIT_INCAPACITATED, TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED, TRAIT_STASIS), TIMESTOP_TRAIT)
 	frozen_mobs -= victim
 	if(isanimal(victim))
 		var/mob/living/simple_animal/animal_victim = victim

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -363,25 +363,19 @@ GLOBAL_LIST_EMPTY(unconscious_appearances)
 	. = ..()
 	if(!.)
 		return
-	owner.add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED, TRAIT_STASIS, TRAIT_TUMOR_SUPPRESSED), TRAIT_STATUS_EFFECT(id))
+	owner.add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED, TRAIT_STASIS), TRAIT_STATUS_EFFECT(id))
 	owner.add_filter("stasis_status_ripple", 2, list("type" = "ripple", "flags" = WAVE_BOUNDED, "radius" = 0, "size" = 2))
 	var/filter = owner.get_filter("stasis_status_ripple")
 	animate(filter, radius = 0, time = 0.2 SECONDS, size = 2, easing = JUMP_EASING, loop = -1, flags = ANIMATION_PARALLEL)
 	animate(radius = 32, time = 1.5 SECONDS, size = 0)
-	if(iscarbon(owner))
-		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.update_bodypart_bleed_overlays()
 
 /datum/status_effect/grouped/stasis/tick(seconds_between_ticks)
 	update_time_of_death()
 
 /datum/status_effect/grouped/stasis/on_remove()
-	owner.remove_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED, TRAIT_STASIS, TRAIT_TUMOR_SUPPRESSED), TRAIT_STATUS_EFFECT(id))
+	owner.remove_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED, TRAIT_STASIS), TRAIT_STATUS_EFFECT(id))
 	owner.remove_filter("stasis_status_ripple")
 	update_time_of_death()
-	if(iscarbon(owner))
-		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.update_bodypart_bleed_overlays()
 	return ..()
 
 /atom/movable/screen/alert/status_effect/stasis

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -19,8 +19,8 @@
 
 	/// What is the lowest amount of time we can set the timer to?
 	var/minimum_timer = SYNDIEBOMB_MIN_TIMER_SECONDS
-	/// What is the highest amount of time we can set the timer to?
-	var/maximum_timer = 100*60 // 100 MINUTES // not using the MINUTES define because those are for deciseconds
+	/// What is the highest amount of time we can set the timer to? IN SECONDS
+	var/maximum_timer = 100 * 60 // 100 MINUTES // not using the MINUTES define because those are for deciseconds
 	/// What is the default amount of time we set the timer to?
 	var/timer_set = SYNDIEBOMB_MIN_TIMER_SECONDS
 	/// Can we be unanchored?
@@ -28,27 +28,29 @@
 	/// Are the wires exposed?
 	var/open_panel = FALSE
 	/// Is the bomb counting down?
-	var/active = FALSE
+	VAR_FINAL/active = FALSE
 	/// What sound do we make as we beep down the timer?
 	var/beepsound = 'sound/items/timer.ogg'
 	/// Is the delay wire pulsed?
-	var/delayedbig = FALSE
+	VAR_FINAL/delayedbig = FALSE
 	/// Is the activation wire pulsed?
-	var/delayedlittle = FALSE
+	VAR_FINAL/delayedlittle = FALSE
 	/// Should we just tell the payload to explode now? Usually triggered by an event (like cutting the wrong wire)
-	var/explode_now = FALSE
+	VAR_FINAL/explode_now = FALSE
 	/// The timer for the bomb.
-	var/detonation_timer
+	VAR_FINAL/detonation_timer
 	/// When do we beep next?
-	var/next_beep
+	VAR_FINAL/next_beep
 	/// If TRUE, more boom wires are added based on the timer set.
 	var/add_boom_wires = TRUE
 	/// Reference to the bomb core inside the bomb, which is the part that actually explodes.
 	var/obj/item/bombcore/payload = /obj/item/bombcore/syndicate
 	/// The countdown that'll show up to ghosts regarding the bomb's timer.
-	var/obj/effect/countdown/syndicatebomb/countdown
+	VAR_FINAL/obj/effect/countdown/syndicatebomb/countdown
 	/// Whether the countdown is visible on examine
-	var/examinable_countdown = TRUE
+	VAR_FINAL/examinable_countdown = TRUE
+	/// World.time that the bomb entered timestop, used to calculate how much time is left on the timer after timestop ends.
+	VAR_PRIVATE/timestop_start
 
 /obj/machinery/syndicatebomb/proc/try_detonate(ignore_active = FALSE)
 	. = (payload in src) && (active || ignore_active)
@@ -108,6 +110,7 @@
 	update_appearance()
 	countdown = new(src)
 	end_processing()
+	RegisterSignal(src, COMSIG_ATOM_TIMESTOP_FREEZE, PROC_REF(on_timestop))
 
 /obj/machinery/syndicatebomb/Destroy()
 	QDEL_NULL(countdown)
@@ -130,9 +133,28 @@
 	icon_state = "[initial(icon_state)][active ? "-active" : "-inactive"][open_panel ? "-wires" : ""]"
 	return ..()
 
+/obj/machinery/syndicatebomb/proc/on_timestop(...)
+	SIGNAL_HANDLER
+	if(!active)
+		return
+	end_processing()
+	timestop_start = world.time
+	RegisterSignal(src, COMSIG_ATOM_TIMESTOP_UNFREEZE, PROC_REF(on_timestop_end))
+
+/obj/machinery/syndicatebomb/proc/on_timestop_end(...)
+	SIGNAL_HANDLER
+	UnregisterSignal(src, COMSIG_ATOM_TIMESTOP_UNFREEZE)
+	if(!active) // defused DURING timestop? badass
+		return
+	var/time_spent_in_timestop = world.time - timestop_start
+	next_beep += time_spent_in_timestop
+	detonation_timer += time_spent_in_timestop
+	begin_processing()
+	timestop_start = null
+
 /obj/machinery/syndicatebomb/proc/seconds_remaining()
 	if(active)
-		. = max(0, round((detonation_timer - world.time) / 10))
+		. = max(0, round((detonation_timer - (timestop_start || world.time)) / 10))
 
 	else
 		. = timer_set

--- a/code/modules/mob/living/basic/guardian/guardian.dm
+++ b/code/modules/mob/living/basic/guardian/guardian.dm
@@ -252,6 +252,11 @@
 	RegisterSignal(to_who, COMSIG_LIVING_ON_WABBAJACKED, PROC_REF(on_summoner_wabbajacked))
 	RegisterSignal(to_who, COMSIG_LIVING_SHAPESHIFTED, PROC_REF(on_summoner_shapeshifted))
 	RegisterSignal(to_who, COMSIG_LIVING_UNSHAPESHIFTED, PROC_REF(on_summoner_unshapeshifted))
+	RegisterSignal(to_who, COMSIG_ATOM_STOPPING_TIME, PROC_REF(on_summoner_timestop))
+	RegisterSignal(to_who, SIGNAL_ADDTRAIT(TRAIT_TIME_STOP_IMMUNE), PROC_REF(on_summoner_timestop_immune_gained))
+	RegisterSignal(to_who, SIGNAL_REMOVETRAIT(TRAIT_TIME_STOP_IMMUNE), PROC_REF(on_summoner_timestop_immune_removed))
+	if (HAS_TRAIT(to_who, TRAIT_TIME_STOP_IMMUNE))
+		ADD_TRAIT(src, TRAIT_TIME_STOP_IMMUNE, REF(summoner))
 	recall(forced = TRUE)
 	leash_to(src, summoner)
 	if (to_who.stat == DEAD)
@@ -268,7 +273,16 @@
 	if (!isnull(summoner_turf))
 		forceMove(summoner_turf)
 	unleash()
-	UnregisterSignal(summoner, list(COMSIG_QDELETING, COMSIG_LIVING_ON_WABBAJACKED, COMSIG_LIVING_SHAPESHIFTED, COMSIG_LIVING_UNSHAPESHIFTED))
+	UnregisterSignal(summoner, list(
+		COMSIG_QDELETING,
+		COMSIG_LIVING_ON_WABBAJACKED,
+		COMSIG_LIVING_SHAPESHIFTED,
+		COMSIG_LIVING_UNSHAPESHIFTED,
+		COMSIG_ATOM_STOPPING_TIME,
+		SIGNAL_ADDTRAIT(TRAIT_TIME_STOP_IMMUNE),
+		SIGNAL_REMOVETRAIT(TRAIT_TIME_STOP_IMMUNE),
+	))
+	REMOVE_TRAIT(src, TRAIT_TIME_STOP_IMMUNE, REF(summoner))
 	if (different_person)
 		summoner.remove_ally(src)
 		remove_faction(summoner.get_faction())
@@ -340,6 +354,22 @@
 	SIGNAL_HANDLER
 	set_summoner(old_summoner)
 	to_chat(src, span_holoparasite("Your summoner has shapeshifted back into their normal form!"))
+
+/// Signal proc for [COMSIG_ATOM_STOPPING_TIME] - when our summoner timestops, we should share their immunity.
+/mob/living/basic/guardian/proc/on_summoner_timestop(mob/living/source, datum/action/cooldown/spell/timestop/timestop, list/immune_atoms)
+	SIGNAL_HANDLER
+	if (timestop.owner_is_immune_to_self_timestop)
+		immune_atoms |= src
+
+/// Signal proc for [SIGNAL_ADDTRAIT(TRAIT_TIME_STOP_IMMUNE)] - when our summoner gains time stop immunity, we should too
+/mob/living/basic/guardian/proc/on_summoner_timestop_immune_gained(mob/living/source, ...)
+	SIGNAL_HANDLER
+	ADD_TRAIT(src, TRAIT_TIME_STOP_IMMUNE, REF(summoner))
+
+/// Signal proc for [SIGNAL_REMOVETRAIT(TRAIT_TIME_STOP_IMMUNE)] - when our summoner loses time stop immunity, we should too
+/mob/living/basic/guardian/proc/on_summoner_timestop_immune_removed(mob/living/source, ...)
+	SIGNAL_HANDLER
+	REMOVE_TRAIT(src, TRAIT_TIME_STOP_IMMUNE, REF(summoner))
 
 /mob/living/basic/guardian/wabbajack(what_to_randomize, change_flags = WABBAJACK)
 	visible_message(span_warning("[src] resists the polymorph!")) // Ha, no

--- a/code/modules/mob/living/carbon/init_signals.dm
+++ b/code/modules/mob/living/carbon/init_signals.dm
@@ -154,3 +154,11 @@
 /mob/living/carbon/on_hearing_loss(datum/source)
 	. = ..()
 	breathing_loop.stop()
+
+/mob/living/carbon/on_stasis_trait_gain(datum/source)
+	. = ..()
+	update_bodypart_bleed_overlays()
+
+/mob/living/carbon/on_stasis_trait_loss(datum/source)
+	. = ..()
+	update_bodypart_bleed_overlays()

--- a/code/modules/mob/living/init_signals.dm
+++ b/code/modules/mob/living/init_signals.dm
@@ -242,11 +242,13 @@
 /// Called when [TRAIT_STASIS] is added to the mob
 /mob/living/proc/on_stasis_trait_gain(datum/source)
 	SIGNAL_HANDLER
+	ADD_TRAIT(src, TRAIT_TUMOR_SUPPRESSED, TRAIT_STASIS)
 	update_incapacitated()
 
 /// Called when [TRAIT_STASIS] is removed from the mob
 /mob/living/proc/on_stasis_trait_loss(datum/source)
 	SIGNAL_HANDLER
+	REMOVE_TRAIT(src, TRAIT_TUMOR_SUPPRESSED, TRAIT_STASIS)
 	update_incapacitated()
 
 /// Called when [TRAIT_NODEATH] is added or removed from the mob

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -158,6 +158,6 @@
 	return ..()
 
 /mob/living/keybind_face_direction(direction)
-	if(IS_UNCONSCIOUS(src))
+	if(!(mobility_flags & MOBILITY_MOVE))
 		return
 	return ..()

--- a/code/modules/spells/spell_types/self/stop_time.dm
+++ b/code/modules/spells/spell_types/self/stop_time.dm
@@ -35,6 +35,8 @@
 	var/list/default_immune_atoms = list()
 	if(owner_is_immune_to_self_timestop)
 		default_immune_atoms += cast_on
+
+	SEND_SIGNAL(cast_on, COMSIG_ATOM_STOPPING_TIME, src, default_immune_atoms)
 	new /obj/effect/timestop/magic(get_turf(cast_on), timestop_range, timestop_duration, default_immune_atoms)
 
 /datum/action/cooldown/spell/timestop/vv_edit_var(var_name, var_value)

--- a/code/modules/unit_tests/spell_timestop.dm
+++ b/code/modules/unit_tests/spell_timestop.dm
@@ -23,9 +23,9 @@
 	jotaro.forceMove(in_range)
 	johnathan.forceMove(out_of_range)
 
-	the_world.manifest()
-	star_platinum.manifest()
-	heirophant_green.manifest()
+	the_world.manifest(TRUE)
+	star_platinum.manifest(TRUE)
+	heirophant_green.manifest(TRUE)
 
 	TEST_ASSERT_EQUAL(the_world.loc, dio.loc, "Holoparasite failed to manifest")
 

--- a/code/modules/unit_tests/spell_timestop.dm
+++ b/code/modules/unit_tests/spell_timestop.dm
@@ -5,6 +5,7 @@
 	var/mob/living/carbon/human/dio = allocate(/mob/living/carbon/human/consistent)
 	var/mob/living/carbon/human/kakyoin = allocate(/mob/living/carbon/human/consistent)
 	var/mob/living/carbon/human/jotaro = allocate(/mob/living/carbon/human/consistent)
+	var/mob/living/carbon/human/johnathan = allocate(/mob/living/carbon/human/consistent)
 
 	var/turf/center = run_loc_floor_bottom_left
 	var/turf/in_range = locate(center.x + 2, center.y + 2, center.z)
@@ -12,19 +13,27 @@
 
 	dio.forceMove(center)
 	kakyoin.forceMove(in_range)
-	jotaro.forceMove(out_of_range)
+	jotaro.forceMove(in_range)
+	johnathan.forceMove(out_of_range)
 
 	var/datum/action/cooldown/spell/timestop/timestop = new(dio)
 	timestop.spell_requirements = NONE
 	timestop.Grant(dio)
 	timestop.Trigger()
-	var/obj/effect/timestop/time_effect = locate() in center
-	TEST_ASSERT(time_effect, "Failed to create timestop effect")
-	sleep(0.1 SECONDS) // timestop is invoked async so let's just wait
 
-	TEST_ASSERT(!dio.IsStun(), "Timestopper should not have frozen themselves when using timestop")
-	TEST_ASSERT(kakyoin.IsStun(), "Timestopper should have frozen the target within 2 tiles of range when using timestop")
-	TEST_ASSERT(!jotaro.IsStun(), "Timestopper should not have frozen the target outside of 2 tiles of range when using timestop")
+	var/datum/action/cooldown/spell/timestop/other_timestop = new(jotaro)
+	other_timestop.Grant(jotaro)
+
+	var/obj/effect/timestop/time_effect = locate() in center
+	TEST_ASSERT_NOTNULL(time_effect, "Failed to create timestop effect")
+	sleep(0.1 SECONDS) // timestop is invoked async so let's give it a moment
+
+	TEST_ASSERT(!HAS_TRAIT_FROM(dio, TRAIT_IMMOBILIZED, TIMESTOP_TRAIT), "Timestopper should not have frozen themselves when using timestop")
+	TEST_ASSERT(HAS_TRAIT_FROM(kakyoin, TRAIT_IMMOBILIZED, TIMESTOP_TRAIT), "Timestopper should have frozen the target within 2 tiles of range when using timestop")
+	TEST_ASSERT(!HAS_TRAIT_FROM(johnathan, TRAIT_IMMOBILIZED, TIMESTOP_TRAIT), "Timestopper should not have frozen the target outside of 2 tiles of range when using timestop")
+	TEST_ASSERT(!HAS_TRAIT_FROM(jotaro, TRAIT_IMMOBILIZED, TIMESTOP_TRAIT), "Timestopper should not have frozen another timestopper when using timestop")
 
 	// cleanup
 	qdel(time_effect)
+
+	TEST_ASSERT(!HAS_TRAIT_FROM(kakyoin, TRAIT_IMMOBILIZED, TIMESTOP_TRAIT), "Timestop didn't unfreeze the target after the effect expired")

--- a/code/modules/unit_tests/spell_timestop.dm
+++ b/code/modules/unit_tests/spell_timestop.dm
@@ -6,9 +6,9 @@
 	var/mob/living/carbon/human/kakyoin = allocate(/mob/living/carbon/human/consistent)
 	var/mob/living/carbon/human/jotaro = allocate(/mob/living/carbon/human/consistent)
 	var/mob/living/carbon/human/johnathan = allocate(/mob/living/carbon/human/consistent)
-	var/mob/living/basic/guardian/the_world = allocate(/mob/living/basic/guardian/stand)
-	var/mob/living/basic/guardian/star_platinum = allocate(/mob/living/basic/guardian/stand)
-	var/mob/living/basic/guardian/heirophant_green = allocate(/mob/living/basic/guardian/stand)
+	var/mob/living/basic/guardian/the_world = allocate(/mob/living/basic/guardian)
+	var/mob/living/basic/guardian/star_platinum = allocate(/mob/living/basic/guardian)
+	var/mob/living/basic/guardian/heirophant_green = allocate(/mob/living/basic/guardian)
 
 	the_world.set_summoner(dio)
 	star_platinum.set_summoner(jotaro)

--- a/code/modules/unit_tests/spell_timestop.dm
+++ b/code/modules/unit_tests/spell_timestop.dm
@@ -29,13 +29,13 @@
 
 	TEST_ASSERT_EQUAL(the_world.loc, dio.loc, "Holoparasite failed to manifest")
 
+	var/datum/action/cooldown/spell/timestop/other_timestop = new(jotaro)
+	other_timestop.Grant(jotaro)
+
 	var/datum/action/cooldown/spell/timestop/timestop = new(dio)
 	timestop.spell_requirements = NONE
 	timestop.Grant(dio)
 	timestop.Trigger()
-
-	var/datum/action/cooldown/spell/timestop/other_timestop = new(jotaro)
-	other_timestop.Grant(jotaro)
 
 	var/obj/effect/timestop/time_effect = locate() in center
 	TEST_ASSERT_NOTNULL(time_effect, "Failed to create timestop effect")

--- a/code/modules/unit_tests/spell_timestop.dm
+++ b/code/modules/unit_tests/spell_timestop.dm
@@ -6,6 +6,13 @@
 	var/mob/living/carbon/human/kakyoin = allocate(/mob/living/carbon/human/consistent)
 	var/mob/living/carbon/human/jotaro = allocate(/mob/living/carbon/human/consistent)
 	var/mob/living/carbon/human/johnathan = allocate(/mob/living/carbon/human/consistent)
+	var/mob/living/basic/guardian/the_world = allocate(/mob/living/basic/guardian/stand)
+	var/mob/living/basic/guardian/star_platinum = allocate(/mob/living/basic/guardian/stand)
+	var/mob/living/basic/guardian/heirophant_green = allocate(/mob/living/basic/guardian/stand)
+
+	the_world.set_summoner(dio)
+	star_platinum.set_summoner(jotaro)
+	heirophant_green.set_summoner(kakyoin)
 
 	var/turf/center = run_loc_floor_bottom_left
 	var/turf/in_range = locate(center.x + 2, center.y + 2, center.z)
@@ -15,6 +22,12 @@
 	kakyoin.forceMove(in_range)
 	jotaro.forceMove(in_range)
 	johnathan.forceMove(out_of_range)
+
+	the_world.manifest()
+	star_platinum.manifest()
+	heirophant_green.manifest()
+
+	TEST_ASSERT_EQUAL(the_world.loc, dio.loc, "Holoparasite failed to manifest")
 
 	var/datum/action/cooldown/spell/timestop/timestop = new(dio)
 	timestop.spell_requirements = NONE
@@ -32,8 +45,12 @@
 	TEST_ASSERT(HAS_TRAIT_FROM(kakyoin, TRAIT_IMMOBILIZED, TIMESTOP_TRAIT), "Timestopper should have frozen the target within 2 tiles of range when using timestop")
 	TEST_ASSERT(!HAS_TRAIT_FROM(johnathan, TRAIT_IMMOBILIZED, TIMESTOP_TRAIT), "Timestopper should not have frozen the target outside of 2 tiles of range when using timestop")
 	TEST_ASSERT(!HAS_TRAIT_FROM(jotaro, TRAIT_IMMOBILIZED, TIMESTOP_TRAIT), "Timestopper should not have frozen another timestopper when using timestop")
+	TEST_ASSERT(!HAS_TRAIT_FROM(the_world, TRAIT_IMMOBILIZED, TIMESTOP_TRAIT), "Timestopper should not have frozen their own holoparasite when using timestop")
+	TEST_ASSERT(!HAS_TRAIT_FROM(star_platinum, TRAIT_IMMOBILIZED, TIMESTOP_TRAIT), "Timestopper should not have frozen a holoparsite from another timestopper when using timestop")
+	TEST_ASSERT(HAS_TRAIT_FROM(heirophant_green, TRAIT_IMMOBILIZED, TIMESTOP_TRAIT), "Timestopper shold not frozen a holoparsite from a non-timestopper when using timestop")
 
 	// cleanup
 	qdel(time_effect)
 
 	TEST_ASSERT(!HAS_TRAIT_FROM(kakyoin, TRAIT_IMMOBILIZED, TIMESTOP_TRAIT), "Timestop didn't unfreeze the target after the effect expired")
+	TEST_ASSERT(!HAS_TRAIT_FROM(heirophant_green, TRAIT_IMMOBILIZED, TIMESTOP_TRAIT), "Timestop didn't unfreeze the target's holoparasite after the effect expired")


### PR DESCRIPTION
## About The Pull Request

Mobs in stopped time are given stasis (chems don't metabolize, blood doesn't leak, etc).

Also syndicate bombs, because why not

## Why It's Good For The Game

Tech didn't exist when Time Stop was made. Now it does. 

## Changelog

:cl: Melbert
balance: Mobs subjected to time stop are now slightly more stopped (chems will no longer metabolize, bleeding will pause, etc). 
balance: Syndicate bombs no longer tick towards detonation when time stopped
refactor: Refactored timestop a teeny bit, primarily its interaction with holoparasites, report any issues next time you jojo larp
/:cl:
