### PR TITLE
Changes thumb & scratch keys

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -95,17 +95,17 @@
 	can_use_flags = EMOTE_CANUSE_REQUIRE_HANDS
 
 /datum/emote/living/carbon/human/scratch_h
-	key = "scratch_h"
+	key = "scratchhead"
 	message = "scratches their head."
 	can_use_flags = EMOTE_CANUSE_REQUIRE_HANDS
 
 /datum/emote/living/carbon/human/thumb_up
-	key = "thumb_u"
+	key = "thumbsup"
 	message = "gives a thumbs up."
 	can_use_flags = EMOTE_CANUSE_REQUIRE_HANDS
 
 /datum/emote/living/carbon/human/thumb_down
-	key = "thumb_d"
+	key = "thumbsdown"
 	message = "gives a thumbs down."
 	can_use_flags = EMOTE_CANUSE_REQUIRE_HANDS
 


### PR DESCRIPTION
## About The Pull Request

Thumbs up emote ``thumb_u`` -> ``thumbsup``
Thumbs down emote ``thumb_d`` -> ``thumbsdown``
Scratch head emote ``scratch_h`` -> ``scratchhead``

## Why It's Good For The Game

I think it's much easier to remember to manually type out if you don't use the Emotes panel this way.

## Changelog

:cl:
qol: Changed thumbs up/down & scratch head emote when manually typing to thumbsup, thumbsdown & scratchhead
/:cl:
