### PR TITLE
Adds a fallback job icon for modularization/downstream purposes

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -137,7 +137,7 @@
 	var/desensitized_base = 1.0
 
 	///If set, adds this as the job icon map (from fontawesome5)
-	var/tgui_icon
+	var/tgui_icon = FA_ICON_QUESTION
 
 /datum/job/New()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

This PR simply catches potential fatal errors in the future by adding a default job icon.
## Why It's Good For The Game

Yesterday, OculisStation's crew monitor bluescreened because of a missing icon for a downstream-exclusive job (Explorer). This should essentially stop that from happening in the future, just in case. I think this is the best way to do it, but I'm open to suggestions of course. This should theoretically have zero impact other than being a safety net for downstream developers.

#97557 caused the issue, but it was just an oversight. I do really appreciate the PR.
