### PR TITLE
Adds a lint to check for uncommonly used line dividers for integrity purposes.

### DIFF
--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -294,6 +294,14 @@ if $grep -i 'securaty|securiy|secuirty' "${code_files[@]}"; then
     echo -e "${RED}ERROR: Misspelling(s) of 'security' detected in code, please fix.${NC}";
     st=1
 fi;
+
+part "ai slop comment detector"
+if $grep -i '—' "${code_files[@]}"; then
+	echo
+	echo -e "${RED}ERROR: EM dash usage detected. You are required to disclose usage of AI tooling during development along with what percentage of the code is written by you versus written by the AI for licensing reasons. Failure to disclose AI usage and to what extent it was used may result in your PR being closed.${NC}"
+	st=1
+fi;
+
 part "map json naming"
 if ls _maps/*.json | $grep "[A-Z]"; then
 	echo


### PR DESCRIPTION
## About The Pull Request

Adds a lint to check for uncommonly used line dividers.

## Why It's Good For The Game

After performing an audit, I've found at least 3 instances of respected developers in the community using AI tooling to write comments, code, and tooling without disclosing their usage of AI tooling. This code has styling issues, technical problems, and were likely overlooked due to the developers in question being community veterans who are expected to know better than to leave vibecoded stuff in their production PRs. 

I'm not gonna name names publicly because that's not productive for actually getting this issue resolved, but this sort of tooling needs to be disclosed when used because it otherwise results in a licensing problem because the US Copyright Office is very clear that entirely AI-produced works fall under the same licensing issue that the monkey who took a selfie does, which has implications for the AGPLv3 and infectivity.

If someone wants to write a better lint, let me know, but this should catch stuff.

## Changelog

:cl:
code: Adds a lint to check for uncommonly used line dividers for integrity purposes.
/:cl: