### PR TITLE
Fixes AI revival

### DIFF
--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -67,6 +67,8 @@
 		return
 	if(stat != DEAD && health <= HEALTH_THRESHOLD_DEAD)
 		death()
+	else if(stat < DEAD)
+		set_stat(STABLE)
 	diag_hud_set_status()
 
 /mob/living/silicon/ai/update_sight()


### PR DESCRIPTION

## About The Pull Request
in #97041 the AI's update_stat() proc lost the portion that brings it out of hard crit, so upon revival the AI is permanently stuck in hard crit, this will no longer be the case
## Why It's Good For The Game
Bug fix go brr I love silicons :)
closes #97545
## Changelog
:cl:
fix: AI are no longer stuck in hard crit forever post-revive
/:cl:
