### PR TITLE
Fix supermatter spiders not having web immunity trait

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/supermatter_spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/supermatter_spider.dm
@@ -41,6 +41,7 @@
 
 /mob/living/basic/supermatter_spider/Initialize(mapload)
 	. = ..()
+	ADD_TRAIT(src, TRAIT_WEB_SURFER, INNATE_TRAIT)
 	AddComponent(/datum/component/swarming)
 
 	AddElement(/datum/element/ai_retaliate)


### PR DESCRIPTION

## About The Pull Request
Adds the `TRAIT_WEB_SURFER` trait to supermatter spiders.

## Why It's Good For The Game
Consistency.

## Changelog
:cl:
fix: Fix supermatter spiders not having web immunity trait
/:cl:
