### PR TITLE
Loot panel QoL

### DIFF
--- a/code/_onclick/click_alt.dm
+++ b/code/_onclick/click_alt.dm
@@ -119,7 +119,7 @@
 ///alt and alt-shift click.
 ///Returns FALSE if the mob is unable to open the loot panel at the target and TRUE if the loot panel was opened.
 /mob/living/proc/try_open_loot_panel_on(atom/target)
-	if(!CAN_I_SEE(target) || (is_blind() && !IN_GIVEN_RANGE(src, target, 1)))
+	if(!(src in viewers(target)) || (is_blind() && !IN_GIVEN_RANGE(src, target, 1)))
 		return FALSE
 
 	// No alt clicking to view turf from beneath

--- a/code/modules/lootpanel/_lootpanel.dm
+++ b/code/modules/lootpanel/_lootpanel.dm
@@ -80,15 +80,12 @@
 		return UI_CLOSE
 
 	if(!(astype(user, /mob/living)?.mobility_flags & (MOBILITY_USE|MOBILITY_PICKUP)))
-		// These flags are removed when unconscious or whatever, we don't need to complicate this further
 		return UI_UPDATE
 
 	if(astype(user, /mob/living/carbon/human)?.dna?.check_mutation(/datum/mutation/telekinesis))
-		// Range check here is just a formality with the "can I see" check above. But you never knowwww
-		return tkMaxRangeCheck(user, source_turf) ? UI_INTERACTIVE : UI_UPDATE
+		return tkMaxRangeCheck(user, source_turf) ? UI_INTERACTIVE : UI_UPDATE // Range check here is just a formality with the viewers check above.
 
 	if(!source_turf.IsReachableBy(user, user.get_active_held_item()?.reach))
-		// Blind check here is what prevents blind mobs from being able to telepathically know a turf's contents from across the room
-		return user.is_blind() ? UI_CLOSE : UI_UPDATE
+		return (get_dist(user, source_turf) >= 3 && user.is_blind()) ? UI_CLOSE : UI_UPDATE
 
 	return UI_INTERACTIVE

--- a/code/modules/lootpanel/_lootpanel.dm
+++ b/code/modules/lootpanel/_lootpanel.dm
@@ -56,7 +56,6 @@
 	var/list/data = list()
 
 	data["contents"] = get_contents()
-	data["is_blind"] = !!user.is_blind()
 	data["searching"] = length(to_image)
 
 	return data
@@ -72,3 +71,24 @@
 			return grab(usr, params)
 
 	return FALSE
+
+/datum/lootpanel/ui_state(mob/user)
+	return GLOB.always_state
+
+/datum/lootpanel/ui_status(mob/user, datum/ui_state/state)
+	if(!(user in viewers(source_turf)) || HAS_TRAIT(src, TRAIT_MOVE_VENTCRAWLING))
+		return UI_CLOSE
+
+	if(!(astype(user, /mob/living)?.mobility_flags & (MOBILITY_USE|MOBILITY_PICKUP)))
+		// These flags are removed when unconscious or whatever, we don't need to complicate this further
+		return UI_UPDATE
+
+	if(astype(user, /mob/living/carbon/human)?.dna?.check_mutation(/datum/mutation/telekinesis))
+		// Range check here is just a formality with the "can I see" check above. But you never knowwww
+		return tkMaxRangeCheck(user, source_turf) ? UI_INTERACTIVE : UI_UPDATE
+
+	if(!source_turf.IsReachableBy(user, user.get_active_held_item()?.reach))
+		// Blind check here is what prevents blind mobs from being able to telepathically know a turf's contents from across the room
+		return user.is_blind() ? UI_CLOSE : UI_UPDATE
+
+	return UI_INTERACTIVE

--- a/code/modules/lootpanel/contents.dm
+++ b/code/modules/lootpanel/contents.dm
@@ -13,13 +13,12 @@
 		reset_contents()
 
 	// Add source turf first
-	var/datum/search_object/source = new(owner, source_turf)
-	add_to_index(source)
+	if(!source_turf.IsObscured())
+		var/datum/search_object/source = new(owner, source_turf)
+		add_to_index(source)
 
-	for(var/atom/thing as anything in source_turf.contents)
-		// validate
-		if(!istype(thing))
-			stack_trace("Non-atom in the contents of [source_turf]!")
+	for(var/atom/thing as anything in source_turf)
+		if(thing.IsObscured())
 			continue
 
 		add_new_searchable(thing, FALSE)

--- a/code/modules/lootpanel/contents.dm
+++ b/code/modules/lootpanel/contents.dm
@@ -13,14 +13,9 @@
 		reset_contents()
 
 	// Add source turf first
-	if(!source_turf.IsObscured())
-		var/datum/search_object/source = new(owner, source_turf)
-		add_to_index(source)
+	add_new_searchable(source_turf, FALSE)
 
 	for(var/atom/thing as anything in source_turf)
-		if(thing.IsObscured())
-			continue
-
 		add_new_searchable(thing, FALSE)
 
 	queue_update()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -2,13 +2,13 @@
 //as they handle all relevant stuff like adding it to the player's screen and updating their overlays.
 
 ///Returns the thing we're currently holding
-/mob/proc/get_active_held_item()
+/mob/proc/get_active_held_item() as /obj/item
 	return get_item_for_held_index(active_hand_index)
 
 
 //Finds the opposite limb for the active one (eg: upper left arm will find the item in upper right arm)
 //So we're treating each "pair" of limbs as a team, so "both" refers to them
-/mob/proc/get_inactive_held_item()
+/mob/proc/get_inactive_held_item() as /obj/item
 	return get_item_for_held_index(get_inactive_hand_index())
 
 

--- a/tgui/packages/tgui/interfaces/LootPanel/LootBox.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/LootBox.tsx
@@ -1,14 +1,9 @@
 import { Button, Stack } from 'tgui-core/components';
-import type { BooleanLike } from 'tgui-core/react';
 import { capitalizeFirst } from 'tgui-core/string';
 
 import { useBackend } from '../../backend';
 import { IconDisplay } from './IconDisplay';
 import type { SearchGroup, SearchItem } from './types';
-
-type Data = {
-  is_blind: BooleanLike;
-};
 
 type Props =
   | {
@@ -19,8 +14,7 @@ type Props =
     };
 
 export function LootBox(props: Props) {
-  const { act, data } = useBackend<Data>();
-  const { is_blind } = data;
+  const { act } = useBackend();
 
   let amount = 0;
   let item: SearchItem;
@@ -63,7 +57,7 @@ export function LootBox(props: Props) {
           overflow="hidden"
           style={{ textOverflow: 'ellipsis' }}
         >
-          {!is_blind && name}
+          {name}
         </Stack.Item>
         <Stack.Item lineHeight="34px" pr={1}>
           {amount > 1 && `x${amount}`}
@@ -71,8 +65,6 @@ export function LootBox(props: Props) {
       </Stack>
     </Button>
   );
-
-  if (is_blind) return content;
 
   return content;
 }


### PR DESCRIPTION
## About The Pull Request

- Loot panel objects can be interacted with while lying down
- Loot panel objects can be interacted with at range if you have telekinesis or a weapon with reach
- Blind people have names in the loot panel back once again, though the panel closes more aggressively when moving away.

## Why It's Good For The Game

It's a little annoying that the loot panel doesn't have 1:1 parity with just picking up or clicking on things manually

## Changelog

:cl: Melbert
qol: Loot panel objects can be interacted with while lying down. 
qol: Loot panel objects can be interacted with at range if you have telekinesis or a weapon with reach.
qol: Blind mobs can see names in the loot panel again, but the panel auto-closes when further than two tiles away.
/:cl:
