### PR TITLE
Fixes master not compiling with reftracking on

### DIFF
--- a/code/modules/admin/view_variables/reference_tracking.dm
+++ b/code/modules/admin/view_variables/reference_tracking.dm
@@ -35,7 +35,6 @@ GLOBAL_ALIST_EMPTY(reftracker_skip_typecache_b)
 		/datum/movespeed_modifier,
 		/datum/painting,
 		/datum/paper_input,
-		/datum/physiology,
 		/datum/plant_gene/reagent,
 		/datum/qdel_item,
 		/datum/stack_recipe,


### PR DESCRIPTION

## About The Pull Request

#96649 deleted the physiology datum but did not remove its mention from a define-only proc used when FAST_REFERENCE_TRACKING is on

## Changelog
Not player facing
