### PR TITLE
Old Boss Achievement and Score Scrub

### DIFF
--- a/code/__DEFINES/achievements.dm
+++ b/code/__DEFINES/achievements.dm
@@ -105,6 +105,7 @@
 #define BOSS_MEDAL_LEGION "Legion Killer"
 #define BOSS_MEDAL_TENDRIL "Tendril Exterminator"
 #define BOSS_MEDAL_WENDIGO "Wendigo Killer"
+#define BOSS_MEDAL_KINGGOAT "King Goat Killer"
 #define BOSS_MEDAL_THETHING "Thing Exterminator"
 
 #define BOSS_MEDAL_MINER_CRUSHER "Blood-drunk Miner Crusher"
@@ -115,6 +116,7 @@
 #define BOSS_MEDAL_HIEROPHANT_CRUSHER "Hierophant Crusher"
 #define BOSS_MEDAL_LEGION_CRUSHER "Legion Crusher"
 #define BOSS_MEDAL_WENDIGO_CRUSHER "Wendigo Crusher"
+#define BOSS_MEDAL_KINGGOAT_CRUSHER "King Goat Crusher"
 #define BOSS_MEDAL_THETHING_CRUSHER "Thing Crusher"
 
 // Medal hub IDs for boss-kill scores
@@ -126,7 +128,9 @@
 #define DRAKE_SCORE "Drakes Killed"
 #define HIEROPHANT_SCORE "Hierophants Killed"
 #define LEGION_SCORE "Legion Killed"
+#define SWARMER_BEACON_SCORE "Swarmer Beacs Killed"
 #define WENDIGO_SCORE "Wendigos Killed"
+#define KINGGOAT_SCORE "King Goat Killed"
 #define TENDRIL_CLEAR_SCORE "Tendrils Killed"
 #define THETHING_SCORE "The Thing Killed"
 

--- a/code/__DEFINES/achievements.dm
+++ b/code/__DEFINES/achievements.dm
@@ -105,7 +105,6 @@
 #define BOSS_MEDAL_LEGION "Legion Killer"
 #define BOSS_MEDAL_TENDRIL "Tendril Exterminator"
 #define BOSS_MEDAL_WENDIGO "Wendigo Killer"
-#define BOSS_MEDAL_KINGGOAT "King Goat Killer"
 #define BOSS_MEDAL_THETHING "Thing Exterminator"
 
 #define BOSS_MEDAL_MINER_CRUSHER "Blood-drunk Miner Crusher"
@@ -116,7 +115,6 @@
 #define BOSS_MEDAL_HIEROPHANT_CRUSHER "Hierophant Crusher"
 #define BOSS_MEDAL_LEGION_CRUSHER "Legion Crusher"
 #define BOSS_MEDAL_WENDIGO_CRUSHER "Wendigo Crusher"
-#define BOSS_MEDAL_KINGGOAT_CRUSHER "King Goat Crusher"
 #define BOSS_MEDAL_THETHING_CRUSHER "Thing Crusher"
 
 // Medal hub IDs for boss-kill scores
@@ -128,9 +126,7 @@
 #define DRAKE_SCORE "Drakes Killed"
 #define HIEROPHANT_SCORE "Hierophants Killed"
 #define LEGION_SCORE "Legion Killed"
-#define SWARMER_BEACON_SCORE "Swarmer Beacs Killed"
 #define WENDIGO_SCORE "Wendigos Killed"
-#define KINGGOAT_SCORE "King Goat Killed"
 #define TENDRIL_CLEAR_SCORE "Tendrils Killed"
 #define THETHING_SCORE "The Thing Killed"
 
@@ -167,6 +163,13 @@
 
 #define CHEF_TOURISTS_SERVED "Tourists Served As Chef"
 #define BARTENDER_TOURISTS_SERVED "Tourists Served As Bartender"
+
+//DB IDs for depreciated (legacy) achievements and score
+#define BOSS_MEDAL_KINGGOAT "King Goat Killer"
+#define BOSS_MEDAL_KINGGOAT_CRUSHER "King Goat Crusher"
+
+#define SWARMER_BEACON_SCORE "Swarmer Beacs Killed"
+#define KINGGOAT_SCORE "King Goat Killed"
 
 /// Value in metadata version that signifies the achievement is archived
 #define ACHIEVEMENT_ARCHIVED_VERSION 9999

--- a/code/__DEFINES/achievements.dm
+++ b/code/__DEFINES/achievements.dm
@@ -105,7 +105,6 @@
 #define BOSS_MEDAL_LEGION "Legion Killer"
 #define BOSS_MEDAL_TENDRIL "Tendril Exterminator"
 #define BOSS_MEDAL_WENDIGO "Wendigo Killer"
-#define BOSS_MEDAL_KINGGOAT "King Goat Killer"
 #define BOSS_MEDAL_THETHING "Thing Exterminator"
 
 #define BOSS_MEDAL_MINER_CRUSHER "Blood-drunk Miner Crusher"
@@ -116,7 +115,6 @@
 #define BOSS_MEDAL_HIEROPHANT_CRUSHER "Hierophant Crusher"
 #define BOSS_MEDAL_LEGION_CRUSHER "Legion Crusher"
 #define BOSS_MEDAL_WENDIGO_CRUSHER "Wendigo Crusher"
-#define BOSS_MEDAL_KINGGOAT_CRUSHER "King Goat Crusher"
 #define BOSS_MEDAL_THETHING_CRUSHER "Thing Crusher"
 
 // Medal hub IDs for boss-kill scores
@@ -128,9 +126,7 @@
 #define DRAKE_SCORE "Drakes Killed"
 #define HIEROPHANT_SCORE "Hierophants Killed"
 #define LEGION_SCORE "Legion Killed"
-#define SWARMER_BEACON_SCORE "Swarmer Beacs Killed"
 #define WENDIGO_SCORE "Wendigos Killed"
-#define KINGGOAT_SCORE "King Goat Killed"
 #define TENDRIL_CLEAR_SCORE "Tendrils Killed"
 #define THETHING_SCORE "The Thing Killed"
 

--- a/code/_globalvars/lists/achievements.dm
+++ b/code/_globalvars/lists/achievements.dm
@@ -1,6 +1,6 @@
 GLOBAL_LIST_EMPTY(commendations)
 ///A list of the current achievement categories supported by the UI and checked by the achievement unit test
-GLOBAL_LIST_INIT(achievement_categories, list("Bosses", "Jobs", "Skills", "Misc", "Mafia", "Scores"))
+GLOBAL_LIST_INIT(achievement_categories, list("Bosses", "Jobs", "Skills", "Misc", "Mafia", "Scores", "Legacy"))
 ///A list of sounds that can be played when unlocking an achievement, set in the preferences.
 GLOBAL_LIST_INIT(achievement_sounds, list(
 	CHEEVO_SOUND_PING = sound('sound/effects/achievement/glockenspiel_ping.ogg', volume = 70),

--- a/code/datums/achievements/boss_achievements.dm
+++ b/code/datums/achievements/boss_achievements.dm
@@ -120,16 +120,3 @@
 	desc = "MacReady would be proud."
 	database_id = BOSS_MEDAL_THETHING_CRUSHER
 	icon_state = "thething"
-
-//should be removed soon
-/datum/award/achievement/boss/king_goat_kill
-	name = "King Goat Killer"
-	desc = "The king is dead, long live the king!"
-	database_id = BOSS_MEDAL_KINGGOAT
-	icon_state = "goatboss"
-
-/datum/award/achievement/boss/king_goat_crusher
-	name = "King Goat Crusher"
-	desc = "The king is dead, long live the king!"
-	database_id = BOSS_MEDAL_KINGGOAT_CRUSHER
-	icon_state = "goatboss"

--- a/code/datums/achievements/boss_achievements.dm
+++ b/code/datums/achievements/boss_achievements.dm
@@ -120,3 +120,16 @@
 	desc = "MacReady would be proud."
 	database_id = BOSS_MEDAL_THETHING_CRUSHER
 	icon_state = "thething"
+
+//should be removed soon
+/datum/award/achievement/boss/king_goat_kill
+	name = "King Goat Killer"
+	desc = "The king is dead, long live the king!"
+	database_id = BOSS_MEDAL_KINGGOAT
+	icon_state = "goatboss"
+
+/datum/award/achievement/boss/king_goat_crusher
+	name = "King Goat Crusher"
+	desc = "The king is dead, long live the king!"
+	database_id = BOSS_MEDAL_KINGGOAT_CRUSHER
+	icon_state = "goatboss"

--- a/code/datums/achievements/boss_scores.dm
+++ b/code/datums/achievements/boss_scores.dm
@@ -43,11 +43,6 @@
 	desc = "You've killed HOW many?"
 	database_id = LEGION_SCORE
 
-/datum/award/score/swarmer_beacon_score
-	name = "Swarmer Beacons Killed"
-	desc = "You've killed HOW many?"
-	database_id = SWARMER_BEACON_SCORE
-
 /datum/award/score/wendigo_score
 	name = "Wendigos Killed"
 	desc = "You've killed HOW many?"

--- a/code/datums/achievements/boss_scores.dm
+++ b/code/datums/achievements/boss_scores.dm
@@ -43,6 +43,11 @@
 	desc = "You've killed HOW many?"
 	database_id = LEGION_SCORE
 
+/datum/award/score/swarmer_beacon_score
+	name = "Swarmer Beacons Killed"
+	desc = "You've killed HOW many?"
+	database_id = SWARMER_BEACON_SCORE
+
 /datum/award/score/wendigo_score
 	name = "Wendigos Killed"
 	desc = "You've killed HOW many?"

--- a/code/datums/achievements/legacy_achievements.dm
+++ b/code/datums/achievements/legacy_achievements.dm
@@ -1,0 +1,27 @@
+/datum/award/achievement/legacy
+	category = "Legacy"
+
+/datum/award/score/legacy
+	category = "Legacy"
+
+/datum/award/achievement/legacy/king_goat_kill
+	name = "King Goat Killer"
+	desc = "The king is dead, long live the king!"
+	database_id = BOSS_MEDAL_KINGGOAT
+	icon_state = "goatboss"
+
+/datum/award/achievement/legacy/king_goat_crusher
+	name = "King Goat Crusher"
+	desc = "The king is dead, long live the king!"
+	database_id = BOSS_MEDAL_KINGGOAT_CRUSHER
+	icon_state = "goatboss"
+
+/datum/award/score/legacy/swarmer_beacon_score
+	name = "Swarmer Beacons Killed"
+	desc = "You've killed HOW many?"
+	database_id = SWARMER_BEACON_SCORE
+
+/datum/award/score/legacy/king_goat_score
+	name = "King Goats Killed"
+	desc = "You've killed HOW many?"
+	database_id = KINGGOAT_SCORE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -920,6 +920,7 @@
 #include "code\datums\achievements\boss_scores.dm"
 #include "code\datums\achievements\job_achievements.dm"
 #include "code\datums\achievements\job_scores.dm"
+#include "code\datums\achievements\legacy_achievements.dm"
 #include "code\datums\achievements\mafia_achievements.dm"
 #include "code\datums\achievements\misc_achievements.dm"
 #include "code\datums\achievements\misc_scores.dm"


### PR DESCRIPTION

## About The Pull Request

Removes the King Goat achievement datums, due to the boss being removed about 6 years ago.
Removes the defines for the King Goat achievements and boss score.
Additionally removes the Swarmer Beacon score datum and defines, due to it being removed a while ago.

## Why It's Good For The Game

Neither of them have been in the game for a long while, and while both of them were removed, the achievements and tracked kills not being removed as well should be dealt with.

## Changelog
:cl:
del: Removed the King Goat achievements and Swarmer Beacon score.
/:cl:
