### PR TITLE
Revenant cannot emag the emergency shuttle console (imarooned pr)

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/revenant/revenant_abilities.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/revenant_abilities.dm
@@ -306,6 +306,13 @@
 	cast_amount = 60
 	unlock_amount = 125
 
+	/// Typecache of stuff we generally don't want emaggable
+	var/static/list/no_emag_typecache = typecacheof(list(
+		/obj/machinery/power/apc,
+		/obj/machinery/power/smes,
+		/obj/machinery/computer/emergency_shuttle,
+	))
+
 // A note to future coders: do not replace this with an EMP because it will wreck malf AIs and everyone will hate you.
 /datum/action/cooldown/spell/aoe/revenant/malfunction/cast_on_thing_in_aoe(turf/victim, mob/living/basic/revenant/caster)
 	for(var/mob/living/basic/bot/bot in victim)
@@ -323,13 +330,13 @@
 		new /obj/effect/temp_visual/revenant(human.loc)
 		human.emp_act(EMP_HEAVY)
 	for(var/obj/thing in victim)
-		//Doesn't work on SMES and APCs, to prevent kekkery.
-		if(istype(thing, /obj/machinery/power/apc) || istype(thing, /obj/machinery/power/smes))
+		if(is_type_in_typecache(thing, no_emag_typecache))
 			continue
-		if(prob(20))
-			if(prob(50))
-				new /obj/effect/temp_visual/revenant(thing.loc)
-			thing.emag_act(caster)
+		if(!prob(20))
+			continue
+		if(prob(50))
+			new /obj/effect/temp_visual/revenant(thing.loc)
+		thing.emag_act(caster)
 	// Only works on cyborgs, not AI!
 	for(var/mob/living/silicon/robot/cyborg in victim)
 		playsound(cyborg, 'sound/machines/warning-buzzer.ogg', 50, TRUE)


### PR DESCRIPTION
## About The Pull Request

Removes the ability for Malfunction to affect the emergency shuttle's console, thus preventing Revenants from early launching

## Why It's Good For The Game

I think Revenants emagging the escape shuttle is...... cringe.

There is practically no feasible way to stop them from doing it (they can just sit in space and spam it until it works), and of course there's no un-emagging the emergency shuttle. So all it means is if you have a Revenant in the round and you didn't deal with it by the time the shuttle arrived you have to be right there or you get left behind. 

It screws over antags: Shuttle is a prime opportunity for opportunism.
It screws over people who don't afk in departures: Better hope for a shuttle beacon lol
It kills dramatic tension in narrow escapes: You can be holding down departures against waves of xenos, and then the ghost just wanders in and sends the shuttle and ok I guess that's over no more fun

And to top it all off it's not like it benefits the Revenant in any way, it's not like you gain something from sending the shuttle faster. You maroon everyone who didn't rush to a pod or departures 2 minutes early and that's it. 

## Changelog

:cl: Melbert
del: Revenant can no longer affect emergency shuttle console with Malfunction
/:cl:
