### PR TITLE
Fixes blood hard dels, part 5

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
@@ -9,6 +9,8 @@
 	#define COMPONENT_MOVABLE_BLOCK_PRE_MOVE (1<<0)
 ///from base of atom/movable/Moved(): (atom/old_loc, dir, forced, list/old_locs)
 #define COMSIG_MOVABLE_MOVED "movable_moved"
+/// Sent to an existing occupant during base turf Initialize(), before subtype effects: (turf/initializing_turf)
+#define COMSIG_MOVABLE_TURF_INITIALIZING "movable_turf_initializing"
 ///from base of atom/movable/Cross(): (/atom/movable)
 #define COMSIG_MOVABLE_CROSS "movable_cross"
 	#define COMPONENT_BLOCK_CROSS (1<<0)

--- a/code/datums/components/material_turf_tracking.dm
+++ b/code/datums/components/material_turf_tracking.dm
@@ -61,21 +61,26 @@
 		var/atom/movable/as_movable = parent
 		RegisterSignal(as_movable, COMSIG_ATOM_ENTERING, PROC_REF(on_source_entering))
 		RegisterSignal(as_movable, COMSIG_ATOM_EXITING, PROC_REF(on_source_exiting))
+		RegisterSignal(as_movable, COMSIG_MOVABLE_TURF_INITIALIZING, PROC_REF(on_turf_initializing))
 		target_turf = as_movable.loc
 
-	if (!isopenturf(target_turf))
+	register_turf(target_turf)
+
+/// Start listening to this turf without triggering effects on anything already on it.
+/datum/component/material_turf_tracking/proc/register_turf(atom/location)
+	if (!isopenturf(location))
 		return
 
 	if (!requires_elevation)
-		RegisterSignal(target_turf, SIGNAL_ADDTRAIT(TRAIT_ELEVATED_TURF), PROC_REF(on_turf_lost))
-		RegisterSignal(target_turf, SIGNAL_REMOVETRAIT(TRAIT_ELEVATED_TURF), PROC_REF(on_turf_gained))
-		if (HAS_TRAIT(target_turf, TRAIT_ELEVATED_TURF))
+		RegisterSignal(location, SIGNAL_ADDTRAIT(TRAIT_ELEVATED_TURF), PROC_REF(on_turf_lost))
+		RegisterSignal(location, SIGNAL_REMOVETRAIT(TRAIT_ELEVATED_TURF), PROC_REF(on_turf_gained))
+		if (HAS_TRAIT(location, TRAIT_ELEVATED_TURF))
 			return
 
 	// Not tracking initializations or existing objects as this would allow you to TP someone from plating by placing a tile underneath
-	RegisterSignal(target_turf, COMSIG_ATOM_ENTERED, PROC_REF(on_entered))
-	RegisterSignal(target_turf, COMSIG_TURF_MOVABLE_THROW_LANDED, PROC_REF(on_entered)) // Need this as shoves are 1 tile throws, and COMSIG_ATOM_ENTERED runs before the throw ends
-	RegisterSignal(target_turf, COMSIG_ATOM_EXITED, PROC_REF(on_exited))
+	RegisterSignal(location, COMSIG_ATOM_ENTERED, PROC_REF(on_entered))
+	RegisterSignal(location, COMSIG_TURF_MOVABLE_THROW_LANDED, PROC_REF(on_entered)) // Need this as shoves are 1 tile throws, and COMSIG_ATOM_ENTERED runs before the throw ends
+	RegisterSignal(location, COMSIG_ATOM_EXITED, PROC_REF(on_exited))
 
 /datum/component/material_turf_tracking/UnregisterFromParent()
 	. = ..()
@@ -84,8 +89,23 @@
 		return
 
 	var/atom/movable/as_movable = parent
-	UnregisterSignal(as_movable, list(COMSIG_ATOM_ENTERING, COMSIG_ATOM_EXITING))
+	UnregisterSignal(as_movable, list(COMSIG_ATOM_ENTERING, COMSIG_ATOM_EXITING, COMSIG_MOVABLE_TURF_INITIALIZING))
 	on_source_exiting(as_movable.loc)
+
+/datum/component/material_turf_tracking/proc/on_turf_initializing(atom/movable/source, turf/initializing_turf)
+	SIGNAL_HANDLER
+	UnregisterSignal(initializing_turf, list(
+		SIGNAL_ADDTRAIT(TRAIT_ELEVATED_TURF),
+		SIGNAL_REMOVETRAIT(TRAIT_ELEVATED_TURF),
+		COMSIG_ATOM_ENTERED,
+		COMSIG_TURF_MOVABLE_THROW_LANDED,
+		COMSIG_ATOM_EXITED,
+	))
+	// Things already here might still land or become elevated, so keep listening for that.
+	// Only clear those callbacks if the new turf means they can no longer touch the material turf.
+	if (!isopenturf(initializing_turf) || (!requires_elevation && HAS_TRAIT(initializing_turf, TRAIT_ELEVATED_TURF)))
+		on_turf_lost(initializing_turf)
+	register_turf(initializing_turf)
 
 /datum/component/material_turf_tracking/proc/on_source_entering(atom/movable/source, atom/entering, atom/old_loc)
 	SIGNAL_HANDLER

--- a/code/datums/components/space_camo.dm
+++ b/code/datums/components/space_camo.dm
@@ -30,7 +30,7 @@
 	src.alpha_to_self = alpha_to_self
 
 /datum/component/space_camo/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_ATOM_ENTERING, PROC_REF(on_atom_entering))
+	RegisterSignals(parent, list(COMSIG_ATOM_ENTERING, COMSIG_MOVABLE_TURF_INITIALIZING), PROC_REF(on_atom_entering))
 	if(!isliving(parent))
 		return
 
@@ -54,6 +54,7 @@
 /datum/component/space_camo/UnregisterFromParent()
 	UnregisterSignal(parent, list(
 		COMSIG_ATOM_ENTERING,
+		COMSIG_MOVABLE_TURF_INITIALIZING,
 		COMSIG_ATOM_WAS_ATTACKED,
 		COMSIG_MOB_ITEM_ATTACK,
 		COMSIG_LIVING_UNARMED_ATTACK,

--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -17,14 +17,14 @@
 
 	src.pixel_shift = pixel_shift
 
-	RegisterSignal(target, COMSIG_ATOM_ENTERING, PROC_REF(on_source_entering))
+	RegisterSignals(target, list(COMSIG_ATOM_ENTERING, COMSIG_MOVABLE_TURF_INITIALIZING), PROC_REF(on_source_entering))
 	RegisterSignal(target, COMSIG_ATOM_EXITING, PROC_REF(on_source_exiting))
 
 	var/atom/atom_target = target
 	register_turf(atom_target, atom_target.loc)
 
 /datum/element/elevation/Detach(atom/movable/source)
-	UnregisterSignal(source, list(COMSIG_ATOM_ENTERING, COMSIG_ATOM_EXITING))
+	UnregisterSignal(source, list(COMSIG_ATOM_ENTERING, COMSIG_MOVABLE_TURF_INITIALIZING, COMSIG_ATOM_EXITING))
 	unregister_turf(source, source.loc)
 	REMOVE_TRAIT(source, TRAIT_ELEVATING_OBJECT, ref(src))
 	return ..()

--- a/code/game/objects/effects/decals/cleanable/blood.dm
+++ b/code/game/objects/effects/decals/cleanable/blood.dm
@@ -75,8 +75,6 @@
 
 /obj/effect/decal/cleanable/blood/Destroy(force)
 	STOP_PROCESSING(SSblood_drying, src)
-	// connect_loc only unregisters via COMSIG_MOVABLE_MOVED, which never fires when the turf we're on gets replaced by ChangeTurf()
-	RemoveElement(/datum/element/connect_loc, loc_connections)
 	return ..()
 
 /// Returns the default blood type for this decal for maploaded decals

--- a/code/game/objects/effects/decals/cleanable/food.dm
+++ b/code/game/objects/effects/decals/cleanable/food.dm
@@ -41,11 +41,6 @@
 	. = ..()
 	AddElement(/datum/element/connect_loc, loc_connections)
 
-/obj/effect/decal/cleanable/food/salt/Destroy(force)
-	// connect_loc only unregisters via COMSIG_MOVABLE_MOVED, which never fires when the turf we're on gets replaced by ChangeTurf()
-	RemoveElement(/datum/element/connect_loc, loc_connections)
-	return ..()
-
 /obj/effect/decal/cleanable/food/salt/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
 	if(is_species(mover, /datum/species/snail))

--- a/code/game/objects/effects/decals/cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/cleanable/fuel.dm
@@ -33,10 +33,6 @@
 
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/effect/decal/cleanable/fuel_pool/Destroy(force)
-	RemoveElement(/datum/element/connect_loc, loc_connections)
-	return ..()
-
 // Just in case of fires, do this after mapload.
 /obj/effect/decal/cleanable/fuel_pool/LateInitialize()
 // We don't want to burn down the create_and_destroy test area

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -21,10 +21,6 @@
 	AddElement(/datum/element/connect_loc, decal_move_connections)
 	AddElement(/datum/element/force_move_pulled)
 
-/obj/effect/decal/Destroy(force)
-	RemoveElement(/datum/element/connect_loc, decal_move_connections)
-	return ..()
-
 /obj/effect/decal/blob_act(obj/structure/blob/B)
 	if(B && B.loc == loc)
 		qdel(src)

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -108,16 +108,9 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	var/list/old_listen_lookup = _listen_lookup?.Copy()
 	var/list/old_signal_procs = _signal_procs?.Copy()
 	var/carryover_turf_flags = (RESERVATION_TURF | UNUSED_RESERVATION_TURF) & turf_flags
-	var/turf/new_turf = new path(src)
+	// Turf references survive replacement, but their signal lists must be set before Initialize.
+	var/turf/new_turf = new path(src, old_listen_lookup, old_signal_procs)
 	new_turf.turf_flags |= carryover_turf_flags
-
-	// WARNING WARNING
-	// Turfs DO NOT lose their signals when they get replaced, REMEMBER THIS
-	// It's possible because turfs are fucked, and if you have one in a list and it's replaced with another one, the list ref points to the new turf
-	if(old_listen_lookup)
-		LAZYOR(new_turf._listen_lookup, old_listen_lookup)
-	if(old_signal_procs)
-		LAZYOR(new_turf._signal_procs, old_signal_procs)
 
 	for(var/datum/callback/callback as anything in post_change_callbacks)
 		callback.InvokeAsync(new_turf)

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -231,7 +231,17 @@
 	if(old_loc && leave_footprints && !broken && !burnt && ishuman(arrived))
 		add_footprint(arrived, get_dir(old_loc, src))
 
-	if(!destination_z || !destination_x || !destination_y || arrived.pulledby || arrived.currently_z_moving)
+	transfer_occupant(arrived)
+
+/turf/open/initialize_occupant(atom/movable/occupant)
+	. = ..()
+	transfer_occupant(occupant)
+
+/// Moves an occupant through a configured connection to another z-level.
+/turf/open/proc/transfer_occupant(atom/movable/occupant)
+	if(!occupant || occupant.loc != src)
+		return
+	if(!destination_z || !destination_x || !destination_y || occupant.pulledby || occupant.currently_z_moving)
 		return
 
 	if(SSatoms.initialized == INITIALIZATION_INNEW_MAPLOAD) // we don't want to be transitioning atoms to another z-level while we are still in mapload
@@ -243,7 +253,7 @@
 	var/itercount = 0
 	while(DT.density || istype(DT.loc,/area/shuttle)) // Extend towards the center of the map, trying to look for a better place to arrive
 		if (itercount++ >= 100)
-			log_game("SPACE Z-TRANSIT ERROR: Could not find a safe place to land [arrived] within 100 iterations.")
+			log_game("SPACE Z-TRANSIT ERROR: Could not find a safe place to land [occupant] within 100 iterations.")
 			break
 		if (tx < 128)
 			tx++
@@ -255,9 +265,9 @@
 			ty--
 		DT = locate(tx, ty, destination_z)
 
-	arrived.zMove(null, DT, ZMOVE_ALLOW_BUCKLED)
+	occupant.zMove(null, DT, ZMOVE_ALLOW_BUCKLED)
 
-	var/atom/movable/current_pull = arrived.pulling
+	var/atom/movable/current_pull = occupant.pulling
 	while (current_pull)
 		var/turf/target_turf = get_step(current_pull.pulledby.loc, REVERSE_DIR(current_pull.pulledby.dir)) || current_pull.pulledby.loc
 		current_pull.zMove(null, target_turf, ZMOVE_ALLOW_BUCKLED)
@@ -353,6 +363,11 @@
 /turf/open/indestructible/honk/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(ismob(arrived))
+		playsound(src, sound, 50, TRUE)
+
+/turf/open/indestructible/honk/initialize_occupant(atom/movable/occupant)
+	. = ..()
+	if(ismob(occupant))
 		playsound(src, sound, 50, TRUE)
 
 /turf/open/indestructible/necropolis

--- a/code/game/turfs/open/cliff.dm
+++ b/code/game/turfs/open/cliff.dm
@@ -52,6 +52,10 @@
 
 	try_fall(arrived)
 
+/turf/open/cliff/initialize_occupant(atom/movable/occupant)
+	. = ..()
+	try_fall(occupant)
+
 /turf/open/cliff/zImpact(atom/movable/falling, levels, turf/prev_turf, flags)
 	. = ..(flags = flags | FALL_INTERCEPTED)
 

--- a/code/game/turfs/open/floor/mineral_floor.dm
+++ b/code/game/turfs/open/floor/mineral_floor.dm
@@ -303,6 +303,13 @@
 	if(isliving(arrived))
 		squeak()
 
+/turf/open/floor/mineral/bananium/initialize_occupant(atom/movable/occupant)
+	. = ..()
+	if(.)
+		return
+	if(isliving(occupant))
+		squeak()
+
 /turf/open/floor/mineral/bananium/attackby(obj/item/W, mob/user, list/modifiers)
 	.=..()
 	if(!.)
@@ -375,6 +382,13 @@
 	if(.)
 		return
 	if(isliving(arrived))
+		radiate()
+
+/turf/open/floor/mineral/uranium/initialize_occupant(atom/movable/occupant)
+	. = ..()
+	if(.)
+		return
+	if(isliving(occupant))
 		radiate()
 
 /turf/open/floor/mineral/uranium/attackby(obj/item/W, mob/user, list/modifiers)

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -77,17 +77,20 @@
 	AddElement(/datum/element/immerse, "immerse", 215)
 	immerse_added = TRUE
 
-/**
- * turf/Initialize() calls Entered on its contents too, however
- * we need to wait for movables that still need to be initialized
- * before we add the immerse element.
- */
 /turf/open/lava/Entered(atom/movable/arrived)
 	. = ..()
-	if(!immerse_added && !is_type_in_typecache(arrived, GLOB.immerse_ignored_movable))
+	apply_lava_effects(arrived)
+
+/turf/open/lava/initialize_occupant(atom/movable/occupant)
+	. = ..()
+	apply_lava_effects(occupant)
+
+/// Entering lava and having the floor turn into lava apply the same effects.
+/turf/open/lava/proc/apply_lava_effects(atom/movable/occupant)
+	if(!immerse_added && !is_type_in_typecache(occupant, GLOB.immerse_ignored_movable))
 		AddElement(/datum/element/immerse, "immerse", 215)
 		immerse_added = TRUE
-	if(burn_stuff(arrived))
+	if(burn_stuff(occupant))
 		START_PROCESSING(SSobj, src)
 
 /turf/open/lava/update_overlays()

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -57,6 +57,11 @@
 	. = ..()
 	if(movable.set_currently_z_moving(CURRENTLY_Z_FALLING))
 		zFall(movable, falling_from_move = TRUE)
+
+/turf/open/openspace/initialize_occupant(atom/movable/occupant)
+	. = ..()
+	zfall_if_on_turf(occupant)
+
 /**
  * Drops movables spawned on this turf after they are successfully initialized.
  * so that spawned movables that should fall to gravity, will fall.

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -58,14 +58,13 @@
 	UnregisterSignal(src, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON)
 	make_immersed(movable)
 
-/**
- * turf/Initialize() calls Entered on its contents too, however
- * we need to wait for movables that still need to be initialized
- * before we add the immerse element.
- */
 /turf/open/water/Entered(atom/movable/arrived)
 	. = ..()
 	make_immersed(arrived)
+
+/turf/open/water/initialize_occupant(atom/movable/occupant)
+	. = ..()
+	make_immersed(occupant)
 
 ///Makes this turf immersable, return true if we actually did anything so child procs don't have to repeat our checks
 /turf/open/water/proc/make_immersed(atom/movable/triggering_atom)
@@ -257,6 +256,13 @@
 	if(!(arrived.flags_1 & INITIALIZED_1)) // If arrived hasn't finished its own Initialize() yet (e.g. during its own creation during mapload), on_atom_inited() will already call enter_hot_spring() for it once
 		return
 	enter_hot_spring(arrived)
+
+/turf/open/water/hot_spring/initialize_occupant(atom/movable/occupant)
+	. = ..()
+	// Uninitialized occupants use on_atom_inited() once their own initialization finishes.
+	if(!(occupant.flags_1 & INITIALIZED_1))
+		return
+	enter_hot_spring(occupant)
 
 /turf/open/water/hot_spring/on_atom_inited(datum/source, atom/movable/movable)
 	enter_hot_spring(movable)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -114,6 +114,13 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	var/skip_minimap_rendering = FALSE
 
 
+/// ChangeTurf passes the old signal tables here so initialization can update them directly.
+/// In particular, occupant initialization can move or delete existing contents before New() returns.
+/turf/New(loc, list/inherited_listen_lookup, list/inherited_signal_procs)
+	_listen_lookup = inherited_listen_lookup
+	_signal_procs = inherited_signal_procs
+	. = ..(loc)
+
 /turf/vv_edit_var(var_name, new_value)
 	var/static/list/banned_edits = list(NAMEOF_STATIC(src, x), NAMEOF_STATIC(src, y), NAMEOF_STATIC(src, z))
 	if(var_name in banned_edits)
@@ -162,7 +169,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		QUEUE_SMOOTH(src)
 
 	for(var/atom/movable/content as anything in src)
-		Entered(content, null)
+		initialize_occupant(content)
 
 	var/area/our_area = loc
 	if(!our_area.area_has_base_lighting && space_lit) //Only provide your own lighting if the area doesn't for you
@@ -185,6 +192,12 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		set_custom_materials(custom_materials)
 
 	return INITIALIZE_HINT_NORMAL
+
+/// Applies this turf to an existing occupant during Initialize(), without announcing movement.
+/// Call the parent first so the occupant can update turf-dependent state before subtype effects run.
+/turf/proc/initialize_occupant(atom/movable/occupant)
+	SHOULD_CALL_PARENT(TRUE)
+	SEND_SIGNAL(occupant, COMSIG_MOVABLE_TURF_INITIALIZING, src)
 
 /// Initializes our adjacent turfs. If you want to avoid this, do not override it, instead set init_air to FALSE
 /turf/proc/Initalize_Atmos(time)
@@ -221,11 +234,12 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		vis_contents.Cut()
 
 /// WARNING WARNING
-/// Turfs DO NOT lose their signals when they get replaced, REMEMBER THIS
+/// Turfs DO NOT lose their external signal connections when they get replaced, REMEMBER THIS
 /// It's possible because turfs are fucked, and if you have one in a list and it's replaced with another one, the list ref points to the new turf
-/// We do it because moving signals over was needlessly expensive, and bloated a very commonly used bit of code
+/// We do it to avoid unregistering and re-registering every signal in a very commonly used bit of code
+/// Signals registered by the turf on itself are cleared so the new type can register its own
 /turf/_clear_signal_refs()
-	return
+	UnregisterSignal(src, _signal_procs?[src])
 
 /turf/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/code/modules/events/immovable_rod/immovable_rod.dm
+++ b/code/modules/events/immovable_rod/immovable_rod.dm
@@ -45,7 +45,7 @@
 
 	SSpoints_of_interest.make_point_of_interest(src)
 
-	RegisterSignal(src, COMSIG_ATOM_ENTERING, PROC_REF(on_entering_atom))
+	RegisterSignals(src, list(COMSIG_ATOM_ENTERING, COMSIG_MOVABLE_TURF_INITIALIZING), PROC_REF(on_entering_atom))
 
 	if(special_target)
 		GLOB.move_manager.home_onto(src, special_target)
@@ -53,7 +53,7 @@
 		GLOB.move_manager.move_towards(src, real_destination)
 
 /obj/effect/immovablerod/Destroy(force)
-	UnregisterSignal(src, COMSIG_ATOM_ENTERING)
+	UnregisterSignal(src, list(COMSIG_ATOM_ENTERING, COMSIG_MOVABLE_TURF_INITIALIZING))
 	SSaugury.unregister_doom(src)
 	destination_turf = null
 	special_target = null


### PR DESCRIPTION
## About The Pull Request

This might actually be the end... I think I've isolated the cause, and it's naturally LAVA. Because ofc it would be.

Fixes https://github.com/tgstation/tgstation/issues/97639
Fixes https://github.com/tgstation/tgstation/issues/97700
Fixes https://github.com/tgstation/tgstation/issues/97693
Fixes https://github.com/tgstation/tgstation/issues/97651
Fixes https://github.com/tgstation/tgstation/issues/97686

So turf initialization currently calls `Entered()` on everything already on the tile. This means, replacing the floor underneath something therefore is identical functionally to if it had moved onto that floor. This can notify existing listeners again and cause duplicate registrations.

This PR aims to separate it into two cases:
1) Actual movement: continues through `Entered()`.
2) Existing occupants: get `initialize_occupant()` when their turf initializes.

Back to the lava: previously, `ChangeTurf()` saved the signal tables, initialized the replacement, then merged the saved tables back in. If initialization deleted a gib, that merge could restore its registration and keep it referenced. This is what was happening with lava:

1) A blood/gib decal sits on a turf, listening for atom_entered through `connect_loc`.
2) `ChangeTurf()` saves that turf’s signal tables and starts constructing lava underneath the decal.
3) Lava initialization calls `Entered()` for things already there.
4) That runs `burn_stuff()` -> `do_burn()`. Lava explicitly removes FIRE_PROOF, then calls the decal’s `fire_act()`, which immediately calls `qdel(src)`. Ordinary fire resistance therefore doesn’t protect blood from lava.
5) Blood deletion tries to unregister its turf signals. But those inherited registrations are still sitting in `ChangeTurf()`’s saved tables, unavailable to cleanup on the new turf.
6) Construction finishes, and` ChangeTurf()` merges those saved tables back, including the reference to the deleted blood.
7) That reference prevents garbage collection, eventually causing a hard delete.

After this PR, the replacement now gets those tables _before_ initialization, so cleanup updates the tables that actually survive.

With initialization now handled explicitly, the inherited-listener exclusions and special signal-dispatch filtering are no longer needed. 

Material tracking also refreshes its subscriptions without rerunning first-entered effects or losing pending landing callbacks.
The result is easier to follow. Now movement notifications mean something moved, and turf setup has its own clearly named path.

I tested this locally but you may want to test merge just in case I missed any edge cases.

## Why It's Good For The Game

blood magic is ILLEGAL. also

<details><summary>live footage from within a typical CI run</summary>

<img width="498" height="351" alt="spooky-volcano-2797087484" src="https://github.com/user-attachments/assets/c1a2debc-9b15-4306-964e-eef4e0aec053" />

</details>

## Changelog

:cl:
refactor: changed the way ChangeTurf() handles signal registration, please report any weird issues with stuff that usually happens on entering certain turfs (elevation, bananium squeaks, lava burning things, etc)
/:cl: