### PR TITLE
FIX TTS reading messages outside of your clear hearing range

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -343,7 +343,8 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			if(deaf_message)
 				deaf_type = MSG_VISUAL
 				message = deaf_message
-				return show_message(message, MSG_VISUAL, deaf_message, deaf_type, avoid_highlight)
+				show_message(message, MSG_VISUAL, deaf_message, deaf_type, avoid_highlight)
+				return FALSE // Return false so TTS doesn't attempt to read this message.
 			return FALSE
 		// Out of message range but within eavesdrop range - alter displayed message
 		if(outside_dist > 0)


### PR DESCRIPTION

## About The Pull Request
This pull request fixes #97308 ,
**The Issue**
If someone is speaking in-game next to you but outside of your range, to be clear, you can still hear the TTS of their message.

This ensures that any message that isn't fully in hearing range will not be played by TTS.

(( I have not tested this as I have no idea how to set up TTS, this should in theory still fix the issue. ))

## Why It's Good For The Game
Bug Fix.

## Changelog
:cl: Richard Blonski
fix: Fixed TTS playing on messages that are out of range to be understood.
/:cl:
