### PR TITLE
Mech UI Improvements and minor QOL 2026

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -541,9 +541,9 @@
 		if(45 to 65)
 			examine_text = "It's badly damaged."
 		if(25 to 45)
-			examine_text = "It's heavily damaged."
+			examine_text = span_warning("It's heavily damaged.")
 		else
-			examine_text = "It's falling apart."
+			examine_text = span_warning("It's falling apart!")
 
 	return examine_text
 

--- a/code/modules/vehicles/mecha/mecha_wreckage.dm
+++ b/code/modules/vehicles/mecha/mecha_wreckage.dm
@@ -10,11 +10,16 @@
 	density = TRUE
 	anchored = FALSE
 	opacity = FALSE
+	/// What types of items/materials can be salvaged using a welder. Each non-stack subtype can only be salvaged once per wreckage.
 	var/list/welder_salvage = list(/obj/item/stack/sheet/plasteel, /obj/item/stack/sheet/iron, /obj/item/stack/rods)
+	/// Total number of times that this wreckage can be salvaged.
 	var/salvage_num = 5
+	/// What types of items/materials can be salvaged using a crowbar. Typically consists of installed mech equipment. Does not interact with salvage_num.
 	var/list/crowbar_salvage = list()
+	/// Tracks if the cables have been salvaged from the mecha wreckage. Only performed once.
 	var/wires_removed = FALSE
-	var/mob/living/silicon/ai/AI //AIs to be salvaged
+	/// AIs to be salvaged
+	var/mob/living/silicon/ai/ai_pilot
 	var/list/parts
 
 /obj/structure/mecha_wreckage/Initialize(mapload, mob/living/silicon/ai/AI_pilot)
@@ -30,17 +35,17 @@
 		parts = null
 	if(!AI_pilot) //Type-checking for this is already done in mecha/Destroy()
 		return
-	AI = AI_pilot
-	AI.apply_damage(150, BURN) //Give the AI a bit of damage from the "shock" of being suddenly shut down
-	INVOKE_ASYNC(AI, TYPE_PROC_REF(/mob/living/silicon, death)) //The damage is not enough to kill the AI, but to be 'corrupted files' in need of repair.
-	AI.forceMove(src) //Put the dead AI inside the wreckage for recovery
+	ai_pilot = AI_pilot
+	ai_pilot.apply_damage(150, BURN) //Give the AI a bit of damage from the "shock" of being suddenly shut down
+	INVOKE_ASYNC(ai_pilot, TYPE_PROC_REF(/mob/living/silicon, death)) //The damage is not enough to kill the AI, but to be 'corrupted files' in need of repair.
+	ai_pilot.forceMove(src) //Put the dead AI inside the wreckage for recovery
 	add_overlay(mutable_appearance('icons/obj/weapons/guns/projectiles.dmi', "green_laser")) //Overlay for the recovery beacon
-	AI.controlled_equipment = null
-	AI.remote_control = null
+	ai_pilot.controlled_equipment = null
+	ai_pilot.remote_control = null
 
 /obj/structure/mecha_wreckage/Destroy()
-	if(AI)
-		QDEL_NULL(AI)
+	if(ai_pilot)
+		QDEL_NULL(ai_pilot)
 	QDEL_LIST(crowbar_salvage)
 	src.visible_message(span_danger("[src]'s superstructure folds in on itself, collapsing into a heap of unsalvageable scrap!"))
 	playsound(src, 'sound/effects/meteorimpact.ogg', 100, TRUE)
@@ -51,7 +56,7 @@
 
 /obj/structure/mecha_wreckage/examine(mob/user)
 	. = ..()
-	if(!AI)
+	if(!ai_pilot)
 		return
 	. += span_notice("The AI recovery beacon is active.")
 
@@ -101,18 +106,18 @@
 	//Proc called on the wreck by the AI card.
 	if(interaction != AI_TRANS_TO_CARD) //AIs can only be transferred in one direction, from the wreck to the card.
 		return
-	if(!AI) //No AI in the wreck
+	if(!ai_pilot) //No AI in the wreck
 		to_chat(user, span_warning("No AI backups found."))
 		return
 	cut_overlays() //Remove the recovery beacon overlay
-	AI.forceMove(card) //Move the dead AI to the card.
-	card.AI = AI
-	if(AI.client) //AI player is still in the dead AI and is connected
-		to_chat(AI, span_notice("The remains of your file system have been recovered on a mobile storage device."))
+	ai_pilot.forceMove(card) //Move the dead AI to the card.
+	card.ai_pilot = ai_pilot
+	if(ai_pilot.client) //AI player is still in the dead AI and is connected
+		to_chat(ai_pilot, span_notice("The remains of your file system have been recovered on a mobile storage device."))
 	else //Give the AI a heads-up that it is probably going to get fixed.
-		AI.notify_revival("You have been recovered from the wreckage!", source = card)
-	to_chat(user, "[span_boldnotice("Backup files recovered")]: [AI.name] ([rand(1000,9999)].exe) salvaged from [name] and stored within local memory.")
-	AI = null
+		ai_pilot.notify_revival("You have been recovered from the wreckage!", source = card)
+	to_chat(user, "[span_boldnotice("Backup files recovered")]: [ai_pilot.name] ([rand(1000,9999)].exe) salvaged from [name] and stored within local memory.")
+	ai_pilot = null
 
 /obj/structure/mecha_wreckage/gygax
 	name = "\improper Gygax wreckage"

--- a/code/modules/vehicles/mecha/mecha_wreckage.dm
+++ b/code/modules/vehicles/mecha/mecha_wreckage.dm
@@ -20,6 +20,7 @@
 	var/wires_removed = FALSE
 	/// AIs to be salvaged
 	var/mob/living/silicon/ai/ai_pilot
+	/// Intact mech parts list that can be welded off. Only one per type can be removed, to a max of 2, with a 60% chance to skip.
 	var/list/parts
 
 /obj/structure/mecha_wreckage/Initialize(mapload, mob/living/silicon/ai/AI_pilot)

--- a/code/modules/vehicles/mecha/mecha_wreckage.dm
+++ b/code/modules/vehicles/mecha/mecha_wreckage.dm
@@ -112,7 +112,7 @@
 		return
 	cut_overlays() //Remove the recovery beacon overlay
 	ai_pilot.forceMove(card) //Move the dead AI to the card.
-	card.ai_pilot = ai_pilot
+	card.AI = ai_pilot
 	if(ai_pilot.client) //AI player is still in the dead AI and is connected
 		to_chat(ai_pilot, span_notice("The remains of your file system have been recovered on a mobile storage device."))
 	else //Give the AI a heads-up that it is probably going to get fixed.

--- a/tgui/packages/tgui/interfaces/Mecha/AlertPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/AlertPane.tsx
@@ -58,11 +58,8 @@ export const AlertPane = (props) => {
                     : 'good')
               }
             >
-              {overclock_mode
-                ? `Overclocking (${Math.round(
-                    overclock_temp_percentage * 100,
-                  )}%)`
-                : 'Overclock'}
+              {overclock_mode ? "Overclocking " : "Overclock "}
+              ({Math.round(Math.max(overclock_temp_percentage * 100, 0))}%)
             </Button>
             {!!overclock_safety_available && (
               <Button

--- a/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
@@ -64,7 +64,7 @@ export const ModulesPane = (props) => {
     <Section
       title= {
         showModuleList ? "Equipment" :
-        <Icon name="screwdriver-wrench"></Icon>}
+        <Icon name="screwdriver-wrench" />}
       fill
       style={{ overflowY: 'auto' }}
       buttons={
@@ -125,7 +125,7 @@ export const ModulesPane = (props) => {
                       {`${moduleSlotLabel(module.slot)} Slot`}
                     </Stack.Item>
                     :
-                    <></>
+                    null
                   }
                 </Stack>
               </Button>
@@ -161,7 +161,7 @@ export const ModulesPane = (props) => {
                       {module.name}
                     </Stack.Item>
                     :
-                    <></>
+                    null
                   }
                 </Stack>
               </Button>

--- a/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ModulesPane.tsx
@@ -11,6 +11,7 @@ import {
   Section,
   Stack,
 } from 'tgui-core/components';
+import { useSharedState } from '../../backend';
 import { formatPower } from 'tgui-core/format';
 import { toFixed } from 'tgui-core/math';
 import { classes } from 'tgui-core/react';
@@ -54,23 +55,41 @@ const moduleSlotLabel = (param) => {
 
 export const ModulesPane = (props) => {
   const { act, data } = useBackend<MainData>();
+  const [showModuleList, setShowModuleList] = useSharedState(
+    'showModuleList',
+    true,
+  );
   const { modules, selected_module_index, weapons_safety } = data;
   return (
     <Section
-      title="Equipment"
+      title= {
+        showModuleList ? "Equipment" :
+        <Icon name="screwdriver-wrench"></Icon>}
       fill
       style={{ overflowY: 'auto' }}
       buttons={
+        <>
         <Button
           icon={!weapons_safety ? 'triangle-exclamation' : 'helmet-safety'}
           color={!weapons_safety ? 'red' : 'default'}
           onClick={() => act('toggle_safety')}
-          content={
+          content={ showModuleList ? <> {
             !weapons_safety
               ? 'Safety Protocols Disabled'
               : 'Safety Protocols Enabled'
           }
+              </> :
+           null
+          }
         />
+        <Button
+          icon={showModuleList ? 'arrow-left' : 'arrow-right'}
+          content={ showModuleList ?
+            'Minimize' : 'Max'
+          }
+          onClick={() => setShowModuleList(!showModuleList)}
+        />
+        </>
       }
     >
       <Stack>
@@ -94,16 +113,20 @@ export const ModulesPane = (props) => {
                       name={moduleSlotIcon(module.slot)}
                     />
                   </Stack.Item>
-                  <Stack.Item
-                    lineHeight="32px"
-                    style={{
-                      textTransform: 'capitalize',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                    }}
-                  >
-                    {`${moduleSlotLabel(module.slot)} Slot`}
-                  </Stack.Item>
+                  {showModuleList?
+                    <Stack.Item
+                      lineHeight="32px"
+                      style={{
+                        textTransform: 'capitalize',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}
+                    >
+                      {`${moduleSlotLabel(module.slot)} Slot`}
+                    </Stack.Item>
+                    :
+                    <></>
+                  }
                 </Stack>
               </Button>
             ) : (
@@ -126,23 +149,27 @@ export const ModulesPane = (props) => {
                       className={classes(['mecha_equipment32x32', module.icon])}
                     />
                   </Stack.Item>
-                  <Stack.Item
-                    lineHeight="32px"
-                    style={{
-                      textTransform: 'capitalize',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                    }}
-                  >
-                    {module.name}
-                  </Stack.Item>
+                  {showModuleList?
+                    <Stack.Item
+                      lineHeight="32px"
+                      style={{
+                        textTransform: 'capitalize',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}
+                    >
+                      {module.name}
+                    </Stack.Item>
+                    :
+                    <></>
+                  }
                 </Stack>
               </Button>
             ),
           )}
         </Stack.Item>
         <Stack.Item grow pl={1}>
-          {selected_module_index !== null && modules[selected_module_index] && (
+          {selected_module_index !== null && modules[selected_module_index] && showModuleList && (
             <ModuleDetails module={modules[selected_module_index]} />
           )}
         </Stack.Item>

--- a/tgui/packages/tgui/interfaces/Mecha/index.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/index.tsx
@@ -10,6 +10,7 @@ import {
 import { formatSiUnit } from 'tgui-core/format';
 
 import { useBackend } from '../../backend';
+import { useSharedState } from '../../backend';
 import { Window } from '../../layouts';
 import { logger } from '../../logging';
 import { AccessConfig } from '../common/AccessConfig';
@@ -19,8 +20,15 @@ import { ModulesPane } from './ModulesPane';
 
 export const Mecha = (props) => {
   const { data } = useBackend<MainData>();
+  const [showModuleList, setShowModuleList] = useSharedState(
+    'showModuleList',
+    true,
+  );
+  const mainWidth = 400;
+  const equipmentWidth = 400;
+  const windowWidth = mainWidth + (showModuleList ? equipmentWidth : 0);
   return (
-    <Window theme={data.ui_theme} width={800} height={560}>
+    <Window theme={data.ui_theme} width={windowWidth} height={560}>
       <Window.Content>
         <Content />
       </Window.Content>
@@ -47,7 +55,7 @@ export const Content = (props) => {
   return (
     <Stack fill>
       <Stack.Item grow={1}>
-        <Stack vertical fill>
+        <Stack vertical fill minWidth='270px'>
           <Stack.Item grow overflow="hidden">
             <Section
               fill


### PR DESCRIPTION
## About The Pull Request

It was brought to my attention that the Mech UI is fairly very large, and that the amount of screenspace blocked by the Mech UI was getting in the way of actually making use of most mechs. So, I did some iteration and tweaks to the UI, adding a toggle so that you can trim down the width of the window, hiding and condensing the equipment screen of the mech.

Extended:
<img width="801" height="561" alt="image" src="https://github.com/user-attachments/assets/35f77f8d-501a-478f-9d11-564c6cfc93c9" />

Minimized:
<img width="400" height="559" alt="image" src="https://github.com/user-attachments/assets/b2f33ff8-e624-41fd-8125-fd9ee26c890a" />
This trims the window width from 800 pixels (extended width) down to a clean 400. This hides the text of the modules half the screen and replaces some text with icons to help force it into that space, while still allowing you to swap the equipment selected, though for finer control you'll need to maximize the tab back open to tweak settings.

Another mild tweak, I adjusted the text for mechs that have an overclock function, so that the text will show what the overclock % while off, since once it's turned off the overclock % will still iterate downwards if you turn it back on.

Documented the code of mecha wreckage which carries the legacy of mech code looking awful and being inconsistent. Also, renamed the AI var(Capital A capital I) to ai_pilot for clarity's sake.

Lastly, while examining a mech, swaps the text span of the mech in it's last 2 damage states to span_warning to match the existing formatting of "It's falling apart!" already seen on every other structure in the game.

## Why It's Good For The Game

* Cleans up a very cluttered UI by offering an option that makes makes more utilitarian without forcing you to play the game half-blind.
* Improves code documentation quality.
* Brings the mech examine text up to parity with other instances of damage states in-game.
* Allows players to keep track of a variable that they're expected to be able to keep track of but is hidden behind the TGUI.

## Changelog

:cl:
qol: All Mechs now have a toggle to trim down the modules pane of the Mech UI.
qol: Mechs will now show their overlock percentage without having it enabled.
spellcheck: Mechs when examined now format their integrity text the same as when other things are falling apart.
/:cl:
