### PR TITLE
standardizes some cuff resist code

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -29,6 +29,10 @@
 	next_move = world.time + ((num + adj)*mod)
 	SEND_SIGNAL(src, COMSIG_LIVING_CHANGENEXT_MOVE, next_move, num)
 
+/mob/living/proc/change_next_special_move(num)
+	changeNext_move(num)
+	last_special = world.time + num
+
 /**
  * Before anything else, defer these calls to a per-mobtype handler.  This allows us to
  * remove istype() spaghetti code, but requires the addition of other handler procs to simplify it.

--- a/code/game/machinery/dna_scanner.dm
+++ b/code/game/machinery/dna_scanner.dm
@@ -76,8 +76,7 @@
 	else if(!locked) //Not locked and not primitive? escape immediately
 		open_machine()
 
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	user.visible_message(span_notice("You see [user] kicking against the door of [src]!"), \
 		span_notice("You lean on the back of [src] and start pushing the door open... (this will take about [DisplayTimeText(breakout_time)].)"), \
 		span_hear("You hear a metallic creaking from [src]."))

--- a/code/game/machinery/experimental_cloner/experimental_cloner_scanner.dm
+++ b/code/game/machinery/experimental_cloner/experimental_cloner_scanner.dm
@@ -105,8 +105,7 @@
 		open_machine()
 		return
 
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	user.visible_message(span_notice("You see [user] kicking against the door of [src]!"), \
 		span_notice("You lean on the back of [src] and start pushing the door open..."), \
 		span_hear("You hear a metallic creaking from [src]."))

--- a/code/game/machinery/fat_sucker.dm
+++ b/code/game/machinery/fat_sucker.dm
@@ -75,8 +75,7 @@
 /obj/machinery/fat_sucker/container_resist_act(mob/living/user)
 	if(!free_exit || state_open)
 		to_chat(user, span_notice("The emergency release is not responding! You start pushing against the hull!"))
-		user.changeNext_move(CLICK_CD_BREAKOUT)
-		user.last_special = world.time + CLICK_CD_BREAKOUT
+		user.change_next_special_move(CLICK_CD_BREAKOUT)
 		user.visible_message(span_notice("You see [user] kicking against the door of [src]!"), \
 			span_notice("You lean on the back of [src] and start pushing the door open... (this will take about [DisplayTimeText(breakout_time)].)"), \
 			span_hear("You hear a metallic creaking from [src]."))

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -96,8 +96,7 @@ The console is located at computer/gulag_teleporter.dm
 			return
 		resist_time *= 0.5
 
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	user.visible_message(
 		span_notice("You see [user] kicking against the door of [src]!"),
 		span_notice("You lean on the back of [src] and start pushing the door open... (this will take about [DisplayTimeText(resist_time)].)"),

--- a/code/game/machinery/hypnochair.dm
+++ b/code/game/machinery/hypnochair.dm
@@ -179,8 +179,7 @@
 	return ..()
 
 /obj/machinery/hypnochair/container_resist_act(mob/living/user)
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	user.visible_message(span_notice("You see [user] kicking against the door of [src]!"), \
 		span_notice("You lean on the back of [src] and start pushing the door open... (this will take about [DisplayTimeText(600)].)"), \
 		span_hear("You hear a metallic creaking from [src]."))

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -579,8 +579,7 @@
 		open_machine()
 		dump_inventory_contents()
 		return
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	user.visible_message(span_notice("You see [user] kicking against the doors of [src]!"), \
 		span_notice("You start kicking against the doors... (this will take about [DisplayTimeText(breakout_time)].)"), \
 		span_hear("You hear a thump from [src]."))

--- a/code/game/objects/effects/spiderwebs.dm
+++ b/code/game/objects/effects/spiderwebs.dm
@@ -234,8 +234,7 @@
 
 /obj/structure/spider/cocoon/container_resist_act(mob/living/user)
 	var/breakout_time = 600
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	to_chat(user, span_notice("You struggle against the tight bonds... (This will take about [DisplayTimeText(breakout_time)].)"))
 	visible_message(span_notice("You see something struggling and writhing in \the [src]!"))
 	if(do_after(user,(breakout_time), target = src))

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -419,6 +419,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	slowdown = 7
 	breakouttime = 30 SECONDS
+	resist_cooldown = CLICK_CD_RANGE
 	slot_flags = ITEM_SLOT_LEGCUFFED
 	/// Icon state for the legcuff overlay
 	var/legcuff_state = "legcuff"

--- a/code/game/objects/items/implants/implant_freedom.dm
+++ b/code/game/objects/items/implants/implant_freedom.dm
@@ -14,6 +14,8 @@
 		to nondestructively unsecure relevant bindings. Unfortunately, this only works for bindings on the arms and legs; \
 		larger restraints, such as straightjackets are too complex for the nanites to deal with."
 
+	var/resist_strength = 3 MINUTES
+
 /obj/item/implant/freedom/implant(mob/living/target, mob/user, silent, force)
 	. = ..()
 	if(!.)
@@ -32,7 +34,7 @@
 
 	uses--
 
-	carbon_imp_in.uncuff()
+	carbon_imp_in.uncuff(resist_strength)
 	var/obj/item/clothing/shoes/shoes = carbon_imp_in.get_item_by_slot(ITEM_SLOT_FEET)
 	if(istype(shoes) && shoes.tied == SHOES_KNOTTED)
 		shoes.adjust_laces(SHOES_TIED, carbon_imp_in)
@@ -42,8 +44,9 @@
 		qdel(src)
 
 /obj/item/implant/freedom/proc/can_trigger(mob/living/carbon/implanted_in)
-	if(implanted_in.handcuffed || implanted_in.legcuffed)
-		return TRUE
+	for(var/obj/item/restraint in implanted_in.get_all_attached_restraints())
+		if(restraint.breakouttime <= resist_strength)
+			return TRUE
 
 	var/obj/item/clothing/shoes/shoes = implanted_in.get_item_by_slot(ITEM_SLOT_FEET)
 	if(istype(shoes) && shoes.tied == SHOES_KNOTTED)

--- a/code/game/objects/items/implants/implantchair.dm
+++ b/code/game/objects/items/implants/implantchair.dm
@@ -126,8 +126,7 @@
 	update_appearance()
 
 /obj/machinery/implantchair/container_resist_act(mob/living/user)
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	user.visible_message(span_notice("You see [user] kicking against the door of [src]!"), \
 		span_notice("You lean on the back of [src] and start pushing the door open... (this will take about [DisplayTimeText(breakout_time)].)"), \
 		span_hear("You hear a metallic creaking from [src]."))

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -140,8 +140,7 @@
 		container_resist_act(user)
 
 /obj/item/pet_carrier/container_resist_act(mob/living/user)
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	if(user.mob_size <= MOB_SIZE_SMALL)
 		to_chat(user, span_notice("You poke a limb through [src]'s bars and start fumbling for the lock switch... (This will take some time.)"))
 		to_chat(loc, span_warning("You see [user] reach through the bars and fumble for the lock switch!"))

--- a/code/game/objects/items/tools/medical/bodybag.dm
+++ b/code/game/objects/items/tools/medical/bodybag.dm
@@ -90,8 +90,7 @@
 	if(user.incapacitated)
 		to_chat(user, span_warning("You can't get out while you're restrained like this!"))
 		return
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	to_chat(user, span_notice("You claw at the fabric of [src], trying to tear it open..."))
 	to_chat(loc, span_warning("Someone starts trying to break free of [src]!"))
 	if(!do_after(user, 12 SECONDS, src, timed_action_flags = (IGNORE_TARGET_LOC_CHANGE|IGNORE_HELD_ITEM)))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1086,8 +1086,7 @@ GAME_VERB_SRC(/obj/structure/closet, verb_toggleopen, view(1), "Toggle Open", nu
 	if(opened)
 		return
 	if(ismovable(loc))
-		user.changeNext_move(CLICK_CD_BREAKOUT)
-		user.last_special = world.time + CLICK_CD_BREAKOUT
+		user.change_next_special_move(CLICK_CD_BREAKOUT)
 		var/atom/movable/movable_parent = loc
 		movable_parent.relay_container_resist_act(user, src)
 		return
@@ -1098,8 +1097,7 @@ GAME_VERB_SRC(/obj/structure/closet, verb_toggleopen, view(1), "Toggle Open", nu
 	if(DOING_INTERACTION_WITH_TARGET(user, src))
 		return
 	//okay, so the closet is either welded or locked... resist!!!
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	user.visible_message(span_warning("[src] begins to shake violently!"), \
 		span_notice("You lean on the back of [src] and start pushing the door open... (this will take about [DisplayTimeText(breakout_time)].)"), \
 		span_hear("You hear banging from [src]."))

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -354,8 +354,7 @@
 	if(opened || ismovable(loc) || !cinched)
 		return ..()
 
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	user.visible_message(span_warning("Someone in [src] begins to wriggle!"), \
 		span_notice("You start wriggling, attempting to loosen [src]'s buckles... (this will take about [DisplayTimeText(breakout_time)].)"), \
 		span_hear("You hear straining cloth from [src]."))
@@ -622,8 +621,7 @@
 		open(user)
 		return
 
-	user.changeNext_move(6 SECONDS)
-	user.last_special = world.time + 6 SECONDS
+	user.change_next_special_move(6 SECONDS)
 	user.visible_message(
 		span_warning("Something in [src] begins to wriggle!"),
 		span_notice("You start wriggling, attempting to climb out of [src]... (This will take about [DisplayTimeText(breakout_time)].)"),

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -113,8 +113,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	if(!locked)
 		open()
 		return
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	user.visible_message(null, \
 		span_notice("You lean on the back of [src] and start pushing the tray open... (this will take about [DisplayTimeText(BREAKDOWN_TIME)].)"), \
 		span_hear("You hear a metallic creaking from [src]."))

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -73,8 +73,7 @@
 		empty_pod()
 		return
 	if(!moving)
-		user.changeNext_move(CLICK_CD_BREAKOUT)
-		user.last_special = world.time + CLICK_CD_BREAKOUT
+		user.change_next_special_move(CLICK_CD_BREAKOUT)
 		to_chat(user, span_notice("You start trying to escape from the pod..."))
 		if(do_after(user, 1 MINUTES, target = src))
 			to_chat(user, span_notice("You manage to open the pod."))

--- a/code/modules/antagonists/abductor/machinery/experiment.dm
+++ b/code/modules/antagonists/abductor/machinery/experiment.dm
@@ -47,8 +47,7 @@
 		to_chat(user, span_warning("[src]'s door won't budge!"))
 
 /obj/machinery/abductor/experiment/container_resist_act(mob/living/user)
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	user.visible_message(span_notice("You see [user] kicking against the door of [src]!"), \
 		span_notice("You lean on the back of [src] and start pushing the door open... (this will take about [DisplayTimeText(breakout_time)].)"), \
 		span_hear("You hear a metallic creaking from [src]."))

--- a/code/modules/antagonists/heretic/magic/wave_of_desperation.dm
+++ b/code/modules/antagonists/heretic/magic/wave_of_desperation.dm
@@ -18,7 +18,7 @@
 	aoe_radius = 3
 
 /datum/action/cooldown/spell/aoe/wave_of_desperation/is_valid_target(mob/living/carbon/cast_on)
-	return ..() && istype(cast_on) && (cast_on.handcuffed || cast_on.legcuffed)
+	return ..() && istype(cast_on) && length(cast_on.get_all_attached_restraints())
 
 // Before the cast, we do some small AOE damage around the caster
 /datum/action/cooldown/spell/aoe/wave_of_desperation/before_cast(mob/living/carbon/cast_on)
@@ -26,12 +26,9 @@
 	if(. & SPELL_CANCEL_CAST)
 		return
 
-	if(cast_on.handcuffed)
-		cast_on.visible_message(span_danger("[cast_on.handcuffed] on [cast_on] shatter!"))
-		QDEL_NULL(cast_on.handcuffed)
-	if(cast_on.legcuffed)
-		cast_on.visible_message(span_danger("[cast_on.legcuffed] on [cast_on] shatters!"))
-		QDEL_NULL(cast_on.legcuffed)
+	for(var/obj/item/restraint in cast_on.get_all_attached_restraints())
+		cast_on.visible_message(span_danger("[restraint] on [cast_on] shatter!"))
+		qdel(restraint)
 
 	cast_on.apply_status_effect(/datum/status_effect/heretic_lastresort)
 	new /obj/effect/temp_visual/knockblast(get_turf(cast_on))

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -516,8 +516,7 @@
 			set_on(TRUE)
 
 /obj/machinery/cryo_cell/container_resist_act(mob/living/user)
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	user.visible_message(span_notice("You see [user] kicking against the glass of [src]!"), \
 		span_notice("You struggle inside [src], kicking the release with your foot... (this will take about [DisplayTimeText(CRYO_BREAKOUT_TIME)].)"), \
 		span_hear("You hear a thump from [src]."))

--- a/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -292,8 +292,7 @@
 	if(opened)
 		return
 	// The player is trying to dig themselves out of an early grave
-	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.change_next_special_move(CLICK_CD_BREAKOUT)
 	user.visible_message(
 		span_warning("[src]'s dirt begins to shift and rumble!"),
 		span_notice("You desperately begin to claw at the dirt around you, trying to force yourself upwards through the soil... (this will take about [DisplayTimeText(breakout_time)].)"),

--- a/code/modules/mob/living/carbon/alien/adult/adult.dm
+++ b/code/modules/mob/living/carbon/alien/adult/adult.dm
@@ -47,9 +47,9 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_CLAW, 0.5, -11)
 	AddElement(/datum/element/strippable, GLOB.strippable_alien_humanoid_items)
 
-/mob/living/carbon/alien/adult/cuff_resist(obj/item/I)
+/mob/living/carbon/alien/adult/cuff_resist(obj/item/cuffs, breakouttime = null, cuff_break = 0)
 	playsound(src, 'sound/mobs/non-humanoids/hiss/hiss5.ogg', 40, TRUE, TRUE)  //Alien roars when starting to break free
-	..(I, cuff_break = INSTANT_CUFFBREAK)
+	..(cuffs, cuff_break = INSTANT_CUFFBREAK)
 
 /mob/living/carbon/alien/adult/resist_grab(moving_resist)
 	if(pulledby.grab_state)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -144,13 +144,11 @@
 		buckled.user_unbuckle_mob(src, src)
 		return
 
-	changeNext_move(CLICK_CD_BREAKOUT)
-	last_special = world.time + CLICK_CD_BREAKOUT
+	change_next_special_move(CLICK_CD_BREAKOUT)
 	var/buckle_cd = 1 MINUTES
 
 	if(handcuffed)
-		var/obj/item/restraints/cuffs = src.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
-		buckle_cd = cuffs.breakouttime
+		buckle_cd = handcuffed.breakouttime
 
 	visible_message(span_warning("[src] attempts to unbuckle [p_them()]self!"),
 				span_notice("You attempt to unbuckle yourself... \
@@ -171,22 +169,24 @@
 	return !!apply_status_effect(/datum/status_effect/stop_drop_roll)
 
 /mob/living/carbon/resist_restraints()
-	var/obj/item/I = null
-	var/type = 0
+	var/obj/item/restraint = get_attached_restraint()
+	if(restraint)
+		change_next_special_move(restraint.resist_cooldown)
+		cuff_resist(restraint)
+
+// Get FIRST restraint we are trying to resist from
+/mob/living/carbon/proc/get_attached_restraint() as /obj/item
+	var/list/restraints = get_all_attached_restraints()
+	if(length(restraints))
+		return restraints[1]
+
+// Get ALL attached restraints we are trying to resist from
+/mob/living/carbon/proc/get_all_attached_restraints() as /list
+	. = list()
 	if(handcuffed)
-		I = handcuffed
-		type = 1
-	else if(legcuffed)
-		I = legcuffed
-		type = 2
-	if(I)
-		if(type == 1)
-			changeNext_move(I.resist_cooldown)
-			last_special = world.time + I.resist_cooldown
-		if(type == 2)
-			changeNext_move(CLICK_CD_RANGE)
-			last_special = world.time + CLICK_CD_RANGE
-		cuff_resist(I)
+		. += handcuffed
+	if(legcuffed)
+		. += legcuffed
 
 /**
  * Helper to break the cuffs from hands
@@ -197,7 +197,7 @@
 /mob/living/carbon/proc/cuff_resist(obj/item/cuffs, breakouttime = null, cuff_break = 0)
 	if((cuff_break != INSTANT_CUFFBREAK) && (SEND_SIGNAL(src, COMSIG_MOB_REMOVING_CUFFS, cuffs) & COMSIG_MOB_BLOCK_CUFF_REMOVAL))
 		return //The blocking object should sent a fluff-appropriate to_chat about cuff removal being blocked
-	if(DOING_INTERACTION(src, REF(cuffs) ))
+	if(DOING_INTERACTION(src, REF(cuffs)))
 		to_chat(src, span_warning("You're already attempting to remove [cuffs]!"))
 		return
 
@@ -223,34 +223,28 @@
 	else if(cuff_break == INSTANT_CUFFBREAK)
 		. = clear_cuffs(cuffs, cuff_break)
 
-/mob/living/carbon/proc/uncuff()
-	if (handcuffed)
-		dropItemToGround(handcuffed, TRUE)
-		changeNext_move(0)
-	if (legcuffed)
-		dropItemToGround(legcuffed, TRUE)
+/mob/living/carbon/proc/uncuff(break_strength = INFINITY)
+	for(var/obj/item/restraint in get_all_attached_restraints())
+		if(restraint.breakouttime >= break_strength)
+			continue
+		dropItemToGround(restraint, TRUE)
 		changeNext_move(0)
 
 /mob/living/carbon/proc/clear_cuffs(obj/item/I, cuff_break)
 	if(!I.loc || buckled)
 		return FALSE
-	if(I != handcuffed && I != legcuffed)
+	var/list/all_restraints = get_all_attached_restraints()
+	if(!(I in all_restraints))
 		return FALSE
 	visible_message(span_danger("[src] manages to [cuff_break ? "break" : "remove"] [I]!"))
 	to_chat(src, span_notice("You successfully [cuff_break ? "break" : "remove"] [I]."))
 
 	if(cuff_break)
-		. = !((I == handcuffed) || (I == legcuffed))
 		qdel(I)
 		return TRUE
-
 	else
-		if(I == handcuffed)
-			dropItemToGround(I, TRUE)
-			return TRUE
-		if(I == legcuffed)
-			dropItemToGround(I, TRUE)
-			return TRUE
+		dropItemToGround(I, TRUE)
+		return TRUE
 
 /mob/living/carbon/proc/accident(obj/item/I)
 	if(!I || (I.item_flags & ABSTRACT) || HAS_TRAIT(I, TRAIT_NODROP))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -573,14 +573,18 @@
 
 #undef CPR_PANIC_SPEED
 
-/mob/living/carbon/human/cuff_resist(obj/item/I)
+/mob/living/carbon/human/get_all_attached_restraints()
+	. = ..()
+	if(wear_suit?.breakouttime)
+		. += wear_suit
+
+/mob/living/carbon/human/cuff_resist(obj/item/cuffs, breakouttime = null, cuff_break = 0)
 	if(HAS_TRAIT(src, TRAIT_HULK))
 		say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
-		if(..(I, cuff_break = FAST_CUFFBREAK))
-			dropItemToGround(I)
+		if(..(cuffs, cuff_break = FAST_CUFFBREAK))
+			dropItemToGround(cuffs)
 	else
-		if(..())
-			dropItemToGround(I)
+		. = ..()
 
 /**
  * Wash the hands, cleaning either the gloves if equipped and not obscured, otherwise the hands themselves if they're not obscured.
@@ -654,14 +658,6 @@
 /mob/living/carbon/human/proc/end_electrocution_animation(mutable_appearance/MA)
 	remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, COLOR_BLACK)
 	cut_overlay(MA)
-
-/mob/living/carbon/human/resist_restraints()
-	if(wear_suit?.breakouttime)
-		changeNext_move(CLICK_CD_BREAKOUT)
-		last_special = world.time + CLICK_CD_BREAKOUT
-		cuff_resist(wear_suit)
-	else
-		..()
 
 /mob/living/carbon/human/clear_cuffs(obj/item/I, cuff_break)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -582,8 +582,6 @@
 	if(HAS_TRAIT(src, TRAIT_HULK))
 		say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
 		. = ..(cuffs, cuff_break = FAST_CUFFBREAK)
-		if(.)
-			dropItemToGround(cuffs)
 	else
 		. = ..()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -581,7 +581,8 @@
 /mob/living/carbon/human/cuff_resist(obj/item/cuffs, breakouttime = null, cuff_break = 0)
 	if(HAS_TRAIT(src, TRAIT_HULK))
 		say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
-		if(..(cuffs, cuff_break = FAST_CUFFBREAK))
+		. = ..(cuffs, cuff_break = FAST_CUFFBREAK)
+		if(.)
 			dropItemToGround(cuffs)
 	else
 		. = ..()


### PR DESCRIPTION

## About The Pull Request
Tries and genecize or turn into helpers some of the cuff resist code, meaning straightjackets are caught in more code without having to had any extra behavoir. There was also some weird reduncency in some procs which i cleaned up, such as the old code dropping cuffs twice because humans had to call drop to clear the straightjacket but thats now handled down in carbon!

I chose to add behavior for freedom implants specifically to maintain there description of being unable to break straitjackets, done by adding a "strength" of a time lower then the jacket.

There was also instances where we had hardcoded times depsite the fact that both cooldowns are on /obj/item so i made them use them. No behavior changes as far as i could test.
## Why It's Good For The Game
Better code, or better behavior in the case of making sure things that break restraints also break straitjackets consistantly.
## Changelog
:cl:
code: Improves some code which means straightjackets are better caught in cuff resist code
/:cl:
