### PR TITLE
Fixes mob ai asyncs finishing and still returning suspend.

### DIFF
--- a/code/datums/ai/_ai_behavior.dm
+++ b/code/datums/ai/_ai_behavior.dm
@@ -104,7 +104,7 @@
 /datum/bt_node/ai_behavior/proc/start_async()
 	async_running = TRUE
 	INVOKE_ASYNC(src, PROC_REF(perform_async), owning_controller)
-	return AI_BEHAVIOR_DELAY
+	return handle_async() || AI_BEHAVIOR_DELAY
 
 ///Override this if you have sleeping behavior, be sure to implement the other async procs in perform()
 /datum/bt_node/ai_behavior/proc/perform_async(datum/ai_controller/controller)


### PR DESCRIPTION
## About The Pull Request

They would get stuck in the resist loop forever due to the async usually finishing whilst still in start_async(), which start_async() never checks for.

Escape captivity mobs are thus not impotent after podding

## Why It's Good For The Game

When an admeme or anything else spawns a mob via pod drop, the mob will actually have working AI, along some other weird cases.

## Changelog

:cl:
fix: Pod dropped mobs no longer have broken AI that's stuck trying to resist forever.
/:cl:
