### PR TITLE
Stops holodeck from bricking itself

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -224,8 +224,12 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 	template.load(bottom_left) //this is what actually loads the holodeck simulation into the map
 
 	if(template.restricted)
-		usr.log_message("loaded a restricted Holodeck program: [program].", LOG_GAME)
-		message_admins("[ADMIN_LOOKUPFLW(usr)] loaded a restricted Holodeck program: [program].")
+		if(usr)
+			usr.log_message("loaded a restricted Holodeck program: [program].", LOG_GAME)
+			message_admins("[ADMIN_LOOKUPFLW(usr)] loaded a restricted Holodeck program: [program].")
+		else
+			log_game("loaded a restricted Holodeck program: [program].")
+			message_admins("loaded a restricted Holodeck program: [program].")
 
 	spawned = template.created_atoms //populate the spawned list with the atoms belonging to the holodeck
 


### PR DESCRIPTION
## About The Pull Request

<img width="600" height="400" alt="hxq7EqkZr1" src="https://github.com/user-attachments/assets/5fe95dcc-1e44-4eb3-b315-c3de4cc0d0a6" />

Holodecks can runtime midway through loading their program, getting stuck forever in an invalid state and bricking themselves.

## Why It's Good For The Game

holodeck becoming unusable for the rest of the round is not good for the game

## Changelog

:cl:
fix: fixes an issue that can cause the holodeck to stop functioning for the entire round
/:cl:

