### PR TITLE
Fix stray cargo supply pod runtime

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -191,7 +191,7 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 			take_contents()
 
 	if(sealed)
-		var/datum/gas_mixture/external_air = loc.return_air()
+		var/datum/gas_mixture/external_air = loc?.return_air()
 		if(external_air && is_maploaded)
 			internal_air = external_air.copy()
 		else


### PR DESCRIPTION

## About The Pull Request
The stray cargo pod would initialize a closet with a null location, then check the air of that location that runtimes. See:

<img width="1063" height="778" alt="Code_iXOTF0uoC0" src="https://github.com/user-attachments/assets/98836dc6-2b4d-4aad-aa96-d722ed581e9b" />

## Why It's Good For The Game
Code no crashy.

## Changelog
:cl:
fix: Fix cargo stray supply pod runtime
/:cl:
