### PR TITLE
Grab signal update, pawn_grabbed_by_enemy fix

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
@@ -84,8 +84,10 @@
 #define COMSIG_MOVABLE_PIPE_EJECTING "movable_pipe_ejecting"
 ///called when the movable successfully has its anchored var changed, from base atom/movable/set_anchored(): (value)
 #define COMSIG_MOVABLE_SET_ANCHORED "movable_set_anchored"
-///from base of atom/movable/setGrabState(): (newstate)
+///from base of atom/movable/setGrabState(). Called on the person grabbing: (newstate)
 #define COMSIG_MOVABLE_SET_GRAB_STATE "living_set_grab_state"
+///from base of atom/movable/setGrabState(). Called on the thing that got grabbed: (newstate)
+#define COMSIG_MOVABLE_CHANGED_GRABBED_STATE "movable_changed_grabbed_state"
 /// from base of mob/living/resist_grab(), to the grabber: (mob/living/grabbed, list/grab_stats)
 #define COMSIG_MOVABLE_GRABBED_RESISTING "movable_grabbed_resisting"
 	#define GRAB_STAT_EFFECTIVE_STATE 1

--- a/code/datums/ai/generic_decorators/pawn_grabbed_by_enemy.dm
+++ b/code/datums/ai/generic_decorators/pawn_grabbed_by_enemy.dm
@@ -4,11 +4,11 @@
 	child_typepath = /datum/bt_node/ai_behavior/resist
 
 /datum/bt_node/decorator/pawn_grabbed_by_enemy/register_observe_signals(atom/pawn)
-	RegisterSignals(pawn, list(COMSIG_LIVING_GET_PULLED, COMSIG_ATOM_NO_LONGER_PULLED, COMSIG_MOVABLE_SET_GRAB_STATE), PROC_REF(on_signal_changed))
+	RegisterSignals(pawn, list(COMSIG_LIVING_GET_PULLED, COMSIG_ATOM_NO_LONGER_PULLED, COMSIG_MOVABLE_CHANGED_GRABBED_STATE), PROC_REF(on_signal_changed))
 	return TRUE
 
 /datum/bt_node/decorator/pawn_grabbed_by_enemy/unregister_observe_signals(atom/pawn)
-	UnregisterSignal(pawn, list(COMSIG_LIVING_GET_PULLED, COMSIG_ATOM_NO_LONGER_PULLED, COMSIG_MOVABLE_SET_GRAB_STATE))
+	UnregisterSignal(pawn, list(COMSIG_LIVING_GET_PULLED, COMSIG_ATOM_NO_LONGER_PULLED, COMSIG_MOVABLE_CHANGED_GRABBED_STATE))
 
 /datum/bt_node/decorator/pawn_grabbed_by_enemy/check_condition(datum/ai_controller/controller)
 	var/mob/living/pawn = controller.pawn

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1739,9 +1739,10 @@
 /atom/movable/proc/setGrabState(newstate)
 	if(newstate == grab_state)
 		return
-	SEND_SIGNAL(src, COMSIG_MOVABLE_SET_GRAB_STATE, newstate)
 	. = grab_state
 	grab_state = newstate
+	SEND_SIGNAL(src, COMSIG_MOVABLE_SET_GRAB_STATE, grab_state)
+	SEND_SIGNAL(pulling, COMSIG_MOVABLE_CHANGED_GRABBED_STATE, grab_state)
 	switch(grab_state) // Current state.
 		if(GRAB_PASSIVE)
 			pulling.remove_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), CHOKEHOLD_TRAIT)

--- a/code/modules/mob/living/carbon/alien/adult/adult.dm
+++ b/code/modules/mob/living/carbon/alien/adult/adult.dm
@@ -86,9 +86,10 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 		return
 	if(newstate > GRAB_AGGRESSIVE)
 		newstate = GRAB_AGGRESSIVE
-	SEND_SIGNAL(src, COMSIG_MOVABLE_SET_GRAB_STATE, newstate)
 	. = grab_state
 	grab_state = newstate
+	SEND_SIGNAL(src, COMSIG_MOVABLE_SET_GRAB_STATE, grab_state)
+	SEND_SIGNAL(pulling, COMSIG_MOVABLE_CHANGED_GRABBED_STATE, grab_state)
 	update_incapacitated()
 	switch(grab_state) // Current state.
 		if(GRAB_PASSIVE)


### PR DESCRIPTION
## About The Pull Request

Adds COMSIG_MOVABLE_CHANGED_GRABBED_STATE for when a change in grab state happens on the object being grabbed. Moves both it and COMSIG_MOVABLE_SET_GRAB_STATE until AFTER the grab state is actually changed. There's no real reason not to do so if you look at the logic.

Makes pawn_grabbed_by_enemy use the new COMSIG_MOVABLE_CHANGED_GRABBED_STATE signal so that the decorator actually starts returning true when its pawn gets aggro grabbed.

## Why It's Good For The Game

Fixes some weird buggy behaviour. Tested and proven to work correctly, if the mob has DEFAULT_AI_FLAGS or CAN_ACT_WHILE_GRABBED that is.

## Changelog

:cl:
fix: Mobs that are aggro grabbed and are meant to escape captivity actually do so.
/:cl:
