### PR TITLE
Tiles can be glassed as to prevent their properties.

### DIFF
--- a/code/datums/components/crafting/tiles.dm
+++ b/code/datums/components/crafting/tiles.dm
@@ -70,6 +70,56 @@
 	)
 	result_amount = 4
 
+/datum/crafting_recipe/glassed_plasma
+	name = "Glassed Plasma Tile"
+	result = /obj/item/stack/tile/mineral/glassed/plasma
+	reqs = list(
+		/obj/item/stack/tile/mineral/plasma = 1,
+		/obj/item/stack/tile/glass = 1,
+	)
+	tool_behaviors = list(TOOL_WELDER)
+	category = CAT_TILES
+
+/datum/crafting_recipe/glassed_uranium
+	name = "Glassed Uranium Tile"
+	result = /obj/item/stack/tile/mineral/glassed/uranium
+	reqs = list(
+		/obj/item/stack/tile/mineral/uranium = 1,
+		/obj/item/stack/tile/glass = 1,
+	)
+	tool_behaviors = list(TOOL_WELDER)
+	category = CAT_TILES
+
+/datum/crafting_recipe/glassed_bananium
+	name = "Glassed Bananium Tile"
+	result = /obj/item/stack/tile/mineral/glassed/bananium
+	reqs = list(
+		/obj/item/stack/tile/mineral/bananium = 1,
+		/obj/item/stack/tile/glass = 1,
+	)
+	tool_behaviors = list(TOOL_WELDER)
+	category = CAT_TILES
+
+/datum/crafting_recipe/glassed_bluespace
+	name = "Glassed Bluespace Tile"
+	result = /obj/item/stack/tile/mineral/glassed/bluespace
+	reqs = list(
+		/obj/item/stack/tile/mineral/bluespace = 1,
+		/obj/item/stack/tile/glass = 1,
+	)
+	tool_behaviors = list(TOOL_WELDER)
+	category = CAT_TILES
+
+/datum/crafting_recipe/glassed_telecrystal
+	name = "Glassed Telecrystal Tile"
+	result = /obj/item/stack/tile/mineral/glassed/telecrystal
+	reqs = list(
+		/obj/item/stack/tile/mineral/telecrystal = 1,
+		/obj/item/stack/tile/glass = 1,
+	)
+	tool_behaviors = list(TOOL_WELDER)
+	category = CAT_TILES
+
 /datum/crafting_recipe/stained_glass_red
 	name = "Red Stained Glass"
 	reqs = list(

--- a/code/game/objects/items/stacks/tiles/tile_mineral.dm
+++ b/code/game/objects/items/stacks/tiles/tile_mineral.dm
@@ -147,7 +147,6 @@
 	turf_type = /turf/open/floor/mineral/bananium
 	mineralType = "bananium"
 	mats_per_unit = list(/datum/material/bananium=SHEET_MATERIAL_AMOUNT*0.25)
-	material_flags = NONE //The slippery comp makes it unpractical for good clown decor. The material tiles should still slip.
 	merge_type = /obj/item/stack/tile/mineral/bananium
 	tile_reskin_types = list(
 		/obj/item/stack/tile/mineral/bananium,

--- a/code/game/objects/items/stacks/tiles/tile_mineral.dm
+++ b/code/game/objects/items/stacks/tiles/tile_mineral.dm
@@ -172,6 +172,7 @@
 	tile_reskin_types = list(
 		/obj/item/stack/tile/mineral/bluespace,
 		/obj/item/stack/tile/mineral/bluespace/tiled,
+		/obj/item/stack/tile/mineral/bluespace/n,
 	)
 
 /obj/item/stack/tile/mineral/bluespace/tiled
@@ -198,6 +199,7 @@
 	tile_reskin_types = list(
 		/obj/item/stack/tile/mineral/telecrystal,
 		/obj/item/stack/tile/mineral/telecrystal/tiled,
+		/obj/item/stack/tile/mineral/telecrystal/s,
 	)
 
 /obj/item/stack/tile/mineral/telecrystal/tiled
@@ -498,3 +500,155 @@
 	mineralType = "snow"
 	merge_type = /obj/item/stack/tile/mineral/snow
 	mats_per_unit = list(/datum/material/snow = HALF_SHEET_MATERIAL_AMOUNT / 2)
+
+///glassed variants of bunch of the floors which otherwise might not be the best to walk through.
+
+/obj/item/stack/tile/mineral/glassed/update_overlays()
+	. = ..()
+	. += mutable_appearance(icon, "tile_glass", layer = src.layer+0.01)
+
+/obj/item/stack/tile/mineral/glassed
+	/// Determines what stack floor type this splits into.
+	var/floorType = null
+	merge_type = /obj/item/stack/tile/mineral/glassed
+
+/obj/item/stack/tile/mineral/glassed/attackby(obj/item/W, mob/user, list/modifiers, list/attack_modifiers)
+	if(W.tool_behaviour == TOOL_WELDER)
+		if(!floorType)
+			to_chat(user, span_warning("You can split these!"))
+			stack_trace("A glassed mineral tile of type [type] doesn't have its floorType set.")
+			return
+		if(W.use_tool(src, user, 0, volume=40))
+			var/floor_type = text2path("/obj/item/stack/tile/mineral/[floorType]")
+			var/obj/item/stack/tile/mineral/new_item = new floor_type(user.drop_location())
+			user.visible_message(span_notice("[user] split [src] into [new_item] and glass tiles with [W]."), \
+				span_notice("You shaped [src] into [new_item] with [W]."), \
+				span_hear("You hear welding."))
+			var/holding = user.is_holding(src)
+			use(4)
+			if(holding && QDELETED(src))
+				user.put_in_hands(new_item)
+				user.put_in_hands(/obj/item/stack/tile/glass)
+	else
+		return ..()
+
+/obj/item/stack/tile/mineral/glassed/plasma
+	name = "plasma tile"
+	singular_name = "plasma floor tile"
+	desc = "A tile made out of highly flammable plasma, glassed as to prevent the fire from actually getting to it."
+	icon_state = "tile_plasma"
+	inhand_icon_state = "tile-plasma"
+	turf_type = /turf/open/floor/mineral/glassed/plasma
+	floorType = "plasma"
+	mats_per_unit = list(/datum/material/plasma=SHEET_MATERIAL_AMOUNT*0.25, /datum/material/glass=SHEET_MATERIAL_AMOUNT*0.25)
+	merge_type = /obj/item/stack/tile/mineral/glassed/plasma
+	tile_reskin_types = list(
+		/obj/item/stack/tile/mineral/glassed/plasma,
+		/obj/item/stack/tile/mineral/glassed/plasma/tiled,
+	)
+
+/obj/item/stack/tile/mineral/glassed/plasma/tiled
+	icon_state = "plasma_tiled"
+	floorType = "plasma/tiled"
+	turf_type = /turf/open/floor/mineral/glassed/plasma/tiled
+	merge_type = /obj/item/stack/tile/mineral/glassed/plasma/tiled
+
+/obj/item/stack/tile/mineral/glassed/uranium
+	name = "uranium tile"
+	singular_name = "uranium floor tile"
+	desc = "A tile made out of uranium. Glassed so you won't get irradiated."
+	icon_state = "tile_uranium"
+	inhand_icon_state = "tile-uranium"
+	turf_type = /turf/open/floor/mineral/glassed/uranium
+	floorType = "uranium"
+	mats_per_unit = list(/datum/material/uranium=SHEET_MATERIAL_AMOUNT*0.25, /datum/material/glass=SHEET_MATERIAL_AMOUNT*0.25)
+	merge_type = /obj/item/stack/tile/mineral/glassed/uranium
+	tile_reskin_types = list(
+		/obj/item/stack/tile/mineral/glassed/uranium,
+		/obj/item/stack/tile/mineral/glassed/uranium/tiled,
+	)
+
+/obj/item/stack/tile/mineral/glassed/uranium/tiled
+	icon_state = "uranium_tiled"
+	floorType = "uranium/tiled"
+	turf_type = /turf/open/floor/mineral/glassed/uranium/tiled
+	merge_type = /obj/item/stack/tile/mineral/glassed/uranium/tiled
+
+/obj/item/stack/tile/mineral/glassed/bananium
+	name = "bananium tile"
+	singular_name = "bananium floor tile"
+	desc = "A glassed, and thus non-slippery tile made out of bananium, HOOOOOOOOONK!"
+	icon_state = "tile_bananium"
+	inhand_icon_state = "tile-bananium"
+	turf_type = /turf/open/floor/mineral/glassed/bananium
+	floorType = "bananium"
+	mats_per_unit = list(/datum/material/bananium=SHEET_MATERIAL_AMOUNT*0.25, /datum/material/glass=SHEET_MATERIAL_AMOUNT*0.25)
+	material_flags = NONE
+	merge_type = /obj/item/stack/tile/mineral/glassed/bananium
+	tile_reskin_types = list(
+		/obj/item/stack/tile/mineral/glassed/bananium,
+		/obj/item/stack/tile/mineral/glassed/bananium/tiled,
+	)
+
+/obj/item/stack/tile/mineral/glassed/bananium/tiled
+	icon_state = "bananium_tiled"
+	floorType = "bananium/tiled"
+	turf_type = /turf/open/floor/mineral/glassed/bananium/tiled
+	merge_type = /obj/item/stack/tile/mineral/glassed/bananium/tiled
+
+/obj/item/stack/tile/mineral/glassed/bluespace
+	name = "bluespace tile"
+	singular_name = "bluespace floor tile"
+	desc = "A glassed tile made out of bluespace crystals. Save to walk on even barefoot."
+	icon_state = "tile_bluespace_c"
+	inhand_icon_state = "tile-bluespace"
+	turf_type = /turf/open/floor/mineral/glassed/bluespace
+	floorType = "bluespace"
+	mats_per_unit = list(/datum/material/bluespace=SHEET_MATERIAL_AMOUNT*0.25, /datum/material/glass=SHEET_MATERIAL_AMOUNT*0.25)
+	merge_type = /obj/item/stack/tile/mineral/glassed/bluespace
+	tile_reskin_types = list(
+		/obj/item/stack/tile/mineral/glassed/bluespace,
+		/obj/item/stack/tile/mineral/glassed/bluespace/tiled,
+		/obj/item/stack/tile/mineral/glassed/bluespace/n,
+	)
+
+/obj/item/stack/tile/mineral/glassed/bluespace/tiled
+	icon_state = "bluespace_c_tiled"
+	floorType = "bluespace/tiled"
+	turf_type = /turf/open/floor/mineral/glassed/bluespace/tiled
+	merge_type = /obj/item/stack/tile/mineral/glassed/bluespace/tiled
+
+/obj/item/stack/tile/mineral/glassed/bluespace/n
+	icon_state = "bluespace_c_n"
+	floorType = "bluespace_n"
+	turf_type = /turf/open/floor/mineral/glassed/bluespace/n
+	merge_type = /obj/item/stack/tile/mineral/glassed/bluespace/n
+
+/obj/item/stack/tile/mineral/glassed/telecrystal
+	name = "telecrystal tile"
+	singular_name = "telecrystal floor tile"
+	desc = "A glassed tile made out of telecrystals. Pretty sure its illegal. But at least its safe to walk on."
+	icon_state = "tile_telecrystal"
+	inhand_icon_state = "tile-telecrystal"
+	turf_type = /turf/open/floor/mineral/glassed/telecrystal
+	mineralType = "telecrystal"
+	mats_per_unit = list(/datum/material/telecrystal=SHEET_MATERIAL_AMOUNT*0.25, /datum/material/glass=SHEET_MATERIAL_AMOUNT*0.25)
+
+	merge_type = /obj/item/stack/tile/mineral/glassed/telecrystal
+	tile_reskin_types = list(
+		/obj/item/stack/tile/mineral/glassed/telecrystal,
+		/obj/item/stack/tile/mineral/glassed/telecrystal/tiled,
+		/obj/item/stack/tile/mineral/glassed/telecrystal/s,
+	)
+
+/obj/item/stack/tile/mineral/glassed/telecrystal/tiled
+	icon_state = "telecrystal_tiled"
+	floorType = "telecrystal/tiled"
+	turf_type = /turf/open/floor/mineral/glassed/bluespace/tiled
+	merge_type = /obj/item/stack/tile/mineral/glassed/telecrystal/tiled
+
+/obj/item/stack/tile/mineral/glassed/telecrystal/s
+	icon_state = "telecrystal_s"
+	floorType = "telecrystal/s"
+	turf_type = /turf/open/floor/mineral/glassed/telecrystal/s
+	merge_type = /obj/item/stack/tile/mineral/glassed/telecrystal/s

--- a/code/game/turfs/open/floor/mineral_floor.dm
+++ b/code/game/turfs/open/floor/mineral_floor.dm
@@ -528,3 +528,99 @@
 
 /turf/open/floor/mineral/abductor/burn_tile()
 	return //unburnable
+
+/// GLASSED; versions of the one below with material_flags = NONE so they don't harm people walking on them.
+
+/turf/open/floor/mineral/glassed/plasma
+	name = "glassed plasma floor"
+	icon_state = "plasma"
+	floor_tile = /obj/item/stack/tile/mineral/glassed/plasma
+	icons = list("plasma","plasma_dam")
+	custom_materials = list(/datum/material/plasma = SMALL_MATERIAL_AMOUNT*5, /datum/material/glass = SMALL_MATERIAL_AMOUNT*5)
+	rust_resistance = RUST_RESISTANCE_BASIC
+	material_flags = NONE
+
+/turf/open/floor/mineral/plasma/tiled
+	name = "tiled plasma floor"
+	icon_state = "plasma_tiled"
+	floor_tile = /obj/item/stack/tile/mineral/glassed/plasma/tiled
+
+/turf/open/floor/mineral/glassed/plasma/tiled/broken_states()
+		return list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
+
+/turf/open/floor/mineral/glassed/bananium
+	name = "glassed bananium floor"
+	icon_state = "bananium"
+	floor_tile = /obj/item/stack/tile/mineral/glassed/bananium
+	icons = list("bananium","bananium_dam")
+	custom_materials = list(/datum/material/bananium = SMALL_MATERIAL_AMOUNT*5, /datum/material/glass = SMALL_MATERIAL_AMOUNT*5)
+	rust_resistance = RUST_RESISTANCE_BASIC
+	material_flags = NONE
+
+/turf/open/floor/mineral/glassed/bananium/tiled
+	name = "glassed tiled bananium floor"
+	icon_state = "bananium_tiled"
+	floor_tile = /obj/item/stack/tile/mineral/glassed/bananium/tiled
+
+/turf/open/floor/mineral/glassed/bananium/tiled/broken_states()
+	return list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
+
+/turf/open/floor/mineral/glassed/uranium
+	article = "a"
+	name = "glassed uranium floor"
+	icon_state = "uranium"
+	floor_tile = /obj/item/stack/tile/mineral/glassed/uranium
+	icons = list("uranium","uranium_dam")
+	custom_materials = list(/datum/material/uranium = SMALL_MATERIAL_AMOUNT*5, /datum/material/glass = SMALL_MATERIAL_AMOUNT*5)
+	rust_resistance = RUST_RESISTANCE_REINFORCED
+	material_flags = NONE
+
+/turf/open/floor/mineral/glassed/uranium/tiled
+	name = "glassed tiled uranium floor"
+	icon_state = "uranium_tiled"
+	floor_tile = /obj/item/stack/tile/mineral/glassed/uranium/tiled
+
+/turf/open/floor/mineral/glassed/uranium/tiled/broken_states()
+	return list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
+
+/turf/open/floor/mineral/glassed/bluespace
+	name = "glassed bluespace floor"
+	icon_state = "bluespacecrystal"
+	floor_tile = /obj/item/stack/tile/mineral/glassed/bluespace
+	custom_materials = list(/datum/material/bluespace = SMALL_MATERIAL_AMOUNT*5, /datum/material/glass = SMALL_MATERIAL_AMOUNT*5)
+	rust_resistance = RUST_RESISTANCE_REINFORCED
+	material_flags = NONE
+
+/turf/open/floor/mineral/glassed/bluespace/broken_states()
+	return list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
+
+/turf/open/floor/mineral/glassed/bluespace/tiled
+	name = "glassed tiled bluespace floor"
+	icon_state = "bluespacecrystal_tiled"
+	floor_tile = /obj/item/stack/tile/mineral/glassed/bluespace/tiled
+
+/turf/open/floor/mineral/glassed/bluespace/n
+	name = "glassed N-marked bluespace floor"
+	icon_state = "bluespacecrystal_n"
+	floor_tile = /obj/item/stack/tile/mineral/glassed/bluespace/n
+
+/turf/open/floor/mineral/glassed/telecrystal
+	name = "glassed telecrystal floor"
+	icon_state = "telecrystal"
+	floor_tile = /obj/item/stack/tile/mineral/glassed/telecrystal
+	custom_materials = list(/datum/material/telecrystal = SMALL_MATERIAL_AMOUNT*5, /datum/material/glass = SMALL_MATERIAL_AMOUNT*5)
+	rust_resistance = RUST_RESISTANCE_REINFORCED
+	material_flags = NONE
+
+/turf/open/floor/mineral/glassed/telecrystal/broken_states()
+	return list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
+
+/turf/open/floor/mineral/glassed/telecrystal/tiled
+	name = "glassed tiled telecrystal floor"
+	icon_state = "telecrystal_tiled"
+	floor_tile = /obj/item/stack/tile/mineral/glassed/telecrystal/tiled
+
+/turf/open/floor/mineral/glassed/telecrystal/s
+	name = "glassed S-marked telecrystal floor"
+	icon_state = "telecrystal_s"
+	floor_tile = /obj/item/stack/tile/mineral/glassed/telecrystal/s


### PR DESCRIPTION
## About The Pull Request

Formerly a part of the floors and walls PR that I was asked to split out.

## Why It's Good For The Game

 Uranium, plasma and other such tiles have unique sprites, that look cool... but, can't really be used in construction because they will irradiate, slip or teleport people. Or pose a major fire hazard. This gives an ability to counteract it.

## Changelog

:cl:
add: Adds the ability to glass the bluespace, uranium, plasma, bananium and telecrystal tiles by combining them with glass tiles in the crafting menu. Resulting tiles have don't have their material properties, and can be separated using a welder.
/:cl:

