### PR TITLE
De-hardcodes death threshold

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -458,7 +458,7 @@
 			H.Paralyze(8 SECONDS)
 		if(H.staminaloss && !H.IsSleeping())
 			var/total_health = (H.health - H.staminaloss)
-			if(total_health <= HEALTH_THRESHOLD_CRIT && !IS_UNCONSCIOUS_OR_CRIT(H))
+			if(total_health <= H.crit_threshold && !IS_UNCONSCIOUS_OR_CRIT(H))
 				H.visible_message(span_warning("[user] delivers a heavy hit to [H]'s head, knocking [H.p_them()] out cold!"), \
 								span_userdanger("You're knocked unconscious by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, user)
 				to_chat(user, span_danger("You deliver a heavy hit to [H]'s head, knocking [H.p_them()] out cold!"))

--- a/code/game/machinery/computer/operating_computer.dm
+++ b/code/game/machinery/computer/operating_computer.dm
@@ -186,7 +186,7 @@
 	data["patient"]["health"] = patient.health
 	data["patient"]["blood_type"] = patient.get_bloodtype()?.name || "UNKNOWN"
 	data["patient"]["maxHealth"] = patient.maxHealth
-	data["patient"]["minHealth"] = HEALTH_THRESHOLD_DEAD
+	data["patient"]["minHealth"] = patient.dead_threshold
 	data["patient"]["bruteLoss"] = patient.get_brute_loss()
 	data["patient"]["fireLoss"] = patient.get_fire_loss()
 	data["patient"]["toxLoss"] = patient.get_tox_loss()

--- a/code/game/machinery/sleepers.dm
+++ b/code/game/machinery/sleepers.dm
@@ -212,7 +212,7 @@
 
 		data["occupant"]["health"] = mob_occupant.health
 		data["occupant"]["maxHealth"] = mob_occupant.maxHealth
-		data["occupant"]["minHealth"] = HEALTH_THRESHOLD_DEAD
+		data["occupant"]["minHealth"] = mob_occupant.dead_threshold
 		data["occupant"]["bruteLoss"] = mob_occupant.get_brute_loss()
 		data["occupant"]["oxyLoss"] = mob_occupant.get_oxy_loss()
 		data["occupant"]["toxLoss"] = mob_occupant.get_tox_loss()

--- a/code/modules/antagonists/blood_worm/actions/revive_host.dm
+++ b/code/modules/antagonists/blood_worm/actions/revive_host.dm
@@ -94,7 +94,7 @@
 		if (feedback)
 			host.balloon_alert(owner, "brain too damaged!")
 		return FALSE
-	if (host.health <= HEALTH_THRESHOLD_DEAD)
+	if (host.health <= host.dead_threshold)
 		if (feedback)
 			host.balloon_alert(owner, "body too damaged!")
 		return FALSE

--- a/code/modules/mining/lavaland/mining_loot/clothing.dm
+++ b/code/modules/mining/lavaland/mining_loot/clothing.dm
@@ -52,7 +52,7 @@
 	var/list/guardians = source.get_all_linked_holoparasites()
 	if (!length(guardians))
 		return
-	if (source.health <= HEALTH_THRESHOLD_DEAD)
+	if (source.health <= source.dead_threshold)
 		for (var/mob/guardian in guardians)
 			if(guardian.loc == src)
 				continue

--- a/code/modules/mining/lavaland/mining_loot/clothing.dm
+++ b/code/modules/mining/lavaland/mining_loot/clothing.dm
@@ -57,7 +57,7 @@
 			if(guardian.loc == src)
 				continue
 			consume_guardian(guardian)
-	else if (source.health > HEALTH_THRESHOLD_CRIT)
+	else if (source.health > source.crit_threshold)
 		for (var/mob/guardian in guardians)
 			if(guardian.loc != src)
 				continue

--- a/code/modules/mob/living/basic/boss/boss.dm
+++ b/code/modules/mob/living/basic/boss/boss.dm
@@ -86,7 +86,7 @@
 
 /// Determines if this mob is worth devouring
 /mob/living/basic/boss/proc/should_devour(mob/living/victim)
-	return victim.stat == DEAD || (victim.health <= HEALTH_THRESHOLD_DEAD && HAS_TRAIT(victim, TRAIT_NODEATH))
+	return victim.stat == DEAD || (victim.health <= victim.dead_threshold && HAS_TRAIT(victim, TRAIT_NODEATH))
 
 /// Devours a target and restores health to the megafauna
 /mob/living/basic/boss/proc/devour(mob/living/victim)

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -68,7 +68,7 @@
 	return // no eyes, no flashing
 
 /mob/living/brain/can_be_revived()
-	if(!container || health <= HEALTH_THRESHOLD_DEAD)
+	if(!container || health <= dead_threshold)
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/living/brain/brain_cybernetic.dm
+++ b/code/modules/mob/living/brain/brain_cybernetic.dm
@@ -21,7 +21,7 @@
 
 /obj/item/organ/brain/cybernetic/check_for_repair(obj/item/item, mob/user)
 	if (item.tool_behaviour == TOOL_MULTITOOL) //attempt to repair the brain
-		if (brainmob?.health <= HEALTH_THRESHOLD_DEAD) //if the brain is fucked anyway, do nothing
+		if (brainmob?.health <= brainmob?.dead_threshold) //if the brain is fucked anyway, do nothing
 			to_chat(user, span_warning("[src] is far too damaged, there's nothing else we can do for it!"))
 			return TRUE
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -216,7 +216,7 @@
 
 /obj/item/organ/brain/proc/check_for_repair(obj/item/item, mob/user)
 	if(damage && item.is_drainable() && item.reagents.has_reagent(/datum/reagent/medicine/mannitol) && (organ_flags & ORGAN_ORGANIC)) //attempt to heal the brain
-		if(brainmob?.health <= HEALTH_THRESHOLD_DEAD) //if the brain is fucked anyway, do nothing
+		if(brainmob?.health <= brainmob?.dead_threshold) //if the brain is fucked anyway, do nothing
 			to_chat(user, span_warning("[src] is far too damaged, there's nothing else we can do for it!"))
 			return TRUE
 

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -16,7 +16,7 @@
 /mob/living/brain/update_stat()
 	if(HAS_TRAIT(src, TRAIT_GODMODE))
 		return
-	if(health > HEALTH_THRESHOLD_DEAD)
+	if(health > dead_threshold)
 		return
 	if(stat != DEAD)
 		death()

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -12,7 +12,7 @@
 		//Aliens breathe in vaccuum
 		return 0
 
-	if(health <= HEALTH_THRESHOLD_CRIT)
+	if(health <= crit_threshold)
 		adjust_oxy_loss(2)
 
 	var/plasma_used = 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -674,7 +674,7 @@
 	if(HAS_TRAIT(src, TRAIT_GODMODE))
 		return
 	if(stat != DEAD)
-		if(health <= HEALTH_THRESHOLD_DEAD && !HAS_TRAIT(src, TRAIT_NODEATH))
+		if(health <= dead_threshold && !HAS_TRAIT(src, TRAIT_NODEATH))
 			death()
 			return
 		if(health <= hardcrit_threshold && !HAS_TRAIT(src, TRAIT_NOHARDCRIT))

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1215,7 +1215,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		humi.apply_damage(burn_damage, BURN, spread_damage = TRUE, wound_clothing = FALSE)
 
 	// For cold damage, we cap at the threshold if you're dead
-	if(humi.get_fire_loss() >= abs(HEALTH_THRESHOLD_DEAD) && humi.stat == DEAD)
+	if(humi.get_fire_loss() >= abs(humi.dead_threshold) && humi.stat == DEAD)
 		return
 
 	// Apply some burn / brute damage to the body (Dependent if the person is hulk or not)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -565,7 +565,7 @@ GAME_VERB_HIDDEN(/mob/living, succumb, "succumb")
 			to_chat(src, span_warning("You are unable to succumb to death! This life continues."), type=MESSAGE_TYPE_INFO)
 			return
 	log_message("Has [whispered ? "whispered his final words" : "succumbed to death"] with [round(health, 0.1)] points of health!", LOG_ATTACK)
-	adjust_oxy_loss(health - HEALTH_THRESHOLD_DEAD)
+	adjust_oxy_loss(health - dead_threshold)
 	updatehealth()
 	if(!whispered)
 		to_chat(src, span_notice("You have given up life and succumbed to death."))
@@ -1037,7 +1037,7 @@ GAME_VERB_PROC(/mob/living, mob_sleep, "Sleep", null)
 /mob/living/proc/can_be_revived()
 	if(HAS_TRAIT(src, TRAIT_NODEATH))
 		return TRUE
-	if(health > HEALTH_THRESHOLD_DEAD)
+	if(health > dead_threshold)
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -53,6 +53,8 @@
 	var/crit_threshold = HEALTH_THRESHOLD_CRIT
 	///When the mob enters hard critical state and is fully incapacitated.
 	var/hardcrit_threshold = HEALTH_THRESHOLD_FULLCRIT
+	///Amount of damage needed to be fully dead
+	var/dead_threshold = HEALTH_THRESHOLD_DEAD
 
 	//Damage dealing vars! These are meaningless outside of specific instances where it's checked and defined.
 	/// Lower bound of damage done by unarmed melee attacks. Mob code is a mess, only works where this is checked for.

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -174,7 +174,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			message_range = 1
 			// this is where deathgasping is processed
 			if(stat == HARD_CRIT)
-				var/health_diff = round(-HEALTH_THRESHOLD_DEAD + health)
+				var/health_diff = round(-dead_threshold + health)
 				// If we cut our message short, abruptly end it with a-..
 				var/message_len = length_char(message)
 				message = copytext_char(message, 1, health_diff) + "[message_len > health_diff ? "-.." : "..."]"

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -65,7 +65,7 @@
 /mob/living/silicon/ai/update_stat()
 	if(HAS_TRAIT(src, TRAIT_GODMODE))
 		return
-	if(stat != DEAD && health <= HEALTH_THRESHOLD_DEAD)
+	if(stat != DEAD && health <= dead_threshold)
 		death()
 	else if(stat < DEAD)
 		set_stat(STABLE)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -128,7 +128,7 @@
 	if(!isliving(target))
 		return
 	var/mob/living/living_target = target
-	if(living_target.stat == DEAD || (living_target.health <= HEALTH_THRESHOLD_DEAD && HAS_TRAIT(living_target, TRAIT_NODEATH)))
+	if(living_target.stat == DEAD || (living_target.health <= dead_threshold && HAS_TRAIT(living_target, TRAIT_NODEATH)))
 		devour(living_target)
 		return
 	if(isnull(client) && ranged && ranged_cooldown <= world.time)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -483,7 +483,7 @@ Difficulty: Hard
 					burst_range = 3
 					INVOKE_ASYNC(src, PROC_REF(burst), get_turf(src), 0.25) //melee attacks on living mobs cause it to release a fast burst if on cooldown
 				OpenFire()
-				if(L.health <= HEALTH_THRESHOLD_DEAD && HAS_TRAIT(L, TRAIT_NODEATH)) //Nope, it still kills yall
+				if(L.health <= L.dead_threshold && HAS_TRAIT(L, TRAIT_NODEATH)) //Nope, it still kills yall
 					devour(L)
 			else
 				devour(L)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -303,7 +303,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	if(QDELETED(mychild) || mychild.stat == DEAD)
 		onEliteLoss()
 		return
-	if(QDELETED(activator) || activator.stat == DEAD || (activator.health <= HEALTH_THRESHOLD_DEAD && HAS_TRAIT(activator, TRAIT_NODEATH)))
+	if(QDELETED(activator) || activator.stat == DEAD || (activator.health <= activator.dead_threshold && HAS_TRAIT(activator, TRAIT_NODEATH)))
 		if(!QDELETED(activator) && HAS_TRAIT(activator, TRAIT_NODEATH)) // dust the unkillable activator
 			activator.dust(drop_items = TRUE)
 		onEliteWon()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -495,7 +495,7 @@
 	if(iscyborg(mob) || islarva(mob))
 		divided_health = (mob.health + mob.maxHealth) / (mob.maxHealth * 2)
 	else if(iscarbon(mob) || isAI(mob) || isbrain(mob))
-		divided_health = abs(HEALTH_THRESHOLD_DEAD - mob.health) / abs(HEALTH_THRESHOLD_DEAD - mob.maxHealth)
+		divided_health = abs(mob.dead_threshold - mob.health) / abs(mob.dead_threshold - mob.maxHealth)
 	return divided_health * 100
 
 /**

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -523,9 +523,9 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	var/need_mob_update
 	need_mob_update += affected_mob.adjust_brute_loss(20 * creation_impurity * metabolization_ratio * seconds_per_tick, required_bodytype = affected_bodytype)
 	need_mob_update += affected_mob.adjust_organ_loss(ORGAN_SLOT_HEART, 4 * ((1 + creation_impurity) * metabolization_ratio * seconds_per_tick), required_organ_flag = affected_organ_flags)
-	if(affected_mob.health < HEALTH_THRESHOLD_CRIT)
+	if(affected_mob.health < affected_mob.crit_threshold)
 		affected_mob.add_movespeed_modifier(/datum/movespeed_modifier/reagent/nooartrium)
-	if(affected_mob.health < HEALTH_THRESHOLD_FULLCRIT)
+	if(affected_mob.health < affected_mob.hardcrit_threshold)
 		affected_mob.add_actionspeed_modifier(/datum/actionspeed_modifier/nooartrium)
 	var/obj/item/organ/heart/heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
 	if(isnull(heart) || (heart.organ_flags & ORGAN_FAILING))

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -537,7 +537,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	. = ..()
 	remove_buffs(affected_mob)
 	var/obj/item/organ/heart/heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
-	if(affected_mob.health < (5 * HEALTH_THRESHOLD_DEAD) || (heart?.organ_flags & ORGAN_FAILING)) // Honestly commendable if you get -500
+	if(affected_mob.health < (5 * affected_mob.dead_threshold) || (heart?.organ_flags & ORGAN_FAILING)) // Honestly commendable if you get -500
 		explosion(affected_mob, light_impact_range = 1, explosion_cause = src)
 		affected_mob.visible_message(span_boldwarning("[affected_mob]'s heart explodes!"))
 		qdel(heart)

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -127,7 +127,7 @@
 	else if(brain.suicided || (brain.brainmob && HAS_TRAIT(brain.brainmob, TRAIT_SUICIDED)))
 		. += span_info("There's a miserable expression on [shown_name]'s face; they must have really hated life. There's no hope of recovery.")
 	else if(brain.brainmob)
-		if(brain.brainmob?.health <= HEALTH_THRESHOLD_DEAD)
+		if(brain.brainmob?.health <= brain.brainmob?.dead_threshold)
 			. += span_info("It's leaking some kind of... clear fluid? The brain inside must be in pretty bad shape.")
 		if(brain.brainmob.key || brain.brainmob.get_ghost(FALSE, TRUE))
 			. += span_info("Its muscles are twitching slightly... It seems to have some life still in it.")


### PR DESCRIPTION
## About The Pull Request

Soft & Hard crit thresholds are vars on the living level while dead threshold isn't, this fixes that.
Also fixes like 2 instances of using defines instead of the living vars for crit thresholds. There is one left in penthrite but it seems intentional so I left it in, while inverse penthrite seemed to want to be consistent with penthrite for no real reason.

## Why It's Good For The Game

Allows some mobs to have longer crit times if ever we'd want to make that a feature sometime.

## Changelog

Nothing player-facing, since this isn't ever changed by any mob.