### PR TITLE
Adds a unit test for job icons

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -222,6 +222,7 @@
 #include "interaction_silicon.dm"
 #include "interaction_structures.dm"
 #include "job_display_order.dm"
+#include "job_icons.dm"
 #include "json_savefile_importing.dm"
 #include "keybinding_init.dm"
 #include "kinetic_crusher.dm"

--- a/code/modules/unit_tests/job_icons.dm
+++ b/code/modules/unit_tests/job_icons.dm
@@ -1,0 +1,9 @@
+/// Tests that all jobs that could be part of the crew manifest (and therefore on the observer menu) has a TGUI icon to display.
+/datum/unit_test/job_icons
+
+/datum/unit_test/job_icons/Run()
+	for(var/datum/job/job as anything in subtypesof(/datum/job))
+		if(!(job::job_flags & JOB_CREW_MANIFEST))
+			continue
+		if(isnull(job::tgui_icon))
+			TEST_FAIL("[job::title] does not have a valid job icon.")


### PR DESCRIPTION
## About The Pull Request

All jobs that are shown on the crew manifest must have an icon, including station trait jobs.

## Why It's Good For The Game

Downstreams, don't forget to not break your observer menu.

## Changelog

Nothing player-facing.