### PR TITLE
Fixes SHIFT+(a number) keybinds not working

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/GamePreferences/KeybindingsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/GamePreferences/KeybindingsPage.tsx
@@ -102,7 +102,10 @@ function formatKeyboardEvent(event: KeyboardEvent): string {
   }
 
   if (isStandardKey(event)) {
-    const key = event.key.toUpperCase();
+    // Seperately pull out digits, otherwise SHIFT+1 turns into '!' and
+    // the keybinding is unusable
+    const digit = event.code?.match(/^Digit(\d)$/)?.[1];
+    const key = digit ?? event.key.toUpperCase();
     text += KEY_CODE_TO_BYOND[key] || key;
   }
 


### PR DESCRIPTION

## About The Pull Request

Trying to set e.g. "SHIFT+2" as a keybind got stored as "SHIFT+@" and thus never worked


## Changelog
:cl: PapaMichael
fix: Setting SHIFT+number keybinds now works
/:cl:
