### PR TITLE
Fixes radstorm ending announcement not showing

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -80,7 +80,8 @@
 	return ..()
 
 /datum/weather/rad_storm/end()
-	if(..())
+	. = ..()
+	if(!.)
 		return
 	priority_announce("The radiation threat has passed. Please return to your workplaces.", "Anomaly Alert")
 	status_alarm(FALSE)


### PR DESCRIPTION

## About The Pull Request

Title


## Changelog
:cl: PapaMichael
fix: Announcements when radiation storms end now properly show
/:cl:
