### PR TITLE
Fixes icemoon tiles counting for blob victory

### DIFF
--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -191,6 +191,7 @@
 	icon_state = "mining"
 	default_gravity = STANDARD_GRAVITY
 	flags_1 = NONE
+	area_flags = NONE
 	area_flags_mapping = UNIQUE_AREA | FLORA_ALLOWED
 	ambience_index = AMBIENCE_ICEMOON
 	sound_environment = SOUND_AREA_ICEMOON


### PR DESCRIPTION

## About The Pull Request

Closes https://github.com/tgstation/tgstation/issues/97709


## Changelog
:cl: PapaMichael
fix: Icemoon tiles no longer count towards the blob's victory
/:cl:
