### PR TITLE
Dummy mood datum

### DIFF
--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -677,6 +677,12 @@
 			return TRUE
 	return FALSE
 
+
+/datum/mood/dummy
+
+/datum/mood/dummy/set_sanity(amount, minimum, maximum, override)
+	return
+
 #undef MINOR_INSANITY_PEN
 #undef MAJOR_INSANITY_PEN
 #undef MOOD_CATEGORY_NUTRITION

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -49,7 +49,7 @@
 	return null
 
 /mob/living/carbon/human/dummy/setup_mood()
-	return
+	mob_mood = new /datum/mood/dummy(src)
 
 /// This proc is for holding effects applied when a mob is missing certain organs
 /// It is called very, very early in human init because all humans innately spawn with no organs and gain them during init


### PR DESCRIPTION

## About The Pull Request
Second half to fully fix* situations where we runtime because we dont have a datum. (by ensuring that we always have said datum) #94772
follow up for #97752
## Why It's Good For The Game
Runtime bad! this keeps dummies from having any actual effects or setting of mood, I dont know if we want any more verbose returns then this tho.
## Changelog
:cl:
code: Dummies have a blank mood datum
/:cl:
