### PR TITLE
Fix DNA console being able to print anomalous mutations, fix DNA console spacing with >8 mutations

### DIFF
--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -25,7 +25,7 @@
 	/// Description of the mutation
 	var/desc = "A mutation."
 	/// Is this mutation currently locked?
-	var/locked
+	var/locked = FALSE
 	/// Quality of the mutation
 	var/quality
 	/// Message given to the user upon gaining this mutation

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -839,6 +839,10 @@
 			if(!mutation)
 				return
 
+			if(length(mutation.sources) && get_mutation_class(mutation) == SCANNER_MUTATION_CLASS_OTHER)
+				say("ERROR: This mutation is anomalous, and cannot be printed.")
+				return
+
 			// Create a new DNA Injector and add the appropriate mutations to it
 			var/obj/item/dnainjector/activator/injector = new /obj/item/dnainjector/activator(loc)
 			LAZYADD(injector.add_mutations, mutation.make_copy())
@@ -965,6 +969,10 @@
 
 			// GUARD CHECK - This should not be possible. Unexpected result
 			if(!original)
+				return
+
+			if(length(original.sources) && get_mutation_class(original) == SCANNER_MUTATION_CLASS_OTHER)
+				say("ERROR: This mutation is anomalous, and cannot be saved.")
 				return
 
 			diskette.mutations += original.make_copy()
@@ -2166,6 +2174,7 @@
 		return SCANNER_MUTATION_CLASS_ACTIVATOR
 	if(MUTATION_SOURCE_MUTATOR in mutation.sources)
 		return SCANNER_MUTATION_CLASS_MUTATOR
+	return null
 
 /**
  * Checks whether a mutation alias has been discovered

--- a/tgui/packages/tgui/interfaces/DnaConsole/MutationInfo.jsx
+++ b/tgui/packages/tgui/interfaces/DnaConsole/MutationInfo.jsx
@@ -16,6 +16,7 @@ import {
   CHROMOSOME_USED,
   MUT_COLORS,
   MUT_EXTRA,
+  MUT_OTHER,
 } from './constants';
 
 /**
@@ -178,7 +179,11 @@ export const MutationInfo = (props) => {
                   <Stack.Item>
                     <Button
                       icon="syringe"
-                      disabled={!isInjectorReady || !mutation.Active}
+                      disabled={
+                        !isInjectorReady ||
+                        !mutation.Active ||
+                        mutation.Class === MUT_OTHER
+                      }
                       onClick={() =>
                         act('print_injector', {
                           mutref: mutation.ByondRef,
@@ -193,7 +198,11 @@ export const MutationInfo = (props) => {
                   <Stack.Item>
                     <Button
                       icon="syringe"
-                      disabled={!isInjectorReady || !mutation.Active}
+                      disabled={
+                        !isInjectorReady ||
+                        !mutation.Active ||
+                        mutation.Class === MUT_OTHER
+                      }
                       onClick={() =>
                         act('print_injector', {
                           mutref: mutation.ByondRef,
@@ -230,7 +239,11 @@ export const MutationInfo = (props) => {
               <Stack.Item>
                 <Button
                   icon="save"
-                  disabled={savedToConsole || !mutation.Active}
+                  disabled={
+                    savedToConsole ||
+                    !mutation.Active ||
+                    mutation.Class === MUT_OTHER
+                  }
                   content="Save to Console"
                   onClick={() =>
                     act('save_console', {
@@ -250,7 +263,8 @@ export const MutationInfo = (props) => {
                     !hasDisk ||
                     diskCapacity <= 0 ||
                     diskReadOnly ||
-                    !mutation.Active
+                    !mutation.Active ||
+                    mutation.Class === MUT_OTHER
                   }
                   content="Save to Disk"
                   onClick={() =>

--- a/tgui/packages/tgui/interfaces/DnaConsole/constants.ts
+++ b/tgui/packages/tgui/interfaces/DnaConsole/constants.ts
@@ -17,6 +17,7 @@ export const GENE_COLORS = {
 
 export const MUT_NORMAL = 1;
 export const MUT_EXTRA = 2;
+export const MUT_OTHER = 3;
 
 export const STORAGE_CONS_SUBMODE_MUTATIONS = 'mutations';
 export const STORAGE_CONS_SUBMODE_CHROMOSOMES = 'chromosomes';

--- a/tgui/packages/tgui/interfaces/DnaConsole/index.jsx
+++ b/tgui/packages/tgui/interfaces/DnaConsole/index.jsx
@@ -28,7 +28,7 @@ export const DnaConsole = (props) => {
   const { consoleMode } = data.view;
 
   return (
-    <Window title="DNA Console" width={539} height={710}>
+    <Window title="DNA Console" width={550} height={710}>
       {!!isPulsing && (
         <Dimmer fontSize="14px" textAlign="center">
           <Icon mr={1} name="spinner" spin />


### PR DESCRIPTION
## About The Pull Request

1. Fix DNA consoles being able to print anomalous mutations

I think the code to block this was just outright removed with no replacement
The code to stop saving them still exists but the code to stop printing is just gone

2. Fix weird spacing when you have >8 mutations

Fixes that weird issue where you the mutation printer goes to 1 wide instead of 2 wide

## Changelog

:cl: Melbert
fix: Fix DNA consoles being able to print anomalous mutations
fix: Fix weird issue where mutation list in the DNA console would go to 1 wide
/:cl:
