### PR TITLE
Fixes a few ai controller hard dels

### DIFF
--- a/code/datums/actions/mobs/create_legion_skull.dm
+++ b/code/datums/actions/mobs/create_legion_skull.dm
@@ -16,4 +16,4 @@
 /datum/action/cooldown/mob_cooldown/create_legion_skull/proc/create(atom/target)
 	var/mob/living/basic/mining/legion_brood/minion = new(owner.loc)
 	minion.assign_creator(owner)
-	minion.ai_controller.blackboard[BB_CURRENT_TARGET] = target
+	minion.ai_controller.set_blackboard_key(BB_CURRENT_TARGET, target)

--- a/code/datums/ai/generic_decorators/pawn_buckled_to_obj.dm
+++ b/code/datums/ai/generic_decorators/pawn_buckled_to_obj.dm
@@ -14,5 +14,5 @@
 	var/mob/living/pawn = controller.pawn
 	if(!isobj(pawn.buckled))
 		return FALSE
-	controller.blackboard[target_key] = pawn.buckled
+	controller.set_blackboard_key(target_key, pawn.buckled)
 	return TRUE

--- a/code/datums/ai/generic_decorators/pawn_contained_in_obj.dm
+++ b/code/datums/ai/generic_decorators/pawn_contained_in_obj.dm
@@ -14,5 +14,5 @@
 	var/mob/living/pawn = controller.pawn
 	if(isturf(pawn.loc) || ismob(pawn.loc) || istype(pawn.loc, /obj/item/mob_holder) || HAS_TRAIT(controller.pawn, TRAIT_MOVE_VENTCRAWLING))
 		return FALSE
-	controller.blackboard[target_key] = pawn.loc
+	controller.set_blackboard_key(target_key, pawn.loc)
 	return TRUE

--- a/code/modules/bitrunning/virtual_domain/domains/heretic_hunt.dm
+++ b/code/modules/bitrunning/virtual_domain/domains/heretic_hunt.dm
@@ -16,7 +16,7 @@
 
 	for(var/mob/living/basic/heretic_summon/helper in created_atoms)
 		helper.ai_controller = new /datum/ai_controller/basic_controller/simple/simple_hostile(helper)
-		helper.ai_controller.blackboard[BB_BASIC_MOB_IDLE_WALK_CHANCE] = 0.1
+		helper.ai_controller.set_blackboard_key(BB_BASIC_MOB_IDLE_WALK_CHANCE, 0.1)
 
 	var/obj/effect/heretic_rune/big/rune = locate() in created_atoms
 	rune.set_greyscale(pick(assoc_to_values(GLOB.heretic_path_to_color)))

--- a/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
@@ -113,7 +113,11 @@
 
 	// Inherit our creator's target and reinforcement requests
 	ai_controller.set_blackboard_key(BB_CURRENT_TARGET, creator.ai_controller.blackboard[BB_CURRENT_TARGET])
-	ai_controller.set_blackboard_key(BB_MINING_MOB_REINFORCEMENTS_REQUESTS, creator.ai_controller.blackboard[BB_MINING_MOB_REINFORCEMENTS_REQUESTS])
+	// Own and track each inherited target independently of our creator's controller
+	var/list/reinforcement_requests = creator.ai_controller.blackboard[BB_MINING_MOB_REINFORCEMENTS_REQUESTS]
+	for (var/target, requests_entry in reinforcement_requests)
+		var/list/request_times = requests_entry
+		ai_controller.set_blackboard_key_assoc_lazylist(BB_MINING_MOB_REINFORCEMENTS_REQUESTS, target, request_times.Copy())
 
 /// Reference handling
 /mob/living/basic/mining/legion_brood/proc/creator_destroyed()


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/97425

Initially sought out to fix this:

```
REF SEARCH Beginning search for references to a /obj/effect/unburrow, looking for 1 refs.
REF SEARCH Finished searching globals
REF SEARCH Finished searching native globals
REF SEARCH Finished searching atoms
REF SEARCH Found /obj/effect/unburrow [0x200de84] in list Datums -> /datum/controller/subsystem/garbage [0x2100001b] -> queues (list) -> /list (list) -> /list (list).
REF SEARCH Datums -> /datum/controller/subsystem/garbage [0x2100001b] -> queues (list) -> /list (list) -> /list (list) does not count as a ref for our count
REF SEARCH Found /obj/effect/unburrow [0x200de84] in list Datums -> /datum/ai_controller/basic_controller/mook [0x2100bce7] -> blackboard (list)[BB_basic_mob_escape_target]
REF SEARCH All references to /obj/effect/unburrow [0x200de84] found, exiting.
REF SEARCH Finished searching datums
TESTING: GC: -- [0x200de84] | /obj/effect/unburrow was unable to be GC'd -- (ref count of 3)
```

But found a number of similar issues. Keys being set without tracking them for deletion, then release() would delete it while the blackboard still holds a ref.

## Why It's Good For The Game

Fixes some flaky ci runtimes that have been cropping up a lot

## Changelog

Not really player-facing