### PR TITLE
Stops bubblegum from harassing CI further

### DIFF
--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -757,6 +757,9 @@
 
 /datum/move_loop/has_target/move_towards/proc/handle_move(source, atom/OldLoc, Dir, Forced = FALSE)
 	SIGNAL_HANDLER
+	if(QDELETED(src))
+		return
+
 	if(moving.loc != moving_towards && home) //If we didn't go where we should have, update slope to account for the deviation
 		update_slope()
 
@@ -777,6 +780,8 @@
 **/
 /datum/move_loop/has_target/move_towards/proc/update_slope()
 	SIGNAL_HANDLER
+	if(QDELETED(src))
+		return
 
 	//You'll notice this is rise over run, except we flip the formula upside down depending on the larger number
 	//This is so we never move more then one tile at once


### PR DESCRIPTION
## About The Pull Request

<img width="1854" height="778" alt="firefox_uTv7iCTmSQ" src="https://github.com/user-attachments/assets/f0d72092-e71c-4216-b28a-7f73dc79ceb9" />

There's another separate issue found in one of the CI runs I saw with bubblegum. `Moved()` queues signal callbacks, then an earlier callback deletes the movement loop, `Destroy()` clears moving, and finally that loop’s handle_move() is invoked, causing null.loc.

## Why It's Good For The Game

Bubblegum stahp

## Changelog

Not player facing