### PR TITLE
Small chat filtering fixes

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -163,4 +163,4 @@
 // Sorted alphabetically
 #define span_tooltip(tip, main_text) ("<span data-component=\"Tooltip\" data-content=\"" + tip + "\" class=\"tooltip\">" + main_text + "</span>")
 /// Creates a tooltip without italicization or a dotted underline under the "say" class.
-#define span_tooltip_subtle(tip, main_text) ("<span data-component=\"Tooltip\" data-content=\"" + tip + "\" class=\"say\">" + main_text + "</span>")
+#define span_tooltip_subtle(tip, main_text) ("<span data-component=\"Tooltip\" data-content=\"" + tip + "\" class=\"tooltip_subtle\">" + main_text + "</span>")

--- a/tgui/packages/tgui-panel/chat/use-chat-pages.ts
+++ b/tgui/packages/tgui-panel/chat/use-chat-pages.ts
@@ -116,6 +116,8 @@ export function useChatPages() {
       ...pagesRecord,
       [currentPageId]: draft,
     });
+
+    chatRenderer.changePage(draft);
   }
 
   function updateChatPage(page: Partial<Page>): void {
@@ -128,6 +130,8 @@ export function useChatPages() {
       ...pagesRecord,
       [currentPageId]: draft,
     });
+
+    chatRenderer.changePage(draft);
   }
 
   return {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -312,6 +312,7 @@ em {
 .emote,
 .infoplain,
 .oocplain,
+.tooltip_subtle,
 .warningplain {
 }
 

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -330,6 +330,7 @@ em {
 .emote,
 .infoplain,
 .oocplain,
+.tooltip_subtle,
 .warningplain {
 }
 


### PR DESCRIPTION

## About The Pull Request

Local filter was catching radio and entertainment. #97613 wrapped the latter in a say span, which is what the chat filter uses to detect "local" chat. Also fixes a small bug where toggling filters doesn't apply instantly.

## Why It's Good For The Game

Bugs bad.

## Changelog
:cl:
fix: radio and entertainment chatter are no longer filtered out by local chat.
/:cl:
