### PR TITLE
Bodypart overlays can have flags assigned to them for rendering effects

### DIFF
--- a/code/__DEFINES/bodyparts.dm
+++ b/code/__DEFINES/bodyparts.dm
@@ -235,11 +235,13 @@ DEFINE_BITFIELD(surgery_state, list(
 /// For scaling the effectiveness of certain effects to the total bodypart count
 #define GET_BODYPART_COEFFICIENT(X) round(X.len / BODYPARTS_DEFAULT_MAXIMUM , 0.1)
 
-/// A part of the bodypart itself
-#define LIMB_OVERLAY_BASE (1<<0)
-/// Some kind of damage applied to the bodypart, like bruising on skin
-#define LIMB_OVERLAY_DAMAGE (1<<1)
-/// Meta-info that is used for rendering info (emissives)
-#define LIMB_OVERLAY_META (1<<3)
-/// Entirely separate from the bodypart, like cream pie
-#define LIMB_OVERLAY_SEPARATE (1<<4)
+// Flag associatd with specific overlays on bodyparts
+// Used to determine how the overlay is handled in rendering
+/// Apply bodypart textures to this
+#define LIMB_OVERLAY_TEXTURED (1<<0)
+/// Contains meta-info used for rendering (i.e. emissives)
+#define LIMB_OVERLAY_META (1<<1)
+/// Overlay is chonky, at least 48 pixels wide
+#define LIMB_OVERLAY_WIDE_ICON (1<<2)
+/// Overlay is toll, at least 48 pixels tall
+#define LIMB_OVERLAY_TALL_ICON (1<<3)

--- a/code/__DEFINES/bodyparts.dm
+++ b/code/__DEFINES/bodyparts.dm
@@ -234,3 +234,12 @@ DEFINE_BITFIELD(surgery_state, list(
 
 /// For scaling the effectiveness of certain effects to the total bodypart count
 #define GET_BODYPART_COEFFICIENT(X) round(X.len / BODYPARTS_DEFAULT_MAXIMUM , 0.1)
+
+/// A part of the bodypart itself
+#define LIMB_OVERLAY_BASE (1<<0)
+/// Some kind of damage applied to the bodypart, like bruising on skin
+#define LIMB_OVERLAY_DAMAGE (1<<1)
+/// Meta-info that is used for rendering info (emissives)
+#define LIMB_OVERLAY_META (1<<3)
+/// Entirely separate from the bodypart, like cream pie
+#define LIMB_OVERLAY_SEPARATE (1<<4)

--- a/code/__DEFINES/bodyparts.dm
+++ b/code/__DEFINES/bodyparts.dm
@@ -245,3 +245,5 @@ DEFINE_BITFIELD(surgery_state, list(
 #define LIMB_OVERLAY_WIDE_ICON (1<<2)
 /// Overlay is toll, at least 48 pixels tall
 #define LIMB_OVERLAY_TALL_ICON (1<<3)
+/// Core part of the bodypart, like the actual bodypart icon
+#define LIMB_OVERLAY_CORE (1<<4)

--- a/code/datums/bodypart_overlays/bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/bodypart_overlay.dm
@@ -22,6 +22,10 @@
 	var/draw_on_husks = HUSK_OVERLAY_NONE
 	/// Determines body area of the overlay for height offsets
 	var/offset_location = NO_MODIFY
+	/// Flags that determine how the overlay is handled by the bodypart.
+	/// For example, [LIMB_OVERLAY_BASE] indicates that it's a a part of the bodypart itself,
+	/// while [LIMB_OVERLAY_SEPARATE] indicates that it's entirely separate from the bodypart, like cream pie
+	var/overlay_flags = LIMB_OVERLAY_BASE
 
 /datum/bodypart_overlay/New()
 	. = ..()
@@ -81,9 +85,10 @@
 	else
 		color_image(main_image, limb, layer_index)
 
-	var/list/created_overlays = list(main_image)
+	var/list/created_overlays = list()
+	created_overlays[main_image] = overlay_flags
 	if(blocks_emissive != EMISSIVE_BLOCK_NONE && !isnull(limb))
-		created_overlays += emissive_blocker(main_image.icon, main_image.icon_state, limb, layer = main_image.layer, alpha = main_image.alpha)
+		created_overlays[emissive_blocker(main_image.icon, main_image.icon_state, limb, layer = main_image.layer, alpha = main_image.alpha)] = LIMB_OVERLAY_META
 
 	return created_overlays
 

--- a/code/datums/bodypart_overlays/bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/bodypart_overlay.dm
@@ -91,7 +91,8 @@
 	var/list/created_overlays = list()
 	created_overlays[main_image] = overlay_flags
 	if(blocks_emissive != EMISSIVE_BLOCK_NONE && !isnull(limb))
-		created_overlays[emissive_blocker(main_image.icon, main_image.icon_state, limb, layer = main_image.layer, alpha = main_image.alpha)] = LIMB_OVERLAY_META
+		var/mutable_appearance/blocker_overlay = emissive_blocker(main_image.icon, main_image.icon_state, limb, layer = main_image.layer, alpha = main_image.alpha)
+		created_overlays[blocker_overlay] = LIMB_OVERLAY_META
 
 	return created_overlays
 

--- a/code/datums/bodypart_overlays/bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/bodypart_overlay.dm
@@ -23,9 +23,7 @@
 	/// Determines body area of the overlay for height offsets
 	var/offset_location = NO_MODIFY
 	/// Flags that determine how the overlay is handled by the bodypart.
-	/// For example, [LIMB_OVERLAY_BASE] indicates that it's a a part of the bodypart itself,
-	/// while [LIMB_OVERLAY_SEPARATE] indicates that it's entirely separate from the bodypart, like cream pie
-	var/overlay_flags = LIMB_OVERLAY_BASE
+	var/overlay_flags = LIMB_OVERLAY_TEXTURED
 
 /datum/bodypart_overlay/New()
 	. = ..()
@@ -33,9 +31,14 @@
 
 /// Used for adding a layer at runtime
 /datum/bodypart_overlay/proc/set_layer(layer_postfix, layer_number)
-	var/list/existing_layers = layers.Copy()
+	var/list/existing_layers = LAZYCOPY(layers)
 	existing_layers[layer_postfix] = layer_number
 	layers = string_assoc_list(existing_layers)
+
+/// Used for adding a layer at runtime without replacing existing layers
+/datum/bodypart_overlay/proc/add_layer(layer_postfix, layer_number)
+	if(isnull(LAZYACCESS(layers, layer_postfix)))
+		set_layer(layer_postfix, layer_number)
 
 /// Used for adding layers at runtime
 /datum/bodypart_overlay/proc/set_layers(list/layer_list)

--- a/code/datums/bodypart_overlays/emote_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/emote_bodypart_overlay.dm
@@ -2,8 +2,8 @@
 /datum/bodypart_overlay/simple/emote
 	icon = 'icons/mob/human/emote_visuals.dmi'
 	offset_location = UPPER_BODY
-	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
-	overlay_flags = LIMB_OVERLAY_SEPARATE
+	layers = list("" = BODY_ADJ_LAYER)
+	overlay_flags = NONE
 	///The body zone to attach the overlay to, overlay won't be added if no bodypart can be found with this
 	var/attached_body_zone = BODY_ZONE_CHEST
 	///The feature key used to figure out what specific bodily feature we offset this to follow

--- a/code/datums/bodypart_overlays/emote_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/emote_bodypart_overlay.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/mob/human/emote_visuals.dmi'
 	offset_location = UPPER_BODY
 	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
+	overlay_flags = LIMB_OVERLAY_SEPARATE
 	///The body zone to attach the overlay to, overlay won't be added if no bodypart can be found with this
 	var/attached_body_zone = BODY_ZONE_CHEST
 	///The feature key used to figure out what specific bodily feature we offset this to follow

--- a/code/datums/bodypart_overlays/markings_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/markings_bodypart_overlay.dm
@@ -1,6 +1,6 @@
 /// For body markings applied on the species, which need some extra code
 /datum/bodypart_overlay/simple/body_marking
-	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
+	layers = list("" = BODY_ADJ_LAYER)
 	offset_location = ENTIRE_BODY
 	/// Listen to the gendercode, if the limb is bimorphic
 	var/use_gender = FALSE

--- a/code/datums/bodypart_overlays/simple_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/simple_bodypart_overlay.dm
@@ -37,3 +37,4 @@
 	icon_state = "soul_pending_eyes"
 	layers = list(EXTERNAL_FRONT = BODY_FRONT_LAYER)
 	offset_location = UPPER_BODY
+	overlay_flags = LIMB_OVERLAY_SEPARATE

--- a/code/datums/bodypart_overlays/simple_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/simple_bodypart_overlay.dm
@@ -9,7 +9,8 @@
 	var/draw_color
 
 /datum/bodypart_overlay/simple/get_image(obj/item/bodypart/limb, layer_index, layer_real)
-	return mutable_appearance(icon, icon_state, layer = layer_real)
+	var/iconstate_to_use = icon_state + (layer_index ? "_[layer_index]" : "")
+	return mutable_appearance(icon, "[iconstate_to_use]", layer = layer_real)
 
 /datum/bodypart_overlay/simple/color_image(image/overlay, obj/item/bodypart/limb, layer_index)
 	overlay.color = draw_color
@@ -21,7 +22,7 @@
 ///A sixpack drawn on the chest
 /datum/bodypart_overlay/simple/sixpack
 	icon_state = "sixpack"
-	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
+	layers = list("" = BODY_ADJ_LAYER)
 	draw_on_husks = HUSK_OVERLAY_GRAYSCALE
 	offset_location = ENTIRE_BODY
 
@@ -29,12 +30,12 @@
 /datum/bodypart_overlay/simple/bags
 	icon_state = "bags"
 	draw_color = COLOR_WEBSAFE_DARK_GRAY
-	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
+	layers = list("" = BODY_ADJ_LAYER)
 	offset_location = UPPER_BODY
 
 ///PENDING eyes drawn on the face
 /datum/bodypart_overlay/simple/soul_pending_eyes
 	icon_state = "soul_pending_eyes"
-	layers = list(EXTERNAL_FRONT = BODY_FRONT_LAYER)
+	layers = list("" = BODY_FRONT_LAYER)
 	offset_location = UPPER_BODY
-	overlay_flags = LIMB_OVERLAY_SEPARATE
+	overlay_flags = NONE

--- a/code/datums/bodypart_overlays/texture_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/texture_bodypart_overlay.dm
@@ -81,6 +81,9 @@
 	cached_lighting_icon = icon(lighting_icon, lighting_icon_state)
 
 /datum/bodypart_texture/mesh/modify_bodypart_appearance(image/appearance, overlay_flags)
+	if(overlay_flags & LIMB_OVERLAY_CORE)
+		return // the bodypart itself doesn't need mesh
+
 	. = ..()
 	// adds an outline so the texture doesn't end abruptly
 	appearance.add_filter("outline", 3, outline_filter(1, outline_color, OUTLINE_SHARP))

--- a/code/datums/bodypart_overlays/texture_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/texture_bodypart_overlay.dm
@@ -92,9 +92,9 @@
 	for(var/i in 0 to filter_width step 32)
 		for(var/j in 0 to filter_height step 32)
 			// adds a displacement map so the outline lines up with the bottom of the sprite
-			appearance.add_filter("displacement_[i]_[j]", 2, displacement_map_filter(cached_displacement_icon, x = i, y = j, size = 1))
+			appearance.add_filter("displacement_[i]/[j]", 2, displacement_map_filter(cached_displacement_icon, x = i, y = j, size = 1))
 			// adds a bit of lighting to make the texture look less flat
-			appearance.add_filter("lighting_[i]_[j]", 4, layering_filter(cached_lighting_icon, x = i, y = j, blend_mode = BLEND_MULTIPLY))
+			appearance.add_filter("lighting_[i]/[j]", 4, layering_filter(cached_lighting_icon, x = i, y = j, blend_mode = BLEND_MULTIPLY))
 
 /datum/bodypart_texture/mesh/black
 	texture_icon_state = "mesh_mask"

--- a/code/datums/bodypart_overlays/texture_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/texture_bodypart_overlay.dm
@@ -13,8 +13,13 @@
 	. = ..()
 	cached_texture_icon = icon(texture_icon, texture_icon_state)
 
-/datum/bodypart_texture/proc/modify_bodypart_appearance(image/appearance)
-	appearance.add_filter("bodypart_texture_[texture_icon_state]", 1, layering_filter(icon = cached_texture_icon, blend_mode = BLEND_INSET_OVERLAY))
+/datum/bodypart_texture/proc/modify_bodypart_appearance(image/appearance, overlay_flags)
+	var/filter_width = (overlay_flags & LIMB_OVERLAY_WIDE_ICON) ? 96 : 32
+	var/filter_height = (overlay_flags & LIMB_OVERLAY_TALL_ICON) ? 96 : 32
+
+	for(var/i in 0 to filter_width step 32)
+		for(var/j in 0 to filter_height step 32)
+			appearance.add_filter("bodypart_texture_[texture_icon_state]_[i]/[j]", 1, layering_filter(cached_texture_icon, x = i, y = j, blend_mode = BLEND_INSET_OVERLAY))
 
 /datum/bodypart_texture/proc/icon_render_key()
 	return type
@@ -40,7 +45,7 @@
 	texture_icon = 'icons/mob/human/textures.dmi'
 	overlay_priority = BODYPART_OVERLAY_CSS_SUICIDE
 
-/datum/bodypart_texture/checkered/modify_bodypart_appearance(image/appearance)
+/datum/bodypart_texture/checkered/modify_bodypart_appearance(image/appearance, overlay_flags)
 	. = ..()
 	appearance.color = COLOR_WHITE
 
@@ -75,24 +80,21 @@
 	cached_displacement_icon = icon(displacement_icon, displacement_icon_state)
 	cached_lighting_icon = icon(lighting_icon, lighting_icon_state)
 
-/datum/bodypart_texture/mesh/modify_bodypart_appearance(image/appearance)
-	if(!should_modify(appearance))
-		return
-
+/datum/bodypart_texture/mesh/modify_bodypart_appearance(image/appearance, overlay_flags)
 	. = ..()
-	// adds a displacement map so the outline lines up with the bottom of the sprite
-	appearance.add_filter("displacement", 2, displacement_map_filter(cached_displacement_icon, size = 1))
 	// adds an outline so the texture doesn't end abruptly
 	appearance.add_filter("outline", 3, outline_filter(1, outline_color, OUTLINE_SHARP))
-	// adds a bit of lighting to make the texture look less flat
-	appearance.add_filter("lighting", 4, layering_filter(cached_lighting_icon, blend_mode = BLEND_MULTIPLY))
 	// forces white (blends better with the texture)
 	appearance.color = COLOR_WHITE
 
-/datum/bodypart_texture/mesh/proc/should_modify(image/appearance)
-	// only apply to other mutant bodyparts. we filter by layer which is *absolutely* not ideal, but hey, work with what you got
-	var/appearance_layer = abs(appearance.layer)
-	return appearance_layer == BODY_ADJ_LAYER || appearance_layer == BODY_FRONT_LAYER || appearance_layer == BODY_BEHIND_LAYER
+	var/filter_width = (overlay_flags & LIMB_OVERLAY_WIDE_ICON) ? 96 : 32
+	var/filter_height = (overlay_flags & LIMB_OVERLAY_TALL_ICON) ? 96 : 32
+	for(var/i in 0 to filter_width step 32)
+		for(var/j in 0 to filter_height step 32)
+			// adds a displacement map so the outline lines up with the bottom of the sprite
+			appearance.add_filter("displacement_[i]_[j]", 2, displacement_map_filter(cached_displacement_icon, x = i, y = j, size = 1))
+			// adds a bit of lighting to make the texture look less flat
+			appearance.add_filter("lighting_[i]_[j]", 4, layering_filter(cached_lighting_icon, x = i, y = j, blend_mode = BLEND_MULTIPLY))
 
 /datum/bodypart_texture/mesh/black
 	texture_icon_state = "mesh_mask"

--- a/code/datums/components/face_decal.dm
+++ b/code/datums/components/face_decal.dm
@@ -39,6 +39,7 @@
 			qdel(src)
 			return
 		bodypart_overlay = new()
+		bodypart_overlay.overlay_flags = LIMB_OVERLAY_SEPARATE
 		bodypart_overlay.set_layers(layers)
 		if(carbon_parent.bodyshape & BODYSHAPE_SNOUTED) //stupid, but external organ bodytypes are not stored on the limb
 			bodypart_overlay.icon_state = "[icon_state]_lizard"

--- a/code/datums/components/face_decal.dm
+++ b/code/datums/components/face_decal.dm
@@ -39,7 +39,7 @@
 			qdel(src)
 			return
 		bodypart_overlay = new()
-		bodypart_overlay.overlay_flags = LIMB_OVERLAY_SEPARATE
+		bodypart_overlay.overlay_flags = NONE
 		bodypart_overlay.set_layers(layers)
 		if(carbon_parent.bodyshape & BODYSHAPE_SNOUTED) //stupid, but external organ bodytypes are not stored on the limb
 			bodypart_overlay.icon_state = "[icon_state]_lizard"

--- a/code/modules/fishing/fish/types/rift.dm
+++ b/code/modules/fishing/fish/types/rift.dm
@@ -723,7 +723,7 @@
 	icon_state = "babbearfish"
 	draw_on_husks = HUSK_OVERLAY_NORMAL
 	offset_location = UPPER_BODY
-	overlay_flags = LIMB_OVERLAY_SEPARATE
+	overlay_flags = NONE
 
 /datum/bodypart_overlay/simple/babbearfish/can_draw_on_bodypart(obj/item/bodypart/bodypart_owner, mob/living/carbon/owner)
 	return ..() && !(bodypart_owner.owner?.obscured_slots & HIDEEARS)

--- a/code/modules/fishing/fish/types/rift.dm
+++ b/code/modules/fishing/fish/types/rift.dm
@@ -723,6 +723,7 @@
 	icon_state = "babbearfish"
 	draw_on_husks = HUSK_OVERLAY_NORMAL
 	offset_location = UPPER_BODY
+	overlay_flags = LIMB_OVERLAY_SEPARATE
 
 /datum/bodypart_overlay/simple/babbearfish/can_draw_on_bodypart(obj/item/bodypart/bodypart_owner, mob/living/carbon/owner)
 	return ..() && !(bodypart_owner.owner?.obscured_slots & HIDEEARS)

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -511,7 +511,11 @@ GLOBAL_LIST_EMPTY(masked_leg_icons_cache)
  * * limb_overlay - The limb image being masked, not necessarily the original limb image as it could be an overlay on top of it
  * Returns the list of masked images, or `null` if the limb_overlay didn't exist
  */
-/obj/item/bodypart/leg/proc/generate_masked_leg(image/limb_overlay)
+/obj/item/bodypart/proc/handle_masking(image/limb_overlay)
+	PROTECTED_PROC(TRUE)
+	return
+
+/obj/item/bodypart/leg/handle_masking(image/limb_overlay)
 	RETURN_TYPE(/list)
 	if(!limb_overlay)
 		return

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -983,7 +983,7 @@ generate/load female uniform sprites matching all previously decided variables
 			continue
 		var/overlay_x = overlay.pixel_x + overlay.pixel_w
 		var/overlay_y = overlay.pixel_y + overlay.pixel_z
-		if (!isnull(parsed_overlays[overlay])) // Nested overlay
+		if (islist(parsed_overlays[overlay])) // Nested overlay
 			overlay_x += parsed_overlays[overlay][SUB_OVERLAY_X_INDEX]
 			overlay_y += parsed_overlays[overlay][SUB_OVERLAY_Y_INDEX]
 		cached_body_width = max(cached_body_width, overlay.get_cached_width())

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1416,7 +1416,7 @@
 			texture.modify_bodypart_appearance(generated_overlay, generated_overlay_flags)
 
 	SEND_SIGNAL(src, COMSIG_BODYPART_GET_LIMB_ICON, ., dropped)
-	return .
+	return assoc_to_keys(.)
 
 /**
  * Takes in an image and greyscales it to later be recolored to look like a husk

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1311,11 +1311,11 @@
 
 	icon_exists_or_scream(limb.icon, limb.icon_state) //Prints a stack trace on the first failure of a given iconstate.
 
-	.[limb] = LIMB_OVERLAY_TEXTURED
+	.[limb] = LIMB_OVERLAY_TEXTURED|LIMB_OVERLAY_CORE
 
 	if(aux_zone) //Hand shit
 		aux = image(limb.icon, "[limb_id]_[aux_zone]", -aux_layer, dir = image_dir)
-		.[aux] = LIMB_OVERLAY_TEXTURED
+		.[aux] = LIMB_OVERLAY_TEXTURED|LIMB_OVERLAY_CORE
 
 	if(dropped && dmg_overlay_type)
 		if(brutestate)
@@ -1357,10 +1357,10 @@
 
 	if(is_husked)
 		for(var/image/husk_image as anything in huskify_image(limb))
-			.[husk_image] = LIMB_OVERLAY_TEXTURED
+			.[husk_image] = LIMB_OVERLAY_TEXTURED|LIMB_OVERLAY_CORE
 		if(aux)
 			for(var/image/husk_image as anything in huskify_image(aux))
-				.[husk_image] = LIMB_OVERLAY_TEXTURED
+				.[husk_image] = LIMB_OVERLAY_TEXTURED|LIMB_OVERLAY_CORE
 		draw_color = is_husked == HUSKED_ZOMBIE ? zombie_color : husk_color
 	else
 		update_draw_color()

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1244,9 +1244,10 @@
 
 	cut_overlays()
 	var/list/standing = get_limb_icon(dropped = TRUE)
-	if(!standing.len)
+	if(!length(standing))
 		icon_state = initial(icon_state)//no overlays found, we default back to initial icon.
 		return
+
 	for(var/image/img as anything in standing)
 		img.pixel_w += px_x
 		img.pixel_z += px_y
@@ -1282,10 +1283,6 @@
 	icon_state = "" //to erase the default sprite, we're building the visual aspects of the bodypart through overlays alone.
 
 	. = list()
-	var/image_dir = null
-	if (dropped)
-		image_dir = SOUTH
-
 	// Stumps are FAKE limbs that hold the spot for REAL limbs. thusly no sprite of their own, so early return!
 	if(IS_STUMP(src))
 		SEND_SIGNAL(src, COMSIG_BODYPART_GET_LIMB_ICON, ., dropped)
@@ -1297,74 +1294,72 @@
 		SEND_SIGNAL(src, COMSIG_BODYPART_GET_LIMB_ICON, ., dropped)
 		return .
 
+	var/image_dir = dropped ? SOUTH : null
 	// Handles invisibility (not alpha or actual invisibility but invisibility)
 	if(is_invisible)
-		. += image(icon_invisible, "invisible_[body_zone]", -BODYPARTS_LAYER, dir = image_dir)
+		.[image(icon_invisible, "invisible_[body_zone]", -BODYPARTS_LAYER, dir = image_dir)] = LIMB_OVERLAY_BASE
 		SEND_SIGNAL(src, COMSIG_BODYPART_GET_LIMB_ICON, ., dropped)
 		return .
 
 	// Normal non-husk handling
 	// This is the MEAT of limb icon code
-	var/used_icon = icon_greyscale
-	if(!should_draw_greyscale || !icon_greyscale)
-		used_icon = icon_static
-
-	var/used_state = "[limb_id]_[body_zone]"
-	if(is_dimorphic) // Does this type of limb have sexual dimorphism?
-		used_state = "[limb_id]_[body_zone]_[limb_gender]"
+	var/used_icon = (should_draw_greyscale && icon_greyscale) || icon_static
+	var/used_state = "[limb_id]_[body_zone][is_dimorphic ? "_[limb_gender]" : ""]"
 
 	var/image/limb = image(used_icon, used_state, -BODYPARTS_LAYER, dir = image_dir)
 	var/image/aux = null
 
 	icon_exists_or_scream(limb.icon, limb.icon_state) //Prints a stack trace on the first failure of a given iconstate.
 
-	. += limb
+	.[limb] = LIMB_OVERLAY_BASE
 
 	if(aux_zone) //Hand shit
 		aux = image(limb.icon, "[limb_id]_[aux_zone]", -aux_layer, dir = image_dir)
-		. += aux
+		.[aux] = LIMB_OVERLAY_BASE
 
 	if(dropped && dmg_overlay_type)
 		if(brutestate)
 			// divided into two overlays: one that gets colored and one that doesn't.
+			var/image/brute_damage_overlay = mutable_appearance('icons/mob/effects/dam_mob.dmi', "[dmg_overlay_type]_[body_zone]_[brutestate]0_overlay", -DAMAGE_LAYER)
+			brute_damage_overlay.appearance_flags |= RESET_COLOR
 			var/image/brute_blood_overlay = image('icons/mob/effects/dam_mob.dmi', "[dmg_overlay_type]_[body_zone]_[brutestate]0", -DAMAGE_LAYER, dir = SOUTH)
 			brute_blood_overlay.color = get_color_from_blood_list(blood_dna_info)
-			var/mutable_appearance/brute_damage_overlay = mutable_appearance('icons/mob/effects/dam_mob.dmi', "[dmg_overlay_type]_[body_zone]_[brutestate]0_overlay", -DAMAGE_LAYER, appearance_flags = RESET_COLOR)
-			if(brute_damage_overlay)
-				brute_blood_overlay.overlays += brute_damage_overlay
-			. += brute_blood_overlay
+			brute_blood_overlay.overlays += brute_damage_overlay
+			.[brute_blood_overlay] = LIMB_OVERLAY_DAMAGE
 		if(burnstate)
-			. += image('icons/mob/effects/dam_mob.dmi', "[dmg_overlay_type]_[body_zone]_0[burnstate]", -DAMAGE_LAYER, dir = SOUTH)
+			.[image('icons/mob/effects/dam_mob.dmi', "[dmg_overlay_type]_[body_zone]_0[burnstate]", -DAMAGE_LAYER, dir = SOUTH)] = LIMB_OVERLAY_DAMAGE
 
 	var/atom/location = loc || owner || src
 	if(blocks_emissive != EMISSIVE_BLOCK_NONE)
 		var/mutable_appearance/limb_em_block = emissive_blocker(limb.icon, limb.icon_state, location, layer = limb.layer, alpha = limb.alpha)
 		if (dropped)
 			limb_em_block = image(limb_em_block, dir = SOUTH)
-		. += limb_em_block
+		.[limb_em_block] = LIMB_OVERLAY_META
 
 		if(aux_zone)
 			var/mutable_appearance/aux_em_block = emissive_blocker(aux.icon, aux.icon_state, location, layer = aux.layer, alpha = aux.alpha)
 			if (dropped)
 				aux_em_block = image(aux_em_block, dir = SOUTH)
-			. += aux_em_block
+			.[aux_em_block] = LIMB_OVERLAY_META
 
 	if(!is_husked && is_emissive)
 		var/mutable_appearance/limb_em = emissive_appearance(limb.icon, "[limb.icon_state]_e", location, layer = limb.layer, alpha = limb.alpha)
 		if (dropped)
 			limb_em = image(limb_em, dir = SOUTH)
-		. += limb_em
+		.[limb_em] = LIMB_OVERLAY_META
 
 		if(aux_zone)
 			var/mutable_appearance/aux_em = emissive_appearance(aux.icon, "[aux.icon_state]_e", location, layer = aux.layer, alpha = aux.alpha)
 			if (dropped)
 				aux_em = image(aux_em, dir = SOUTH)
-			. += aux_em
+			.[aux_em] = LIMB_OVERLAY_META
 
 	if(is_husked)
-		. += huskify_image(thing_to_husk = limb)
+		for(var/image/husk_image as anything in huskify_image(limb))
+			.[husk_image] = LIMB_OVERLAY_BASE|LIMB_OVERLAY_DAMAGE
 		if(aux)
-			. += huskify_image(thing_to_husk = aux)
+			for(var/image/husk_image as anything in huskify_image(aux))
+				.[husk_image] = LIMB_OVERLAY_BASE|LIMB_OVERLAY_DAMAGE
 		draw_color = is_husked == HUSKED_ZOMBIE ? zombie_color : husk_color
 	else
 		update_draw_color()
@@ -1375,22 +1370,22 @@
 			aux.color = "[draw_color]"
 
 	// No need to handle leg layering if dropped, we only face south anyways
-	if(!dropped && ((body_zone == BODY_ZONE_R_LEG) || (body_zone == BODY_ZONE_L_LEG)))
+	if(!dropped)
 		// Legs are a bit goofy in regards to layering, and we will need two images instead of one to fix that
-		var/obj/item/bodypart/leg/leg_source = src
-		for(var/image/limb_image in .)
+		for(var/generated_overlay, generated_overlay_flags in .)
 			// Remove the old, unmasked image
-			. -= limb_image
+			. -= generated_overlay
 			// Add two masked images based on the old one
-			. += leg_source.generate_masked_leg(limb_image)
+			for(var/masked_image in handle_masking(generated_overlay))
+				.[masked_image] = generated_overlay_flags
 
-	// Apply height to the overlays we generated so far
-	// This is done before collecting bodypart overlays so we don't apply height twice to the same overlays
-	if(!dropped && !isnull(owner))
-		for(var/image/generated_overlay as anything in .)
-			// While you may think that heads could be applied with UPPER_BODY instead of ENTIRE_BODY to save us one filter,
-			// it's more important to keep it consistent for things like getflaticon
-			owner.apply_height(generated_overlay, ENTIRE_BODY)
+		// Apply height to the overlays we generated so far
+		// This is done before collecting bodypart overlays so we don't apply height twice to the same overlays
+		if(!isnull(owner))
+			for(var/generated_overlay, generated_overlay_flags in .)
+				// While you may think that heads could be applied with UPPER_BODY instead of ENTIRE_BODY to save us one filter,
+				// it's more important to keep it consistent for things like getflaticon
+				owner.apply_height(generated_overlay, ENTIRE_BODY)
 
 	// Draw external organs like horns and frills
 	// Height is applied again in here so we can specify where the overlay is set (ie offset_location)
@@ -1400,19 +1395,18 @@
 
 		for (var/mutable_appearance/actual_overlay as anything in overlay.get_all_overlays(src))
 			if(dropped || isnull(owner))
-				. += image(actual_overlay, dir = SOUTH)
+				.[image(actual_overlay, dir = SOUTH)] = overlay.overlay_flags
 				continue
 
 			owner.apply_height(actual_overlay, overlay.offset_location)
-			. += actual_overlay
+			.[actual_overlay] = overlay.overlay_flags
 
 	// Then texture everything at once, including bodypart overlays
 	for(var/datum/bodypart_texture/texture as anything in bodypart_textures)
 		if(!texture.can_texture_bodypart(src))
 			continue
-		for(var/image/generated_overlay as anything in .)
-			var/appearance_plane = PLANE_TO_TRUE(generated_overlay.plane)
-			if(appearance_plane != FLOAT_PLANE && appearance_plane != GAME_PLANE)
+		for(var/generated_overlay, generated_overlay_flags in .)
+			if(!(generated_overlay_flags & LIMB_OVERLAY_BASE))
 				continue
 
 			texture.modify_bodypart_appearance(generated_overlay)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1297,7 +1297,7 @@
 	var/image_dir = dropped ? SOUTH : null
 	// Handles invisibility (not alpha or actual invisibility but invisibility)
 	if(is_invisible)
-		.[image(icon_invisible, "invisible_[body_zone]", -BODYPARTS_LAYER, dir = image_dir)] = LIMB_OVERLAY_BASE
+		.[image(icon_invisible, "invisible_[body_zone]", -BODYPARTS_LAYER, dir = image_dir)] = NONE
 		SEND_SIGNAL(src, COMSIG_BODYPART_GET_LIMB_ICON, ., dropped)
 		return .
 
@@ -1311,11 +1311,11 @@
 
 	icon_exists_or_scream(limb.icon, limb.icon_state) //Prints a stack trace on the first failure of a given iconstate.
 
-	.[limb] = LIMB_OVERLAY_BASE
+	.[limb] = LIMB_OVERLAY_TEXTURED
 
 	if(aux_zone) //Hand shit
 		aux = image(limb.icon, "[limb_id]_[aux_zone]", -aux_layer, dir = image_dir)
-		.[aux] = LIMB_OVERLAY_BASE
+		.[aux] = LIMB_OVERLAY_TEXTURED
 
 	if(dropped && dmg_overlay_type)
 		if(brutestate)
@@ -1325,9 +1325,10 @@
 			var/image/brute_blood_overlay = image('icons/mob/effects/dam_mob.dmi', "[dmg_overlay_type]_[body_zone]_[brutestate]0", -DAMAGE_LAYER, dir = SOUTH)
 			brute_blood_overlay.color = get_color_from_blood_list(blood_dna_info)
 			brute_blood_overlay.overlays += brute_damage_overlay
-			.[brute_blood_overlay] = LIMB_OVERLAY_DAMAGE
+			.[brute_blood_overlay] = NONE
 		if(burnstate)
-			.[image('icons/mob/effects/dam_mob.dmi', "[dmg_overlay_type]_[body_zone]_0[burnstate]", -DAMAGE_LAYER, dir = SOUTH)] = LIMB_OVERLAY_DAMAGE
+			var/image/burn_damage_overlay = image('icons/mob/effects/dam_mob.dmi', "[dmg_overlay_type]_[body_zone]_0[burnstate]", -DAMAGE_LAYER, dir = SOUTH)
+			.[burn_damage_overlay] = NONE
 
 	var/atom/location = loc || owner || src
 	if(blocks_emissive != EMISSIVE_BLOCK_NONE)
@@ -1356,10 +1357,10 @@
 
 	if(is_husked)
 		for(var/image/husk_image as anything in huskify_image(limb))
-			.[husk_image] = LIMB_OVERLAY_BASE|LIMB_OVERLAY_DAMAGE
+			.[husk_image] = LIMB_OVERLAY_TEXTURED
 		if(aux)
 			for(var/image/husk_image as anything in huskify_image(aux))
-				.[husk_image] = LIMB_OVERLAY_BASE|LIMB_OVERLAY_DAMAGE
+				.[husk_image] = LIMB_OVERLAY_TEXTURED
 		draw_color = is_husked == HUSKED_ZOMBIE ? zombie_color : husk_color
 	else
 		update_draw_color()
@@ -1373,10 +1374,13 @@
 	if(!dropped)
 		// Legs are a bit goofy in regards to layering, and we will need two images instead of one to fix that
 		for(var/generated_overlay, generated_overlay_flags in .)
+			var/list/maked_generated_overlays = handle_masking(generated_overlay)
+			if(!length(maked_generated_overlays))
+				continue
 			// Remove the old, unmasked image
 			. -= generated_overlay
-			// Add two masked images based on the old one
-			for(var/masked_image in handle_masking(generated_overlay))
+			// Add in the new, masked images (with the same flags)
+			for(var/masked_image in maked_generated_overlays)
 				.[masked_image] = generated_overlay_flags
 
 		// Apply height to the overlays we generated so far
@@ -1406,10 +1410,10 @@
 		if(!texture.can_texture_bodypart(src))
 			continue
 		for(var/generated_overlay, generated_overlay_flags in .)
-			if(!(generated_overlay_flags & LIMB_OVERLAY_BASE))
+			if(!(generated_overlay_flags & LIMB_OVERLAY_TEXTURED))
 				continue
 
-			texture.modify_bodypart_appearance(generated_overlay)
+			texture.modify_bodypart_appearance(generated_overlay, generated_overlay_flags)
 
 	SEND_SIGNAL(src, COMSIG_BODYPART_GET_LIMB_ICON, ., dropped)
 	return .

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -264,26 +264,26 @@
 
 /// Makes sure that the owner's bodytype flags match the flags of all of its parts and organs
 /mob/living/carbon/proc/synchronize_bodytypes()
-	var/all_limb_flags = NONE
+	var/all_overlay_flags = NONE
 	for(var/obj/item/bodypart/limb as anything in get_bodyparts(include_stumps = TRUE))
 		for(var/obj/item/organ/organ in limb)
-			all_limb_flags |= organ.external_bodytypes
-		all_limb_flags |= limb.bodytype
+			all_overlay_flags |= organ.external_bodytypes
+		all_overlay_flags |= limb.bodytype
 
-	bodytype = all_limb_flags
+	bodytype = all_overlay_flags
 
 /// Makes sure that the owner's bodyshape flags match the flags of all of its parts and organs
 /mob/living/carbon/proc/synchronize_bodyshapes()
-	var/all_limb_flags = NONE
+	var/all_overlay_flags = NONE
 	for(var/obj/item/bodypart/limb as anything in get_bodyparts(include_stumps = TRUE))
 		for(var/obj/item/organ/organ in limb)
-			all_limb_flags |= organ.external_bodyshapes
-		all_limb_flags |= limb.bodyshape
+			all_overlay_flags |= organ.external_bodyshapes
+		all_overlay_flags |= limb.bodyshape
 
 	if(obscured_slots & HIDESNOUT)
-		all_limb_flags &= ~BODYSHAPE_SNOUTED
+		all_overlay_flags &= ~BODYSHAPE_SNOUTED
 
-	bodyshape = all_limb_flags
+	bodyshape = all_overlay_flags
 
 /proc/skintone2hex(skin_tone)
 	. = 0

--- a/code/modules/surgery/organs/external/_visual_organs.dm
+++ b/code/modules/surgery/organs/external/_visual_organs.dm
@@ -326,6 +326,7 @@ Unlike normal organs, we're actually inside a persons limbs at all times
 	feature_key = FEATURE_POD_HAIR
 	dyable = TRUE
 	offset_location = UPPER_BODY
+	overlay_flags = NONE
 
 	///This layer will be colored differently than the rest of the organ. So we can get differently colored flowers or something
 	var/color_swapped_layer = EXTERNAL_FRONT

--- a/code/modules/surgery/organs/external/wings/wings.dm
+++ b/code/modules/surgery/organs/external/wings/wings.dm
@@ -269,6 +269,7 @@
 	)
 	feature_key = FEATURE_WINGS
 	offset_location = ENTIRE_BODY
+	overlay_flags = parent_type::overlay_flags | LIMB_OVERLAY_WIDE_ICON
 	/// Slot we check against
 	var/slot_blocker = HIDEJUMPSUIT
 

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -74,8 +74,9 @@
 		new_item.set_custom_materials(null)
 		items_list += WEAKREF(new_item)
 
-	// Overlay is done in two layers, "[state]" and "[state]_hand"
-	bodypart_aug?.add_layer("hand", BODYPARTS_HIGH_LAYER)
+	if(hand_state)
+		// Overlay is done in two layers, "[state]" and "[state]_hand"
+		bodypart_aug?.add_layer("hand", BODYPARTS_HIGH_LAYER)
 
 /obj/item/organ/cyberimp/arm/toolkit/Destroy()
 	hand = null

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -12,7 +12,11 @@
 	///A ref for the arm we're taking up. Mostly for the unregister signal upon removal
 	var/obj/hand
 
-/obj/item/organ/cyberimp/arm/get_overlay_state(image_layer, obj/item/bodypart/limb)
+/obj/item/organ/cyberimp/arm/swap_zone(target_zone)
+	. = ..()
+	update_overlay_state()
+
+/obj/item/organ/cyberimp/arm/get_overlay_state()
 	return "[aug_overlay][zone == BODY_ZONE_L_ARM ? "_left" : "_right"]"
 
 /obj/item/organ/cyberimp/arm/on_mob_insert(mob/living/carbon/arm_owner)

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -73,6 +73,8 @@
 		var/atom/new_item = new typepath(src)
 		new_item.set_custom_materials(null)
 		items_list += WEAKREF(new_item)
+	// melbert todo
+	bodypart_aug?.set_layer("hand", BODYPARTS_HIGH_LAYER)
 
 /obj/item/organ/cyberimp/arm/toolkit/Destroy()
 	hand = null
@@ -119,22 +121,6 @@
 		to_chat(owner, span_warning("The electromagnetic pulse causes [src] to malfunction!"))
 		// give the owner an idea about why his implant is glitching
 		Retract()
-
-/obj/item/organ/cyberimp/arm/toolkit/get_overlay(image_layer, obj/item/bodypart/limb)
-	if (!hand_state)
-		return ..()
-
-	var/mutable_appearance/arm_overlay = mutable_appearance(
-		icon = aug_icon,
-		icon_state = get_overlay_state(),
-		layer = image_layer,
-	)
-	var/mutable_appearance/hand_overlay = mutable_appearance(
-		icon = aug_icon,
-		icon_state = "[get_overlay_state()]_hand",
-		layer = -BODYPARTS_HIGH_LAYER,
-	)
-	return list(arm_overlay, hand_overlay)
 
 /**
  * Called when the mob uses the "drop item" hotkey

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -73,8 +73,9 @@
 		var/atom/new_item = new typepath(src)
 		new_item.set_custom_materials(null)
 		items_list += WEAKREF(new_item)
-	// melbert todo
-	bodypart_aug?.set_layer("hand", BODYPARTS_HIGH_LAYER)
+
+	// Overlay is done in two layers, "[state]" and "[state]_hand"
+	bodypart_aug?.add_layer("hand", BODYPARTS_HIGH_LAYER)
 
 /obj/item/organ/cyberimp/arm/toolkit/Destroy()
 	hand = null

--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -238,7 +238,6 @@
 	if(!silent)
 		to_chat(owner, span_notice("You turn your thrusters set on."))
 	update_appearance()
-	owner.update_body_parts()
 
 /obj/item/organ/cyberimp/chest/thrusters/proc/deactivate(silent = FALSE)
 	if(!on)
@@ -249,11 +248,10 @@
 		to_chat(owner, span_notice("You turn your thrusters set off."))
 	on = FALSE
 	update_appearance()
-	owner.update_body_parts()
 
 /obj/item/organ/cyberimp/chest/thrusters/update_icon_state()
 	icon_state = "[base_icon_state][on ? "-on" : null]"
-	bodypart_aug?.icon_state = get_overlay_state()
+	update_overlay_state()
 	return ..()
 
 /obj/item/organ/cyberimp/chest/thrusters/proc/allow_thrust(num, use_fuel = TRUE)
@@ -291,7 +289,7 @@
 	deactivate(silent = TRUE)
 	return FALSE
 
-/obj/item/organ/cyberimp/chest/thrusters/get_overlay_state(image_layer, obj/item/bodypart/limb)
+/obj/item/organ/cyberimp/chest/thrusters/get_overlay_state()
 	return "[aug_overlay][on ? "_on" : ""]"
 
 /obj/item/organ/cyberimp/chest/spine

--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -189,6 +189,7 @@
 	base_icon_state = "imp_jetpack"
 	aug_overlay = "imp_jetpack"
 	emissive_overlay = TRUE
+	overlay_layer = BODYPARTS_HIGH_LAYER
 	actions_types = list(/datum/action/item_action/organ_action/toggle)
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = HALF_SHEET_MATERIAL_AMOUNT)
@@ -207,7 +208,6 @@
 		CALLBACK(src, PROC_REF(allow_thrust), 0.01), \
 		/datum/effect_system/trail_follow/ion, \
 	)
-	bodypart_aug?.set_layer(EXTERNAL_ADJACENT, BODYPARTS_HIGH_LAYER)
 
 /obj/item/organ/cyberimp/chest/thrusters/Remove(mob/living/carbon/thruster_owner, special, movement_flags)
 	if(on)

--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -207,6 +207,7 @@
 		CALLBACK(src, PROC_REF(allow_thrust), 0.01), \
 		/datum/effect_system/trail_follow/ion, \
 	)
+	bodypart_aug?.set_layer(EXTERNAL_ADJACENT, BODYPARTS_HIGH_LAYER)
 
 /obj/item/organ/cyberimp/chest/thrusters/Remove(mob/living/carbon/thruster_owner, special, movement_flags)
 	if(on)
@@ -252,6 +253,7 @@
 
 /obj/item/organ/cyberimp/chest/thrusters/update_icon_state()
 	icon_state = "[base_icon_state][on ? "-on" : null]"
+	bodypart_aug?.icon_state = get_overlay_state()
 	return ..()
 
 /obj/item/organ/cyberimp/chest/thrusters/proc/allow_thrust(num, use_fuel = TRUE)
@@ -291,11 +293,6 @@
 
 /obj/item/organ/cyberimp/chest/thrusters/get_overlay_state(image_layer, obj/item/bodypart/limb)
 	return "[aug_overlay][on ? "_on" : ""]"
-
-/obj/item/organ/cyberimp/chest/thrusters/get_overlay(image_layer, obj/item/bodypart/limb)
-	. = ..()
-	for (var/image/overlay as anything in .)
-		overlay.layer = -BODYPARTS_HIGH_LAYER // makes absolutely zero sense why it would layer ontop of jumpsuits but it looks cool
 
 /obj/item/organ/cyberimp/chest/spine
 	name = "\improper Herculean gravitronic spinal implant"

--- a/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
@@ -12,6 +12,8 @@
 	var/aug_overlay = null
 	/// Does the implant have an emissive overlay too?
 	var/emissive_overlay = FALSE
+	/// Mob layer the overlay will be placed onto
+	var/overlay_layer = BODY_ADJ_LAYER
 	/// Bodypart overlay we're going to apply to whoever we're implanted into
 	var/datum/bodypart_overlay/simple/augment/bodypart_aug = null
 
@@ -23,6 +25,7 @@
 		bodypart_aug.icon = aug_icon
 		bodypart_aug.icon_state = get_overlay_state()
 		bodypart_aug.emissive = emissive_overlay
+		bodypart_aug.set_layer("", overlay_layer)
 
 /obj/item/organ/cyberimp/Destroy()
 	. = ..()
@@ -42,17 +45,18 @@
 		limb.remove_bodypart_overlay(bodypart_aug)
 
 /datum/bodypart_overlay/simple/augment
-	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
+	layers = list("" = BODY_ADJ_LAYER)
 	draw_on_husks = HUSK_OVERLAY_NORMAL
 	offset_location = ENTIRE_BODY
-	overlay_flags = LIMB_OVERLAY_SEPARATE
+	overlay_flags = NONE
 	/// Whether the overlay has an emissive appeareance too
 	var/emissive = FALSE
 
 /datum/bodypart_overlay/simple/augment/get_overlay(obj/item/bodypart/limb, layer_index, layer_real)
 	. = ..()
 	if(emissive)
-		.[emissive_appearance(icon, "[icon_state]_e", limb.owner || limb, layer = layer_real)] = LIMB_OVERLAY_META
+		var/iconstate_to_use = icon_state + (layer_index ? "_[layer_index]" : "") + "_e"
+		.[emissive_appearance(icon, iconstate_to_use, limb, layer = layer_real)] = LIMB_OVERLAY_META
 
 /obj/item/organ/cyberimp/feel_for_damage(self_aware)
 	// No feeling in implants (yet?)

--- a/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
@@ -31,18 +31,34 @@
 	. = ..()
 	QDEL_NULL(bodypart_aug) // Do this after Remove() has done its thing, otherwise on_bodypart_remove() will not properly remove the overlay
 
+/// Returns what icon_state the bodypart overlay should be in.
+/// Defaults to whatever is set in the variable, but can be overridden by subtypes which need multiple states
 /obj/item/organ/cyberimp/proc/get_overlay_state()
 	return aug_overlay
 
+/// Refreshes the overlay's icon_state, then calls update_bodyparts if necessary
+/obj/item/organ/cyberimp/proc/update_overlay_state()
+	if(isnull(bodypart_aug))
+		return
+
+	var/old_aug_state = bodypart_aug.icon_state
+	bodypart_aug.icon_state = get_overlay_state()
+	if(old_aug_state != bodypart_aug.icon_state)
+		owner?.update_body_parts()
+
 /obj/item/organ/cyberimp/on_bodypart_insert(obj/item/bodypart/limb)
 	. = ..()
-	if (bodypart_aug)
-		limb.add_bodypart_overlay(bodypart_aug)
+	if(isnull(bodypart_aug))
+		return
+
+	limb.add_bodypart_overlay(bodypart_aug)
 
 /obj/item/organ/cyberimp/on_bodypart_remove(obj/item/bodypart/limb)
 	. = ..()
-	if (bodypart_aug)
-		limb.remove_bodypart_overlay(bodypart_aug)
+	if(isnull(bodypart_aug))
+		return
+
+	limb.remove_bodypart_overlay(bodypart_aug)
 
 /datum/bodypart_overlay/simple/augment
 	layers = list("" = BODY_ADJ_LAYER)

--- a/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
@@ -13,13 +13,16 @@
 	/// Does the implant have an emissive overlay too?
 	var/emissive_overlay = FALSE
 	/// Bodypart overlay we're going to apply to whoever we're implanted into
-	var/datum/bodypart_overlay/augment/bodypart_aug = null
+	var/datum/bodypart_overlay/simple/augment/bodypart_aug = null
 
 /obj/item/organ/cyberimp/Initialize(mapload)
 	. = ..()
 	if (aug_overlay)
 		visual = TRUE
-		bodypart_aug = new(src)
+		bodypart_aug = new()
+		bodypart_aug.icon = aug_icon
+		bodypart_aug.icon_state = get_overlay_state()
+		bodypart_aug.emissive = emissive_overlay
 
 /obj/item/organ/cyberimp/Destroy()
 	. = ..()
@@ -27,12 +30,6 @@
 
 /obj/item/organ/cyberimp/proc/get_overlay_state()
 	return aug_overlay
-
-/obj/item/organ/cyberimp/proc/get_overlay(image_layer, obj/item/bodypart/limb)
-	. = list()
-	. += image(icon = aug_icon, icon_state = get_overlay_state(), layer = image_layer)
-	if (emissive_overlay)
-		. += emissive_appearance(aug_icon, "[get_overlay_state()]_e", limb.owner || limb, image_layer)
 
 /obj/item/organ/cyberimp/on_bodypart_insert(obj/item/bodypart/limb)
 	. = ..()
@@ -44,36 +41,18 @@
 	if (bodypart_aug)
 		limb.remove_bodypart_overlay(bodypart_aug)
 
-/datum/bodypart_overlay/augment
+/datum/bodypart_overlay/simple/augment
 	layers = list(EXTERNAL_ADJACENT = BODY_ADJ_LAYER)
 	draw_on_husks = HUSK_OVERLAY_NORMAL
 	offset_location = ENTIRE_BODY
-	/// Implant that owns this overlay
-	var/obj/item/organ/cyberimp/implant
+	overlay_flags = LIMB_OVERLAY_SEPARATE
+	/// Whether the overlay has an emissive appeareance too
+	var/emissive = FALSE
 
-/datum/bodypart_overlay/augment/New(obj/item/organ/cyberimp/implant)
+/datum/bodypart_overlay/simple/augment/get_overlay(obj/item/bodypart/limb, layer_index, layer_real)
 	. = ..()
-	src.implant = implant
-
-/datum/bodypart_overlay/augment/Destroy(force)
-	implant = null
-	return ..()
-
-/datum/bodypart_overlay/augment/icon_render_key(obj/item/bodypart/limb)
-	. = ..()
-	. += implant.get_overlay_state()
-
-/datum/bodypart_overlay/augment/get_overlay(obj/item/bodypart/limb, layer_index, layer_real)
-	var/list/imageset = implant.get_overlay(layer_real, limb)
-	if(blocks_emissive == EMISSIVE_BLOCK_NONE || !limb)
-		return imageset
-
-	var/list/all_images = list()
-	for(var/image/overlay as anything in imageset)
-		all_images += overlay
-		all_images += emissive_blocker(overlay.icon, overlay.icon_state, limb, layer = overlay.layer, alpha = overlay.alpha)
-
-	return all_images
+	if(emissive)
+		.[emissive_appearance(icon, "[icon_state]_e", limb.owner || limb, layer = layer_real)] = LIMB_OVERLAY_META
 
 /obj/item/organ/cyberimp/feel_for_damage(self_aware)
 	// No feeling in implants (yet?)

--- a/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
@@ -55,8 +55,8 @@
 /datum/bodypart_overlay/simple/augment/get_overlay(obj/item/bodypart/limb, layer_index, layer_real)
 	. = ..()
 	if(emissive)
-		var/iconstate_to_use = icon_state + (layer_index ? "_[layer_index]" : "") + "_e"
-		.[emissive_appearance(icon, iconstate_to_use, limb, layer = layer_real)] = LIMB_OVERLAY_META
+		var/mutable_appearance/emissive_overlay = emissive_appearance(icon, icon_state + (layer_index ? "_[layer_index]" : "") + "_e", limb, layer = layer_real)
+		.[emissive_overlay] = LIMB_OVERLAY_META
 
 /obj/item/organ/cyberimp/feel_for_damage(self_aware)
 	// No feeling in implants (yet?)

--- a/code/modules/surgery/organs/internal/ears/_ears.dm
+++ b/code/modules/surgery/organs/internal/ears/_ears.dm
@@ -235,7 +235,7 @@
 /datum/bodypart_overlay/mutant/cat_ears/cybernetic
 	color_source = null
 	dyable = FALSE
-	overlay_flags = LIMB_OVERLAY_SEPARATE
+	overlay_flags = NONE
 	/// Color of the inner ear
 	var/inner_color = "#F0004A"
 

--- a/code/modules/surgery/organs/internal/ears/_ears.dm
+++ b/code/modules/surgery/organs/internal/ears/_ears.dm
@@ -235,6 +235,7 @@
 /datum/bodypart_overlay/mutant/cat_ears/cybernetic
 	color_source = null
 	dyable = FALSE
+	overlay_flags = LIMB_OVERLAY_SEPARATE
 	/// Color of the inner ear
 	var/inner_color = "#F0004A"
 
@@ -252,7 +253,7 @@
 	var/list/all_images = ..()
 	var/mutable_appearance/ear_holder = all_images[1]
 	var/mutable_appearance/inner = ear_holder.overlays[2]
-	all_images += emissive_appearance(inner.icon, inner.icon_state, limb, layer = inner.layer, alpha = inner.alpha * 0.75)
+	all_images[emissive_appearance(inner.icon, inner.icon_state, limb, layer = inner.layer, alpha = inner.alpha * 0.75)] = LIMB_OVERLAY_META
 	return all_images
 
 /datum/bodypart_overlay/mutant/cat_ears/cybernetic/green

--- a/code/modules/surgery/organs/internal/ears/_ears.dm
+++ b/code/modules/surgery/organs/internal/ears/_ears.dm
@@ -253,7 +253,8 @@
 	var/list/all_images = ..()
 	var/mutable_appearance/ear_holder = all_images[1]
 	var/mutable_appearance/inner = ear_holder.overlays[2]
-	all_images[emissive_appearance(inner.icon, inner.icon_state, limb, layer = inner.layer, alpha = inner.alpha * 0.75)] = LIMB_OVERLAY_META
+	var/mutable_appearance/emissive_overlay = emissive_appearance(inner.icon, inner.icon_state, limb, layer = inner.layer, alpha = inner.alpha * 0.75)
+	all_images[emissive_overlay] = LIMB_OVERLAY_META
 	return all_images
 
 /datum/bodypart_overlay/mutant/cat_ears/cybernetic/green


### PR DESCRIPTION
## About The Pull Request

Fixes #97602
Fixes #97649

The list of overlays generated by `get_limb_icon` are now assoc `overlay = flags`
The flags set are used by stuff like bodypart textures to determine how they should be affected

For example, `LIMB_OVERLAY_TEXTURED` indicates that that overlay can be textured by a bodypart overlay (duh)

## Changelog

:cl: Melbert
fix: Large wings are now fully affected by suit meshes or voidwalker curse
fix: Cream pies no longer get affected by suit meshes or voidwalker curse
refactor: Refactored bodypart rendering ever so slightly to fix some bodypart texture issues, report anything weird like missing overlays
/:cl:
