### PR TITLE
Just kinda 5x autogrow's power cost to see what happens

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -10,6 +10,7 @@
 	circuit = /obj/item/circuitboard/machine/hydroponics
 	interaction_flags_click = FORBID_TELEKINESIS_REACH
 	use_power = NO_POWER_USE
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 5
 	///The amount of water in the tray (max 100)
 	var/waterlevel = 0
 	///The maximum amount of water in the tray


### PR DESCRIPTION
## About The Pull Request

Increases active power cost of auto-grow from 1kw to 5kw
Halves idle power cost of hydroponics trays from 100w to 50w

## Why It's Good For The Game

I was looking into statistics out of interest for the other power related PR

And I found that hydroponics trays, which allegedly "uses a high power cost", only expends 1kw of power

1 kw is 0.15% of the station's default power output. (Technically 0.01% if the engine is hotwired.)
Base Metastation uses about 67% (lol) of the station's default power output.

Yes, the station has room for **33%** more power usage - And despite this, turning auto-grow on every single tray expends **3%** of the station's power, still leaving **30%** room for t4 parts

(Yeah as a fun fact, if you tier 4 upgraded every single room in the station but botany, and activated auto-grow for every tray, botany wouldn't even hit top 5 most power draw rooms)

Anywayyyyys 5x-ing the power output bumps it up from 0.15% to 0.75%, and if you activated auto-grow on every tray, 3% to 15%, which still comfortably leaves 18% power to do whatever I guess

## Changelog

:cl: Melbert
balance: Hydroponics auto-grow uses 5x more power (don't worry, if you think this is a lot, it's still less than 1% of the station's default power output per tray) 
balance: Hydroponics default power usage reduced by 2x
/:cl:
