### PR TITLE
Operating computers don't show experiments if there's no techwebs at all.

### DIFF
--- a/tgui/packages/tgui/interfaces/OperatingComputer/index.tsx
+++ b/tgui/packages/tgui/interfaces/OperatingComputer/index.tsx
@@ -16,7 +16,7 @@ import {
 export const OperatingComputer = () => {
   const [tab, setTab] = useSharedState('tab', 1);
   const { data } = useBackend<OperatingComputerData>();
-  const { surgeries } = data;
+  const { surgeries, techwebs } = data;
 
   const { query, setQuery, results } = useFuzzySearch({
     searchArray: surgeries,
@@ -51,12 +51,14 @@ export const OperatingComputer = () => {
               >
                 Operation Catalog
               </Tabs.Tab>
-              <Tabs.Tab
-                selected={tab === ComputerTabs.Experiments}
-                onClick={() => setTab(3)}
-              >
-                Experiments
-              </Tabs.Tab>
+              {!!techwebs.length && (
+                <Tabs.Tab
+                  selected={tab === ComputerTabs.Experiments}
+                  onClick={() => setTab(3)}
+                >
+                  Experiments
+                </Tabs.Tab>
+              )}
             </Tabs>
           </Stack.Item>
           <Stack.Item grow>


### PR DESCRIPTION
## About The Pull Request

Small PR just for the sake of modularizing research

## Why It's Good For The Game

Wahoo!

## Changelog

:cl:
del: Operating computers no longer has the Experiments tab if there's no research servers in existence.
/:cl: