### PR TITLE
Coroner LARP: Arm bruise wounds

### DIFF
--- a/code/__DEFINES/wounds.dm
+++ b/code/__DEFINES/wounds.dm
@@ -109,6 +109,8 @@ GLOBAL_LIST_INIT(bio_state_anatomy, list(
 #define WOUND_SERIES_LOSS_BASIC "wound_series_loss_basic"
 /// Cranial fissure wound.
 #define WOUND_SERIES_CRANIAL_FISSURE "wound_series_cranial_fissure"
+/// Bruise wound.
+#define WOUND_SERIES_BRUISING "wound_series_bruising"
 
 /// A assoc list of (wound typepath -> wound_pregen_data instance). Every wound should have a pregen data.
 GLOBAL_LIST_INIT_TYPED(all_wound_pregen_data, /datum/wound_pregen_data, generate_wound_static_data())

--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -46,8 +46,10 @@
 
 	if(ishuman(attack_target))
 		wound_source += " a human"
+	else if(issilicon(attack_target))
+		wound_source += " something mechanical"
 	else
-		wound_source += " a [attack_target::name]"
+		wound_source += " an animal"
 	arm_bruises.apply_wound(arm, TRUE, wound_source = wound_source)
 
 /datum/status_effect/limp

--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -16,11 +16,28 @@
 	owner.visible_message(span_danger("[owner]'s body tenses up noticeably, gritting against [owner.p_their()] pain!"), span_notice("<b>Your senses sharpen as your body tenses up from the wounds you've sustained!</b>"), \
 		vision_distance=COMBAT_MESSAGE_RANGE)
 	MODIFY_PHYSIOLOGY(owner, PHYS_COEFF_BLEED, WOUND_DETERMINATION_BLEED_MOD)
+	RegisterSignal(owner, COMSIG_LIVING_UNARMED_ATTACK, PROC_REF(unarmed_strike))
 
 /datum/status_effect/determined/on_remove()
 	owner.visible_message(span_danger("[owner]'s body slackens noticeably!"), span_warning("<b>Your adrenaline rush dies off, and the pain from your wounds come aching back in...</b>"), vision_distance=COMBAT_MESSAGE_RANGE)
 	MODIFY_PHYSIOLOGY(owner, PHYS_COEFF_BLEED, 1/WOUND_DETERMINATION_BLEED_MOD)
+	UnregisterSignal(owner, COMSIG_LIVING_UNARMED_ATTACK)
 	return ..()
+
+/datum/status_effect/determined/proc/unarmed_strike(mob/living/source, atom/attack_target, proximity, modifiers)
+	SIGNAL_HANDLER
+
+	if(!proximity || !isliving(attack_target))
+		return NONE
+
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
+		var/obj/item/bodypart/arm = source.get_active_hand()
+		var/datum/wound/bruised/arm_bruises = arm.get_wound_type(/datum/wound/bruised)
+		if(isnull(arm_bruises))
+			arm_bruises = new()
+			arm_bruises.apply_wound(arm, TRUE, wound_source = "determination shoving")
+		else
+			arm_bruises.bruise_ticks = initial(arm_bruises.bruise_ticks)
 
 /datum/status_effect/limp
 	id = "limp"

--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -45,7 +45,7 @@
 		wound_source = "offensive injuries from attempting to fight"
 
 	if(ishuman(attack_target))
-		wound_source += " a human"
+		wound_source += " a humanoid"
 	else if(issilicon(attack_target))
 		wound_source += " something mechanical"
 	else

--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -30,14 +30,25 @@
 	if(!proximity || !isliving(attack_target))
 		return NONE
 
+	var/obj/item/bodypart/arm = source.get_active_hand()
+	var/datum/wound/bruised/arm_bruises = arm.get_wound_type(/datum/wound/bruised)
+	if(!isnull(arm_bruises))
+		arm_bruises.bruise_ticks = initial(arm_bruises.bruise_ticks)
+		return
+	arm_bruises = new /datum/wound/bruised()
+
+	var/wound_source
+
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
-		var/obj/item/bodypart/arm = source.get_active_hand()
-		var/datum/wound/bruised/arm_bruises = arm.get_wound_type(/datum/wound/bruised)
-		if(isnull(arm_bruises))
-			arm_bruises = new()
-			arm_bruises.apply_wound(arm, TRUE, wound_source = "determination shoving")
-		else
-			arm_bruises.bruise_ticks = initial(arm_bruises.bruise_ticks)
+		wound_source = "defensive injuries from attempting to ward off"
+	else
+		wound_source = "offensive injuries from attempting to fight"
+
+	if(ishuman(attack_target))
+		wound_source += " a human"
+	else
+		wound_source += " a [attack_target::name]"
+	arm_bruises.apply_wound(arm, TRUE, wound_source = wound_source)
 
 /datum/status_effect/limp
 	id = "limp"

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -728,11 +728,15 @@
 	for(var/i in 1 to severity)
 		severity_text_formatted += "!"
 
-	return "[name] detected!<br>\
+	var/scanner_text = "[name] detected!<br>\
 		Risk: [severity_text_formatted]<br>\
-		Description: [simple_desc || desc]<br>\
-		<i>Treatment Guide: [simple_treat_text]</i><br>\
-		<i>Homemade Remedies: [homemade_treat_text]</i>"
+		Description: [simple_desc || desc]<br>"
+	if(simple_treat_text)
+		scanner_text += "<i>Treatment Guide: [simple_treat_text]</i><br>"
+	if(homemade_treat_text)
+		scanner_text += "<i>Homemade Remedies: [homemade_treat_text]</i>"
+
+	return scanner_text
 
 /**
  * Returns what text describes this wound

--- a/code/datums/wounds/bruised.dm
+++ b/code/datums/wounds/bruised.dm
@@ -35,7 +35,6 @@
 
 	bruise_ticks--
 	if(!bruise_ticks)
-		to_chat(victim, span_green("The cut on your [limb.plaintext_zone] has [!limb.can_bleed() ? "healed up" : "stopped bleeding"]!"))
 		qdel(src)
 
 /datum/wound/bruised/on_xadone(power)

--- a/code/datums/wounds/bruised.dm
+++ b/code/datums/wounds/bruised.dm
@@ -27,6 +27,7 @@
 	simple_treat_text = null
 	homemade_treat_text = null
 
+	///How many ticks the bruise has left until it disappears. Only ticks away while the victim is alive.
 	var/bruise_ticks = 25
 
 /datum/wound/bruised/handle_process(seconds_per_tick)

--- a/code/datums/wounds/bruised.dm
+++ b/code/datums/wounds/bruised.dm
@@ -5,11 +5,10 @@
  * Very minor, flavor wounds, for the Coroner to see what may have led up to an individual's death.
  */
 /datum/wound_pregen_data/bruised
-	abstract = TRUE
-
-	required_wounding_type = WOUND_BLUNT
+	abstract = FALSE
+	wound_path_to_generate = /datum/wound/bruised
 	required_limb_biostate = BIO_FLESH
-
+	required_wounding_type = NONE
 	wound_series = WOUND_SERIES_BRUISING
 
 /datum/wound/bruised
@@ -19,7 +18,7 @@
 	sound_effect = null
 	treat_text = "Will treat itself overtime."
 	treat_text_short = "Best left alone."
-	examine_desc = "appears bruised"
+	examine_desc = null
 	occur_text = "gets bruised up"
 	threshold_penalty = 1
 	processes = TRUE
@@ -31,7 +30,7 @@
 	var/bruise_ticks = 25
 
 /datum/wound/bruised/handle_process(seconds_per_tick)
-	if (!victim || HAS_TRAIT(victim, TRAIT_STASIS) || !IS_DEAD_OR_FAKING(victim))
+	if (!victim || HAS_TRAIT(victim, TRAIT_STASIS) || IS_DEAD_OR_FAKING(victim))
 		return
 
 	bruise_ticks--
@@ -46,29 +45,3 @@
 /datum/wound/bruised/on_synthflesh(reac_volume)
 	. = ..()
 	qdel(src)
-
-/*
-/datum/wound/bruised/moderate
-	name = "Rough Abrasion"
-	desc = "Patient's skin has been badly scraped, generating moderate blood loss."
-	treat_text = "Apply bandaging or suturing to the wound. \
-		Follow up with food and a rest period."
-	treat_text_short = "Apply bandaging or suturing."
-	examine_desc = "has an open cut"
-	occur_text = "is cut open, slowly leaking blood"
-	sound_effect = 'sound/effects/wounds/blood1.ogg'
-	severity = WOUND_SEVERITY_MODERATE
-	initial_flow = 1.75
-	minimum_flow = 0.5
-	clot_rate = 0.04
-	series_threshold_penalty = 10
-	status_effect_type = /datum/status_effect/wound/slash/flesh/moderate
-	scar_keyword = "slashmoderate"
-
-	simple_treat_text = "<b>Bandaging</b> the wound will reduce blood loss, help the wound close by itself quicker, and speed up the blood recovery period. The wound itself can be slowly <b>sutured</b> shut."
-	homemade_treat_text = "<b>Tea</b> stimulates the body's natural healing systems, slightly fastening clotting. The wound itself can be rinsed off on a sink or shower as well. Other remedies are unnecessary."
-
-/datum/wound/bruised/moderate/update_descriptions()
-	if(!limb.can_bleed())
-		occur_text = "is cut open"
-*/

--- a/code/datums/wounds/bruised.dm
+++ b/code/datums/wounds/bruised.dm
@@ -1,0 +1,74 @@
+
+/*
+ * Bruise wounds
+ *
+ * Very minor, flavor wounds, for the Coroner to see what may have led up to an individual's death.
+ */
+/datum/wound_pregen_data/bruised
+	abstract = TRUE
+
+	required_wounding_type = WOUND_BLUNT
+	required_limb_biostate = BIO_FLESH
+
+	wound_series = WOUND_SERIES_BRUISING
+
+/datum/wound/bruised
+	name = "Bruising"
+	undiagnosed_name = "Bruising"
+	desc = "Patient's skin appears bruised, showing marks of resistance."
+	sound_effect = null
+	treat_text = "Will treat itself overtime."
+	treat_text_short = "Best left alone."
+	examine_desc = "appears bruised"
+	occur_text = "gets bruised up"
+	threshold_penalty = 1
+	processes = TRUE
+	default_scar_file = null//FLESH_SCAR_FILE
+	severity = WOUND_SEVERITY_TRIVIAL
+	simple_treat_text = null
+	homemade_treat_text = null
+
+	var/bruise_ticks = 25
+
+/datum/wound/bruised/handle_process(seconds_per_tick)
+	if (!victim || HAS_TRAIT(victim, TRAIT_STASIS) || !IS_DEAD_OR_FAKING(victim))
+		return
+
+	bruise_ticks--
+	if(!bruise_ticks)
+		to_chat(victim, span_green("The cut on your [limb.plaintext_zone] has [!limb.can_bleed() ? "healed up" : "stopped bleeding"]!"))
+		qdel(src)
+
+/datum/wound/bruised/on_xadone(power)
+	. = ..()
+	qdel(src)
+
+/datum/wound/bruised/on_synthflesh(reac_volume)
+	. = ..()
+	qdel(src)
+
+/*
+/datum/wound/bruised/moderate
+	name = "Rough Abrasion"
+	desc = "Patient's skin has been badly scraped, generating moderate blood loss."
+	treat_text = "Apply bandaging or suturing to the wound. \
+		Follow up with food and a rest period."
+	treat_text_short = "Apply bandaging or suturing."
+	examine_desc = "has an open cut"
+	occur_text = "is cut open, slowly leaking blood"
+	sound_effect = 'sound/effects/wounds/blood1.ogg'
+	severity = WOUND_SEVERITY_MODERATE
+	initial_flow = 1.75
+	minimum_flow = 0.5
+	clot_rate = 0.04
+	series_threshold_penalty = 10
+	status_effect_type = /datum/status_effect/wound/slash/flesh/moderate
+	scar_keyword = "slashmoderate"
+
+	simple_treat_text = "<b>Bandaging</b> the wound will reduce blood loss, help the wound close by itself quicker, and speed up the blood recovery period. The wound itself can be slowly <b>sutured</b> shut."
+	homemade_treat_text = "<b>Tea</b> stimulates the body's natural healing systems, slightly fastening clotting. The wound itself can be rinsed off on a sink or shower as well. Other remedies are unnecessary."
+
+/datum/wound/bruised/moderate/update_descriptions()
+	if(!limb.can_bleed())
+		occur_text = "is cut open"
+*/

--- a/code/datums/wounds/bruised.dm
+++ b/code/datums/wounds/bruised.dm
@@ -22,7 +22,7 @@
 	occur_text = "gets bruised up"
 	threshold_penalty = 1
 	processes = TRUE
-	default_scar_file = null//FLESH_SCAR_FILE
+	default_scar_file = null
 	severity = WOUND_SEVERITY_TRIVIAL
 	simple_treat_text = null
 	homemade_treat_text = null

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -80,6 +80,8 @@
 				. += span_notice(tourniquet_msg)
 
 		for(var/datum/wound/iter_wound as anything in body_part.wounds)
+			if(isnull(iter_wound.examine_desc))
+				continue
 			. += span_danger(iter_wound.get_examine_description(user))
 
 		var/surgery_examine = body_part.get_surgery_examine()

--- a/code/modules/unit_tests/medical_wounds.dm
+++ b/code/modules/unit_tests/medical_wounds.dm
@@ -12,10 +12,12 @@
 	var/i = 1
 	var/list/iter_test_wound_list
 
-	for(iter_test_wound_list in list(list(/datum/wound/blunt/bone/moderate, /datum/wound/blunt/bone/severe, /datum/wound/blunt/bone/critical),\
-										list(/datum/wound/slash/flesh/moderate, /datum/wound/slash/flesh/severe, /datum/wound/slash/flesh/critical),\
-										list(/datum/wound/pierce/bleed/moderate, /datum/wound/pierce/bleed/severe, /datum/wound/pierce/bleed/critical),\
-										list(/datum/wound/burn/flesh/moderate, /datum/wound/burn/flesh/severe, /datum/wound/burn/flesh/critical)))
+	for(iter_test_wound_list in list(
+		list(/datum/wound/blunt/bone/moderate, /datum/wound/blunt/bone/severe, /datum/wound/blunt/bone/critical), \
+		list(/datum/wound/slash/flesh/moderate, /datum/wound/slash/flesh/severe, /datum/wound/slash/flesh/critical), \
+		list(/datum/wound/pierce/bleed/moderate, /datum/wound/pierce/bleed/severe, /datum/wound/pierce/bleed/critical), \
+		list(/datum/wound/burn/flesh/moderate, /datum/wound/burn/flesh/severe, /datum/wound/burn/flesh/critical), \
+	))
 
 		TEST_ASSERT_EQUAL(length(victim.all_wounds), 0, "Patient is somehow wounded before test")
 		var/datum/wound/iter_test_wound

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2358,6 +2358,7 @@
 #include "code\datums\wounds\_wounds.dm"
 #include "code\datums\wounds\blunt.dm"
 #include "code\datums\wounds\bones.dm"
+#include "code\datums\wounds\bruised.dm"
 #include "code\datums\wounds\burns.dm"
 #include "code\datums\wounds\cranial_fissure.dm"
 #include "code\datums\wounds\loss.dm"


### PR DESCRIPTION
## About The Pull Request

While you're determined and try to shove or punch someone, you'll get bruises along your hands from hitting too hard, which shows up in an Autopsy scan. Being alive will slowly tick the bruises away until they disappear, so this will only appear if you die somewhat close to when you actually gain the wound.


<img width="363" height="110" alt="image" src="https://github.com/user-attachments/assets/685997d5-a7b0-46ee-8d2b-7c5f8ab4fe31" />


<img width="381" height="111" alt="image" src="https://github.com/user-attachments/assets/730f71f5-4a88-468e-99dd-17610ac86367" />


This gives a little bit more insight into the Autopsy report to at least be able to tell if someone's dying moments were spent resisting or fighting.

## Why It's Good For The Game

I like the idea of more in-depth investigations and one of the things that interests me is being able to tell whether or not someone went down fighting or defending themselves, which this aims to be.

## Changelog

:cl:
add: Added bruise wounds to your hands if you attack people in a near-death state. They show up on autopsies.
/:cl: