### PR TITLE
Clown op uplink refresh

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -429,6 +429,8 @@
 #define SLIPPERY_WHEN_LYING_DOWN (1<<6)
 ///Like sliding, but it's short, it doesn't knockdown, it doesn't stun, it just staggers a bit.
 #define WEAK_SLIDE (1<<7)
+/// You can even slip if you're experiencing nograv or flying
+#define SLIP_IN_NOGRAV (1<<8)
 
 #define MAX_CHICKENS 50
 

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -27,6 +27,8 @@
 	var/daze_time = 3 SECONDS
 	/// Flags for how slippery the parent is. See [__DEFINES/mobs.dm]
 	var/lube_flags
+	/// If we slip when we are attacked with
+	var/slip_on_damage = FALSE
 	/// Optional callback allowing you to define custom conditions for slipping
 	var/datum/callback/can_slip_callback
 	/// Optional call back that is called when a mob slips on this component
@@ -59,6 +61,7 @@
  * * force_drop - should the crossing mob drop items in its hands or not
  * * slot_whitelist - flags controlling where on a mob this item can be equipped to make the parent mob slippery full list [here][ITEM_SLOT_OCLOTHING]
  * * datum/callback/on_slip_callback - Callback to add custom behaviours as the crossing mob is slipped
+ * * slip_on_damage - whether the component should cause slipping when the parent attacks the target
  */
 /datum/component/slippery/Initialize(
 	knockdown,
@@ -69,6 +72,7 @@
 	force_drop = FALSE,
 	slot_whitelist,
 	datum/callback/can_slip_callback,
+	slip_on_damage = FALSE,
 )
 	src.knockdown_time = max(knockdown, 0)
 	src.paralyze_time = max(paralyze, 0)
@@ -89,6 +93,9 @@
 		RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
 		RegisterSignal(parent, COMSIG_ITEM_APPLY_FANTASY_BONUSES, PROC_REF(apply_fantasy_bonuses))
 		RegisterSignal(parent, COMSIG_ITEM_REMOVE_FANTASY_BONUSES, PROC_REF(remove_fantasy_bonuses))
+		if(slip_on_damage)
+			RegisterSignal(parent, COMSIG_ITEM_AFTERATTACK, PROC_REF(slip_on_afterattack))
+			RegisterSignal(parent, COMSIG_MOVABLE_IMPACT, PROC_REF(slip_on_throw_impact))
 
 /datum/component/slippery/Destroy(force)
 	can_slip_callback = null
@@ -135,6 +142,7 @@
 	force_drop = FALSE,
 	slot_whitelist,
 	datum/callback/can_slip_callback,
+	slip_on_damage = FALSE,
 )
 	if(component)
 		knockdown = component.knockdown_time
@@ -171,7 +179,7 @@
 		if(HAS_TRAIT(turf, TRAIT_TURF_IGNORE_SLIPPERY))
 			return
 	var/mob/living/victim = arrived
-	if(victim.movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
+	if((victim.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) && !(lube_flags & SLIP_IN_NOGRAV))
 		return
 	if(can_slip_callback && !can_slip_callback.Invoke(holder, victim))
 		return
@@ -247,3 +255,19 @@
 /datum/component/slippery/UnregisterFromParent()
 	. = ..()
 	qdel(GetComponent(/datum/component/connect_loc_behalf))
+
+/datum/component/slippery/proc/slip_on_afterattack(datum/source, atom/target, mob/user, ...)
+	SIGNAL_HANDLER
+
+	if(!slip_on_damage || !isliving(target))
+		return
+
+	Slip(source, target)
+
+/datum/component/slippery/proc/slip_on_throw_impact(datum/source, atom/hit_atom, datum/thrownthing/throwing_datum, caught)
+	SIGNAL_HANDLER
+
+	if(!slip_on_damage || !isliving(hit_atom) || caught)
+		return
+
+	Slip(source, hit_atom)

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -94,9 +94,8 @@
 		RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
 		RegisterSignal(parent, COMSIG_ITEM_APPLY_FANTASY_BONUSES, PROC_REF(apply_fantasy_bonuses))
 		RegisterSignal(parent, COMSIG_ITEM_REMOVE_FANTASY_BONUSES, PROC_REF(remove_fantasy_bonuses))
-		if(slip_on_damage)
-			RegisterSignal(parent, COMSIG_ITEM_AFTERATTACK, PROC_REF(slip_on_afterattack))
-			RegisterSignal(parent, COMSIG_MOVABLE_IMPACT, PROC_REF(slip_on_throw_impact))
+		RegisterSignal(parent, COMSIG_ITEM_AFTERATTACK, PROC_REF(slip_on_afterattack))
+		RegisterSignal(parent, COMSIG_MOVABLE_IMPACT, PROC_REF(slip_on_throw_impact))
 
 /datum/component/slippery/Destroy(force)
 	can_slip_callback = null

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -81,6 +81,7 @@
 	src.lube_flags = lube_flags
 	src.can_slip_callback = can_slip_callback
 	src.on_slip_callback = on_slip_callback
+	src.slip_on_damage = slip_on_damage
 	if(slot_whitelist)
 		src.slot_whitelist = slot_whitelist
 
@@ -148,7 +149,7 @@
 		knockdown = component.knockdown_time
 		lube_flags = component.lube_flags
 		on_slip_callback = component.on_slip_callback
-		can_slip_callback = component.on_slip_callback
+		can_slip_callback = component.can_slip_callback
 		paralyze = component.paralyze_time
 		daze = component.daze_time
 		force_drop = component.force_drop_items
@@ -161,6 +162,7 @@
 	src.lube_flags = lube_flags
 	src.on_slip_callback = on_slip_callback
 	src.can_slip_callback = can_slip_callback
+	src.slip_on_damage = slip_on_damage
 	if(slot_whitelist)
 		src.slot_whitelist = slot_whitelist
 /**

--- a/code/game/atom/atom_act.dm
+++ b/code/game/atom/atom_act.dm
@@ -160,7 +160,7 @@
 
 ///Handle the atom being slipped over
 /atom/proc/handle_slip(mob/living/carbon/slipped_carbon, knockdown_amount, obj/slipping_object, lube, paralyze, daze, force_drop)
-	return
+	return FALSE
 
 ///Used for making a sound when a mob involuntarily falls into the ground.
 /atom/proc/handle_fall(mob/faller)

--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -189,6 +189,21 @@
 		Upon arming, attempts to sync with any other detected microexplosives for increased detonation yield; \
 		the handshake process between microbombs, however, takes a bit, and only gets longer as more microbombs are detected."
 
+// Version with the same appearance and delay as a macrobomb, but is actually a microbomb with a surprise!
+/obj/item/implant/explosive/macro/fake
+	explosion_light = /obj/item/implant/explosive::explosion_light
+	explosion_heavy = /obj/item/implant/explosive::explosion_heavy
+	explosion_devastate = /obj/item/implant/explosive::explosion_devastate
+
+/obj/item/implant/explosive/macro/fake/explode(atom/override_explode_target)
+	honkerblast(
+		origin = override_explode_target || src,
+		light_range = /obj/item/implant/explosive/macro::explosion_light * 0.5,
+		medium_range = /obj/item/implant/explosive/macro::explosion_heavy * 0.5,
+		heavy_range = /obj/item/implant/explosive/macro::explosion_devastate * 0.5,
+	)
+	return ..()
+
 ///Microbomb which prevents you from going into critical condition but also explodes after a timer when you reach critical condition in the first place.
 /obj/item/implant/explosive/deniability
 	name = "tactical deniability implant"
@@ -247,6 +262,10 @@
 /obj/item/implanter/explosive_macro
 	name = "implanter (macrobomb)"
 	imp_type = /obj/item/implant/explosive/macro
+
+/obj/item/implanter/explosive_macro/fake
+	name = "implanter (fake macrobomb)"
+	imp_type = /obj/item/implant/explosive/macro/fake
 
 /obj/item/implanter/tactical_deniability
 	name = "implanter (tactical deniability)"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -794,6 +794,8 @@
 
 	// You need this for the gun
 	new /obj/item/dnainjector/clumsymut(src)
+	// And a bonus
+	new /obj/item/reagent_containers/spray/waterflower/lube/super(src)
 
 /obj/item/implanter/induction_implant
 	name = "implanter (nuclear operative)"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -412,10 +412,15 @@
 
 /obj/item/storage/box/syndie_kit/clownpins
 	name = "ultra hilarious firing pin box"
+	var/pin_type = /obj/item/firing_pin/clown/ultra
 
 /obj/item/storage/box/syndie_kit/clownpins/PopulateContents()
-	for(var/i in 1 to 7)
-		new /obj/item/firing_pin/clown/ultra(src)
+	for(var/i in 1 to 4)
+		new pin_type(src)
+
+/obj/item/storage/box/syndie_kit/clownpins/super
+	name = "super ultra hilarious firing pin box"
+	pin_type = /obj/item/firing_pin/clown/ultra/selfdestruct
 
 /obj/item/storage/box/syndie_kit/imp_storage
 	name = "storage implant box"
@@ -742,13 +747,11 @@
 /obj/item/storage/box/syndie_kit/induction_kit
 	name = "syndicate induction kit"
 	desc = "Contains all you need for introducing your newest comrade to the Syndicate and all its worker's benefits."
+	var/implant_type = /obj/item/implanter/induction_implant
 
 /obj/item/storage/box/syndie_kit/induction_kit/PopulateContents()
 	// Basic weaponry, so they have something to use.
-	new /obj/item/gun/ballistic/automatic/pistol/clandestine(src) // 6 TC, but free for nukies
-	new /obj/item/ammo_box/magazine/m10mm/hp(src) // 3 TC, a reward for the teamwork involved
-	new /obj/item/ammo_box/magazine/m10mm/ap(src) // 3 TC, a reward for the teamwork involved
-	new /obj/item/pen/edagger(src) // 2 TC
+	give_weaponry()
 	// The necessary equipment to help secure that disky.
 	new /obj/item/radio/headset/syndicate/alt(src) // 5 TC / Free for nukies
 	new /obj/item/modular_computer/pda/nukeops(src) // ?? TC / Free for nukies
@@ -764,22 +767,48 @@
 	new /obj/item/clothing/gloves/fingerless(src)
 	new /obj/item/book/manual/nuclear(src) // Very important
 	// The most important part of the kit, the implant that gives them the syndicate faction.
-	new /obj/item/implanter/induction_implant(src)
+	new implant_type(src)
 	// Tactical map implant so they can see the minimap with the rest of the team.
 	new /obj/item/implanter/tacmap/nuclear(src)
 	// All in all, 6+3+3+2+5+2+4 = ~25 TC of 'miscellaneous' items.
 	// This is a lot of value for 10 TC, but you have to keep in mind that you NEED someone to get this stuff station-side.
 	// Pretty much all of it is a bad deal for reinforcements or yourself as they already have similar or good-enough alternatives.
 
+/obj/item/storage/box/syndie_kit/induction_kit/proc/give_weaponry()
+	new /obj/item/gun/ballistic/automatic/pistol/clandestine(src) // 6 TC, but free for nukies
+	new /obj/item/ammo_box/magazine/m10mm/hp(src) // 3 TC, a reward for the teamwork involved
+	new /obj/item/ammo_box/magazine/m10mm/ap(src) // 3 TC, a reward for the teamwork involved
+	new /obj/item/pen/edagger(src) // 2 TC
+
+/obj/item/storage/box/syndie_kit/induction_kit/clown
+	name = "syndicate circus induction kit"
+	desc = "A special induction kit for joining the syndicate circus."
+	implant_type = /obj/item/implanter/induction_implant/clown
+
+/obj/item/storage/box/syndie_kit/induction_kit/clown/give_weaponry()
+	// Toy gun instead of real gun
+	var/obj/item/gun/ballistic/automatic/pistol/toy/riot/clandestine/gun = new(src)
+	qdel(gun.pin)
+	var/obj/item/firing_pin/clown/ultra/new_pin = new()
+	new_pin.gun_insert(null, gun, TRUE)
+
+	// You need this for the gun
+	new /obj/item/dnainjector/clumsymut(src)
+
 /obj/item/implanter/induction_implant
 	name = "implanter (nuclear operative)"
 	desc = "A sterile automatic implant injector. You can see a tiny, somehow legible sticker on the side: 'NOT A BRAINWASH DEVICE'"
 	imp_type = /obj/item/implant/nuclear_operative
 
+/obj/item/implanter/induction_implant/clown
+	name = "implanter (syndicate circus)"
+	imp_type = /obj/item/implant/nuclear_operative/clown
+
 /obj/item/implant/nuclear_operative
 	name = "nuclear operative implant"
 	desc = "Registers you as a member of a Syndicate nuclear operative team."
 	implant_color = "r"
+	var/antag_datum_type = /datum/antagonist/nukeop
 
 /obj/item/implant/nuclear_operative/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
 	. = ..()
@@ -799,12 +828,12 @@
 			human_target.reagents.add_reagent(/datum/reagent/toxin, 2)
 			return FALSE
 
-	if(!human_target.is_antag()) // GTFO. Technically not foolproof but making a heartbreaker or a paradox clone a nuke op sounds hilarious
+	if(is_valid_inductee(target)) // GTFO. Technically not foolproof but making a heartbreaker or a paradox clone a nuke op sounds hilarious
 		to_chat(human_target, span_notice("Huh? Nothing happened? But you're starting to feel a little ill..."))
 		human_target.reagents.add_reagent(/datum/reagent/toxin, 15)
 		return FALSE
 
-	var/datum/antagonist/nukeop/nuke_datum = new()
+	var/datum/antagonist/nukeop/nuke_datum = new antag_datum_type()
 	nuke_datum.send_to_spawnpoint = FALSE
 	nuke_datum.give_bonus_tc = FALSE
 	nuke_datum.nukeop_outfit = null
@@ -824,6 +853,17 @@
 	to_chat(target, span_notice("You feel a little less nuclear."))
 	to_chat(target, span_userdanger("You're no longer identified as a nuclear operative! You are free to follow any valid goals you wish, even continuing to secure the disk. Just make sure neither any turrets nor operatives kill you on sight."))
 	return TRUE
+
+/obj/item/implant/nuclear_operative/proc/is_valid_inductee(mob/living/target)
+	return target.is_antag()
+
+/obj/item/implant/nuclear_operative/clown
+	name = "syndicate circus implant"
+	desc = "Registers the wearer as a member of the syndicate circus."
+	antag_datum_type = /datum/antagonist/nukeop/clownop
+
+/obj/item/implant/nuclear_operative/clown/is_valid_inductee(mob/living/target)
+	return HAS_MIND_TRAIT(target, TRAIT_CLUMSY) || HAS_MIND_TRAIT(target, TRAIT_NAIVE) || ..()
 
 /obj/item/storage/box/syndie_kit/poster_box
 	name = "syndicate poster pack"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -391,6 +391,12 @@
 /obj/item/storage/box/syndie_kit/imp_macrobomb/PopulateContents()
 	new /obj/item/implanter/explosive_macro(src)
 
+/obj/item/storage/box/syndie_kit/imp_macrobomb_fake
+	name = "fake macrobomb implant box"
+
+/obj/item/storage/box/syndie_kit/imp_macrobomb_fake/PopulateContents()
+	new /obj/item/implanter/explosive_macro/clown(src)
+
 /obj/item/storage/box/syndie_kit/imp_deniability
 	name = "tactical deniability implant box"
 

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -395,7 +395,7 @@
 	name = "fake macrobomb implant box"
 
 /obj/item/storage/box/syndie_kit/imp_macrobomb_fake/PopulateContents()
-	new /obj/item/implanter/explosive_macro/clown(src)
+	new /obj/item/implanter/explosive_macro/fake(src)
 
 /obj/item/storage/box/syndie_kit/imp_deniability
 	name = "tactical deniability implant box"

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -523,10 +523,11 @@
 	return TRUE
 
 /turf/open/handle_slip(mob/living/slipper, knockdown_amount, obj/slippable, lube, paralyze_amount, daze_amount, force_drop)
-	if(slipper.movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
-		return FALSE
-	if(!has_gravity(src))
-		return FALSE
+	if(!(lube & SLIP_IN_NOGRAV))
+		if(slipper.movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
+			return FALSE
+		if(!has_gravity(src))
+			return FALSE
 
 	var/slide_distance = 4
 	if(lube & SLIDE_ICE)

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -125,7 +125,7 @@ GLOBAL_LIST_EMPTY(starlight)
 	return attack_hand(user, modifiers)
 
 /turf/open/space/handle_slip()
-	return
+	return FALSE
 
 /turf/open/space/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	. = ..()

--- a/code/modules/antagonists/clown_ops/clown_weapons.dm
+++ b/code/modules/antagonists/clown_ops/clown_weapons.dm
@@ -67,7 +67,7 @@
 		lube_flags = GALOSHES_DONT_HELP|SLIP_WHEN_CRAWLING, \
 		force_drop_items = TRUE, \
 		can_slip_callback = CALLBACK(src, PROC_REF(is_active)), \
-		slip_on_damage = TRUE,
+		slip_on_damage = TRUE, \
 	)
 
 /obj/item/melee/energy/sword/bananium/proc/make_less_slippery()
@@ -77,7 +77,7 @@
 		lube_flags = GALOSHES_DONT_HELP, \
 		force_drop_items = FALSE, \
 		can_slip_callback = CALLBACK(src, PROC_REF(is_active)), \
-		slip_on_damage = FALSE,
+		slip_on_damage = FALSE, \
 	)
 
 /obj/item/melee/energy/sword/bananium/proc/is_active()

--- a/code/modules/antagonists/clown_ops/clown_weapons.dm
+++ b/code/modules/antagonists/clown_ops/clown_weapons.dm
@@ -10,6 +10,9 @@
 	volume = 30
 	list_reagents = list(/datum/reagent/lube = 30)
 
+/obj/item/reagent_containers/spray/waterflower/lube/super
+	list_reagents = list(/datum/reagent/lube/superlube = 30)
+
 //BANANIUM SWORD
 
 /obj/item/melee/energy/sword/bananium
@@ -35,32 +38,50 @@
 		attack_verb_simple_on = list("slip"), \
 		clumsy_check = FALSE, \
 	)
-	RegisterSignal(src, COMSIG_TRANSFORMING_ON_TRANSFORM, PROC_REF(on_transform))
+	make_less_slippery()
 
 /obj/item/melee/energy/sword/bananium/on_transform(obj/item/source, mob/user, active)
 	. = ..()
-	adjust_slipperiness()
-
-/*
- * Adds or removes a slippery component, depending on whether the sword is active or not.
- */
-/obj/item/melee/energy/sword/bananium/proc/adjust_slipperiness()
 	if(HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
-		AddComponent(/datum/component/slippery, 60, GALOSHES_DONT_HELP)
+		ADD_TRAIT(src, TRAIT_CUSTOM_TAP_SOUND, INNATE_TRAIT)
+		hitsound = 'sound/misc/slip.ogg'
 	else
-		qdel(GetComponent(/datum/component/slippery))
+		REMOVE_TRAIT(src, TRAIT_CUSTOM_TAP_SOUND, INNATE_TRAIT)
+		hitsound = initial(hitsound)
 
-/obj/item/melee/energy/sword/bananium/attack(mob/living/M, mob/living/user)
+/obj/item/melee/energy/sword/bananium/equipped(mob/user, slot, initial)
 	. = ..()
-	if(HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
-		var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
-		slipper.Slip(src, M)
+	if((slot & ITEM_SLOT_HANDS) && HAS_TRAIT(user, TRAIT_CLUMSY))
+		make_very_slippery()
+	else
+		make_less_slippery()
 
-/obj/item/melee/energy/sword/bananium/throw_impact(atom/hit_atom, throwingdatum)
+/obj/item/melee/energy/sword/bananium/dropped(mob/user, silent)
 	. = ..()
-	if(HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
-		var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
-		slipper.Slip(src, hit_atom)
+	make_less_slippery()
+
+/obj/item/melee/energy/sword/bananium/proc/make_very_slippery()
+	AddComponent( \
+		/datum/component/slippery, \
+		knockdown = 8 SECONDS, \
+		lube_flags = GALOSHES_DONT_HELP|SLIP_WHEN_CRAWLING, \
+		force_drop_items = TRUE, \
+		can_slip_callback = CALLBACK(src, PROC_REF(is_active)), \
+		slip_on_damage = TRUE,
+	)
+
+/obj/item/melee/energy/sword/bananium/proc/make_less_slippery()
+	AddComponent( \
+		/datum/component/slippery, \
+		knockdown = 4 SECONDS, \
+		lube_flags = GALOSHES_DONT_HELP, \
+		force_drop_items = FALSE, \
+		can_slip_callback = CALLBACK(src, PROC_REF(is_active)), \
+		slip_on_damage = FALSE,
+	)
+
+/obj/item/melee/energy/sword/bananium/proc/is_active()
+	return HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE)
 
 /obj/item/melee/energy/sword/bananium/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(!istype(tool, /obj/item/melee/energy/sword/bananium))
@@ -78,8 +99,7 @@
 	if(!HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
 		attack_self(user)
 	user.visible_message(span_suicide("[user] is [pick("slitting [user.p_their()] stomach open with", "falling on")] [src]! It looks like [user.p_theyre()] trying to commit seppuku, but the blade slips off of [user.p_them()] harmlessly!"))
-	var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
-	slipper.Slip(src, user)
+	user.attackby(src, user)
 	return SHAME
 
 //BANANIUM SHIELD
@@ -99,30 +119,37 @@
 	active_throw_speed = 1
 	can_clumsy_use = TRUE
 
+	hitsound = 'sound/misc/slip.ogg'
+
 /obj/item/shield/energy/bananium/on_transform(obj/item/source, mob/user, active)
 	. = ..()
-	adjust_comedy()
-
-/*
- * Adds or removes a slippery and boomerang component, depending on whether the shield is active or not.
- */
-/obj/item/shield/energy/bananium/proc/adjust_comedy()
 	if(HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
-		AddComponent(/datum/component/slippery, 60, GALOSHES_DONT_HELP)
-		AddComponent(/datum/component/boomerang, throw_range+2, TRUE)
+		AddComponent(/datum/component/slippery, 6 SECONDS, GALOSHES_DONT_HELP, slip_on_damage = TRUE, can_slip_callback = CALLBACK(src, PROC_REF(is_active)))
+		if(HAS_TRAIT(user, TRAIT_CLUMSY))
+			AddComponent(/datum/component/boomerang, throw_range + 2, TRUE)
+		else
+			AddComponent(/datum/component/boomerang, throw_range + 1)
+		ADD_TRAIT(src, TRAIT_CUSTOM_TAP_SOUND, INNATE_TRAIT)
+		hitsound = 'sound/misc/slip.ogg'
+
 	else
 		qdel(GetComponent(/datum/component/slippery))
 		qdel(GetComponent(/datum/component/boomerang))
+		REMOVE_TRAIT(src, TRAIT_CUSTOM_TAP_SOUND, INNATE_TRAIT)
+		hitsound = initial(hitsound)
 
-/obj/item/shield/energy/bananium/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-	if(HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
-		var/caught = hit_atom.hitby(src, FALSE, FALSE, throwingdatum=throwingdatum)
-		if(iscarbon(hit_atom) && !caught)//if they are a carbon and they didn't catch it
-			var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
-			slipper.Slip(src, hit_atom)
+/obj/item/shield/energy/bananium/proc/is_active()
+	return HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE)
+
+/obj/item/shield/energy/bananium/equipped(mob/user, slot, initial)
+	. = ..()
+	if(!HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
+		return
+
+	if(HAS_TRAIT(user, TRAIT_CLUMSY))
+		AddComponent(/datum/component/boomerang, throw_range + 2, TRUE)
 	else
-		return ..()
-
+		AddComponent(/datum/component/boomerang, throw_range + 1)
 
 //BOMBANANA
 

--- a/code/modules/antagonists/clown_ops/clown_weapons.dm
+++ b/code/modules/antagonists/clown_ops/clown_weapons.dm
@@ -57,10 +57,6 @@
 	else
 		make_less_slippery()
 
-/obj/item/melee/energy/sword/bananium/dropped(mob/user, silent)
-	. = ..()
-	make_less_slippery()
-
 /obj/item/melee/energy/sword/bananium/proc/make_very_slippery()
 	AddComponent( \
 		/datum/component/slippery, \

--- a/code/modules/antagonists/clown_ops/clown_weapons.dm
+++ b/code/modules/antagonists/clown_ops/clown_weapons.dm
@@ -39,6 +39,7 @@
 		clumsy_check = FALSE, \
 	)
 	make_less_slippery()
+	RegisterSignal(src, COMSIG_TRANSFORMING_ON_TRANSFORM, PROC_REF(on_transform))
 
 /obj/item/melee/energy/sword/bananium/on_transform(obj/item/source, mob/user, active)
 	. = ..()
@@ -65,7 +66,7 @@
 		/datum/component/slippery, \
 		knockdown = 8 SECONDS, \
 		lube_flags = GALOSHES_DONT_HELP|SLIP_WHEN_CRAWLING, \
-		force_drop_items = TRUE, \
+		force_drop = TRUE, \
 		can_slip_callback = CALLBACK(src, PROC_REF(is_active)), \
 		slip_on_damage = TRUE, \
 	)
@@ -75,7 +76,7 @@
 		/datum/component/slippery, \
 		knockdown = 4 SECONDS, \
 		lube_flags = GALOSHES_DONT_HELP, \
-		force_drop_items = FALSE, \
+		force_drop = FALSE, \
 		can_slip_callback = CALLBACK(src, PROC_REF(is_active)), \
 		slip_on_damage = FALSE, \
 	)

--- a/code/modules/antagonists/clown_ops/outfits.dm
+++ b/code/modules/antagonists/clown_ops/outfits.dm
@@ -2,19 +2,16 @@
 	name = "Clown Operative - Basic"
 	uniform = /obj/item/clothing/under/syndicate
 	shoes = /obj/item/clothing/shoes/clown_shoes/combat
-	mask = /obj/item/clothing/mask/gas/clown_hat
+	mask = /obj/item/clothing/mask/gas/clown_hat/clownops
 	gloves = /obj/item/clothing/gloves/combat
 	back = /obj/item/storage/backpack/clown
 	ears = /obj/item/radio/headset/syndicate/alt
-	l_pocket = /obj/item/pinpointer/nuke/syndicate
+	l_pocket = /obj/item/modular_computer/pda/nukeops
 	r_pocket = /obj/item/bikehorn
 	id = /obj/item/card/id/advanced/chameleon/elite
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/toy/riot/clandestine = 1, //The clown op equivalent to the Ansem
-		/obj/item/pen/edagger = 1,
-		/obj/item/dnainjector/clumsymut = 1, //in case you want to be clumsy for the memes
-		/obj/item/storage/box/syndie_kit/clownpins = 1, //for any guns that you get your grubby little clown op mitts on
-		/obj/item/reagent_containers/spray/waterflower/lube = 1,
+		/obj/item/reagent_containers/spray/waterflower/lube/super = 1,
 		/obj/item/mod/skin_applier/honkerative = 1,
 	)
 	box = /obj/item/storage/box/survival/syndie
@@ -23,6 +20,16 @@
 	uplink_type = /obj/item/uplink/clownop
 
 	id_trim = /datum/id_trim/chameleon/operative/clown
+
+/datum/outfit/syndicate/clownop/post_equip(mob/living/carbon/human/nukie, visuals_only)
+	. = ..()
+	var/obj/item/gun/ballistic/automatic/pistol/toy/riot/clandestine/gun = locate() in back
+	if(!isnull(gun))
+		qdel(gun.pin)
+		var/obj/item/firing_pin/clown/ultra/new_pin = new()
+		new_pin.gun_insert(null, gun, TRUE)
+
+	nukie.dna.add_mutation(/datum/mutation/clumsy, MUTATION_SOURCE_MUTATOR)
 
 /datum/outfit/syndicate/clownop/no_crystals
 	name = "Clown Operative - Reinforcement"

--- a/code/modules/antagonists/clown_ops/outfits.dm
+++ b/code/modules/antagonists/clown_ops/outfits.dm
@@ -9,8 +9,8 @@
 	l_pocket = /obj/item/modular_computer/pda/nukeops
 	r_pocket = /obj/item/bikehorn
 	id = /obj/item/card/id/advanced/chameleon/elite
+	belt = /obj/item/gun/ballistic/automatic/pistol/toy/riot/clandestine
 	backpack_contents = list(
-		/obj/item/gun/ballistic/automatic/pistol/toy/riot/clandestine = 1, //The clown op equivalent to the Ansem
 		/obj/item/reagent_containers/spray/waterflower/lube/super = 1,
 		/obj/item/mod/skin_applier/honkerative = 1,
 	)
@@ -23,11 +23,15 @@
 
 /datum/outfit/syndicate/clownop/post_equip(mob/living/carbon/human/nukie, visuals_only)
 	. = ..()
-	var/obj/item/gun/ballistic/automatic/pistol/toy/riot/clandestine/gun = locate() in back
+	var/list/nukie_contents = nukie.get_all_contents()
+	var/obj/item/gun/ballistic/automatic/pistol/toy/riot/clandestine/gun = locate() in nukie_contents
 	if(!isnull(gun))
 		qdel(gun.pin)
 		var/obj/item/firing_pin/clown/ultra/new_pin = new()
 		new_pin.gun_insert(null, gun, TRUE)
+
+	var/obj/item/clothing/mask/gas/syndicate/old_mask = locate() in nukie_contents
+	qdel(old_mask)
 
 	nukie.dna.add_mutation(/datum/mutation/clumsy, MUTATION_SOURCE_MUTATOR)
 

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -349,6 +349,13 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 		to_chat(user, span_notice("Your Clown Mask has now morphed into [choice], all praise the Honkmother!"))
 		return TRUE
 
+/obj/item/clothing/mask/gas/clown_hat/clownops
+	name = "tactical clown wig and mask"
+	desc = "A tactical twist on a troubadour's tradition."
+	flash_protect = FLASH_PROTECTION_FLASH
+	resistance_flags = FIRE_PROOF
+	flags_cover = MASKCOVERSEYES | PEPPERPROOF
+
 /obj/item/clothing/mask/gas/sexyclown
 	name = "sexy-clown wig and mask"
 	desc = "A feminine clown mask for the dabbling crossdressers or female entertainers."

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -1,12 +1,10 @@
 /mob/living/carbon/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, daze, force_drop = FALSE)
-	if(movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
-		return FALSE
-	if(!(loc.handle_slip(src, knockdown_amount, slipped_on, lube_flags, paralyze, daze, force_drop)))
+	if(!loc.handle_slip(src, knockdown_amount, slipped_on, lube_flags, paralyze, daze, force_drop))
 		return FALSE
 	if(!(lube_flags & SLIDE_ICE))
 		log_combat(src, (slipped_on || get_turf(src)), "slipped on the", null, ((lube_flags & SLIDE) ? "(SLIDING)" : null))
-	..()
-	return TRUE
+
+	return ..()
 
 /mob/living/carbon/Move(NewLoc, direct)
 	. = ..()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -379,6 +379,7 @@ GAME_VERB_HIDDEN(/client, drop_item, "drop item")
  */
 /mob/proc/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, daze, force_drop = FALSE)
 	SEND_SIGNAL(src, COMSIG_MOB_SLIPPED, knockdown_amount, slipped_on, lube_flags, paralyze, daze, force_drop)
+	return TRUE
 
 /mob/living/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, daze, force_drop = FALSE)
 	add_mob_memory(/datum/memory/was_slipped, antagonist = slipped_on)

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -15,6 +15,7 @@
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 	casing_ejector = FALSE
 	can_muzzle_flash = FALSE
+	min_recoil = 0
 
 /obj/item/gun/ballistic/automatic/toy/riot
 	spawn_magazine_type = /obj/item/ammo_box/magazine/toy/smg/riot
@@ -25,6 +26,7 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/toy/pistol
 	fire_sound = 'sound/items/syringeproj.ogg'
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
+	min_recoil = 0
 
 /obj/item/gun/ballistic/automatic/pistol/toy/riot
 	spawn_magazine_type = /obj/item/ammo_box/magazine/toy/pistol/riot
@@ -51,6 +53,7 @@
 	pb_knockback = 0
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 	can_muzzle_flash = FALSE
+	min_recoil = 0
 
 /obj/item/gun/ballistic/shotgun/toy/handle_chamber(empty_chamber = TRUE, from_firing = TRUE, chamber_next_round = TRUE)
 	. = ..()
@@ -78,6 +81,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	gun_flags = NONE
 	can_muzzle_flash = FALSE
+	min_recoil = 0
 
 /obj/item/gun/ballistic/shotgun/toy/crossbow/riot
 	spawn_magazine_type =  /obj/item/ammo_box/magazine/internal/shot/toy/crossbow/riot
@@ -93,6 +97,7 @@
 	clumsy_check = FALSE
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 	can_muzzle_flash = FALSE
+	min_recoil = 0
 
 /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted //Use this for actual toys
 	pin = /obj/item/firing_pin
@@ -113,6 +118,7 @@
 	clumsy_check = FALSE
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 	can_muzzle_flash = FALSE
+	min_recoil = 0
 
 /obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted //Use this for actual toys
 	pin = /obj/item/firing_pin

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -165,24 +165,19 @@
 	if(QDELETED(user))  //how the hell...?
 		stack_trace("/obj/item/firing_pin/clown/ultra/pin_auth called with a [isnull(user) ? "null" : "invalid"] user.")
 		return TRUE
-	if(HAS_TRAIT(user, TRAIT_CLUMSY)) //clumsy
+	if(HAS_MIND_TRAIT(user, TRAIT_CLUMSY)) // Clumsy, which clowns are usually (but not always)
 		return TRUE
-	if(user.mind)
-		if(is_clown_job(user.mind.assigned_role)) //traitor clowns can use this, even though they're technically not clumsy
-			return TRUE
-		if(user.mind.has_antag_datum(/datum/antagonist/nukeop/clownop)) //clown ops aren't clumsy by default and technically don't have an assigned role of "Clown", but come on, they're basically clowns
-			return TRUE
-		if(user.mind.has_antag_datum(/datum/antagonist/nukeop/leader/clownop)) //Wanna hear a funny joke?
-			return TRUE //The clown op leader antag datum isn't a subtype of the normal clown op antag datum.
+	if(HAS_MIND_TRAIT(user, TRAIT_NAIVE)) // Naive, which clowns are always
+		return TRUE
 	return FALSE
 
 /obj/item/firing_pin/clown/ultra/gun_insert(mob/living/user, obj/item/gun/new_gun, starting = FALSE)
-	..()
+	. = ..()
 	new_gun.clumsy_check = FALSE
 
 /obj/item/firing_pin/clown/ultra/gun_remove(mob/living/user)
 	gun.clumsy_check = initial(gun.clumsy_check)
-	..()
+	return ..()
 
 // Now two times deadlier!
 /obj/item/firing_pin/clown/ultra/selfdestruct

--- a/code/modules/uplink/uplink_items/badass.dm
+++ b/code/modules/uplink/uplink_items/badass.dm
@@ -59,6 +59,7 @@
 	name = "Clown Costume"
 	desc = "Nothing is more terrifying than clowns with fully automatic weaponry."
 	item = /obj/item/storage/backpack/duffelbag/clown/syndie
+	// Not purchaseable from clown ops, because they are already clowns
 
 /datum/uplink_item/badass/costumes/tactical_naptime
 	name = "Sleepy Time Pajama Bundle"
@@ -66,12 +67,14 @@
 	item = /obj/item/storage/box/syndie_kit/sleepytime
 	limited_stock = 1
 	cant_discount = TRUE
+	purchasable_from = parent_type::purchasable_from | UPLINK_CLOWN_OPS
 
 /datum/uplink_item/badass/costumes/obvious_chameleon
 	name = "Broken Chameleon Kit"
 	desc = "A set of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more! \
 			Please note that this kit did NOT pass quality control."
 	item = /obj/item/storage/box/syndie_kit/chameleon/broken
+	purchasable_from = parent_type::purchasable_from | UPLINK_CLOWN_OPS
 
 /datum/uplink_item/badass/costumes/centcom_official
 	name = "CentCom Official Costume"

--- a/code/modules/uplink/uplink_items/clownops.dm
+++ b/code/modules/uplink/uplink_items/clownops.dm
@@ -30,10 +30,10 @@
 	purchasable_from = UPLINK_CLOWN_OPS | UPLINK_SPY
 
 /datum/uplink_item/weapon_kits/clownoppin
-	name = "Ultra Hilarious Firing Pin"
+	name = "Ultra Hilarious Firing Pins"
 	desc = "A firing pin that, when inserted into a gun, makes that gun only useable by clowns and clumsy people and makes that gun honk whenever anyone tries to fire it."
 	cost = 1 //much cheaper for clown ops than for clowns
-	item = /obj/item/firing_pin/clown/ultra
+	item = /obj/item/storage/box/syndie_kit/clownpins
 	purchasable_from = UPLINK_CLOWN_OPS
 	uplink_item_flags = SYNDIE_TRIPS_CONTRABAND
 
@@ -41,7 +41,7 @@
 	name = "Super Ultra Hilarious Firing Pin"
 	desc = "Like the ultra hilarious firing pin, except the gun you insert this pin into explodes when someone who isn't clumsy or a clown tries to fire it."
 	cost = 4 //much cheaper for clown ops than for clowns
-	item = /obj/item/firing_pin/clown/ultra/selfdestruct
+	item = /obj/item/storage/box/syndie_kit/clownpins/super
 	purchasable_from = UPLINK_CLOWN_OPS
 	uplink_item_flags = SYNDIE_TRIPS_CONTRABAND
 
@@ -152,9 +152,10 @@
 	purchasable_from = UPLINK_CLOWN_OPS
 
 /datum/uplink_item/badass/clownopclumsinessinjector //clowns can buy this too, but it's in the role-restricted items section for them
-	name = "Clumsiness Injector"
-	desc = "Inject yourself with this to become as clumsy as a clown... or inject someone ELSE with it to make THEM as clumsy as a clown. Useful for clown operatives who wish to reconnect with their former clownish nature or for clown operatives who wish to torment and play with their prey before killing them."
-	item = /obj/item/dnainjector/clumsymut
-	cost = 1
+	name = "Clumsiness Anti-Injector"
+	desc = "Inject yourself with this to clownteract your inherent clumsiness. \
+		A must have for operatives who require an extra level of precision for their planned routine."
+	item = /obj/item/dnainjector/anticlumsy
+	cost = 2
 	purchasable_from = UPLINK_CLOWN_OPS
 	uplink_item_flags = SYNDIE_TRIPS_CONTRABAND

--- a/code/modules/uplink/uplink_items/clownops.dm
+++ b/code/modules/uplink/uplink_items/clownops.dm
@@ -38,7 +38,7 @@
 	uplink_item_flags = SYNDIE_TRIPS_CONTRABAND
 
 /datum/uplink_item/weapon_kits/clownopsuperpin
-	name = "Super Ultra Hilarious Firing Pin"
+	name = "Super Ultra Hilarious Firing Pins"
 	desc = "Like the ultra hilarious firing pin, except the gun you insert this pin into explodes when someone who isn't clumsy or a clown tries to fire it."
 	cost = 4 //much cheaper for clown ops than for clowns
 	item = /obj/item/storage/box/syndie_kit/clownpins/super

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -954,6 +954,14 @@
 	restricted = TRUE
 	purchasable_from = UPLINK_ALL_SYNDIE_OPS
 
+/datum/uplink_item/implants/nuclear/macrobomb/fake
+	name = "Fake Macrobomb Implant"
+	desc = "A bomb implant with the same delay as a true macrobomb, but is ultimately no greater than a standard microbomb. \
+		However, its detonation also comes with a surprise that the standard microbomb doesn't..."
+	item = /obj/item/storage/box/syndie_kit/imp_macrobomb_fake
+	cost = /datum/uplink_item/implants/nuclear/microbomb::cost
+	purchasable_from = UPLINK_CLOWN_OPS
+
 /datum/uplink_item/implants/nuclear/deniability
 	name = "Tactical Deniability Implant"
 	desc = "An implant injected into the brain, and later activated either manually or automatically upon entering critical condition. \

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -714,6 +714,14 @@
 	cost = 10
 	purchasable_from = UPLINK_NUKE_OPS
 
+/datum/uplink_item/bundles_tc/induction_kit/clown
+	name = "Syndicate Circus Induction Kit"
+	desc = "Found a particularly entertaining and skilled performer on the station? \
+		This kit allows you to induct them into the Syndicate circus! Contains equipment them with all the necessary gear for their new role. \
+		*NOT* for usage with Reinforcements, and does not brainwash the target!"
+	item = /obj/item/storage/box/syndie_kit/induction_kit/clown
+	purchasable_from = UPLINK_CLOWN_OPS
+
 /datum/uplink_item/bundles_tc/cowboy
 	name = "Syndicate Outlaw Kit"
 	desc = "There've been high tales of an outlaw 'round these parts. A fella so ruthless and efficient no ranger could ever capture 'em. \
@@ -806,7 +814,7 @@
 	desc = "An upgraded, elite version of the Syndicate MODsuit. It features fireproofing, and also \
 		provides the user with superior armor and mobility compared to the standard Syndicate MODsuit."
 	item = /obj/item/mod/control/pre_equipped/elite
-	purchasable_from = (UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY)
+	purchasable_from = (UPLINK_SERIOUS_OPS | UPLINK_SPY)
 
 /datum/uplink_item/suits/energy_shield
 	name = "MODsuit Energy Shield Module"
@@ -873,7 +881,6 @@
 	item = /obj/item/assault_pod
 	cost = 30
 	surplus = 0
-	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
 	restricted = TRUE
 	purchasable_from = UPLINK_FIREBASE_OPS
 
@@ -883,7 +890,7 @@
 		In its crowbar configuration, it can be used to force open airlocks. Very useful for entering the station or its departments."
 	item = /obj/item/crowbar/power/syndicate
 	cost = 4
-	purchasable_from = UPLINK_SERIOUS_OPS | UPLINK_SPY
+	purchasable_from = UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY
 
 /datum/uplink_item/device_tools/medkit
 	name = "Syndicate Combat Medic Kit"
@@ -892,7 +899,7 @@
 		for faster healing on the field. Also comes with basic medical tools and sterlizer."
 	item = /obj/item/storage/medkit/tactical
 	cost = 4
-	purchasable_from = UPLINK_SERIOUS_OPS
+	purchasable_from = UPLINK_ALL_SYNDIE_OPS
 
 /datum/uplink_item/device_tools/medkit/premium
 	name = "Syndicate Combat Medical Suite"
@@ -910,7 +917,7 @@
 	desc = "A potion recovered at great risk by undercover Syndicate operatives and then subsequently modified with Syndicate technology. \
 		Using it will make any animal sentient, and bound to serve you, as well as implanting an internal radio for communication and an internal ID card for opening doors."
 	cost = 4
-	purchasable_from = UPLINK_SERIOUS_OPS | UPLINK_SPY
+	purchasable_from = UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY
 	restricted = TRUE
 
 // Implants
@@ -927,6 +934,7 @@
 		in any creature, biological or mechanical."
 	item = /obj/item/storage/box/syndie_kit/imp_deathrattle
 	cost = 4
+	purchasable_from = UPLINK_ALL_SYNDIE_OPS
 
 /datum/uplink_item/implants/nuclear/microbomb
 	name = "Microbomb Implant"
@@ -935,7 +943,7 @@
 		This will permanently destroy your body, however."
 	item = /obj/item/storage/box/syndie_kit/imp_microbomb
 	cost = 2
-	purchasable_from = UPLINK_SERIOUS_OPS | UPLINK_SPY
+	purchasable_from = UPLINK_ALL_SYNDIE_OPS | UPLINK_SPY
 
 /datum/uplink_item/implants/nuclear/macrobomb
 	name = "Macrobomb Implant"
@@ -944,6 +952,7 @@
 	item = /obj/item/storage/box/syndie_kit/imp_macrobomb
 	cost = 20
 	restricted = TRUE
+	purchasable_from = UPLINK_ALL_SYNDIE_OPS
 
 /datum/uplink_item/implants/nuclear/deniability
 	name = "Tactical Deniability Implant"
@@ -1012,7 +1021,7 @@
 		micro-organism symbiosis to slime-core weaponization, this special Authorization Key can let you push past the boundaries \
 		of bio-terrorism at breakneck speeds. As a bonus, these labs even come equipped with natural life support! *Plants not included."
 	item = /obj/item/keycard/syndicate_bio
-	purchasable_from = UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS
+	purchasable_from = UPLINK_FIREBASE_OPS
 
 /datum/uplink_item/base_keys/chem_key
 	name = "Syndicate Chemical Plant Access Card"
@@ -1021,7 +1030,7 @@
 		can be instantly delivered to your location. Create groundbreaking chemical agents, cook up, sell the best of drugs, \
 		and listen to the best classic music today!"
 	item = /obj/item/keycard/syndicate_chem
-	purchasable_from = UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS
+	purchasable_from = UPLINK_FIREBASE_OPS
 
 /datum/uplink_item/base_keys/fridge_key
 	name = "Lopez's Access Card"
@@ -1030,14 +1039,14 @@
 		pocket during this morning's briefing. He's been looking for it since. Take it, get into the fridge, and cook up whatever \
 		you need before he gets back. And remember: DON'T TELL ANYONE! -M.T"
 	item = /obj/item/keycard/syndicate_fridge
-	purchasable_from = UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS
+	purchasable_from = UPLINK_FIREBASE_OPS
 
 /datum/uplink_item/base_keys/custodial_key
 	name = "Syndicate Custodial Access Card"
 	desc = "Your workplace dirty? No problem! with this card you gain access to the custodial. Containing a janitorial cart \
 	with some janitorial supplies and an canister of water vapour."
 	item = /obj/item/keycard/syndicate_custodial
-	purchasable_from = UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS
+	purchasable_from = UPLINK_FIREBASE_OPS
 
 // Hats
 // It is fundamental for the game's health for there to be a hat crate for nuclear operatives.

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -14,7 +14,7 @@
 	item = /obj/item/gun/syringe/syndicate
 	cost = 4
 	surplus = 50
-	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
+	purchasable_from = ~UPLINK_SERIOUS_OPS
 
 /datum/uplink_item/stealthy_weapons/dehy_carp
 	name = "Dehydrated Space Carp"
@@ -74,7 +74,7 @@
 			falls asleep, they will be able to move and act."
 	item = /obj/item/pen/sleepy
 	cost = 4
-	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
+	purchasable_from = ~UPLINK_FIREBASE_OPS
 
 
 /datum/uplink_item/stealthy_weapons/origami_kit

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -23,7 +23,7 @@
 			an artificial intelligence is watching you is useful for knowing when to maintain cover, and finding nearby \
 			blind spots can help you identify escape routes."
 	item = /obj/item/multitool/ai_detect
-	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
+	purchasable_from = ~UPLINK_FIREBASE_OPS
 	cost = 1
 
 /datum/uplink_item/stealthy_tools/chameleon
@@ -120,7 +120,7 @@
 	limited_stock = 1
 	cost = 4
 	restricted = TRUE
-	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS) //Can still be purchased by loneops to give them an edge.
+	purchasable_from = ~UPLINK_FIREBASE_OPS //Can still be purchased by loneops to give them an edge.
 
 /datum/uplink_item/stealthy_tools/telecomm_blackout/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
 	force_event(/datum/round_event_control/communications_blackout, "a syndicate virus")
@@ -135,7 +135,7 @@
 	limited_stock = 1
 	cost = 6
 	restricted = TRUE
-	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS) //Can still be purchased by loneops to give them an edge.
+	purchasable_from = ~UPLINK_FIREBASE_OPS //Can still be purchased by loneops to give them an edge.
 
 /datum/uplink_item/stealthy_tools/blackout/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
 	force_event(/datum/round_event_control/grid_check, "a syndicate virus")


### PR DESCRIPTION
## About The Pull Request

Clown op outfit changes:

- No longer spawns with edagger
- No longer spawns with an ansem pistol
- No longer spawns with clumsy injector
- No longer spawns with a box of clown firing pins
- Now spawns innately clumsy 
   - (clumsiness can be removed for 2 tc in the uplink)
- Now spawns with nukie PDA, rather than a pinpointer
- Lube flower now contains superlube, rather than lube
- Toy pistol now spawns with clown firing pin installed, rather than a default firing pin
- Clown mask is now fire proof, pepper proof, and has flash protection 
   - (dubbed "tactical clown mask")

Clown op item changes:

- Bananium sword can now slip people lying down, flying, or with no gravity
- Bananium sword now slips longer for clumsy wielders and shorter for non-clumsy wielders
- Bananium shield no longer "auto-catches" for non-clumsy wielders (meaning you have to manually turn on throw mode)
- Funny firing pins now check for clumsy or naive, rather than clumsy or clown or clownop
- Toy guns no longer have cosmetic recoil

Items now in the clown op uplink:

- Dart pistol
   - (might find something funny with this, like super laughter syringes)
- Microbomb Implant
- Macrobomb Implant
   - (exploding clowns are funny)
- Deathrattle Implant
   - (dead clowns are funny)
- Sentience Potion
   - (cayenne is funny)
- Combat Medkit
   - (for keeping clowns alive. the more expensive surgical kit is still restricted)
- Jaws of Life
   - (door prying can be funny)
- Sleepytime Pajama Bundle
- Broken Chameleon Kit
   - (random costume stuff, seemed fitting for clowns)

Items removed from the clown op uplink:

- Elite syndicate MODsuit 
   - (clown skin does not apply to the elite mod, normal bloodreds are free in the infiltrator)
- Ultra Hilarious Firing Pin 
   - (replaced with box)
- Super Ultra Hilarious Firing Pin 
   - (replaced with box)
- Clumsiness Injector 
   - (clown ops now spawn clumsy)

New items in the clown op uplink:

- Circus Induction Kit 
   - (same as the nukie induction kit, but for clown ops)
- Ultra Hilarious Firing Pins 
   - (now comes with 5, same price as the single pin)
- Super Ultra Hilarious Firing Pins 
   - (now comes with 5, same price as the single pin)
- Clumsiness Anti-Injector 
   - (innate clumsiness can be removed with this, 2tc)
- Fake Macrobomb Implant

## Why It's Good For The Game

Clown op uplink is pretty sad, so I wanted to give them a refresh with some new tools for high level pranks.

## Changelog

:cl: Melbert
del: Toy guns no longer have cosmetic recoil effects
balance: Bananium swords are now slippier, particularly in the hands of clowns
balance: Bananium shields are now slippier, particularly in the hands of clowns
balance: Added and removed several items from the clown operative outfit and uplink
/:cl:
