### PR TITLE
Makes Candela LoS checks a bit more forgiving

### DIFF
--- a/code/datums/components/candela_node.dm
+++ b/code/datums/components/candela_node.dm
@@ -156,9 +156,8 @@
 	// We use can_see rather than view() because view() is not a raycast and can end up putting beams through walls, as it sees around corners in a weird fasion
 	var/list/our_links = network.linked_nodes[src]
 	for (var/datum/component/candela_node/other_node as anything in our_links)
-		if (!can_see(parent, other_node.parent, MINING_BEACON_MAX_REACH) || !can_see(other_node.parent, parent, MINING_BEACON_MAX_REACH))
-			continue
-		located_nodes |= other_node
+		if (can_see(parent, other_node.parent, MINING_BEACON_MAX_REACH) || can_see(other_node.parent, parent, MINING_BEACON_MAX_REACH))
+			located_nodes |= other_node
 
 	if (length(located_nodes))
 		// No nodes were cut, don't do anything
@@ -178,7 +177,7 @@
 		if (node_dist >= min_dist)
 			continue
 
-		if (!can_see(parent, thing, MINING_BEACON_MAX_REACH) || !can_see(thing, parent, MINING_BEACON_MAX_REACH))
+		if (!can_see(parent, thing, MINING_BEACON_MAX_REACH) && !can_see(thing, parent, MINING_BEACON_MAX_REACH))
 			continue
 
 		min_dist = node_dist
@@ -246,8 +245,11 @@ GLOBAL_LIST_EMPTY(mining_beacon_networks)
 	var/list/need_updates = list(new_node)
 	for (var/atom/movable/thing in view(MINING_BEACON_MAX_REACH, new_node.parent))
 		var/datum/component/candela_node/actual_node = atoms_to_nodes[thing]
+		if (!actual_node || actual_node == new_node)
+			continue
+
 		// Need a can_see check to avoid beams going through walls
-		if (!actual_node || actual_node == new_node || !can_see(thing, new_node.parent, MINING_BEACON_MAX_REACH) || !can_see(new_node.parent, thing, MINING_BEACON_MAX_REACH))
+		if (!can_see(thing, new_node.parent, MINING_BEACON_MAX_REACH) && !can_see(new_node.parent, thing, MINING_BEACON_MAX_REACH))
 			continue
 
 		if (linked_nodes[actual_node])
@@ -427,7 +429,7 @@ GLOBAL_LIST_EMPTY(mining_beacon_networks)
 	var/datum/component/candela_node/current_closest = null
 	var/datum/candela_item_handler/master = all_handlers[1]
 	var/datum/component/candela_node/closest_node = master.closest_node
-	if (closest_node && can_see(source, closest_node.parent, MINING_BEACON_MAX_REACH) && can_see(closest_node.parent, source, MINING_BEACON_MAX_REACH))
+	if (closest_node && (can_see(source, closest_node.parent, MINING_BEACON_MAX_REACH) || can_see(closest_node.parent, source, MINING_BEACON_MAX_REACH)))
 		current_closest = closest_node
 
 	for (var/datum/component/candela_node/network_node as anything in linked_nodes)
@@ -438,7 +440,7 @@ GLOBAL_LIST_EMPTY(mining_beacon_networks)
 			continue
 
 		// Need a can_see rather than viewers() to avoid beams going through walls
-		if (can_see(source, network_node.parent, MINING_BEACON_MAX_REACH) && can_see(network_node.parent, source, MINING_BEACON_MAX_REACH))
+		if (can_see(source, network_node.parent, MINING_BEACON_MAX_REACH) || can_see(network_node.parent, source, MINING_BEACON_MAX_REACH))
 			current_closest = network_node
 
 	if (current_closest)

--- a/code/modules/mining/equipment/candela_network/candela_item_handler.dm
+++ b/code/modules/mining/equipment/candela_network/candela_item_handler.dm
@@ -140,7 +140,7 @@
 		if (node_dist >= cur_dist)
 			continue
 
-		if (!can_see(our_turf, node_turf, MINING_BEACON_MAX_REACH) || !can_see(node_turf, our_turf, MINING_BEACON_MAX_REACH))
+		if (!can_see(our_turf, node_turf, MINING_BEACON_MAX_REACH) && !can_see(node_turf, our_turf, MINING_BEACON_MAX_REACH))
 			continue
 
 		cur_node = node
@@ -166,7 +166,7 @@
 			if (node_dist >= cur_dist)
 				continue
 
-			if (!can_see(our_turf, node_turf, MINING_BEACON_MAX_REACH) || !can_see(node_turf, our_turf, MINING_BEACON_MAX_REACH))
+			if (!can_see(our_turf, node_turf, MINING_BEACON_MAX_REACH) && !can_see(node_turf, our_turf, MINING_BEACON_MAX_REACH))
 				continue
 
 			cur_node = node


### PR DESCRIPTION

## About The Pull Request
Currently to make a connection Candela units need to both be able to see eachother via a direct raycast, which is used because view() is a lot more forgiving and gives sight around corners which ended up making the beams render over multiple tiles of walls in a rather ugly pattern.
This PR changes that to only require one of the nodes to see the other rather than both. Two-way checks were added because can_see is non-deterministic and the output varies based on argument order, A can see B but B may not be able to see A due to tile path tracing changing based on arg order.

Before vs now

<img width="241" height="268" alt="image" src="https://github.com/user-attachments/assets/a024b198-90f7-464d-b21b-c1809e527938" />

<img width="209" height="255" alt="dreamseeker_53KPjccNGv" src="https://github.com/user-attachments/assets/68f2fdd5-5e8d-4b2e-99e4-bea53b03467d" />

## Why It's Good For The Game
This way nodes placed next to a corner will be able to see nodes around said corner without another node being placed right next to it when you try to move around the wall.
Should also fix beacons sometimes having issues linking up around corners despite a connection being drawn.

## Changelog
:cl:
qol: Made Candela LoS checks a bit more forgiving
/:cl:
